### PR TITLE
feat(mpp): foundation — GUCs, transport, mesh, DSM layout (1/6)

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -129,6 +129,32 @@ static DYNAMIC_FILTER_BATCH_SIZE: GucSetting<i32> = GucSetting::<i32>::new(0);
 /// use per-segment ordinal pruning to reduce dictionary decoding.
 static ENABLE_SEGMENTED_TOPK: GucSetting<bool> = GucSetting::<bool>::new(true);
 
+/// Gate the MPP (Massively Parallel Processing) plan partitioning path for JoinScan
+/// and AggregateScan. When off, behavior is identical to `origin/main`.
+static ENABLE_MPP: GucSetting<bool> = GucSetting::<bool>::new(false);
+
+/// When on, `mpp_log!()` routes through `pgrx::warning!()` so runtime traces appear in
+/// the Postgres server log (and in CI benchmark logs). When off, `mpp_log!()` is a no-op.
+static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
+
+/// Dedicated diagnostic GUC for per-shuffle EOF row counts. These lines emit concurrently
+/// from every participant and can reorder between runs, so they're kept off `mpp_debug` to
+/// avoid flaking regress expected files. Turn this on in long-running benchmark queries to
+/// capture per-seat input/output row counts per shuffle at WARNING level (server log + CI
+/// logs). When off, the same call sites route through `debug1!()` — still reachable via
+/// `SET log_min_messages = DEBUG1` but invisible to CI's default WARNING capture.
+static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
+
+/// Total number of MPP participants (leader + workers). Default 4 splits
+/// scan + shuffle + partial-aggregate work across 4 processes. PG's
+/// `max_parallel_workers_per_gather` still caps the actual worker count
+/// at exec time, so users in constrained environments see fewer.
+static MPP_WORKER_COUNT: GucSetting<i32> = GucSetting::<i32>::new(4);
+
+/// When the in-memory drain buffer for incoming MPP batches grows past this many megabytes
+/// per participant, spill to a Postgres BufFile. 0 disables spilling (keep everything in RAM).
+static MPP_DRAIN_WATERMARK_MB: GucSetting<i32> = GucSetting::<i32>::new(256);
+
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -401,6 +427,66 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_mpp",
+        c"Enable ParadeDB's MPP (Massively Parallel Processing) plan partitioning",
+        c"When enabled, JoinScan and AggregateScan may hash-partition every table by the \
+          join key and shuffle intermediate rows between workers, so each row is scanned \
+          exactly once. Default is false; off path is identical to non-MPP behavior.",
+        &ENABLE_MPP,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.mpp_debug",
+        c"Emit verbose MPP runtime diagnostics",
+        c"When enabled, `mpp_log!()` calls route through `pgrx::warning!()` so MPP \
+          lifecycle and transport events appear in the Postgres server log. Default is false.",
+        &MPP_DEBUG,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.mpp_trace",
+        c"Emit per-shuffle EOF row counts at WARNING level",
+        c"When enabled, ShuffleStream and DrainGatherStream EOF trace lines route through \
+          `pgrx::warning!()` so per-participant input/output row counts appear in the \
+          Postgres server log (and in CI benchmark logs). These lines emit concurrently \
+          from every participant and can reorder run-to-run, so they're kept off \
+          `mpp_debug` to avoid flaking regress expected files. Default is false.",
+        &MPP_TRACE,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_worker_count",
+        c"Total MPP participants (leader + parallel workers)",
+        c"Sets the number of MPP participants per query when `enable_mpp` is on. \
+          The queue mesh and drain thread are general over N; milestone-1 default is 2.",
+        &MPP_WORKER_COUNT,
+        1,
+        64,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_drain_watermark_mb",
+        c"High-water mark for MPP drain buffer (spill not yet implemented)",
+        c"Reserved. When the in-memory drain buffer per participant exceeds this \
+          many megabytes, incoming batches will spill to a Postgres BufFile-backed \
+          temp file. Spilling is not yet wired up as of Phase 2; the GUC is defined \
+          now so future benchmarks can exercise the cap without schema churn.",
+        &MPP_DRAIN_WATERMARK_MB,
+        0,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -573,6 +659,26 @@ pub fn dynamic_filter_batch_size() -> i32 {
 
 pub fn enable_segmented_topk() -> bool {
     ENABLE_SEGMENTED_TOPK.get()
+}
+
+pub fn enable_mpp() -> bool {
+    ENABLE_MPP.get()
+}
+
+pub fn mpp_debug() -> bool {
+    MPP_DEBUG.get()
+}
+
+pub fn mpp_trace() -> bool {
+    MPP_TRACE.get()
+}
+
+pub fn mpp_worker_count() -> i32 {
+    MPP_WORKER_COUNT.get()
+}
+
+pub fn mpp_drain_watermark_mb() -> i32 {
+    MPP_DRAIN_WATERMARK_MB.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -479,8 +479,8 @@ pub fn init() {
         c"High-water mark for MPP drain buffer (spill not yet implemented)",
         c"Reserved. When the in-memory drain buffer per participant exceeds this \
           many megabytes, incoming batches will spill to a Postgres BufFile-backed \
-          temp file. Spilling is not yet wired up as of Phase 2; the GUC is defined \
-          now so future benchmarks can exercise the cap without schema churn.",
+          temp file. Spilling is not yet wired up; the GUC is defined now so future \
+          benchmarks can exercise the cap without schema churn.",
         &MPP_DRAIN_WATERMARK_MB,
         0,
         i32::MAX,

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -151,10 +151,6 @@ static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// at exec time, so users in constrained environments see fewer.
 static MPP_WORKER_COUNT: GucSetting<i32> = GucSetting::<i32>::new(4);
 
-/// When the in-memory drain buffer for incoming MPP batches grows past this many megabytes
-/// per participant, spill to a Postgres BufFile. 0 disables spilling (keep everything in RAM).
-static MPP_DRAIN_WATERMARK_MB: GucSetting<i32> = GucSetting::<i32>::new(256);
-
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -473,20 +469,6 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
-
-    GucRegistry::define_int_guc(
-        c"paradedb.mpp_drain_watermark_mb",
-        c"High-water mark for MPP drain buffer (spill not yet implemented)",
-        c"Reserved. When the in-memory drain buffer per participant exceeds this \
-          many megabytes, incoming batches will spill to a Postgres BufFile-backed \
-          temp file. Spilling is not yet wired up; the GUC is defined now so future \
-          benchmarks can exercise the cap without schema churn.",
-        &MPP_DRAIN_WATERMARK_MB,
-        0,
-        i32::MAX,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -675,10 +657,6 @@ pub fn mpp_trace() -> bool {
 
 pub fn mpp_worker_count() -> i32 {
     MPP_WORKER_COUNT.get()
-}
-
-pub fn mpp_drain_watermark_mb() -> i32 {
-    MPP_DRAIN_WATERMARK_MB.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -140,7 +140,7 @@ static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// Dedicated diagnostic GUC for per-shuffle EOF row counts. These lines emit concurrently
 /// from every participant and can reorder between runs, so they're kept off `mpp_debug` to
 /// avoid flaking regress expected files. Turn this on in long-running benchmark queries to
-/// capture per-seat input/output row counts per shuffle at WARNING level (server log + CI
+/// capture per-participant input/output row counts per shuffle at WARNING level (server log + CI
 /// logs). When off, the same call sites route through `debug1!()` — still reachable via
 /// `SET log_min_messages = DEBUG1` but invisible to CI's default WARNING capture.
 static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -151,6 +151,20 @@ static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// at exec time, so users in constrained environments see fewer.
 static MPP_WORKER_COUNT: GucSetting<i32> = GucSetting::<i32>::new(4);
 
+/// Per-edge shm_mq queue size in bytes. Each MPP query allocates
+/// `num_meshes × N×(N-1) × mpp_queue_size` of dynamic shared memory: at
+/// N=4 with 3 meshes (group-by aggregate's worst case) the default 64 MiB
+/// produces ~2.3 GiB per query, sized so a ~100 MiB Partial-aggregate burst
+/// on the post-agg mesh fits without backpressure. Operators on memory-
+/// constrained boxes will want to dial this down; that's the explicit
+/// reason it's exposed instead of held as a `pub const`.
+///
+/// This is a foundation-era knob and may be replaced once mesh
+/// multiplexing lands (one queue carrying tagged messages from N stages
+/// instead of N meshes), at which point the right user knob is more
+/// likely a per-query DSM cap than a raw per-edge byte count.
+static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024);
+
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -469,6 +483,23 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_queue_size",
+        c"Per-edge shm_mq queue size for MPP shuffles",
+        c"Sets the per-edge shm_mq queue size for MPP shuffles. Accepts standard \
+          Postgres byte units (e.g. '64MB', '1GB', '512kB'). Total DSM per query is \
+          `num_meshes × N×(N-1) × mpp_queue_size`; at the default 64MB and N=4 with \
+          3 meshes that is ~2.3GB per query. Lower this on memory-constrained boxes; \
+          raise it only if a single shuffle batch routinely backs up the queue. \
+          Foundation-era knob — likely to be replaced by a per-query DSM cap once \
+          mesh multiplexing lands.",
+        &MPP_QUEUE_SIZE,
+        64 * 1024,
+        1024 * 1024 * 1024,
+        GucContext::Userset,
+        GucFlags::UNIT_BYTE,
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -657,6 +688,10 @@ pub fn mpp_trace() -> bool {
 
 pub fn mpp_worker_count() -> i32 {
     MPP_WORKER_COUNT.get()
+}
+
+pub fn mpp_queue_size() -> usize {
+    MPP_QUEUE_SIZE.get() as usize
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -466,7 +466,7 @@ pub fn init() {
         c"paradedb.mpp_worker_count",
         c"Total MPP participants (leader + parallel workers)",
         c"Sets the number of MPP participants per query when `enable_mpp` is on. \
-          The queue mesh and drain thread are general over N; milestone-1 default is 2.",
+          The queue mesh and drain thread are general over N.",
         &MPP_WORKER_COUNT,
         1,
         64,

--- a/pg_search/src/parallel_worker/mqueue.rs
+++ b/pg_search/src/parallel_worker/mqueue.rs
@@ -189,6 +189,23 @@ impl MessageQueueReceiver {
         }
     }
 
+    /// Wrap an already-acquired `shm_mq_handle` pointer directly. Used by
+    /// the MPP mesh where `shm_mq_attach` is called from a non-standard
+    /// layout (one `shm_mq_create` up front for every mesh slot, then each
+    /// participant attaches as sender or receiver separately).
+    ///
+    /// # Safety
+    /// `handle` must be a non-null `shm_mq_handle*` returned by a successful
+    /// `shm_mq_attach` call, and ownership of the handle (detach on drop) is
+    /// transferred into the returned receiver.
+    pub unsafe fn from_raw_handle(handle: *mut pg_sys::shm_mq_handle) -> Self {
+        Self {
+            handle: MessageQueueHandle {
+                handle: unsafe { NonNull::new_unchecked(handle) },
+            },
+        }
+    }
+
     pub fn recv(&self) -> Result<Vec<u8>, MessageQueueRecvError> {
         unsafe {
             let mut len = 0usize;

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -38,6 +38,7 @@ pub mod expr_eval;
 mod hook;
 pub mod joinscan;
 pub mod limit_offset;
+pub mod mpp;
 pub mod opexpr;
 pub mod orderby;
 pub mod parallel;

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -39,7 +39,6 @@
 #![allow(dead_code)]
 
 use pgrx::pg_sys;
-use std::ptr::NonNull;
 
 use crate::parallel_worker::mqueue::{
     MessageQueueReceiver, MessageQueueRecvError, MessageQueueSendError, MessageQueueSender,
@@ -76,14 +75,6 @@ pub fn aligned_queue_bytes(queue_bytes: usize) -> usize {
     queue_bytes & !(MAXIMUM_ALIGNOF - 1)
 }
 
-/// Total DSM bytes needed to hold the mesh's shm_mq regions (exclusive of
-/// header and plan bytes). Does NOT include `BUFFERALIGN` rounding that
-/// `shm_toc_allocate` applies — that is PG's concern.
-#[inline]
-pub fn mesh_queue_bytes(n: u32, queue_bytes: usize) -> usize {
-    num_edges(n) * aligned_queue_bytes(queue_bytes)
-}
-
 /// Layout description for the MPP mesh DSM region. Consumed by the custom
 /// scan's `estimate_dsm_custom_scan` / `initialize_dsm_custom_scan` hooks and
 /// by the shuffle operators — a pure compile-time data shape that callers can
@@ -102,17 +93,10 @@ impl MeshLayout {
         }
     }
 
-    /// DSM bytes required for the queue array alone (see `mesh_queue_bytes`).
-    ///
-    /// Prefer `dsm_queue_bytes_checked` in production code paths; this
-    /// wrapping form is kept for tests and `Debug` that assume finite N.
-    pub fn dsm_queue_bytes(&self) -> usize {
-        mesh_queue_bytes(self.total_participants, self.queue_bytes)
-    }
-
-    /// Overflow-checked variant. Returns `None` if `num_edges * aligned_bytes`
-    /// overflows `usize`. `compute_dsm_layout` uses this so a pathological
-    /// caller (`N=u32::MAX`) fails cleanly instead of wrapping.
+    /// Overflow-checked DSM-byte computation. Returns `None` if
+    /// `num_edges * aligned_bytes` overflows `usize`. `compute_dsm_layout`
+    /// uses this so a pathological caller (`N=u32::MAX`) fails cleanly
+    /// instead of wrapping.
     pub fn dsm_queue_bytes_checked(&self) -> Option<usize> {
         let edges = num_edges(self.total_participants);
         edges.checked_mul(aligned_queue_bytes(self.queue_bytes))
@@ -121,12 +105,6 @@ impl MeshLayout {
     /// Aligned per-queue size.
     pub fn aligned_queue_bytes(&self) -> usize {
         aligned_queue_bytes(self.queue_bytes)
-    }
-
-    /// Offset of the shm_mq region for edge `src -> dst` from the queue
-    /// array base pointer.
-    pub fn edge_offset(&self, src: u32, dst: u32) -> usize {
-        edge_slot(src, dst, self.total_participants) * self.aligned_queue_bytes()
     }
 }
 
@@ -255,25 +233,6 @@ pub struct ShmMqReceiver {
 unsafe impl Send for ShmMqReceiver {}
 
 impl ShmMqReceiver {
-    /// Create *and* attach a new shm_mq region. The underlying wrapper calls
-    /// `shm_mq_create` at `address`, which initializes the ring buffer
-    /// header in place — use this for single-queue standalone setups.
-    ///
-    /// # Safety
-    /// See `MessageQueueReceiver::new`. Caller holds a valid `ParallelContext`
-    /// and the memory at `address` is uninitialized / safe to stomp.
-    pub unsafe fn create_and_attach(
-        pcxt: NonNull<pg_sys::ParallelContext>,
-        address: *mut std::ffi::c_void,
-        size: usize,
-    ) -> Self {
-        unsafe {
-            Self {
-                inner: MessageQueueReceiver::new(pcxt, address, size),
-            }
-        }
-    }
-
     /// Attach as receiver to an *already-created* shm_mq. Used by the MPP
     /// mesh wiring where the leader calls `shm_mq_create` for every slot
     /// up front, and each participant then attaches to the slots it owns.
@@ -408,21 +367,23 @@ mod tests {
     fn mesh_layout_offsets_are_contiguous_and_non_overlapping() {
         let layout = MeshLayout::new(4, 64 * 1024);
         let slot_bytes = layout.aligned_queue_bytes();
+        let n = layout.total_participants;
         let mut offsets = Vec::new();
-        for src in 0..4u32 {
-            for dst in 0..4u32 {
+        for src in 0..n {
+            for dst in 0..n {
                 if src == dst {
                     continue;
                 }
-                offsets.push(layout.edge_offset(src, dst));
+                offsets.push(edge_slot(src, dst, n) * slot_bytes);
             }
         }
         offsets.sort();
-        // Monotonic and each offset == slot_bytes * slot_index
         for (i, off) in offsets.iter().enumerate() {
             assert_eq!(*off, i * slot_bytes);
         }
-        // Total matches expectation
-        assert_eq!(layout.dsm_queue_bytes(), num_edges(4) * slot_bytes);
+        assert_eq!(
+            layout.dsm_queue_bytes_checked().unwrap(),
+            num_edges(n) * slot_bytes
+        );
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -36,7 +36,7 @@
 //! are in this file so the full production transport stack lives next to the
 //! layout math.
 
-#![allow(dead_code)] // consumer lands in Phase 2c / Phase 4
+#![allow(dead_code)]
 
 use pgrx::pg_sys;
 use std::ptr::NonNull;
@@ -84,11 +84,10 @@ pub fn mesh_queue_bytes(n: u32, queue_bytes: usize) -> usize {
     num_edges(n) * aligned_queue_bytes(queue_bytes)
 }
 
-/// Layout description for the MPP mesh DSM region. Phase 2c will wire this
-/// into the custom scan's `estimate_dsm_custom_scan` / `initialize_dsm_custom_scan`
-/// hooks. For now the layout is a pure compile-time data shape that Phase 3
-/// operators and Phase 4 AggregateScan wiring can reason about without needing
-/// a running Postgres.
+/// Layout description for the MPP mesh DSM region. Consumed by the custom
+/// scan's `estimate_dsm_custom_scan` / `initialize_dsm_custom_scan` hooks and
+/// by the shuffle operators — a pure compile-time data shape that callers can
+/// reason about without needing a running Postgres.
 #[derive(Debug, Clone, Copy)]
 pub struct MeshLayout {
     pub total_participants: u32,

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -1,0 +1,429 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! MPP queue mesh: DSM layout for the directed N×(N-1) shm_mq mesh.
+//!
+//! Every participant has `N-1` inbound and `N-1` outbound queues — one per
+//! peer. We pack them into a single DSM region as a compact 1D array of
+//! `N*(N-1)` shm_mq regions (self-edges are elided; the self-partition bypasses
+//! the mesh entirely).
+//!
+//! ```text
+//! edge(src, dst)  where src != dst
+//!   slot = src * (N-1) + compact_dst
+//!   compact_dst = if dst < src { dst } else { dst - 1 }
+//! ```
+//!
+//! Each slot holds exactly one shm_mq region of `MAXALIGN_DOWN(queue_bytes)`
+//! bytes (Postgres requires maxalign for shm_mq). The total DSM payload for
+//! queues is therefore `N*(N-1) * aligned_queue_bytes`.
+//!
+//! The shm_mq-backed `BatchChannelSender`/`BatchChannelReceiver` implementations
+//! are in this file so the full production transport stack lives next to the
+//! layout math.
+
+#![allow(dead_code)] // consumer lands in Phase 2c / Phase 4
+
+use pgrx::pg_sys;
+use std::ptr::NonNull;
+
+use crate::parallel_worker::mqueue::{
+    MessageQueueReceiver, MessageQueueRecvError, MessageQueueSendError, MessageQueueSender,
+};
+use crate::postgres::customscan::mpp::transport::{
+    BatchChannelReceiver, BatchChannelSender, RecvOutcome,
+};
+use datafusion::common::DataFusionError;
+
+/// Compute the linear slot index for a directed edge `src -> dst` in an
+/// N-participant mesh. `src == dst` is invalid (self-partition bypasses the
+/// mesh).
+#[inline]
+pub fn edge_slot(src: u32, dst: u32, n: u32) -> usize {
+    debug_assert_ne!(src, dst, "self-edges are not in the mesh");
+    debug_assert!(src < n);
+    debug_assert!(dst < n);
+    let compact_dst = if dst < src { dst } else { dst - 1 };
+    (src as usize) * (n as usize - 1) + (compact_dst as usize)
+}
+
+/// Total number of directed edges in the mesh: `N*(N-1)`.
+#[inline]
+pub fn num_edges(n: u32) -> usize {
+    (n as usize) * (n as usize).saturating_sub(1)
+}
+
+/// Compute the aligned per-queue size Postgres will accept (MAXALIGN_DOWN of
+/// the user request). Callers pre-size one shm_mq slot to this; every slot is
+/// the same size so slot indexing is a simple multiply.
+#[inline]
+pub fn aligned_queue_bytes(queue_bytes: usize) -> usize {
+    const MAXIMUM_ALIGNOF: usize = pg_sys::MAXIMUM_ALIGNOF as usize;
+    queue_bytes & !(MAXIMUM_ALIGNOF - 1)
+}
+
+/// Total DSM bytes needed to hold the mesh's shm_mq regions (exclusive of
+/// header and plan bytes). Does NOT include `BUFFERALIGN` rounding that
+/// `shm_toc_allocate` applies — that is PG's concern.
+#[inline]
+pub fn mesh_queue_bytes(n: u32, queue_bytes: usize) -> usize {
+    num_edges(n) * aligned_queue_bytes(queue_bytes)
+}
+
+/// Layout description for the MPP mesh DSM region. Phase 2c will wire this
+/// into the custom scan's `estimate_dsm_custom_scan` / `initialize_dsm_custom_scan`
+/// hooks. For now the layout is a pure compile-time data shape that Phase 3
+/// operators and Phase 4 AggregateScan wiring can reason about without needing
+/// a running Postgres.
+#[derive(Debug, Clone, Copy)]
+pub struct MeshLayout {
+    pub total_participants: u32,
+    pub queue_bytes: usize,
+}
+
+impl MeshLayout {
+    pub fn new(total_participants: u32, queue_bytes: usize) -> Self {
+        Self {
+            total_participants,
+            queue_bytes,
+        }
+    }
+
+    /// DSM bytes required for the queue array alone (see `mesh_queue_bytes`).
+    ///
+    /// Prefer `dsm_queue_bytes_checked` in production code paths; this
+    /// wrapping form is kept for tests and `Debug` that assume finite N.
+    pub fn dsm_queue_bytes(&self) -> usize {
+        mesh_queue_bytes(self.total_participants, self.queue_bytes)
+    }
+
+    /// Overflow-checked variant. Returns `None` if `num_edges * aligned_bytes`
+    /// overflows `usize`. `compute_dsm_layout` uses this so a pathological
+    /// caller (`N=u32::MAX`) fails cleanly instead of wrapping.
+    pub fn dsm_queue_bytes_checked(&self) -> Option<usize> {
+        let edges = num_edges(self.total_participants);
+        edges.checked_mul(aligned_queue_bytes(self.queue_bytes))
+    }
+
+    /// Aligned per-queue size.
+    pub fn aligned_queue_bytes(&self) -> usize {
+        aligned_queue_bytes(self.queue_bytes)
+    }
+
+    /// Offset of the shm_mq region for edge `src -> dst` from the queue
+    /// array base pointer.
+    pub fn edge_offset(&self, src: u32, dst: u32) -> usize {
+        edge_slot(src, dst, self.total_participants) * self.aligned_queue_bytes()
+    }
+}
+
+/// shm_mq-backed `BatchChannelSender`. Wraps the existing MessageQueueSender
+/// so we reuse its detach-on-drop behavior and the pgrx-safe FFI.
+///
+/// ## Thread-safety contract
+///
+/// `BatchChannelSender: Send`, so this type must be movable across threads.
+/// The `unsafe impl Send` below is only safe when the sender is **used** from
+/// a thread that owns a valid `PGPROC` (i.e., the main backend thread or a
+/// dedicated parallel-worker backend). `MessageQueueSender::send` calls
+/// `shm_mq_send(nowait=false)`, which internally uses `WaitLatch` and
+/// `CHECK_FOR_INTERRUPTS` — both are process-global Postgres primitives that
+/// are not thread-safe off a backend thread.
+///
+/// MPP's `HashRepartitionExec::execute` always runs inside DataFusion on the
+/// main backend thread, so production use always satisfies this contract.
+///
+/// In debug builds the thread id captured at [`ShmMqSender::attach`] is
+/// asserted on every `send_bytes` — a regression that moves the sender to a
+/// non-backend thread will panic instead of silently invoking unsafe PG
+/// primitives off-thread.
+pub struct ShmMqSender {
+    inner: MessageQueueSender,
+    #[cfg(debug_assertions)]
+    attach_thread: std::thread::ThreadId,
+}
+
+// SAFETY: see struct doc. Production callers keep the sender on the main
+// backend thread; the debug_assertions guard in `send_bytes` catches
+// violations in CI.
+unsafe impl Send for ShmMqSender {}
+
+impl ShmMqSender {
+    /// # Safety
+    /// - `seg` must be a valid `dsm_segment*`
+    /// - `mq` must point to a shm_mq region that has been `shm_mq_create`'d at
+    ///   its address with the expected size and has had `shm_mq_set_receiver`
+    ///   called by the peer.
+    pub unsafe fn attach(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
+        unsafe {
+            Self {
+                inner: MessageQueueSender::new(seg, mq),
+                #[cfg(debug_assertions)]
+                attach_thread: std::thread::current().id(),
+            }
+        }
+    }
+}
+
+impl BatchChannelSender for ShmMqSender {
+    fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            std::thread::current().id(),
+            self.attach_thread,
+            "ShmMqSender::send_bytes called from a thread other than the one that \
+             called attach(); shm_mq_send uses WaitLatch + CHECK_FOR_INTERRUPTS which \
+             are process-global Postgres primitives and unsafe off the backend thread."
+        );
+        self.inner.send(bytes).map_err(|e| match e {
+            MessageQueueSendError::Detached => {
+                DataFusionError::Execution("mpp: shm_mq sender detached".into())
+            }
+            MessageQueueSendError::WouldBlock => {
+                // `send` is blocking; WouldBlock means `try_send`-style path
+                // was exercised. Treated as a transport error.
+                DataFusionError::Execution("mpp: shm_mq send would block".into())
+            }
+            MessageQueueSendError::Unknown(code) => {
+                crate::mpp_log!("mpp: shm_mq send unknown code {code}");
+                DataFusionError::Execution(format!("mpp: shm_mq send unknown code {code}"))
+            }
+        })
+    }
+
+    fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            std::thread::current().id(),
+            self.attach_thread,
+            "ShmMqSender::try_send_bytes called from a thread other than the one that \
+             called attach(); shm_mq_send touches process-global Postgres primitives \
+             and is unsafe off the backend thread."
+        );
+        match self.inner.try_send(bytes) {
+            Ok(Some(())) => Ok(true),
+            Ok(None) => Ok(false),
+            Err(MessageQueueSendError::Detached) => Err(DataFusionError::Execution(
+                "mpp: shm_mq sender detached".into(),
+            )),
+            Err(MessageQueueSendError::WouldBlock) => {
+                // Shouldn't happen — `try_send` maps WOULD_BLOCK to Ok(None)
+                // in the Rust wrapper. Treat as non-fatal retry.
+                Ok(false)
+            }
+            Err(MessageQueueSendError::Unknown(code)) => {
+                crate::mpp_log!("mpp: shm_mq try_send unknown code {code}");
+                Err(DataFusionError::Execution(format!(
+                    "mpp: shm_mq try_send unknown code {code}"
+                )))
+            }
+        }
+    }
+}
+
+/// shm_mq-backed `BatchChannelReceiver`. The caller creates the shm_mq via
+/// `MessageQueueReceiver::new` during DSM initialization.
+///
+/// The inner [`MessageQueueReceiver`] holds a `NonNull<shm_mq_handle>`, which
+/// makes the struct `!Send` by default. The drain thread takes ownership of
+/// the receiver for the query's lifetime, and we only call
+/// `shm_mq_receive(nowait=true)` from that thread — Postgres's nowait path
+/// does not touch thread-unsafe state (no `WaitLatch`, no
+/// `CHECK_FOR_INTERRUPTS`). Attach and all subsequent receives happen on the
+/// same thread, so the cross-thread move at spawn time is safe.
+pub struct ShmMqReceiver {
+    inner: MessageQueueReceiver,
+}
+
+// SAFETY: see struct doc. `NonNull<shm_mq_handle>` is a pointer into DSM that
+// is valid across threads within the same backend process, and we guarantee
+// single-threaded access (the drain thread) plus only `nowait=true` shm_mq
+// operations — the only thread-unsafe PG paths (latch wait, CFI) are excluded.
+unsafe impl Send for ShmMqReceiver {}
+
+impl ShmMqReceiver {
+    /// Create *and* attach a new shm_mq region. The underlying wrapper calls
+    /// `shm_mq_create` at `address`, which initializes the ring buffer
+    /// header in place — use this for single-queue standalone setups.
+    ///
+    /// # Safety
+    /// See `MessageQueueReceiver::new`. Caller holds a valid `ParallelContext`
+    /// and the memory at `address` is uninitialized / safe to stomp.
+    pub unsafe fn create_and_attach(
+        pcxt: NonNull<pg_sys::ParallelContext>,
+        address: *mut std::ffi::c_void,
+        size: usize,
+    ) -> Self {
+        unsafe {
+            Self {
+                inner: MessageQueueReceiver::new(pcxt, address, size),
+            }
+        }
+    }
+
+    /// Attach as receiver to an *already-created* shm_mq. Used by the MPP
+    /// mesh wiring where the leader calls `shm_mq_create` for every slot
+    /// up front, and each participant then attaches to the slots it owns.
+    /// Skips `shm_mq_create` entirely — calling create twice on the same
+    /// address would re-initialize the ring-buffer header and corrupt any
+    /// in-flight messages.
+    ///
+    /// # Safety
+    /// - `mq` must point to a shm_mq that was previously initialized by
+    ///   `shm_mq_create` in this or another backend of the same parallel
+    ///   context.
+    /// - `seg` may be NULL on workers, where `initialize_worker_custom_scan`
+    ///   does not surface the DSM segment pointer. In that case,
+    ///   `shm_mq_attach` skips registering an `on_dsm_detach` callback and
+    ///   relies on process-exit cleanup. That's safe for parallel workers
+    ///   whose process lifetime matches the query, but unsafe for long-lived
+    ///   backend reuse.
+    /// - No other participant has already set itself as receiver for this
+    ///   queue (PG rejects a second set_receiver call).
+    pub unsafe fn attach_existing(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
+        unsafe {
+            pg_sys::shm_mq_set_receiver(mq, pg_sys::MyProc);
+            let handle = pg_sys::shm_mq_attach(mq, seg, std::ptr::null_mut());
+            Self {
+                inner: MessageQueueReceiver::from_raw_handle(handle),
+            }
+        }
+    }
+}
+
+impl BatchChannelReceiver for ShmMqReceiver {
+    fn try_recv(&self) -> RecvOutcome {
+        match self.inner.try_recv() {
+            Ok(Some(bytes)) => RecvOutcome::Bytes(bytes),
+            Ok(None) => RecvOutcome::Empty,
+            Err(MessageQueueRecvError::Detached) => RecvOutcome::Detached,
+            Err(MessageQueueRecvError::WouldBlock) => RecvOutcome::Empty,
+            Err(MessageQueueRecvError::Unknown(code)) => {
+                // Collapse to Detached so the drain thread observes EOF for
+                // this source and the query surfaces the failure upstream.
+                // Log first so the underlying code is visible in benchmark
+                // logs when `paradedb.mpp_debug` is on.
+                crate::mpp_log!("mpp: shm_mq recv unknown code {code}, treating as detached");
+                RecvOutcome::Detached
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn edge_slot_packs_without_self_edges() {
+        // N=4: 12 edges
+        //   0->1=0, 0->2=1, 0->3=2
+        //   1->0=3, 1->2=4, 1->3=5
+        //   2->0=6, 2->1=7, 2->3=8
+        //   3->0=9, 3->1=10, 3->2=11
+        let n = 4;
+        assert_eq!(edge_slot(0, 1, n), 0);
+        assert_eq!(edge_slot(0, 2, n), 1);
+        assert_eq!(edge_slot(0, 3, n), 2);
+        assert_eq!(edge_slot(1, 0, n), 3);
+        assert_eq!(edge_slot(1, 2, n), 4);
+        assert_eq!(edge_slot(1, 3, n), 5);
+        assert_eq!(edge_slot(2, 0, n), 6);
+        assert_eq!(edge_slot(2, 1, n), 7);
+        assert_eq!(edge_slot(2, 3, n), 8);
+        assert_eq!(edge_slot(3, 0, n), 9);
+        assert_eq!(edge_slot(3, 1, n), 10);
+        assert_eq!(edge_slot(3, 2, n), 11);
+    }
+
+    #[test]
+    fn edge_slot_n2() {
+        // N=2: 2 edges (0->1, 1->0)
+        assert_eq!(edge_slot(0, 1, 2), 0);
+        assert_eq!(edge_slot(1, 0, 2), 1);
+    }
+
+    #[test]
+    fn edge_slot_is_injective() {
+        // Every (src, dst) pair maps to a unique slot in [0, N*(N-1))
+        for n in [2u32, 3, 4, 5, 8] {
+            let mut seen = std::collections::HashSet::new();
+            for src in 0..n {
+                for dst in 0..n {
+                    if src == dst {
+                        continue;
+                    }
+                    let slot = edge_slot(src, dst, n);
+                    assert!(
+                        slot < num_edges(n),
+                        "slot {slot} out of range for n={n} edge {src}->{dst}"
+                    );
+                    assert!(
+                        seen.insert(slot),
+                        "duplicate slot {slot} for n={n} edge {src}->{dst}"
+                    );
+                }
+            }
+            assert_eq!(seen.len(), num_edges(n));
+        }
+    }
+
+    #[test]
+    fn num_edges_matches_formula() {
+        assert_eq!(num_edges(0), 0);
+        assert_eq!(num_edges(1), 0);
+        assert_eq!(num_edges(2), 2);
+        assert_eq!(num_edges(3), 6);
+        assert_eq!(num_edges(4), 12);
+        assert_eq!(num_edges(8), 56);
+    }
+
+    #[test]
+    fn aligned_queue_bytes_rounds_down_to_maxalign() {
+        let maxalign = pg_sys::MAXIMUM_ALIGNOF as usize;
+        // Must be <= input and aligned
+        for req in [0, 1, 7, 8, 15, 16, 1024, 1025, 1_048_576, 8 * 1024 * 1024] {
+            let got = aligned_queue_bytes(req);
+            assert!(got <= req);
+            assert_eq!(got % maxalign, 0, "not aligned: {got} for req {req}");
+            // Round-down invariant: req - got < maxalign
+            assert!(req - got < maxalign);
+        }
+    }
+
+    #[test]
+    fn mesh_layout_offsets_are_contiguous_and_non_overlapping() {
+        let layout = MeshLayout::new(4, 64 * 1024);
+        let slot_bytes = layout.aligned_queue_bytes();
+        let mut offsets = Vec::new();
+        for src in 0..4u32 {
+            for dst in 0..4u32 {
+                if src == dst {
+                    continue;
+                }
+                offsets.push(layout.edge_offset(src, dst));
+            }
+        }
+        offsets.sort();
+        // Monotonic and each offset == slot_bytes * slot_index
+        for (i, off) in offsets.iter().enumerate() {
+            assert_eq!(*off, i * slot_bytes);
+        }
+        // Total matches expectation
+        assert_eq!(layout.dsm_queue_bytes(), num_edges(4) * slot_bytes);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -40,6 +40,7 @@
 
 use pgrx::pg_sys;
 
+use crate::mpp_log;
 use crate::parallel_worker::mqueue::{
     MessageQueueReceiver, MessageQueueRecvError, MessageQueueSendError, MessageQueueSender,
 };
@@ -176,7 +177,7 @@ impl BatchChannelSender for ShmMqSender {
                 DataFusionError::Execution("mpp: shm_mq send would block".into())
             }
             MessageQueueSendError::Unknown(code) => {
-                crate::mpp_log!("mpp: shm_mq send unknown code {code}");
+                mpp_log!("mpp: shm_mq send unknown code {code}");
                 DataFusionError::Execution(format!("mpp: shm_mq send unknown code {code}"))
             }
         })
@@ -203,7 +204,7 @@ impl BatchChannelSender for ShmMqSender {
                 Ok(false)
             }
             Err(MessageQueueSendError::Unknown(code)) => {
-                crate::mpp_log!("mpp: shm_mq try_send unknown code {code}");
+                mpp_log!("mpp: shm_mq try_send unknown code {code}");
                 Err(DataFusionError::Execution(format!(
                     "mpp: shm_mq try_send unknown code {code}"
                 )))
@@ -275,7 +276,7 @@ impl BatchChannelReceiver for ShmMqReceiver {
                 // this source and the query surfaces the failure upstream.
                 // Log first so the underlying code is visible in benchmark
                 // logs when `paradedb.mpp_debug` is on.
-                crate::mpp_log!("mpp: shm_mq recv unknown code {code}, treating as detached");
+                mpp_log!("mpp: shm_mq recv unknown code {code}, treating as detached");
                 RecvOutcome::Detached
             }
         }

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -126,12 +126,14 @@ impl MeshLayout {
 /// main backend thread, so production use always satisfies this contract.
 ///
 /// In debug builds the thread id captured at [`ShmMqSender::attach`] is
-/// asserted on every `send_bytes` — a regression that moves the sender to a
-/// non-backend thread will panic instead of silently invoking unsafe PG
-/// primitives off-thread.
+/// asserted on every `send_bytes` via `debug_assert_eq!` — a regression that
+/// moves the sender to a non-backend thread will panic instead of silently
+/// invoking unsafe PG primitives off-thread. The field is kept in release
+/// builds too (8 bytes per sender) so the `debug_assert_eq!` call sites can
+/// stay clean of `#[cfg(debug_assertions)]` annotations; the assertion macro
+/// itself self-disables in release.
 pub struct ShmMqSender {
     inner: MessageQueueSender,
-    #[cfg(debug_assertions)]
     attach_thread: std::thread::ThreadId,
 }
 
@@ -150,7 +152,6 @@ impl ShmMqSender {
         unsafe {
             Self {
                 inner: MessageQueueSender::new(seg, mq),
-                #[cfg(debug_assertions)]
                 attach_thread: std::thread::current().id(),
             }
         }
@@ -159,7 +160,6 @@ impl ShmMqSender {
 
 impl BatchChannelSender for ShmMqSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
-        #[cfg(debug_assertions)]
         debug_assert_eq!(
             std::thread::current().id(),
             self.attach_thread,
@@ -184,7 +184,6 @@ impl BatchChannelSender for ShmMqSender {
     }
 
     fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
-        #[cfg(debug_assertions)]
         debug_assert_eq!(
             std::thread::current().id(),
             self.attach_thread,

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -37,7 +37,7 @@ use serde::{Deserialize, Serialize};
 /// Injected into the DataFusion `SessionConfig` via `config_options` so downstream
 /// operators (optimizer rules, hash partitioners) can discover it without an
 /// out-of-band side channel.
-#[allow(dead_code)] // wired up in Phase 2
+#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MppParticipantConfig {
     /// 0-based index of this participant. The leader is always index 0.
@@ -46,7 +46,7 @@ pub struct MppParticipantConfig {
     pub total_participants: u32,
 }
 
-#[allow(dead_code)] // wired up in Phase 2
+#[allow(dead_code)]
 impl MppParticipantConfig {
     pub fn is_leader(&self) -> bool {
         self.participant_index == 0
@@ -65,7 +65,7 @@ impl MppParticipantConfig {
 /// set, the provider calls `reader.search_segments(sharded_ids)` and each
 /// participant reads only its share of segments.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // consumed by scan layer in Phase 2
+#[allow(dead_code)]
 pub struct MppShardConfig {
     pub participant_index: u32,
     pub total_participants: u32,

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! MPP (Massively Parallel Processing) plan partitioning for JoinScan and AggregateScan.
+//!
+//! Issue #4152. Hash-partitions every table by the join key and shuffles intermediate
+//! rows between workers through PostgreSQL `shm_mq` queues, so each row is scanned
+//! exactly once. Guarded by `paradedb.enable_mpp` (default off).
+//!
+//! Transport deadlock-avoidance relies on one dedicated drain thread per participant
+//! that reads all inbound queues into a spillable local buffer — this decouples
+//! consumer-side backpressure from producer-side backpressure.
+
+pub mod mesh;
+pub mod session;
+pub mod transport;
+pub mod worker;
+
+use serde::{Deserialize, Serialize};
+
+/// Describes this participant's seat in an MPP query.
+///
+/// Injected into the DataFusion `SessionConfig` via `config_options` so downstream
+/// operators (optimizer rules, hash partitioners) can discover it without an
+/// out-of-band side channel.
+#[allow(dead_code)] // wired up in Phase 2
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MppParticipantConfig {
+    /// 0-based index of this participant. The leader is always index 0.
+    pub participant_index: u32,
+    /// Total number of participants (leader + workers).
+    pub total_participants: u32,
+}
+
+#[allow(dead_code)] // wired up in Phase 2
+impl MppParticipantConfig {
+    pub fn is_leader(&self) -> bool {
+        self.participant_index == 0
+    }
+}
+
+/// Session-scoped MPP sharding info. Stashed as a DataFusion session
+/// `config_extension` by `exec_datafusion_aggregate` on every participant
+/// before `build_join_aggregate_plan` runs, so `PgSearchTableProvider::scan`
+/// can shard segments deterministically across participants.
+///
+/// This is the path that lets the lazy-scan code (one `ScanState` wrapping
+/// a `MultiSegmentSearchResults` of *all* segments) still parallelize — the
+/// coarse shard at the `PgSearchScanPlan::states` vec level doesn't help
+/// that path since there's only one state to filter. With `MppShardConfig`
+/// set, the provider calls `reader.search_segments(sharded_ids)` and each
+/// participant reads only its share of segments.
+#[derive(Clone, Debug)]
+#[allow(dead_code)] // consumed by scan layer in Phase 2
+pub struct MppShardConfig {
+    pub participant_index: u32,
+    pub total_participants: u32,
+}
+
+/// Emit a runtime trace when `paradedb.mpp_debug` is on.
+///
+/// Routed through `pgrx::warning!` so the line appears in the Postgres server log
+/// (and in CI benchmark logs). No-op when the GUC is off.
+#[macro_export]
+macro_rules! mpp_log {
+    ($($arg:tt)*) => {
+        if $crate::gucs::mpp_debug() {
+            pgrx::warning!($($arg)*);
+        }
+    };
+}

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -46,13 +46,6 @@ pub struct MppParticipantConfig {
     pub total_participants: u32,
 }
 
-#[allow(dead_code)]
-impl MppParticipantConfig {
-    pub fn is_leader(&self) -> bool {
-        self.participant_index == 0
-    }
-}
-
 /// Session-scoped MPP sharding info. Stashed as a DataFusion session
 /// `config_extension` by `exec_datafusion_aggregate` on every participant
 /// before `build_join_aggregate_plan` runs, so `PgSearchTableProvider::scan`

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -32,7 +32,7 @@ pub mod worker;
 
 use serde::{Deserialize, Serialize};
 
-/// Describes this participant's seat in an MPP query.
+/// Describes this participant's position in an MPP query.
 ///
 /// Injected into the DataFusion `SessionConfig` via `config_options` so downstream
 /// operators (optimizer rules, hash partitioners) can discover it without an

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -17,9 +17,9 @@
 
 //! MPP (Massively Parallel Processing) plan partitioning for JoinScan and AggregateScan.
 //!
-//! Issue #4152. Hash-partitions every table by the join key and shuffles intermediate
-//! rows between workers through PostgreSQL `shm_mq` queues, so each row is scanned
-//! exactly once. Guarded by `paradedb.enable_mpp` (default off).
+//! Hash-partitions every table by the join key and shuffles intermediate rows between
+//! workers through PostgreSQL `shm_mq` queues, so each row is scanned exactly once.
+//! Guarded by `paradedb.enable_mpp` (default off).
 //!
 //! Transport deadlock-avoidance relies on one dedicated drain thread per participant
 //! that reads all inbound queues into a spillable local buffer — this decouples

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -1,0 +1,282 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Plan broadcast codec for MPP.
+//!
+//! The leader builds a DataFusion `LogicalPlan`, serializes it via the existing
+//! `PgSearchExtensionCodec` in `pg_search/src/scan/codec.rs`, and wraps it
+//! alongside the session profile + participant count in [`MppPlanBroadcast`].
+//! That wrapper is `bincode`-serialized into a DSM region, workers read and
+//! deserialize it, then reconstruct their own [`MppParticipantConfig`]
+//! (identical `total_participants`, distinct `participant_index`) before
+//! calling `create_datafusion_session_context_mpp`.
+//!
+//! The plan bytes are the same for every participant — participant identity
+//! comes from the worker's seat in the mesh, not from the plan encoding.
+
+#![allow(dead_code)] // consumer lands in Phase 2c / Phase 4
+
+use serde::{Deserialize, Serialize};
+
+use crate::postgres::customscan::mpp::MppParticipantConfig;
+
+/// Wire-format tag for the DataFusion session profile. Distinct from the
+/// `SessionContextProfile` enum in `joinscan/scan_state.rs` so we can evolve
+/// the wire representation without forcing `Serialize`/`Deserialize` on the
+/// executor-local type (which may later carry non-serializable fields like
+/// `Arc<dyn ...>`). Conversion happens at (de)serialization time via the
+/// `From` impls below, which compile-break if either enum grows an unmapped
+/// variant.
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum MppSessionProfile {
+    Join = 0,
+    Aggregate = 1,
+}
+
+impl From<MppSessionProfile>
+    for crate::postgres::customscan::joinscan::scan_state::SessionContextProfile
+{
+    fn from(wire: MppSessionProfile) -> Self {
+        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
+        match wire {
+            MppSessionProfile::Join => SessionContextProfile::Join,
+            MppSessionProfile::Aggregate => SessionContextProfile::Aggregate,
+        }
+    }
+}
+
+impl From<crate::postgres::customscan::joinscan::scan_state::SessionContextProfile>
+    for MppSessionProfile
+{
+    fn from(
+        executor: crate::postgres::customscan::joinscan::scan_state::SessionContextProfile,
+    ) -> Self {
+        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
+        match executor {
+            SessionContextProfile::Join => MppSessionProfile::Join,
+            SessionContextProfile::Aggregate => MppSessionProfile::Aggregate,
+        }
+    }
+}
+
+impl MppSessionProfile {
+    /// Convenience wrapper for call sites that prefer a method over the
+    /// `From` conversion.
+    pub fn to_session_profile(
+        self,
+    ) -> crate::postgres::customscan::joinscan::scan_state::SessionContextProfile {
+        self.into()
+    }
+}
+
+/// Current wire-format version of [`MppPlanBroadcast`]. Bumped when fields are
+/// added or reordered so an old worker reading a new leader's bytes aborts
+/// cleanly instead of silently decoding shifted fields. bincode 2 does not
+/// tag fields, so we do our own versioning.
+pub const MPP_PLAN_BROADCAST_VERSION: u8 = 1;
+
+/// Bundle the leader writes into DSM at query start; every worker reads the
+/// same bytes and reconstructs its own `MppParticipantConfig` from the mesh
+/// seat.
+///
+/// Wire format: bincode 2 `config::standard()` (varint-encoded, intentional
+/// divergence from the persistent storage layer which uses `config::legacy()`
+/// — this bundle is transient DSM traffic, never written to disk). The first
+/// byte is [`MPP_PLAN_BROADCAST_VERSION`]; readers reject mismatches so an
+/// older worker will never silently decode a newer leader's layout.
+///
+/// TODO(perf): `logical_plan` is `Vec<u8>`, which forces bincode to allocate
+/// a fresh copy at decode time. For large plans (~500 KB) this is four copies
+/// total: serialize-side (leader), bincode buffer (leader), DSM (both), and
+/// deserialize-side (worker). A hand-rolled frame with a `&[u8]` view over
+/// DSM would drop two of them; revisit if plan-broadcast cost shows up in
+/// profiling.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct MppPlanBroadcast {
+    /// Wire-format version. Always equal to `MPP_PLAN_BROADCAST_VERSION` for
+    /// bytes produced by `serialize`; `deserialize` rejects mismatches.
+    version: u8,
+    /// DataFusion logical plan bytes, produced by
+    /// `crate::scan::codec::serialize_logical_plan`. Workers must use
+    /// `deserialize_logical_plan_with_runtime` (not the test-only
+    /// `deserialize_logical_plan`) so the runtime bindings attach correctly
+    /// before physical planning.
+    pub logical_plan: Vec<u8>,
+    pub total_participants: u32,
+    pub session_profile: MppSessionProfile,
+}
+
+impl MppPlanBroadcast {
+    pub fn new(
+        logical_plan: Vec<u8>,
+        total_participants: u32,
+        session_profile: MppSessionProfile,
+    ) -> Self {
+        Self {
+            version: MPP_PLAN_BROADCAST_VERSION,
+            logical_plan,
+            total_participants,
+            session_profile,
+        }
+    }
+
+    pub fn serialize(&self) -> Result<Vec<u8>, bincode::error::EncodeError> {
+        bincode::serde::encode_to_vec(self, bincode::config::standard())
+    }
+
+    pub fn deserialize(bytes: &[u8]) -> Result<Self, bincode::error::DecodeError> {
+        let (decoded, consumed): (Self, usize) =
+            bincode::serde::decode_from_slice(bytes, bincode::config::standard())?;
+        if consumed != bytes.len() {
+            // Defense in depth: MPP plan bytes live in DSM at a known-length
+            // offset; if the input slice is longer than the bincode frame,
+            // either the caller passed the wrong slice bounds or the frame
+            // itself is corrupt. Either case should fail loudly rather than
+            // silently drop trailing bytes.
+            return Err(bincode::error::DecodeError::OtherString(format!(
+                "MppPlanBroadcast: consumed {consumed} of {} input bytes",
+                bytes.len()
+            )));
+        }
+        if decoded.version != MPP_PLAN_BROADCAST_VERSION {
+            return Err(bincode::error::DecodeError::OtherString(format!(
+                "MppPlanBroadcast version mismatch: got {}, expected {}",
+                decoded.version, MPP_PLAN_BROADCAST_VERSION
+            )));
+        }
+        Ok(decoded)
+    }
+
+    /// Produce the per-participant config for the worker that occupies the
+    /// given seat. The leader is always seat 0.
+    ///
+    /// This uses `assert!` (not `debug_assert!`) because a silently bad seat
+    /// index in release builds would manifest as "hash partitioner drops
+    /// every row mapped to the nonexistent seat" — exactly the class of bug
+    /// that produced COUNT(*) = 0 in the prior attempt (see project memory
+    /// `project_mpp_correctness_bug.md`). Fail loudly at worker boot instead.
+    pub fn participant_config(&self, participant_index: u32) -> MppParticipantConfig {
+        assert!(
+            participant_index < self.total_participants,
+            "participant_index {participant_index} >= total_participants {}",
+            self.total_participants
+        );
+        MppParticipantConfig {
+            participant_index,
+            total_participants: self.total_participants,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plan_broadcast_round_trips() {
+        let orig = MppPlanBroadcast::new(
+            vec![0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe],
+            4,
+            MppSessionProfile::Aggregate,
+        );
+        let bytes = orig.serialize().expect("serialize");
+        let decoded = MppPlanBroadcast::deserialize(&bytes).expect("deserialize");
+        assert_eq!(decoded.logical_plan, orig.logical_plan);
+        assert_eq!(decoded.total_participants, orig.total_participants);
+        assert_eq!(decoded.session_profile, orig.session_profile);
+    }
+
+    #[test]
+    fn participant_config_differs_per_seat() {
+        let bc = MppPlanBroadcast::new(vec![], 3, MppSessionProfile::Join);
+        let leader = bc.participant_config(0);
+        let w1 = bc.participant_config(1);
+        let w2 = bc.participant_config(2);
+        assert_eq!(leader.participant_index, 0);
+        assert!(leader.is_leader());
+        assert_eq!(w1.participant_index, 1);
+        assert!(!w1.is_leader());
+        assert_eq!(w2.participant_index, 2);
+        for pc in [leader, w1, w2] {
+            assert_eq!(pc.total_participants, 3);
+        }
+    }
+
+    #[test]
+    fn profile_maps_to_executor_enum() {
+        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
+        assert!(matches!(
+            MppSessionProfile::Join.to_session_profile(),
+            SessionContextProfile::Join
+        ));
+        assert!(matches!(
+            MppSessionProfile::Aggregate.to_session_profile(),
+            SessionContextProfile::Aggregate
+        ));
+    }
+
+    #[test]
+    fn deserialize_rejects_truncated_bytes() {
+        let orig = MppPlanBroadcast::new(vec![1, 2, 3, 4], 2, MppSessionProfile::Join);
+        let bytes = orig.serialize().unwrap();
+        // Truncate by removing the last byte — should not round-trip.
+        let truncated = &bytes[..bytes.len() - 1];
+        assert!(MppPlanBroadcast::deserialize(truncated).is_err());
+    }
+
+    #[test]
+    fn deserialize_rejects_version_mismatch() {
+        let mut orig = MppPlanBroadcast::new(vec![1, 2, 3], 2, MppSessionProfile::Join);
+        orig.version = MPP_PLAN_BROADCAST_VERSION.wrapping_add(1);
+        let bytes = orig.serialize().unwrap();
+        let err = MppPlanBroadcast::deserialize(&bytes).expect_err("version mismatch must reject");
+        let msg = format!("{err}");
+        assert!(msg.contains("version mismatch"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn enum_round_trips_via_from_impls() {
+        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
+        for wire in [MppSessionProfile::Join, MppSessionProfile::Aggregate] {
+            let executor: SessionContextProfile = wire.into();
+            let wire2: MppSessionProfile = executor.into();
+            assert_eq!(wire, wire2);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "participant_index")]
+    fn participant_config_panics_on_out_of_bounds_seat() {
+        let bc = MppPlanBroadcast::new(vec![], 2, MppSessionProfile::Join);
+        // Seat 2 is out of bounds for total_participants=2; panic at boot
+        // time beats a silently dropped partition in production.
+        let _ = bc.participant_config(2);
+    }
+
+    #[test]
+    fn plan_broadcast_round_trips_large_payload() {
+        // Simulate a realistic logical-plan byte vector (e.g., ~10 KB).
+        let big = (0..10_000u32)
+            .map(|i| (i % 251) as u8) // non-trivial pattern
+            .collect::<Vec<u8>>();
+        let orig = MppPlanBroadcast::new(big.clone(), 2, MppSessionProfile::Aggregate);
+        let bytes = orig.serialize().unwrap();
+        let decoded = MppPlanBroadcast::deserialize(&bytes).unwrap();
+        assert_eq!(decoded.logical_plan, big);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -28,7 +28,7 @@
 //! The plan bytes are the same for every participant — participant identity
 //! comes from the worker's seat in the mesh, not from the plan encoding.
 
-#![allow(dead_code)] // consumer lands in Phase 2c / Phase 4
+#![allow(dead_code)]
 
 use serde::{Deserialize, Serialize};
 

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -74,16 +74,6 @@ impl From<crate::postgres::customscan::joinscan::scan_state::SessionContextProfi
     }
 }
 
-impl MppSessionProfile {
-    /// Convenience wrapper for call sites that prefer a method over the
-    /// `From` conversion.
-    pub fn to_session_profile(
-        self,
-    ) -> crate::postgres::customscan::joinscan::scan_state::SessionContextProfile {
-        self.into()
-    }
-}
-
 /// Current wire-format version of [`MppPlanBroadcast`]. Bumped when fields are
 /// added or reordered so an old worker reading a new leader's bytes aborts
 /// cleanly instead of silently decoding shifted fields. bincode 2 does not
@@ -208,26 +198,11 @@ mod tests {
         let w1 = bc.participant_config(1);
         let w2 = bc.participant_config(2);
         assert_eq!(leader.participant_index, 0);
-        assert!(leader.is_leader());
         assert_eq!(w1.participant_index, 1);
-        assert!(!w1.is_leader());
         assert_eq!(w2.participant_index, 2);
         for pc in [leader, w1, w2] {
             assert_eq!(pc.total_participants, 3);
         }
-    }
-
-    #[test]
-    fn profile_maps_to_executor_enum() {
-        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
-        assert!(matches!(
-            MppSessionProfile::Join.to_session_profile(),
-            SessionContextProfile::Join
-        ));
-        assert!(matches!(
-            MppSessionProfile::Aggregate.to_session_profile(),
-            SessionContextProfile::Aggregate
-        ));
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -25,13 +25,17 @@
 //! (identical `total_participants`, distinct `participant_index`) before
 //! calling `create_datafusion_session_context_mpp`.
 //!
-//! The plan bytes are the same for every participant — participant identity
-//! comes from the worker's position in the mesh, not from the plan encoding.
+//! The broadcast bytes are byte-identical across participants; the physical
+//! plans each participant builds from those bytes are structurally similar
+//! but not literally identical — each one injects its own segment shard and
+//! participant index at physical-planning time. Participant identity comes
+//! from the worker's position in the mesh, not from the plan encoding.
 
 #![allow(dead_code)]
 
 use serde::{Deserialize, Serialize};
 
+use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
 use crate::postgres::customscan::mpp::MppParticipantConfig;
 
 /// Wire-format tag for the DataFusion session profile. Distinct from the
@@ -48,11 +52,8 @@ pub enum MppSessionProfile {
     Aggregate = 1,
 }
 
-impl From<MppSessionProfile>
-    for crate::postgres::customscan::joinscan::scan_state::SessionContextProfile
-{
+impl From<MppSessionProfile> for SessionContextProfile {
     fn from(wire: MppSessionProfile) -> Self {
-        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
         match wire {
             MppSessionProfile::Join => SessionContextProfile::Join,
             MppSessionProfile::Aggregate => SessionContextProfile::Aggregate,
@@ -60,13 +61,8 @@ impl From<MppSessionProfile>
     }
 }
 
-impl From<crate::postgres::customscan::joinscan::scan_state::SessionContextProfile>
-    for MppSessionProfile
-{
-    fn from(
-        executor: crate::postgres::customscan::joinscan::scan_state::SessionContextProfile,
-    ) -> Self {
-        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
+impl From<SessionContextProfile> for MppSessionProfile {
+    fn from(executor: SessionContextProfile) -> Self {
         match executor {
             SessionContextProfile::Join => MppSessionProfile::Join,
             SessionContextProfile::Aggregate => MppSessionProfile::Aggregate,
@@ -227,7 +223,6 @@ mod tests {
 
     #[test]
     fn enum_round_trips_via_from_impls() {
-        use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
         for wire in [MppSessionProfile::Join, MppSessionProfile::Aggregate] {
             let executor: SessionContextProfile = wire.into();
             let wire2: MppSessionProfile = executor.into();

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -26,7 +26,7 @@
 //! calling `create_datafusion_session_context_mpp`.
 //!
 //! The plan bytes are the same for every participant — participant identity
-//! comes from the worker's seat in the mesh, not from the plan encoding.
+//! comes from the worker's position in the mesh, not from the plan encoding.
 
 #![allow(dead_code)]
 
@@ -81,8 +81,8 @@ impl From<crate::postgres::customscan::joinscan::scan_state::SessionContextProfi
 pub const MPP_PLAN_BROADCAST_VERSION: u8 = 1;
 
 /// Bundle the leader writes into DSM at query start; every worker reads the
-/// same bytes and reconstructs its own `MppParticipantConfig` from the mesh
-/// seat.
+/// same bytes and reconstructs its own `MppParticipantConfig` from its
+/// participant index.
 ///
 /// Wire format: bincode 2 `config::standard()` (varint-encoded, intentional
 /// divergence from the persistent storage layer which uses `config::legacy()`
@@ -152,14 +152,15 @@ impl MppPlanBroadcast {
         Ok(decoded)
     }
 
-    /// Produce the per-participant config for the worker that occupies the
-    /// given seat. The leader is always seat 0.
+    /// Produce the per-participant config for the worker at the given
+    /// participant index. The leader is always index 0.
     ///
-    /// This uses `assert!` (not `debug_assert!`) because a silently bad seat
-    /// index in release builds would manifest as "hash partitioner drops
-    /// every row mapped to the nonexistent seat" — exactly the class of bug
-    /// that produced COUNT(*) = 0 in the prior attempt (see project memory
-    /// `project_mpp_correctness_bug.md`). Fail loudly at worker boot instead.
+    /// This uses `assert!` (not `debug_assert!`) because a silently bad
+    /// participant index in release builds would manifest as "hash
+    /// partitioner drops every row mapped to the nonexistent participant" —
+    /// exactly the class of bug that produced COUNT(*) = 0 in the prior
+    /// attempt (see project memory `project_mpp_correctness_bug.md`). Fail
+    /// loudly at worker boot instead.
     pub fn participant_config(&self, participant_index: u32) -> MppParticipantConfig {
         assert!(
             participant_index < self.total_participants,
@@ -192,7 +193,7 @@ mod tests {
     }
 
     #[test]
-    fn participant_config_differs_per_seat() {
+    fn participant_config_differs_per_participant_index() {
         let bc = MppPlanBroadcast::new(vec![], 3, MppSessionProfile::Join);
         let leader = bc.participant_config(0);
         let w1 = bc.participant_config(1);
@@ -236,10 +237,11 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "participant_index")]
-    fn participant_config_panics_on_out_of_bounds_seat() {
+    fn participant_config_panics_on_out_of_bounds_index() {
         let bc = MppPlanBroadcast::new(vec![], 2, MppSessionProfile::Join);
-        // Seat 2 is out of bounds for total_participants=2; panic at boot
-        // time beats a silently dropped partition in production.
+        // Participant index 2 is out of bounds for total_participants=2;
+        // panic at boot time beats a silently dropped partition in
+        // production.
         let _ = bc.participant_config(2);
     }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -26,10 +26,10 @@
 //!   cannot propagate backpressure to remote producers and cause the N×N cycle
 //!   that deadlocked the prior attempt.
 //!
-//! Phase 2 adds the shm_mq-backed sender/receiver and the drain thread spawn
-//! logic on top of these primitives.
+//! The shm_mq-backed sender/receiver and drain thread spawn logic build on
+//! top of these primitives.
 
-#![allow(dead_code)] // wired up in Phase 2
+#![allow(dead_code)]
 
 use std::collections::VecDeque;
 use std::sync::{Arc, Condvar, Mutex};
@@ -215,8 +215,8 @@ impl DrainBuffer {
     ///
     /// Using this from a `Stream::poll_next` lets `DrainGatherStream` return
     /// `Poll::Pending` instead of blocking the executor thread — critical
-    /// once Phase 5 wires peer-to-peer backpressure, where a blocking wait
-    /// could deadlock with this worker's own outbound pump.
+    /// under peer-to-peer backpressure, where a blocking wait could deadlock
+    /// with this worker's own outbound pump.
     pub fn poll_pop_front(&self, waker: &std::task::Waker) -> Option<DrainItem> {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         if let Some(batch) = guard.queue.pop_front() {

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -34,6 +34,7 @@
 use std::collections::VecDeque;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;
+#[cfg(test)]
 use std::time::Duration;
 
 use datafusion::arrow::array::RecordBatch;
@@ -43,14 +44,10 @@ use datafusion::common::DataFusionError;
 
 /// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message.
 ///
-/// Each message carries its own schema header, which costs a few hundred bytes
-/// per batch but makes the receiver stateless — simpler lifetime management
-/// across shm_mq hand-offs, and the overhead is negligible at typical 64K-row
-/// batch sizes.
-///
-/// Prefer [`encode_batch_into`] on the hot path — reusing a scratch buffer
-/// avoids the ~500 KB / batch allocator traffic the 25M GROUP BY benchmark
-/// spends 19 s on.
+/// Test-only allocating wrapper for [`encode_batch_into`]; production hot paths
+/// reuse a scratch `Vec` so the ~500 KB/batch allocator traffic the 25M GROUP BY
+/// benchmark once spent 19 s on stays out of the critical loop.
+#[cfg(test)]
 pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
     let mut buf = Vec::with_capacity(1024);
     encode_batch_into(batch, &mut buf)?;
@@ -176,6 +173,7 @@ impl DrainBuffer {
     /// of the cancel/eof check would silently drop buffered data on an
     /// otherwise-clean shutdown; the
     /// `drain_buffer_drains_buffered_before_eof` test locks this in.
+    #[cfg(test)]
     pub fn pop_front(&self) -> DrainItem {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         loop {
@@ -189,18 +187,10 @@ impl DrainBuffer {
         }
     }
 
-    /// Snapshot the number of batches currently buffered. For debug/telemetry.
-    #[cfg(any(test, feature = "pg_test"))]
-    pub fn len(&self) -> usize {
-        self.inner
-            .lock()
-            .expect("DrainBuffer mutex poisoned")
-            .queue
-            .len()
-    }
-
-    /// True if `cancel` has been called. The drain thread consults this so a
-    /// `DrainHandle::drop` with a live peer sender still tears down cleanly.
+    /// True if `cancel` has been called. The test-only `drain_loop` and its
+    /// tests consult this; the cooperative production path watches the flag
+    /// through `notify_source_done` fan-out instead.
+    #[cfg(test)]
     pub fn is_cancelled(&self) -> bool {
         self.inner
             .lock()
@@ -309,6 +299,10 @@ impl MppSender {
         self
     }
 
+    /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
+    /// Production call sites (`ShuffleStream::process_batch`) always pass a
+    /// `SendBatchStats` so per-peer wall-time shows up in the EOF trace.
+    #[cfg(test)]
     pub fn send_batch(&self, batch: &RecordBatch) -> Result<(), DataFusionError> {
         let mut stats = SendBatchStats::default();
         self.send_batch_traced(batch, &mut stats)
@@ -412,6 +406,12 @@ pub enum RecvBatchOutcome {
 }
 
 /// Configuration for [`spawn_drain_thread`].
+///
+/// Only used by the thread-backed drain path, which is test-only: pgrx panics
+/// on any pg FFI call (including `shm_mq_receive`) from a non-backend thread,
+/// so production uses [`DrainHandle::cooperative`] — see the notes on
+/// `DrainHandle::spawn` for details.
+#[cfg(test)]
 pub struct DrainConfig {
     /// Receivers to drain. Ownership moves into the spawned thread.
     pub receivers: Vec<MppReceiver>,
@@ -423,6 +423,7 @@ pub struct DrainConfig {
     pub idle_sleep: Duration,
 }
 
+#[cfg(test)]
 impl DrainConfig {
     pub fn new(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
         Self {
@@ -435,15 +436,11 @@ impl DrainConfig {
 
 /// Spawn the dedicated drain thread.
 ///
-/// The thread round-robins through every receiver with non-blocking `try_recv`,
-/// pushes decoded batches into `buffer`, and marks each source done as soon as
-/// it observes a detach or decode error. When every source is done, the thread
-/// exits. Its `JoinHandle` is returned so the caller can join on shutdown.
-///
-/// Prefer [`DrainHandle::spawn`] over this raw function — `DrainHandle` pins
-/// the cancel+join invariant at the type level so a dropped handle guarantees
-/// the thread has torn down before DSM is detached, regardless of whether the
-/// consumer path panicked.
+/// Test-only: the thread round-robins through every receiver with non-blocking
+/// `try_recv`, pushes decoded batches into `buffer`, and marks each source
+/// done as soon as it observes a detach or decode error. When every source is
+/// done, the thread exits.
+#[cfg(test)]
 pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusionError>> {
     std::thread::spawn(move || drain_loop(config))
 }
@@ -484,14 +481,11 @@ pub struct DrainHandle {
 
 impl DrainHandle {
     /// Spawn a drain thread and wrap the join handle together with the buffer
-    /// it drains into. The returned handle is `!Send`-tolerant (std::thread
-    /// join handles are Send), so it may live on any thread that manages the
-    /// query's lifecycle.
-    ///
-    /// Safe for in-proc test receivers (std::sync::mpsc). NOT safe for
-    /// `shm_mq`-backed receivers — pgrx panics on any pg FFI call from a
-    /// non-backend thread. Production paths must use
-    /// [`Self::cooperative`] instead.
+    /// it drains into. Test-only: pgrx's `check_active_thread` panics on any
+    /// pg FFI call (including `shm_mq_receive`) from a non-backend thread, so
+    /// a real mesh receiver can never drain from a std::thread worker.
+    /// Production paths must use [`Self::cooperative`] instead.
+    #[cfg(test)]
     pub fn spawn(config: DrainConfig) -> Self {
         let buffer = Arc::clone(&config.buffer);
         let join = spawn_drain_thread(config);
@@ -622,6 +616,7 @@ impl Drop for DrainHandle {
     }
 }
 
+#[cfg(test)]
 fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
     let DrainConfig {
         receivers,
@@ -677,15 +672,18 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
 /// SPSC channel pair for unit tests and in-process single-worker validation.
 /// Bounded capacity via `std::sync::mpsc::sync_channel` so tests can exercise
 /// backpressure (`send` blocks when full).
+#[cfg(test)]
 pub fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
     (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
 }
 
+#[cfg(test)]
 pub struct InProcSender {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
 }
 
+#[cfg(test)]
 pub struct InProcReceiver {
     // The std::sync::mpsc receiver is !Sync; wrap in a Mutex so the drain
     // thread can hold it behind a `Box<dyn BatchChannelReceiver>` (which is
@@ -695,6 +693,7 @@ pub struct InProcReceiver {
     rx: Mutex<std::sync::mpsc::Receiver<Vec<u8>>>,
 }
 
+#[cfg(test)]
 impl BatchChannelSender for InProcSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
         self.tx.send(bytes.to_vec()).map_err(|_| {
@@ -703,6 +702,7 @@ impl BatchChannelSender for InProcSender {
     }
 }
 
+#[cfg(test)]
 impl BatchChannelReceiver for InProcReceiver {
     fn try_recv(&self) -> RecvOutcome {
         let rx = self.rx.lock().expect("InProcReceiver mutex poisoned");

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -1,0 +1,1106 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Transport layer for MPP shuffle.
+//!
+//! Layout:
+//! - [`encode_batch`] / [`decode_batch`] serialize `RecordBatch` via Arrow IPC.
+//! - [`DrainBuffer`] is the local per-participant queue that the drain thread
+//!   writes into and the DataFusion consumer reads from. It decouples
+//!   consumer-side backpressure from producer-side backpressure: the drain thread
+//!   always makes forward progress on the inbound shm_mqs, so a stalled consumer
+//!   cannot propagate backpressure to remote producers and cause the N×N cycle
+//!   that deadlocked the prior attempt.
+//!
+//! Phase 2 adds the shm_mq-backed sender/receiver and the drain thread spawn
+//! logic on top of these primitives.
+
+#![allow(dead_code)] // wired up in Phase 2
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::JoinHandle;
+use std::time::Duration;
+
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::ipc::reader::StreamReader;
+use datafusion::arrow::ipc::writer::StreamWriter;
+use datafusion::common::DataFusionError;
+
+/// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message.
+///
+/// Each message carries its own schema header, which costs a few hundred bytes
+/// per batch but makes the receiver stateless — simpler lifetime management
+/// across shm_mq hand-offs, and the overhead is negligible at typical 64K-row
+/// batch sizes.
+///
+/// Prefer [`encode_batch_into`] on the hot path — reusing a scratch buffer
+/// avoids the ~500 KB / batch allocator traffic the 25M GROUP BY benchmark
+/// spends 19 s on.
+pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
+    let mut buf = Vec::with_capacity(1024);
+    encode_batch_into(batch, &mut buf)?;
+    Ok(buf)
+}
+
+/// Serialize `batch` into `buf`, clearing `buf` first so the caller's
+/// already-allocated capacity is reused. Caller is expected to hold `buf`
+/// alive across many encode calls (one per sender) so the peak-sized
+/// allocation amortizes.
+pub fn encode_batch_into(batch: &RecordBatch, buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
+    buf.clear();
+    let mut writer = StreamWriter::try_new(&mut *buf, batch.schema_ref())?;
+    writer.write(batch)?;
+    writer.finish()?;
+    Ok(())
+}
+
+/// Inverse of [`encode_batch`]. Expects exactly one batch per message.
+pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusionError> {
+    let mut reader = StreamReader::try_new(bytes, None)?;
+    let batch = reader.next().ok_or_else(|| {
+        DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_batch".into())
+    })??;
+    Ok(batch)
+}
+
+/// Local queue that sits between the drain thread and the DataFusion consumer.
+///
+/// Push side: the drain thread appends fully-deserialized batches as they arrive
+/// from inbound shm_mqs. When a source queue detaches, [`DrainBuffer::notify_source_done`]
+/// is called; once all sources are done AND the queue is empty, `pop_front` returns
+/// [`DrainItem::Eof`].
+///
+/// Pop side: the consumer calls `pop_front` which blocks on the condvar until
+/// either a batch is available or EOF has been reached.
+#[derive(Debug)]
+pub struct DrainBuffer {
+    inner: Mutex<DrainBufferInner>,
+    cond: Condvar,
+}
+
+#[derive(Debug)]
+struct DrainBufferInner {
+    queue: VecDeque<RecordBatch>,
+    num_sources: u32,
+    sources_done: u32,
+    /// Consumer-side cancel flag. When set (e.g., query cancelled), the drain
+    /// thread should stop pushing and unblock waiting consumers with EOF.
+    cancelled: bool,
+    /// Most recently registered async waker from a `poll_pop_front` caller.
+    /// Woken on push / source-done / cancel so a stream running inside a
+    /// DataFusion `poll_next` returns `Poll::Pending` without blocking the
+    /// executor thread. `Option` so we don't allocate one if the buffer is
+    /// only consumed synchronously via `pop_front`.
+    waker: Option<std::task::Waker>,
+}
+
+/// Yielded by [`DrainBuffer::pop_front`].
+#[derive(Debug)]
+pub enum DrainItem {
+    /// A batch produced by one of the inbound shm_mqs.
+    Batch(RecordBatch),
+    /// All source queues have detached and the local queue is drained.
+    Eof,
+}
+
+impl DrainBuffer {
+    /// Create a drain buffer expecting `num_sources` inbound queues. For a
+    /// participant in an N-way mesh, `num_sources == N - 1` (all peers
+    /// excluding self — the self-partition bypasses the buffer).
+    pub fn new(num_sources: u32) -> Arc<Self> {
+        Arc::new(Self {
+            inner: Mutex::new(DrainBufferInner {
+                queue: VecDeque::new(),
+                num_sources,
+                sources_done: 0,
+                cancelled: false,
+                waker: None,
+            }),
+            cond: Condvar::new(),
+        })
+    }
+
+    /// Push a freshly-received batch into the local queue.
+    pub fn push_batch(&self, batch: RecordBatch) {
+        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        guard.queue.push_back(batch);
+        self.cond.notify_one();
+        if let Some(w) = guard.waker.take() {
+            w.wake();
+        }
+    }
+
+    /// Mark one source queue as detached. Safe to call from the drain thread
+    /// after observing `SHM_MQ_DETACHED` on a given inbound queue.
+    pub fn notify_source_done(&self) {
+        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        guard.sources_done = guard.sources_done.saturating_add(1);
+        if guard.sources_done >= guard.num_sources {
+            self.cond.notify_all();
+            if let Some(w) = guard.waker.take() {
+                w.wake();
+            }
+        }
+    }
+
+    /// Cancel all further pushes and wake all consumers with EOF.
+    pub fn cancel(&self) {
+        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        guard.cancelled = true;
+        self.cond.notify_all();
+        if let Some(w) = guard.waker.take() {
+            w.wake();
+        }
+    }
+
+    /// Block until a batch is available, EOF is reached, or the buffer is
+    /// cancelled.
+    ///
+    /// INVARIANT: any already-buffered batch is returned *before* honoring
+    /// either cancellation or all-sources-done. Reordering the queue pop ahead
+    /// of the cancel/eof check would silently drop buffered data on an
+    /// otherwise-clean shutdown; the
+    /// `drain_buffer_drains_buffered_before_eof` test locks this in.
+    pub fn pop_front(&self) -> DrainItem {
+        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        loop {
+            if let Some(batch) = guard.queue.pop_front() {
+                return DrainItem::Batch(batch);
+            }
+            if guard.cancelled || guard.sources_done >= guard.num_sources {
+                return DrainItem::Eof;
+            }
+            guard = self.cond.wait(guard).expect("DrainBuffer mutex poisoned");
+        }
+    }
+
+    /// Snapshot the number of batches currently buffered. For debug/telemetry.
+    #[cfg(any(test, feature = "pg_test"))]
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("DrainBuffer mutex poisoned")
+            .queue
+            .len()
+    }
+
+    /// True if `cancel` has been called. The drain thread consults this so a
+    /// `DrainHandle::drop` with a live peer sender still tears down cleanly.
+    pub fn is_cancelled(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("DrainBuffer mutex poisoned")
+            .cancelled
+    }
+
+    /// Async-friendly variant of `pop_front`. Returns `DrainItem` when a
+    /// batch or EOF is immediately available; otherwise registers `waker`
+    /// to be woken on the next `push_batch` / `notify_source_done` / `cancel`
+    /// and returns `None`.
+    ///
+    /// Using this from a `Stream::poll_next` lets `DrainGatherStream` return
+    /// `Poll::Pending` instead of blocking the executor thread — critical
+    /// once Phase 5 wires peer-to-peer backpressure, where a blocking wait
+    /// could deadlock with this worker's own outbound pump.
+    pub fn poll_pop_front(&self, waker: &std::task::Waker) -> Option<DrainItem> {
+        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        if let Some(batch) = guard.queue.pop_front() {
+            return Some(DrainItem::Batch(batch));
+        }
+        if guard.cancelled || guard.sources_done >= guard.num_sources {
+            return Some(DrainItem::Eof);
+        }
+        // Register (or replace) the waker. Only one consumer at a time is
+        // expected — DrainGatherStream — so simple replacement is fine.
+        guard.waker = Some(waker.clone());
+        None
+    }
+}
+
+/// Outcome of a single non-blocking receive attempt.
+#[derive(Debug)]
+pub enum RecvOutcome {
+    /// One serialized Arrow IPC message ready to decode.
+    Bytes(Vec<u8>),
+    /// No data currently available but the peer is still attached.
+    Empty,
+    /// The peer has detached; no more bytes will ever arrive on this channel.
+    Detached,
+}
+
+/// Non-blocking byte channel receiver. Implementations: shm_mq (production),
+/// `std::sync::mpsc` (tests). Must be `Send` because the drain thread takes
+/// ownership.
+pub trait BatchChannelReceiver: Send {
+    fn try_recv(&self) -> RecvOutcome;
+}
+
+/// Byte channel sender paired with [`BatchChannelReceiver`]. `send` blocks when
+/// the channel is full. Dropping the sender signals EOF to the receiver.
+///
+/// `Send` is required because unit tests and future producer-pump threads move
+/// senders across thread boundaries. Production shm_mq senders, however, must
+/// only be *used* from the main backend thread — the blocking shm_mq send path
+/// (`nowait=false`) touches `WaitLatch`/`CHECK_FOR_INTERRUPTS`, which is not
+/// safe off-thread. See [`crate::postgres::customscan::mpp::mesh::ShmMqSender`]
+/// for the safety contract.
+pub trait BatchChannelSender: Send {
+    fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError>;
+
+    /// Non-blocking variant. Returns `Ok(true)` on success, `Ok(false)`
+    /// when the channel is full (caller should retry), `Err` on detach /
+    /// transport error. Default falls back to the blocking send — safe
+    /// for in-proc channels used by tests where "full" doesn't arise.
+    fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
+        self.send_bytes(bytes).map(|()| true)
+    }
+}
+
+/// High-level sender: encodes a `RecordBatch` then pushes bytes through the
+/// underlying channel.
+///
+/// With `cooperative_drain` set, `send_batch` breaks the symmetric-send
+/// deadlock on a single-threaded tokio runtime by interleaving send-retries
+/// with `DrainHandle::poll_drain_pass` on the same mesh's inbound side.
+/// Each participant's sender doing the same guarantees mutual progress:
+/// our drain pulls peer-shipped rows out of our inbound queues, which
+/// frees peers' outbound-to-us send space, which lets their sends un-stall.
+pub struct MppSender {
+    channel: Box<dyn BatchChannelSender>,
+    cooperative_drain: Option<Arc<DrainHandle>>,
+    /// Scratch buffer reused across every `encode_batch_into` on this
+    /// sender. Sized by the first batch; subsequent batches clear and
+    /// re-fill without reallocating. Interior mutability lets the caller
+    /// keep the `&self` signature (senders live inside `ShuffleWiring`
+    /// behind a shared borrow during `process_batch`).
+    scratch: std::cell::RefCell<Vec<u8>>,
+}
+
+impl MppSender {
+    pub fn new(channel: Box<dyn BatchChannelSender>) -> Self {
+        Self {
+            channel,
+            cooperative_drain: None,
+            scratch: std::cell::RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Attach a drain handle whose `poll_drain_pass` is called between
+    /// send retries when the channel is full. Required on production
+    /// shm_mq backends (see struct docs); tests without pressure can
+    /// omit it.
+    pub fn with_cooperative_drain(mut self, drain: Arc<DrainHandle>) -> Self {
+        self.cooperative_drain = Some(drain);
+        self
+    }
+
+    pub fn send_batch(&self, batch: &RecordBatch) -> Result<(), DataFusionError> {
+        let mut stats = SendBatchStats::default();
+        self.send_batch_traced(batch, &mut stats)
+    }
+
+    /// `send_batch` variant that accumulates per-call timings and spin counts
+    /// into `stats`. Callers that report these at EOF (e.g., `ShuffleStream`)
+    /// use this to diagnose where time goes when the outbound queue is full.
+    pub fn send_batch_traced(
+        &self,
+        batch: &RecordBatch,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
+        let mut scratch = self.scratch.borrow_mut();
+        let t_enc = std::time::Instant::now();
+        encode_batch_into(batch, &mut scratch)?;
+        stats.encode += t_enc.elapsed();
+        let Some(drain) = self.cooperative_drain.as_ref() else {
+            // No drain attached (unit tests, in-proc channels): fall back
+            // to the blocking send path.
+            return self.channel.send_bytes(&scratch);
+        };
+        let mut first_try = true;
+        let t_wait_start = std::time::Instant::now();
+        loop {
+            // `pgrx::check_for_interrupts!()` pulls in PG symbols
+            // (`ProcessInterrupts`, `PG_exception_stack`, `CopyErrorData`, …)
+            // that aren't linked into the crate's `--tests` / llvm-cov build.
+            // This fn is reached from `#[cfg(test)]` code in this file and
+            // `shuffle.rs`, so gate the check out of test builds; `InProc`
+            // channels used in tests never block, so the send side of the
+            // loop returns on the first iteration anyway.
+            #[cfg(not(test))]
+            pgrx::check_for_interrupts!();
+            if self.channel.try_send_bytes(&scratch)? {
+                if !first_try {
+                    stats.send_wait += t_wait_start.elapsed();
+                }
+                return Ok(());
+            }
+            first_try = false;
+            stats.spin_iters += 1;
+            // Would-block: pull from our own mesh's inbound so peers' sends
+            // to us unblock. Without this interleave two participants
+            // blocking on symmetric sends deadlock — neither gets to drain.
+            let t_drain = std::time::Instant::now();
+            let _ = drain.poll_drain_pass();
+            stats.coop_drain_in_spin += t_drain.elapsed();
+            std::thread::yield_now();
+        }
+    }
+}
+
+/// Per-call timing + spin metrics for [`MppSender::send_batch_traced`].
+/// All fields accumulate; callers zero or reuse as needed.
+#[derive(Default, Debug, Clone)]
+pub struct SendBatchStats {
+    /// Cumulative time spent inside `encode_batch` (Arrow IPC serialization).
+    pub encode: std::time::Duration,
+    /// Cumulative wall time in the send-retry spin after the first failed
+    /// `try_send_bytes`. Zero if the first try succeeded.
+    pub send_wait: std::time::Duration,
+    /// Cumulative time spent in `poll_drain_pass` while spinning on a full
+    /// outbound. A subset of `send_wait`; the remainder is `yield_now` +
+    /// the (small) cost of `try_send_bytes` itself.
+    pub coop_drain_in_spin: std::time::Duration,
+    /// Count of `try_send_bytes` calls that returned `Ok(false)` (full).
+    pub spin_iters: u64,
+}
+
+/// High-level receiver: pulls bytes via the underlying channel and decodes them
+/// into `RecordBatch`. Used by the drain thread.
+pub struct MppReceiver {
+    channel: Box<dyn BatchChannelReceiver>,
+}
+
+impl MppReceiver {
+    pub fn new(channel: Box<dyn BatchChannelReceiver>) -> Self {
+        Self { channel }
+    }
+
+    pub fn try_recv_batch(&self) -> RecvBatchOutcome {
+        match self.channel.try_recv() {
+            RecvOutcome::Bytes(bytes) => match decode_batch(&bytes) {
+                Ok(batch) => RecvBatchOutcome::Batch(batch),
+                Err(e) => RecvBatchOutcome::Error(e),
+            },
+            RecvOutcome::Empty => RecvBatchOutcome::Empty,
+            RecvOutcome::Detached => RecvBatchOutcome::Detached,
+        }
+    }
+}
+
+/// Decoded result of an [`MppReceiver::try_recv_batch`].
+#[derive(Debug)]
+pub enum RecvBatchOutcome {
+    Batch(RecordBatch),
+    Empty,
+    Detached,
+    Error(DataFusionError),
+}
+
+/// Configuration for [`spawn_drain_thread`].
+pub struct DrainConfig {
+    /// Receivers to drain. Ownership moves into the spawned thread.
+    pub receivers: Vec<MppReceiver>,
+    /// Destination buffer.
+    pub buffer: Arc<DrainBuffer>,
+    /// How long to sleep when every receiver is empty but some are still
+    /// attached. Tuning: small values reduce end-of-batch latency but raise
+    /// CPU; 1 ms is a safe default until we integrate with WaitLatch.
+    pub idle_sleep: Duration,
+}
+
+impl DrainConfig {
+    pub fn new(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
+        Self {
+            receivers,
+            buffer,
+            idle_sleep: Duration::from_millis(1),
+        }
+    }
+}
+
+/// Spawn the dedicated drain thread.
+///
+/// The thread round-robins through every receiver with non-blocking `try_recv`,
+/// pushes decoded batches into `buffer`, and marks each source done as soon as
+/// it observes a detach or decode error. When every source is done, the thread
+/// exits. Its `JoinHandle` is returned so the caller can join on shutdown.
+///
+/// Prefer [`DrainHandle::spawn`] over this raw function — `DrainHandle` pins
+/// the cancel+join invariant at the type level so a dropped handle guarantees
+/// the thread has torn down before DSM is detached, regardless of whether the
+/// consumer path panicked.
+pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusionError>> {
+    std::thread::spawn(move || drain_loop(config))
+}
+
+/// RAII wrapper around a drain thread's `JoinHandle` and its `DrainBuffer`.
+///
+/// On drop, the handle cancels the buffer (unblocking the drain thread if it
+/// is sleeping on an empty cycle) and joins the thread. This guarantees the
+/// drain thread never outlives the query's DSM segment — if `ExecEndCustomScan`
+/// panics after dropping the handle, the thread has already been torn down
+/// and cannot touch the freed shm_mq memory.
+///
+/// Review finding: the prior implementation's `JoinHandle` was hanging off
+/// free-form execution state, so an error path that skipped manual cleanup
+/// left a zombie drain thread alive with dangling DSM pointers. Enforcing
+/// cancel+join via Drop closes that window.
+pub struct DrainHandle {
+    buffer: Arc<DrainBuffer>,
+    /// Background-thread variant: `Some(JoinHandle)`. In-proc tests still use
+    /// this path — their `InProcReceiver` is an `std::sync::mpsc` wrapper, not
+    /// a pg FFI call, so the drain thread is safe. Wrapped in `Mutex` so
+    /// `shutdown(&self)` can take the handle without needing `&mut self` —
+    /// this lets cooperative senders hold `Arc<DrainHandle>` shares.
+    join: Mutex<Option<JoinHandle<Result<(), DataFusionError>>>>,
+    /// Cooperative variant: the receivers are owned by the handle and polled
+    /// inline from `DrainGatherStream::poll_next` via [`Self::poll_drain_pass`].
+    /// Production uses this variant because any pg FFI call
+    /// (`shm_mq_receive` included) from a non-backend thread panics pgrx's
+    /// `check_active_thread` guard. `None` when the handle was spawned
+    /// instead of constructed cooperatively.
+    ///
+    /// `Send` bound on `MppReceiver` is preserved — the receivers move
+    /// thread-once at construction then are only accessed from the backend
+    /// thread; the `Mutex` is just for interior mutability, not
+    /// cross-thread coordination.
+    coop_receivers: Mutex<Option<Vec<Option<MppReceiver>>>>,
+}
+
+impl DrainHandle {
+    /// Spawn a drain thread and wrap the join handle together with the buffer
+    /// it drains into. The returned handle is `!Send`-tolerant (std::thread
+    /// join handles are Send), so it may live on any thread that manages the
+    /// query's lifecycle.
+    ///
+    /// Safe for in-proc test receivers (std::sync::mpsc). NOT safe for
+    /// `shm_mq`-backed receivers — pgrx panics on any pg FFI call from a
+    /// non-backend thread. Production paths must use
+    /// [`Self::cooperative`] instead.
+    pub fn spawn(config: DrainConfig) -> Self {
+        let buffer = Arc::clone(&config.buffer);
+        let join = spawn_drain_thread(config);
+        Self {
+            buffer,
+            join: Mutex::new(Some(join)),
+            coop_receivers: Mutex::new(None),
+        }
+    }
+
+    /// Construct a cooperative drain handle: the receivers are stashed in the
+    /// handle and drained inline from `DrainGatherStream::poll_next` (see
+    /// [`Self::poll_drain_pass`]). No background thread. This is the correct
+    /// variant for production pg backend workers — the drain work runs on
+    /// the backend thread, so any pg FFI inside `shm_mq_receive` is safe.
+    pub fn cooperative(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
+        let wrapped = receivers.into_iter().map(Some).collect();
+        Self {
+            buffer,
+            join: Mutex::new(None),
+            coop_receivers: Mutex::new(Some(wrapped)),
+        }
+    }
+
+    /// Pull batches from each live receiver into the buffer. Called from
+    /// `DrainGatherStream::poll_next` and from `MppSender::send_batch`'s
+    /// cooperative spin — drain work happens on the backend thread
+    /// (pgrx-safe). No-op for thread-backed handles.
+    ///
+    /// Each pass drains *every available* batch from each receiver (up to
+    /// a safety cap). Pulling only one batch per source per call means
+    /// that under steady producer pressure the cooperative sender's
+    /// spin-loop cannot keep up — we'd fall N:1 behind peers' sends and
+    /// the mesh stalls once any queue fills. Draining until the receiver
+    /// reports `Empty` bounds each pass by queue depth rather than by
+    /// spin-loop iteration count.
+    ///
+    /// Returns `Ok(true)` if anything changed (a batch pushed or a source
+    /// marked done), `Ok(false)` if nothing changed in this pass.
+    pub fn poll_drain_pass(&self) -> Result<bool, DataFusionError> {
+        // Bound per-source pulls per call. The upper limit exists to give
+        // the caller a chance to re-try its own send between drains —
+        // otherwise a participant with a very fast peer could drain
+        // indefinitely on one source and starve its own outbound.
+        const MAX_BATCHES_PER_SOURCE_PER_PASS: usize = 256;
+
+        let mut guard = self.coop_receivers.lock().unwrap();
+        let Some(slots) = guard.as_mut() else {
+            // Thread-backed handle — caller should read from buffer directly.
+            return Ok(false);
+        };
+        let mut progress = false;
+        for slot in slots.iter_mut() {
+            let Some(rx) = slot.as_ref() else {
+                continue;
+            };
+            for _ in 0..MAX_BATCHES_PER_SOURCE_PER_PASS {
+                match rx.try_recv_batch() {
+                    RecvBatchOutcome::Batch(b) => {
+                        self.buffer.push_batch(b);
+                        progress = true;
+                    }
+                    RecvBatchOutcome::Empty => break,
+                    RecvBatchOutcome::Detached => {
+                        *slot = None;
+                        self.buffer.notify_source_done();
+                        progress = true;
+                        break;
+                    }
+                    RecvBatchOutcome::Error(e) => {
+                        *slot = None;
+                        self.buffer.notify_source_done();
+                        return Err(e);
+                    }
+                }
+            }
+        }
+        Ok(progress)
+    }
+
+    /// True if this handle drains cooperatively (no background thread).
+    pub fn is_cooperative(&self) -> bool {
+        self.coop_receivers.lock().unwrap().is_some()
+    }
+
+    /// Access the shared buffer so consumers (typically `GatherExec`) can
+    /// `pop_front` without holding the handle itself.
+    pub fn buffer(&self) -> &Arc<DrainBuffer> {
+        &self.buffer
+    }
+
+    /// Cancel the drain explicitly and join the thread (thread-backed only).
+    /// For cooperative handles, simply drops the receivers (signalling detach
+    /// to peer senders) and returns. Called by the consumer at natural
+    /// shutdown; the Drop impl handles panic paths.
+    pub fn shutdown(&self) -> Result<(), DataFusionError> {
+        self.buffer.cancel();
+        // Drop receivers (if any) so peer shm_mq senders observe detach.
+        let _ = self.coop_receivers.lock().unwrap().take();
+        self.join_inner()
+    }
+
+    fn join_inner(&self) -> Result<(), DataFusionError> {
+        let join_opt = self.join.lock().unwrap().take();
+        if let Some(join) = join_opt {
+            match join.join() {
+                Ok(res) => res,
+                Err(panic) => Err(DataFusionError::Execution(format!(
+                    "mpp: drain thread panicked: {panic:?}"
+                ))),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for DrainHandle {
+    fn drop(&mut self) {
+        let has_join = self.join.lock().unwrap().is_some();
+        if has_join {
+            // Cancel and join even on the panic path. We swallow any error
+            // here because Drop cannot fail; callers who care should use
+            // `shutdown()` to observe the thread's result.
+            self.buffer.cancel();
+            let _ = self.join_inner();
+        }
+    }
+}
+
+fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
+    let DrainConfig {
+        receivers,
+        buffer,
+        idle_sleep,
+    } = config;
+
+    let mut done = vec![false; receivers.len()];
+    loop {
+        // Observe cancellation before each pass so a `DrainHandle::drop` with
+        // live peer senders tears down cleanly. Without this check, the drain
+        // thread would spin `try_recv` forever because no source has detached.
+        if buffer.is_cancelled() {
+            return Ok(());
+        }
+
+        let mut got_any = false;
+        let mut all_done = true;
+        for (i, rx) in receivers.iter().enumerate() {
+            if done[i] {
+                continue;
+            }
+            all_done = false;
+            match rx.try_recv_batch() {
+                RecvBatchOutcome::Batch(batch) => {
+                    got_any = true;
+                    buffer.push_batch(batch);
+                }
+                RecvBatchOutcome::Empty => {}
+                RecvBatchOutcome::Detached => {
+                    done[i] = true;
+                    buffer.notify_source_done();
+                }
+                RecvBatchOutcome::Error(e) => {
+                    // Treat a decode error as a fatal detach for this source
+                    // so the consumer can observe EOF and abort the query.
+                    done[i] = true;
+                    buffer.notify_source_done();
+                    return Err(e);
+                }
+            }
+        }
+
+        if all_done {
+            return Ok(());
+        }
+        if !got_any {
+            std::thread::sleep(idle_sleep);
+        }
+    }
+}
+
+/// SPSC channel pair for unit tests and in-process single-worker validation.
+/// Bounded capacity via `std::sync::mpsc::sync_channel` so tests can exercise
+/// backpressure (`send` blocks when full).
+pub fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
+    let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
+    (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
+}
+
+pub struct InProcSender {
+    tx: std::sync::mpsc::SyncSender<Vec<u8>>,
+}
+
+pub struct InProcReceiver {
+    // The std::sync::mpsc receiver is !Sync; wrap in a Mutex so the drain
+    // thread can hold it behind a `Box<dyn BatchChannelReceiver>` (which is
+    // `Send + Sync`-relaxed by design, but we only need Send for the thread
+    // hand-off). Tests only ever access from one thread so the Mutex is
+    // uncontended.
+    rx: Mutex<std::sync::mpsc::Receiver<Vec<u8>>>,
+}
+
+impl BatchChannelSender for InProcSender {
+    fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
+        self.tx.send(bytes.to_vec()).map_err(|_| {
+            DataFusionError::Execution("mpp: in-proc channel detached during send".into())
+        })
+    }
+}
+
+impl BatchChannelReceiver for InProcReceiver {
+    fn try_recv(&self) -> RecvOutcome {
+        let rx = self.rx.lock().expect("InProcReceiver mutex poisoned");
+        match rx.try_recv() {
+            Ok(bytes) => RecvOutcome::Bytes(bytes),
+            Err(std::sync::mpsc::TryRecvError::Empty) => RecvOutcome::Empty,
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => RecvOutcome::Detached,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc as StdArc;
+    use std::thread;
+
+    fn sample_batch(rows: i32) -> RecordBatch {
+        let schema = StdArc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..rows);
+        let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
+        RecordBatch::try_new(schema, vec![StdArc::new(ids), StdArc::new(names)]).unwrap()
+    }
+
+    #[test]
+    fn codec_round_trips_a_batch() {
+        let orig = sample_batch(128);
+        let bytes = encode_batch(&orig).expect("encode");
+        let decoded = decode_batch(&bytes).expect("decode");
+        assert_eq!(orig.schema(), decoded.schema());
+        assert_eq!(orig.num_rows(), decoded.num_rows());
+        assert_eq!(orig.num_columns(), decoded.num_columns());
+        // Equality across the whole batch
+        for col in 0..orig.num_columns() {
+            assert_eq!(orig.column(col).as_ref(), decoded.column(col).as_ref());
+        }
+    }
+
+    #[test]
+    fn codec_round_trips_many_batch_sizes() {
+        for rows in [0, 1, 7, 64, 1024] {
+            let orig = sample_batch(rows);
+            let bytes = encode_batch(&orig).expect("encode");
+            let decoded = decode_batch(&bytes).expect("decode");
+            assert_eq!(orig.num_rows(), decoded.num_rows());
+        }
+    }
+
+    #[test]
+    fn drain_buffer_pop_returns_pushed_batches_in_order() {
+        let buf = DrainBuffer::new(1);
+        buf.push_batch(sample_batch(3));
+        buf.push_batch(sample_batch(5));
+        buf.notify_source_done();
+
+        match buf.pop_front() {
+            DrainItem::Batch(b) => assert_eq!(b.num_rows(), 3),
+            DrainItem::Eof => panic!("expected batch"),
+        }
+        match buf.pop_front() {
+            DrainItem::Batch(b) => assert_eq!(b.num_rows(), 5),
+            DrainItem::Eof => panic!("expected batch"),
+        }
+        matches!(buf.pop_front(), DrainItem::Eof);
+    }
+
+    #[test]
+    fn drain_buffer_pop_blocks_until_push_then_eof() {
+        let buf = DrainBuffer::new(2);
+        let producer = StdArc::clone(&buf);
+        let handle = thread::spawn(move || {
+            thread::sleep(std::time::Duration::from_millis(20));
+            producer.push_batch(sample_batch(2));
+            producer.notify_source_done();
+            thread::sleep(std::time::Duration::from_millis(20));
+            producer.notify_source_done();
+        });
+
+        match buf.pop_front() {
+            DrainItem::Batch(b) => assert_eq!(b.num_rows(), 2),
+            DrainItem::Eof => panic!("expected batch first"),
+        }
+        assert!(matches!(buf.pop_front(), DrainItem::Eof));
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn drain_buffer_cancel_unblocks_waiter() {
+        let buf = DrainBuffer::new(1);
+        let canceller = StdArc::clone(&buf);
+        let handle = thread::spawn(move || {
+            thread::sleep(std::time::Duration::from_millis(20));
+            canceller.cancel();
+        });
+        assert!(matches!(buf.pop_front(), DrainItem::Eof));
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn in_proc_channel_round_trips_through_mpp_sender_receiver() {
+        let (tx, rx) = in_proc_channel(8);
+        let sender = MppSender::new(Box::new(tx));
+        let receiver = MppReceiver::new(Box::new(rx));
+
+        sender.send_batch(&sample_batch(4)).unwrap();
+        std::mem::drop(sender);
+
+        match receiver.try_recv_batch() {
+            RecvBatchOutcome::Batch(b) => assert_eq!(b.num_rows(), 4),
+            other => panic!("expected batch, got {other:?}"),
+        }
+        assert!(matches!(
+            receiver.try_recv_batch(),
+            RecvBatchOutcome::Detached
+        ));
+    }
+
+    #[test]
+    fn drain_thread_drains_single_source() {
+        let (tx, rx) = in_proc_channel(4);
+        let sender = MppSender::new(Box::new(tx));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let buffer = DrainBuffer::new(1);
+
+        let join = spawn_drain_thread(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
+
+        thread::spawn(move || {
+            for rows in [1, 2, 3, 4, 5] {
+                sender.send_batch(&sample_batch(rows)).unwrap();
+            }
+            // Drop sender to signal EOF
+        })
+        .join()
+        .unwrap();
+
+        let mut received = Vec::new();
+        while let DrainItem::Batch(b) = buffer.pop_front() {
+            received.push(b.num_rows());
+        }
+        assert_eq!(received, vec![1, 2, 3, 4, 5]);
+        join.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn drain_handle_shutdown_joins_cleanly() {
+        let (tx, rx) = in_proc_channel(4);
+        let sender = MppSender::new(Box::new(tx));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let buffer = DrainBuffer::new(1);
+        let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
+
+        sender.send_batch(&sample_batch(2)).unwrap();
+        std::mem::drop(sender); // detach
+                                // Pop the one batch
+        assert!(matches!(buffer.pop_front(), DrainItem::Batch(_)));
+        assert!(matches!(buffer.pop_front(), DrainItem::Eof));
+        handle.shutdown().unwrap();
+    }
+
+    #[test]
+    fn drain_handle_drop_cancels_and_joins() {
+        // Build a drain that never detaches (we keep the sender alive), then
+        // drop the handle. The Drop impl must cancel the buffer and join the
+        // thread without hanging.
+        let (tx, rx) = in_proc_channel(4);
+        let _sender_kept_alive = MppSender::new(Box::new(tx));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let buffer = DrainBuffer::new(1);
+        let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
+
+        // Simulate consumer path error: drop the handle without calling
+        // shutdown(). The drain thread must exit before drop returns.
+        let start = std::time::Instant::now();
+        drop(handle);
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < std::time::Duration::from_secs(2),
+            "DrainHandle::drop took too long: {elapsed:?}"
+        );
+        // Consumer observes EOF because cancel was called.
+        assert!(matches!(buffer.pop_front(), DrainItem::Eof));
+    }
+
+    #[test]
+    fn drain_thread_drains_n2_mesh_100k_batches() {
+        // Milestone-1 gate: simulate the 2-participant mesh. Each of two
+        // producers pushes 50_000 small batches through a bounded channel;
+        // the drain thread interleaves and the consumer reads EOF exactly
+        // after receiving all 100_000 batches. Exercises backpressure
+        // (bounded capacity = 16) without deadlock.
+        const PER_SOURCE: usize = 50_000;
+        let (tx0, rx0) = in_proc_channel(16);
+        let (tx1, rx1) = in_proc_channel(16);
+        let receivers = vec![
+            MppReceiver::new(Box::new(rx0)),
+            MppReceiver::new(Box::new(rx1)),
+        ];
+        let buffer = DrainBuffer::new(2);
+        let drain_join = spawn_drain_thread(DrainConfig::new(receivers, StdArc::clone(&buffer)));
+
+        let tx0_send = MppSender::new(Box::new(tx0));
+        let tx1_send = MppSender::new(Box::new(tx1));
+        let batch_template = sample_batch(1);
+
+        let p0 = {
+            let b = batch_template.clone();
+            thread::spawn(move || {
+                for _ in 0..PER_SOURCE {
+                    tx0_send.send_batch(&b).unwrap();
+                }
+            })
+        };
+        let p1 = {
+            let b = batch_template.clone();
+            thread::spawn(move || {
+                for _ in 0..PER_SOURCE {
+                    tx1_send.send_batch(&b).unwrap();
+                }
+            })
+        };
+
+        let mut total = 0usize;
+        while let DrainItem::Batch(_) = buffer.pop_front() {
+            total += 1;
+        }
+        assert_eq!(total, 2 * PER_SOURCE);
+        p0.join().unwrap();
+        p1.join().unwrap();
+        drain_join.join().unwrap().unwrap();
+    }
+
+    #[test]
+    fn drain_buffer_drains_buffered_before_eof() {
+        // Even if all sources have finished and cancel fires, any already-
+        // buffered batches must be observed before Eof.
+        let buf = DrainBuffer::new(1);
+        buf.push_batch(sample_batch(1));
+        buf.push_batch(sample_batch(1));
+        buf.notify_source_done();
+        buf.cancel();
+
+        assert!(matches!(buf.pop_front(), DrainItem::Batch(_)));
+        assert!(matches!(buf.pop_front(), DrainItem::Batch(_)));
+        assert!(matches!(buf.pop_front(), DrainItem::Eof));
+    }
+
+    // ---------------------------------------------------------------------
+    // Throughput microbenches.
+    //
+    // These are `#[ignore]` by default because they spin for seconds and
+    // spam stdout. Run with:
+    //
+    //   cargo test --package pg_search --release \
+    //       postgres::customscan::mpp::transport::tests::throughput \
+    //       -- --ignored --nocapture
+    //
+    // They help us bound the transport layer's cost independently of
+    // DataFusion/Tantivy. All use the `in_proc_channel` backend (same
+    // `MppSender`/`MppReceiver` trait boundary as the shm_mq one), so
+    // numbers here are an optimistic ceiling — shm_mq adds the ring-buffer
+    // copy + cross-process notification cost on top. If these numbers are
+    // already below the row rate the real query needs, we know IPC encode
+    // + channel handoff is the bottleneck without needing CI data.
+    // ---------------------------------------------------------------------
+
+    /// Row shape matching the post-Partial shuffle in
+    /// `aggregate_join_groupby`: a grouping key (title string) plus two
+    /// partial-aggregate accumulators (COUNT u64, SUM i64).
+    fn postagg_shape_batch(rows: usize) -> RecordBatch {
+        use datafusion::arrow::array::{Int64Array, UInt64Array};
+        let schema = StdArc::new(Schema::new(vec![
+            Field::new("title", DataType::Utf8, false),
+            Field::new("count_partial", DataType::UInt64, false),
+            Field::new("sum_partial", DataType::Int64, false),
+        ]));
+        // Titles averaging ~30 bytes — typical for the docs dataset.
+        let titles = StringArray::from_iter_values(
+            (0..rows).map(|i| format!("file_{i:012}_title_with_some_length")),
+        );
+        let counts = UInt64Array::from_iter_values((0..rows as u64).map(|i| i % 64 + 1));
+        let sums = Int64Array::from_iter_values((0..rows as i64).map(|i| i * 1024));
+        RecordBatch::try_new(
+            schema,
+            vec![StdArc::new(titles), StdArc::new(counts), StdArc::new(sums)],
+        )
+        .unwrap()
+    }
+
+    /// Row shape matching the probe-side shuffle in the same query:
+    /// `pages.fileId` (u64) plus `pages.sizeInBytes` (i64).
+    fn probe_shape_batch(rows: usize) -> RecordBatch {
+        use datafusion::arrow::array::{Int64Array, UInt64Array};
+        let schema = StdArc::new(Schema::new(vec![
+            Field::new("fileId", DataType::UInt64, false),
+            Field::new("sizeInBytes", DataType::Int64, false),
+        ]));
+        let ids =
+            UInt64Array::from_iter_values((0..rows as u64).map(|i| i.wrapping_mul(2654435761)));
+        let sizes = Int64Array::from_iter_values((0..rows as i64).map(|i| i * 37));
+        RecordBatch::try_new(schema, vec![StdArc::new(ids), StdArc::new(sizes)]).unwrap()
+    }
+
+    fn bench_throughput(
+        label: &str,
+        make_batch: fn(usize) -> RecordBatch,
+        batch_rows: usize,
+        total_rows: usize,
+    ) {
+        let batches = total_rows.div_ceil(batch_rows);
+        let template = make_batch(batch_rows);
+        // Encode once up front so we also report pure-encode throughput
+        // separately. Real queries encode inside the hot path per batch.
+        let enc_start = std::time::Instant::now();
+        let mut enc_bytes = 0usize;
+        for _ in 0..batches {
+            enc_bytes += encode_batch(&template).expect("encode").len();
+        }
+        let enc_elapsed = enc_start.elapsed();
+
+        // N=2 mesh: two senders, one drain thread, one consumer. Matches
+        // the gb_postagg / gb_right topology in the real query.
+        let (tx0, rx0) = in_proc_channel(16);
+        let (tx1, rx1) = in_proc_channel(16);
+        let receivers = vec![
+            MppReceiver::new(Box::new(rx0)),
+            MppReceiver::new(Box::new(rx1)),
+        ];
+        let buffer = DrainBuffer::new(2);
+        let drain_join = spawn_drain_thread(DrainConfig::new(receivers, StdArc::clone(&buffer)));
+        let tx0_send = MppSender::new(Box::new(tx0));
+        let tx1_send = MppSender::new(Box::new(tx1));
+
+        let per_source = batches / 2;
+        let round_trip_start = std::time::Instant::now();
+        let p0 = {
+            let b = template.clone();
+            thread::spawn(move || {
+                for _ in 0..per_source {
+                    tx0_send.send_batch(&b).unwrap();
+                }
+            })
+        };
+        let p1 = {
+            let b = template.clone();
+            thread::spawn(move || {
+                for _ in 0..per_source {
+                    tx1_send.send_batch(&b).unwrap();
+                }
+            })
+        };
+
+        let mut got_rows = 0usize;
+        let mut got_batches = 0usize;
+        while let DrainItem::Batch(b) = buffer.pop_front() {
+            got_rows += b.num_rows();
+            got_batches += 1;
+        }
+        p0.join().unwrap();
+        p1.join().unwrap();
+        drain_join.join().unwrap().unwrap();
+        let rt_elapsed = round_trip_start.elapsed();
+
+        let enc_mb_per_s = (enc_bytes as f64 / (1024.0 * 1024.0)) / enc_elapsed.as_secs_f64();
+        let enc_rows_per_s = (batches * batch_rows) as f64 / enc_elapsed.as_secs_f64();
+        let rt_rows_per_s = got_rows as f64 / rt_elapsed.as_secs_f64();
+        let rt_bytes_total_mb = enc_bytes as f64 / (1024.0 * 1024.0);
+        let rt_mb_per_s = rt_bytes_total_mb / rt_elapsed.as_secs_f64();
+        let per_batch_us = rt_elapsed.as_micros() as f64 / got_batches as f64;
+
+        println!(
+            "[throughput] {label:<18} batch_rows={batch_rows:<5} batches={got_batches:<6} rows={got_rows} \
+             encode_only: {enc_rows_per_s:>11.0} rows/s {enc_mb_per_s:>7.1} MB/s | \
+             round_trip: {rt_rows_per_s:>11.0} rows/s {rt_mb_per_s:>7.1} MB/s ({per_batch_us:.1}us/batch)"
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn throughput_postagg_shape() {
+        // Sweeps batch size to show per-batch fixed cost vs per-row cost.
+        // 1.25M total rows ≈ what one seat ships through gb_postagg at
+        // 25M scale. 625K per seat × 2 = 1.25M.
+        for batch_rows in [128, 512, 2048, 8192, 32_768] {
+            bench_throughput("postagg", postagg_shape_batch, batch_rows, 1_250_000);
+        }
+    }
+
+    #[test]
+    #[ignore]
+    fn throughput_probe_shape() {
+        // 12.5M total rows ≈ what one seat ships through gb_right at 25M.
+        for batch_rows in [128, 512, 2048, 8192, 32_768] {
+            bench_throughput("probe", probe_shape_batch, batch_rows, 12_500_000);
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -327,6 +327,13 @@ impl MppSender {
         };
         let mut first_try = true;
         let t_wait_start = std::time::Instant::now();
+        // This spin is synchronous and runs on the backend thread that
+        // DataFusion calls `poll_next` on; there is no Tokio runtime in the
+        // MPP transport path, so neither `yield_now` nor `poll_drain_pass`
+        // can starve an async executor. The cooperative `poll_drain_pass`
+        // call below pulls peer sends *on the same thread*, which is what
+        // breaks the symmetric N×N send/receive deadlock — an async-style
+        // `await` would not work here because we have no executor to wake.
         loop {
             // `pgrx::check_for_interrupts!()` pulls in PG symbols
             // (`ProcessInterrupts`, `PG_exception_stack`, `CopyErrorData`, …)

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -1088,8 +1088,8 @@ mod tests {
     #[ignore]
     fn throughput_postagg_shape() {
         // Sweeps batch size to show per-batch fixed cost vs per-row cost.
-        // 1.25M total rows ≈ what one seat ships through gb_postagg at
-        // 25M scale. 625K per seat × 2 = 1.25M.
+        // 1.25M total rows ≈ what one participant ships through gb_postagg at
+        // 25M scale. 625K per participant × 2 = 1.25M.
         for batch_rows in [128, 512, 2048, 8192, 32_768] {
             bench_throughput("postagg", postagg_shape_batch, batch_rows, 1_250_000);
         }
@@ -1098,7 +1098,7 @@ mod tests {
     #[test]
     #[ignore]
     fn throughput_probe_shape() {
-        // 12.5M total rows ≈ what one seat ships through gb_right at 25M.
+        // 12.5M total rows ≈ what one participant ships through gb_right at 25M.
         for batch_rows in [128, 512, 2048, 8192, 32_768] {
             bench_throughput("probe", probe_shape_batch, batch_rows, 12_500_000);
         }

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -717,7 +717,7 @@ impl BatchChannelReceiver for InProcReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use datafusion::arrow::array::{Int32Array, StringArray};
+    use datafusion::arrow::array::{Int32Array, Int64Array, StringArray, UInt64Array};
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use std::sync::Arc as StdArc;
     use std::thread;
@@ -977,7 +977,6 @@ mod tests {
     /// `aggregate_join_groupby`: a grouping key (title string) plus two
     /// partial-aggregate accumulators (COUNT u64, SUM i64).
     fn postagg_shape_batch(rows: usize) -> RecordBatch {
-        use datafusion::arrow::array::{Int64Array, UInt64Array};
         let schema = StdArc::new(Schema::new(vec![
             Field::new("title", DataType::Utf8, false),
             Field::new("count_partial", DataType::UInt64, false),
@@ -999,7 +998,6 @@ mod tests {
     /// Row shape matching the probe-side shuffle in the same query:
     /// `pages.fileId` (u64) plus `pages.sizeInBytes` (i64).
     fn probe_shape_batch(rows: usize) -> RecordBatch {
-        use datafusion::arrow::array::{Int64Array, UInt64Array};
         let schema = StdArc::new(Schema::new(vec![
             Field::new("fileId", DataType::UInt64, false),
             Field::new("sizeInBytes", DataType::Int64, false),

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -348,8 +348,10 @@ impl MppSender {
             // Would-block: pull from our own mesh's inbound so peers' sends
             // to us unblock. Without this interleave two participants
             // blocking on symmetric sends deadlock — neither gets to drain.
+            // Errors propagate so a peer detaching mid-spin doesn't leave the
+            // sender looping forever on a closed mesh.
             let t_drain = std::time::Instant::now();
-            let _ = drain.poll_drain_pass();
+            drain.poll_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
             std::thread::yield_now();
         }
@@ -523,9 +525,14 @@ impl DrainHandle {
     /// reports `Empty` bounds each pass by queue depth rather than by
     /// spin-loop iteration count.
     ///
-    /// Returns `Ok(true)` if anything changed (a batch pushed or a source
-    /// marked done), `Ok(false)` if nothing changed in this pass.
-    pub fn poll_drain_pass(&self) -> Result<bool, DataFusionError> {
+    /// Returns `Ok(())` once every cooperative receiver has been pulled until
+    /// `Empty` (or detached). A previous version returned a `bool` indicating
+    /// whether any progress had been made; no caller used it (the
+    /// cooperative-spin loop in [`MppSender::send_batch`] retries on its own
+    /// `try_send_bytes` regardless of drain progress), so the return is now
+    /// just `Result<()>` so transport errors propagate instead of being
+    /// silently dropped at the call site.
+    pub fn poll_drain_pass(&self) -> Result<(), DataFusionError> {
         // Bound per-source pulls per call. The upper limit exists to give
         // the caller a chance to re-try its own send between drains —
         // otherwise a participant with a very fast peer could drain
@@ -535,9 +542,8 @@ impl DrainHandle {
         let mut guard = self.coop_receivers.lock().unwrap();
         let Some(slots) = guard.as_mut() else {
             // Thread-backed handle — caller should read from buffer directly.
-            return Ok(false);
+            return Ok(());
         };
-        let mut progress = false;
         for slot in slots.iter_mut() {
             let Some(rx) = slot.as_ref() else {
                 continue;
@@ -546,13 +552,11 @@ impl DrainHandle {
                 match rx.try_recv_batch() {
                     RecvBatchOutcome::Batch(b) => {
                         self.buffer.push_batch(b);
-                        progress = true;
                     }
                     RecvBatchOutcome::Empty => break,
                     RecvBatchOutcome::Detached => {
                         *slot = None;
                         self.buffer.notify_source_done();
-                        progress = true;
                         break;
                     }
                     RecvBatchOutcome::Error(e) => {
@@ -563,7 +567,7 @@ impl DrainHandle {
                 }
             }
         }
-        Ok(progress)
+        Ok(())
     }
 
     /// True if this handle drains cooperatively (no background thread).

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -207,6 +207,15 @@ impl DrainBuffer {
     /// `Poll::Pending` instead of blocking the executor thread — critical
     /// under peer-to-peer backpressure, where a blocking wait could deadlock
     /// with this worker's own outbound pump.
+    ///
+    /// Why hand-rolled instead of `tokio::sync::mpsc`: the producer side is
+    /// a real OS thread (the drain thread) that blocks inside the `shm_mq`
+    /// FFI; it cannot be a Tokio task because `shm_mq_receive` has no async
+    /// readiness signal. Swapping `DrainBuffer` for `mpsc::unbounded_channel`
+    /// and calling `rx.poll_recv(cx)` on the consumer is plausible, but the
+    /// producer stays an OS thread regardless, and the small
+    /// `Mutex<Option<Waker>>` is the entire delta — not load-bearing for
+    /// correctness. Tracked as a post-merge follow-up.
     pub fn poll_pop_front(&self, waker: &std::task::Waker) -> Option<DrainItem> {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         if let Some(batch) = guard.queue.pop_front() {

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -336,13 +336,18 @@ impl MppSender {
         };
         let mut first_try = true;
         let t_wait_start = std::time::Instant::now();
-        // This spin is synchronous and runs on the backend thread that
-        // DataFusion calls `poll_next` on; there is no Tokio runtime in the
-        // MPP transport path, so neither `yield_now` nor `poll_drain_pass`
-        // can starve an async executor. The cooperative `poll_drain_pass`
-        // call below pulls peer sends *on the same thread*, which is what
-        // breaks the symmetric N×N send/receive deadlock — an async-style
-        // `await` would not work here because we have no executor to wake.
+        // The send-spin is synchronous and runs on the same backend thread
+        // that DataFusion calls `poll_next` on. There is no Tokio runtime
+        // here: producing and consuming for this participant happen on this
+        // one thread, time-sliced. When `try_send_bytes` returns "would
+        // block", we don't sleep waiting for room — we synchronously pull
+        // the peer's already-arrived batches via `poll_drain_pass` so their
+        // writers can advance. Without that interleave, two participants
+        // each blocking on a full outbound and never reading the other side
+        // would deadlock. `std::thread::yield_now` here is just a
+        // scheduler hint between OS threads (e.g., another backend's worker
+        // thread on the box); it is *not* a Tokio yield, so there is no
+        // starved async task waiting in the wings.
         loop {
             // `pgrx::check_for_interrupts!()` pulls in PG symbols
             // (`ProcessInterrupts`, `PG_exception_stack`, `CopyErrorData`, …)

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -336,18 +336,39 @@ impl MppSender {
         };
         let mut first_try = true;
         let t_wait_start = std::time::Instant::now();
-        // The send-spin is synchronous and runs on the same backend thread
-        // that DataFusion calls `poll_next` on. There is no Tokio runtime
-        // here: producing and consuming for this participant happen on this
-        // one thread, time-sliced. When `try_send_bytes` returns "would
-        // block", we don't sleep waiting for room — we synchronously pull
-        // the peer's already-arrived batches via `poll_drain_pass` so their
-        // writers can advance. Without that interleave, two participants
-        // each blocking on a full outbound and never reading the other side
-        // would deadlock. `std::thread::yield_now` here is just a
-        // scheduler hint between OS threads (e.g., another backend's worker
-        // thread on the box); it is *not* a Tokio yield, so there is no
-        // starved async task waiting in the wings.
+        // Mental model: a current-thread Tokio runtime lives on the
+        // backend thread (DataFusion needs one to drive `Stream`s). This
+        // spin runs *inside* one of those Tokio tasks — specifically the
+        // body of `ShuffleStream::poll_next`. While we spin we hold the
+        // runtime: any sibling Tokio task on the same runtime is paused
+        // until we return.
+        //
+        // What saves us today is plan shape, not Tokio plumbing. The MPP
+        // topology built by `walker.rs` is linear (`ChainExec` polls its
+        // input synchronously; no `RepartitionExec` / `CoalescePartitions`
+        // forks a parallel driver above us), so the runtime has only one
+        // "live" task per query, and starving siblings is moot — there
+        // are none. The deadlock that the cooperative drain prevents is a
+        // *cross-participant* hazard, not a same-runtime task hazard:
+        // two participants each blocking on a full outbound and never
+        // reading the other side. We break that by driving our own
+        // inbound synchronously: `poll_drain_pass` pulls peer batches
+        // that have already arrived, freeing their slots so peers'
+        // writers can advance, then we retry our send. `try_send_bytes`
+        // succeeding is the only exit. `std::thread::yield_now` is an OS
+        // scheduler hint; it is not a Tokio yield, so it does not
+        // surrender the runtime — that's deliberate, because if the
+        // current task gave up the runtime mid-spin and no other ready
+        // Tokio task happened to drive forward progress, the runtime
+        // would idle.
+        //
+        // If a future planner change introduces a parallel operator
+        // above the shuffle (so the Tokio runtime ends up multiplexing
+        // siblings), this loop becomes a real starvation source and
+        // wants to be rewritten as `async fn` with periodic
+        // `tokio::task::yield_now().await`. The cooperative drain
+        // primitive itself already lives off `Stream` infrastructure
+        // ready for that — the spin is the only synchronous holdout.
         loop {
             // `pgrx::check_for_interrupts!()` pulls in PG symbols
             // (`ProcessInterrupts`, `PG_exception_stack`, `CopyErrorData`, …)

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -309,77 +309,97 @@ impl MppSender {
     }
 
     /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
-    /// Production call sites (`ShuffleStream::process_batch`) always pass a
-    /// `SendBatchStats` so per-peer wall-time shows up in the EOF trace.
+    /// Production call sites (`ShuffleStream::process_batch`) always pass
+    /// a `SendBatchStats` so per-peer wall-time shows up in the EOF trace.
+    /// Wraps the async send in a tiny current-thread Tokio runtime so test
+    /// `#[test]` functions don't have to be `#[tokio::test]` and the
+    /// existing OS-thread-spawning test harnesses don't have to plumb an
+    /// async runtime themselves.
     #[cfg(test)]
     pub fn send_batch(&self, batch: &RecordBatch) -> Result<(), DataFusionError> {
         let mut stats = SendBatchStats::default();
-        self.send_batch_traced(batch, &mut stats)
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .build()
+            .expect("test tokio runtime build");
+        rt.block_on(self.send_batch_traced(batch, &mut stats))
     }
 
-    /// `send_batch` variant that accumulates per-call timings and spin counts
-    /// into `stats`. Callers that report these at EOF (e.g., `ShuffleStream`)
-    /// use this to diagnose where time goes when the outbound queue is full.
-    pub fn send_batch_traced(
+    /// `send_batch` variant that accumulates per-call timings and spin
+    /// counts into `stats`. Callers that report these at EOF (e.g.,
+    /// `ShuffleStream`) use this to diagnose where time goes when the
+    /// outbound queue is full.
+    ///
+    /// Async because the cooperative-spin path needs to surrender the
+    /// Tokio runtime back periodically — see the body comment.
+    pub async fn send_batch_traced(
         &self,
         batch: &RecordBatch,
         stats: &mut SendBatchStats,
     ) -> Result<(), DataFusionError> {
-        let mut scratch = self.scratch.borrow_mut();
+        // Take the scratch buffer out of the `RefCell` rather than
+        // holding a `RefMut` across the spin below. The spin contains
+        // `pgrx::check_for_interrupts!()`, which can `longjmp` through
+        // Rust frames; a `longjmp` does not run `Drop`, so a `RefMut`
+        // held across it would leave the cell perpetually borrowed and
+        // panic the next caller. `replace` is atomic — the cell is
+        // never observed in a borrowed state — and we put the buffer
+        // back at the end so its heap allocation survives across calls.
+        // If the spin longjmps anyway, the cell holds the default empty
+        // `Vec` and the next call simply re-allocates.
+        let mut scratch = self.scratch.replace(Vec::new());
+        let result = self.send_with_scratch(batch, &mut scratch, stats).await;
+        self.scratch.replace(scratch);
+        result
+    }
+
+    async fn send_with_scratch(
+        &self,
+        batch: &RecordBatch,
+        scratch: &mut Vec<u8>,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
         let t_enc = std::time::Instant::now();
-        encode_batch_into(batch, &mut scratch)?;
+        encode_batch_into(batch, scratch)?;
         stats.encode += t_enc.elapsed();
         let Some(drain) = self.cooperative_drain.as_ref() else {
-            // No drain attached (unit tests, in-proc channels): fall back
-            // to the blocking send path.
-            return self.channel.send_bytes(&scratch);
+            // No drain attached (unit tests, in-proc channels): fall
+            // back to the blocking send path.
+            return self.channel.send_bytes(scratch);
         };
         let mut first_try = true;
         let t_wait_start = std::time::Instant::now();
         // Mental model: a current-thread Tokio runtime lives on the
-        // backend thread (DataFusion needs one to drive `Stream`s). This
-        // spin runs *inside* one of those Tokio tasks — specifically the
-        // body of `ShuffleStream::poll_next`. While we spin we hold the
-        // runtime: any sibling Tokio task on the same runtime is paused
-        // until we return.
+        // backend thread (DataFusion needs one to drive `Stream`s).
+        // This spin runs *inside* a Tokio task — specifically the body
+        // of `ShuffleStream::poll_next`. The deadlock the cooperative
+        // drain prevents is *cross-participant*, not same-runtime: two
+        // peers each blocking on a full outbound and never reading the
+        // other side. We break that by driving our own inbound on this
+        // same OS thread via `poll_drain_pass`, which pulls peer
+        // batches that have already arrived and frees their slots so
+        // peers' writers can advance.
         //
-        // What saves us today is plan shape, not Tokio plumbing. The MPP
-        // topology built by `walker.rs` is linear (`ChainExec` polls its
-        // input synchronously; no `RepartitionExec` / `CoalescePartitions`
-        // forks a parallel driver above us), so the runtime has only one
-        // "live" task per query, and starving siblings is moot — there
-        // are none. The deadlock that the cooperative drain prevents is a
-        // *cross-participant* hazard, not a same-runtime task hazard:
-        // two participants each blocking on a full outbound and never
-        // reading the other side. We break that by driving our own
-        // inbound synchronously: `poll_drain_pass` pulls peer batches
-        // that have already arrived, freeing their slots so peers'
-        // writers can advance, then we retry our send. `try_send_bytes`
-        // succeeding is the only exit. `std::thread::yield_now` is an OS
-        // scheduler hint; it is not a Tokio yield, so it does not
-        // surrender the runtime — that's deliberate, because if the
-        // current task gave up the runtime mid-spin and no other ready
-        // Tokio task happened to drive forward progress, the runtime
-        // would idle.
-        //
-        // If a future planner change introduces a parallel operator
-        // above the shuffle (so the Tokio runtime ends up multiplexing
-        // siblings), this loop becomes a real starvation source and
-        // wants to be rewritten as `async fn` with periodic
-        // `tokio::task::yield_now().await`. The cooperative drain
-        // primitive itself already lives off `Stream` infrastructure
-        // ready for that — the spin is the only synchronous holdout.
+        // The `tokio::task::yield_now().await` between iterations
+        // hands the runtime back to the executor each spin. Today's
+        // MPP topology is linear (`ChainExec` polls inline, no
+        // `RepartitionExec` / `CoalescePartitions` driver above the
+        // shuffle), so there are no sibling Tokio tasks ready to run
+        // and yielding is effectively a no-op cost. Once the planner
+        // grows a parallel operator above us, those siblings start
+        // making forward progress during this yield instead of
+        // starving.
         loop {
             // `pgrx::check_for_interrupts!()` pulls in PG symbols
-            // (`ProcessInterrupts`, `PG_exception_stack`, `CopyErrorData`, …)
-            // that aren't linked into the crate's `--tests` / llvm-cov build.
-            // This fn is reached from `#[cfg(test)]` code in this file and
-            // `shuffle.rs`, so gate the check out of test builds; `InProc`
-            // channels used in tests never block, so the send side of the
-            // loop returns on the first iteration anyway.
+            // (`ProcessInterrupts`, `PG_exception_stack`,
+            // `CopyErrorData`, …) that aren't linked into the crate's
+            // `--tests` / llvm-cov build. This fn is reached from
+            // `#[cfg(test)]` code in this file and `shuffle.rs`, so
+            // gate the check out of test builds; `InProc` channels
+            // used in tests never block, so the send side of the loop
+            // returns on the first iteration anyway.
             #[cfg(not(test))]
             pgrx::check_for_interrupts!();
-            if self.channel.try_send_bytes(&scratch)? {
+            if self.channel.try_send_bytes(scratch)? {
                 if !first_try {
                     stats.send_wait += t_wait_start.elapsed();
                 }
@@ -387,15 +407,16 @@ impl MppSender {
             }
             first_try = false;
             stats.spin_iters += 1;
-            // Would-block: pull from our own mesh's inbound so peers' sends
-            // to us unblock. Without this interleave two participants
-            // blocking on symmetric sends deadlock — neither gets to drain.
-            // Errors propagate so a peer detaching mid-spin doesn't leave the
-            // sender looping forever on a closed mesh.
+            // Would-block: pull from our own mesh's inbound so peers'
+            // sends to us unblock. Without this interleave two
+            // participants blocking on symmetric sends deadlock —
+            // neither gets to drain. Errors propagate so a peer
+            // detaching mid-spin doesn't leave the sender looping
+            // forever on a closed mesh.
             let t_drain = std::time::Instant::now();
             drain.poll_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
-            std::thread::yield_now();
+            tokio::task::yield_now().await;
         }
     }
 }
@@ -409,9 +430,10 @@ pub struct SendBatchStats {
     /// Cumulative wall time in the send-retry spin after the first failed
     /// `try_send_bytes`. Zero if the first try succeeded.
     pub send_wait: std::time::Duration,
-    /// Cumulative time spent in `poll_drain_pass` while spinning on a full
-    /// outbound. A subset of `send_wait`; the remainder is `yield_now` +
-    /// the (small) cost of `try_send_bytes` itself.
+    /// Cumulative time spent in `poll_drain_pass` while spinning on a
+    /// full outbound. A subset of `send_wait`; the remainder is the
+    /// `tokio::task::yield_now()` await + the (small) cost of
+    /// `try_send_bytes` itself.
     pub coop_drain_in_spin: std::time::Duration,
     /// Count of `try_send_bytes` calls that returned `Ok(false)` (full).
     pub spin_iters: u64,

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -1,0 +1,701 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! MPP worker lifecycle and DSM coordination.
+//!
+//! The DSM region laid out by the leader during `initialize_dsm_custom_scan`
+//! and read by workers during `initialize_worker_custom_scan` looks like:
+//!
+//! ```text
+//! +---------------------------------------------------------+
+//! | MppDsmHeader (repr C, fixed size, MAXALIGN-padded)      |
+//! +---------------------------------------------------------+
+//! | plan_bytes: Vec<u8> copied verbatim (length from header) |
+//! +---------------------------------------------------------+
+//! | padding to MAXALIGN                                      |
+//! +---------------------------------------------------------+
+//! | shm_mq mesh region: N*(N-1) * aligned_queue_bytes        |
+//! +---------------------------------------------------------+
+//! ```
+//!
+//! The header is deliberately a C-repr POD struct so both the leader and
+//! workers can read it via plain pointer arithmetic without Rust ownership
+//! shenanigans. The plan bytes are then `bincode`-decoded into
+//! [`MppPlanBroadcast`] (see `session.rs`).
+//!
+//! This module deliberately does NOT wrap `pg_sys::shm_mq_create` /
+//! `shm_mq_attach`; those calls are driven by the custom scan's
+//! `initialize_dsm_custom_scan` / `initialize_worker_custom_scan` callbacks in
+//! Phase 4, feeding back into [`ShmMqSender`](super::mesh::ShmMqSender) and
+//! [`ShmMqReceiver`](super::mesh::ShmMqReceiver). Here we only own the
+//! sizing/offset math and the header layout.
+
+#![allow(dead_code)] // caller lands in Phase 4
+
+use crate::postgres::customscan::mpp::mesh::{MeshLayout, ShmMqReceiver, ShmMqSender};
+use crate::postgres::customscan::mpp::transport::{MppReceiver, MppSender};
+use pgrx::pg_sys;
+use std::mem::size_of;
+
+/// Magic number stamped at the head of an MPP DSM region. Distinct from any
+/// of the other Postgres DSM magic numbers in the crate; workers assert this
+/// matches on attach to catch catastrophic layout mismatches (e.g., the leader
+/// running a different build than the worker).
+pub const MPP_DSM_MAGIC: u32 = 0x4D50_5053; // "MPPS" in ASCII
+
+/// Current on-DSM header version. Bumped when the header layout or
+/// interpretation changes. Independent of `MPP_PLAN_BROADCAST_VERSION`, which
+/// versions the embedded plan bytes.
+pub const MPP_DSM_HEADER_VERSION: u32 = 1;
+
+/// Compile-time build hash: a 64-bit FNV-1a over the crate version string. On
+/// a cluster where the leader and its workers all load the same pg_search .so,
+/// this is identical across participants by construction. Its purpose is to
+/// catch the exotic case of a newer leader somehow ending up paired with an
+/// older worker image (rolling reload, stale postmaster). Cheap to add now,
+/// annoying to retrofit after workers are attaching.
+pub const MPP_BUILD_HASH: u64 = fnv1a_64(env!("CARGO_PKG_VERSION").as_bytes());
+
+const fn fnv1a_64(bytes: &[u8]) -> u64 {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut i = 0;
+    while i < bytes.len() {
+        hash ^= bytes[i] as u64;
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+        i += 1;
+    }
+    hash
+}
+
+/// C-repr header stamped at offset 0 of the MPP DSM region.
+///
+/// Field ordering is fixed: four `u32`s (16 bytes, naturally aligned), then
+/// six `u64`s (48 bytes, naturally aligned). Total size = 64 bytes, **no
+/// internal padding**, on every supported target (x86_64 / aarch64 / Linux /
+/// macOS / Windows). Workers read individual fields by name, not by offset,
+/// but the no-padding guarantee means the whole struct can be memcpy'd
+/// between processes without surprises. If a future change reorders fields
+/// or introduces a mixed-width sequence that induces padding, bump
+/// `MPP_DSM_HEADER_VERSION` so stale workers reject the new layout at
+/// `validate()` rather than read garbage. The
+/// `header_size_has_no_padding` test locks this in.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+pub struct MppDsmHeader {
+    /// Sanity-check magic. Workers panic on mismatch.
+    pub magic: u32,
+    /// Header layout version.
+    pub header_version: u32,
+    /// Total participants (leader + workers).
+    pub total_participants: u32,
+    /// Number of independent shuffle meshes packed into this DSM region.
+    /// Each mesh occupies `num_edges(total_participants) * aligned_queue_bytes`
+    /// contiguous bytes starting at `mesh_offset + i * per_mesh_bytes`.
+    /// All meshes share the same `aligned_queue_bytes`, so per-mesh offsets
+    /// are derivable without a separate offset table.
+    pub num_meshes: u32,
+    /// Compile-time FNV-1a over `CARGO_PKG_VERSION`. Workers reject
+    /// mismatches to catch the rolling-reload / postmaster-restart edge
+    /// case where a newer leader ends up paired with a stale worker image.
+    pub build_hash: u64,
+    /// Per-edge shm_mq slot size in bytes (MAXALIGN_DOWN of the user
+    /// request). Shared by every mesh; a future extension for heterogeneous
+    /// queue sizes would need a per-mesh sidecar and a header-version bump.
+    pub aligned_queue_bytes: u64,
+    /// Byte offset from the DSM base to the plan bytes.
+    pub plan_offset: u64,
+    /// Plan byte count.
+    pub plan_len: u64,
+    /// Byte offset from the DSM base to the start of the first mesh's queue
+    /// array. Mesh `i`'s array starts at
+    /// `mesh_offset + i * num_edges(total_participants) * aligned_queue_bytes`.
+    pub mesh_offset: u64,
+    /// Total DSM region size (header + plan + meshes with MAXALIGN padding).
+    /// `validate(region_total)` bounds-checks every offset against this so
+    /// a corrupt header that still matches magic+version cannot redirect
+    /// the worker to read arbitrary DSM memory.
+    pub region_total: u64,
+}
+
+impl MppDsmHeader {
+    /// The single constructor: the header's offsets cannot disagree with the
+    /// layout the leader actually wrote, because both come from the same
+    /// `DsmLayout`. There is no free-form `new(plan_offset, plan_len, …)` —
+    /// that API let callers build headers that lied about the region.
+    pub fn from_layout(mesh: &MeshLayout, dsm: &DsmLayout) -> Self {
+        Self {
+            magic: MPP_DSM_MAGIC,
+            header_version: MPP_DSM_HEADER_VERSION,
+            total_participants: mesh.total_participants,
+            num_meshes: dsm.num_meshes,
+            build_hash: MPP_BUILD_HASH,
+            aligned_queue_bytes: mesh.aligned_queue_bytes() as u64,
+            plan_offset: dsm.plan_offset as u64,
+            plan_len: dsm.plan_len as u64,
+            mesh_offset: dsm.mesh_offset as u64,
+            region_total: dsm.total as u64,
+        }
+    }
+
+    /// Byte offset from the DSM base to mesh index `mesh_idx`'s queue array.
+    pub fn mesh_base_offset(&self, mesh_idx: u32) -> u64 {
+        debug_assert!(mesh_idx < self.num_meshes);
+        let n = self.total_participants as u64;
+        let edges = n * n.saturating_sub(1);
+        self.mesh_offset + (mesh_idx as u64) * edges * self.aligned_queue_bytes
+    }
+
+    /// Validate a header read out of DSM. `region_total` is the size of the
+    /// DSM region the caller just attached to; the header's own offsets are
+    /// bounds-checked against it so a corrupt header that still happens to
+    /// match magic + version + build hash cannot redirect the worker to read
+    /// arbitrary DSM memory.
+    pub fn validate(&self, region_total: u64) -> Result<(), &'static str> {
+        if self.magic != MPP_DSM_MAGIC {
+            return Err("mpp: DSM header magic mismatch");
+        }
+        if self.header_version != MPP_DSM_HEADER_VERSION {
+            return Err("mpp: DSM header version mismatch");
+        }
+        if self.build_hash != MPP_BUILD_HASH {
+            return Err("mpp: DSM build-hash mismatch (leader/worker binary skew?)");
+        }
+        if self.total_participants == 0 {
+            return Err("mpp: total_participants must be > 0");
+        }
+        if self.region_total != region_total {
+            return Err("mpp: DSM region_total in header disagrees with attached size");
+        }
+        match self.plan_offset.checked_add(self.plan_len) {
+            None => return Err("mpp: plan_offset + plan_len overflows"),
+            Some(end) if end > self.mesh_offset => {
+                return Err("mpp: plan would overlap mesh");
+            }
+            _ => {}
+        }
+        if self.mesh_offset > region_total {
+            return Err("mpp: mesh_offset past end of region");
+        }
+        Ok(())
+    }
+}
+
+/// Absolute maximum DSM region an MPP query will allocate. 16 GiB is two
+/// orders of magnitude beyond any realistic workload (reference attempt used
+/// 8 MB per queue × 12 edges = 96 MB at N=4). The cap makes `compute_dsm_layout`
+/// fail early on a pathologically oversized request instead of asking PG to
+/// allocate ~`usize::MAX` bytes.
+pub const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
+
+/// Pure-math helper: compute the total DSM bytes needed for an MPP region
+/// carrying `plan_len` plan bytes and `num_meshes` independent meshes that
+/// each share the same [`MeshLayout`].
+///
+/// Layout: `header | pad | plan | pad | mesh_0 | mesh_1 | … | mesh_{N-1}`.
+///
+/// All meshes share `aligned_queue_bytes` so per-mesh offsets are derivable
+/// from `(mesh_offset, aligned_queue_bytes, total_participants)` without a
+/// sidecar offset table — see [`MppDsmHeader::mesh_base_offset`].
+///
+/// Fails (instead of panicking or silently overflowing) on any arithmetic
+/// overflow and on regions exceeding [`MPP_DSM_MAX_BYTES`]. The caller is
+/// expected to `ereport(ERROR)` with the returned string.
+pub fn compute_dsm_layout(
+    layout: &MeshLayout,
+    num_meshes: u32,
+    plan_len: usize,
+) -> Result<DsmLayout, &'static str> {
+    if layout.total_participants == 0 {
+        return Err("mpp: total_participants must be > 0");
+    }
+    if num_meshes == 0 {
+        return Err("mpp: num_meshes must be > 0");
+    }
+    let header_size = size_of::<MppDsmHeader>();
+    let after_header =
+        align_up_maxalign_checked(header_size).ok_or("mpp: header alignment overflowed usize")?;
+    let plan_offset = after_header;
+    let plan_end = plan_offset
+        .checked_add(plan_len)
+        .ok_or("mpp: plan_offset + plan_len overflowed usize")?;
+    let after_plan =
+        align_up_maxalign_checked(plan_end).ok_or("mpp: plan alignment overflowed usize")?;
+    let mesh_offset = after_plan;
+    let per_mesh_bytes = layout
+        .dsm_queue_bytes_checked()
+        .ok_or("mpp: mesh queue bytes overflowed usize")?;
+    let mesh_bytes = per_mesh_bytes
+        .checked_mul(num_meshes as usize)
+        .ok_or("mpp: total mesh bytes overflowed usize")?;
+    let total = mesh_offset
+        .checked_add(mesh_bytes)
+        .ok_or("mpp: region total overflowed usize")?;
+    if total > MPP_DSM_MAX_BYTES {
+        return Err("mpp: DSM region exceeds MPP_DSM_MAX_BYTES");
+    }
+    Ok(DsmLayout {
+        total,
+        plan_offset,
+        plan_len,
+        mesh_offset,
+        mesh_bytes,
+        num_meshes,
+    })
+}
+
+/// Result of [`compute_dsm_layout`]. All offsets are byte offsets from the
+/// DSM region base pointer.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DsmLayout {
+    pub total: usize,
+    pub plan_offset: usize,
+    pub plan_len: usize,
+    /// Offset to mesh 0's queue array. Mesh `i` starts at
+    /// `mesh_offset + i * (num_edges(N) * aligned_queue_bytes)`.
+    pub mesh_offset: usize,
+    /// Total bytes for all meshes combined (sum of per-mesh queue arrays).
+    pub mesh_bytes: usize,
+    /// Number of independent meshes packed into this region.
+    pub num_meshes: u32,
+}
+
+/// MAXALIGN_UP: round `n` up to the nearest multiple of `MAXIMUM_ALIGNOF`.
+/// Overflow-checked variant — returns `None` if the alignment would push `n`
+/// past `usize::MAX`. `compute_dsm_layout` uses this so pathological
+/// `plan_len == usize::MAX` fails cleanly instead of wrapping.
+#[inline]
+fn align_up_maxalign_checked(n: usize) -> Option<usize> {
+    const MA: usize = pgrx::pg_sys::MAXIMUM_ALIGNOF as usize;
+    let rem = n % MA;
+    if rem == 0 {
+        return Some(n);
+    }
+    n.checked_add(MA - rem)
+}
+
+// ----------------------------------------------------------------------------
+// PG-facing DSM init / attach. These functions perform raw pg_sys FFI and
+// require a live Postgres backend — they compile on their own but are only
+// testable via `#[pg_test]`. Phase 4 wires them into the custom scan's
+// `estimate_dsm_custom_scan` / `initialize_dsm_custom_scan` /
+// `initialize_worker_custom_scan` hooks.
+// ----------------------------------------------------------------------------
+
+/// Address of the shm_mq region for directed edge `src -> dst` in mesh
+/// `mesh_idx` inside an MPP DSM region whose base pointer is `base`.
+///
+/// # Safety
+/// - `base` must be the DSM region base that `header` was read from.
+/// - `header` must have passed `validate(region_total)`.
+/// - `mesh_idx` must be less than `header.num_meshes`.
+/// - `src` and `dst` must be less than `header.total_participants` and not
+///   equal to each other.
+#[inline]
+pub unsafe fn edge_address(
+    base: *mut u8,
+    header: &MppDsmHeader,
+    mesh_idx: u32,
+    src: u32,
+    dst: u32,
+) -> *mut u8 {
+    use crate::postgres::customscan::mpp::mesh::edge_slot;
+    let slot = edge_slot(src, dst, header.total_participants);
+    let mesh_base = header.mesh_base_offset(mesh_idx) as usize;
+    let byte_offset = mesh_base + slot * (header.aligned_queue_bytes as usize);
+    unsafe { base.add(byte_offset) }
+}
+
+/// Leader-side: initialize a freshly-allocated MPP DSM region. Stamps the
+/// header, copies the plan bytes into place, and calls `shm_mq_create` for
+/// every directed edge in the mesh. Sets receiver for edges whose destination
+/// is the leader (seat 0); leader also attaches as sender for edges it
+/// produces (src == 0). Worker-to-worker edges are created but unclaimed —
+/// the destination worker claims them during `attach_dsm_as_worker`.
+///
+/// Returns the leader's outbound senders + inbound receivers (indexed by
+/// peer seat; self slot is `None`).
+///
+/// # Safety
+/// - `base` must point to a DSM region of at least `dsm.total` bytes.
+/// - Caller must not have `shm_mq_create`'d any of the mesh slots already.
+/// - Callable only from the leader backend thread, since it sets
+///   sender/receiver procs to `MyProc`.
+pub unsafe fn initialize_dsm_as_leader(
+    base: *mut u8,
+    dsm: &DsmLayout,
+    mesh: &MeshLayout,
+    plan_bytes: &[u8],
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<Vec<LeaderMesh>, &'static str> {
+    if plan_bytes.len() != dsm.plan_len {
+        return Err("mpp: plan_bytes length disagrees with DsmLayout.plan_len");
+    }
+
+    let header = MppDsmHeader::from_layout(mesh, dsm);
+    unsafe {
+        std::ptr::write(base as *mut MppDsmHeader, header);
+        std::ptr::copy_nonoverlapping(plan_bytes.as_ptr(), base.add(dsm.plan_offset), dsm.plan_len);
+    }
+
+    let n = mesh.total_participants;
+    let slot_size = mesh.aligned_queue_bytes();
+    let mut meshes: Vec<LeaderMesh> = Vec::with_capacity(dsm.num_meshes as usize);
+
+    for mesh_idx in 0..dsm.num_meshes {
+        let mut outbound: Vec<Option<MppSender>> = (0..n).map(|_| None).collect();
+        let mut inbound: Vec<Option<MppReceiver>> = (0..n).map(|_| None).collect();
+
+        for src in 0..n {
+            for dst in 0..n {
+                if src == dst {
+                    continue;
+                }
+                let addr = unsafe { edge_address(base, &header, mesh_idx, src, dst) };
+                let mq = unsafe { pg_sys::shm_mq_create(addr as *mut _, slot_size) };
+                if dst == 0 {
+                    let receiver = unsafe { ShmMqReceiver::attach_existing(seg, mq) };
+                    inbound[src as usize] = Some(MppReceiver::new(Box::new(receiver)));
+                } else if src == 0 {
+                    let sender = unsafe { ShmMqSender::attach(seg, mq) };
+                    outbound[dst as usize] = Some(MppSender::new(Box::new(sender)));
+                }
+                // Worker-to-worker edges: created in DSM, claimed later by their
+                // destination worker in `attach_dsm_as_worker`.
+            }
+        }
+
+        meshes.push(LeaderMesh { outbound, inbound });
+    }
+
+    Ok(meshes)
+}
+
+/// Leader's mesh wiring after `initialize_dsm_as_leader`. `outbound[0]` and
+/// `inbound[0]` are always `None` (self).
+pub struct LeaderMesh {
+    pub outbound: Vec<Option<MppSender>>,
+    pub inbound: Vec<Option<MppReceiver>>,
+}
+
+/// Worker-side: attach to an already-initialized MPP DSM region.
+///
+/// # Safety
+/// - `base` must point to a DSM region of at least `region_total` bytes,
+///   initialized by a leader via `initialize_dsm_as_leader` and still
+///   attached to this process.
+/// - `participant_index` must be the seat the calling worker occupies
+///   (typically `ParallelWorkerNumber + 1` since leader is seat 0).
+/// - Callable only from the worker backend thread, since it sets receiver /
+///   sender procs to `MyProc`.
+pub unsafe fn attach_dsm_as_worker(
+    base: *mut u8,
+    region_total: u64,
+    participant_index: u32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<WorkerAttach, &'static str> {
+    let header = unsafe { std::ptr::read_unaligned(base as *const MppDsmHeader) };
+    header.validate(region_total)?;
+
+    if participant_index >= header.total_participants {
+        return Err("mpp: participant_index out of range");
+    }
+    if participant_index == 0 {
+        return Err("mpp: attach_dsm_as_worker called for leader seat");
+    }
+
+    let n = header.total_participants;
+    let mut meshes: Vec<WorkerMesh> = Vec::with_capacity(header.num_meshes as usize);
+
+    for mesh_idx in 0..header.num_meshes {
+        let mut outbound: Vec<Option<MppSender>> = (0..n).map(|_| None).collect();
+        let mut inbound: Vec<Option<MppReceiver>> = (0..n).map(|_| None).collect();
+
+        for src in 0..n {
+            for dst in 0..n {
+                if src == dst {
+                    continue;
+                }
+                let addr = unsafe { edge_address(base, &header, mesh_idx, src, dst) };
+                let mq = addr as *mut pg_sys::shm_mq;
+                if dst == participant_index {
+                    let receiver = unsafe { ShmMqReceiver::attach_existing(seg, mq) };
+                    inbound[src as usize] = Some(MppReceiver::new(Box::new(receiver)));
+                } else if src == participant_index {
+                    let sender = unsafe { ShmMqSender::attach(seg, mq) };
+                    outbound[dst as usize] = Some(MppSender::new(Box::new(sender)));
+                }
+            }
+        }
+
+        meshes.push(WorkerMesh { outbound, inbound });
+    }
+
+    let plan_bytes_ptr = unsafe { base.add(header.plan_offset as usize) };
+    let plan_bytes_len = header.plan_len as usize;
+
+    Ok(WorkerAttach {
+        meshes,
+        plan_bytes_ptr,
+        plan_bytes_len,
+        participant_index,
+        total_participants: header.total_participants,
+    })
+}
+
+/// Worker's per-mesh wiring entry.
+pub struct WorkerMesh {
+    pub outbound: Vec<Option<MppSender>>,
+    pub inbound: Vec<Option<MppReceiver>>,
+}
+
+/// Worker's full attach result, including one entry per mesh plus the pointer
+/// to the plan bytes.
+pub struct WorkerAttach {
+    pub meshes: Vec<WorkerMesh>,
+    /// Raw pointer to the plan bytes inside DSM. The worker must read these
+    /// before detaching. Plans are write-once by the leader, so no
+    /// synchronization is required for this read.
+    pub plan_bytes_ptr: *const u8,
+    pub plan_bytes_len: usize,
+    pub participant_index: u32,
+    pub total_participants: u32,
+}
+
+impl WorkerAttach {
+    /// Copy the plan bytes out of DSM into an owned `Vec`. `bincode::decode`
+    /// takes `&[u8]`; holding a borrow into DSM across later FFI would be a
+    /// footgun. Call exactly once per worker on startup.
+    ///
+    /// # Safety
+    /// Must be called while the DSM region is still attached to this process.
+    pub unsafe fn copy_plan_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(self.plan_bytes_len);
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                self.plan_bytes_ptr,
+                out.as_mut_ptr(),
+                self.plan_bytes_len,
+            );
+            out.set_len(self.plan_bytes_len);
+        }
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_header() -> (MeshLayout, DsmLayout, MppDsmHeader) {
+        let mesh = MeshLayout::new(4, 8 * 1024);
+        let dsm = compute_dsm_layout(&mesh, 1, 1024).unwrap();
+        let header = MppDsmHeader::from_layout(&mesh, &dsm);
+        (mesh, dsm, header)
+    }
+
+    #[test]
+    fn header_accepts_valid_layout() {
+        let (_, dsm, h) = sample_header();
+        h.validate(dsm.total as u64).unwrap();
+        assert_eq!(h.total_participants, 4);
+        assert_eq!(h.build_hash, MPP_BUILD_HASH);
+    }
+
+    #[test]
+    fn header_validate_rejects_bad_magic() {
+        let (_, dsm, mut h) = sample_header();
+        h.magic = 0xdead_beef;
+        assert!(h.validate(dsm.total as u64).is_err());
+    }
+
+    #[test]
+    fn header_validate_rejects_bad_version() {
+        let (_, dsm, mut h) = sample_header();
+        h.header_version = MPP_DSM_HEADER_VERSION.wrapping_add(1);
+        assert!(h.validate(dsm.total as u64).is_err());
+    }
+
+    #[test]
+    fn header_validate_rejects_bad_build_hash() {
+        let (_, dsm, mut h) = sample_header();
+        h.build_hash = MPP_BUILD_HASH.wrapping_add(1);
+        let err = h.validate(dsm.total as u64).unwrap_err();
+        assert!(err.contains("build-hash"));
+    }
+
+    #[test]
+    fn header_validate_rejects_zero_participants() {
+        let (_, dsm, mut h) = sample_header();
+        h.total_participants = 0;
+        assert!(h.validate(dsm.total as u64).is_err());
+    }
+
+    #[test]
+    fn header_validate_rejects_region_size_mismatch() {
+        let (_, dsm, h) = sample_header();
+        // Attached region is smaller than header claims.
+        assert!(h.validate((dsm.total - 1) as u64).is_err());
+    }
+
+    #[test]
+    fn header_validate_rejects_plan_overlapping_mesh() {
+        let (_, dsm, mut h) = sample_header();
+        h.plan_len = (dsm.mesh_offset - dsm.plan_offset + 1) as u64;
+        // Note: region_total still matches, so only the overlap check fires.
+        let err = h.validate(dsm.total as u64).unwrap_err();
+        assert!(err.contains("overlap mesh") || err.contains("overflows"));
+    }
+
+    #[test]
+    fn compute_dsm_layout_is_consistent() {
+        let layout = MeshLayout::new(4, 64 * 1024);
+        let plan_len = 12_345;
+        let dsm = compute_dsm_layout(&layout, 1, plan_len).unwrap();
+        assert!(dsm.plan_offset >= size_of::<MppDsmHeader>());
+        assert_eq!(dsm.plan_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
+        assert!(dsm.mesh_offset >= dsm.plan_offset + plan_len);
+        assert_eq!(dsm.mesh_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
+        assert_eq!(dsm.mesh_bytes, layout.dsm_queue_bytes());
+        assert_eq!(dsm.total, dsm.mesh_offset + dsm.mesh_bytes);
+        assert_eq!(dsm.plan_len, plan_len);
+        assert_eq!(dsm.num_meshes, 1);
+    }
+
+    #[test]
+    fn compute_dsm_layout_scales_with_num_meshes() {
+        let layout = MeshLayout::new(4, 64 * 1024);
+        let one = compute_dsm_layout(&layout, 1, 0).unwrap();
+        let three = compute_dsm_layout(&layout, 3, 0).unwrap();
+        assert_eq!(three.mesh_bytes, 3 * layout.dsm_queue_bytes());
+        assert_eq!(three.mesh_offset, one.mesh_offset);
+        assert_eq!(three.total - one.total, 2 * layout.dsm_queue_bytes());
+        assert_eq!(three.num_meshes, 3);
+
+        let header = MppDsmHeader::from_layout(&layout, &three);
+        // mesh_base_offset(0) is mesh_offset; mesh_base_offset(i) bumps by
+        // num_edges * aligned_queue_bytes per index.
+        assert_eq!(header.mesh_base_offset(0), header.mesh_offset);
+        let per_mesh = (4u64 * 3) * header.aligned_queue_bytes;
+        assert_eq!(header.mesh_base_offset(1), header.mesh_offset + per_mesh);
+        assert_eq!(
+            header.mesh_base_offset(2),
+            header.mesh_offset + 2 * per_mesh
+        );
+    }
+
+    #[test]
+    fn compute_dsm_layout_handles_zero_plan() {
+        let layout = MeshLayout::new(2, 8 * 1024);
+        let dsm = compute_dsm_layout(&layout, 1, 0).unwrap();
+        assert_eq!(dsm.plan_len, 0);
+        assert_eq!(dsm.mesh_offset, dsm.plan_offset);
+        assert_eq!(
+            dsm.mesh_bytes,
+            2 * crate::postgres::customscan::mpp::mesh::aligned_queue_bytes(8 * 1024)
+        );
+    }
+
+    #[test]
+    fn compute_dsm_layout_rejects_zero_participants() {
+        let layout = MeshLayout::new(0, 8 * 1024);
+        assert!(compute_dsm_layout(&layout, 1, 0).is_err());
+    }
+
+    #[test]
+    fn compute_dsm_layout_rejects_zero_meshes() {
+        let layout = MeshLayout::new(2, 8 * 1024);
+        assert!(compute_dsm_layout(&layout, 0, 0).is_err());
+    }
+
+    #[test]
+    fn compute_dsm_layout_rejects_overflow() {
+        let layout = MeshLayout::new(2, 8 * 1024);
+        assert!(compute_dsm_layout(&layout, 1, usize::MAX).is_err());
+    }
+
+    #[test]
+    fn compute_dsm_layout_rejects_oversized_region() {
+        // N=1000 with 16 MB queues = ~16 TB. Far past the cap.
+        let layout = MeshLayout::new(1000, 16 * 1024 * 1024);
+        assert!(compute_dsm_layout(&layout, 1, 0).is_err());
+    }
+
+    #[test]
+    fn align_up_maxalign_rounds_correctly() {
+        let ma = pgrx::pg_sys::MAXIMUM_ALIGNOF as usize;
+        assert_eq!(align_up_maxalign_checked(0), Some(0));
+        assert_eq!(align_up_maxalign_checked(1), Some(ma));
+        assert_eq!(align_up_maxalign_checked(ma), Some(ma));
+        assert_eq!(align_up_maxalign_checked(ma + 1), Some(2 * ma));
+        assert_eq!(align_up_maxalign_checked(2 * ma - 1), Some(2 * ma));
+        // Overflow edge case
+        assert_eq!(align_up_maxalign_checked(usize::MAX), None);
+    }
+
+    #[test]
+    fn header_round_trips_through_c_repr_copy() {
+        // Simulate what the leader/worker actually do: write header bytes
+        // into a byte buffer, then read them back via pointer cast. Uses
+        // `read_unaligned` because `Vec<u8>` allocations are only guaranteed
+        // to be byte-aligned; in production the DSM base pointer is
+        // MAXALIGN-aligned by PG, but exercising read_unaligned here keeps
+        // Miri and strict-provenance targets happy.
+        let (_, dsm, original) = sample_header();
+
+        let mut buf = vec![0u8; size_of::<MppDsmHeader>() * 2];
+        unsafe {
+            std::ptr::copy_nonoverlapping(
+                &original as *const MppDsmHeader as *const u8,
+                buf.as_mut_ptr(),
+                size_of::<MppDsmHeader>(),
+            );
+        }
+        let read_back = unsafe { std::ptr::read_unaligned(buf.as_ptr() as *const MppDsmHeader) };
+        read_back.validate(dsm.total as u64).unwrap();
+        assert_eq!(read_back.magic, MPP_DSM_MAGIC);
+        assert_eq!(read_back.build_hash, MPP_BUILD_HASH);
+        assert_eq!(read_back.total_participants, original.total_participants);
+        assert_eq!(read_back.plan_offset, original.plan_offset);
+        assert_eq!(read_back.plan_len, original.plan_len);
+        assert_eq!(read_back.mesh_offset, original.mesh_offset);
+        assert_eq!(read_back.region_total, original.region_total);
+    }
+
+    #[test]
+    fn fnv1a_matches_spec_basis() {
+        // FNV-1a-64 of the empty input must be the spec's offset basis
+        // (0xcbf2_9ce4_8422_2325). Pins the algorithm so a refactor
+        // swapping prime/basis silently can't land.
+        assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
+    }
+
+    #[test]
+    fn fnv1a_is_deterministic_and_differentiating() {
+        assert_eq!(fnv1a_64(b"1.0.0"), fnv1a_64(b"1.0.0"));
+        assert_ne!(fnv1a_64(b"1.0.0"), fnv1a_64(b"1.0.1"));
+        assert_ne!(fnv1a_64(b""), fnv1a_64(b"x"));
+    }
+
+    #[test]
+    fn header_size_has_no_padding() {
+        // Four u32 (16) + six u64 (48) = 64 bytes with no padding on any
+        // supported target. If this ever breaks, either fields were
+        // reordered or a new mixed-width field was added —
+        // bump MPP_DSM_HEADER_VERSION before landing.
+        assert_eq!(size_of::<MppDsmHeader>(), 64);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -451,8 +451,6 @@ pub unsafe fn attach_dsm_as_worker(
         meshes,
         plan_bytes_ptr,
         plan_bytes_len,
-        participant_index,
-        total_participants: header.total_participants,
     })
 }
 
@@ -471,8 +469,6 @@ pub struct WorkerAttach {
     /// synchronization is required for this read.
     pub plan_bytes_ptr: *const u8,
     pub plan_bytes_len: usize,
-    pub participant_index: u32,
-    pub total_participants: u32,
 }
 
 impl WorkerAttach {

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -39,12 +39,12 @@
 //!
 //! This module deliberately does NOT wrap `pg_sys::shm_mq_create` /
 //! `shm_mq_attach`; those calls are driven by the custom scan's
-//! `initialize_dsm_custom_scan` / `initialize_worker_custom_scan` callbacks in
-//! Phase 4, feeding back into [`ShmMqSender`](super::mesh::ShmMqSender) and
+//! `initialize_dsm_custom_scan` / `initialize_worker_custom_scan` callbacks,
+//! feeding back into [`ShmMqSender`](super::mesh::ShmMqSender) and
 //! [`ShmMqReceiver`](super::mesh::ShmMqReceiver). Here we only own the
 //! sizing/offset math and the header layout.
 
-#![allow(dead_code)] // caller lands in Phase 4
+#![allow(dead_code)]
 
 use crate::postgres::customscan::mpp::mesh::{MeshLayout, ShmMqReceiver, ShmMqSender};
 use crate::postgres::customscan::mpp::transport::{MppReceiver, MppSender};
@@ -290,7 +290,7 @@ fn align_up_maxalign_checked(n: usize) -> Option<usize> {
 // ----------------------------------------------------------------------------
 // PG-facing DSM init / attach. These functions perform raw pg_sys FFI and
 // require a live Postgres backend — they compile on their own but are only
-// testable via `#[pg_test]`. Phase 4 wires them into the custom scan's
+// testable via `#[pg_test]`. The custom scan wires them into its
 // `estimate_dsm_custom_scan` / `initialize_dsm_custom_scan` /
 // `initialize_worker_custom_scan` hooks.
 // ----------------------------------------------------------------------------

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -569,7 +569,7 @@ mod tests {
         assert_eq!(dsm.plan_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
         assert!(dsm.mesh_offset >= dsm.plan_offset + plan_len);
         assert_eq!(dsm.mesh_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
-        assert_eq!(dsm.mesh_bytes, layout.dsm_queue_bytes());
+        assert_eq!(dsm.mesh_bytes, layout.dsm_queue_bytes_checked().unwrap());
         assert_eq!(dsm.total, dsm.mesh_offset + dsm.mesh_bytes);
         assert_eq!(dsm.plan_len, plan_len);
         assert_eq!(dsm.num_meshes, 1);
@@ -580,9 +580,10 @@ mod tests {
         let layout = MeshLayout::new(4, 64 * 1024);
         let one = compute_dsm_layout(&layout, 1, 0).unwrap();
         let three = compute_dsm_layout(&layout, 3, 0).unwrap();
-        assert_eq!(three.mesh_bytes, 3 * layout.dsm_queue_bytes());
+        let queue_bytes = layout.dsm_queue_bytes_checked().unwrap();
+        assert_eq!(three.mesh_bytes, 3 * queue_bytes);
         assert_eq!(three.mesh_offset, one.mesh_offset);
-        assert_eq!(three.total - one.total, 2 * layout.dsm_queue_bytes());
+        assert_eq!(three.total - one.total, 2 * queue_bytes);
         assert_eq!(three.num_meshes, 3);
 
         let header = MppDsmHeader::from_layout(&layout, &three);

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -322,12 +322,12 @@ pub unsafe fn edge_address(
 /// Leader-side: initialize a freshly-allocated MPP DSM region. Stamps the
 /// header, copies the plan bytes into place, and calls `shm_mq_create` for
 /// every directed edge in the mesh. Sets receiver for edges whose destination
-/// is the leader (seat 0); leader also attaches as sender for edges it
+/// is the leader (participant 0); leader also attaches as sender for edges it
 /// produces (src == 0). Worker-to-worker edges are created but unclaimed —
 /// the destination worker claims them during `attach_dsm_as_worker`.
 ///
 /// Returns the leader's outbound senders + inbound receivers (indexed by
-/// peer seat; self slot is `None`).
+/// peer participant; self slot is `None`).
 ///
 /// # Safety
 /// - `base` must point to a DSM region of at least `dsm.total` bytes.
@@ -397,8 +397,8 @@ pub struct LeaderMesh {
 /// - `base` must point to a DSM region of at least `region_total` bytes,
 ///   initialized by a leader via `initialize_dsm_as_leader` and still
 ///   attached to this process.
-/// - `participant_index` must be the seat the calling worker occupies
-///   (typically `ParallelWorkerNumber + 1` since leader is seat 0).
+/// - `participant_index` must be the index the calling worker occupies
+///   (typically `ParallelWorkerNumber + 1` since leader is participant 0).
 /// - Callable only from the worker backend thread, since it sets receiver /
 ///   sender procs to `MyProc`.
 pub unsafe fn attach_dsm_as_worker(
@@ -414,7 +414,7 @@ pub unsafe fn attach_dsm_as_worker(
         return Err("mpp: participant_index out of range");
     }
     if participant_index == 0 {
-        return Err("mpp: attach_dsm_as_worker called for leader seat");
+        return Err("mpp: attach_dsm_as_worker called for leader participant");
     }
 
     let n = header.total_participants;

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -305,7 +305,7 @@ fn align_up_maxalign_checked(n: usize) -> Option<usize> {
 /// - `src` and `dst` must be less than `header.total_participants` and not
 ///   equal to each other.
 #[inline]
-pub unsafe fn edge_address(
+unsafe fn edge_address(
     base: *mut u8,
     header: &MppDsmHeader,
     mesh_idx: u32,

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -46,7 +46,7 @@
 
 #![allow(dead_code)]
 
-use crate::postgres::customscan::mpp::mesh::{MeshLayout, ShmMqReceiver, ShmMqSender};
+use crate::postgres::customscan::mpp::mesh::{edge_slot, MeshLayout, ShmMqReceiver, ShmMqSender};
 use crate::postgres::customscan::mpp::transport::{MppReceiver, MppSender};
 use pgrx::pg_sys;
 use std::mem::size_of;
@@ -312,7 +312,6 @@ pub unsafe fn edge_address(
     src: u32,
     dst: u32,
 ) -> *mut u8 {
-    use crate::postgres::customscan::mpp::mesh::edge_slot;
     let slot = edge_slot(src, dst, header.total_participants);
     let mesh_base = header.mesh_base_offset(mesh_idx) as usize;
     let byte_offset = mesh_base + slot * (header.aligned_queue_bytes as usize);
@@ -495,6 +494,7 @@ impl WorkerAttach {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::postgres::customscan::mpp::mesh::aligned_queue_bytes;
 
     fn sample_header() -> (MeshLayout, DsmLayout, MppDsmHeader) {
         let mesh = MeshLayout::new(4, 8 * 1024);
@@ -600,10 +600,7 @@ mod tests {
         let dsm = compute_dsm_layout(&layout, 1, 0).unwrap();
         assert_eq!(dsm.plan_len, 0);
         assert_eq!(dsm.mesh_offset, dsm.plan_offset);
-        assert_eq!(
-            dsm.mesh_bytes,
-            2 * crate::postgres::customscan::mpp::mesh::aligned_queue_bytes(8 * 1024)
-        );
+        assert_eq!(dsm.mesh_bytes, 2 * aligned_queue_bytes(8 * 1024));
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -60,7 +60,7 @@ pub const MPP_DSM_MAGIC: u32 = 0x4D50_5053; // "MPPS" in ASCII
 /// Current on-DSM header version. Bumped when the header layout or
 /// interpretation changes. Independent of `MPP_PLAN_BROADCAST_VERSION`, which
 /// versions the embedded plan bytes.
-pub const MPP_DSM_HEADER_VERSION: u32 = 2;
+pub const MPP_DSM_HEADER_VERSION: u32 = 1;
 
 /// C-repr header stamped at offset 0 of the MPP DSM region.
 ///

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -60,31 +60,12 @@ pub const MPP_DSM_MAGIC: u32 = 0x4D50_5053; // "MPPS" in ASCII
 /// Current on-DSM header version. Bumped when the header layout or
 /// interpretation changes. Independent of `MPP_PLAN_BROADCAST_VERSION`, which
 /// versions the embedded plan bytes.
-pub const MPP_DSM_HEADER_VERSION: u32 = 1;
-
-/// Compile-time build hash: a 64-bit FNV-1a over the crate version string. On
-/// a cluster where the leader and its workers all load the same pg_search .so,
-/// this is identical across participants by construction. Its purpose is to
-/// catch the exotic case of a newer leader somehow ending up paired with an
-/// older worker image (rolling reload, stale postmaster). Cheap to add now,
-/// annoying to retrofit after workers are attaching.
-pub const MPP_BUILD_HASH: u64 = fnv1a_64(env!("CARGO_PKG_VERSION").as_bytes());
-
-const fn fnv1a_64(bytes: &[u8]) -> u64 {
-    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
-    let mut i = 0;
-    while i < bytes.len() {
-        hash ^= bytes[i] as u64;
-        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
-        i += 1;
-    }
-    hash
-}
+pub const MPP_DSM_HEADER_VERSION: u32 = 2;
 
 /// C-repr header stamped at offset 0 of the MPP DSM region.
 ///
 /// Field ordering is fixed: four `u32`s (16 bytes, naturally aligned), then
-/// six `u64`s (48 bytes, naturally aligned). Total size = 64 bytes, **no
+/// five `u64`s (40 bytes, naturally aligned). Total size = 56 bytes, **no
 /// internal padding**, on every supported target (x86_64 / aarch64 / Linux /
 /// macOS / Windows). Workers read individual fields by name, not by offset,
 /// but the no-padding guarantee means the whole struct can be memcpy'd
@@ -108,10 +89,6 @@ pub struct MppDsmHeader {
     /// All meshes share the same `aligned_queue_bytes`, so per-mesh offsets
     /// are derivable without a separate offset table.
     pub num_meshes: u32,
-    /// Compile-time FNV-1a over `CARGO_PKG_VERSION`. Workers reject
-    /// mismatches to catch the rolling-reload / postmaster-restart edge
-    /// case where a newer leader ends up paired with a stale worker image.
-    pub build_hash: u64,
     /// Per-edge shm_mq slot size in bytes (MAXALIGN_DOWN of the user
     /// request). Shared by every mesh; a future extension for heterogeneous
     /// queue sizes would need a per-mesh sidecar and a header-version bump.
@@ -142,7 +119,6 @@ impl MppDsmHeader {
             header_version: MPP_DSM_HEADER_VERSION,
             total_participants: mesh.total_participants,
             num_meshes: dsm.num_meshes,
-            build_hash: MPP_BUILD_HASH,
             aligned_queue_bytes: mesh.aligned_queue_bytes() as u64,
             plan_offset: dsm.plan_offset as u64,
             plan_len: dsm.plan_len as u64,
@@ -162,17 +138,14 @@ impl MppDsmHeader {
     /// Validate a header read out of DSM. `region_total` is the size of the
     /// DSM region the caller just attached to; the header's own offsets are
     /// bounds-checked against it so a corrupt header that still happens to
-    /// match magic + version + build hash cannot redirect the worker to read
-    /// arbitrary DSM memory.
+    /// match magic + version cannot redirect the worker to read arbitrary
+    /// DSM memory.
     pub fn validate(&self, region_total: u64) -> Result<(), &'static str> {
         if self.magic != MPP_DSM_MAGIC {
             return Err("mpp: DSM header magic mismatch");
         }
         if self.header_version != MPP_DSM_HEADER_VERSION {
             return Err("mpp: DSM header version mismatch");
-        }
-        if self.build_hash != MPP_BUILD_HASH {
-            return Err("mpp: DSM build-hash mismatch (leader/worker binary skew?)");
         }
         if self.total_participants == 0 {
             return Err("mpp: total_participants must be > 0");
@@ -508,7 +481,6 @@ mod tests {
         let (_, dsm, h) = sample_header();
         h.validate(dsm.total as u64).unwrap();
         assert_eq!(h.total_participants, 4);
-        assert_eq!(h.build_hash, MPP_BUILD_HASH);
     }
 
     #[test]
@@ -523,14 +495,6 @@ mod tests {
         let (_, dsm, mut h) = sample_header();
         h.header_version = MPP_DSM_HEADER_VERSION.wrapping_add(1);
         assert!(h.validate(dsm.total as u64).is_err());
-    }
-
-    #[test]
-    fn header_validate_rejects_bad_build_hash() {
-        let (_, dsm, mut h) = sample_header();
-        h.build_hash = MPP_BUILD_HASH.wrapping_add(1);
-        let err = h.validate(dsm.total as u64).unwrap_err();
-        assert!(err.contains("build-hash"));
     }
 
     #[test]
@@ -661,7 +625,6 @@ mod tests {
         let read_back = unsafe { std::ptr::read_unaligned(buf.as_ptr() as *const MppDsmHeader) };
         read_back.validate(dsm.total as u64).unwrap();
         assert_eq!(read_back.magic, MPP_DSM_MAGIC);
-        assert_eq!(read_back.build_hash, MPP_BUILD_HASH);
         assert_eq!(read_back.total_participants, original.total_participants);
         assert_eq!(read_back.plan_offset, original.plan_offset);
         assert_eq!(read_back.plan_len, original.plan_len);
@@ -670,26 +633,11 @@ mod tests {
     }
 
     #[test]
-    fn fnv1a_matches_spec_basis() {
-        // FNV-1a-64 of the empty input must be the spec's offset basis
-        // (0xcbf2_9ce4_8422_2325). Pins the algorithm so a refactor
-        // swapping prime/basis silently can't land.
-        assert_eq!(fnv1a_64(b""), 0xcbf2_9ce4_8422_2325);
-    }
-
-    #[test]
-    fn fnv1a_is_deterministic_and_differentiating() {
-        assert_eq!(fnv1a_64(b"1.0.0"), fnv1a_64(b"1.0.0"));
-        assert_ne!(fnv1a_64(b"1.0.0"), fnv1a_64(b"1.0.1"));
-        assert_ne!(fnv1a_64(b""), fnv1a_64(b"x"));
-    }
-
-    #[test]
     fn header_size_has_no_padding() {
-        // Four u32 (16) + six u64 (48) = 64 bytes with no padding on any
+        // Four u32 (16) + five u64 (40) = 56 bytes with no padding on any
         // supported target. If this ever breaks, either fields were
         // reordered or a new mixed-width field was added —
         // bump MPP_DSM_HEADER_VERSION before landing.
-        assert_eq!(size_of::<MppDsmHeader>(), 64);
+        assert_eq!(size_of::<MppDsmHeader>(), 56);
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -184,6 +184,16 @@ pub const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 /// from `(mesh_offset, aligned_queue_bytes, total_participants)` without a
 /// sidecar offset table — see [`MppDsmHeader::mesh_base_offset`].
 ///
+/// One mesh is allocated per planner cut (probe-side, post-agg, …), so the
+/// total DSM cost is `num_meshes × N×(N-1) × aligned_queue_bytes`. With the
+/// default `paradedb.mpp_queue_size = 64 MiB`, that's ~768 MiB at N=2 with
+/// 3 meshes and ~2.3 GiB at N=4 with 3 meshes. An alternative explored in
+/// the prototype at <https://github.com/paradedb/paradedb/pull/4184>
+/// multiplexes all logical streams over a single per-pair mesh; that
+/// trades per-mesh isolation for a single header-version bump and a
+/// stream-tag in the wire frame, and would make this scale linearly in
+/// participants instead of in (participants × cuts).
+///
 /// Fails (instead of panicking or silently overflowing) on any arithmetic
 /// overflow and on regions exceeding [`MPP_DSM_MAX_BYTES`]. The caller is
 /// expected to `ereport(ERROR)` with the returned string.

--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -1,0 +1,144 @@
+-- =====================================================================
+-- MPP smoke test: verify GUCs exist and accept sensible values.
+--
+-- This is the Phase 0 / 4b gate — if any of these SHOW/SET fails, either
+-- the extension didn't load or the MPP GUCs weren't registered in init().
+-- Nothing here exercises the actual MPP data path yet (that lands when
+-- AggregateScan's ParallelQueryCapable hooks are wired); this test locks
+-- in the GUC surface so a future accidental rename breaks loudly.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- GUCs must be visible after the extension loads.
+SHOW paradedb.enable_mpp;
+ paradedb.enable_mpp 
+---------------------
+ off
+(1 row)
+
+SHOW paradedb.mpp_debug;
+ paradedb.mpp_debug 
+--------------------
+ off
+(1 row)
+
+SHOW paradedb.mpp_worker_count;
+ paradedb.mpp_worker_count 
+---------------------------
+ 4
+(1 row)
+
+SHOW paradedb.mpp_drain_watermark_mb;
+ paradedb.mpp_drain_watermark_mb 
+---------------------------------
+ 256
+(1 row)
+
+-- Defaults: MPP is off until explicitly enabled.
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
+ enable_mpp_default_off 
+------------------------
+ f
+(1 row)
+
+SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;
+ mpp_debug_default_off 
+-----------------------
+ f
+(1 row)
+
+SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default;
+ worker_count_default 
+----------------------
+                    4
+(1 row)
+
+SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_default_mb;
+ watermark_default_mb 
+----------------------
+                  256
+(1 row)
+
+-- Toggle the boolean GUCs and verify they stick.
+SET paradedb.enable_mpp TO on;
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_after_set_on;
+ enable_mpp_after_set_on 
+-------------------------
+ t
+(1 row)
+
+SET paradedb.enable_mpp TO off;
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_after_set_off;
+ enable_mpp_after_set_off 
+--------------------------
+ f
+(1 row)
+
+SET paradedb.mpp_debug TO on;
+SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_after_set_on;
+ mpp_debug_after_set_on 
+------------------------
+ t
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+-- Worker count: accepts 1..64 per the GUC definition.
+SET paradedb.mpp_worker_count TO 2;
+SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_two;
+ worker_count_two 
+------------------
+                2
+(1 row)
+
+SET paradedb.mpp_worker_count TO 4;
+SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_four;
+ worker_count_four 
+-------------------
+                 4
+(1 row)
+
+-- Out-of-range worker count must fail (GUC min=1, max=64).
+DO $$
+BEGIN
+    BEGIN
+        PERFORM set_config('paradedb.mpp_worker_count', '0', true);
+        RAISE EXCEPTION 'expected worker_count=0 to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'worker_count=0 correctly rejected';
+    END;
+    BEGIN
+        PERFORM set_config('paradedb.mpp_worker_count', '65', true);
+        RAISE EXCEPTION 'expected worker_count=65 to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'worker_count=65 correctly rejected';
+    END;
+END$$;
+-- Drain watermark: 0 disables spill, values > 0 enable it.
+SET paradedb.mpp_drain_watermark_mb TO 0;
+SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_zero;
+ watermark_zero 
+----------------
+              0
+(1 row)
+
+SET paradedb.mpp_drain_watermark_mb TO 256;
+SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_256;
+ watermark_256 
+---------------
+           256
+(1 row)
+
+-- MPP GUCs must not affect non-MPP queries at all. Run a trivial query
+-- with mpp_debug on to confirm it's a no-op (no warnings except the
+-- expected ones) and results are correct.
+SET paradedb.mpp_debug TO on;
+SELECT 1 AS trivial_query_still_works;
+ trivial_query_still_works 
+---------------------------
+                         1
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_debug;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_drain_watermark_mb;

--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -27,12 +27,6 @@ SHOW paradedb.mpp_worker_count;
  4
 (1 row)
 
-SHOW paradedb.mpp_drain_watermark_mb;
- paradedb.mpp_drain_watermark_mb 
----------------------------------
- 256
-(1 row)
-
 -- Defaults: MPP is off until explicitly enabled.
 SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
  enable_mpp_default_off 
@@ -50,12 +44,6 @@ SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default
  worker_count_default 
 ----------------------
                     4
-(1 row)
-
-SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_default_mb;
- watermark_default_mb 
-----------------------
-                  256
 (1 row)
 
 -- Toggle the boolean GUCs and verify they stick.
@@ -112,21 +100,6 @@ BEGIN
         RAISE NOTICE 'worker_count=65 correctly rejected';
     END;
 END$$;
--- Drain watermark: 0 disables spill, values > 0 enable it.
-SET paradedb.mpp_drain_watermark_mb TO 0;
-SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_zero;
- watermark_zero 
-----------------
-              0
-(1 row)
-
-SET paradedb.mpp_drain_watermark_mb TO 256;
-SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_256;
- watermark_256 
----------------
-           256
-(1 row)
-
 -- MPP GUCs must not affect non-MPP queries at all. Run a trivial query
 -- with mpp_debug on to confirm it's a no-op (no warnings except the
 -- expected ones) and results are correct.
@@ -141,4 +114,3 @@ SET paradedb.mpp_debug TO off;
 RESET paradedb.enable_mpp;
 RESET paradedb.mpp_debug;
 RESET paradedb.mpp_worker_count;
-RESET paradedb.mpp_drain_watermark_mb;

--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -27,6 +27,12 @@ SHOW paradedb.mpp_worker_count;
  4
 (1 row)
 
+SHOW paradedb.mpp_queue_size;
+ paradedb.mpp_queue_size 
+-------------------------
+ 64MB
+(1 row)
+
 -- Defaults: MPP is off until explicitly enabled.
 SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
  enable_mpp_default_off 
@@ -44,6 +50,12 @@ SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default
  worker_count_default 
 ----------------------
                     4
+(1 row)
+
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_default;
+ queue_size_default 
+--------------------
+ 64MB
 (1 row)
 
 -- Toggle the boolean GUCs and verify they stick.
@@ -100,6 +112,44 @@ BEGIN
         RAISE NOTICE 'worker_count=65 correctly rejected';
     END;
 END$$;
+-- Queue size: accepts standard Postgres byte units (kB, MB, GB).
+SET paradedb.mpp_queue_size TO '32MB';
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_32mb;
+ queue_size_after_32mb 
+-----------------------
+ 32MB
+(1 row)
+
+SET paradedb.mpp_queue_size TO '1GB';
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_1gb;
+ queue_size_after_1gb 
+----------------------
+ 1GB
+(1 row)
+
+SET paradedb.mpp_queue_size TO '64MB';
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_back_to_default;
+ queue_size_back_to_default 
+----------------------------
+ 64MB
+(1 row)
+
+-- Out-of-range queue size must fail (GUC min=64kB, max=1GB).
+DO $$
+BEGIN
+    BEGIN
+        PERFORM set_config('paradedb.mpp_queue_size', '4kB', true);
+        RAISE EXCEPTION 'expected mpp_queue_size=4kB to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'mpp_queue_size=4kB correctly rejected';
+    END;
+    BEGIN
+        PERFORM set_config('paradedb.mpp_queue_size', '2GB', true);
+        RAISE EXCEPTION 'expected mpp_queue_size=2GB to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'mpp_queue_size=2GB correctly rejected';
+    END;
+END$$;
 -- MPP GUCs must not affect non-MPP queries at all. Run a trivial query
 -- with mpp_debug on to confirm it's a no-op (no warnings except the
 -- expected ones) and results are correct.
@@ -114,3 +164,4 @@ SET paradedb.mpp_debug TO off;
 RESET paradedb.enable_mpp;
 RESET paradedb.mpp_debug;
 RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_queue_size;

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -1,0 +1,74 @@
+-- =====================================================================
+-- MPP smoke test: verify GUCs exist and accept sensible values.
+--
+-- This is the Phase 0 / 4b gate — if any of these SHOW/SET fails, either
+-- the extension didn't load or the MPP GUCs weren't registered in init().
+-- Nothing here exercises the actual MPP data path yet (that lands when
+-- AggregateScan's ParallelQueryCapable hooks are wired); this test locks
+-- in the GUC surface so a future accidental rename breaks loudly.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+-- GUCs must be visible after the extension loads.
+SHOW paradedb.enable_mpp;
+SHOW paradedb.mpp_debug;
+SHOW paradedb.mpp_worker_count;
+SHOW paradedb.mpp_drain_watermark_mb;
+
+-- Defaults: MPP is off until explicitly enabled.
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
+SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;
+SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default;
+SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_default_mb;
+
+-- Toggle the boolean GUCs and verify they stick.
+SET paradedb.enable_mpp TO on;
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_after_set_on;
+SET paradedb.enable_mpp TO off;
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_after_set_off;
+
+SET paradedb.mpp_debug TO on;
+SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_after_set_on;
+SET paradedb.mpp_debug TO off;
+
+-- Worker count: accepts 1..64 per the GUC definition.
+SET paradedb.mpp_worker_count TO 2;
+SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_two;
+SET paradedb.mpp_worker_count TO 4;
+SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_four;
+
+-- Out-of-range worker count must fail (GUC min=1, max=64).
+DO $$
+BEGIN
+    BEGIN
+        PERFORM set_config('paradedb.mpp_worker_count', '0', true);
+        RAISE EXCEPTION 'expected worker_count=0 to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'worker_count=0 correctly rejected';
+    END;
+    BEGIN
+        PERFORM set_config('paradedb.mpp_worker_count', '65', true);
+        RAISE EXCEPTION 'expected worker_count=65 to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'worker_count=65 correctly rejected';
+    END;
+END$$;
+
+-- Drain watermark: 0 disables spill, values > 0 enable it.
+SET paradedb.mpp_drain_watermark_mb TO 0;
+SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_zero;
+SET paradedb.mpp_drain_watermark_mb TO 256;
+SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_256;
+
+-- MPP GUCs must not affect non-MPP queries at all. Run a trivial query
+-- with mpp_debug on to confirm it's a no-op (no warnings except the
+-- expected ones) and results are correct.
+SET paradedb.mpp_debug TO on;
+SELECT 1 AS trivial_query_still_works;
+SET paradedb.mpp_debug TO off;
+
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_debug;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_drain_watermark_mb;

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -14,11 +14,13 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SHOW paradedb.enable_mpp;
 SHOW paradedb.mpp_debug;
 SHOW paradedb.mpp_worker_count;
+SHOW paradedb.mpp_queue_size;
 
 -- Defaults: MPP is off until explicitly enabled.
 SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
 SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;
 SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default;
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_default;
 
 -- Toggle the boolean GUCs and verify they stick.
 SET paradedb.enable_mpp TO on;
@@ -53,6 +55,31 @@ BEGIN
     END;
 END$$;
 
+-- Queue size: accepts standard Postgres byte units (kB, MB, GB).
+SET paradedb.mpp_queue_size TO '32MB';
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_32mb;
+SET paradedb.mpp_queue_size TO '1GB';
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_1gb;
+SET paradedb.mpp_queue_size TO '64MB';
+SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_back_to_default;
+
+-- Out-of-range queue size must fail (GUC min=64kB, max=1GB).
+DO $$
+BEGIN
+    BEGIN
+        PERFORM set_config('paradedb.mpp_queue_size', '4kB', true);
+        RAISE EXCEPTION 'expected mpp_queue_size=4kB to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'mpp_queue_size=4kB correctly rejected';
+    END;
+    BEGIN
+        PERFORM set_config('paradedb.mpp_queue_size', '2GB', true);
+        RAISE EXCEPTION 'expected mpp_queue_size=2GB to be rejected';
+    EXCEPTION WHEN invalid_parameter_value THEN
+        RAISE NOTICE 'mpp_queue_size=2GB correctly rejected';
+    END;
+END$$;
+
 -- MPP GUCs must not affect non-MPP queries at all. Run a trivial query
 -- with mpp_debug on to confirm it's a no-op (no warnings except the
 -- expected ones) and results are correct.
@@ -63,3 +90,4 @@ SET paradedb.mpp_debug TO off;
 RESET paradedb.enable_mpp;
 RESET paradedb.mpp_debug;
 RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_queue_size;

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -14,13 +14,11 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SHOW paradedb.enable_mpp;
 SHOW paradedb.mpp_debug;
 SHOW paradedb.mpp_worker_count;
-SHOW paradedb.mpp_drain_watermark_mb;
 
 -- Defaults: MPP is off until explicitly enabled.
 SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
 SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;
 SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default;
-SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_default_mb;
 
 -- Toggle the boolean GUCs and verify they stick.
 SET paradedb.enable_mpp TO on;
@@ -55,12 +53,6 @@ BEGIN
     END;
 END$$;
 
--- Drain watermark: 0 disables spill, values > 0 enable it.
-SET paradedb.mpp_drain_watermark_mb TO 0;
-SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_zero;
-SET paradedb.mpp_drain_watermark_mb TO 256;
-SELECT current_setting('paradedb.mpp_drain_watermark_mb')::int AS watermark_256;
-
 -- MPP GUCs must not affect non-MPP queries at all. Run a trivial query
 -- with mpp_debug on to confirm it's a no-op (no warnings except the
 -- expected ones) and results are correct.
@@ -71,4 +63,3 @@ SET paradedb.mpp_debug TO off;
 RESET paradedb.enable_mpp;
 RESET paradedb.mpp_debug;
 RESET paradedb.mpp_worker_count;
-RESET paradedb.mpp_drain_watermark_mb;


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #4152

## Summary

First PR in a 6-PR chain that wires up MPP (Massively Parallel Processing) plan partitioning for JoinScan and AggregateScan. This PR lands the foundation only — GUCs, the Arrow-IPC transport layer, the `shm_mq` mesh, plan-broadcast codec, and DSM header layout.

All code is dead until later PRs wire it to the custom scans. `paradedb.enable_mpp` defaults to off, so end-user behaviour is unchanged.

**Chain (1/6):** **this** → #4828 → #4869 → #4870 → #4932 → #4872

## Why

Today's "Broadcast Join" hash-partitions one table across parallel workers and replicates every other table — each non-partitioned table gets scanned once per worker. True MPP hash-partitions every table by the join key and shuffles intermediate rows between workers, so each row is scanned exactly once. On the 25 M-row `aggregate_join_count` benchmark that's projected to reduce scanned work by ~82 %.

Splitting the work into a chain of focused PRs keeps each layer reviewable: the transport/codec primitives here can be reasoned about without touching Postgres custom-scan internals, which come in subsequent PRs.

## How

- Introduces a handful of MPP-facing GUCs so operators can opt in, pick a worker count, control drain buffering, and turn on tracing.
- Adds an Arrow-IPC transport layer with a dedicated drain thread per participant. The drain thread decouples producer-side from consumer-side backpressure, so the cyclic-backpressure deadlock that killed the previous attempt cannot form.
- Lays out an N×(N−1) directed mesh of shared-memory queues on top of Postgres' `shm_mq`, plus a small helper on the parallel-worker queue wrapper so receivers can be built from a raw handle.
- Defines a bincode-encoded plan broadcast that the leader will ship to workers once higher layers wire it up, and a session-profile enum so those workers know whether they belong to an aggregate or a join pipeline.
- Installs a `repr(C)` DSM header and sizing/offset math so the leader and workers agree on offsets via plain pointer arithmetic rather than a second shared-memory round-trip.

## Reviewer's guide

- Start with `transport.rs` — the drain-thread design is the single most important thing to get right; everything else builds on it.
- Then skim `mesh.rs` and `session.rs` as "data on the wire" and "data in shared memory".
- Finish with `worker.rs` for the DSM layout math — the sizing tests there lock it in.
- No live callers yet: correctness review is unit-test-scoped.

## Test plan

- [x] `cargo check -p pg_search --features pg18` clean
- [x] `cargo test -p pg_search --lib mpp:: --features pg18 -- --test-threads=1` — transport/codec/drain/mesh-layout/DSM-header unit tests green
- [x] `pg_search/tests/pg_regress/sql/mpp_smoke.sql` locks in the GUC surface (SHOW/SET, range rejection, no-op on non-MPP queries)
- [x] Existing regress tests pass unchanged with `enable_mpp = off` (byte-identical to `main`)
