### PR TITLE
feat(mpp): DataFusion operators — MppShuffleExec, sharded scan (2/5)

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -53,8 +53,8 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            cpu: 8
-            ram: 32
+            cpu: 16
+            ram: 64
             runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             platform: linux/amd64

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +323,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-flight"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302b2e036335f3f04d65dad3f74ff1f2aae6dc671d6aa04dc6b61193761e16fb"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-schema",
+ "base64",
+ "bytes",
+ "futures",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "arrow-ipc"
 version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +355,7 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex 0.13.0",
+ "zstd",
 ]
 
 [[package]]
@@ -696,6 +732,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -732,6 +811,15 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
  "serde",
 ]
 
@@ -908,6 +996,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1844,11 +1953,13 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
  "datafusion-functions-table",
  "datafusion-functions-window",
  "datafusion-optimizer",
@@ -1858,13 +1969,16 @@ dependencies = [
  "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-session",
+ "datafusion-sql",
  "futures",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
+ "parquet",
  "rand 0.9.4",
  "regex",
+ "sqlparser",
  "tempfile",
  "tokio",
  "url",
@@ -1936,7 +2050,9 @@ dependencies = [
  "libc",
  "log",
  "object_store",
+ "parquet",
  "paste",
+ "sqlparser",
  "tokio",
  "web-time",
 ]
@@ -2053,6 +2169,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-datasource-parquet"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-distributed"
+version = "1.0.0"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=dfa96e74b365e56c83fae81d5dcae24528f1c090#dfa96e74b365e56c83fae81d5dcae24528f1c090"
+dependencies = [
+ "arrow-flight",
+ "arrow-ipc",
+ "arrow-select",
+ "async-trait",
+ "bincode 1.3.3",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "dashmap",
+ "datafusion",
+ "datafusion-proto",
+ "delegate",
+ "futures",
+ "http",
+ "itertools 0.14.0",
+ "moka",
+ "object_store",
+ "pin-project",
+ "prost",
+ "rand 0.9.4",
+ "sketches-ddsketch",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "datafusion-doc"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2100,6 +2282,7 @@ dependencies = [
  "itertools 0.14.0",
  "paste",
  "serde_json",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2176,6 +2359,31 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -2372,6 +2580,7 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-table",
@@ -2427,6 +2636,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-sql"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
+ "indexmap",
+ "log",
+ "regex",
+ "sqlparser",
+]
+
+[[package]]
 name = "decimal-bytes"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2434,6 +2661,17 @@ checksum = "269277cb6b69f2fa55423ff5f3ff61f783893488b4e019b50fd4b57e077e1d4e"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3444,6 +3682,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3619,6 +3876,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "human_bytes"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3649,9 +3912,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3673,6 +3938,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4019,6 +4297,12 @@ checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "interpolate_name"
@@ -4724,6 +5008,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4793,6 +5083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4818,6 +5114,26 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock 3.4.2",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener 5.4.1",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -5161,6 +5477,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -5232,6 +5557,42 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half 2.7.1",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "object_store",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -5355,6 +5716,7 @@ dependencies = [
 name = "pg_search"
 version = "0.23.3"
 dependencies = [
+ "ahash 0.8.12",
  "anyhow",
  "arrow-array",
  "arrow-buffer",
@@ -5362,12 +5724,13 @@ dependencies = [
  "arrow-select",
  "async-stream",
  "async-trait",
- "bincode",
+ "bincode 2.0.1",
  "bitpacking",
  "bytemuck",
  "bytes",
  "chrono",
  "datafusion",
+ "datafusion-distributed",
  "datafusion-proto",
  "decimal-bytes",
  "derive_more",
@@ -5697,6 +6060,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6135,6 +6518,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -7057,6 +7449,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7318,6 +7716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "soa_derive"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7376,6 +7780,27 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7757,6 +8182,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tantivy"
 version = "0.26.0"
 source = "git+https://github.com/paradedb/tantivy.git?rev=8494dfb9f46ba8d538bcc93d1f012b48b23bb145#8494dfb9f46ba8d538bcc93d1f012b48b23bb145"
@@ -8060,6 +8491,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -8368,6 +8810,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8375,11 +8857,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-47PxAqkKNIIO1LpVeDAZBRIYpsMuTsULB5GeMx/ihLo=";
+  cargoHash = "sha256-PkESzsIgmDsRSiV3L2y8kfOtrT4/Qdz9VQYqvVTstZo=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -29,6 +29,9 @@ arrow-array = "58.1.0"
 arrow-buffer = "58.1.0"
 arrow-schema = "58.1.0"
 arrow-select = "58.1.0"
+# Match the version datafusion 53 and arrow use for ahash::RandomState, which
+# DataFusion's `create_hashes` helper requires as input.
+ahash = "0.8"
 bitpacking = "0.9.3"
 chrono = "0.4.44"
 time = "0.3.47"
@@ -77,6 +80,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "dfa96e74b365e56c83fae81d5dcae24528f1c090" }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod mesh;
 pub mod session;
+pub mod shuffle;
 pub mod transport;
 pub mod worker;
 

--- a/pg_search/src/postgres/customscan/mpp/shuffle.rs
+++ b/pg_search/src/postgres/customscan/mpp/shuffle.rs
@@ -1,0 +1,1500 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Shuffle operator primitives for MPP.
+//!
+//! [`MppShuffleExec`] declares `Partitioning::Hash(keys, N)` natively (or
+//! `UnknownPartitioning(1)` for the scalar-final gather) and, on the
+//! participant's `drive_partition`, merges its producer-side stream (drives
+//! upstream, hash-routes via [`RowPartitioner`], ships peer rows through
+//! [`MppSender`]) with its consumer-side stream (drains peer-shipped rows
+//! from `shm_mq`). Other partitions return empty.
+//!
+//! # Why a separate operator instead of `datafusion_distributed::NetworkShuffleExec`
+//!
+//! Both implement [`NetworkBoundary`] and declare `Partitioning::Hash(keys, N)`,
+//! so DataFusion's optimizer sees the same plan-shape vocabulary either way.
+//! The split is only in `execute()`, because the fork's transport doesn't fit
+//! ParadeDB's runtime:
+//!
+//! * **Transport** — `NetworkShuffleExec` dials a URL-addressed worker via
+//!   Tonic/gRPC and consumes a `FlightRecordBatchStream`. ParadeDB has no
+//!   URLs and no HTTP server; participants are parallel workers in one
+//!   Postgres backend, talking through DSM `shm_mq` ring buffers.
+//! * **Consumer concurrency** — the fork demuxes per-partition
+//!   `tokio::sync::mpsc` channels under a `MemoryReservation` budget,
+//!   pulled by async tasks. `shm_mq` is a fixed-size ring, so a stalled
+//!   DataFusion consumer would propagate backpressure to remote producers
+//!   and deadlock the mesh. We instead run a drain thread per participant
+//!   into a spillable [`DrainBuffer`](super::transport::DrainBuffer).
+//! * **Cancellation** — Flight uses Tonic tokens / HTTP/2 stream resets;
+//!   ParadeDB uses Postgres-style `check_for_interrupts!()` and DSM
+//!   teardown. The cooperative-spin path in `MppSender::send_batch_traced`
+//!   is shaped around that and has no Flight analogue.
+//!
+//! [`BoundaryFactory`](datafusion_distributed::BoundaryFactory) is the
+//! extension point that lets us slot `MppShuffleExec` into the same walker
+//! without forking the planner. Generalizing `NetworkShuffleExec` itself
+//! behind a `WorkerTransport` trait (URL resolution, demux task, memory
+//! budget, cancellation) belongs upstream in
+//! `datafusion-contrib/datafusion-distributed`, not in our fork.
+//!
+//! [`NetworkShuffleExec`]: https://github.com/datafusion-contrib/datafusion-distributed
+
+use std::any::Any;
+use std::fmt;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use datafusion::arrow::array::{RecordBatch, UInt64Array};
+use datafusion::arrow::compute::take;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::hash_utils::create_hashes;
+use datafusion::common::{DataFusionError, Result as DFResult};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::{EmptyRecordBatchStream, RecordBatchStreamAdapter};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+};
+use futures::Stream;
+use tokio::task::yield_now;
+
+#[cfg(not(test))]
+use crate::gucs::mpp_trace;
+use crate::postgres::customscan::mpp::transport::{
+    DrainHandle, DrainItem, MppSender, SendBatchStats,
+};
+use datafusion_distributed::{NetworkBoundary, Stage};
+use uuid::Uuid;
+
+/// GUC read wrapper that is inert under `cfg(test)`.
+///
+/// `pgrx::guc::GucSetting::get()` calls `check_active_thread`, which panics
+/// if invoked from a thread other than the one that first touched the
+/// pgrx FFI layer. `cargo test` (no `--test-threads=1`) runs each test on
+/// a fresh worker thread, so a GUC read inside a stream poller blows up
+/// across threads. The production path still reads the GUC; tests just see
+/// `false` (no trace instrumentation needed for correctness).
+#[inline]
+fn mpp_trace_flag() -> bool {
+    #[cfg(not(test))]
+    {
+        mpp_trace()
+    }
+    #[cfg(test)]
+    {
+        false
+    }
+}
+
+/// Assigns each row of a `RecordBatch` to one of N destination participants.
+///
+/// Implementations must return exactly `batch.num_rows()` values, each in
+/// `0..total_participants`. `ShuffleExec` uses this at the top of its
+/// producer loop to fan rows out across the mesh.
+///
+/// TODO(future): align this with DataFusion's own `Partitioning` so the
+/// routing decision rides on the optimizer's existing partition concept
+/// rather than a parallel one. The destination model
+/// (`datafusion-distributed`'s `PartitionIsolatorExec`) is to express
+/// participant identity as a `Partitioning::Hash` partition that the
+/// transport peels off, which would let us delete this trait. Out of
+/// scope for the MPP chain — flagged for a follow-up ticket.
+pub trait RowPartitioner: Send + Sync {
+    /// Return a destination index in `0..total_participants` for every row.
+    fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError>;
+
+    /// Total destinations this partitioner will target. Used by
+    /// `ShuffleExec` to size per-destination scratch arrays.
+    fn total_participants(&self) -> u32;
+}
+
+/// Production partitioner: hashes one or more key columns and assigns each
+/// row to `hash % total_participants`.
+///
+/// Uses `create_hashes` with `ahash::RandomState::with_seeds(0, 0, 0, 0)` —
+/// the same seed DataFusion uses for `REPARTITION_RANDOM_STATE`, so routing
+/// is stable across workers.
+///
+/// NULL keys hash to a single sentinel, so a heavily-NULL key column skews
+/// destinations. Correct (the receiving HashJoin/Aggregate clusters NULL keys
+/// the same way), but worth checking `mpp_trace`'s per-peer `rows_sent` if
+/// a hot peer shows up.
+///
+/// TODO: accept `Vec<Arc<dyn PhysicalExpr>>` instead of column indices so the
+/// routing stays byte-compatible if a planner pushes `CAST(col)` or similar
+/// into the key list. Today we only accept column refs.
+pub struct HashPartitioner {
+    /// Indices into the input schema for the key columns to hash.
+    key_columns: Vec<usize>,
+    total_participants: u32,
+}
+
+impl HashPartitioner {
+    pub fn new(key_columns: Vec<usize>, total_participants: u32) -> Self {
+        assert!(
+            total_participants > 0,
+            "HashPartitioner requires total_participants >= 1"
+        );
+        Self {
+            key_columns,
+            total_participants,
+        }
+    }
+}
+
+impl RowPartitioner for HashPartitioner {
+    fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError> {
+        if self.total_participants == 1 {
+            // Single participant degenerate case — everyone is self.
+            return Ok(vec![0u32; batch.num_rows()]);
+        }
+        if self.key_columns.is_empty() {
+            return Err(DataFusionError::Internal(
+                "HashPartitioner: no key columns provided".into(),
+            ));
+        }
+        let columns: Vec<_> = self
+            .key_columns
+            .iter()
+            .map(|&idx| batch.column(idx).clone())
+            .collect();
+        let mut hashes_buf = vec![0u64; batch.num_rows()];
+        // Use a fixed, non-zero seed so hashes stay stable across calls.
+        let random_state = ahash::RandomState::with_seeds(0, 0, 0, 0);
+        create_hashes(&columns, &random_state, &mut hashes_buf)?;
+        let n = self.total_participants as u64;
+        Ok(hashes_buf.into_iter().map(|h| (h % n) as u32).collect())
+    }
+
+    fn total_participants(&self) -> u32 {
+        self.total_participants
+    }
+}
+
+/// Route every row to one fixed destination. Used by the scalar-aggregate
+/// final-gather: workers ship Partial rows to the leader's participant for
+/// `FinalPartitioned`.
+pub struct FixedTargetPartitioner {
+    target: u32,
+    total_participants: u32,
+}
+
+impl FixedTargetPartitioner {
+    pub fn new(target: u32, total_participants: u32) -> Self {
+        assert!(total_participants > 0);
+        assert!(
+            target < total_participants,
+            "FixedTargetPartitioner: target {target} >= total_participants {total_participants}"
+        );
+        Self {
+            target,
+            total_participants,
+        }
+    }
+}
+
+impl RowPartitioner for FixedTargetPartitioner {
+    fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError> {
+        Ok(vec![self.target; batch.num_rows()])
+    }
+
+    fn total_participants(&self) -> u32 {
+        self.total_participants
+    }
+}
+
+/// Scatter a `RecordBatch` into one sub-batch per destination participant.
+///
+/// Returns a `Vec` of length `total_participants`. Each entry is either:
+/// - `Some(sub_batch)` if one or more rows of `batch` routed to that participant; or
+/// - `None` if no rows routed to that participant (skip a send round-trip).
+///
+/// Row order within each sub-batch matches the original batch. Uses
+/// `arrow::compute::take` so the implementation is zero-copy per-column for
+/// fixed-width arrays and slice-copy for variable-width.
+pub fn split_batch_by_partition(
+    batch: &RecordBatch,
+    destinations: &[u32],
+    total_participants: u32,
+) -> Result<Vec<Option<RecordBatch>>, DataFusionError> {
+    if destinations.len() != batch.num_rows() {
+        return Err(DataFusionError::Internal(format!(
+            "split_batch_by_partition: destinations.len()={} != batch.num_rows()={}",
+            destinations.len(),
+            batch.num_rows()
+        )));
+    }
+    if total_participants == 0 {
+        return Err(DataFusionError::Internal(
+            "split_batch_by_partition: total_participants must be > 0".into(),
+        ));
+    }
+
+    // Bucket row indices per destination. Allocate lazily so single-destination
+    // inputs don't pay for N unused Vecs.
+    let n = total_participants as usize;
+    let mut buckets: Vec<Option<Vec<u64>>> = (0..n).map(|_| None).collect();
+    for (row_idx, &dest) in destinations.iter().enumerate() {
+        if dest as usize >= n {
+            return Err(DataFusionError::Internal(format!(
+                "split_batch_by_partition: destination {dest} >= total_participants {total_participants}"
+            )));
+        }
+        buckets[dest as usize]
+            .get_or_insert_with(Vec::new)
+            .push(row_idx as u64);
+    }
+
+    let schema = batch.schema();
+    let mut out: Vec<Option<RecordBatch>> = Vec::with_capacity(n);
+    for bucket in buckets {
+        match bucket {
+            None => out.push(None),
+            Some(indices) => {
+                let idx_array = UInt64Array::from(indices);
+                let taken_cols: Result<Vec<_>, DataFusionError> = batch
+                    .columns()
+                    .iter()
+                    .map(|c| {
+                        take(c.as_ref(), &idx_array, None)
+                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+                    })
+                    .collect();
+                let taken_cols = taken_cols?;
+                let sub = RecordBatch::try_new(schema.clone(), taken_cols)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                out.push(Some(sub));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// How this participant connects to the mesh. Moved into `ShuffleExec`
+/// at construction; the operator owns the senders and drops them at stream
+/// EOF / abort so peers observe detach.
+pub struct ShuffleWiring {
+    pub partitioner: Arc<dyn RowPartitioner>,
+    /// One slot per participant. Slot at `participant_index` must be `None`;
+    /// the rest must be `Some(MppSender)`. Asserted by `ShuffleExec::new`.
+    pub outbound_senders: Vec<Option<MppSender>>,
+    pub participant_index: u32,
+    /// Inbound drain handle for the same mesh. When set,
+    /// `build_shuffle_stream` calls `poll_drain_pass` every iteration so
+    /// inbound queues keep draining even when outbound sends aren't
+    /// blocking — otherwise a fast-sending participant never reads its
+    /// inbound, peers stall trying to ship to it, and the mesh deadlocks.
+    pub cooperative_drain: Option<Arc<DrainHandle>>,
+}
+
+/// Mutable per-stream state for [`build_shuffle_stream`]. Trace fields are
+/// only read by [`log_shuffle_eof`] which is `cfg(not(test))`-gated; the
+/// `cfg_attr` silences `dead_code` under `cfg(test)`.
+#[cfg_attr(test, allow(dead_code))]
+struct ShuffleState {
+    /// Taken to `None` once the child is exhausted so peer senders detach
+    /// and signal EOF.
+    wiring: Option<ShuffleWiring>,
+    /// At most one self-share queued for the next outer-loop yield.
+    self_queue: Option<RecordBatch>,
+    participant_index: u32,
+    rows_in: u64,
+    rows_self: u64,
+    /// Per-destination counters for the EOF trace; entry at
+    /// `participant_index` stays 0.
+    rows_sent: Vec<u64>,
+    batches_in: u64,
+    time_in_partition: Duration,
+    time_in_split: Duration,
+    time_in_encode: Duration,
+    time_in_send_wait: Duration,
+    time_in_coop_drain_in_spin: Duration,
+    send_spin_iters: u64,
+}
+
+impl ShuffleState {
+    fn new(wiring: ShuffleWiring) -> Self {
+        let total = wiring.partitioner.total_participants() as usize;
+        let participant_index = wiring.participant_index;
+        Self {
+            wiring: Some(wiring),
+            self_queue: None,
+            participant_index,
+            rows_in: 0,
+            rows_self: 0,
+            rows_sent: vec![0u64; total],
+            batches_in: 0,
+            time_in_partition: Duration::ZERO,
+            time_in_split: Duration::ZERO,
+            time_in_encode: Duration::ZERO,
+            time_in_send_wait: Duration::ZERO,
+            time_in_coop_drain_in_spin: Duration::ZERO,
+            send_spin_iters: 0,
+        }
+    }
+
+    /// Process one input batch: partition rows, queue our self-share,
+    /// ship peer-shares via `MppSender`. Mutates row/timing counters.
+    /// `async` because `MppSender::send_batch_traced` yields to the Tokio
+    /// runtime in its cooperative-spin loop — see that fn's body comment.
+    async fn process_batch(&mut self, batch: RecordBatch, trace_on: bool) -> DFResult<()> {
+        let rows = batch.num_rows() as u64;
+        if rows == 0 {
+            return Ok(());
+        }
+        self.rows_in += rows;
+        self.batches_in += 1;
+        let wiring = self.wiring.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("ShuffleStream: wiring missing mid-stream".into())
+        })?;
+        let t_part = trace_on.then(Instant::now);
+        let dests = wiring.partitioner.partition_for_each_row(&batch)?;
+        if let Some(t0) = t_part {
+            self.time_in_partition += t0.elapsed();
+        }
+        let n = wiring.partitioner.total_participants();
+        let t_split = trace_on.then(Instant::now);
+        let mut subs = split_batch_by_partition(&batch, &dests, n)?;
+        if let Some(t0) = t_split {
+            self.time_in_split += t0.elapsed();
+        }
+
+        // Self first (see run_shuffle_pump docstring for rationale).
+        if let Some(self_sub) = subs[wiring.participant_index as usize].take() {
+            self.rows_self += self_sub.num_rows() as u64;
+            // Slot is always free here: process_batch only runs when the
+            // outer pump has just yielded any prior self-share, and each
+            // input batch produces at most one self-share.
+            debug_assert!(self.self_queue.is_none(), "self_queue overwrite");
+            self.self_queue = Some(self_sub);
+        }
+        let mut send_stats = SendBatchStats::default();
+        for (dest_idx, sub) in subs.into_iter().enumerate() {
+            if dest_idx as u32 == wiring.participant_index {
+                debug_assert!(sub.is_none());
+                continue;
+            }
+            let Some(sub) = sub else { continue };
+            let sender = wiring.outbound_senders[dest_idx].as_ref().ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "ShuffleStream: no outbound sender for participant {dest_idx}"
+                ))
+            })?;
+            let sub_rows = sub.num_rows() as u64;
+            sender.send_batch_traced(&sub, &mut send_stats).await?;
+            self.rows_sent[dest_idx] += sub_rows;
+        }
+        if trace_on {
+            self.time_in_encode += send_stats.encode;
+            self.time_in_send_wait += send_stats.send_wait;
+            self.time_in_coop_drain_in_spin += send_stats.coop_drain_in_spin;
+            self.send_spin_iters += send_stats.spin_iters;
+        }
+        Ok(())
+    }
+}
+
+/// Async stream powering [`ShuffleExec`]: pulls from `child`, hash-routes
+/// peer rows out through `wiring`'s senders, yields the self-share locally,
+/// and pumps the cooperative inbound drain between iterations.
+fn build_shuffle_stream(
+    mut child: SendableRecordBatchStream,
+    wiring: ShuffleWiring,
+    tag: &'static str,
+) -> impl Stream<Item = DFResult<RecordBatch>> + Send {
+    use futures::StreamExt;
+
+    async_stream::stream! {
+        let trace_on = mpp_trace_flag();
+        let first_poll_at = trace_on.then(Instant::now);
+        let mut time_in_child = Duration::ZERO;
+        let mut time_in_process = Duration::ZERO;
+        let mut time_in_coop_drain = Duration::ZERO;
+        let mut state = ShuffleState::new(wiring);
+
+        let outcome: DFResult<()> = 'pump: loop {
+            // Yield queued self-shares first so each re-enters the loop and
+            // re-runs the inbound drain below before pulling more.
+            if let Some(b) = state.self_queue.take() {
+                yield Ok(b);
+                continue 'pump;
+            }
+
+            // Cooperative inbound drain (see `ShuffleWiring::cooperative_drain`)
+            // — keeps peer sends un-stalled even when our outbound is fast.
+            if let Some(w) = state.wiring.as_ref() {
+                if let Some(drain) = w.cooperative_drain.as_ref() {
+                    let t0 = trace_on.then(Instant::now);
+                    let _ = drain.poll_drain_pass();
+                    if let Some(t0) = t0 {
+                        time_in_coop_drain += t0.elapsed();
+                    }
+                }
+            }
+
+            // Pull until a batch produces a self-row, or the child exhausts.
+            'pull: loop {
+                let t_child = trace_on.then(Instant::now);
+                let next = child.next().await;
+                if let Some(t0) = t_child {
+                    time_in_child += t0.elapsed();
+                }
+                match next {
+                    None => break 'pump Ok(()),
+                    Some(Err(e)) => break 'pump Err(e),
+                    Some(Ok(batch)) => {
+                        let t_proc = trace_on.then(Instant::now);
+                        let result = state.process_batch(batch, trace_on).await;
+                        if let Some(t0) = t_proc {
+                            time_in_process += t0.elapsed();
+                        }
+                        if let Err(e) = result {
+                            break 'pump Err(e);
+                        }
+                        if state.self_queue.is_some() {
+                            continue 'pump;
+                        }
+                        continue 'pull;
+                    }
+                }
+            }
+        };
+
+        // EOF/error tail: drop wiring so peers detach. A queued self-share
+        // is intentionally discarded if outcome is `Err` — DataFusion's
+        // contract is no items after a yielded error.
+        state.wiring.take();
+        log_shuffle_eof(
+            tag,
+            &state,
+            ShuffleTimings {
+                first_poll_at,
+                time_in_child,
+                time_in_process,
+                time_in_coop_drain,
+            },
+        );
+        if let Err(e) = outcome {
+            yield Err(e);
+        }
+    }
+}
+
+/// Wall-clock timings emitted at EOF by [`log_shuffle_eof`]. `cfg_attr`
+/// silences `dead_code` under `cfg(test)` (same reason as [`ShuffleState`]).
+#[cfg_attr(test, allow(dead_code))]
+struct ShuffleTimings {
+    /// `Some` iff `mpp_trace_flag()` was on at first poll.
+    first_poll_at: Option<Instant>,
+    time_in_child: Duration,
+    time_in_process: Duration,
+    /// Top-of-iteration cooperative drain time; excludes the in-spin drain
+    /// inside `send_batch_traced`.
+    time_in_coop_drain: Duration,
+}
+
+/// EOF trace emitter. `cfg(not(test))`-gated because the unit-test target
+/// can't link the FFI symbols `pgrx::{warning,debug1}!` expand into; the
+/// runtime EOF path itself is still exercised by tests.
+fn log_shuffle_eof(tag: &'static str, state: &ShuffleState, t: ShuffleTimings) {
+    #[cfg(not(test))]
+    {
+        let sent_summary = state
+            .rows_sent
+            .iter()
+            .enumerate()
+            .map(|(i, n)| format!("->{i}={n}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let wall_ms = t
+            .first_poll_at
+            .map(|s| s.elapsed().as_secs_f64() * 1000.0)
+            .unwrap_or(0.0);
+        let child_ms = t.time_in_child.as_secs_f64() * 1000.0;
+        let process_ms = t.time_in_process.as_secs_f64() * 1000.0;
+        let coop_ms = t.time_in_coop_drain.as_secs_f64() * 1000.0;
+        let part_ms = state.time_in_partition.as_secs_f64() * 1000.0;
+        let split_ms = state.time_in_split.as_secs_f64() * 1000.0;
+        let encode_ms = state.time_in_encode.as_secs_f64() * 1000.0;
+        let send_wait_ms = state.time_in_send_wait.as_secs_f64() * 1000.0;
+        let drain_in_spin_ms = state.time_in_coop_drain_in_spin.as_secs_f64() * 1000.0;
+        if mpp_trace() {
+            pgrx::warning!(
+                "mpp: ShuffleStream[{}] participant={} EOF rows_in={} batches_in={} self={} sent=[{}] wall_ms={:.1} child_ms={:.1} process_ms={:.1} coop_drain_ms={:.1} part_ms={:.1} split_ms={:.1} encode_ms={:.1} send_wait_ms={:.1} drain_in_spin_ms={:.1} spin_iters={}",
+                tag,
+                state.participant_index,
+                state.rows_in,
+                state.batches_in,
+                state.rows_self,
+                sent_summary,
+                wall_ms,
+                child_ms,
+                process_ms,
+                coop_ms,
+                part_ms,
+                split_ms,
+                encode_ms,
+                send_wait_ms,
+                drain_in_spin_ms,
+                state.send_spin_iters,
+            );
+        } else {
+            pgrx::debug1!(
+                "mpp: ShuffleStream[{}] participant={} EOF rows_in={} self={} sent=[{}]",
+                tag,
+                state.participant_index,
+                state.rows_in,
+                state.rows_self,
+                sent_summary
+            );
+        }
+    }
+    #[cfg(test)]
+    {
+        let _ = (tag, state, t);
+    }
+}
+
+/// RAII guard: cancels the drain on stream drop so peer senders observe
+/// detach and stop pushing into a buffer no one reads (which would otherwise
+/// grow unbounded on `LIMIT` shortcuts, query cancel, or panic). Shutdown
+/// is idempotent, so the natural EOF/Err tail can call it too.
+struct ShutdownOnDrop {
+    handle: Arc<DrainHandle>,
+}
+
+impl Drop for ShutdownOnDrop {
+    fn drop(&mut self) {
+        let _ = self.handle.shutdown();
+    }
+}
+
+/// Build the async stream that powers [`DrainGatherExec`]. Yields decoded
+/// peer batches in arrival order; cleanly returns once every inbound
+/// source has detached and the buffer is drained.
+///
+/// Cooperative drain: for pg-backed handles the drain work happens on
+/// the consumer's own task (not a background thread, which would panic
+/// on pgrx's `check_active_thread` the moment it touched any pg FFI via
+/// `shm_mq_receive`). Each loop iteration runs one drain pass and then
+/// `try_pop`s the buffer; on empty we yield to the executor so sibling
+/// tasks (peer `ShuffleExec`s shipping us rows) can make progress before
+/// the next pass.
+fn build_drain_gather_stream(
+    handle: Arc<DrainHandle>,
+    schema: SchemaRef,
+    tag: &'static str,
+    participant_index: u32,
+) -> impl Stream<Item = DFResult<RecordBatch>> + Send {
+    async_stream::stream! {
+        // Held across the whole body so any early-drop of the stream
+        // (LIMIT shortcut, cancel, panic) still cancels the buffer and
+        // releases the receivers. Peer senders observe detach on their
+        // next outbound `try_send_bytes` instead of looping forever.
+        let _shutdown_guard = ShutdownOnDrop { handle: handle.clone() };
+
+        let trace_on = mpp_trace_flag();
+        let first_poll_at = trace_on.then(Instant::now);
+        let mut time_in_drain_pass = Duration::ZERO;
+        let mut time_in_pop = Duration::ZERO;
+        let mut pending_polls: u64 = 0;
+        let mut rows_received: u64 = 0;
+        let mut batches_received: u64 = 0;
+
+        let coop = handle.is_cooperative();
+        let buffer = handle.buffer().clone();
+
+        // Outcome of the loop body. Both break paths run the same
+        // shutdown + log_eof tail below; using a local `Result` keeps the
+        // tail in one place rather than duplicating it at every exit.
+        let outcome: DFResult<()> = 'drain: loop {
+            // A peer that crashes before sending its detach leaves us
+            // pinned in the cooperative loop until statement_timeout;
+            // honor query cancel so the consumer can exit promptly.
+            // Gated out of `cargo test --lib` for the same reason as
+            // the `MppSender::send_batch_traced` spin: the macro pulls
+            // `ProcessInterrupts` / `PG_exception_stack` / `CopyErrorData`
+            // FFI symbols that aren't linked into the unit-test binary.
+            #[cfg(not(test))]
+            pgrx::check_for_interrupts!();
+
+            if coop {
+                let t0 = trace_on.then(Instant::now);
+                let res = handle.poll_drain_pass();
+                if let Some(t0) = t0 {
+                    time_in_drain_pass += t0.elapsed();
+                }
+                if let Err(e) = res {
+                    // Any batches already pushed into the buffer by an
+                    // earlier successful pass are intentionally discarded:
+                    // DataFusion's contract for a yielded `Err` is that no
+                    // subsequent items follow, so partial results would
+                    // mislead aggregators above us.
+                    break 'drain Err(e);
+                }
+            }
+
+            let t_pop = trace_on.then(Instant::now);
+            let item = if coop {
+                buffer.try_pop()
+            } else {
+                Some(buffer.recv().await)
+            };
+            if let Some(t0) = t_pop {
+                time_in_pop += t0.elapsed();
+            }
+
+            match item {
+                Some(DrainItem::Batch(b)) => {
+                    // Peer-shipped batches went through encode_batch /
+                    // decode_batch, so their schema comes from IPC metadata
+                    // rather than from what we expected locally. A peer
+                    // running a drifted schema would otherwise silently
+                    // feed garbage into the Union above us.
+                    if b.schema() != schema {
+                        break 'drain Err(DataFusionError::Internal(format!(
+                            "DrainGatherExec: peer batch schema {:?} disagrees with expected {:?}",
+                            b.schema(),
+                            schema
+                        )));
+                    }
+                    rows_received += b.num_rows() as u64;
+                    batches_received += 1;
+                    yield Ok(b);
+                }
+                Some(DrainItem::Eof) => break 'drain Ok(()),
+                None => {
+                    // Cooperative path only: buffer empty + sources still
+                    // alive. Yield so peer `ShuffleExec`s can produce, then
+                    // loop back into another drain pass.
+                    if trace_on {
+                        pending_polls += 1;
+                    }
+                    yield_now().await;
+                }
+            }
+        };
+
+        // Single shutdown + log_eof tail. Joins the drain thread
+        // deterministically so plan teardown doesn't leave a zombie
+        // holding DSM pointers; logs trailing trace metrics.
+        let shutdown_err = handle.shutdown().err();
+        log_drain_gather_eof(
+            tag,
+            participant_index,
+            DrainGatherTrace {
+                rows_received,
+                batches_received,
+                first_poll_at,
+                time_in_drain_pass,
+                time_in_pop,
+                pending_polls,
+            },
+        );
+        if let Err(e) = outcome {
+            yield Err(e);
+        } else if let Some(e) = shutdown_err {
+            yield Err(e);
+        }
+    }
+}
+
+/// EOF metrics for [`build_drain_gather_stream`]; see [`ShuffleTimings`]
+/// for the same `cfg_attr` rationale.
+#[cfg_attr(test, allow(dead_code))]
+struct DrainGatherTrace {
+    rows_received: u64,
+    batches_received: u64,
+    /// `Some` iff `mpp_trace_flag()` was on at first poll.
+    first_poll_at: Option<Instant>,
+    time_in_drain_pass: Duration,
+    time_in_pop: Duration,
+    /// `try_pop` returned `None`; subset of cooperative-only iterations.
+    pending_polls: u64,
+}
+
+/// EOF trace emitter; `cfg(not(test))`-gated for the same FFI-link reason
+/// as [`log_shuffle_eof`].
+fn log_drain_gather_eof(tag: &'static str, participant_index: u32, t: DrainGatherTrace) {
+    #[cfg(not(test))]
+    {
+        let wall_ms = t
+            .first_poll_at
+            .map(|s| s.elapsed().as_secs_f64() * 1000.0)
+            .unwrap_or(0.0);
+        let drain_ms = t.time_in_drain_pass.as_secs_f64() * 1000.0;
+        let pop_ms = t.time_in_pop.as_secs_f64() * 1000.0;
+        if mpp_trace() {
+            pgrx::warning!(
+                "mpp: DrainGatherStream[{}] participant={} EOF rows_received={} batches_received={} wall_ms={:.1} drain_ms={:.1} pop_ms={:.1} pending_polls={}",
+                tag,
+                participant_index,
+                t.rows_received,
+                t.batches_received,
+                wall_ms,
+                drain_ms,
+                pop_ms,
+                t.pending_polls,
+            );
+        } else {
+            pgrx::debug1!(
+                "mpp: DrainGatherStream[{}] participant={} EOF rows_received={} batches_received={}",
+                tag,
+                participant_index,
+                t.rows_received,
+                t.batches_received
+            );
+        }
+    }
+    #[cfg(test)]
+    {
+        let _ = (tag, participant_index, t);
+    }
+}
+
+/// Single-operator MPP shuffle. Shape-aligned with
+/// `datafusion_distributed::NetworkShuffleExec`: declares
+/// `Partitioning::Hash(keys, N)` natively (or `UnknownPartitioning(1)` for
+/// the scalar-final gather). The walker emits one per cut.
+///
+/// Only `execute(drive_partition)` does work — it returns the merged
+/// producer + drain stream. Other partitions return an empty stream:
+/// for hash boundaries those rows live on peers; for fixed-target gathers
+/// non-target participants still drive upstream so their rows ship out,
+/// then yield empty.
+///
+/// `wiring` and `drain_handle` are one-shot. The first `execute(p)` with
+/// `p == drive_partition` consumes both; later calls error rather than
+/// silently re-running.
+pub struct MppShuffleExec {
+    input: Arc<dyn ExecutionPlan>,
+    wiring: Mutex<Option<ShuffleWiring>>,
+    drain_handle: Mutex<Option<Arc<DrainHandle>>>,
+    plan_properties: Arc<PlanProperties>,
+    tag: &'static str,
+    participant_index: u32,
+    drive_partition: u32,
+    /// Stage this boundary consumes from. Stamped by the walker via
+    /// [`NetworkBoundary::with_input_stage`]; `None` only on un-stamped
+    /// test fixtures that construct `MppShuffleExec` directly. The fork's
+    /// [`NetworkBoundary`] trait returns `&Stage`, so we keep an owned
+    /// field rather than synthesize one on demand. ParadeDB's u64
+    /// `query_id` round-trips as the low 64 bits of a UUID
+    /// ([`Uuid::from_u128`] of `query_id as u128`).
+    input_stage: Option<Stage>,
+}
+
+impl fmt::Debug for MppShuffleExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MppShuffleExec")
+            .field("tag", &self.tag)
+            .field("drive_partition", &self.drive_partition)
+            .field("participant_index", &self.participant_index)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MppShuffleExec {
+    /// Construct an `MppShuffleExec`.
+    ///
+    /// - `hash_keys`: when `Some`, output partitioning is
+    ///   `Partitioning::Hash(keys, total_participants)` — the hash-shuffle
+    ///   case. When `None`, output is `UnknownPartitioning(1)` — the
+    ///   scalar-final gather case where every row routes to one target.
+    /// - `drive_partition`: the output partition that triggers the
+    ///   participant's work. For hash shuffles this is `participant_index`;
+    ///   for fixed-target gathers it is `target` on every participant.
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        wiring: ShuffleWiring,
+        drain_handle: Arc<DrainHandle>,
+        hash_keys: Option<Vec<Arc<dyn PhysicalExpr>>>,
+        drive_partition: u32,
+        tag: &'static str,
+    ) -> Self {
+        let n = wiring.partitioner.total_participants();
+        let participant_index = wiring.participant_index;
+        assert_eq!(
+            wiring.outbound_senders.len(),
+            n as usize,
+            "MppShuffleExec: outbound_senders.len() != total_participants"
+        );
+        assert!(
+            participant_index < n,
+            "MppShuffleExec: participant_index >= total_participants"
+        );
+        assert!(
+            wiring.outbound_senders[participant_index as usize].is_none(),
+            "MppShuffleExec: self participant sender slot must be None"
+        );
+        assert!(
+            drive_partition < n,
+            "MppShuffleExec: drive_partition ({drive_partition}) >= total_participants ({n})"
+        );
+
+        let partitioning = match &hash_keys {
+            Some(keys) => Partitioning::Hash(keys.clone(), n as usize),
+            None => Partitioning::UnknownPartitioning(1),
+        };
+        let eq_properties = EquivalenceProperties::new(input.schema());
+        let plan_properties = Arc::new(PlanProperties::new(
+            eq_properties,
+            partitioning,
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+
+        Self {
+            input,
+            wiring: Mutex::new(Some(wiring)),
+            drain_handle: Mutex::new(Some(drain_handle)),
+            plan_properties,
+            tag,
+            participant_index,
+            drive_partition,
+            input_stage: None,
+        }
+    }
+}
+
+impl NetworkBoundary for MppShuffleExec {
+    fn input_stage(&self) -> &Stage {
+        // Walker-emitted boundaries always have `input_stage = Some(_)` from
+        // `with_input_stage`; the placeholder only fires for un-stamped test
+        // fixtures.
+        self.input_stage.as_ref().unwrap_or_else(|| {
+            static PLACEHOLDER: OnceLock<Stage> = OnceLock::new();
+            PLACEHOLDER.get_or_init(|| Stage::new_unaddressed(Uuid::nil(), 0, 0))
+        })
+    }
+
+    fn with_input_stage(&self, stage: Stage) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let wiring = self.wiring.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec::with_input_stage: wiring already consumed".into(),
+            )
+        })?;
+        let drain_handle = self.drain_handle.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec::with_input_stage: drain handle already consumed".into(),
+            )
+        })?;
+        let hash_keys = match &self.plan_properties.partitioning {
+            Partitioning::Hash(exprs, _) => Some(exprs.clone()),
+            _ => None,
+        };
+        let mut node = MppShuffleExec::new(
+            self.input.clone(),
+            wiring,
+            drain_handle,
+            hash_keys,
+            self.drive_partition,
+            self.tag,
+        );
+        node.input_stage = Some(stage);
+        Ok(Arc::new(node))
+    }
+}
+
+impl DisplayAs for MppShuffleExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MppShuffleExec: tag={} drive_partition={} participant={}",
+            self.tag, self.drive_partition, self.participant_index
+        )
+    }
+}
+
+impl ExecutionPlan for MppShuffleExec {
+    fn name(&self) -> &str {
+        "MppShuffleExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "MppShuffleExec expects exactly one child, got {}",
+                children.len()
+            )));
+        }
+        let wiring = self.wiring.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec: with_new_children called after wiring consumed".into(),
+            )
+        })?;
+        let drain_handle = self.drain_handle.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec: with_new_children called after drain handle consumed".into(),
+            )
+        })?;
+        let hash_keys = match &self.plan_properties.partitioning {
+            Partitioning::Hash(exprs, _) => Some(exprs.clone()),
+            _ => None,
+        };
+        Ok(Arc::new(MppShuffleExec::new(
+            children.into_iter().next().unwrap(),
+            wiring,
+            drain_handle,
+            hash_keys,
+            self.drive_partition,
+            self.tag,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let n = self.plan_properties.partitioning.partition_count();
+        if partition >= n {
+            return Err(DataFusionError::Internal(format!(
+                "MppShuffleExec: partition {partition} >= partition_count {n}"
+            )));
+        }
+        if partition as u32 != self.drive_partition {
+            // Other partitions: empty stream. The drive_partition's stream
+            // performs all the work (drives upstream, ships peers, drains
+            // inbound). DataFusion will iterate execute(p) for every p in
+            // the declared partition count; only the drive partition is
+            // load-bearing.
+            return Ok(Box::pin(EmptyRecordBatchStream::new(self.input.schema())));
+        }
+
+        let wiring =
+            self.wiring.lock().unwrap().take().ok_or_else(|| {
+                DataFusionError::Internal("MppShuffleExec: already executed".into())
+            })?;
+        let drain_handle = self.drain_handle.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec: drain handle already consumed before execute".into(),
+            )
+        })?;
+
+        let child_stream = self.input.execute(0, context)?;
+        let producer = build_shuffle_stream(child_stream, wiring, self.tag);
+        let consumer = build_drain_gather_stream(
+            drain_handle,
+            self.input.schema(),
+            self.tag,
+            self.participant_index,
+        );
+
+        // `select` polls producer and consumer on the same task and yields
+        // whichever has a batch ready first; the cooperative-drain pattern
+        // in `build_shuffle_stream` keeps both halves making progress.
+        let merged = futures::stream::select(producer, consumer);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.input.schema(),
+            merged,
+        )))
+    }
+}
+
+// `pub` (in test builds only, since the whole module is gated `#[cfg(test)]`)
+// so `plan_build.rs::tests` can reuse `ModuloPartitioner`. Keeping the
+// shared test helpers here rather than in a separate `test_helpers` module
+// avoids introducing a second test-utility surface for one type.
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::transport::{
+        in_proc_channel, DrainBuffer, DrainConfig, DrainItem, MppReceiver, MppSender,
+    };
+    use datafusion::arrow::array::{Int32Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    // ---- shared test helpers ----
+
+    /// Test-only partitioner: row `i` -> destination `i % total_participants`.
+    ///
+    /// Not suitable for production because adjacent rows land on different
+    /// participants regardless of their join key, which would break
+    /// HashJoin/Aggregate correctness. Useful in unit tests because the
+    /// routing is trivially predictable without committing to a specific
+    /// hash output.
+    pub struct ModuloPartitioner {
+        total_participants: u32,
+    }
+
+    impl ModuloPartitioner {
+        pub fn new(total_participants: u32) -> Self {
+            assert!(total_participants > 0);
+            Self { total_participants }
+        }
+    }
+
+    impl RowPartitioner for ModuloPartitioner {
+        fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError> {
+            let n = self.total_participants;
+            Ok((0..batch.num_rows() as u32).map(|i| i % n).collect())
+        }
+
+        fn total_participants(&self) -> u32 {
+            self.total_participants
+        }
+    }
+
+    /// Used by tests to verify round-trip: `split_batch_by_partition` followed
+    /// by `concat_batches` (over the same ordering) produces a permutation of
+    /// the original batch rows grouped by destination. In production, the
+    /// consumer side doesn't need this — the DrainBuffer just yields
+    /// sub-batches directly.
+    fn concat_batches(
+        schema: &SchemaRef,
+        batches: impl IntoIterator<Item = RecordBatch>,
+    ) -> Result<RecordBatch, DataFusionError> {
+        let collected: Vec<RecordBatch> = batches.into_iter().collect();
+        if collected.is_empty() {
+            return RecordBatch::try_new(schema.clone(), vec![])
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
+        }
+        let refs: Vec<&RecordBatch> = collected.iter().collect();
+        datafusion::arrow::compute::concat_batches(schema, refs)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+
+    /// Synchronous producer-side shuffle pump.
+    ///
+    /// Consumes an iterator of input batches, partitions each batch by the
+    /// supplied [`RowPartitioner`], ships the non-self sub-batches through
+    /// `outbound_senders[j]` (for `j != participant_index`), and delivers
+    /// the self-partition sub-batch via `push_self`.
+    ///
+    /// ## Ownership contract
+    ///
+    /// `outbound_senders` is passed **by value** and dropped when the pump
+    /// returns (Ok or Err). Dropping the senders is what signals clean EOF
+    /// to peer `MppReceiver`s on the other end of the channel — the peer's
+    /// drain thread observes `Detached` and marks its corresponding source
+    /// done. Taking this by `&mut` would leave senders alive in the
+    /// caller's scope and let peers block forever; moving ownership into
+    /// this function makes the end-of-stream signal automatic.
+    ///
+    /// ## Error semantics
+    ///
+    /// On any error (partition compute, scatter, `push_self`, or `send`)
+    /// the pump returns `Err(DataFusionError)` immediately, dropping all
+    /// remaining senders. Peers cannot distinguish a truncated shuffle
+    /// from a clean EOF — the shm_mq / channel protocol doesn't carry an
+    /// explicit "abort" tag. It is therefore the caller's responsibility
+    /// to propagate the error up through the DataFusion `ExecutionPlan`
+    /// so every worker aborts the whole query, not just this operator. A
+    /// silent drop would make peers' downstream aggregate nodes happily
+    /// finalize over incomplete input and return wrong answers.
+    /// `build_shuffle_stream` honors this by surfacing the error via the
+    /// stream's `Err` item.
+    ///
+    /// ## Producer order
+    ///
+    /// Inside each input batch we push the self-partition to `push_self`
+    /// *first*, then the peer sub-batches. That means a local downstream
+    /// operator (e.g., FinalAgg on our participant) can start consuming
+    /// the self-partition even while some peer sender is blocked on
+    /// back-pressure. If we pushed peers first, a full-sender stall on
+    /// participant 0 would indirectly stall our own consumer because it
+    /// never sees any self rows until the stall unblocks.
+    ///
+    /// This is the non-streaming core of `ShuffleExec`: the DataFusion
+    /// operator composes this same logic inside a `Stream::poll_next`,
+    /// but the synchronous form is unit-testable without setting up a
+    /// DataFusion runtime.
+    fn run_shuffle_pump<I>(
+        input: I,
+        partitioner: &dyn RowPartitioner,
+        outbound_senders: Vec<Option<MppSender>>,
+        participant_index: u32,
+        mut push_self: impl FnMut(RecordBatch) -> Result<(), DataFusionError>,
+    ) -> Result<(), DataFusionError>
+    where
+        I: IntoIterator<Item = Result<RecordBatch, DataFusionError>>,
+    {
+        let n = partitioner.total_participants();
+        if outbound_senders.len() != n as usize {
+            return Err(DataFusionError::Internal(format!(
+                "run_shuffle_pump: outbound_senders.len()={} != total_participants={}",
+                outbound_senders.len(),
+                n
+            )));
+        }
+        if participant_index >= n {
+            return Err(DataFusionError::Internal(format!(
+                "run_shuffle_pump: participant_index {participant_index} >= total_participants {n}"
+            )));
+        }
+
+        for batch_result in input {
+            let batch = batch_result?;
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            let dests = partitioner.partition_for_each_row(&batch)?;
+            let mut subs = split_batch_by_partition(&batch, &dests, n)?;
+
+            // Push self first so a blocked peer send doesn't starve the
+            // local downstream consumer — see module docstring.
+            if let Some(self_sub) = subs[participant_index as usize].take() {
+                push_self(self_sub)?;
+            }
+
+            for (dest_idx, sub) in subs.into_iter().enumerate() {
+                if dest_idx as u32 == participant_index {
+                    // Already handled above (taken() cleared the slot).
+                    debug_assert!(sub.is_none());
+                    continue;
+                }
+                let Some(sub) = sub else { continue };
+                let sender = outbound_senders[dest_idx].as_ref().ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "run_shuffle_pump: no outbound sender for participant {dest_idx}"
+                    ))
+                })?;
+                sender.send_batch(&sub)?;
+            }
+        }
+
+        // `outbound_senders` drops here: peer MppReceivers observe
+        // `Detached` and mark their source done, producing clean EOF on
+        // the remote drain.
+        drop(outbound_senders);
+        Ok(())
+    }
+
+    // ---- tests ----
+
+    fn sample_batch(rows: i32) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..rows);
+        let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
+    }
+
+    #[test]
+    fn modulo_partitioner_round_robins() {
+        let batch = sample_batch(7);
+        let p = ModuloPartitioner::new(3);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        assert_eq!(dests, vec![0, 1, 2, 0, 1, 2, 0]);
+    }
+
+    #[test]
+    fn split_batch_by_partition_preserves_order() {
+        let batch = sample_batch(6);
+        let dests = vec![0, 1, 0, 1, 0, 1]; // N=2
+        let out = split_batch_by_partition(&batch, &dests, 2).unwrap();
+        assert_eq!(out.len(), 2);
+        let p0 = out[0].as_ref().unwrap();
+        let p1 = out[1].as_ref().unwrap();
+        assert_eq!(p0.num_rows(), 3);
+        assert_eq!(p1.num_rows(), 3);
+        // Within each destination, original order is preserved.
+        let ids_p0 = p0.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(ids_p0.values(), &[0, 2, 4]);
+        let ids_p1 = p1.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(ids_p1.values(), &[1, 3, 5]);
+    }
+
+    #[test]
+    fn split_batch_by_partition_returns_none_for_empty_destinations() {
+        let batch = sample_batch(4);
+        let dests = vec![0, 0, 0, 0]; // All to 0
+        let out = split_batch_by_partition(&batch, &dests, 3).unwrap();
+        assert!(out[0].is_some());
+        assert!(out[1].is_none());
+        assert!(out[2].is_none());
+    }
+
+    #[test]
+    fn split_batch_by_partition_rejects_length_mismatch() {
+        let batch = sample_batch(4);
+        let dests = vec![0, 1]; // Wrong length
+        assert!(split_batch_by_partition(&batch, &dests, 2).is_err());
+    }
+
+    #[test]
+    fn split_batch_by_partition_rejects_out_of_range_destination() {
+        let batch = sample_batch(3);
+        let dests = vec![0, 5, 0]; // Destination 5 > total=2
+        assert!(split_batch_by_partition(&batch, &dests, 2).is_err());
+    }
+
+    #[test]
+    fn split_roundtrips_via_concat() {
+        // Full round-trip: split then concat in destination order; the
+        // result is a permutation of the original batch by destination.
+        let batch = sample_batch(8);
+        let p = ModuloPartitioner::new(3);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        let split = split_batch_by_partition(&batch, &dests, 3).unwrap();
+        let schema = batch.schema();
+        let concatenated = concat_batches(&schema, split.into_iter().flatten()).unwrap();
+        assert_eq!(concatenated.num_rows(), batch.num_rows());
+        // IDs should appear grouped by destination (0,3,6 then 1,4,7 then 2,5).
+        let ids = concatenated
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(ids.values(), &[0, 3, 6, 1, 4, 7, 2, 5]);
+    }
+
+    #[test]
+    fn hash_partitioner_is_deterministic() {
+        let batch = sample_batch(100);
+        let p = HashPartitioner::new(vec![0], 4);
+        let dests_a = p.partition_for_each_row(&batch).unwrap();
+        let dests_b = p.partition_for_each_row(&batch).unwrap();
+        assert_eq!(dests_a, dests_b);
+        assert_eq!(dests_a.len(), 100);
+        for d in &dests_a {
+            assert!(*d < 4);
+        }
+    }
+
+    #[test]
+    fn hash_partitioner_is_deterministic_with_multi_column_keys() {
+        // Production HashJoin keys are typically composite. Verify that
+        // multi-column routing is deterministic across repeated calls
+        // and that all destinations stay within `[0, total_participants)`.
+        // (DataFusion's `create_hashes` combines per-column hashes
+        // commutatively, so swapping `vec![0, 1]` for `vec![1, 0]` does
+        // not change the destination — that's not a property worth
+        // asserting here.)
+        let batch = sample_batch(64);
+        let p = HashPartitioner::new(vec![0, 1], 4);
+        let dests_a = p.partition_for_each_row(&batch).unwrap();
+        let dests_b = p.partition_for_each_row(&batch).unwrap();
+        assert_eq!(dests_a, dests_b);
+        assert_eq!(dests_a.len(), 64);
+        for d in &dests_a {
+            assert!(*d < 4);
+        }
+        // Distribution sanity: with 64 rows over 4 destinations, every
+        // bucket should have at least one row. A multi-column key that
+        // accidentally collapsed to a single hash would drop most of
+        // these to zero.
+        let mut hits = [false; 4];
+        for d in &dests_a {
+            hits[*d as usize] = true;
+        }
+        assert!(hits.iter().all(|h| *h));
+    }
+
+    #[test]
+    fn hash_partitioner_degenerate_n1_routes_all_to_zero() {
+        let batch = sample_batch(50);
+        let p = HashPartitioner::new(vec![0], 1);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        assert!(dests.iter().all(|&d| d == 0));
+    }
+
+    #[test]
+    fn hash_partitioner_requires_key_columns() {
+        let batch = sample_batch(10);
+        let p = HashPartitioner::new(vec![], 2);
+        assert!(p.partition_for_each_row(&batch).is_err());
+    }
+
+    /// Harness: wire N=2 in-proc channels and feed `batches` through the
+    /// pump as participant 0. Returns (self_batches, peer_batches).
+    fn drive_pump_n2(
+        batches: Vec<RecordBatch>,
+        partitioner: &dyn RowPartitioner,
+    ) -> (Vec<RecordBatch>, Vec<RecordBatch>) {
+        let (tx, rx) = in_proc_channel(16);
+        let senders: Vec<Option<MppSender>> = vec![
+            None,                               // participant 0 = self, no sender
+            Some(MppSender::new(Box::new(tx))), // participant 1 = peer
+        ];
+
+        let mut self_batches = Vec::new();
+
+        let input_iter = batches.into_iter().map(Ok::<_, DataFusionError>);
+        run_shuffle_pump(input_iter, partitioner, senders, 0, |b| {
+            self_batches.push(b);
+            Ok(())
+        })
+        .unwrap();
+        // `senders` was moved into the pump and dropped on return; peer
+        // receiver now observes `Detached` on its next `try_recv`.
+
+        // Drain the peer channel into a DrainBuffer via the drain thread so
+        // we exercise the actual drain path end-to-end.
+        let receiver = MppReceiver::new(Box::new(rx));
+        let buffer = DrainBuffer::new(1);
+        let drain_handle =
+            DrainHandle::spawn(DrainConfig::new(vec![receiver], Arc::clone(&buffer)));
+
+        let mut peer_batches = Vec::new();
+        while let DrainItem::Batch(b) = buffer.pop_front() {
+            peer_batches.push(b);
+        }
+        drain_handle.shutdown().unwrap();
+
+        (self_batches, peer_batches)
+    }
+
+    #[test]
+    fn pump_routes_self_and_peer_partitions_end_to_end() {
+        // Row i -> participant (i % 2). With 6 input rows: self gets 0,2,4; peer
+        // gets 1,3,5. Verifies the full stack: partition → scatter → send
+        // over in-proc channel → drain thread → drain buffer.
+        let input = vec![sample_batch(6)];
+        let partitioner = ModuloPartitioner::new(2);
+        let (self_b, peer_b) = drive_pump_n2(input, &partitioner);
+
+        assert_eq!(self_b.len(), 1);
+        assert_eq!(peer_b.len(), 1);
+
+        let self_ids = self_b[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(self_ids.values(), &[0, 2, 4]);
+
+        let peer_ids = peer_b[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(peer_ids.values(), &[1, 3, 5]);
+    }
+
+    #[test]
+    fn pump_handles_multiple_batches() {
+        let input = vec![sample_batch(4), sample_batch(4), sample_batch(4)];
+        let partitioner = ModuloPartitioner::new(2);
+        let (self_b, peer_b) = drive_pump_n2(input, &partitioner);
+        // 3 batches × 2 rows each per destination
+        let self_total: usize = self_b.iter().map(|b| b.num_rows()).sum();
+        let peer_total: usize = peer_b.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(self_total, 6);
+        assert_eq!(peer_total, 6);
+    }
+
+    #[test]
+    fn pump_skips_empty_batches() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let empty = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from_iter_values([])),
+                Arc::new(StringArray::from_iter_values::<String, _>([])),
+            ],
+        )
+        .unwrap();
+        let input = vec![empty, sample_batch(2)];
+        let partitioner = ModuloPartitioner::new(2);
+        let (self_b, peer_b) = drive_pump_n2(input, &partitioner);
+        let self_total: usize = self_b.iter().map(|b| b.num_rows()).sum();
+        let peer_total: usize = peer_b.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(self_total, 1);
+        assert_eq!(peer_total, 1);
+    }
+
+    #[test]
+    fn pump_propagates_input_errors() {
+        let err: Result<RecordBatch, DataFusionError> =
+            Err(DataFusionError::Execution("synthetic".into()));
+        let (tx, _rx) = in_proc_channel(1);
+        let senders: Vec<Option<MppSender>> = vec![None, Some(MppSender::new(Box::new(tx)))];
+        let partitioner = ModuloPartitioner::new(2);
+
+        let result = run_shuffle_pump(vec![err], &partitioner, senders, 0, |_| Ok(()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pump_errors_when_peer_slot_is_none() {
+        // Participant 1 should route rows to a peer, but there's no MppSender.
+        // Must fail with a meaningful error rather than silently drop data.
+        let partitioner = ModuloPartitioner::new(2);
+        let senders: Vec<Option<MppSender>> = vec![None, None];
+        let result = run_shuffle_pump(
+            vec![Ok(sample_batch(2))], // row 0 -> participant 0 (self), row 1 -> participant 1 (peer)
+            &partitioner,
+            senders,
+            0,
+            |_| Ok(()),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("no outbound sender for participant 1"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pump_rejects_wrong_sender_count() {
+        let partitioner = ModuloPartitioner::new(2);
+        // Only 1 sender slot for N=2.
+        let senders: Vec<Option<MppSender>> = vec![None];
+        let result = run_shuffle_pump(vec![Ok(sample_batch(4))], &partitioner, senders, 0, |_| {
+            Ok(())
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn hash_partitioner_distributes_across_participants() {
+        // Over 1000 rows with 4 participants, every participant should get at least some.
+        // This is a statistical claim that should hold for any non-adversarial
+        // hash.
+        let batch = sample_batch(1000);
+        let p = HashPartitioner::new(vec![0], 4);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        let mut counts = [0usize; 4];
+        for d in &dests {
+            counts[*d as usize] += 1;
+        }
+        for (participant, count) in counts.iter().enumerate() {
+            assert!(
+                *count > 100,
+                "participant {participant} only received {count}/1000 rows — partitioner is skewed"
+            );
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! Transport layer for MPP shuffle.
 //!
 //! Layout:
@@ -23,19 +24,20 @@
 //!   writes into and the DataFusion consumer reads from. It decouples
 //!   consumer-side backpressure from producer-side backpressure: the drain thread
 //!   always makes forward progress on the inbound shm_mqs, so a stalled consumer
-//!   cannot propagate backpressure to remote producers and cause the N×N cycle
-//!   that deadlocked the prior attempt.
+//!   cannot propagate backpressure to remote producers and cause an N×N
+//!   peer-stall cycle.
 //!
 //! The shm_mq-backed sender/receiver and drain thread spawn logic build on
 //! top of these primitives.
 
-#![allow(dead_code)]
-
 use std::collections::VecDeque;
-use std::sync::{Arc, Condvar, Mutex};
-use std::thread::JoinHandle;
+use std::future::poll_fn;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::task::{Poll, Waker};
 #[cfg(test)]
-use std::time::Duration;
+use std::thread;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::ipc::reader::StreamReader;
@@ -103,7 +105,7 @@ struct DrainBufferInner {
     /// DataFusion `poll_next` returns `Poll::Pending` without blocking the
     /// executor thread. `Option` so we don't allocate one if the buffer is
     /// only consumed synchronously via `pop_front`.
-    waker: Option<std::task::Waker>,
+    waker: Option<Waker>,
 }
 
 /// Yielded by [`DrainBuffer::pop_front`].
@@ -198,35 +200,61 @@ impl DrainBuffer {
             .cancelled
     }
 
-    /// Async-friendly variant of `pop_front`. Returns `DrainItem` when a
-    /// batch or EOF is immediately available; otherwise registers `waker`
-    /// to be woken on the next `push_batch` / `notify_source_done` / `cancel`
-    /// and returns `None`.
-    ///
-    /// Using this from a `Stream::poll_next` lets `DrainGatherStream` return
-    /// `Poll::Pending` instead of blocking the executor thread — critical
-    /// under peer-to-peer backpressure, where a blocking wait could deadlock
-    /// with this worker's own outbound pump.
-    ///
-    /// Why hand-rolled instead of `tokio::sync::mpsc`: the producer side is
-    /// a real OS thread (the drain thread) that blocks inside the `shm_mq`
-    /// FFI; it cannot be a Tokio task because `shm_mq_receive` has no async
-    /// readiness signal. Swapping `DrainBuffer` for `mpsc::unbounded_channel`
-    /// and calling `rx.poll_recv(cx)` on the consumer is plausible, but the
-    /// producer stays an OS thread regardless, and the small
-    /// `Mutex<Option<Waker>>` is the entire delta — not load-bearing for
-    /// correctness. Tracked as a post-merge follow-up.
-    pub fn poll_pop_front(&self, waker: &std::task::Waker) -> Option<DrainItem> {
+    /// Async-friendly variant of `pop_front`. Returns immediately with a
+    /// batch or EOF if available; otherwise registers `waker` (to be woken
+    /// on the next `push_batch` / `notify_source_done` / `cancel`) and
+    /// returns `None`. Lets `DrainGatherStream::poll_next` return
+    /// `Poll::Pending` instead of blocking the executor thread.
+    pub fn poll_pop_front(&self, waker: &Waker) -> Option<DrainItem> {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        if let Some(item) = Self::try_pop_locked(&mut guard) {
+            return Some(item);
+        }
+        // Single-consumer invariant; switch to `Vec<Waker>` if ever lifted.
+        debug_assert!(
+            guard.waker.is_none() || guard.waker.as_ref().unwrap().will_wake(waker),
+            "DrainBuffer::poll_pop_front: second consumer registered a different waker — \
+             only one consumer is supported per buffer"
+        );
+        guard.waker = Some(waker.clone());
+        None
+    }
+
+    /// Await-able wrapper over [`poll_pop_front`]. Use only for thread-backed
+    /// drains; cooperative handles must use [`try_pop`](Self::try_pop) +
+    /// executor yield (otherwise the await suspends with no one to wake it).
+    pub async fn recv(self: &Arc<Self>) -> DrainItem {
+        let buf = Arc::clone(self);
+        poll_fn(move |cx| match buf.poll_pop_front(cx.waker()) {
+            Some(item) => Poll::Ready(item),
+            None => Poll::Pending,
+        })
+        .await
+    }
+
+    /// Non-blocking, non-waker variant of [`poll_pop_front`]. Returns the
+    /// front item or `DrainItem::Eof` if all sources have detached and
+    /// the queue is drained; returns `None` only when more data may yet
+    /// arrive. Cooperative consumers loop on `poll_drain_pass` + `try_pop`,
+    /// yielding to the executor between iterations.
+    pub fn try_pop(&self) -> Option<DrainItem> {
+        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        Self::try_pop_locked(&mut guard)
+    }
+
+    /// Shared body of [`try_pop`] and [`poll_pop_front`]. Returns
+    /// `Some(Batch)` if the queue has data, `Some(Eof)` if all sources
+    /// have detached or the buffer is cancelled, and `None` otherwise.
+    /// Lets the two public entry points stay in lockstep on the
+    /// "buffered data wins over cancellation/EOF" invariant locked in
+    /// by `drain_buffer_drains_buffered_before_eof`.
+    fn try_pop_locked(guard: &mut MutexGuard<'_, DrainBufferInner>) -> Option<DrainItem> {
         if let Some(batch) = guard.queue.pop_front() {
             return Some(DrainItem::Batch(batch));
         }
         if guard.cancelled || guard.sources_done >= guard.num_sources {
             return Some(DrainItem::Eof);
         }
-        // Register (or replace) the waker. Only one consumer at a time is
-        // expected — DrainGatherStream — so simple replacement is fine.
-        guard.waker = Some(waker.clone());
         None
     }
 }
@@ -289,6 +317,19 @@ pub struct MppSender {
     /// behind a shared borrow during `process_batch`).
     scratch: std::cell::RefCell<Vec<u8>>,
 }
+
+// SAFETY: `MppSender` lives inside `ShuffleWiring`, which is owned by a
+// single `ShuffleExec` running on a single backend thread. The async
+// `send_batch_traced` future captures `&self` and contains a Tokio
+// `yield_now().await`; the compiler conservatively requires the future
+// to be `Send`, which forces `&MppSender: Send` and therefore
+// `MppSender: Sync`. At runtime the future is created and consumed on
+// the same thread (DataFusion's current-thread runtime on the backend),
+// so there is no actual cross-thread aliasing of the inner `RefCell` or
+// of the `Box<dyn BatchChannelSender>`. This mirrors the same
+// single-thread-by-construction contract that justifies
+// `unsafe impl Send for ShmMqSender` over in `mesh.rs`.
+unsafe impl Sync for MppSender {}
 
 impl MppSender {
     pub fn new(channel: Box<dyn BatchChannelSender>) -> Self {
@@ -358,7 +399,7 @@ impl MppSender {
         scratch: &mut Vec<u8>,
         stats: &mut SendBatchStats,
     ) -> Result<(), DataFusionError> {
-        let t_enc = std::time::Instant::now();
+        let t_enc = Instant::now();
         encode_batch_into(batch, scratch)?;
         stats.encode += t_enc.elapsed();
         let Some(drain) = self.cooperative_drain.as_ref() else {
@@ -367,7 +408,7 @@ impl MppSender {
             return self.channel.send_bytes(scratch);
         };
         let mut first_try = true;
-        let t_wait_start = std::time::Instant::now();
+        let t_wait_start = Instant::now();
         // Mental model: a current-thread Tokio runtime lives on the
         // backend thread (DataFusion needs one to drive `Stream`s).
         // This spin runs *inside* a Tokio task — specifically the body
@@ -413,7 +454,7 @@ impl MppSender {
             // neither gets to drain. Errors propagate so a peer
             // detaching mid-spin doesn't leave the sender looping
             // forever on a closed mesh.
-            let t_drain = std::time::Instant::now();
+            let t_drain = Instant::now();
             drain.poll_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
             tokio::task::yield_now().await;
@@ -426,15 +467,15 @@ impl MppSender {
 #[derive(Default, Debug, Clone)]
 pub struct SendBatchStats {
     /// Cumulative time spent inside `encode_batch` (Arrow IPC serialization).
-    pub encode: std::time::Duration,
+    pub encode: Duration,
     /// Cumulative wall time in the send-retry spin after the first failed
     /// `try_send_bytes`. Zero if the first try succeeded.
-    pub send_wait: std::time::Duration,
+    pub send_wait: Duration,
     /// Cumulative time spent in `poll_drain_pass` while spinning on a
     /// full outbound. A subset of `send_wait`; the remainder is the
     /// `tokio::task::yield_now()` await + the (small) cost of
     /// `try_send_bytes` itself.
-    pub coop_drain_in_spin: std::time::Duration,
+    pub coop_drain_in_spin: Duration,
     /// Count of `try_send_bytes` calls that returned `Ok(false)` (full).
     pub spin_iters: u64,
 }
@@ -508,7 +549,7 @@ impl DrainConfig {
 /// done, the thread exits.
 #[cfg(test)]
 pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusionError>> {
-    std::thread::spawn(move || drain_loop(config))
+    thread::spawn(move || drain_loop(config))
 }
 
 /// RAII wrapper around a drain thread's `JoinHandle` and its `DrainBuffer`.
@@ -732,7 +773,7 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
             return Ok(());
         }
         if !got_any {
-            std::thread::sleep(idle_sleep);
+            thread::sleep(idle_sleep);
         }
     }
 }
@@ -847,10 +888,10 @@ mod tests {
         let buf = DrainBuffer::new(2);
         let producer = StdArc::clone(&buf);
         let handle = thread::spawn(move || {
-            thread::sleep(std::time::Duration::from_millis(20));
+            thread::sleep(Duration::from_millis(20));
             producer.push_batch(sample_batch(2));
             producer.notify_source_done();
-            thread::sleep(std::time::Duration::from_millis(20));
+            thread::sleep(Duration::from_millis(20));
             producer.notify_source_done();
         });
 
@@ -867,7 +908,7 @@ mod tests {
         let buf = DrainBuffer::new(1);
         let canceller = StdArc::clone(&buf);
         let handle = thread::spawn(move || {
-            thread::sleep(std::time::Duration::from_millis(20));
+            thread::sleep(Duration::from_millis(20));
             canceller.cancel();
         });
         assert!(matches!(buf.pop_front(), DrainItem::Eof));
@@ -948,11 +989,11 @@ mod tests {
 
         // Simulate consumer path error: drop the handle without calling
         // shutdown(). The drain thread must exit before drop returns.
-        let start = std::time::Instant::now();
+        let start = Instant::now();
         drop(handle);
         let elapsed = start.elapsed();
         assert!(
-            elapsed < std::time::Duration::from_secs(2),
+            elapsed < Duration::from_secs(2),
             "DrainHandle::drop took too long: {elapsed:?}"
         );
         // Consumer observes EOF because cancel was called.
@@ -961,11 +1002,11 @@ mod tests {
 
     #[test]
     fn drain_thread_drains_n2_mesh_100k_batches() {
-        // Milestone-1 gate: simulate the 2-participant mesh. Each of two
-        // producers pushes 50_000 small batches through a bounded channel;
-        // the drain thread interleaves and the consumer reads EOF exactly
-        // after receiving all 100_000 batches. Exercises backpressure
-        // (bounded capacity = 16) without deadlock.
+        // Simulates a 2-participant mesh under load. Each of two producers
+        // pushes 50_000 small batches through a bounded channel; the drain
+        // thread interleaves and the consumer reads EOF exactly after
+        // receiving all 100_000 batches. Exercises backpressure (bounded
+        // capacity = 16) without deadlock.
         const PER_SOURCE: usize = 50_000;
         let (tx0, rx0) = in_proc_channel(16);
         let (tx1, rx1) = in_proc_channel(16);
@@ -1086,7 +1127,7 @@ mod tests {
         let template = make_batch(batch_rows);
         // Encode once up front so we also report pure-encode throughput
         // separately. Real queries encode inside the hot path per batch.
-        let enc_start = std::time::Instant::now();
+        let enc_start = Instant::now();
         let mut enc_bytes = 0usize;
         for _ in 0..batches {
             enc_bytes += encode_batch(&template).expect("encode").len();
@@ -1107,7 +1148,7 @@ mod tests {
         let tx1_send = MppSender::new(Box::new(tx1));
 
         let per_source = batches / 2;
-        let round_trip_start = std::time::Instant::now();
+        let round_trip_start = Instant::now();
         let p0 = {
             let b = template.clone();
             thread::spawn(move || {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -163,6 +163,9 @@ pub struct PgSearchScanPlan {
     deferred_ctid_plan_position: Option<usize>,
     /// When true, a HashJoin InList was successfully pushed down to a TermSet query.
     dynamic_filter_pushdown: Arc<AtomicBool>,
+    /// Sort order preserved across `with_filter_pushdown` rebuilds so the
+    /// rebuilt plan keeps its equivalence properties.
+    sort_order: Option<SortByField>,
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -245,7 +248,73 @@ impl PgSearchScanPlan {
             indexrelid,
             deferred_ctid_plan_position,
             dynamic_filter_pushdown: Arc::new(AtomicBool::new(false)),
+            sort_order: sort_order.cloned(),
         }
+    }
+
+    /// Produce a plan identical to `dyn_plan` but with `dynamic_filters` emptied.
+    ///
+    /// Used by MPP: the join's dynamic-filter Arc is pushed to the probe-side
+    /// scan by `FilterPushdown`, but MPP needs to apply it *after* the probe
+    /// shuffle (so local bounds are not applied to rows destined for peer
+    /// participants). We strip it from the scan and re-apply it via a
+    /// `FilterExec` above the post-shuffle output.
+    ///
+    /// Transfers scan state out of the original plan — the original becomes
+    /// a dead stub whose `execute` returns empty streams. Returns the plan
+    /// unchanged when there are no dynamic filters to strip.
+    ///
+    /// # Caller contract
+    ///
+    /// This is a primitive: it strips unconditionally and does not validate
+    /// that re-attaching the filter elsewhere is safe. It is correct only
+    /// when the caller is rebuilding the plan such that the stripped
+    /// filter will be reapplied above a `ShuffleExec` that crosses
+    /// participant boundaries.
+    ///
+    /// In particular, do *not* call this on a scan whose enclosing
+    /// `HashJoinExec` lives entirely on one participant (e.g., a join that
+    /// is itself below a shuffle): the dynamic filter is fully populated
+    /// locally there and dropping it loses a valuable optimization with no
+    /// correctness benefit.
+    #[allow(dead_code)] // walker (PR #4870) is the live caller
+    pub fn strip_dynamic_filters_from_dyn(
+        dyn_plan: Arc<dyn ExecutionPlan>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let scan = match dyn_plan.as_any().downcast_ref::<PgSearchScanPlan>() {
+            Some(s) => s,
+            None => {
+                return Err(DataFusionError::Internal(
+                    "strip_dynamic_filters_from_dyn called on a non-PgSearchScanPlan ExecutionPlan"
+                        .into(),
+                ));
+            }
+        };
+
+        if scan.dynamic_filters.is_empty() {
+            return Ok(dyn_plan);
+        }
+
+        let taken = {
+            let mut guard = scan.states.lock().map_err(|e| {
+                DataFusionError::Internal(format!("Failed to lock PgSearchScanPlan state: {e}"))
+            })?;
+            std::mem::take(&mut *guard)
+        };
+        let states: Vec<ScanState> = taken.into_iter().flatten().map(|u| u.0).collect();
+
+        let schema = scan.properties.eq_properties.schema().clone();
+        let new_plan = PgSearchScanPlan::new(
+            states,
+            schema,
+            scan.query_for_display.clone(),
+            scan.sort_order.as_ref(),
+            scan.deferred_fields.clone(),
+            scan.ffhelper.clone(),
+            scan.indexrelid,
+            scan.deferred_ctid_plan_position,
+        );
+        Ok(Arc::new(new_plan))
     }
 
     pub fn has_deferred_fields(&self) -> bool {
@@ -573,6 +642,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                 dynamic_filter_pushdown: Arc::new(AtomicBool::new(
                     self.dynamic_filter_pushdown.load(Ordering::Relaxed),
                 )),
+                sort_order: self.sort_order.clone(),
             });
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #4152
- Stacked on top of #4827
- Consumes paradedb/datafusion-distributed#3 (fork PR adding the extension points this chain depends on)

## What

Second PR in the 5-PR MPP chain. Adds the DataFusion shuffle operator that routes batches between MPP participants, teaches the scan layer to read its own slice of segments, and pulls in the `datafusion-distributed` fork dep the rest of the chain consumes.

Still dead code — nothing calls the operator until #4870 (walker) and #4932 (AggregateScan + JoinScan activation) land.

**Chain (2/5):** #4827 → **this** → #4869 → #4870 → #4932

## Why

With the transport + DSM primitives from #4827 in place, the next layer is the DataFusion glue. Landing the operator before the assembler keeps the DataFusion-contract review (partitioning, polling, schema, backpressure) separate from the planner-walk review. The scan-layer slicing is bundled because the shuffle is useless without it — each participant must only read its own segments.

## How

- A single shuffle operator that declares hash partitioning natively to DataFusion's optimizer but moves batches through our in-process shm_mq mesh instead of gRPC. Shape-aligned with the fork's `NetworkShuffleExec`; ships separately because the transport models don't overlap (the operator's doc explains why).
- The row-routing primitives the operator needs (hash + fixed-target) and a row-scatter helper.
- Scan-layer sharding so each participant opens only its segments, plus a probe-side dynamic-filter lift so filters don't cross the shuffle boundary.
- Pins the `datafusion-distributed` fork dep at `dfa96e74` from paradedb/datafusion-distributed#3, which adds the extension points the chain consumes (factory trait + pooled adapter, network-boundary extractor registry, sync annotator, thin walker entry). Default Flight callers are unchanged.

## Reviewer's Guide

- Read the `shuffle.rs` module doc first — it covers why we ship a separate operator instead of using the fork's.
- Then the operator and its row-routing primitives, then the scan-layer files.
- The fork-PR description summarises each extension point; consumers of those land here (`BoundaryFactory`, extractor registry) and in #4870 (`annotate_plan_sync`, `distribute_annotated_plan`, `PooledBoundaryFactory`).

## Tests

- `cargo check` / `cargo clippy` clean.
- Unit tests for the operator and the row-routing primitives.
- Regression suite unchanged with `enable_mpp = off`; identical to `main`.