### PR TITLE
feat(mpp): plan assembly — shape classifier, plan builder (3/5)

### DIFF
--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -27,7 +27,9 @@
 
 pub mod chain;
 pub mod mesh;
+pub mod plan_build;
 pub mod session;
+pub mod shape;
 pub mod shuffle;
 pub mod transport;
 pub mod worker;

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -1,0 +1,332 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! MPP physical-plan primitives.
+//!
+//! # What MPP actually does, and where this module fits
+//!
+//! The milestone-1 benchmark is `SELECT COUNT(*) FROM f JOIN p ON f.id = p.fileId
+//! WHERE f.content ||| 'Section'` — a scalar aggregate over a join. The MPP win
+//! for that query comes from **hash-partitioning the join inputs**, not from
+//! partitioning the aggregate output. Per worker, the physical plan looks like:
+//!
+//! ```text
+//!     AggregateExec(Partial, COUNT(*))            ← emits one partial row per worker
+//!       HashJoinExec(PartitionMode::Partitioned)
+//!         wrap_with_mpp_shuffle([Scan f → Filter], hash=[f.id])
+//!         wrap_with_mpp_shuffle([Scan p         ], hash=[p.fileId])
+//! ```
+//!
+//! PG's `Gather` concatenates all participants' Partial outputs and PG's
+//! `Finalize Aggregate` sums them into the final COUNT. Our CustomScan produces
+//! partial rows; Postgres handles the finalization above us.
+//!
+//! # What this module provides
+//!
+//! [`wrap_with_mpp_shuffle`] is the single reusable primitive that wraps any
+//! `ExecutionPlan` with the MPP mesh topology:
+//!
+//! ```text
+//!     inner ──── ShuffleExec (hash, self-partition out) ─┐
+//!                                                         ├→ UnionExec
+//!                          DrainGatherExec (peer rows) ───┘
+//! ```
+//!
+//! The output stream emits exactly the rows of `inner` that hash to this
+//! participant's seat — some from local computation, some from peers —
+//! merged into a single Arrow IPC-compatible `SendableRecordBatchStream`.
+//!
+//! Callers (AggregateScan, future JoinScan MPP) compose `HashJoinExec`,
+//! `AggregateExec(Partial)`, or any other DataFusion operator on top of the
+//! wrapped child. Because each wrap consumes one directed mesh of shm_mqs
+//! (one `ShuffleWiring` + one `DrainHandle`), a binary hash-partitioned join
+//! needs **two** independent mesh wirings — one per side. Phase 4b-iv's DSM
+//! hook layer allocates and distributes them; this module is ABI-agnostic
+//! about where they come from.
+//!
+//! # What was here before
+//!
+//! An earlier version of this module shipped `build_mpp_aggregate_plan` that
+//! composed `Partial → Shuffle → Union(DrainGather) → FinalPartitioned`. That
+//! topology is structurally correct for *hash-partitioned GROUP BY* aggregates
+//! where each final group lives on exactly one participant — but it is
+//! **incorrect for scalar aggregates** (our benchmark target). The final
+//! `FinalPartitioned` on a participant whose inbound side is empty emits a
+//! spurious all-NULL row; PG's Gather concatenates that into the output and
+//! breaks the scalar contract. The broken helper is replaced rather than
+//! patched: pre-join-shuffle of raw rows (this module) is the correct
+//! building block for the benchmark and cleanly composes with DataFusion's
+//! existing `HashJoinExec(Partitioned)`.
+
+#![allow(dead_code)] // caller lands in Phase 4b-iv step 4
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+
+use crate::postgres::customscan::mpp::chain::ChainExec;
+
+use crate::postgres::customscan::mpp::shuffle::{DrainGatherExec, ShuffleExec, ShuffleWiring};
+use crate::postgres::customscan::mpp::transport::DrainHandle;
+
+/// Inputs to [`wrap_with_mpp_shuffle`].
+///
+/// - `child`: the plan whose output rows should be hash-shuffled across the
+///   mesh. Typically `Scan → Filter` for one side of a join.
+/// - `wiring`: the outbound half of this participant's mesh edge — one
+///   `MppSender` per peer seat, `None` at the self seat. `ShuffleExec`
+///   consumes it.
+/// - `drain_handle`: the inbound half — a `DrainBuffer` whose drain thread
+///   is reading peer-sent rows for this participant. `DrainGatherExec`
+///   consumes it.
+/// - `wrapped_schema`: schema of both `child.schema()` and the peer-sent
+///   Arrow IPC batches. Must be the same on both sides so `UnionExec` can
+///   splice them. Also used by `DrainGatherExec` to reject schema-drifted
+///   peer batches at decode time.
+pub struct MppShuffleInputs {
+    pub child: Arc<dyn ExecutionPlan>,
+    pub wiring: ShuffleWiring,
+    pub drain_handle: Arc<DrainHandle>,
+    pub wrapped_schema: SchemaRef,
+    /// Diagnostic label used in `mpp_log!` row-count reports. Typically one
+    /// of `"left"`, `"right"`, `"postagg"`, `"final"`. Purely for tracing;
+    /// no control flow depends on it.
+    pub tag: &'static str,
+}
+
+/// Wrap a child plan with the MPP hash-shuffle topology.
+///
+/// Output: a single-partition stream that contains
+///   - rows of `child` that hashed to this participant's seat (via
+///     `ShuffleExec` — peer-bound rows are shipped to `wiring.outbound`
+///     before being dropped from the local stream);
+///   - rows sent by peers via shm_mq that the drain thread has read into
+///     `drain_handle.buffer` (via `DrainGatherExec`).
+///
+/// `UnionExec` alone would give us two partitions (one per child); since
+/// each caller (the PG Gather loop, HashJoinExec, etc.) only drives
+/// `execute(0)`, the second partition's `DrainGatherExec` would never be
+/// polled and peer-shipped rows would pile up unread. `CoalescePartitionsExec`
+/// above the Union merges the two streams into one partition so everything
+/// is read through partition 0. The output therefore has
+/// `Partitioning::UnknownPartitioning(1)`, which is what downstream
+/// `HashJoinExec(Partitioned)` expects as a pre-shuffled input.
+///
+/// Both mesh halves (`wiring` + `drain_handle`) are consumed on this single
+/// call. A two-input join needs TWO independent calls to this function —
+/// one per side — with independently-allocated meshes.
+pub fn wrap_with_mpp_shuffle(
+    inputs: MppShuffleInputs,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let MppShuffleInputs {
+        child,
+        wiring,
+        drain_handle,
+        wrapped_schema,
+        tag,
+    } = inputs;
+    let participant_index = wiring.participant_index;
+
+    // Multi-partition children (e.g. a PgSearchTableProvider scan that emits one
+    // partition per Tantivy segment) need to be coalesced first: `ShuffleExec`
+    // only consumes its child's partition 0, so without this every segment
+    // beyond the first would be dropped silently, producing correct group
+    // counts but wildly wrong per-group aggregates.
+    let child: Arc<dyn ExecutionPlan> = if child.output_partitioning().partition_count() > 1 {
+        Arc::new(CoalescePartitionsExec::new(child))
+    } else {
+        child
+    };
+
+    // Self-side: ShuffleExec partitions `child`'s stream by
+    // `wiring.partitioner`, emits the rows whose hash lands on this seat,
+    // and concurrently ships rows destined for peers through `wiring.outbound`.
+    let shuffle: Arc<dyn ExecutionPlan> = Arc::new(ShuffleExec::new(child, wiring, tag));
+
+    // Peer-side: DrainGatherExec streams the batches the drain thread has
+    // pulled from this participant's inbound shm_mqs.
+    let gather: Arc<dyn ExecutionPlan> = Arc::new(DrainGatherExec::new(
+        drain_handle,
+        wrapped_schema.clone(),
+        tag,
+        participant_index,
+    ));
+
+    // Splice both streams, then coalesce into a single output partition so
+    // downstream operators driven via `execute(0)` pull from both self AND
+    // peer branches. Without the coalesce, the Union's partition 1 (the
+    // gather side) is orphaned and peer rows are never read.
+    // ChainExec emits a single output partition by polling `shuffle` to
+    // exhaustion first, then `gather`. Two observations make this safe:
+    //
+    //  1. `ShuffleExec` is a leaf-driver: polling it pumps rows through the
+    //     scan → split → ship-to-peers pipeline regardless of whether our
+    //     gather side is also being polled. The drain thread (plain
+    //     `std::thread`, not a tokio task) reads peer-shipped rows into
+    //     `DrainBuffer` *concurrently* with the shuffle's poll, independent
+    //     of the operator's own polling cadence.
+    //  2. `DrainGatherExec` only blocks until its sources mark EOF. Peers'
+    //     senders drop when their own `ShuffleExec` children exhaust — which
+    //     happens as soon as they finish their scan, regardless of whether
+    //     we're currently reading their shipments.
+    //
+    // Together: the self→peer and peer→self flows run concurrently via the
+    // drain threads; the operator's single-threaded poll order is just a
+    // consumption order and cannot cause a cycle. This avoids the
+    // `CoalescePartitionsExec` concurrent-poll deadlock we hit when both
+    // branches spawned tokio tasks that blocked in `shm_mq_send`.
+    ChainExec::try_new(shuffle, gather, wrapped_schema)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::shuffle::ModuloPartitioner;
+    use crate::postgres::customscan::mpp::transport::{
+        in_proc_channel, DrainBuffer, DrainConfig, DrainItem, MppReceiver, MppSender,
+    };
+    use datafusion::arrow::array::{Int32Array, RecordBatch, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::physical_plan::ExecutionPlanProperties;
+    use datafusion::prelude::SessionContext;
+    use futures::StreamExt;
+
+    fn sample_batch(rows: i32) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..rows);
+        let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
+    }
+
+    /// Drive a two-participant mesh in-process: our side shuffles a 10-row
+    /// input at seat 0 with `ModuloPartitioner(2)`, a simulated peer ships
+    /// synthetic batches into our inbound drain. The wrapped stream should
+    /// emit:
+    ///
+    /// - self-partition rows (even IDs: 0,2,4,6,8)
+    /// - peer-partition rows (synthetic IDs 100,200 from the peer)
+    ///
+    /// and the outbound channel should carry the odd IDs that ShuffleExec
+    /// shipped away (1,3,5,7,9).
+    #[test]
+    fn wrap_with_mpp_shuffle_splices_self_and_peer() {
+        let batch = sample_batch(10);
+        let schema = batch.schema();
+        let input = MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap();
+
+        let (out_tx, out_rx) = in_proc_channel(16);
+        let (in_tx, in_rx) = in_proc_channel(16);
+
+        let wiring = ShuffleWiring {
+            partitioner: Arc::new(ModuloPartitioner::new(2)),
+            outbound_senders: vec![None, Some(MppSender::new(Box::new(out_tx)))],
+            participant_index: 0,
+            cooperative_drain: None,
+        };
+
+        // Simulated peer: ship two synthetic batches with a small delay so
+        // the drain thread actually waits on the waker path at least once.
+        let peer_schema = schema.clone();
+        let peer_thread = std::thread::spawn(move || {
+            let sender = MppSender::new(Box::new(in_tx));
+            for (id, name) in [(100i32, "peer100"), (200i32, "peer200")] {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                let b = RecordBatch::try_new(
+                    peer_schema.clone(),
+                    vec![
+                        Arc::new(Int32Array::from_iter_values([id])),
+                        Arc::new(StringArray::from_iter_values([name.to_string()])),
+                    ],
+                )
+                .unwrap();
+                sender.send_batch(&b).unwrap();
+            }
+        });
+
+        let inbound_recv = MppReceiver::new(Box::new(in_rx));
+        let drain_buffer = DrainBuffer::new(1);
+        let drain_handle = DrainHandle::spawn(DrainConfig::new(
+            vec![inbound_recv],
+            Arc::clone(&drain_buffer),
+        ));
+
+        let wrapped = wrap_with_mpp_shuffle(MppShuffleInputs {
+            child: input,
+            wiring,
+            drain_handle: Arc::new(drain_handle),
+            wrapped_schema: schema.clone(),
+            tag: "test",
+        })
+        .unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let ctx = SessionContext::new();
+
+        let mut emitted_ids = Vec::new();
+        rt.block_on(async {
+            let n = wrapped.output_partitioning().partition_count();
+            for p in 0..n {
+                let mut s = wrapped.execute(p, ctx.task_ctx()).unwrap();
+                while let Some(b) = s.next().await {
+                    let b = b.unwrap();
+                    let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+                    emitted_ids.extend(ids.values().iter().copied());
+                }
+            }
+        });
+
+        // Drain the outbound channel to verify the peer-destined rows
+        // actually got shipped.
+        let out_receiver = MppReceiver::new(Box::new(out_rx));
+        let out_buffer = DrainBuffer::new(1);
+        let out_handle = DrainHandle::spawn(DrainConfig::new(
+            vec![out_receiver],
+            Arc::clone(&out_buffer),
+        ));
+        let mut outbound_ids = Vec::new();
+        while let DrainItem::Batch(b) = out_buffer.pop_front() {
+            outbound_ids.extend(
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied(),
+            );
+        }
+        out_handle.shutdown().unwrap();
+        peer_thread.join().unwrap();
+
+        // Union output: self-partition (even IDs) + peer-simulated (100, 200).
+        emitted_ids.sort();
+        assert_eq!(emitted_ids, vec![0, 2, 4, 6, 8, 100, 200]);
+        // Outbound: ShuffleExec shipped odd IDs (rows that hashed to seat 1).
+        outbound_ids.sort();
+        assert_eq!(outbound_ids, vec![1, 3, 5, 7, 9]);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -50,13 +50,13 @@
 //! participant's seat — some from local computation, some from peers —
 //! merged into a single Arrow IPC-compatible `SendableRecordBatchStream`.
 //!
-//! Callers (AggregateScan, future JoinScan MPP) compose `HashJoinExec`,
+//! Callers (AggregateScan, JoinScan MPP) compose `HashJoinExec`,
 //! `AggregateExec(Partial)`, or any other DataFusion operator on top of the
 //! wrapped child. Because each wrap consumes one directed mesh of shm_mqs
 //! (one `ShuffleWiring` + one `DrainHandle`), a binary hash-partitioned join
-//! needs **two** independent mesh wirings — one per side. Phase 4b-iv's DSM
-//! hook layer allocates and distributes them; this module is ABI-agnostic
-//! about where they come from.
+//! needs **two** independent mesh wirings — one per side. The DSM hook layer
+//! allocates and distributes them; this module is ABI-agnostic about where
+//! they come from.
 //!
 //! # What was here before
 //!
@@ -72,7 +72,7 @@
 //! building block for the benchmark and cleanly composes with DataFusion's
 //! existing `HashJoinExec(Partitioned)`.
 
-#![allow(dead_code)] // caller lands in Phase 4b-iv step 4
+#![allow(dead_code)]
 
 use std::sync::Arc;
 

--- a/pg_search/src/postgres/customscan/mpp/shape.rs
+++ b/pg_search/src/postgres/customscan/mpp/shape.rs
@@ -1,0 +1,673 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! MPP plan-shape classifier + per-shape physical-plan builders.
+//!
+//! Different query shapes want different MPP topologies — trying to force one
+//! plan structure across all of them breaks correctness (the earlier
+//! `build_mpp_aggregate_plan` baked in a post-Partial-shuffle topology that
+//! produced spurious rows for scalar aggregation). This module classifies the
+//! query, dispatches to the right builder, and each builder composes only the
+//! nodes it needs.
+//!
+//! # Supported shapes
+//!
+//! [`MppPlanShape::ScalarAggOnBinaryJoin`] — e.g., `SELECT COUNT(*) FROM f
+//! JOIN p WHERE ...`. Per worker: pre-join shuffle of each side → HashJoin →
+//! AggregateExec(Partial). Partial rows are shipped to PG's Gather and
+//! finalized by PG's native `Finalize Aggregate` above. No post-Partial
+//! shuffle is inserted (it would produce spurious all-NULL rows for scalar
+//! aggregation on non-hit workers).
+//!
+//! [`MppPlanShape::GroupByAggOnBinaryJoin`] — e.g., `SELECT k, COUNT(*) FROM
+//! f JOIN p GROUP BY k`. Per worker: pre-join shuffle → HashJoin →
+//! AggregateExec(Partial) → post-Partial shuffle on group keys →
+//! AggregateExec(FinalPartitioned). Each worker emits final rows for its
+//! group-key hash partition; PG's Gather concatenates — no double-count
+//! because every group lives on exactly one worker.
+//!
+//! [`MppPlanShape::GroupByAggSingleTable`] — `SELECT k, COUNT(*) FROM t
+//! GROUP BY k`. No join; Partial → post-Partial shuffle → FinalPartitioned.
+//!
+//! [`MppPlanShape::JoinOnly`] — `SELECT ... FROM f JOIN p`. Pre-join shuffle
+//! → HashJoin → emit rows (no aggregate).
+//!
+//! [`MppPlanShape::Ineligible`] — fall back to the non-MPP serial path.
+//!
+//! # What this module *does not* do
+//!
+//! The DSM hook layer allocates the mesh wirings. A single shuffle =
+//! one mesh. Binary join under `ScalarAggOnBinaryJoin` or
+//! `GroupByAggOnBinaryJoin` needs TWO meshes (one per join input).
+//! `GroupByAggOnBinaryJoin` adds a THIRD mesh for the post-Partial
+//! shuffle. Multi-mesh DSM allocation is a separate piece — this module
+//! takes pre-allocated wirings as parameters.
+
+#![allow(dead_code)]
+// caller lands once create_custom_path flips parallel-safe
+// `CoalesceBatchesExec` is deprecated in favor of arrow-rs's `BatchCoalescer`,
+// but DataFusion 52 still ships it as an `ExecutionPlan` node — the replacement
+// is a streaming coalescer, not a plan node, so we cannot drop into the same
+// slot. Remove this allow when the wrapper migrates.
+#![allow(deprecated)]
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::Result;
+use datafusion::logical_expr::JoinType;
+use datafusion::physical_expr::aggregate::AggregateFunctionExpr;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::joins::utils::JoinOn;
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+use datafusion::physical_plan::ExecutionPlan;
+
+use crate::postgres::customscan::mpp::plan_build::{wrap_with_mpp_shuffle, MppShuffleInputs};
+use crate::postgres::customscan::mpp::shuffle::ShuffleWiring;
+use crate::postgres::customscan::mpp::transport::DrainHandle;
+
+/// Classify a query so the dispatcher picks the right topology.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum MppPlanShape {
+    ScalarAggOnBinaryJoin,
+    GroupByAggOnBinaryJoin,
+    GroupByAggSingleTable,
+    JoinOnly,
+    Ineligible,
+}
+
+/// Shape-classification inputs. Kept as plain fields rather than a reference
+/// to a larger state so callers can construct it from whatever they have
+/// (RelNode walk, AggregateCSClause inspection, test synthetic data).
+pub struct ClassifyInputs {
+    /// Number of tables in the join. 0 = no join, 1 = single table,
+    /// 2 = binary join, >=3 = multi-table join.
+    pub n_join_tables: usize,
+    /// True if the query has a GROUP BY clause with at least one column.
+    pub has_group_by: bool,
+    /// True if every aggregate function in the targetlist is one of
+    /// COUNT/SUM/MIN/MAX/AVG/BOOL_*/STDDEV_*/VAR_* — the set with a safe
+    /// Partial/Final split. `false` for COUNT(DISTINCT), ARRAY_AGG,
+    /// STRING_AGG, ordered-set, hypothetical-set aggregates.
+    pub all_aggregates_splittable: bool,
+    /// True if the query has at least one aggregate (COUNT, SUM, …). When
+    /// `false`, we're classifying a join-only shape.
+    pub has_aggregate: bool,
+}
+
+/// Classify the query into an [`MppPlanShape`].
+///
+/// Rules (all implicitly `AND`-ed):
+///   * Two tables + has_aggregate + splittable: binary-join aggregate.
+///     Split further on `has_group_by` to pick scalar vs group-by topology.
+///   * One table + has_aggregate + group_by + splittable:
+///     single-table group-by aggregate (post-Partial shuffle helps when
+///     cardinality is high).
+///   * Two tables + no_aggregate: join-only.
+///   * Otherwise: Ineligible.
+pub fn classify(inputs: &ClassifyInputs) -> MppPlanShape {
+    if !inputs.all_aggregates_splittable && inputs.has_aggregate {
+        return MppPlanShape::Ineligible;
+    }
+    match (
+        inputs.n_join_tables,
+        inputs.has_aggregate,
+        inputs.has_group_by,
+    ) {
+        (2, true, false) => MppPlanShape::ScalarAggOnBinaryJoin,
+        (2, true, true) => MppPlanShape::GroupByAggOnBinaryJoin,
+        (1, true, true) => MppPlanShape::GroupByAggSingleTable,
+        (2, false, _) => MppPlanShape::JoinOnly,
+        _ => MppPlanShape::Ineligible,
+    }
+}
+
+// ============================================================================
+// Per-shape plan builders
+// ============================================================================
+
+/// Inputs to [`build_scalar_agg_on_binary_join`]. Both `left_child` and
+/// `right_child` are the pre-shuffle scans (scan → filter) for each join
+/// input. The wirings + drains are the caller-allocated halves of three
+/// independent meshes: one per join input plus a final-gather mesh that
+/// routes every worker's Partial row to the leader seat so a single
+/// `AggregateExec(FinalPartitioned)` on the leader produces the one-row
+/// scalar result.
+pub struct ScalarAggOnBinaryJoinInputs {
+    pub left_child: Arc<dyn ExecutionPlan>,
+    pub right_child: Arc<dyn ExecutionPlan>,
+    pub left_shuffle: ShuffleWiring,
+    pub left_drain: std::sync::Arc<DrainHandle>,
+    pub left_schema: SchemaRef,
+    pub right_shuffle: ShuffleWiring,
+    pub right_drain: std::sync::Arc<DrainHandle>,
+    pub right_schema: SchemaRef,
+    /// Join keys, as `(left_expr, right_expr)` pairs.
+    pub join_on: JoinOn,
+    /// Column projection applied to the `HashJoinExec` output. DataFusion
+    /// may prune the raw `left_schema ++ right_schema` down to only the
+    /// columns that flow up into the aggregate; `aggr_expr`'s `Column`
+    /// references use indices into that projected schema. Forwarding the
+    /// same projection here keeps those indices valid.
+    pub join_projection: Option<Vec<usize>>,
+    pub aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
+    pub filter_expr: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    /// Wiring for the final-gather mesh: every participant ships its
+    /// Partial row to one fixed target seat (the leader, seat 0) via a
+    /// [`FixedTargetPartitioner`](super::shuffle::FixedTargetPartitioner).
+    /// The caller must build this with `target == 0` so PG's Gather sees
+    /// exactly one row (from the leader) per query.
+    pub final_shuffle: ShuffleWiring,
+    pub final_drain: std::sync::Arc<DrainHandle>,
+    /// The original `HashJoinExec` from the standard plan. Rebuilt here via
+    /// `builder().with_new_children(...)` so its `dynamic_filter` Arc (populated
+    /// by `SharedBuildAccumulator` once the local build side completes) is
+    /// preserved across the MPP rewrite. The bridge strips the Arc from the
+    /// probe-side `PgSearchScanPlan` and this module re-applies it as a
+    /// [`FilterExec`] on top of the post-shuffle probe stream (see below).
+    pub original_hash_join: Arc<HashJoinExec>,
+}
+
+/// Build the MPP plan for a scalar aggregate over a binary join.
+///
+/// # Leader / worker asymmetry
+///
+/// For a scalar aggregate, DataFusion's `AggregateExec(FinalPartitioned)`
+/// emits *one* row even when its input is empty (the SQL semantics for
+/// `SELECT COUNT(*) FROM empty` is `0`, not "no row"). If every
+/// participant ran the full plan, PG's Gather above would concatenate N
+/// rows (one per worker + leader), breaking the scalar contract.
+///
+/// Instead, the leader and workers build asymmetric plans driven by
+/// `is_leader`:
+///
+/// **Leader** (is_leader = true):
+/// ```text
+///     AggregateExec(FinalPartitioned)
+///       wrap_with_mpp_shuffle(final_mesh, all-to-seat-0)
+///         AggregateExec(Partial)
+///           HashJoinExec(PartitionMode::Partitioned)
+///             wrap_with_mpp_shuffle(left_child,  left_wiring, left_drain)
+///             wrap_with_mpp_shuffle(right_child, right_wiring, right_drain)
+/// ```
+/// Leader's own Partial row stays local (self-partition == target 0);
+/// its drain receives Partial rows from every worker. `FinalPartitioned`
+/// sums N partials → emits one row.
+///
+/// **Worker** (is_leader = false):
+/// ```text
+///     wrap_with_mpp_shuffle(final_mesh, all-to-seat-0)   ← no FinalPartitioned
+///       AggregateExec(Partial)
+///         HashJoinExec(PartitionMode::Partitioned)
+///           wrap_with_mpp_shuffle(left_child,  …)
+///           wrap_with_mpp_shuffle(right_child, …)
+/// ```
+/// Worker's ShuffleExec ships its Partial row to seat 0 via the final
+/// mesh (self != target so its self-partition is empty). Worker's
+/// DrainGatherExec reads from the worker's inbound receivers on the
+/// final mesh, which are empty by construction (everyone ships *to*
+/// seat 0, nobody ships *to* the worker). The worker's stream therefore
+/// emits zero rows — PG's Gather sees exactly one row per query (from
+/// the leader).
+pub fn build_scalar_agg_on_binary_join(
+    inputs: ScalarAggOnBinaryJoinInputs,
+    is_leader: bool,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let left_shuffled = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: inputs.left_child,
+        wiring: inputs.left_shuffle,
+        drain_handle: inputs.left_drain,
+        wrapped_schema: inputs.left_schema,
+        tag: "scalar_left",
+    })?;
+    let right_shuffled = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: inputs.right_child,
+        wiring: inputs.right_shuffle,
+        drain_handle: inputs.right_drain,
+        wrapped_schema: inputs.right_schema,
+        tag: "scalar_right",
+    })?;
+
+    // Re-apply the HashJoin's dynamic filter above the post-shuffle probe
+    // stream. The filter was stripped from the probe-side scan by the bridge
+    // so it isn't applied before shuffle routing (which would drop rows
+    // destined for peer participants); re-attaching it here lets each
+    // participant's local `SharedBuildAccumulator` populate the Arc once its
+    // local build side finishes, and the `FilterExec` then prunes probe rows
+    // that cannot match any local build key.
+    let right_probe: Arc<dyn ExecutionPlan> =
+        match inputs.original_hash_join.dynamic_filter_for_test().cloned() {
+            Some(df) => Arc::new(FilterExec::try_new(df, right_shuffled)?),
+            None => right_shuffled,
+        };
+
+    // Rebuild through the builder so the `dynamic_filter` field survives. A
+    // plain `HashJoinExec::try_new` would clear it (the builder initializes
+    // `dynamic_filter: None` and `try_new` never calls `with_dynamic_filter`),
+    // orphaning the Arc held by the `FilterExec` above.
+    let join = inputs
+        .original_hash_join
+        .builder()
+        .with_new_children(vec![left_shuffled, right_probe])?
+        .build_exec()?;
+    let join_schema = join.schema();
+
+    let partial: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+        AggregateMode::Partial,
+        PhysicalGroupBy::new_single(vec![]),
+        inputs.aggr_expr.clone(),
+        inputs.filter_expr.clone(),
+        join,
+        join_schema,
+    )?);
+    let partial_schema = partial.schema();
+
+    let gathered = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: partial,
+        wiring: inputs.final_shuffle,
+        drain_handle: inputs.final_drain,
+        wrapped_schema: partial_schema.clone(),
+        tag: "scalar_final",
+    })?;
+
+    if !is_leader {
+        // Worker plan: stream drives the shuffle (shipping Partial to
+        // the leader) and returns zero rows locally.
+        return Ok(gathered);
+    }
+
+    let final_agg = AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        PhysicalGroupBy::new_single(vec![]),
+        inputs.aggr_expr,
+        inputs.filter_expr,
+        gathered,
+        partial_schema,
+    )?;
+    Ok(Arc::new(final_agg))
+}
+
+/// Inputs to [`build_groupby_agg_on_binary_join`]. Adds a third mesh
+/// (`postagg_shuffle` + `postagg_drain`) on top of
+/// [`ScalarAggOnBinaryJoinInputs`] for the Partial → FinalPartitioned
+/// shuffle on group keys. Caller supplies group-by expressions +
+/// per-partial schema.
+pub struct GroupByAggOnBinaryJoinInputs {
+    pub left_child: Arc<dyn ExecutionPlan>,
+    pub right_child: Arc<dyn ExecutionPlan>,
+    pub left_shuffle: ShuffleWiring,
+    pub left_drain: std::sync::Arc<DrainHandle>,
+    pub left_schema: SchemaRef,
+    pub right_shuffle: ShuffleWiring,
+    pub right_drain: std::sync::Arc<DrainHandle>,
+    pub right_schema: SchemaRef,
+    pub join_on: JoinOn,
+    /// See [`ScalarAggOnBinaryJoinInputs::join_projection`].
+    pub join_projection: Option<Vec<usize>>,
+    pub group_by: PhysicalGroupBy,
+    pub aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
+    pub filter_expr: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    pub postagg_shuffle: ShuffleWiring,
+    pub postagg_drain: std::sync::Arc<DrainHandle>,
+    /// See [`ScalarAggOnBinaryJoinInputs::original_hash_join`].
+    pub original_hash_join: Arc<HashJoinExec>,
+}
+
+/// Build the MPP plan for a GROUP BY aggregate over a binary join.
+///
+/// Symmetric across all seats — no leader/worker asymmetry. Each seat
+/// runs the same plan; rows land on the seat that owns their group-by
+/// hash partition, so `FinalPartitioned` on each seat emits a disjoint
+/// set of groups and PG's Gather concatenates.
+///
+/// Shape (every seat):
+/// ```text
+///     AggregateExec(FinalPartitioned, group_by)
+///       wrap_with_mpp_shuffle(gb_postagg, HashPartitioner(group_keys))
+///         CoalesceBatchesExec(target = 64 Ki rows)
+///           AggregateExec(Partial, group_by)
+///             HashJoinExec(Partitioned)
+///               wrap_with_mpp_shuffle(gb_left)
+///               wrap_with_mpp_shuffle(gb_right)
+/// ```
+///
+/// # Why `CoalesceBatchesExec` before the post-agg shuffle
+///
+/// `AggregateExec(Partial)` emits DataFusion's default 8 Ki-row batches.
+/// At 25 M input / 3.12 M distinct groups, that's ~191 batches per seat
+/// going over shm_mq via Arrow-IPC. Per-batch overhead (schema/dictionary
+/// preamble + per-iteration dispatch in `ShuffleStream::process_batch`)
+/// dominates at small batch sizes. Coalescing to 64 Ki rows collapses
+/// that to ~24 batches, amortizing the fixed per-batch cost ~8× and
+/// keeping payload under the 64 MiB `shm_mq` queue capacity so
+/// backpressure stays near zero.
+///
+/// # Why hash-partition (not gather-to-leader) once coalesce lands
+///
+/// Hash-partitioning by group keys lets each seat finalize 1/N of the
+/// distinct groups in parallel; the gather-to-leader variant
+/// (earlier `FixedTargetPartitioner(0)`) serialized `Final` on the
+/// leader. Gather was a win only while per-batch encode cost was the
+/// binding constraint — with batches coalesced, encode is cheap enough
+/// that parallel `Final` dominates.
+pub fn build_groupby_agg_on_binary_join(
+    inputs: GroupByAggOnBinaryJoinInputs,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let left_shuffled = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: inputs.left_child,
+        wiring: inputs.left_shuffle,
+        drain_handle: inputs.left_drain,
+        wrapped_schema: inputs.left_schema,
+        tag: "gb_left",
+    })?;
+    let right_shuffled = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: inputs.right_child,
+        wiring: inputs.right_shuffle,
+        drain_handle: inputs.right_drain,
+        wrapped_schema: inputs.right_schema,
+        tag: "gb_right",
+    })?;
+
+    // See `build_scalar_agg_on_binary_join` for the rationale behind this
+    // post-shuffle `FilterExec` + `builder()` rebuild.
+    let right_probe: Arc<dyn ExecutionPlan> =
+        match inputs.original_hash_join.dynamic_filter_for_test().cloned() {
+            Some(df) => Arc::new(FilterExec::try_new(df, right_shuffled)?),
+            None => right_shuffled,
+        };
+
+    let join = inputs
+        .original_hash_join
+        .builder()
+        .with_new_children(vec![left_shuffled, right_probe])?
+        .build_exec()?;
+    let join_schema = join.schema();
+
+    let partial: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+        AggregateMode::Partial,
+        inputs.group_by.clone(),
+        inputs.aggr_expr.clone(),
+        inputs.filter_expr.clone(),
+        join,
+        join_schema,
+    )?);
+    // Coalesce Partial's default 8 Ki-row batches into 64 Ki-row batches
+    // before the post-agg shuffle so Arrow-IPC encode amortizes over
+    // ~8× fewer batches. See the function-level doc for why.
+    let coalesced_partial: Arc<dyn ExecutionPlan> =
+        Arc::new(CoalesceBatchesExec::new(partial, 65_536));
+    let partial_schema = coalesced_partial.schema();
+
+    let repartitioned = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: coalesced_partial,
+        wiring: inputs.postagg_shuffle,
+        drain_handle: inputs.postagg_drain,
+        wrapped_schema: partial_schema.clone(),
+        tag: "gb_postagg",
+    })?;
+
+    let final_agg = AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        inputs.group_by,
+        inputs.aggr_expr,
+        inputs.filter_expr,
+        repartitioned,
+        partial_schema,
+    )?;
+    Ok(Arc::new(final_agg))
+}
+
+/// Inputs to [`build_groupby_agg_single_table`]. Single mesh (post-Partial
+/// shuffle only) — no pre-join shuffle because there's no join.
+pub struct GroupByAggSingleTableInputs {
+    pub child: Arc<dyn ExecutionPlan>,
+    pub group_by: PhysicalGroupBy,
+    pub aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
+    pub filter_expr: Vec<Option<Arc<dyn PhysicalExpr>>>,
+    pub child_schema: SchemaRef,
+    pub postagg_shuffle: ShuffleWiring,
+    pub postagg_drain: std::sync::Arc<DrainHandle>,
+}
+
+/// Build the MPP plan for a GROUP BY aggregate over a single table.
+///
+/// Shape:
+/// ```text
+///     AggregateExec(FinalPartitioned)
+///       wrap_with_mpp_shuffle(AggregateExec(Partial), group_by_key_hash)
+/// ```
+///
+/// Pays off at high cardinality where the Final aggregate is the serial
+/// bottleneck on a single-table scan.
+pub fn build_groupby_agg_single_table(
+    inputs: GroupByAggSingleTableInputs,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let partial: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+        AggregateMode::Partial,
+        inputs.group_by.clone(),
+        inputs.aggr_expr.clone(),
+        inputs.filter_expr.clone(),
+        inputs.child,
+        inputs.child_schema,
+    )?);
+    let partial_schema = partial.schema();
+
+    let repartitioned = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: partial,
+        wiring: inputs.postagg_shuffle,
+        drain_handle: inputs.postagg_drain,
+        wrapped_schema: partial_schema.clone(),
+        tag: "gb_single_postagg",
+    })?;
+
+    let final_agg = AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        inputs.group_by,
+        inputs.aggr_expr,
+        inputs.filter_expr,
+        repartitioned,
+        partial_schema,
+    )?;
+    Ok(Arc::new(final_agg))
+}
+
+/// Inputs to [`build_join_only`]. Two meshes (one per join input).
+pub struct JoinOnlyInputs {
+    pub left_child: Arc<dyn ExecutionPlan>,
+    pub right_child: Arc<dyn ExecutionPlan>,
+    pub left_shuffle: ShuffleWiring,
+    pub left_drain: std::sync::Arc<DrainHandle>,
+    pub left_schema: SchemaRef,
+    pub right_shuffle: ShuffleWiring,
+    pub right_drain: std::sync::Arc<DrainHandle>,
+    pub right_schema: SchemaRef,
+    pub join_on: JoinOn,
+    /// See [`ScalarAggOnBinaryJoinInputs::join_projection`].
+    pub join_projection: Option<Vec<usize>>,
+    pub join_type: JoinType,
+}
+
+/// Build the MPP plan for a join without an aggregate on top. Emits the
+/// join output rows directly.
+///
+/// Shape:
+/// ```text
+///     HashJoinExec(PartitionMode::Partitioned)
+///       wrap_with_mpp_shuffle(left_child,  hash=[left_key])
+///       wrap_with_mpp_shuffle(right_child, hash=[right_key])
+/// ```
+pub fn build_join_only(inputs: JoinOnlyInputs) -> Result<Arc<dyn ExecutionPlan>> {
+    let left_shuffled = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: inputs.left_child,
+        wiring: inputs.left_shuffle,
+        drain_handle: inputs.left_drain,
+        wrapped_schema: inputs.left_schema,
+        tag: "join_left",
+    })?;
+    let right_shuffled = wrap_with_mpp_shuffle(MppShuffleInputs {
+        child: inputs.right_child,
+        wiring: inputs.right_shuffle,
+        drain_handle: inputs.right_drain,
+        wrapped_schema: inputs.right_schema,
+        tag: "join_right",
+    })?;
+
+    let join = HashJoinExec::try_new(
+        left_shuffled,
+        right_shuffled,
+        inputs.join_on,
+        None,
+        &inputs.join_type,
+        inputs.join_projection,
+        PartitionMode::Partitioned,
+        datafusion::common::NullEquality::NullEqualsNothing,
+        false,
+    )?;
+    Ok(Arc::new(join))
+}
+
+// ============================================================================
+// Counting meshes needed per shape — useful for the DSM hook sizing pass
+// ============================================================================
+
+/// How many independent shuffle meshes does this shape need?
+///
+/// - `ScalarAggOnBinaryJoin`: 3 (left + right pre-join + final-gather-to-leader)
+/// - `GroupByAggOnBinaryJoin`: 3 (left + right pre-join + post-Partial)
+/// - `GroupByAggSingleTable`: 1 (post-Partial)
+/// - `JoinOnly`: 2 (left + right pre-join)
+/// - `Ineligible`: 0 — not reachable through an MPP path
+pub fn shuffles_required(shape: MppPlanShape) -> u32 {
+    match shape {
+        MppPlanShape::ScalarAggOnBinaryJoin => 3,
+        MppPlanShape::GroupByAggOnBinaryJoin => 3,
+        MppPlanShape::GroupByAggSingleTable => 1,
+        MppPlanShape::JoinOnly => 2,
+        MppPlanShape::Ineligible => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs(n: usize, group: bool, agg: bool, splittable: bool) -> ClassifyInputs {
+        ClassifyInputs {
+            n_join_tables: n,
+            has_group_by: group,
+            has_aggregate: agg,
+            all_aggregates_splittable: splittable,
+        }
+    }
+
+    #[test]
+    fn classify_scalar_agg_on_binary_join() {
+        // COUNT(*) FROM f JOIN p WHERE ...
+        assert_eq!(
+            classify(&inputs(2, false, true, true)),
+            MppPlanShape::ScalarAggOnBinaryJoin
+        );
+    }
+
+    #[test]
+    fn classify_groupby_agg_on_binary_join() {
+        // SELECT k, COUNT(*) FROM f JOIN p GROUP BY k
+        assert_eq!(
+            classify(&inputs(2, true, true, true)),
+            MppPlanShape::GroupByAggOnBinaryJoin
+        );
+    }
+
+    #[test]
+    fn classify_groupby_agg_single_table() {
+        // SELECT k, COUNT(*) FROM t GROUP BY k
+        assert_eq!(
+            classify(&inputs(1, true, true, true)),
+            MppPlanShape::GroupByAggSingleTable
+        );
+    }
+
+    #[test]
+    fn classify_join_only() {
+        // SELECT * FROM f JOIN p — no aggregate at all.
+        assert_eq!(
+            classify(&inputs(2, false, false, true)),
+            MppPlanShape::JoinOnly
+        );
+        // A CLASSIFY_OUTPUT_BY with no aggregate is still join-only; GROUP BY
+        // without aggregates is unusual SQL but should not elevate to group-by
+        // aggregate shape because there's no partial state to shuffle.
+        assert_eq!(
+            classify(&inputs(2, true, false, true)),
+            MppPlanShape::JoinOnly
+        );
+    }
+
+    #[test]
+    fn classify_rejects_unsplittable_aggregates() {
+        // ARRAY_AGG, COUNT(DISTINCT), etc. aren't safe to Partial/Final split.
+        assert_eq!(
+            classify(&inputs(2, false, true, false)),
+            MppPlanShape::Ineligible
+        );
+        assert_eq!(
+            classify(&inputs(2, true, true, false)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn classify_rejects_single_table_scalar() {
+        // Single-table scalar aggregates don't benefit from MPP — the
+        // aggregate is already O(rows/workers) via PG's native parallel
+        // scan. No shuffle needed.
+        assert_eq!(
+            classify(&inputs(1, false, true, true)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn classify_rejects_no_tables() {
+        assert_eq!(
+            classify(&inputs(0, false, false, true)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn classify_rejects_multi_table_join() {
+        // 3+ table joins aren't wired yet (scope = milestone 1 binary join).
+        // Extend `classify` when milestone-2 adds them.
+        assert_eq!(
+            classify(&inputs(3, false, true, true)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn shuffles_required_matches_shape_definition() {
+        assert_eq!(shuffles_required(MppPlanShape::ScalarAggOnBinaryJoin), 3);
+        assert_eq!(shuffles_required(MppPlanShape::GroupByAggOnBinaryJoin), 3);
+        assert_eq!(shuffles_required(MppPlanShape::GroupByAggSingleTable), 1);
+        assert_eq!(shuffles_required(MppPlanShape::JoinOnly), 2);
+        assert_eq!(shuffles_required(MppPlanShape::Ineligible), 0);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/shape.rs
+++ b/pg_search/src/postgres/customscan/mpp/shape.rs
@@ -159,14 +159,6 @@ pub struct ScalarAggOnBinaryJoinInputs {
     pub right_shuffle: ShuffleWiring,
     pub right_drain: std::sync::Arc<DrainHandle>,
     pub right_schema: SchemaRef,
-    /// Join keys, as `(left_expr, right_expr)` pairs.
-    pub join_on: JoinOn,
-    /// Column projection applied to the `HashJoinExec` output. DataFusion
-    /// may prune the raw `left_schema ++ right_schema` down to only the
-    /// columns that flow up into the aggregate; `aggr_expr`'s `Column`
-    /// references use indices into that projected schema. Forwarding the
-    /// same projection here keeps those indices valid.
-    pub join_projection: Option<Vec<usize>>,
     pub aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
     pub filter_expr: Vec<Option<Arc<dyn PhysicalExpr>>>,
     /// Wiring for the final-gather mesh: every participant ships its
@@ -318,9 +310,6 @@ pub struct GroupByAggOnBinaryJoinInputs {
     pub right_shuffle: ShuffleWiring,
     pub right_drain: std::sync::Arc<DrainHandle>,
     pub right_schema: SchemaRef,
-    pub join_on: JoinOn,
-    /// See [`ScalarAggOnBinaryJoinInputs::join_projection`].
-    pub join_projection: Option<Vec<usize>>,
     pub group_by: PhysicalGroupBy,
     pub aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
     pub filter_expr: Vec<Option<Arc<dyn PhysicalExpr>>>,
@@ -434,60 +423,6 @@ pub fn build_groupby_agg_on_binary_join(
     Ok(Arc::new(final_agg))
 }
 
-/// Inputs to [`build_groupby_agg_single_table`]. Single mesh (post-Partial
-/// shuffle only) — no pre-join shuffle because there's no join.
-pub struct GroupByAggSingleTableInputs {
-    pub child: Arc<dyn ExecutionPlan>,
-    pub group_by: PhysicalGroupBy,
-    pub aggr_expr: Vec<Arc<AggregateFunctionExpr>>,
-    pub filter_expr: Vec<Option<Arc<dyn PhysicalExpr>>>,
-    pub child_schema: SchemaRef,
-    pub postagg_shuffle: ShuffleWiring,
-    pub postagg_drain: std::sync::Arc<DrainHandle>,
-}
-
-/// Build the MPP plan for a GROUP BY aggregate over a single table.
-///
-/// Shape:
-/// ```text
-///     AggregateExec(FinalPartitioned)
-///       wrap_with_mpp_shuffle(AggregateExec(Partial), group_by_key_hash)
-/// ```
-///
-/// Pays off at high cardinality where the Final aggregate is the serial
-/// bottleneck on a single-table scan.
-pub fn build_groupby_agg_single_table(
-    inputs: GroupByAggSingleTableInputs,
-) -> Result<Arc<dyn ExecutionPlan>> {
-    let partial: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
-        AggregateMode::Partial,
-        inputs.group_by.clone(),
-        inputs.aggr_expr.clone(),
-        inputs.filter_expr.clone(),
-        inputs.child,
-        inputs.child_schema,
-    )?);
-    let partial_schema = partial.schema();
-
-    let repartitioned = wrap_with_mpp_shuffle(MppShuffleInputs {
-        child: partial,
-        wiring: inputs.postagg_shuffle,
-        drain_handle: inputs.postagg_drain,
-        wrapped_schema: partial_schema.clone(),
-        tag: "gb_single_postagg",
-    })?;
-
-    let final_agg = AggregateExec::try_new(
-        AggregateMode::FinalPartitioned,
-        inputs.group_by,
-        inputs.aggr_expr,
-        inputs.filter_expr,
-        repartitioned,
-        partial_schema,
-    )?;
-    Ok(Arc::new(final_agg))
-}
-
 /// Inputs to [`build_join_only`]. Two meshes (one per join input).
 pub struct JoinOnlyInputs {
     pub left_child: Arc<dyn ExecutionPlan>,
@@ -499,7 +434,10 @@ pub struct JoinOnlyInputs {
     pub right_drain: std::sync::Arc<DrainHandle>,
     pub right_schema: SchemaRef,
     pub join_on: JoinOn,
-    /// See [`ScalarAggOnBinaryJoinInputs::join_projection`].
+    /// Column projection applied to the `HashJoinExec` output. DataFusion
+    /// may prune the raw `left_schema ++ right_schema` down to only the
+    /// columns the caller needs; forwarding the same projection here keeps
+    /// downstream column indices valid.
     pub join_projection: Option<Vec<usize>>,
     pub join_type: JoinType,
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #4152
- Stacked on top of #4828

## What

Third PR in the 5-PR MPP chain. Adds the logic that classifies a query into one of four MPP-eligible plan shapes and assembles the corresponding shuffle / drain / union topology on top of a standard DataFusion plan. Still dead code — the exec bridge that invokes this lands in the next PR alongside the customscan glue it depends on.

**Review as a stacked PR.** Targets `moe/mpp-02-operators` (#4828).

## Why

The plan shape determines how many shuffle edges a query needs (and therefore how many shm_mq meshes to allocate in DSM), and which stages run `Partial` vs `FinalPartitioned` aggregate. Splitting that policy into its own file makes the topology explicit, keeps the eligibility decision free of DataFusion execution plumbing, and gives follow-up PRs a single place to add new shapes.

## How

- `shape.rs` — `MppPlanShape` enum with a 2×2×2 classifier over `(n_table_scans, has_aggregate, has_group_by)`; per-shape topology builders (`build_scalar_agg_on_binary_join`, `build_groupby_agg_on_binary_join`, `build_join_only`); `shuffles_required` lookup used by the coordinator to size the DSM region.
- `plan_build.rs` — `wrap_with_mpp_shuffle` composes a `ChainExec` under a `Union` that stitches this participant's local scan stream onto the cross-participant drain stream. This is the seam where the single-partition DataFusion view meets the N-partition MPP reality.

## Tests

- `cargo check -p pg_search --features pg18` clean
- `cargo test -p pg_search --lib mpp:: --features pg18 -- --test-threads=1` green — classifier truth-table, `shuffles_required` per shape, shape-builder plan-tree correctness
- Regression suite unchanged with `enable_mpp = off`