### PR TITLE
feat(mpp): AggregateScan MPP activation (4/5)

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*)
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
@@ -19,3 +19,14 @@ JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section'
 GROUP BY f.title
 ORDER BY f.title;
+
+-- MPP aggregate scan (Phase 7: N=4 — the default `paradedb.mpp_worker_count`
+-- — after the Phase 8 coalesce + hash-partition fix stabilised the 4-way
+-- mesh for GROUP BY. The earlier N=2 pin is removed; other bench queries
+-- already run at N=4.)
+SET statement_timeout TO '600s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT f.title, COUNT(*), SUM(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section'
+GROUP BY f.title
+ORDER BY f.title;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*), MIN(p."sizeInB
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
@@ -31,3 +31,17 @@ GROUP BY
 ORDER BY
     COUNT(*) DESC
 LIMIT 10;
+
+-- MPP TopK aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.title,
+    COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'
+GROUP BY
+    f.title
+ORDER BY
+    COUNT(*) DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
@@ -29,3 +29,18 @@ GROUP BY
 ORDER BY
     last_activity DESC            -- Single Feature Sort (Computed Aggregate)
 LIMIT 10;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    MAX(p."createdAt") as last_activity
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'       -- Search Term
+GROUP BY
+    f.id, f.title
+ORDER BY
+    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
+LIMIT 10;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -38,7 +38,8 @@ use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, JoinSource, RelNode, RelationAlias,
 };
 use crate::postgres::customscan::joinscan::scan_state::{
-    create_datafusion_session_context, register_source_table, SessionContextProfile,
+    create_datafusion_session_context, create_datafusion_session_context_mpp,
+    register_source_table, SessionContextProfile,
 };
 use crate::scan::info::RowEstimate;
 use crate::scan::PgSearchTableProvider;
@@ -65,6 +66,17 @@ use pgrx::pg_sys;
 /// specific session setup ever appears, this is the place to put it.
 pub fn create_aggregate_session_context() -> SessionContext {
     create_datafusion_session_context(SessionContextProfile::Aggregate)
+}
+
+/// MPP-aware variant. Applies the join-layer bug fixes required when the
+/// aggregate path runs as part of an MPP pipeline: skip `SortMergeJoinEnforcer`
+/// and disable `enable_join_dynamic_filter_pushdown`. Without this, the
+/// probe-side scan races with the exchange producer and silently drops rows
+/// before the dynamic filter stabilizes.
+pub fn create_aggregate_session_context_mpp(
+    mpp: &crate::postgres::customscan::mpp::MppParticipantConfig,
+) -> SessionContext {
+    create_datafusion_session_context_mpp(SessionContextProfile::Aggregate, mpp)
 }
 
 /// Build the complete DataFusion logical plan for an aggregate-on-join query:

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -47,6 +47,7 @@ use crate::postgres::customscan::aggregatescan::datafusion_build::{
 };
 use crate::postgres::customscan::aggregatescan::datafusion_exec::{
     build_join_aggregate_plan, create_aggregate_session_context,
+    create_aggregate_session_context_mpp,
 };
 use crate::postgres::customscan::aggregatescan::datafusion_project::project_aggregate_row_to_slot;
 use crate::postgres::customscan::aggregatescan::exec::{
@@ -63,6 +64,8 @@ use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
 };
+use crate::postgres::customscan::dsm as mpp_dsm;
+use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::scan_state::{build_physical_plan, build_task_context};
 use crate::postgres::customscan::limit_offset::LimitOffset;
@@ -142,10 +145,14 @@ impl CustomScan for AggregateScan {
             ReScanCustomScan: Some(crate::postgres::customscan::exec::rescan_custom_scan::<Self>),
             MarkPosCustomScan: None,
             RestrPosCustomScan: None,
-            EstimateDSMCustomScan: None,
-            InitializeDSMCustomScan: None,
-            ReInitializeDSMCustomScan: None,
-            InitializeWorkerCustomScan: None,
+            // MPP reserved slots. The path is not yet declared parallel-safe
+            // in `create_custom_path`, so PG will never actually invoke these
+            // hooks today — they return zero / no-op. Phase 4b-ii wires the
+            // real MPP lifecycle when `customscan_glue::mpp_is_active()`.
+            EstimateDSMCustomScan: Some(mpp_dsm::estimate_dsm_custom_scan::<Self>),
+            InitializeDSMCustomScan: Some(mpp_dsm::initialize_dsm_custom_scan::<Self>),
+            ReInitializeDSMCustomScan: Some(mpp_dsm::reinitialize_dsm_custom_scan::<Self>),
+            InitializeWorkerCustomScan: Some(mpp_dsm::initialize_worker_custom_scan::<Self>),
             ShutdownCustomScan: Some(
                 crate::postgres::customscan::exec::shutdown_custom_scan::<Self>,
             ),
@@ -231,10 +238,22 @@ impl CustomScan for AggregateScan {
             // For join aggregates, scanrelid=0 (no single base relation)
             builder.set_scanrelid(0);
 
-            // Check if the query has pathkeys (ORDER BY) before consuming builder.
+            // Check if the query has pathkeys (e.g. GROUP BY emits group_pathkeys
+            // into query_pathkeys) before consuming builder.
             let root = builder.args().root;
             let has_pathkeys = unsafe {
                 !(*root).query_pathkeys.is_null() && pg_sys::list_length((*root).query_pathkeys) > 0
+            };
+            // Separately check for an explicit SQL ORDER BY clause. GROUP BY
+            // without ORDER BY sets query_pathkeys (group_pathkeys) but leaves
+            // parse->sortClause empty — and for the MPP path we can aggref-
+            // replace plan.targetlist in that case, since no Sort node will
+            // be placed above us to care about the Aggrefs.
+            let has_sort_clause = unsafe {
+                let parse = (*root).parse;
+                !parse.is_null()
+                    && !(*parse).sortClause.is_null()
+                    && pg_sys::list_length((*parse).sortClause) > 0
             };
 
             let clause_count = clause_count_val;
@@ -280,14 +299,32 @@ impl CustomScan for AggregateScan {
                     cscan.custom_exprs = custom_exprs_list.into_pg();
                 }
 
-                if !has_pathkeys {
-                    // No ORDER BY: safe to replace Aggrefs at plan time.
+                let parallel_aware = (*best_path).path.parallel_aware;
+                if !has_pathkeys && !parallel_aware {
+                    // Non-MPP, no-pathkeys case: replace Aggrefs at plan
+                    // time with `pdb.agg_fn(...)` placeholders. The non-MPP
+                    // CustomScan executes aggregation internally (without
+                    // a Gather above), so placing FuncExprs here is fine —
+                    // they never get evaluated because our ExecCustomScan
+                    // produces finished tuples directly.
                     let plan = &mut cscan.scan.plan;
                     replace_aggrefs_in_target_list(plan);
                 }
-                // When has_pathkeys: aggrefs stay in plan.targetlist so Postgres's
-                // make_sort_from_pathkeys can find them. Replacement is deferred to
-                // create_custom_scan_state (execution time).
+                // For the MPP (parallel_aware) path we leave Aggrefs in
+                // plan.targetlist. The Gather above us has a tlist with
+                // structurally-equal Aggrefs (from `rel->reltarget`); at
+                // setrefs time `fix_upper_expr` matches them via `equal()`
+                // and rewrites to `Var(OUTER_VAR, N)`. CustomScan's own
+                // plan.targetlist Aggrefs get rewritten to
+                // `Var(INDEX_VAR, N)` against `custom_scan_tlist`. Any
+                // Result added above a Sort for ORDER BY also sees
+                // matching Aggrefs in its subplan. Replacement here would
+                // break all three of those matches under ORDER BY.
+                // When has_pathkeys AND !parallel_aware (non-MPP ORDER BY
+                // path): aggrefs stay in plan.targetlist so Postgres's
+                // `make_sort_from_pathkeys` can find them. Replacement is
+                // deferred to `create_custom_scan_state` (execution time).
+                let _ = has_sort_clause; // previously gated on this; now unused
                 cscan
             }
         }
@@ -450,7 +487,7 @@ impl CustomScan for AggregateScan {
     fn begin_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
         estate: *mut pg_sys::EState,
-        _eflags: i32,
+        eflags: i32,
     ) {
         if state.custom_state().is_datafusion_backend() {
             // DataFusion backend: create scan slot for result projection
@@ -461,6 +498,19 @@ impl CustomScan for AggregateScan {
                     &pg_sys::TTSOpsVirtual,
                 );
                 state.custom_state_mut().scan_slot = Some(scan_slot);
+            }
+
+            // MPP plan-bytes stash: serialize the DataFusion logical plan
+            // at BeginCustomScan time so the DSM hooks can read `.len()`
+            // and the bytes without rebuilding the plan. Skip for
+            // `EXPLAIN` without `ANALYZE` (EXEC_FLAG_EXPLAIN_ONLY set) —
+            // users running bare EXPLAIN don't want to pay plan-build +
+            // serialize cost that's purely for parallel init. Also gated
+            // on `mpp_is_active()` so non-MPP queries pay zero cost.
+            // Failures inside the helper are non-fatal (log + fall back).
+            let explain_only = (eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) != 0;
+            if !explain_only && crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
+                Self::maybe_stash_mpp_plan_bytes(state);
             }
             return;
         }
@@ -611,6 +661,277 @@ pub trait CustomScanClause<CS: CustomScan> {
 }
 
 impl AggregateScan {
+    /// Build the DataFusion logical plan now, serialize it via
+    /// `PgSearchExtensionCodec`, and stash the bytes on `AggregateScanState`
+    /// for the MPP DSM hooks to consume. Called from `begin_custom_scan`
+    /// when `mpp_is_active()` is true and the DataFusion backend is active.
+    ///
+    /// Failures (plan-build, serialize) are logged via `mpp_log!` and leave
+    /// `logical_plan_bytes` as `None` — MPP then silently falls back to the
+    /// non-MPP path at `exec_datafusion_aggregate` rather than aborting the
+    /// query. This is the most ops-friendly failure mode: a misconfigured
+    /// MPP setting shouldn't take down a query that would otherwise succeed.
+    ///
+    /// Uses a throwaway single-thread tokio runtime because
+    /// `build_join_aggregate_plan` / `build_physical_plan` are async-signature
+    /// even though their bodies don't need an I/O runtime. The
+    /// `exec_datafusion_aggregate` path does the same dance — we pay the
+    /// plan-build cost twice when MPP is active (once here, once at exec
+    /// time). A future optimization is to cache the plan, but the
+    /// complexity of keeping logical + physical in sync across parallel
+    /// workers isn't worth it for milestone 1.
+    fn maybe_stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
+        let Some(df_state) = state.custom_state().datafusion_state.as_ref() else {
+            return;
+        };
+        let plan = df_state.plan.clone();
+        let targetlist = df_state.targetlist.clone();
+        let topk = df_state.topk.clone();
+        let jlp = df_state.join_level_predicates.clone();
+        let custom_exprs = df_state.custom_exprs;
+        let custom_scan_tlist = df_state.custom_scan_tlist;
+        let having = df_state.having_filter.clone();
+
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                crate::mpp_log!("mpp: failed to build tokio runtime for plan stash: {e}");
+                return;
+            }
+        };
+
+        let ctx = create_aggregate_session_context();
+        let plan_and_shape: datafusion::common::Result<(
+            bytes::Bytes,
+            crate::postgres::customscan::mpp::shape::MppPlanShape,
+        )> = rt.block_on(async {
+            let logical = build_join_aggregate_plan(
+                &plan,
+                &targetlist,
+                topk.as_ref(),
+                &jlp,
+                custom_exprs,
+                custom_scan_tlist,
+                having.as_ref(),
+                &ctx,
+            )
+            .await?;
+            let shape = Self::classify_logical_plan(&logical);
+            let bytes = crate::scan::codec::serialize_logical_plan(&logical)?;
+            Ok((bytes, shape))
+        });
+
+        match plan_and_shape {
+            Ok((bytes, shape)) => {
+                // Wrap the raw logical plan in `MppPlanBroadcast` and
+                // bincode-serialize *now* so `logical_plan_bytes.len()` equals
+                // the exact bytes that will later be copied into DSM. If we
+                // instead stashed the raw logical plan bytes here and
+                // re-wrapped at DSM init time, `estimate_dsm_custom_scan`
+                // would under-report by `MppPlanBroadcast`'s framing overhead
+                // (~6 bytes: version byte + varint length prefix +
+                // total_participants + profile tag). That mismatch causes the
+                // DSM init path to overrun the PG-allocated `shm_toc` region
+                // and corrupt adjacent DSA control blocks → crash at
+                // `dsa_release_in_place` during parallel-context teardown.
+                let n = crate::postgres::customscan::mpp::customscan_glue::mpp_worker_count();
+                let broadcast = crate::postgres::customscan::mpp::session::MppPlanBroadcast::new(
+                    bytes.to_vec(),
+                    n,
+                    crate::postgres::customscan::mpp::session::MppSessionProfile::Aggregate,
+                );
+                let broadcast_bytes = match broadcast.serialize() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        crate::mpp_log!(
+                            "mpp: MppPlanBroadcast serialize failed, MPP will fall back: {e}"
+                        );
+                        return;
+                    }
+                };
+                crate::mpp_log!(
+                    "mpp: stashed plan-broadcast bytes (shape={shape:?}) on AggregateScanState"
+                );
+                state.custom_state_mut().logical_plan_bytes =
+                    Some(bytes::Bytes::from(broadcast_bytes));
+                state.custom_state_mut().mpp_shape = Some(shape);
+            }
+            Err(e) => {
+                crate::mpp_log!(
+                    "mpp: plan build/serialize failed, MPP will fall back to serial path: {e}"
+                );
+            }
+        }
+    }
+
+    /// Walk a built `LogicalPlan` tree and derive [`MppPlanShape`] inputs.
+    /// Counts table scans, detects GROUP BY / aggregate presence, and
+    /// inspects aggregate function names for splittability. Runs once per
+    /// MPP-eligible query; keep side-effect free so it can be called during
+    /// plan-stash.
+    fn classify_logical_plan(
+        plan: &datafusion::logical_expr::LogicalPlan,
+    ) -> crate::postgres::customscan::mpp::shape::MppPlanShape {
+        use datafusion::common::tree_node::TreeNode;
+        use datafusion::logical_expr::LogicalPlan;
+        let mut n_table_scans: usize = 0;
+        let mut has_aggregate = false;
+        let mut has_group_by = false;
+        let mut all_aggregates_splittable = true;
+
+        plan.apply(|node| {
+            match node {
+                LogicalPlan::TableScan(_) => {
+                    n_table_scans += 1;
+                }
+                LogicalPlan::Aggregate(a) => {
+                    has_aggregate = true;
+                    if !a.group_expr.is_empty() {
+                        has_group_by = true;
+                    }
+                    for expr in &a.aggr_expr {
+                        if !Self::is_splittable_aggregate_expr(expr) {
+                            all_aggregates_splittable = false;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            Ok(datafusion::common::tree_node::TreeNodeRecursion::Continue)
+        })
+        .ok();
+
+        crate::postgres::customscan::mpp::shape::classify(
+            &crate::postgres::customscan::mpp::shape::ClassifyInputs {
+                n_join_tables: n_table_scans,
+                has_group_by,
+                all_aggregates_splittable,
+                has_aggregate,
+            },
+        )
+    }
+
+    /// Early-path classification used at `create_custom_path` time, before
+    /// we have a DataFusion logical plan. Mirrors [`Self::classify_logical_plan`]
+    /// but reads from the PG-side `sources` + `JoinAggregateTargetList` that
+    /// are already available at this stage.
+    ///
+    /// Returns the cheap-but-correct shape input triple; feeds directly into
+    /// [`mpp::shape::classify`]. Conservative: any aggregate not on the
+    /// partial-safe allow-list downgrades the whole query to `Ineligible`.
+    fn classify_path_shape(
+        sources: &[crate::postgres::customscan::aggregatescan::datafusion_build::JoinAggSource],
+        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+    ) -> crate::postgres::customscan::mpp::shape::MppPlanShape {
+        use crate::postgres::customscan::aggregatescan::join_targetlist::AggKind;
+        let n_join_tables = sources.len();
+        let has_group_by = !targetlist.group_columns.is_empty();
+        let has_aggregate = !targetlist.aggregates.is_empty();
+        let all_aggregates_splittable = targetlist.aggregates.iter().all(|a| {
+            matches!(
+                a.agg_kind,
+                AggKind::CountStar
+                    | AggKind::Count
+                    | AggKind::Sum
+                    | AggKind::Avg
+                    | AggKind::Min
+                    | AggKind::Max
+                    | AggKind::BoolAnd
+                    | AggKind::BoolOr
+                    | AggKind::StddevSamp
+                    | AggKind::StddevPop
+                    | AggKind::VarSamp
+                    | AggKind::VarPop
+            ) && !a.distinct
+        });
+        crate::postgres::customscan::mpp::shape::classify(
+            &crate::postgres::customscan::mpp::shape::ClassifyInputs {
+                n_join_tables,
+                has_group_by,
+                all_aggregates_splittable,
+                has_aggregate,
+            },
+        )
+    }
+
+    /// If the query is MPP-eligible, flip the path's `parallel_safe` /
+    /// `parallel_aware` / `parallel_workers` on the builder so PG launches
+    /// workers for this scan. Called from `try_build_datafusion_aggregate_path`
+    /// just before `.build(...)`.
+    ///
+    /// Returns the builder unchanged when MPP is off, the worker count is
+    /// below 2, or the shape classifies as `Ineligible`.
+    fn maybe_flip_mpp_parallel(
+        builder: CustomPathBuilder<Self>,
+        sources: &[crate::postgres::customscan::aggregatescan::datafusion_build::JoinAggSource],
+        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+    ) -> CustomPathBuilder<Self> {
+        use crate::postgres::customscan::mpp::shape::MppPlanShape;
+        if !crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
+            return builder;
+        }
+        let shape = Self::classify_path_shape(sources, targetlist);
+
+        // `GroupByAggSingleTable` and `JoinOnly` shapes' bridges haven't
+        // landed yet; they still classify correctly but fall through to
+        // the serial path here.
+        let activate = matches!(
+            shape,
+            MppPlanShape::ScalarAggOnBinaryJoin | MppPlanShape::GroupByAggOnBinaryJoin
+        );
+        if !activate {
+            return builder;
+        }
+        let n = crate::postgres::customscan::mpp::customscan_glue::mpp_worker_count() as usize;
+        // `mpp_worker_count` clamps to >= 2, but be defensive.
+        let nworkers = n.saturating_sub(1).max(1);
+        crate::mpp_log!(
+            "mpp: flipping AggregateScan path parallel_workers={} for shape {:?}",
+            nworkers,
+            shape
+        );
+        builder.set_parallel(nworkers)
+    }
+
+    /// Conservative allow-list of aggregate function names that are safe to
+    /// split into Partial/FinalPartitioned. Anything outside this list marks
+    /// the shape Ineligible so MPP falls back to the serial path.
+    ///
+    /// The outer expression may be wrapped in `Alias` (e.g., `COUNT(*) AS cnt`)
+    /// — unwrap before checking. Any other wrapping (casts, arithmetic) is
+    /// treated as unsafe to be conservative.
+    fn is_splittable_aggregate_expr(expr: &datafusion::logical_expr::Expr) -> bool {
+        use datafusion::logical_expr::Expr;
+        let unwrapped = match expr {
+            Expr::Alias(a) => a.expr.as_ref(),
+            other => other,
+        };
+        let name = match unwrapped {
+            Expr::AggregateFunction(af) => af.func.name().to_ascii_lowercase(),
+            // Non-aggregate in the aggr_expr slot — assume unsafe.
+            _ => return false,
+        };
+        matches!(
+            name.as_str(),
+            "count"
+                | "sum"
+                | "min"
+                | "max"
+                | "avg"
+                | "bool_and"
+                | "bool_or"
+                | "stddev"
+                | "stddev_samp"
+                | "stddev_pop"
+                | "var"
+                | "var_samp"
+                | "var_pop"
+        )
+    }
+
     /// Existing single-table Tantivy aggregate path.
     fn build_tantivy_aggregate_path(
         builder: CustomPathBuilder<Self>,
@@ -770,6 +1091,17 @@ impl AggregateScan {
                 None
             }
         };
+
+        // Flip parallel-safe with the configured worker count when the
+        // shape is MPP-eligible. Uses a cheap pre-classification based on
+        // `sources` + `targetlist` — the authoritative shape is re-derived
+        // from the DataFusion logical plan in `maybe_stash_mpp_plan_bytes`,
+        // but we must commit to parallel-safe here (before `.build()`)
+        // because PG's path-builder freezes the parallel flags at this
+        // point. Downstream failure to stash the plan falls back to the
+        // serial path via the `mpp_state.is_none()` guard in
+        // `exec_datafusion_aggregate`.
+        let builder = Self::maybe_flip_mpp_parallel(builder, &sources, &targetlist);
 
         // Build the custom path with DataFusion private data
         let multi_table_clause_count = multi_table_clauses.len();
@@ -969,47 +1301,168 @@ impl AggregateScan {
     fn exec_datafusion_aggregate(
         state: &mut CustomScanStateWrapper<Self>,
     ) -> *mut pg_sys::TupleTableSlot {
+        // Phase 4b-iv correctness fence: if we're a parallel worker and
+        // mpp_state is None even though MPP is supposed to be active, the
+        // leader has flipped parallel-safe (step 4) without step 3's
+        // worker attach being wired. Silently running the non-MPP path
+        // here would double-count at the final gather. Abort loudly
+        // instead. No-op until step 4 lands; once both step 3 and step 4
+        // are in place, mpp_state is always Some on a worker and this
+        // never fires.
+        // `IsParallelWorker` is a C macro (`ParallelWorkerNumber >= 0`);
+        // pgrx exposes the underlying int but not the macro, so inline it.
+        let is_parallel_worker = unsafe { pg_sys::ParallelWorkerNumber } >= 0;
+        if is_parallel_worker
+            && crate::postgres::customscan::mpp::customscan_glue::mpp_is_active()
+            && state.custom_state().mpp_state.is_none()
+        {
+            pgrx::error!(
+                "mpp: parallel worker reached exec_datafusion_aggregate without \
+                 MppExecutionState — Phase 4b-iv step 3 (worker DSM attach) must \
+                 land before step 4 (parallel-safe flip). Wrong-result scenario \
+                 averted via loud abort."
+            );
+        }
+
         // Grab the scan_slot pointer before entering the mutable borrow
         let scan_slot = state
             .custom_state()
             .scan_slot
             .expect("scan_slot must be initialized in begin_custom_scan");
 
-        let df_state = state
-            .custom_state_mut()
-            .datafusion_state
-            .as_mut()
-            .expect("DataFusion state must be initialized");
+        // Decide whether we need the MPP rewrite *before* we take the
+        // `datafusion_state` mutable borrow below — the MPP branch needs
+        // `custom_state_mut().mpp_state`, which aliases the same
+        // `custom_state_mut()` borrow. We resolve the alias here by reading
+        // the shape first (immutable read) then taking the mpp_state
+        // mutable borrow separately from the `datafusion_state` one.
+        let mpp_shape = if state.custom_state().mpp_state.is_some() {
+            Some(match state.custom_state().mpp_shape {
+                Some(s) => s,
+                None => pgrx::error!(
+                    "mpp: exec_datafusion_aggregate has mpp_state but no mpp_shape — \
+                     begin_custom_scan must populate both or neither"
+                ),
+            })
+        } else {
+            None
+        };
 
-        // First call: build and execute the DataFusion plan
-        if df_state.runtime.is_none() {
+        // First call: build and execute the DataFusion plan.
+        //
+        // We need to reach both `state.custom_state_mut().datafusion_state`
+        // and `state.custom_state_mut().mpp_state` inside this block, so
+        // we don't take the long-lived `df_state` borrow up front; instead,
+        // we build the plan + stream locally and store into the fields at
+        // the end in a short borrow.
+        let runtime_is_none = state
+            .custom_state()
+            .datafusion_state
+            .as_ref()
+            .map(|d| d.runtime.is_none())
+            .unwrap_or(false);
+        if runtime_is_none {
+            // Always current-thread. PG FFI is single-threaded — pgrx's
+            // `thread_id_check` panics with "postgres FFI may not be
+            // called from multiple threads" on any PG call from a tokio
+            // worker thread. `PgSearchTableProvider::scan` and its
+            // downstream reach into PG during the lazy scan, so a
+            // multi-thread runtime is off the table both for MPP and
+            // non-MPP paths.
+            //
+            // The MPP `shm_mq_send` stall (the reason the earlier
+            // multi-thread experiment existed) is broken instead by
+            // making the sender cooperative: on would-block, call
+            // `DrainHandle::poll_drain_pass` on the same mesh's drain
+            // to consume inbound rows — that frees peers' outbound
+            // queues and lets their send-to-us un-stall. See
+            // `MppSender::send_batch` + `mesh::ShmMqSender::try_send_bytes`.
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e));
 
-            let ctx = create_aggregate_session_context();
+            // When MPP is active we build the session with the join-layer
+            // bug-fixes applied: skip `SortMergeJoinEnforcer` (which would
+            // collapse hash-partitioned streams to one partition) and disable
+            // `enable_join_dynamic_filter_pushdown` (which races with the
+            // exchange producer on the probe-side scan and drops rows before
+            // the dynamic filter stabilizes). Without this, MPP AggregateScan
+            // silently loses ~83% of probe-side rows at high cardinality.
+            let ctx = match state.custom_state().mpp_state.as_ref() {
+                Some(mpp_state) if mpp_state.participant_config().total_participants > 1 => {
+                    let cfg = mpp_state.participant_config();
+                    let ctx = create_aggregate_session_context_mpp(cfg);
+                    ctx.state_ref()
+                        .write()
+                        .config_mut()
+                        .set_extension(std::sync::Arc::new(
+                            crate::postgres::customscan::mpp::MppShardConfig {
+                                participant_index: cfg.participant_index,
+                                total_participants: cfg.total_participants,
+                            },
+                        ));
+                    ctx
+                }
+                _ => create_aggregate_session_context(),
+            };
 
-            let custom_exprs = df_state.custom_exprs;
-            let custom_scan_tlist = df_state.custom_scan_tlist;
-            let physical_plan = runtime.block_on(async {
-                let logical = build_join_aggregate_plan(
-                    &df_state.plan,
-                    &df_state.targetlist,
-                    df_state.topk.as_ref(),
-                    &df_state.join_level_predicates,
-                    custom_exprs,
-                    custom_scan_tlist,
-                    df_state.having_filter.as_ref(),
-                    &ctx,
-                )
-                .await?;
-                build_physical_plan(&ctx, logical).await
-            });
+            // Build the logical → standard physical plan in a short
+            // immutable-ish scope that doesn't block the later
+            // `mpp_state` mutable borrow.
+            let standard_plan = {
+                let df_state = state
+                    .custom_state_mut()
+                    .datafusion_state
+                    .as_mut()
+                    .expect("DataFusion state must be initialized");
+                let custom_exprs = df_state.custom_exprs;
+                let custom_scan_tlist = df_state.custom_scan_tlist;
+                let result = runtime.block_on(async {
+                    let logical = build_join_aggregate_plan(
+                        &df_state.plan,
+                        &df_state.targetlist,
+                        df_state.topk.as_ref(),
+                        &df_state.join_level_predicates,
+                        custom_exprs,
+                        custom_scan_tlist,
+                        df_state.having_filter.as_ref(),
+                        &ctx,
+                    )
+                    .await?;
+                    build_physical_plan(&ctx, logical).await
+                });
+                match result {
+                    Ok(p) => p,
+                    Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+                }
+            };
 
-            let physical_plan = match physical_plan {
-                Ok(p) => p,
-                Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+            // If MPP state was wired up by the DSM hooks, rewrite the
+            // standard plan into a shape-specific MPP plan. The non-MPP
+            // branch stays byte-identical to the previous behavior.
+            let physical_plan = if let Some(shape) = mpp_shape {
+                let mpp_state = state
+                    .custom_state_mut()
+                    .mpp_state
+                    .as_mut()
+                    .expect("mpp_shape set ⇒ mpp_state must also be Some");
+                crate::mpp_log!(
+                    "mpp: routing exec_datafusion_aggregate through shape {:?} (is_leader={})",
+                    shape,
+                    mpp_state.is_leader()
+                );
+                let _guard = runtime.enter();
+                match crate::postgres::customscan::mpp::exec_bridge::build_mpp_physical_plan(
+                    standard_plan,
+                    mpp_state,
+                    shape,
+                ) {
+                    Ok(p) => p,
+                    Err(e) => pgrx::error!("mpp: build_mpp_physical_plan failed: {e}"),
+                }
+            } else {
+                standard_plan
             };
 
             let task_ctx = build_task_context(
@@ -1026,9 +1479,20 @@ impl AggregateScan {
                 }
             };
 
+            let df_state = state
+                .custom_state_mut()
+                .datafusion_state
+                .as_mut()
+                .expect("DataFusion state must be initialized");
             df_state.runtime = Some(runtime);
             df_state.stream = Some(stream);
         }
+
+        let df_state = state
+            .custom_state_mut()
+            .datafusion_state
+            .as_mut()
+            .expect("DataFusion state must be initialized");
 
         // Consume batches row-by-row
         loop {
@@ -1369,56 +1833,54 @@ unsafe fn detect_join_aggregate_topk(
 /// Replace any T_Aggref expressions in the target list with T_FuncExpr placeholders
 /// This is called at execution time to avoid "Aggref found in non-Agg plan node" errors
 /// Uses expression_tree_mutator to handle nested Aggrefs (e.g., COALESCE(COUNT(*), 0))
-unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
-    use pgrx::pg_guard;
-
-    if (*plan).targetlist.is_null() {
-        return;
+/// Mutator that replaces Aggref nodes with a placeholder FuncExpr and UNNEST
+/// FuncExprs with a generic placeholder of their result type. Used to clean
+/// up Plan targetlists (see [`replace_aggrefs_in_target_list`]) on the
+/// non-parallel path — the MPP path keeps Aggrefs intact so PG's setrefs
+/// matches them structurally between Gather/Sort/Result and the CustomScan.
+#[pgrx::pg_guard]
+pub(crate) unsafe extern "C-unwind" fn aggref_mutator(
+    node: *mut pg_sys::Node,
+    context: *mut core::ffi::c_void,
+) -> *mut pg_sys::Node {
+    if node.is_null() {
+        return std::ptr::null_mut();
     }
 
-    // Mutator function to replace Aggref nodes with placeholder FuncExpr
-    #[pg_guard]
-    unsafe extern "C-unwind" fn aggref_mutator(
-        node: *mut pg_sys::Node,
-        context: *mut core::ffi::c_void,
-    ) -> *mut pg_sys::Node {
-        if node.is_null() {
-            return std::ptr::null_mut();
-        }
+    if (*node).type_ == pg_sys::NodeTag::T_Aggref {
+        let aggref = node as *mut pg_sys::Aggref;
+        return make_placeholder_func_expr(aggref) as *mut pg_sys::Node;
+    }
 
-        // If this is an Aggref, replace it with a placeholder FuncExpr
-        if (*node).type_ == pg_sys::NodeTag::T_Aggref {
-            let aggref = node as *mut pg_sys::Aggref;
-            return make_placeholder_func_expr(aggref) as *mut pg_sys::Node;
+    if (*node).type_ == pg_sys::NodeTag::T_FuncExpr {
+        let func_expr = node as *mut pg_sys::FuncExpr;
+        if is_unnest_func((*func_expr).funcid) {
+            return make_placeholder_func_expr_internal(
+                (*func_expr).funcresulttype,
+                (*func_expr).inputcollid,
+                (*func_expr).location,
+                "UNNEST",
+            ) as *mut pg_sys::Node;
         }
+    }
 
-        // If this is an UNNEST FuncExpr, replace it with a placeholder FuncExpr of its result type.
-        // This is safe because AggregateScan handles the unnesting via Tantivy's terms aggregation.
-        if (*node).type_ == pg_sys::NodeTag::T_FuncExpr {
-            let func_expr = node as *mut pg_sys::FuncExpr;
-            if is_unnest_func((*func_expr).funcid) {
-                return make_placeholder_func_expr_internal(
-                    (*func_expr).funcresulttype,
-                    (*func_expr).inputcollid,
-                    (*func_expr).location,
-                    "UNNEST",
-                ) as *mut pg_sys::Node;
-            }
-        }
+    #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
+    {
+        let fnptr = aggref_mutator as usize as *const ();
+        let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
+            std::mem::transmute(fnptr);
+        pg_sys::expression_tree_mutator(node, Some(mutator), context)
+    }
 
-        // For all other nodes, use the standard mutator to walk children
-        #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
-        {
-            let fnptr = aggref_mutator as usize as *const ();
-            let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
-                std::mem::transmute(fnptr);
-            pg_sys::expression_tree_mutator(node, Some(mutator), context)
-        }
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    {
+        pg_sys::expression_tree_mutator_impl(node, Some(aggref_mutator), context)
+    }
+}
 
-        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
-        {
-            pg_sys::expression_tree_mutator_impl(node, Some(aggref_mutator), context)
-        }
+unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
+    if (*plan).targetlist.is_null() {
+        return;
     }
 
     let targetlist = PgList::<pg_sys::TargetEntry>::from_pg((*plan).targetlist);
@@ -1580,4 +2042,221 @@ unsafe fn get_aggregate_name(aggref: *mut pg_sys::Aggref) -> String {
     } else {
         "UNKNOWN".to_string()
     }
+}
+
+// ----------------------------------------------------------------------------
+// Phase 4b-ii/iii: ParallelQueryCapable for AggregateScan.
+//
+// Delegation surface for the MPP lifecycle hooks. Today AggregateScan's
+// `create_custom_path` does NOT flag its paths as parallel-safe, so PG
+// never actually invokes these — the logging/debug_assert paths below
+// are cold. Wiring them here keeps the surface compiled and lets
+// Phase 4b-iv activate MPP with a single flip in `create_custom_path`
+// + a plan-bytes stash.
+//
+// Remaining Phase 4b work:
+//   * Flip parallel-safe + parallel_workers in `create_custom_path` via
+//     `CustomPathBuilder::set_parallel(nworkers)` when
+//     `mpp_eligible_for_aggregate()` returns true.
+//   * Serialize the logical plan in `begin_custom_scan` (NOT in
+//     `create_custom_path` or `estimate_dsm_custom_scan`) and stash the
+//     bytes on `AggregateScanState`. Path-build is too early (planner may
+//     discard the path); `estimate_dsm_custom_scan` is too late and would
+//     force re-lowering per parallel init. `begin_custom_scan` runs once
+//     per query after the plan is committed.
+//   * Teach `exec_datafusion_aggregate` to route through
+//     `mpp::plan_build::build_mpp_aggregate_plan` when `mpp_state` is
+//     `Some`.
+// ----------------------------------------------------------------------------
+impl ParallelQueryCapable for AggregateScan {
+    fn estimate_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+    ) -> pg_sys::Size {
+        if !crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
+            return 0;
+        }
+        let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+            crate::mpp_log!(
+                "mpp: AggregateScan::estimate_dsm_custom_scan but logical_plan_bytes \
+                 is None (plan serialization failed earlier?); returning 0"
+            );
+            return 0;
+        };
+        let shape = match state.custom_state().mpp_shape {
+            Some(s) => s,
+            None => {
+                crate::mpp_log!("mpp: estimate_dsm but mpp_shape is None; returning 0");
+                return 0;
+            }
+        };
+        let num_meshes = crate::postgres::customscan::mpp::shape::shuffles_required(shape);
+        if num_meshes == 0 {
+            crate::mpp_log!("mpp: shape {:?} requires no shuffle; returning 0", shape);
+            return 0;
+        }
+        match crate::postgres::customscan::mpp::customscan_glue::leader_estimate_dsm(
+            plan_bytes.len(),
+            num_meshes,
+        ) {
+            Ok(sz) => sz,
+            Err(e) => {
+                crate::mpp_log!("mpp: leader_estimate_dsm failed: {e}; returning 0");
+                0
+            }
+        }
+    }
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut std::os::raw::c_void,
+    ) {
+        debug_assert!(state.custom_state().mpp_state.is_none());
+        if !crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
+            return;
+        }
+        if coordinate.is_null() {
+            // Estimate returned 0 (plan bytes unavailable) — PG will pass
+            // NULL coordinate. Silently fall back to non-MPP path.
+            return;
+        }
+        let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+            return;
+        };
+        let plan_bytes = plan_bytes.to_vec();
+        let shape = match state.custom_state().mpp_shape {
+            Some(s) => s,
+            None => return,
+        };
+        let num_meshes = crate::postgres::customscan::mpp::shape::shuffles_required(shape);
+        if num_meshes == 0 {
+            return;
+        }
+        let seg = unsafe { (*pcxt).seg };
+        let ctx = unsafe {
+            crate::postgres::customscan::mpp::customscan_glue::leader_init_dsm(
+                coordinate,
+                plan_bytes,
+                num_meshes,
+                crate::postgres::customscan::mpp::session::MppSessionProfile::Aggregate,
+                seg,
+            )
+        };
+        match ctx {
+            Ok(leader_ctx) => {
+                crate::mpp_log!(
+                    "mpp: AggregateScan leader initialized DSM for {} participants",
+                    leader_ctx.participant_config().total_participants
+                );
+                state.custom_state_mut().mpp_state = Some(leader_ctx);
+            }
+            Err(e) => {
+                // DSM init is in the hot path of parallel-query startup —
+                // a partial init leaves the region in an undefined state,
+                // so ERROR rather than silently degrade.
+                pgrx::error!("mpp: leader_init_dsm failed: {e}");
+            }
+        }
+    }
+
+    fn reinitialize_dsm_custom_scan(
+        _state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+        _coordinate: *mut std::os::raw::c_void,
+    ) {
+        // Rescan is Phase 5+ territory. A rescanned MPP aggregate would
+        // need a full mesh teardown + rebuild.
+    }
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _toc: *mut pg_sys::shm_toc,
+        coordinate: *mut std::os::raw::c_void,
+    ) {
+        debug_assert!(state.custom_state().mpp_state.is_none());
+        if !crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
+            return;
+        }
+        if coordinate.is_null() {
+            return;
+        }
+
+        // Worker-side attach. PG passes `shm_toc` (not a full
+        // `ParallelContext`), so we don't have access to `pcxt->seg`
+        // directly. We pass NULL for the seg to `worker_init_dsm`:
+        // `shm_mq_attach` handles NULL seg by skipping its
+        // `on_dsm_detach` callback and letting process-exit clean up
+        // the shm_mq handles. Safe for parallel-worker lifetimes where
+        // the process dies with the query (Phase 4b-iv scope).
+        //
+        // For region_total, we read the header's own `region_total`
+        // field (the first 8 bytes of the header's final u64). This
+        // loses the independence of the check but is the only source
+        // available without a seg pointer. A defense-in-depth
+        // independent check can land later via `dsm_find_mapping` +
+        // `dsm_segment_map_length`.
+        let region_total = unsafe {
+            let header = std::ptr::read_unaligned(
+                coordinate as *const crate::postgres::customscan::mpp::worker::MppDsmHeader,
+            );
+            header.region_total
+        };
+        let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+        let ctx = unsafe {
+            crate::postgres::customscan::mpp::customscan_glue::worker_init_dsm(
+                coordinate,
+                region_total,
+                worker_number,
+                std::ptr::null_mut(), // seg unknown to worker init; shm_mq_attach handles NULL
+            )
+        };
+        match ctx {
+            Ok(worker_ctx) => {
+                let _ = region_total;
+                crate::mpp_log!(
+                    "mpp: AggregateScan worker {} attached to DSM ({} participants)",
+                    worker_number,
+                    worker_ctx.participant_config().total_participants
+                );
+                state.custom_state_mut().mpp_state = Some(worker_ctx);
+            }
+            Err(e) => {
+                // Worker-side DSM attach failure is fatal for the same
+                // reason the leader side is: the worker now has no valid
+                // MPP state but the leader expects MPP partials.
+                // Aborting here lets the leader's query fail cleanly
+                // with a diagnostic rather than silently returning
+                // wrong answers.
+                pgrx::error!("mpp: worker_init_dsm failed on worker {worker_number}: {e}");
+            }
+        }
+    }
+}
+
+/// Eligibility predicate for firing the MPP path from `create_custom_path`.
+///
+/// Rules (derived from the eligibility research):
+///   * `paradedb.enable_mpp` ON AND `paradedb.mpp_worker_count` >= 2
+///   * Aggregate is over a JOIN (RELOPT_JOINREL), not a single table
+///   * (Phase 4b-iv) only COUNT / SUM / MIN / MAX / AVG / BOOL_* /
+///     STDDEV_* / VAR_* aggregates — no DISTINCT, ARRAY_AGG, STRING_AGG
+///   * (Phase 4b-iv) GROUP BY keys are simple column references
+///
+/// Today this is consulted by the stub trait impl's diagnostic log and by
+/// Phase 4b-iv's parallel-safe flip. Kept here so the eligibility rule has
+/// one canonical home.
+#[allow(dead_code)] // first caller lands in Phase 4b-iv
+pub fn mpp_eligible_for_aggregate(input_rel_kind: pg_sys::RelOptKind::Type) -> bool {
+    if !crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
+        return false;
+    }
+    // Milestone 1: only fire MPP on aggregate-over-JOIN. Single-table
+    // aggregates already run serially fast enough that the shuffle cost
+    // would dominate. RELOPT_OTHER_JOINREL covers partition-wise join
+    // rollups — same semantics, just a different RelOptKind tag.
+    matches!(
+        input_rel_kind,
+        pg_sys::RelOptKind::RELOPT_JOINREL | pg_sys::RelOptKind::RELOPT_OTHER_JOINREL
+    )
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -2114,11 +2114,7 @@ impl ParallelQueryCapable for AggregateScan {
         let seg = unsafe { (*pcxt).seg };
         let ctx = unsafe {
             crate::postgres::customscan::mpp::customscan_glue::leader_init_dsm(
-                coordinate,
-                plan_bytes,
-                num_meshes,
-                crate::postgres::customscan::mpp::session::MppSessionProfile::Aggregate,
-                seg,
+                coordinate, plan_bytes, num_meshes, seg,
             )
         };
         match ctx {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -145,10 +145,9 @@ impl CustomScan for AggregateScan {
             ReScanCustomScan: Some(crate::postgres::customscan::exec::rescan_custom_scan::<Self>),
             MarkPosCustomScan: None,
             RestrPosCustomScan: None,
-            // MPP reserved slots. The path is not yet declared parallel-safe
-            // in `create_custom_path`, so PG will never actually invoke these
-            // hooks today — they return zero / no-op. Phase 4b-ii wires the
-            // real MPP lifecycle when `customscan_glue::mpp_is_active()`.
+            // MPP DSM slots. These are only invoked when the path is flagged
+            // parallel-safe in `create_custom_path`; they wire the MPP
+            // lifecycle when `customscan_glue::mpp_is_active()`.
             EstimateDSMCustomScan: Some(mpp_dsm::estimate_dsm_custom_scan::<Self>),
             InitializeDSMCustomScan: Some(mpp_dsm::initialize_dsm_custom_scan::<Self>),
             ReInitializeDSMCustomScan: Some(mpp_dsm::reinitialize_dsm_custom_scan::<Self>),
@@ -1301,14 +1300,10 @@ impl AggregateScan {
     fn exec_datafusion_aggregate(
         state: &mut CustomScanStateWrapper<Self>,
     ) -> *mut pg_sys::TupleTableSlot {
-        // Phase 4b-iv correctness fence: if we're a parallel worker and
-        // mpp_state is None even though MPP is supposed to be active, the
-        // leader has flipped parallel-safe (step 4) without step 3's
-        // worker attach being wired. Silently running the non-MPP path
-        // here would double-count at the final gather. Abort loudly
-        // instead. No-op until step 4 lands; once both step 3 and step 4
-        // are in place, mpp_state is always Some on a worker and this
-        // never fires.
+        // Correctness fence: if we're a parallel worker and `mpp_state` is
+        // None even though MPP is supposed to be active, the worker DSM
+        // attach didn't run. Silently running the non-MPP path here would
+        // double-count at the final gather. Abort loudly instead.
         // `IsParallelWorker` is a C macro (`ParallelWorkerNumber >= 0`);
         // pgrx exposes the underlying int but not the macro, so inline it.
         let is_parallel_worker = unsafe { pg_sys::ParallelWorkerNumber } >= 0;
@@ -1318,9 +1313,8 @@ impl AggregateScan {
         {
             pgrx::error!(
                 "mpp: parallel worker reached exec_datafusion_aggregate without \
-                 MppExecutionState — Phase 4b-iv step 3 (worker DSM attach) must \
-                 land before step 4 (parallel-safe flip). Wrong-result scenario \
-                 averted via loud abort."
+                 MppExecutionState — worker DSM attach did not run. Wrong-result \
+                 scenario averted via loud abort."
             );
         }
 
@@ -2045,28 +2039,12 @@ unsafe fn get_aggregate_name(aggref: *mut pg_sys::Aggref) -> String {
 }
 
 // ----------------------------------------------------------------------------
-// Phase 4b-ii/iii: ParallelQueryCapable for AggregateScan.
-//
-// Delegation surface for the MPP lifecycle hooks. Today AggregateScan's
-// `create_custom_path` does NOT flag its paths as parallel-safe, so PG
-// never actually invokes these — the logging/debug_assert paths below
-// are cold. Wiring them here keeps the surface compiled and lets
-// Phase 4b-iv activate MPP with a single flip in `create_custom_path`
-// + a plan-bytes stash.
-//
-// Remaining Phase 4b work:
-//   * Flip parallel-safe + parallel_workers in `create_custom_path` via
-//     `CustomPathBuilder::set_parallel(nworkers)` when
-//     `mpp_eligible_for_aggregate()` returns true.
-//   * Serialize the logical plan in `begin_custom_scan` (NOT in
-//     `create_custom_path` or `estimate_dsm_custom_scan`) and stash the
-//     bytes on `AggregateScanState`. Path-build is too early (planner may
-//     discard the path); `estimate_dsm_custom_scan` is too late and would
-//     force re-lowering per parallel init. `begin_custom_scan` runs once
-//     per query after the plan is committed.
-//   * Teach `exec_datafusion_aggregate` to route through
-//     `mpp::plan_build::build_mpp_aggregate_plan` when `mpp_state` is
-//     `Some`.
+// ParallelQueryCapable for AggregateScan — delegation surface for the MPP
+// lifecycle hooks. `create_custom_path` flags the path parallel-safe via
+// `CustomPathBuilder::set_parallel(nworkers)` when `mpp_eligible_for_aggregate()`
+// is true; `begin_custom_scan` serializes the logical plan and stashes the
+// bytes on `AggregateScanState`; `exec_datafusion_aggregate` routes through
+// `mpp::plan_build::build_mpp_aggregate_plan` when `mpp_state` is `Some`.
 // ----------------------------------------------------------------------------
 impl ParallelQueryCapable for AggregateScan {
     fn estimate_dsm_custom_scan(
@@ -2165,8 +2143,8 @@ impl ParallelQueryCapable for AggregateScan {
         _pcxt: *mut pg_sys::ParallelContext,
         _coordinate: *mut std::os::raw::c_void,
     ) {
-        // Rescan is Phase 5+ territory. A rescanned MPP aggregate would
-        // need a full mesh teardown + rebuild.
+        // Rescan is out of scope. A rescanned MPP aggregate would need a
+        // full mesh teardown + rebuild.
     }
 
     fn initialize_worker_custom_scan(
@@ -2188,7 +2166,7 @@ impl ParallelQueryCapable for AggregateScan {
         // `shm_mq_attach` handles NULL seg by skipping its
         // `on_dsm_detach` callback and letting process-exit clean up
         // the shm_mq handles. Safe for parallel-worker lifetimes where
-        // the process dies with the query (Phase 4b-iv scope).
+        // the process dies with the query.
         //
         // For region_total, we read the header's own `region_total`
         // field (the first 8 bytes of the header's final u64). This
@@ -2236,17 +2214,15 @@ impl ParallelQueryCapable for AggregateScan {
 
 /// Eligibility predicate for firing the MPP path from `create_custom_path`.
 ///
-/// Rules (derived from the eligibility research):
+/// Rules:
 ///   * `paradedb.enable_mpp` ON AND `paradedb.mpp_worker_count` >= 2
 ///   * Aggregate is over a JOIN (RELOPT_JOINREL), not a single table
-///   * (Phase 4b-iv) only COUNT / SUM / MIN / MAX / AVG / BOOL_* /
-///     STDDEV_* / VAR_* aggregates — no DISTINCT, ARRAY_AGG, STRING_AGG
-///   * (Phase 4b-iv) GROUP BY keys are simple column references
+///   * Only COUNT / SUM / MIN / MAX / AVG / BOOL_* / STDDEV_* / VAR_*
+///     aggregates — no DISTINCT, ARRAY_AGG, STRING_AGG
+///   * GROUP BY keys are simple column references
 ///
-/// Today this is consulted by the stub trait impl's diagnostic log and by
-/// Phase 4b-iv's parallel-safe flip. Kept here so the eligibility rule has
-/// one canonical home.
-#[allow(dead_code)] // first caller lands in Phase 4b-iv
+/// Kept here so the eligibility rule has one canonical home.
+#[allow(dead_code)]
 pub fn mpp_eligible_for_aggregate(input_rel_kind: pg_sys::RelOptKind::Type) -> bool {
     if !crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
         return false;

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -140,10 +140,9 @@ pub struct AggregateScanState {
     /// MPP lifecycle state. Populated by `initialize_dsm_custom_scan`
     /// (leader) or `initialize_worker_custom_scan` (worker) when
     /// `mpp_is_active()` AND the path was flagged parallel-safe. Left
-    /// `None` for the serial (non-MPP) code path. Phase 4b-iv will
-    /// teach `exec_datafusion_aggregate` to route through
-    /// `mpp::plan_build::build_mpp_aggregate_plan` when this field is
-    /// `Some`.
+    /// `None` for the serial (non-MPP) code path. When `Some`,
+    /// `exec_datafusion_aggregate` routes through
+    /// `mpp::plan_build::build_mpp_aggregate_plan`.
     ///
     /// ## Drop ordering
     ///
@@ -151,9 +150,9 @@ pub struct AggregateScanState {
     /// matters because `MppExecutionState` owns shm_mq handles pointing
     /// into PG's DSM segment. PG's `ExecEndCustomScan` tears down our
     /// state *before* `ExecParallelCleanup` detaches the DSM segment, so
-    /// dropping `mpp_state` while DSM is still mapped is safe. Phase 4b-iv
-    /// will also wire a `DrainHandle` into `MppExecutionState::Leader`;
-    /// that handle must `join()` its drain thread before the DSM detaches,
+    /// dropping `mpp_state` while DSM is still mapped is safe.
+    /// `MppExecutionState::Leader` also holds a `DrainHandle`; that
+    /// handle must `join()` its drain thread before the DSM detaches,
     /// so don't move `mpp_state` earlier in this struct without revisiting
     /// the Drop chain.
     pub mpp_state: Option<crate::postgres::customscan::mpp::customscan_glue::MppExecutionState>,

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -111,6 +111,52 @@ pub struct AggregateScanState {
     /// Created once during begin_custom_scan and cleared/reused for each row
     /// to avoid per-row memory allocation and leaks
     pub scan_slot: Option<*mut pg_sys::TupleTableSlot>,
+
+    /// Serialized `MppPlanBroadcast` bytes (version byte + serialized
+    /// DataFusion logical plan + total_participants + session_profile,
+    /// bincode-encoded). Populated on the leader in `begin_custom_scan`
+    /// when `mpp_is_active()` and the DataFusion backend is active. The
+    /// bytes are consumed by `estimate_dsm_custom_scan` (just `.len()`)
+    /// and `initialize_dsm_custom_scan` (copied verbatim into DSM for
+    /// workers). These are the exact bytes that land in DSM — the
+    /// broadcast wrapping is done here, not at DSM-init time, so that
+    /// `.len()` at estimate time matches the bytes actually written at
+    /// init time (otherwise the DSM write overruns PG's `shm_toc`
+    /// allocation and corrupts adjacent DSA control regions).
+    ///
+    /// `None` means either:
+    ///   - MPP is off (the common case),
+    ///   - OR the Tantivy backend is active (non-DataFusion path), OR
+    ///   - plan serialization failed (logged via `mpp_log!`; MPP will
+    ///     silently fall back to the non-MPP path).
+    pub logical_plan_bytes: Option<bytes::Bytes>,
+
+    /// Classified MPP shape for this query, populated alongside
+    /// `logical_plan_bytes`. Drives the number of shuffle meshes the
+    /// coordinator allocates in DSM and the per-shape plan builder used
+    /// at exec time. `None` whenever `logical_plan_bytes` is `None`.
+    pub mpp_shape: Option<crate::postgres::customscan::mpp::shape::MppPlanShape>,
+
+    /// MPP lifecycle state. Populated by `initialize_dsm_custom_scan`
+    /// (leader) or `initialize_worker_custom_scan` (worker) when
+    /// `mpp_is_active()` AND the path was flagged parallel-safe. Left
+    /// `None` for the serial (non-MPP) code path. Phase 4b-iv will
+    /// teach `exec_datafusion_aggregate` to route through
+    /// `mpp::plan_build::build_mpp_aggregate_plan` when this field is
+    /// `Some`.
+    ///
+    /// ## Drop ordering
+    ///
+    /// Declared LAST in the struct so it's the last field dropped. This
+    /// matters because `MppExecutionState` owns shm_mq handles pointing
+    /// into PG's DSM segment. PG's `ExecEndCustomScan` tears down our
+    /// state *before* `ExecParallelCleanup` detaches the DSM segment, so
+    /// dropping `mpp_state` while DSM is still mapped is safe. Phase 4b-iv
+    /// will also wire a `DrainHandle` into `MppExecutionState::Leader`;
+    /// that handle must `join()` its drain thread before the DSM detaches,
+    /// so don't move `mpp_state` earlier in this struct without revisiting
+    /// the Drop chain.
+    pub mpp_state: Option<crate::postgres::customscan::mpp::customscan_glue::MppExecutionState>,
 }
 
 impl AggregateScanState {

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -324,9 +324,93 @@ pub extern "C-unwind" fn paradedb_upper_paths_callback<CS>(
         ));
 
         for path in paths {
-            add_path(output_rel, path);
+            add_upper_path(root, output_rel, path);
         }
     }
+}
+
+/// Upper-rel variant of [`add_path`]. `add_path` handles base/join rels well
+/// because PG's path generator calls `generate_useful_gather_paths()` AFTER
+/// the `set_rel_pathlist_hook` fires — so a partial path added there still
+/// gets wrapped in a `Gather` by core. For `UPPERREL_GROUP_AGG`, the
+/// sequence is reversed: core has already finished gather-path generation
+/// before `create_upper_paths_hook` runs, and any partial path we add at
+/// this stage is orphaned.
+///
+/// This helper wraps the MPP-ready parallel-aware custom path with an
+/// explicit `GatherPath` via `pg_sys::create_gather_path` and adds that to
+/// `output_rel->pathlist`, which is the one PG's grouping-path chooser
+/// compares against the serial aggregate path. Non-parallel custom paths
+/// fall through to the same `add_path` behavior used everywhere else.
+unsafe fn add_upper_path(
+    root: *mut pg_sys::PlannerInfo,
+    rel: *mut pg_sys::RelOptInfo,
+    mut path: pg_sys::CustomPath,
+) {
+    let forced = path.flags & Flags::Force as u32 != 0;
+    path.flags ^= Flags::Force as u32;
+
+    if forced {
+        (*rel).pathlist = std::ptr::null_mut();
+        (*rel).partial_pathlist = std::ptr::null_mut();
+    }
+
+    if path.path.parallel_aware {
+        // The MPP path itself is parallel-safe; PG needs to see it as a
+        // partial path so it and the Gather wrapper agree about workers.
+        let partial_copy = PgMemoryContexts::CurrentMemoryContext
+            .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+        pg_sys::add_partial_path(rel, partial_copy.cast());
+
+        // Wrap with Gather so the grouping-path chooser actually sees a
+        // runnable parallel plan in `output_rel->pathlist`. Use the rel's
+        // reltarget directly so Gather's pathtarget structurally equals
+        // `final_target` — otherwise `create_ordered_paths` adds a
+        // ProjectionPath (→ Result plan node) above the Sort, whose
+        // targetlist carries unreplaceable Aggrefs that crash setrefs
+        // with "Aggref found in non-Agg plan node".
+        //
+        // Aggrefs in Gather.tlist get rewritten to Var(OUTER_VAR, N) by
+        // setrefs so long as the subplan (CustomScan) tlist carries
+        // structurally-equal Aggrefs — see `set_customscan_references`
+        // and `fix_upper_expr` for the matching logic.
+        let gather_target = (*rel).reltarget;
+
+        let mut rows = (*partial_copy).path.rows;
+        let gather = pg_sys::create_gather_path(
+            root,
+            rel,
+            partial_copy.cast::<pg_sys::Path>(),
+            gather_target,
+            std::ptr::null_mut(),
+            &mut rows,
+        );
+
+        // Clear competing paths so the chooser actually considers Gather;
+        // otherwise a single-worker serial aggregate path with matching
+        // total cost may win by tie-break. We re-add a high-cost serial
+        // fallback below so PG always has something non-partial to pick.
+        (*rel).pathlist = std::ptr::null_mut();
+
+        pg_sys::add_path(rel, gather.cast());
+
+        // High-cost serial fallback: same as non-upper-rel `add_path`.
+        // Keeps a non-parallel path in the list for cases where the
+        // Gather wrapper can't run (e.g., max_parallel_workers == 0).
+        let fallback = PgMemoryContexts::CurrentMemoryContext
+            .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+        (*fallback).path.parallel_aware = false;
+        (*fallback).path.parallel_safe = false;
+        (*fallback).path.parallel_workers = 0;
+        (*fallback).path.total_cost = 1_000_000_000.0;
+        (*fallback).path.startup_cost = 1_000_000_000.0;
+        pg_sys::add_path(rel, fallback.cast());
+        return;
+    }
+
+    let serial = PgMemoryContexts::CurrentMemoryContext
+        .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+    pg_sys::add_path(rel, serial.cast());
 }
 
 /// Static variable to store the previous planner hook (e.g., from Citus or other extensions)

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -327,7 +327,7 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
 ///      preserved across the MPP HashJoin rebuild (via `builder()`) and
 ///      re-applied as a `FilterExec` above the post-shuffle probe stream by
 ///      `shape::build_*_on_binary_join`. See `exec_bridge.rs`.
-#[allow(dead_code)] // first MPP caller lands in Phase 4
+#[allow(dead_code)] // first caller is the MPP path
 pub fn create_datafusion_session_context_mpp(
     profile: SessionContextProfile,
     mpp: &crate::postgres::customscan::mpp::MppParticipantConfig,

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -255,11 +255,23 @@ pub enum SessionContextProfile {
 /// Build the shared core of a DataFusion [`SessionStateBuilder`] with:
 /// - Visibility filtering (logical + physical)
 /// - Late materialization
-/// - SortMergeJoinEnforcer (when columnar sort enabled)
+/// - SortMergeJoinEnforcer (when columnar sort enabled *and* MPP is inactive)
 /// - `PgSearchQueryPlanner`
 ///
 /// Callers append their own TopK rule and FilterPushdown passes.
-pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
+///
+/// When `mpp` is `Some` with `total_participants > 1`, two bug-fix paths from
+/// the reference MPP implementation apply:
+///   1. `SortMergeJoinEnforcer` is skipped. The SPM rewrite collapses hash
+///      partitions to one, which would make our `HashRepartitionExec::execute(i)`
+///      return empty for all `i != leader`.
+///   2. Caller `create_datafusion_session_context_mpp` disables
+///      `enable_join_dynamic_filter_pushdown` so probe-side scans do not race
+///      with the exchange producer and emit zero rows.
+pub(crate) fn build_base_session_with_mpp(
+    config: SessionConfig,
+    mpp: Option<&crate::postgres::customscan::mpp::MppParticipantConfig>,
+) -> SessionStateBuilder {
     use super::visibility_filter::VisibilityFilterOptimizerRule;
     use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
 
@@ -273,7 +285,14 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
             crate::scan::late_materialization::LateMaterializationRule,
         ));
 
-    if crate::gucs::is_columnar_sort_enabled() {
+    // Treat any non-None MppParticipantConfig as "MPP is active" — even N=1
+    // MPP (leader-only) shares the shuffle operator tree with N>1, so the
+    // SortMergeJoinEnforcer's partition-collapsing behavior is undesirable
+    // in both cases. Callers that do *not* want the bug-fix semantics pass
+    // `None`.
+    let mpp_active = mpp.is_some();
+
+    if crate::gucs::is_columnar_sort_enabled() && !mpp_active {
         builder = builder.with_physical_optimizer_rule(Arc::new(SortMergeJoinEnforcer::new()));
     }
 
@@ -297,6 +316,29 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
 /// - [`SessionContextProfile::Aggregate`]: appends a single `FilterPushdown`
 ///   post-pass; SegmentedTopK does not apply to aggregate-on-join queries.
 pub fn create_datafusion_session_context(profile: SessionContextProfile) -> SessionContext {
+    create_datafusion_session_context_inner(profile, None)
+}
+
+/// MPP-aware variant of [`create_datafusion_session_context`]. Applies the
+/// reference implementation's join-layer adjustment when the participant
+/// config indicates more than one participant:
+///   1. Skip `SortMergeJoinEnforcer` (handled by `build_base_session_with_mpp`).
+///   2. Keep `enable_join_dynamic_filter_pushdown = true`. The filter Arc is
+///      preserved across the MPP HashJoin rebuild (via `builder()`) and
+///      re-applied as a `FilterExec` above the post-shuffle probe stream by
+///      `shape::build_*_on_binary_join`. See `exec_bridge.rs`.
+#[allow(dead_code)] // first MPP caller lands in Phase 4
+pub fn create_datafusion_session_context_mpp(
+    profile: SessionContextProfile,
+    mpp: &crate::postgres::customscan::mpp::MppParticipantConfig,
+) -> SessionContext {
+    create_datafusion_session_context_inner(profile, Some(mpp))
+}
+
+fn create_datafusion_session_context_inner(
+    profile: SessionContextProfile,
+    mpp: Option<&crate::postgres::customscan::mpp::MppParticipantConfig>,
+) -> SessionContext {
     let mut config = SessionConfig::new().with_target_partitions(1);
     if matches!(profile, SessionContextProfile::Join) {
         config
@@ -305,11 +347,41 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
             .enable_topk_dynamic_filter_pushdown = true;
     }
 
-    let mut builder = build_base_session(config);
+    // Disable DataFusion's "skip partial aggregation" probe for MPP sessions.
+    //
+    // In Partial mode, DataFusion samples the first
+    // `skip_partial_aggregation_probe_rows_threshold` (default 100_000) rows
+    // and, if the distinct-group ratio exceeds
+    // `skip_partial_aggregation_probe_ratio_threshold` (default 0.8), flips
+    // the operator into pass-through mode — every subsequent input row is
+    // emitted as its own partial output row with no deduplication. The
+    // downstream `FinalPartitioned` still produces correct results because it
+    // merges duplicates, but the intermediate shuffle must carry ~distinct_
+    // groups × rows_per_group rows instead of ~distinct_groups rows.
+    //
+    // On the 25M `aggregate_join_groupby` bench this fanout was ~7× (gb_postagg
+    // rows_in = 22M across seats for 3.1M distinct groups), and 22M rows
+    // through shm_mq saturated the shuffle for > 600s. Single-process
+    // DataFusion never pays that cost because there's no shuffle; the skip
+    // probe is a pure win in single-process. For MPP it is the dominant cost.
+    //
+    // Setting the ratio threshold to 1.1 (> 1.0, which is the max achievable
+    // ratio) disables the switch unconditionally. Partial mode still benefits
+    // from in-memory hash-table dedup within each batch flush.
+    if mpp.is_some() {
+        config
+            .options_mut()
+            .execution
+            .skip_partial_aggregation_probe_ratio_threshold = 1.1;
+    }
+
+    let mut builder = build_base_session_with_mpp(config, mpp);
+
+    let mpp_active = mpp.is_some();
 
     match profile {
         SessionContextProfile::Join => {
-            if crate::gucs::is_columnar_sort_enabled() {
+            if crate::gucs::is_columnar_sort_enabled() && !mpp_active {
                 builder = builder.with_physical_optimizer_rule(Arc::new(
                     FilterPushdown::new_post_optimization(),
                 ));

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -1,0 +1,251 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! One-call façade that AggregateScan / JoinScan customscan hooks call into
+//! for MPP DSM setup.
+//!
+//! Customscan code typically has three hook points where MPP needs to
+//! participate:
+//!
+//! - `estimate_dsm_custom_scan` — leader, returns the DSM region size. Call
+//!   [`estimate_mpp_dsm`] with the serialized-plan length and mesh config.
+//! - `initialize_dsm_custom_scan` — leader, initializes DSM with leader seat
+//!   wiring. Call [`init_mpp_dsm_leader`] and stash the returned
+//!   [`LeaderMesh`](super::worker::LeaderMesh) in execution state.
+//! - `initialize_worker_custom_scan` — worker, attaches to DSM with this
+//!   worker's seat wiring. Call [`attach_mpp_dsm_worker`] and stash the
+//!   returned [`WorkerMesh`](super::worker::WorkerMesh) + decoded plan.
+//!
+//! Each function is a thin wrapper over [`super::worker`] primitives plus a
+//! plan-broadcast encode/decode. Keeping them here isolates the hook-facing
+//! glue from the lower-level DSM math so future refactors on either side
+//! stay localized.
+
+#![allow(dead_code)] // First caller lands when AggregateScan MPP path is wired up.
+
+use pgrx::pg_sys;
+
+use crate::postgres::customscan::mpp::mesh::MeshLayout;
+use crate::postgres::customscan::mpp::session::{MppPlanBroadcast, MppSessionProfile};
+use crate::postgres::customscan::mpp::worker::{
+    attach_dsm_as_worker, compute_dsm_layout, initialize_dsm_as_leader, DsmLayout, LeaderMesh,
+};
+
+/// Compute the exact DSM size the MPP custom scan needs for a plan of
+/// `plan_bytes_len` bytes, N participants, `num_meshes` independent shuffle
+/// meshes, and the configured per-edge queue size.
+///
+/// Returns `Err` on any arithmetic overflow or if the resulting region would
+/// exceed [`super::worker::MPP_DSM_MAX_BYTES`].
+pub fn estimate_mpp_dsm(
+    plan_bytes_len: usize,
+    total_participants: u32,
+    num_meshes: u32,
+    queue_bytes: usize,
+) -> Result<usize, &'static str> {
+    let mesh = MeshLayout::new(total_participants, queue_bytes);
+    let dsm = compute_dsm_layout(&mesh, num_meshes, plan_bytes_len)?;
+    Ok(dsm.total)
+}
+
+/// Leader's DSM-init entry point. Serializes `plan` into a
+/// [`MppPlanBroadcast`], writes the bytes + header + shm_mq regions into the
+/// DSM region at `coordinate`, and returns the leader's mesh wiring.
+///
+/// # Safety
+/// - `coordinate` must point to the start of a DSM region of size >= the
+///   estimate returned by [`estimate_mpp_dsm`] with the same parameters.
+/// - Caller is the leader backend and holds `pcxt` / `seg`.
+/// - Caller must not have written to the region already.
+///
+/// On `Err`, the DSM region may be partially initialized; the caller should
+/// treat this as an abort condition and tear down the parallel context
+/// rather than retrying.
+pub unsafe fn init_mpp_dsm_leader(
+    coordinate: *mut std::ffi::c_void,
+    plan_broadcast_bytes: Vec<u8>,
+    total_participants: u32,
+    num_meshes: u32,
+    session_profile: MppSessionProfile,
+    queue_bytes: usize,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<LeaderMppContext, String> {
+    // `plan_broadcast_bytes` is the already-serialized `MppPlanBroadcast`
+    // payload — the caller is responsible for matching these exact bytes
+    // against the `estimate_mpp_dsm` size the PG planner used to allocate
+    // the DSM region. Re-wrapping here would produce a different length
+    // than estimate and overrun the DSM allocation.
+    let mesh = MeshLayout::new(total_participants, queue_bytes);
+    let dsm = compute_dsm_layout(&mesh, num_meshes, plan_broadcast_bytes.len())
+        .map_err(|e| format!("mpp: compute_dsm_layout failed: {e}"))?;
+
+    let base = coordinate as *mut u8;
+    let meshes = unsafe {
+        initialize_dsm_as_leader(base, &dsm, &mesh, &plan_broadcast_bytes, seg)
+            .map_err(|e| format!("mpp: initialize_dsm_as_leader failed: {e}"))?
+    };
+
+    Ok(LeaderMppContext {
+        meshes,
+        layout: dsm,
+        participant_config: super::MppParticipantConfig {
+            participant_index: 0,
+            total_participants,
+        },
+        session_profile,
+    })
+}
+
+/// Bundle returned to the leader after [`init_mpp_dsm_leader`]. The caller
+/// owns both the mesh wiring (for the leader's own shuffle participation)
+/// and the config that the leader feeds into its DataFusion session.
+pub struct LeaderMppContext {
+    /// One [`LeaderMesh`] per shuffle mesh, in the order the shape requested.
+    pub meshes: Vec<LeaderMesh>,
+    pub layout: DsmLayout,
+    pub participant_config: super::MppParticipantConfig,
+    pub session_profile: MppSessionProfile,
+}
+
+/// Worker's DSM-attach entry point. Reads the header, validates, attaches as
+/// sender/receiver for this worker's seat, and decodes the plan broadcast.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer the leader initialized.
+/// - `region_total` must match the DSM's attached size.
+/// - `worker_number` is the PG-assigned `ParallelWorkerNumber`; the worker's
+///   seat is `worker_number + 1` (leader is seat 0).
+/// - Caller is the worker backend and holds `pcxt` / `seg`.
+pub unsafe fn attach_mpp_dsm_worker(
+    coordinate: *mut std::ffi::c_void,
+    region_total: u64,
+    worker_number: i32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<WorkerMppContext, String> {
+    if worker_number < 0 {
+        return Err("mpp: worker_number < 0".into());
+    }
+    let participant_index = (worker_number as u32)
+        .checked_add(1)
+        .ok_or_else(|| "mpp: worker_number + 1 overflowed u32".to_string())?;
+
+    let base = coordinate as *mut u8;
+    let attach = unsafe { attach_dsm_as_worker(base, region_total, participant_index, seg) }
+        .map_err(|e| format!("mpp: attach_dsm_as_worker failed: {e}"))?;
+
+    // The plan bytes live inside DSM. Copy them out so we don't hold a borrow
+    // across subsequent FFI. `bincode::decode_from_slice` wants `&[u8]`.
+    let plan_bytes = unsafe { attach.copy_plan_bytes() };
+    let broadcast = MppPlanBroadcast::deserialize(&plan_bytes)
+        .map_err(|e| format!("mpp: plan deserialize failed: {e}"))?;
+    let participant_config = broadcast.participant_config(participant_index);
+
+    Ok(WorkerMppContext {
+        meshes: attach.meshes,
+        plan: broadcast,
+        participant_config,
+    })
+}
+
+/// Bundle returned to a worker after [`attach_mpp_dsm_worker`]. The caller
+/// rebuilds its DataFusion logical plan from `plan.logical_plan`, constructs
+/// a session with `participant_config` + `plan.session_profile`, and wires
+/// the returned meshes into `ShuffleExec` (one mesh per shuffle).
+pub struct WorkerMppContext {
+    pub meshes: Vec<crate::postgres::customscan::mpp::worker::WorkerMesh>,
+    pub plan: MppPlanBroadcast,
+    pub participant_config: super::MppParticipantConfig,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn estimate_matches_compute_dsm_layout() {
+        // Cross-check: estimate_mpp_dsm returns the same `total` as a direct
+        // compute_dsm_layout call for any given config.
+        for &(plan_len, n, num_meshes, q) in &[
+            (0usize, 2u32, 1u32, 8 * 1024usize),
+            (1024, 2, 1, 8 * 1024),
+            (500_000, 4, 3, 64 * 1024),
+        ] {
+            let mesh = MeshLayout::new(n, q);
+            let direct = compute_dsm_layout(&mesh, num_meshes, plan_len).unwrap();
+            let via_estimate = estimate_mpp_dsm(plan_len, n, num_meshes, q).unwrap();
+            assert_eq!(direct.total, via_estimate);
+        }
+    }
+
+    #[test]
+    fn estimate_rejects_overflow() {
+        assert!(estimate_mpp_dsm(usize::MAX, 2, 1, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_rejects_zero_participants() {
+        assert!(estimate_mpp_dsm(100, 0, 1, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_rejects_zero_meshes() {
+        assert!(estimate_mpp_dsm(100, 2, 0, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_scales_with_num_meshes() {
+        let one = estimate_mpp_dsm(0, 4, 1, 64 * 1024).unwrap();
+        let three = estimate_mpp_dsm(0, 4, 3, 64 * 1024).unwrap();
+        // Header + padding is constant; per-mesh bytes is N*(N-1)*q.
+        // Difference between 3 and 1 meshes is exactly 2 * per-mesh bytes.
+        let per_mesh = 4 * 3 * 64 * 1024;
+        assert_eq!(three - one, 2 * per_mesh);
+    }
+
+    #[test]
+    fn init_does_not_rewrap_plan_bytes() {
+        // Regression: the caller must pass **pre-serialized** broadcast
+        // bytes to `init_mpp_dsm_leader`, whose length matches the
+        // `estimate_mpp_dsm(plan_broadcast_bytes.len(), …)` used to size
+        // the DSM region. Earlier, `init_mpp_dsm_leader` re-wrapped the
+        // raw logical plan in `MppPlanBroadcast` + bincode-serialized it
+        // inside the body, producing bytes ~6 larger than estimate — the
+        // tail of the last mesh queue then overran the DSM region and
+        // corrupted adjacent `shm_toc` allocations (crash at
+        // `dsa_release_in_place` teardown).
+        //
+        // This test pins the invariant *statically* by asserting, for a
+        // representative raw plan, that `MppPlanBroadcast::serialize().len()
+        // != raw_plan.len()`. If some future refactor ever undoes the
+        // pre-serialize step, every test that actually exercises the DSM
+        // path will crash; this one additionally documents the
+        // why-it-matters so the regression is caught at code-review time.
+        let raw_plan: Vec<u8> = (0..1024u32).map(|i| (i & 0xff) as u8).collect();
+        let bc = MppPlanBroadcast::new(raw_plan.clone(), 2, MppSessionProfile::Aggregate);
+        let broadcast_bytes = bc.serialize().unwrap();
+        assert_ne!(
+            broadcast_bytes.len(),
+            raw_plan.len(),
+            "MppPlanBroadcast wrapping adds framing; callers must size DSM against \
+             the wrapped bytes, not raw plan bytes"
+        );
+        assert!(
+            broadcast_bytes.len() > raw_plan.len(),
+            "wrapped bytes must be strictly larger than raw (sanity)"
+        );
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -40,9 +40,9 @@
 use pgrx::pg_sys;
 
 use crate::postgres::customscan::mpp::mesh::MeshLayout;
-use crate::postgres::customscan::mpp::session::{MppPlanBroadcast, MppSessionProfile};
+use crate::postgres::customscan::mpp::session::MppPlanBroadcast;
 use crate::postgres::customscan::mpp::worker::{
-    attach_dsm_as_worker, compute_dsm_layout, initialize_dsm_as_leader, DsmLayout, LeaderMesh,
+    attach_dsm_as_worker, compute_dsm_layout, initialize_dsm_as_leader, LeaderMesh,
 };
 
 /// Compute the exact DSM size the MPP custom scan needs for a plan of
@@ -80,7 +80,6 @@ pub unsafe fn init_mpp_dsm_leader(
     plan_broadcast_bytes: Vec<u8>,
     total_participants: u32,
     num_meshes: u32,
-    session_profile: MppSessionProfile,
     queue_bytes: usize,
     seg: *mut pg_sys::dsm_segment,
 ) -> Result<LeaderMppContext, String> {
@@ -101,12 +100,10 @@ pub unsafe fn init_mpp_dsm_leader(
 
     Ok(LeaderMppContext {
         meshes,
-        layout: dsm,
         participant_config: super::MppParticipantConfig {
             participant_index: 0,
             total_participants,
         },
-        session_profile,
     })
 }
 
@@ -116,9 +113,7 @@ pub unsafe fn init_mpp_dsm_leader(
 pub struct LeaderMppContext {
     /// One [`LeaderMesh`] per shuffle mesh, in the order the shape requested.
     pub meshes: Vec<LeaderMesh>,
-    pub layout: DsmLayout,
     pub participant_config: super::MppParticipantConfig,
-    pub session_profile: MppSessionProfile,
 }
 
 /// Worker's DSM-attach entry point. Reads the header, validates, attaches as
@@ -156,24 +151,22 @@ pub unsafe fn attach_mpp_dsm_worker(
 
     Ok(WorkerMppContext {
         meshes: attach.meshes,
-        plan: broadcast,
         participant_config,
     })
 }
 
 /// Bundle returned to a worker after [`attach_mpp_dsm_worker`]. The caller
-/// rebuilds its DataFusion logical plan from `plan.logical_plan`, constructs
-/// a session with `participant_config` + `plan.session_profile`, and wires
-/// the returned meshes into `ShuffleExec` (one mesh per shuffle).
+/// constructs a session with `participant_config` and wires the returned
+/// meshes into `ShuffleExec` (one mesh per shuffle).
 pub struct WorkerMppContext {
     pub meshes: Vec<crate::postgres::customscan::mpp::worker::WorkerMesh>,
-    pub plan: MppPlanBroadcast,
     pub participant_config: super::MppParticipantConfig,
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::postgres::customscan::mpp::session::MppSessionProfile;
 
     #[test]
     fn estimate_matches_compute_dsm_layout() {

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -48,7 +48,6 @@ use crate::postgres::customscan::mpp::coordinator::{
     attach_mpp_dsm_worker, estimate_mpp_dsm, init_mpp_dsm_leader, LeaderMppContext,
     WorkerMppContext,
 };
-use crate::postgres::customscan::mpp::session::MppSessionProfile;
 
 /// Per-query MPP state a customscan's execution state stores. Distinct
 /// variants for leader vs worker because the two have different wiring
@@ -65,13 +64,6 @@ impl MppExecutionState {
         match self {
             MppExecutionState::Leader(l) => &l.participant_config,
             MppExecutionState::Worker(w) => &w.participant_config,
-        }
-    }
-
-    pub fn session_profile(&self) -> MppSessionProfile {
-        match self {
-            MppExecutionState::Leader(l) => l.session_profile,
-            MppExecutionState::Worker(w) => w.plan.session_profile,
         }
     }
 
@@ -143,7 +135,6 @@ pub unsafe fn leader_init_dsm(
     coordinate: *mut std::ffi::c_void,
     plan_broadcast_bytes: Vec<u8>,
     num_meshes: u32,
-    session_profile: MppSessionProfile,
     seg: *mut pg_sys::dsm_segment,
 ) -> Result<MppExecutionState, String> {
     if coordinate.is_null() {
@@ -157,7 +148,6 @@ pub unsafe fn leader_init_dsm(
             plan_broadcast_bytes,
             n,
             num_meshes,
-            session_profile,
             DEFAULT_MPP_QUEUE_BYTES,
             seg,
         )?

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -40,7 +40,7 @@
 //! `ParallelQueryCapable` impl is five lines of delegation and never touches
 //! raw shm_mq FFI directly.
 
-#![allow(dead_code)] // First caller is AggregateScan Phase 4b wiring.
+#![allow(dead_code)] // First caller is AggregateScan wiring.
 
 use pgrx::pg_sys;
 

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Glue between PostgreSQL customscan DSM hooks and the MPP coordinator.
+//!
+//! AggregateScan / JoinScan implement `ParallelQueryCapable` with trait
+//! methods that receive raw pg_sys pointers. This module packages those raw
+//! calls into typed helpers that each customscan can call with minimal
+//! boilerplate:
+//!
+//! - [`MppExecutionState`] is the per-query MPP state the customscan's
+//!   execution state stores in a `Option<MppExecutionState>` field. It owns
+//!   the coordinator results (leader or worker mesh), the drain handle
+//!   (created once the worker has wired the receivers), and the decoded
+//!   plan broadcast.
+//! - [`leader_estimate_dsm`] computes the DSM size for the customscan's
+//!   `estimate_dsm_custom_scan` hook given the size of the serialized
+//!   logical plan and the MPP GUC config.
+//! - [`leader_init_dsm`] handles the full leader-side setup in one call.
+//! - [`worker_init_dsm`] mirrors [`leader_init_dsm`] on the worker side:
+//!   attach, decode plan, return everything the worker needs to rebuild its
+//!   DataFusion session.
+//!
+//! Each helper is a thin wrapper over [`crate::postgres::customscan::mpp::coordinator`]
+//! plus a couple of GUC reads — the intent is that AggregateScan's
+//! `ParallelQueryCapable` impl is five lines of delegation and never touches
+//! raw shm_mq FFI directly.
+
+#![allow(dead_code)] // First caller is AggregateScan Phase 4b wiring.
+
+use pgrx::pg_sys;
+
+use crate::postgres::customscan::mpp::coordinator::{
+    attach_mpp_dsm_worker, estimate_mpp_dsm, init_mpp_dsm_leader, LeaderMppContext,
+    WorkerMppContext,
+};
+use crate::postgres::customscan::mpp::session::MppSessionProfile;
+
+/// Per-query MPP state a customscan's execution state stores. Distinct
+/// variants for leader vs worker because the two have different wiring
+/// shapes — the leader pre-creates the mesh; the worker attaches to it —
+/// and forcing a common bundle would either waste fields or require a
+/// second level of Option.
+pub enum MppExecutionState {
+    Leader(LeaderMppContext),
+    Worker(WorkerMppContext),
+}
+
+impl MppExecutionState {
+    pub fn participant_config(&self) -> &crate::postgres::customscan::mpp::MppParticipantConfig {
+        match self {
+            MppExecutionState::Leader(l) => &l.participant_config,
+            MppExecutionState::Worker(w) => &w.participant_config,
+        }
+    }
+
+    pub fn session_profile(&self) -> MppSessionProfile {
+        match self {
+            MppExecutionState::Leader(l) => l.session_profile,
+            MppExecutionState::Worker(w) => w.plan.session_profile,
+        }
+    }
+
+    pub fn is_leader(&self) -> bool {
+        matches!(self, MppExecutionState::Leader(_))
+    }
+}
+
+/// True when the `paradedb.enable_mpp` GUC is on AND the worker count is at
+/// least 2. The customscan checks this before announcing parallel-safe
+/// paths; if false, the non-MPP serial path is used.
+pub fn mpp_is_active() -> bool {
+    crate::gucs::enable_mpp() && crate::gucs::mpp_worker_count() >= 2
+}
+
+/// Read the configured MPP worker count from GUC. Clamps below at 2 because
+/// the MPP code paths assume at least 2 participants; callers that see
+/// `< 2` here should fall back to the non-MPP path via [`mpp_is_active`].
+pub fn mpp_worker_count() -> u32 {
+    // `max(2)` rather than `clamp(2, ...)`: GUC is already `i32`-bounded,
+    // and naive `clamp(2, u32::MAX as i32)` underflows the upper bound to -1.
+    crate::gucs::mpp_worker_count().max(2) as u32
+}
+
+/// Per-edge shm_mq queue capacity in bytes. Fixed at 8 MiB — matches the
+/// reference attempt's sizing and comfortably holds typical Arrow IPC
+/// partial-aggregate batches. Eventually this should come from a GUC so
+/// ops can tune without recompiling, but 8 MiB is sufficient for the
+/// milestone-1 benchmark target.
+// 64 MiB per directed edge, per mesh. The 25M-row benchmark's
+// GROUP BY variant ships ~100 MiB of Partial rows through the postagg
+// mesh per participant; at 8 MiB per edge the queue fills repeatedly
+// and the cooperative-drain spin consumes most of the budget. 64 MiB
+// lets each Partial burst fit in a single queue without backpressure,
+// at the cost of a larger DSM allocation (N×(N-1)×num_meshes×64 MiB —
+// 768 MiB at N=2 × 3 meshes, ~2.3 GiB at N=4 × 3 meshes).
+pub const DEFAULT_MPP_QUEUE_BYTES: usize = 64 * 1024 * 1024;
+
+/// Customscan `estimate_dsm_custom_scan` implementation for an MPP-enabled
+/// plan. Given the serialized logical plan length, returns the total DSM
+/// bytes the coordinator will need.
+///
+/// Call from the customscan's `ParallelQueryCapable::estimate_dsm_custom_scan`
+/// when [`mpp_is_active`] is true.
+pub fn leader_estimate_dsm(plan_bytes_len: usize, num_meshes: u32) -> Result<pg_sys::Size, String> {
+    let n = mpp_worker_count();
+    estimate_mpp_dsm(plan_bytes_len, n, num_meshes, DEFAULT_MPP_QUEUE_BYTES)
+        .map(|sz| sz as pg_sys::Size)
+        .map_err(|e| format!("mpp: estimate DSM failed: {e}"))
+}
+
+/// Customscan `initialize_dsm_custom_scan` implementation for an MPP leader.
+/// Takes the DSM `coordinate` pointer the PG hook received, the pre-serialized
+/// `MppPlanBroadcast` bytes (same bytes whose length was reported by
+/// [`leader_estimate_dsm`]), the session profile, and the DSM segment pointer.
+/// Returns the [`MppExecutionState::Leader`] the customscan should stash in
+/// its execution state.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer PG supplied to
+///   `initialize_dsm_custom_scan`. It must remain valid for the query's
+///   lifetime.
+/// - `seg` must be valid. On the leader it comes from `pcxt->seg`.
+/// - `plan_broadcast_bytes.len()` must equal the value passed to
+///   [`leader_estimate_dsm`]; otherwise the DSM write overruns the region PG
+///   allocated and corrupts adjacent `shm_toc` allocations (including the
+///   DSA control regions used by parallel tuple queues).
+pub unsafe fn leader_init_dsm(
+    coordinate: *mut std::ffi::c_void,
+    plan_broadcast_bytes: Vec<u8>,
+    num_meshes: u32,
+    session_profile: MppSessionProfile,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<MppExecutionState, String> {
+    if coordinate.is_null() {
+        return Err("mpp: leader_init_dsm given null coordinate".into());
+    }
+
+    let n = mpp_worker_count();
+    let leader = unsafe {
+        init_mpp_dsm_leader(
+            coordinate,
+            plan_broadcast_bytes,
+            n,
+            num_meshes,
+            session_profile,
+            DEFAULT_MPP_QUEUE_BYTES,
+            seg,
+        )?
+    };
+    Ok(MppExecutionState::Leader(leader))
+}
+
+/// Customscan `initialize_worker_custom_scan` implementation. Called on
+/// worker backends with the `coordinate` pointer and the worker's
+/// `ParallelWorkerNumber`.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer PG supplied.
+/// - `seg` may be NULL — `initialize_worker_custom_scan` does not surface
+///   the DSM segment pointer, so callers typically pass NULL. `shm_mq_attach`
+///   handles NULL seg by skipping its `on_dsm_detach` callback; cleanup
+///   then relies on process exit. Safe for parallel-worker lifetimes where
+///   the process dies with the query.
+/// - `region_total` must be the size of the attached DSM region. Callers
+///   without an independent source can read it from the header itself
+///   (trading the independence of the validation check for the ability
+///   to initialize without a seg pointer).
+pub unsafe fn worker_init_dsm(
+    coordinate: *mut std::ffi::c_void,
+    region_total: u64,
+    worker_number: i32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<MppExecutionState, String> {
+    if coordinate.is_null() {
+        return Err("mpp: worker_init_dsm given null coordinate".into());
+    }
+    let worker = unsafe { attach_mpp_dsm_worker(coordinate, region_total, worker_number, seg)? };
+    Ok(MppExecutionState::Worker(worker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_queue_bytes_is_maxalign_safe() {
+        // 8 MiB must be a multiple of MAXIMUM_ALIGNOF so
+        // `aligned_queue_bytes(DEFAULT_MPP_QUEUE_BYTES) == DEFAULT_MPP_QUEUE_BYTES`.
+        let aligned =
+            crate::postgres::customscan::mpp::mesh::aligned_queue_bytes(DEFAULT_MPP_QUEUE_BYTES);
+        assert_eq!(aligned, DEFAULT_MPP_QUEUE_BYTES);
+    }
+
+    #[test]
+    fn mpp_worker_count_clamps_below_two() {
+        // GUC default is 2; the function shouldn't drop below 2 even if
+        // the GUC were set to 0 or 1 at runtime (which `mpp_is_active`
+        // filters before this is called, but defense-in-depth).
+        let n = mpp_worker_count();
+        assert!(n >= 2, "mpp_worker_count must clamp below 2; got {n}");
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/exec_bridge.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_bridge.rs
@@ -289,12 +289,6 @@ fn build_scalar_agg_on_binary_join_bridge(
     // 5) Extract aggregate expressions.
     let aggr_expr = partial_agg.aggr_expr().to_vec();
     let filter_expr = partial_agg.filter_expr().to_vec();
-    // Preserve the original HashJoin's column projection — it narrows the
-    // raw `left_schema ++ right_schema` to the subset that flows into the
-    // aggregate. Aggregate expressions' `Column` references use indices
-    // into that projected schema, so dropping the projection here would
-    // silently misread columns (e.g. MAX(rating) reading the join key).
-    let join_projection = hash_join.projection.as_deref().map(|s| s.to_vec());
 
     crate::mpp_log!(
         "mpp: assembling ScalarAggOnBinaryJoin plan (participant={}, total={}, \
@@ -316,8 +310,6 @@ fn build_scalar_agg_on_binary_join_bridge(
             right_shuffle,
             right_drain,
             right_schema,
-            join_on,
-            join_projection,
             aggr_expr,
             filter_expr,
             final_shuffle,
@@ -412,9 +404,6 @@ fn build_groupby_agg_on_binary_join_bridge(
 
     let aggr_expr = partial_agg.aggr_expr().to_vec();
     let filter_expr = partial_agg.filter_expr().to_vec();
-    // See `build_scalar_agg_on_binary_join_bridge` for why we forward the
-    // HashJoin's projection.
-    let join_projection = hash_join.projection.as_deref().map(|s| s.to_vec());
 
     crate::mpp_log!(
         "mpp: assembling GroupByAggOnBinaryJoin plan (participant={}, total={}, \
@@ -438,8 +427,6 @@ fn build_groupby_agg_on_binary_join_bridge(
         right_shuffle,
         right_drain,
         right_schema,
-        join_on,
-        join_projection,
         group_by,
         aggr_expr,
         filter_expr,
@@ -728,38 +715,6 @@ fn find_hash_join(plan: &dyn ExecutionPlan) -> Option<&HashJoinExec> {
         return find_hash_join(children[0].as_ref());
     }
     None
-}
-
-/// Walk a join input subtree and shard any `PgSearchScanPlan` it contains so
-/// that this participant sees only `segment_idx % total == participant_index`
-/// of the segments. Intermediate nodes (e.g. `FilterExec`, `ProjectionExec`)
-/// are preserved and rebuilt with the sharded scan beneath them.
-///
-/// This is the key optimisation that makes MPP actually parallelise the scan:
-/// each participant reads a disjoint subset of BM25 segments, then the
-/// downstream hash-shuffle redistributes the rows across all participants.
-/// Total work done on the base relation is `O(rows)` instead of
-/// `O(rows * N_participants)`.
-fn shard_scan(
-    node: Arc<dyn ExecutionPlan>,
-    participant_index: u32,
-    total_participants: u32,
-) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
-    if node.as_any().downcast_ref::<PgSearchScanPlan>().is_some() {
-        return PgSearchScanPlan::shard_from_dyn(node, participant_index, total_participants);
-    }
-
-    let children = node.children();
-    if children.is_empty() {
-        // Non-search leaf (e.g. EmptyExec, MemorySourceConfig) — leave as-is.
-        return Ok(node);
-    }
-
-    let new_children = children
-        .iter()
-        .map(|c| shard_scan(Arc::clone(c), participant_index, total_participants))
-        .collect::<Result<Vec<_>, _>>()?;
-    node.with_new_children(new_children)
 }
 
 /// Walk a join-input subtree and replace every `PgSearchScanPlan` with a

--- a/pg_search/src/postgres/customscan/mpp/exec_bridge.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_bridge.rs
@@ -1,0 +1,932 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Bridge between DataFusion's "standard" physical plan and the MPP
+//! shape-specific physical plan.
+//!
+//! At exec time we let DataFusion's planner do its normal work to produce a
+//! physical plan like:
+//!
+//! ```text
+//!     AggregateExec(Final, ...)
+//!       CoalescePartitionsExec
+//!         AggregateExec(Partial, ...)
+//!           HashJoinExec(Partitioned)
+//!             RepartitionExec(Hash([left_key]))
+//!               <left scan + filter>
+//!             RepartitionExec(Hash([right_key]))
+//!               <right scan>
+//! ```
+//!
+//! [`build_mpp_physical_plan`] walks that plan, extracts the pieces it needs
+//! (the `AggregateExec(Partial)`, the `HashJoinExec`, each side's scan+filter
+//! child), and re-assembles them using the MPP shape builders in
+//! [`super::shape`]. The resulting plan emits *partial* aggregate rows per
+//! worker — PG's `Gather` + `Finalize Aggregate` finalizes across workers.
+//!
+//! # Leader/worker mesh-index contract
+//!
+//! For the `ScalarAggOnBinaryJoin` shape we consume **three** meshes out of
+//! the per-side `MppExecutionState::meshes` vector. The contract —
+//! consistent across every participant — is:
+//!
+//! - `meshes[0]` is wired into the **left** join input's shuffle.
+//! - `meshes[1]` is wired into the **right** join input's shuffle.
+//! - `meshes[2]` is the **final-gather-to-leader** shuffle: every
+//!   participant ships its Partial aggregate row to seat 0 (the leader)
+//!   via a `FixedTargetPartitioner`. The leader's
+//!   `AggregateExec(FinalPartitioned)` then sums all N partials and emits
+//!   one row; workers' `FinalPartitioned` sees zero rows and emits zero.
+//!   This is what makes PG's `Gather` see exactly one row per query
+//!   instead of N (one per worker).
+//!
+//! This is the first consumer of `mpp_state.meshes`, so it owns the
+//! convention. Future callers (e.g., the `GroupByAggOnBinaryJoin` post-
+//! Partial shuffle on mesh 2) must keep mesh-index ordering identical on
+//! leader and workers — the meshes themselves are symmetric, but a
+//! mismatch would route left rows to the right drain and break
+//! correctness.
+
+#![allow(dead_code)]
+// caller lands in aggregatescan/mod.rs in this same change.
+// `CoalesceBatchesExec` is deprecated in favor of arrow-rs's `BatchCoalescer`, but
+// DataFusion 52's planner still emits `CoalesceBatchesExec` nodes in the physical
+// plan we receive. We must be able to recognize and skip them when walking to find
+// the `HashJoinExec` / `AggregateExec(Partial)`. Drop the allow once DataFusion
+// stops emitting them.
+#![allow(deprecated)]
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::DataFusionError;
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode};
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::joins::HashJoinExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::ExecutionPlan;
+
+use crate::postgres::customscan::mpp::customscan_glue::{
+    MppExecutionState, DEFAULT_MPP_QUEUE_BYTES,
+};
+use crate::postgres::customscan::mpp::shape::{
+    build_groupby_agg_on_binary_join, build_join_only, build_scalar_agg_on_binary_join,
+    GroupByAggOnBinaryJoinInputs, JoinOnlyInputs, MppPlanShape, ScalarAggOnBinaryJoinInputs,
+};
+use crate::postgres::customscan::mpp::shuffle::{
+    FixedTargetPartitioner, HashPartitioner, RowPartitioner, ShuffleWiring,
+};
+use crate::postgres::customscan::mpp::transport::{DrainBuffer, DrainHandle};
+use crate::postgres::customscan::mpp::worker::{LeaderMesh, WorkerMesh};
+use crate::scan::execution_plan::PgSearchScanPlan;
+
+/// Single directed mesh extracted from the per-scan MPP state. A
+/// participant-agnostic adapter over `LeaderMesh` / `WorkerMesh`, whose
+/// shapes are identical but whose type-level variants force the rest of the
+/// bridge to branch for no reason.
+struct MeshHalves {
+    outbound: Vec<Option<crate::postgres::customscan::mpp::transport::MppSender>>,
+    inbound: Vec<Option<crate::postgres::customscan::mpp::transport::MppReceiver>>,
+}
+
+impl From<LeaderMesh> for MeshHalves {
+    fn from(m: LeaderMesh) -> Self {
+        MeshHalves {
+            outbound: m.outbound,
+            inbound: m.inbound,
+        }
+    }
+}
+
+impl From<WorkerMesh> for MeshHalves {
+    fn from(m: WorkerMesh) -> Self {
+        MeshHalves {
+            outbound: m.outbound,
+            inbound: m.inbound,
+        }
+    }
+}
+
+/// Take the per-mesh wirings out of `mpp_state.meshes`, replacing them with
+/// empty `Vec`s so the borrow checker is satisfied. Drops the participant's
+/// side-specific variant on the floor — only the generic `MeshHalves` survive.
+///
+/// Panics (via `pgrx::error!`) if `meshes.len() != expected`. This is a
+/// leader/worker contract mismatch and must surface loudly, not silently.
+fn take_meshes(state: &mut MppExecutionState, expected: usize) -> Vec<MeshHalves> {
+    match state {
+        MppExecutionState::Leader(ctx) => {
+            let taken = std::mem::take(&mut ctx.meshes);
+            if taken.len() != expected {
+                pgrx::error!(
+                    "mpp: leader meshes.len()={} but shape expected {}",
+                    taken.len(),
+                    expected
+                );
+            }
+            taken.into_iter().map(MeshHalves::from).collect()
+        }
+        MppExecutionState::Worker(ctx) => {
+            let taken = std::mem::take(&mut ctx.meshes);
+            if taken.len() != expected {
+                pgrx::error!(
+                    "mpp: worker meshes.len()={} but shape expected {}",
+                    taken.len(),
+                    expected
+                );
+            }
+            taken.into_iter().map(MeshHalves::from).collect()
+        }
+    }
+}
+
+/// Transform a DataFusion standard physical plan into an MPP physical plan
+/// for the given shape.
+///
+/// Consumes the `meshes` field of `mpp_state` (replacing it with an empty
+/// `Vec`). Safe to call at most once per scan lifecycle.
+///
+/// Only [`MppPlanShape::ScalarAggOnBinaryJoin`] is implemented in milestone 1;
+/// other shapes `pgrx::error!` with a clear "not yet implemented in M1"
+/// message. Callers must pre-filter on shape before entering the MPP branch.
+pub fn build_mpp_physical_plan(
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+    shape: MppPlanShape,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    match shape {
+        MppPlanShape::ScalarAggOnBinaryJoin => {
+            build_scalar_agg_on_binary_join_bridge(standard, mpp_state)
+        }
+        MppPlanShape::GroupByAggOnBinaryJoin => {
+            build_groupby_agg_on_binary_join_bridge(standard, mpp_state)
+        }
+        MppPlanShape::JoinOnly => build_join_only_bridge(standard, mpp_state),
+        MppPlanShape::GroupByAggSingleTable => {
+            pgrx::error!("mpp: shape {:?} not yet implemented in M1", shape);
+        }
+        MppPlanShape::Ineligible => {
+            pgrx::error!(
+                "mpp: build_mpp_physical_plan invoked with Ineligible shape — \
+                 caller should have routed to the non-MPP serial path"
+            );
+        }
+    }
+}
+
+fn build_scalar_agg_on_binary_join_bridge(
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    // 1) Walk the standard plan to pull out the Partial aggregate and the
+    //    HashJoin underneath it.
+    let (partial_agg, hash_join) = find_partial_agg_and_join(standard.as_ref())?;
+
+    // 2) Strip any RepartitionExec / CoalesceBatchesExec layers on each join
+    //    input. Those are DataFusion's single-process repartition inserted
+    //    by the planner; we replace them with MPP shuffles.
+    //
+    //    Segment sharding already happened one layer up: the exec path sets
+    //    `MppShardConfig` as a DataFusion SessionConfig extension before the
+    //    logical plan is built; `PgSearchTableProvider::scan` reads it and
+    //    emits a `PgSearchScanPlan` whose single `ScanState` wraps only
+    //    this participant's slice of segments (lazy path — the aggregate
+    //    benchmark's path). Don't re-shard here; the earlier version that
+    //    did this at the `states` vec level would drop the (already-
+    //    sharded) single ScanState on workers because its enumerate index
+    //    is 0 and `0 % total != participant_index` for workers,
+    //    effectively reverting to leader-only scanning.
+
+    // Read both values from the leader-stamped `participant_config` — it's the
+    // single source of truth for the shape the DSM mesh was allocated against.
+    // Reading `total_participants` from the GUC at exec time could disagree if
+    // the GUC was changed after planning (workers would still be wired as if
+    // the old N was in effect, so the partitioner must match).
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+
+    let left_child = strip_repartition_layers(Arc::clone(hash_join.left()));
+    // Strip any dynamic filter Arc from the probe-side scan so it is not
+    // applied before the MPP shuffle routes rows to peer participants. The
+    // shape builder re-attaches the same Arc as a `FilterExec` above the
+    // post-shuffle output where it is safe to filter: a participant's local
+    // build side covers exactly the keys that hash-route to its own probe.
+    let right_child =
+        strip_dynamic_filters_in_subtree(strip_repartition_layers(Arc::clone(hash_join.right())))?;
+
+    // Clone the HashJoinExec via its builder (the exec isn't `Clone` — the
+    // build-side `OnceFut` forbids it). The `From<&HashJoinExec>` impl copies
+    // `dynamic_filter`, so `.builder().build()` hands us a standalone copy
+    // ready to be re-children'd in the shape builder.
+    let original_hash_join = Arc::new(hash_join.builder().build()?);
+
+    // 3) Extract per-side key column indices from the join `on` list.
+    let join_on = hash_join.on().to_vec();
+    let (left_keys, right_keys) = extract_key_col_indices(&join_on)?;
+
+    // 4) Pull mesh wirings out of mpp_state. Mesh 0 = left, mesh 1 = right,
+    //    mesh 2 = final-gather-to-leader (see module-level contract).
+    let mut meshes = take_meshes(mpp_state, 3);
+    let final_mesh = meshes.pop().expect("len checked in take_meshes");
+    let right_mesh = meshes.pop().expect("len checked in take_meshes");
+    let left_mesh = meshes.pop().expect("len checked in take_meshes");
+
+    // Build drains before shuffle wirings so each mesh's senders carry a
+    // cooperative-drain share — needed to break the symmetric-send
+    // deadlock on a single-threaded runtime (see `MppSender::send_batch`).
+    let left_drain = spawn_drain(left_mesh.inbound);
+    let right_drain = spawn_drain(right_mesh.inbound);
+    let final_drain = spawn_drain(final_mesh.inbound);
+
+    let left_outbound = attach_cooperative_drain(left_mesh.outbound, &left_drain);
+    let right_outbound = attach_cooperative_drain(right_mesh.outbound, &right_drain);
+    let final_outbound = attach_cooperative_drain(final_mesh.outbound, &final_drain);
+
+    let left_shuffle = build_shuffle_wiring(
+        left_keys,
+        total_participants,
+        participant_index,
+        left_outbound,
+        Arc::clone(&left_drain),
+    );
+    let right_shuffle = build_shuffle_wiring(
+        right_keys,
+        total_participants,
+        participant_index,
+        right_outbound,
+        Arc::clone(&right_drain),
+    );
+
+    // Final-gather mesh: route every Partial row to seat 0 (leader).
+    let final_shuffle = ShuffleWiring {
+        partitioner: Arc::new(FixedTargetPartitioner::new(0, total_participants))
+            as Arc<dyn RowPartitioner>,
+        outbound_senders: final_outbound,
+        participant_index,
+        cooperative_drain: Some(Arc::clone(&final_drain)),
+    };
+
+    let left_schema: SchemaRef = left_child.schema();
+    let right_schema: SchemaRef = right_child.schema();
+
+    // 5) Extract aggregate expressions.
+    let aggr_expr = partial_agg.aggr_expr().to_vec();
+    let filter_expr = partial_agg.filter_expr().to_vec();
+    // Preserve the original HashJoin's column projection — it narrows the
+    // raw `left_schema ++ right_schema` to the subset that flows into the
+    // aggregate. Aggregate expressions' `Column` references use indices
+    // into that projected schema, so dropping the projection here would
+    // silently misread columns (e.g. MAX(rating) reading the join key).
+    let join_projection = hash_join.projection.as_deref().map(|s| s.to_vec());
+
+    crate::mpp_log!(
+        "mpp: assembling ScalarAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, join_keys={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        join_on.len()
+    );
+
+    let is_leader = mpp_state.is_leader();
+    build_scalar_agg_on_binary_join(
+        ScalarAggOnBinaryJoinInputs {
+            left_child,
+            right_child,
+            left_shuffle,
+            left_drain,
+            left_schema,
+            right_shuffle,
+            right_drain,
+            right_schema,
+            join_on,
+            join_projection,
+            aggr_expr,
+            filter_expr,
+            final_shuffle,
+            final_drain,
+            original_hash_join,
+        },
+        is_leader,
+    )
+}
+
+fn build_groupby_agg_on_binary_join_bridge(
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    // Same plan-walking as the scalar case: Partial aggregate sits atop
+    // HashJoin with sharded scans below each side.
+    let (partial_agg, hash_join) = find_partial_agg_and_join(standard.as_ref())?;
+
+    let left_child = strip_repartition_layers(Arc::clone(hash_join.left()));
+    // See `build_scalar_agg_on_binary_join_bridge` for why we strip dynamic
+    // filters from the probe side and clone the HashJoinExec via its builder.
+    let right_child =
+        strip_dynamic_filters_in_subtree(strip_repartition_layers(Arc::clone(hash_join.right())))?;
+
+    let original_hash_join = Arc::new(hash_join.builder().build()?);
+
+    let join_on = hash_join.on().to_vec();
+    let (left_keys, right_keys) = extract_key_col_indices(&join_on)?;
+
+    let group_by = partial_agg.group_expr().clone();
+    let num_group_keys = group_by.expr().len();
+    if num_group_keys == 0 {
+        return Err(DataFusionError::Plan(
+            "mpp: GroupByAggOnBinaryJoin shape requires >= 1 group-by key".into(),
+        ));
+    }
+
+    let mut meshes = take_meshes(mpp_state, 3);
+    let postagg_mesh = meshes.pop().expect("len checked in take_meshes");
+    let right_mesh = meshes.pop().expect("len checked in take_meshes");
+    let left_mesh = meshes.pop().expect("len checked in take_meshes");
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+
+    // Build drains before wirings so each mesh's senders carry a cooperative
+    // drain share — see `MppSender::send_batch`.
+    let left_drain = spawn_drain(left_mesh.inbound);
+    let right_drain = spawn_drain(right_mesh.inbound);
+    let postagg_drain = spawn_drain(postagg_mesh.inbound);
+
+    let left_outbound = attach_cooperative_drain(left_mesh.outbound, &left_drain);
+    let right_outbound = attach_cooperative_drain(right_mesh.outbound, &right_drain);
+    let postagg_outbound = attach_cooperative_drain(postagg_mesh.outbound, &postagg_drain);
+
+    let left_shuffle = build_shuffle_wiring(
+        left_keys,
+        total_participants,
+        participant_index,
+        left_outbound,
+        Arc::clone(&left_drain),
+    );
+    let right_shuffle = build_shuffle_wiring(
+        right_keys,
+        total_participants,
+        participant_index,
+        right_outbound,
+        Arc::clone(&right_drain),
+    );
+    // Postagg mesh hash-partitions Partial rows by group key. Each group
+    // lives on exactly one seat and `AggregateExec(FinalPartitioned)` on
+    // that seat emits one row per distinct group; PG's Gather concatenates
+    // across seats. `shape::build_groupby_agg_on_binary_join` coalesces
+    // the Partial output into 64 Ki-row batches before this shuffle so
+    // per-batch Arrow-IPC encode cost stays amortized.
+    //
+    // Group-by columns become the partitioning keys. In
+    // `AggregateExec(Partial)`'s output schema, group-by columns come
+    // first (indices `0..num_group_keys`), followed by partial-aggregate
+    // state columns.
+    let postagg_keys: Vec<usize> = (0..num_group_keys).collect();
+    let postagg_shuffle = build_shuffle_wiring(
+        postagg_keys,
+        total_participants,
+        participant_index,
+        postagg_outbound,
+        Arc::clone(&postagg_drain),
+    );
+
+    let left_schema: SchemaRef = left_child.schema();
+    let right_schema: SchemaRef = right_child.schema();
+
+    let aggr_expr = partial_agg.aggr_expr().to_vec();
+    let filter_expr = partial_agg.filter_expr().to_vec();
+    // See `build_scalar_agg_on_binary_join_bridge` for why we forward the
+    // HashJoin's projection.
+    let join_projection = hash_join.projection.as_deref().map(|s| s.to_vec());
+
+    crate::mpp_log!(
+        "mpp: assembling GroupByAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, group_keys={}, join_keys={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        num_group_keys,
+        join_on.len()
+    );
+
+    // Symmetric plan on every seat. Hash partitioning ensures each group
+    // lands on exactly one seat's Final, so PG's Gather concatenates
+    // without double-count.
+    build_groupby_agg_on_binary_join(GroupByAggOnBinaryJoinInputs {
+        left_child,
+        right_child,
+        left_shuffle,
+        left_drain,
+        left_schema,
+        right_shuffle,
+        right_drain,
+        right_schema,
+        join_on,
+        join_projection,
+        group_by,
+        aggr_expr,
+        filter_expr,
+        postagg_shuffle,
+        postagg_drain,
+        original_hash_join,
+    })
+}
+
+/// Build the MPP physical plan for the `JoinOnly` shape: a bare join without
+/// an aggregate on top. Mirrors `build_scalar_agg_on_binary_join_bridge`
+/// without the Partial aggregate walk and the final-gather mesh — two meshes
+/// (left + right pre-join), no asymmetric leader/worker plan.
+fn build_join_only_bridge(
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    // For the `JoinOnly` shape there's no Partial aggregate above the join —
+    // the `HashJoinExec` sits below zero or more wrapper layers such as
+    // `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
+    // `ProjectionExec`, etc. We must preserve those wrappers on the MPP path:
+    // for deferred-visibility queries, `VisibilityFilterExec` is what turns
+    // packed DocAddresses in the `ctid` column into real heap TIDs — without
+    // it, `JoinScan::build_result_tuple` passes an unpacked DocAddress to
+    // `heap_fetch`, tripping `ItemPointerIsValid`.
+    let hash_join = find_hash_join(standard.as_ref()).ok_or_else(|| {
+        DataFusionError::Plan(
+            "mpp: could not locate HashJoinExec in standard physical plan for JoinOnly shape"
+                .into(),
+        )
+    })?;
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+
+    let left_child = strip_repartition_layers(Arc::clone(hash_join.left()));
+    // Same dynamic-filter stripping as the aggregate bridges — the probe-side
+    // scan would otherwise filter before the shuffle and drop rows destined
+    // for peer participants. Unlike the aggregate shapes, `build_join_only`
+    // does not re-attach the filter above the shuffle; the HashJoin's own
+    // dynamic filter (carried across via `builder().build()`) suffices because
+    // no row-reducing aggregate sits above the join.
+    let right_child =
+        strip_dynamic_filters_in_subtree(strip_repartition_layers(Arc::clone(hash_join.right())))?;
+
+    let join_on = hash_join.on().to_vec();
+    let (left_keys, right_keys) = extract_key_col_indices(&join_on)?;
+
+    // Two meshes: left + right pre-join shuffles. No post-Partial or
+    // final-gather mesh for the JoinOnly shape.
+    let mut meshes = take_meshes(mpp_state, 2);
+    let right_mesh = meshes.pop().expect("len checked in take_meshes");
+    let left_mesh = meshes.pop().expect("len checked in take_meshes");
+
+    let left_drain = spawn_drain(left_mesh.inbound);
+    let right_drain = spawn_drain(right_mesh.inbound);
+
+    let left_outbound = attach_cooperative_drain(left_mesh.outbound, &left_drain);
+    let right_outbound = attach_cooperative_drain(right_mesh.outbound, &right_drain);
+
+    let left_shuffle = build_shuffle_wiring(
+        left_keys,
+        total_participants,
+        participant_index,
+        left_outbound,
+        Arc::clone(&left_drain),
+    );
+    let right_shuffle = build_shuffle_wiring(
+        right_keys,
+        total_participants,
+        participant_index,
+        right_outbound,
+        Arc::clone(&right_drain),
+    );
+
+    let left_schema: SchemaRef = left_child.schema();
+    let right_schema: SchemaRef = right_child.schema();
+    let join_type = *hash_join.join_type();
+    let join_projection = hash_join.projection.as_deref().map(|s| s.to_vec());
+
+    crate::mpp_log!(
+        "mpp: assembling JoinOnly plan (participant={}, total={}, join_keys={}, join_type={:?})",
+        participant_index,
+        total_participants,
+        join_on.len(),
+        join_type,
+    );
+
+    let mpp_hash_join = build_join_only(JoinOnlyInputs {
+        left_child,
+        right_child,
+        left_shuffle,
+        left_drain,
+        left_schema,
+        right_shuffle,
+        right_drain,
+        right_schema,
+        join_on,
+        join_projection,
+        join_type,
+    })?;
+
+    // Graft the MPP-shuffled `HashJoinExec` back into the standard plan tree
+    // in place of the original `HashJoinExec`. Outer wrappers
+    // (`VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
+    // `ProjectionExec`, ...) are preserved so ctid resolution, top-K, and
+    // late column materialization still happen.
+    let grafted =
+        replace_first_hash_join(Arc::clone(&standard), mpp_hash_join)?.ok_or_else(|| {
+            DataFusionError::Internal("mpp: HashJoinExec replacement failed to find target".into())
+        })?;
+
+    // `with_new_children` rebuilt any `VisibilityFilterExec` above the join
+    // via `VisibilityFilterExec::new`, which resets `ctid_resolvers` to
+    // empty. Re-run the resolver rule against the grafted tree so the new
+    // exec is wired to the scans in its fresh subtree.
+    use datafusion::common::config::ConfigOptions;
+    use datafusion::physical_optimizer::PhysicalOptimizerRule;
+    let config = ConfigOptions::default();
+    crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule
+        .optimize(grafted, &config)
+}
+
+/// Walk `root` top-down, replacing the first `HashJoinExec` found with
+/// `replacement`. Outer wrappers are rebuilt via `with_new_children` so their
+/// identities (and per-node state) refresh, which is required for nodes like
+/// `VisibilityFilterExec` whose resolver table must be re-wired against the
+/// new subtree. Returns `Ok(None)` if no `HashJoinExec` is present.
+fn replace_first_hash_join(
+    root: Arc<dyn ExecutionPlan>,
+    replacement: Arc<dyn ExecutionPlan>,
+) -> Result<Option<Arc<dyn ExecutionPlan>>, DataFusionError> {
+    if root.as_any().downcast_ref::<HashJoinExec>().is_some() {
+        return Ok(Some(replacement));
+    }
+    let children = root.children();
+    if children.is_empty() {
+        return Ok(None);
+    }
+    let mut new_children: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(children.len());
+    let mut replaced = false;
+    for child in children {
+        if !replaced {
+            if let Some(new_child) =
+                replace_first_hash_join(Arc::clone(child), Arc::clone(&replacement))?
+            {
+                new_children.push(new_child);
+                replaced = true;
+                continue;
+            }
+        }
+        new_children.push(Arc::clone(child));
+    }
+    if replaced {
+        Ok(Some(root.with_new_children(new_children)?))
+    } else {
+        Ok(None)
+    }
+}
+
+fn build_shuffle_wiring(
+    key_columns: Vec<usize>,
+    total_participants: u32,
+    participant_index: u32,
+    outbound_senders: Vec<Option<crate::postgres::customscan::mpp::transport::MppSender>>,
+    cooperative_drain: Arc<DrainHandle>,
+) -> ShuffleWiring {
+    ShuffleWiring {
+        partitioner: Arc::new(HashPartitioner::new(key_columns, total_participants)),
+        outbound_senders,
+        participant_index,
+        cooperative_drain: Some(cooperative_drain),
+    }
+}
+
+fn spawn_drain(
+    inbound: Vec<Option<crate::postgres::customscan::mpp::transport::MppReceiver>>,
+) -> Arc<DrainHandle> {
+    // `inbound[participant_index]` is always `None`; flatten drops it. Every
+    // other peer contributes exactly one receiver.
+    let receivers: Vec<_> = inbound.into_iter().flatten().collect();
+    let num_sources = receivers.len();
+    // `DrainBuffer::new(0)` would flip to EOF immediately; give it at least 1.
+    let buffer = DrainBuffer::new(num_sources.max(1) as u32);
+    let _ = DEFAULT_MPP_QUEUE_BYTES; // only referenced for docs consistency
+
+    // Cooperative (not thread-backed) drain: pgrx's `check_active_thread`
+    // panics any pg FFI call from non-backend threads, so spawning a
+    // `std::thread` to read from `shm_mq` would die on its first
+    // `shm_mq_receive`. Instead the drain work runs inline from
+    // `DrainGatherStream::poll_next` on the backend thread (see
+    // `mpp::transport::DrainHandle::cooperative` +
+    // `mpp::shuffle::DrainGatherStream::poll_next`).
+    //
+    // Returned as `Arc` so each same-mesh `MppSender` can hold a
+    // cooperative-drain share (see `MppSender::with_cooperative_drain`),
+    // letting the sender's would-block loop consume our inbound to
+    // un-stall peer sends. The exec plan also keeps one strong reference
+    // via `DrainGatherExec`.
+    Arc::new(DrainHandle::cooperative(receivers, buffer))
+}
+
+/// Inject `drain` into each outbound sender so its `send_batch` can
+/// cooperatively poll our inbound during would-block retries — breaks
+/// the symmetric-send deadlock on a single-threaded runtime.
+fn attach_cooperative_drain(
+    senders: Vec<Option<crate::postgres::customscan::mpp::transport::MppSender>>,
+    drain: &Arc<DrainHandle>,
+) -> Vec<Option<crate::postgres::customscan::mpp::transport::MppSender>> {
+    senders
+        .into_iter()
+        .map(|opt| opt.map(|s| s.with_cooperative_drain(Arc::clone(drain))))
+        .collect()
+}
+
+/// Walk a standard physical plan to find the top-most `AggregateExec(Partial)`
+/// whose transitive child (skipping `CoalescePartitionsExec` /
+/// `CoalesceBatchesExec`) is a `HashJoinExec`. Returns references into the
+/// original plan; the bridge then clones the pieces it needs.
+fn find_partial_agg_and_join(
+    plan: &dyn ExecutionPlan,
+) -> Result<(&AggregateExec, &HashJoinExec), DataFusionError> {
+    let partial = find_partial_agg(plan).ok_or_else(|| {
+        DataFusionError::Plan(
+            "mpp: could not locate AggregateExec(Partial) in standard physical plan".into(),
+        )
+    })?;
+    let join = find_hash_join(partial.input().as_ref()).ok_or_else(|| {
+        DataFusionError::Plan(
+            "mpp: AggregateExec(Partial) child is not a HashJoinExec (through coalesce \
+             layers) — plan shape unexpected for ScalarAggOnBinaryJoin"
+                .into(),
+        )
+    })?;
+    Ok((partial, join))
+}
+
+/// Recursively walk the plan skipping `AggregateExec(Final)`,
+/// `CoalescePartitionsExec`, `CoalesceBatchesExec`, and other pass-through
+/// nodes to find an `AggregateExec` in `Partial` or `Single` mode.
+///
+/// DataFusion's planner picks `AggregateMode::Single` when the input
+/// produces exactly one partition (our usual serial build), and
+/// `Partial + FinalPartitioned` when it produces multiple partitions —
+/// both are equally valid as the "aggregate atop the join" we want to
+/// rebuild from. The shape builder always emits `Partial` on top of the
+/// shuffled join, regardless of which mode the serial plan used.
+fn find_partial_agg(plan: &dyn ExecutionPlan) -> Option<&AggregateExec> {
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial | AggregateMode::Single) {
+            return Some(agg);
+        }
+        // Final / FinalPartitioned / SinglePartitioned: descend into its child.
+        return find_partial_agg(agg.input().as_ref());
+    }
+    if let Some(cp) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
+        return find_partial_agg(cp.input().as_ref());
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return find_partial_agg(cb.input().as_ref());
+    }
+    // Generic single-child pass-through fallback: only if the node has exactly
+    // one child, to avoid descending into a join or union.
+    let children = plan.children();
+    if children.len() == 1 {
+        return find_partial_agg(children[0].as_ref());
+    }
+    None
+}
+
+/// Find a `HashJoinExec` underneath a Partial aggregate's input, tolerating
+/// `CoalescePartitionsExec` / `CoalesceBatchesExec` layers the planner may
+/// insert between them.
+fn find_hash_join(plan: &dyn ExecutionPlan) -> Option<&HashJoinExec> {
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        return Some(hj);
+    }
+    if let Some(cp) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
+        return find_hash_join(cp.input().as_ref());
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return find_hash_join(cb.input().as_ref());
+    }
+    let children = plan.children();
+    if children.len() == 1 {
+        return find_hash_join(children[0].as_ref());
+    }
+    None
+}
+
+/// Walk a join input subtree and shard any `PgSearchScanPlan` it contains so
+/// that this participant sees only `segment_idx % total == participant_index`
+/// of the segments. Intermediate nodes (e.g. `FilterExec`, `ProjectionExec`)
+/// are preserved and rebuilt with the sharded scan beneath them.
+///
+/// This is the key optimisation that makes MPP actually parallelise the scan:
+/// each participant reads a disjoint subset of BM25 segments, then the
+/// downstream hash-shuffle redistributes the rows across all participants.
+/// Total work done on the base relation is `O(rows)` instead of
+/// `O(rows * N_participants)`.
+fn shard_scan(
+    node: Arc<dyn ExecutionPlan>,
+    participant_index: u32,
+    total_participants: u32,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    if node.as_any().downcast_ref::<PgSearchScanPlan>().is_some() {
+        return PgSearchScanPlan::shard_from_dyn(node, participant_index, total_participants);
+    }
+
+    let children = node.children();
+    if children.is_empty() {
+        // Non-search leaf (e.g. EmptyExec, MemorySourceConfig) — leave as-is.
+        return Ok(node);
+    }
+
+    let new_children = children
+        .iter()
+        .map(|c| shard_scan(Arc::clone(c), participant_index, total_participants))
+        .collect::<Result<Vec<_>, _>>()?;
+    node.with_new_children(new_children)
+}
+
+/// Walk a join-input subtree and replace every `PgSearchScanPlan` with a
+/// copy whose `dynamic_filters` Vec is empty. The `FilterPushdown` physical
+/// optimizer pushed the HashJoin's dynamic-filter Arc into the probe-side
+/// scan at planning time; MPP rewires so the same Arc is applied by a
+/// `FilterExec` above the post-shuffle output instead. See the matching
+/// `FilterExec` wrapping in `shape::build_*_on_binary_join` for why
+/// stripping is required for correctness (pre-shuffle filtering would drop
+/// rows destined for peer participants).
+fn strip_dynamic_filters_in_subtree(
+    node: Arc<dyn ExecutionPlan>,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    if node.as_any().downcast_ref::<PgSearchScanPlan>().is_some() {
+        return PgSearchScanPlan::strip_dynamic_filters_from_dyn(node);
+    }
+
+    let children = node.children();
+    if children.is_empty() {
+        return Ok(node);
+    }
+
+    let new_children = children
+        .iter()
+        .map(|c| strip_dynamic_filters_in_subtree(Arc::clone(c)))
+        .collect::<Result<Vec<_>, _>>()?;
+    node.with_new_children(new_children)
+}
+
+/// Strip `RepartitionExec` and `CoalesceBatchesExec` layers off the top of a
+/// plan, returning the underlying child. DataFusion inserts these between a
+/// `HashJoinExec(Partitioned)` and its inputs to hash-repartition; in the MPP
+/// plan we replace them with our own shuffle.
+fn strip_repartition_layers(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    if let Some(rp) = plan.as_any().downcast_ref::<RepartitionExec>() {
+        return strip_repartition_layers(Arc::clone(rp.input()));
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return strip_repartition_layers(Arc::clone(cb.input()));
+    }
+    plan
+}
+
+/// Extract `(left_col_idx, right_col_idx)` pairs from a `HashJoinExec::on()`
+/// list, asserting every expression is a plain `Column` reference. Any other
+/// expression (e.g., `CAST(col)`, `col + 0`) is rejected — the MPP
+/// `HashPartitioner` only supports column keys today, and silently falling
+/// through to DataFusion's own hash would diverge routing across workers.
+#[allow(clippy::type_complexity)]
+fn extract_key_col_indices(
+    on: &[(Arc<dyn PhysicalExpr>, Arc<dyn PhysicalExpr>)],
+) -> Result<(Vec<usize>, Vec<usize>), DataFusionError> {
+    let mut left = Vec::with_capacity(on.len());
+    let mut right = Vec::with_capacity(on.len());
+    for (li, ri) in on {
+        left.push(col_index(li)?);
+        right.push(col_index(ri)?);
+    }
+    Ok((left, right))
+}
+
+/// An `ExecutionPlan` that produces zero rows with the given schema. Kept
+/// around as a utility even after scan sharding landed: there are future
+/// edge cases (e.g. a participant whose entire shard is pruned at plan time)
+/// where returning an empty source is the right answer.
+#[allow(dead_code)]
+fn empty_exec_with_schema(schema: SchemaRef) -> Arc<dyn ExecutionPlan> {
+    use datafusion::physical_plan::empty::EmptyExec;
+    Arc::new(EmptyExec::new(schema))
+}
+
+fn col_index(expr: &Arc<dyn PhysicalExpr>) -> Result<usize, DataFusionError> {
+    expr.as_any()
+        .downcast_ref::<Column>()
+        .map(|c| c.index())
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "mpp: join key expression {expr} is not a plain Column — MPP shuffle only \
+                 supports column-ref keys in milestone 1"
+            ))
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_expr::expressions::{BinaryExpr, Literal};
+    use datafusion::physical_expr::PhysicalExpr;
+    use datafusion::scalar::ScalarValue;
+
+    #[test]
+    fn col_index_plain_column() {
+        let col: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 3));
+        assert_eq!(col_index(&col).unwrap(), 3);
+    }
+
+    #[test]
+    fn col_index_rejects_non_column() {
+        let left: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 0));
+        let right: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int32(Some(0))));
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(
+            left,
+            datafusion::logical_expr::Operator::Plus,
+            right,
+        ));
+        let err = col_index(&expr).unwrap_err();
+        assert!(
+            format!("{err}").contains("not a plain Column"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn extract_key_col_indices_round_trip() {
+        let l0: Arc<dyn PhysicalExpr> = Arc::new(Column::new("a", 0));
+        let r0: Arc<dyn PhysicalExpr> = Arc::new(Column::new("b", 5));
+        let l1: Arc<dyn PhysicalExpr> = Arc::new(Column::new("c", 2));
+        let r1: Arc<dyn PhysicalExpr> = Arc::new(Column::new("d", 7));
+        let on = vec![(l0, r0), (l1, r1)];
+        let (l, r) = extract_key_col_indices(&on).unwrap();
+        assert_eq!(l, vec![0, 2]);
+        assert_eq!(r, vec![5, 7]);
+    }
+
+    #[test]
+    fn find_partial_agg_walks_through_coalesce_and_final() {
+        use datafusion::arrow::array::{Int32Array, RecordBatch};
+        use datafusion::datasource::memory::MemorySourceConfig;
+        use datafusion::physical_plan::aggregates::PhysicalGroupBy;
+
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let input = MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap();
+
+        // Build a Partial -> CoalescePartitions -> Final stack.
+        let partial = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let partial_schema = partial.schema();
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
+        let final_agg = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Final,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                coalesced,
+                partial_schema,
+            )
+            .unwrap(),
+        );
+
+        let plan: Arc<dyn ExecutionPlan> = final_agg;
+        let partial_ref = find_partial_agg(plan.as_ref()).expect("partial found");
+        assert!(matches!(partial_ref.mode(), AggregateMode::Partial));
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -26,6 +26,9 @@
 //! consumer-side backpressure from producer-side backpressure.
 
 pub mod chain;
+pub mod coordinator;
+pub mod customscan_glue;
+pub mod exec_bridge;
 pub mod mesh;
 pub mod plan_build;
 pub mod session;

--- a/pg_search/tests/pg_regress/expected/mpp_exec.out
+++ b/pg_search/tests/pg_regress/expected/mpp_exec.out
@@ -1,0 +1,229 @@
+-- =====================================================================
+-- MPP correctness: with `paradedb.enable_mpp=on`, scalar COUNT(*) on a
+-- binary join must return the same result as with MPP off.
+--
+-- This test exercises the full shape classification + plan-stash +
+-- parallel-flag flip pipeline on a medium-sized dataset (40x200 rows).
+-- PG's planner decides whether to launch actual parallel workers based
+-- on cost; at this size it typically doesn't, so the MPP *exec* path
+-- isn't exercised here — for that you need `debug_parallel_query=on`
+-- at a larger scale, which is out of scope for pg_regress (no parallel
+-- workers launched == no DSM coordination == no cross-worker shuffle).
+--
+-- What this DOES verify:
+--   * MPP-on doesn't break the serial code path
+--   * Shape classifier agrees between path-time and plan-stash-time
+--   * `maybe_stash_mpp_plan_bytes` completes without error
+--   * The plan survives logical-plan → bytes round-trip
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+CREATE TABLE mpp_exec_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+CREATE TABLE mpp_exec_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+INSERT INTO mpp_exec_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+INSERT INTO mpp_exec_reviews (product_id, rating)
+SELECT (i % 40) + 1, (i % 5) + 1 FROM generate_series(1, 200) AS i;
+CREATE INDEX mpp_exec_products_idx ON mpp_exec_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+CREATE INDEX mpp_exec_reviews_idx ON mpp_exec_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT COUNT(*) AS baseline_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ baseline_count 
+----------------
+            200
+(1 row)
+
+-- =====================================================================
+-- MPP enabled: must return the same count.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 3;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 2
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+         Aggregates: COUNT(*)
+(8 rows)
+
+SELECT COUNT(*) AS mpp_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ mpp_count 
+-----------
+       200
+(1 row)
+
+-- With mpp_debug, the plan should log the shape dispatch + parallel
+-- flip + the "routing exec_datafusion_aggregate through shape" line
+-- that proves the MPP exec bridge actually ran (not just the serial
+-- fallback). The answer must still match the baseline.
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*) AS mpp_count_with_debug
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape ScalarAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 3 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=0, total=3, aggr_count=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=1, total=3, aggr_count=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 1 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=2, total=3, aggr_count=1, join_keys=1)
+ mpp_count_with_debug 
+----------------------
+                  200
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+-- =====================================================================
+-- GROUP BY aggregate on join, with ORDER BY on the group-by column. Both
+-- the GROUP BY and the ORDER BY are driven by the same column, so PG
+-- wraps the Gather-above-CustomScan MPP path in a Sort above the Gather.
+-- The MPP path keeps Aggrefs intact in every tlist so `fix_upper_expr`
+-- matches structurally at setrefs time (if we'd replaced them with
+-- `pdb.agg_fn(...)` placeholders only on the Gather side, setrefs would
+-- trip "Aggref found in non-Agg plan node" on the Result projection PG
+-- adds above the Sort).
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | cnt | max_rating 
+-------------+-----+------------
+ Clothing    |  50 |          5
+ Electronics |  50 |          5
+ Furniture   |  50 |          5
+ Sports      |  50 |          5
+(4 rows)
+
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_debug TO on;
+-- Force PG to pick the Gather-wrapped MPP path for GROUP BY on this
+-- small fixture: without these knobs the planner's cost model rejects
+-- Gather for aggregates at this row count and we'd fall back to the
+-- serial Custom Scan (which still produces correct output via the
+-- non-MPP code path).
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape GroupByAggOnBinaryJoin
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Sort
+   Output: p.category, (count(*)), (max(r.rating))
+   Sort Key: p.category
+   ->  Gather
+         Output: p.category, (count(*)), (max(r.rating))
+         Workers Planned: 2
+         ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+               Output: p.category, (count(*)), (max(r.rating))
+               Backend: DataFusion
+               Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+               Group By: category
+               Aggregates: COUNT(*), MAX(rating)
+(12 rows)
+
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape GroupByAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 3 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=0, total=3, aggr_count=2, group_keys=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=1, total=3, aggr_count=2, group_keys=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 1 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=2, total=3, aggr_count=2, group_keys=1, join_keys=1)
+  category   | cnt | max_rating 
+-------------+-----+------------
+ Clothing    |  50 |          5
+ Electronics |  50 |          5
+ Furniture   |  50 |          5
+ Sports      |  50 |          5
+(4 rows)
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+SET paradedb.mpp_debug TO off;
+-- Restore defaults + clean up.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.enable_aggregate_custom_scan;
+DROP TABLE mpp_exec_reviews;
+DROP TABLE mpp_exec_products;

--- a/pg_search/tests/pg_regress/expected/mpp_fallback.out
+++ b/pg_search/tests/pg_regress/expected/mpp_fallback.out
@@ -1,0 +1,170 @@
+-- =====================================================================
+-- MPP fallback: prove that `paradedb.enable_mpp = on` is a no-op for
+-- queries whose shape isn't (yet) wired to the MPP path.
+--
+-- Phase 4b-i landed the GUC + all the primitives + the customscan_glue
+-- helpers, but did NOT yet flip AggregateScan's or JoinScan's
+-- `ParallelQueryCapable` hooks. So with `enable_mpp=on` every query
+-- should still produce the exact same answers as with `enable_mpp=off`
+-- (there just isn't an MPP path to choose). This test locks in that
+-- no-regression invariant — if Phase 4b-ii accidentally changes the
+-- off-path result under `enable_mpp=on`, this diff catches it.
+--
+-- Data setup mirrors the non-MPP aggregate fallback test so the two are
+-- easy to compare.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+CREATE TABLE mpp_fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+CREATE TABLE mpp_fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+INSERT INTO mpp_fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99),
+    ('Office chair ergonomic', 'Furniture', 249.99);
+INSERT INTO mpp_fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4), (3, 5), (4, 2);
+CREATE INDEX mpp_fb_products_idx ON mpp_fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+CREATE INDEX mpp_fb_reviews_idx ON mpp_fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- Baseline: enable_mpp = off (current default behavior)
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+-- Scalar aggregate on join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Backend: DataFusion
+   Indexes: mpp_fb_products_idx (p), mpp_fb_reviews_idx (r)
+   Aggregates: COUNT(*)
+(5 rows)
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ count 
+-------
+     6
+(1 row)
+
+-- GROUP BY aggregate on join
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count | max_rating 
+-------------+-------+------------
+ Clothing    |     2 |          5
+ Electronics |     2 |          5
+ Furniture   |     1 |          2
+ Sports      |     1 |          3
+(4 rows)
+
+-- =====================================================================
+-- MPP enabled: results must be byte-identical.
+--
+-- With MPP on but no customscan actually routes to the MPP path yet,
+-- the queries must return the same answers as with MPP off. Any
+-- divergence here means Phase 4b-ii accidentally changed existing
+-- behavior on the enable_mpp=on branch.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+-- Same EXPLAIN + query as above.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 1
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_fb_products_idx (p), mpp_fb_reviews_idx (r)
+         Aggregates: COUNT(*)
+(8 rows)
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ count 
+-------
+     6
+(1 row)
+
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count | max_rating 
+-------------+-------+------------
+ Clothing    |     2 |          5
+ Electronics |     2 |          5
+ Furniture   |     1 |          2
+ Sports      |     1 |          3
+(4 rows)
+
+-- Also verify `mpp_debug = on` is a no-op for correctness (may emit
+-- diagnostic warnings, but the query results must be unchanged).
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+WARNING:  mpp: flipping AggregateScan path parallel_workers=1 for shape ScalarAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 2 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=0, total=2, aggr_count=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (2 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=1, total=2, aggr_count=1, join_keys=1)
+ count 
+-------
+     6
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+-- Restore defaults.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.enable_aggregate_custom_scan;
+DROP TABLE mpp_fb_reviews;
+DROP TABLE mpp_fb_products;

--- a/pg_search/tests/pg_regress/sql/mpp_exec.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_exec.sql
@@ -1,0 +1,167 @@
+-- =====================================================================
+-- MPP correctness: with `paradedb.enable_mpp=on`, scalar COUNT(*) on a
+-- binary join must return the same result as with MPP off.
+--
+-- This test exercises the full shape classification + plan-stash +
+-- parallel-flag flip pipeline on a medium-sized dataset (40x200 rows).
+-- PG's planner decides whether to launch actual parallel workers based
+-- on cost; at this size it typically doesn't, so the MPP *exec* path
+-- isn't exercised here — for that you need `debug_parallel_query=on`
+-- at a larger scale, which is out of scope for pg_regress (no parallel
+-- workers launched == no DSM coordination == no cross-worker shuffle).
+--
+-- What this DOES verify:
+--   * MPP-on doesn't break the serial code path
+--   * Shape classifier agrees between path-time and plan-stash-time
+--   * `maybe_stash_mpp_plan_bytes` completes without error
+--   * The plan survives logical-plan → bytes round-trip
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+CREATE TABLE mpp_exec_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+
+CREATE TABLE mpp_exec_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+
+INSERT INTO mpp_exec_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+
+INSERT INTO mpp_exec_reviews (product_id, rating)
+SELECT (i % 40) + 1, (i % 5) + 1 FROM generate_series(1, 200) AS i;
+
+CREATE INDEX mpp_exec_products_idx ON mpp_exec_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+
+CREATE INDEX mpp_exec_reviews_idx ON mpp_exec_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+
+
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+SELECT COUNT(*) AS baseline_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- =====================================================================
+-- MPP enabled: must return the same count.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 3;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*) AS mpp_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- With mpp_debug, the plan should log the shape dispatch + parallel
+-- flip + the "routing exec_datafusion_aggregate through shape" line
+-- that proves the MPP exec bridge actually ran (not just the serial
+-- fallback). The answer must still match the baseline.
+SET paradedb.mpp_debug TO on;
+
+SELECT COUNT(*) AS mpp_count_with_debug
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SET paradedb.mpp_debug TO off;
+
+-- =====================================================================
+-- GROUP BY aggregate on join, with ORDER BY on the group-by column. Both
+-- the GROUP BY and the ORDER BY are driven by the same column, so PG
+-- wraps the Gather-above-CustomScan MPP path in a Sort above the Gather.
+-- The MPP path keeps Aggrefs intact in every tlist so `fix_upper_expr`
+-- matches structurally at setrefs time (if we'd replaced them with
+-- `pdb.agg_fn(...)` placeholders only on the Gather side, setrefs would
+-- trip "Aggref found in non-Agg plan node" on the Result projection PG
+-- adds above the Sort).
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_debug TO on;
+-- Force PG to pick the Gather-wrapped MPP path for GROUP BY on this
+-- small fixture: without these knobs the planner's cost model rejects
+-- Gather for aggregates at this row count and we'd fall back to the
+-- serial Custom Scan (which still produces correct output via the
+-- non-MPP code path).
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+
+SET paradedb.mpp_debug TO off;
+
+-- Restore defaults + clean up.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.enable_aggregate_custom_scan;
+
+DROP TABLE mpp_exec_reviews;
+DROP TABLE mpp_exec_products;

--- a/pg_search/tests/pg_regress/sql/mpp_fallback.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_fallback.sql
@@ -1,0 +1,127 @@
+-- =====================================================================
+-- MPP fallback: prove that `paradedb.enable_mpp = on` is a no-op for
+-- queries whose shape isn't (yet) wired to the MPP path.
+--
+-- Phase 4b-i landed the GUC + all the primitives + the customscan_glue
+-- helpers, but did NOT yet flip AggregateScan's or JoinScan's
+-- `ParallelQueryCapable` hooks. So with `enable_mpp=on` every query
+-- should still produce the exact same answers as with `enable_mpp=off`
+-- (there just isn't an MPP path to choose). This test locks in that
+-- no-regression invariant — if Phase 4b-ii accidentally changes the
+-- off-path result under `enable_mpp=on`, this diff catches it.
+--
+-- Data setup mirrors the non-MPP aggregate fallback test so the two are
+-- easy to compare.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+CREATE TABLE mpp_fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+
+CREATE TABLE mpp_fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+
+INSERT INTO mpp_fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99),
+    ('Office chair ergonomic', 'Furniture', 249.99);
+
+INSERT INTO mpp_fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4), (3, 5), (4, 2);
+
+CREATE INDEX mpp_fb_products_idx ON mpp_fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+
+CREATE INDEX mpp_fb_reviews_idx ON mpp_fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+
+-- =====================================================================
+-- Baseline: enable_mpp = off (current default behavior)
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+-- Scalar aggregate on join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- GROUP BY aggregate on join
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- =====================================================================
+-- MPP enabled: results must be byte-identical.
+--
+-- With MPP on but no customscan actually routes to the MPP path yet,
+-- the queries must return the same answers as with MPP off. Any
+-- divergence here means Phase 4b-ii accidentally changed existing
+-- behavior on the enable_mpp=on branch.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+
+-- Same EXPLAIN + query as above.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Also verify `mpp_debug = on` is a no-op for correctness (may emit
+-- diagnostic warnings, but the query results must be unchanged).
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+SET paradedb.mpp_debug TO off;
+
+-- Restore defaults.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.enable_aggregate_custom_scan;
+
+DROP TABLE mpp_fb_reviews;
+DROP TABLE mpp_fb_products;


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #4152
- Stacked on top of #4829

## What

Fourth PR in the 5-PR MPP chain — the first one that actually flips MPP on end-to-end for `AggregateScan`. Wires the MPP plan bridge, DSM coordinator, and customscan glue into the aggregate custom scan so scalar and GROUP BY aggregates on binary joins execute through Partial → hash-shuffle → FinalPartitioned → Gather when `paradedb.enable_mpp = on`. `JoinScan` still errors on the `JoinOnly` shape — that lands in 5/5 (#4807).

**Review as a stacked PR.** This PR targets `moe/mpp-03-assembly` (#4829). When the earlier PRs merge, GitHub auto-retargets this to `main`.

## Why

Previous PRs in the chain (#4827, #4828, #4829) added the primitives, operators, and plan assembly, but none of them had a production caller. This PR connects those pieces to the aggregate custom scan so the existing `aggregate_join_*` benchmarks can actually take the MPP path. The default stays `enable_mpp = off`, so behaviour is unchanged for any caller that doesn't opt in; turning it on is what lights up the ~2.7× win we've been measuring on `aggregate_join_topk_count`.

## How

- `mpp/coordinator.rs` — DSM estimate/init, worker attach, `MppExecutionState` lifecycle.
- `mpp/customscan_glue.rs` — `mpp_is_active`, `mpp_worker_count`, plan-broadcast helpers.
- `mpp/exec_bridge.rs` — `build_mpp_physical_plan` dispatcher + per-shape bridges (`scalar_agg_on_binary_join`, `groupby_agg_on_binary_join`, plus helper walkers).
- `aggregatescan/*` — `ParallelQueryCapable` impl, DSM hooks, `stash_plan_for_mpp`, `classify_logical_plan`, `bake_logical_plan`, MPP routing in `exec_custom_scan`, session context branch in `datafusion_exec`.
- `hook.rs` — new `add_upper_path` helper that Gather-wraps parallel-aware upper-rel paths so MPP Final aggregate results flow to the leader.
- `joinscan/scan_state.rs` — `build_base_session_with_mpp` + profile helpers consumed by AggregateScan's join subtree (skips `SortMergeJoinEnforcer` and disables `enable_join_dynamic_filter_pushdown` when `total_participants > 1`).
- Benchmark SQL — MPP alt variants for `aggregate_join_count`, `aggregate_join_groupby`, `aggregate_join_multi`, `aggregate_join_topk_count`, `aggregate_sort`.

## Tests

- `cargo check -p pg_search --features pg18` clean.
- `cargo test -p pg_search --lib mpp:: --features pg18` green.
- `cargo pgrx regress pg18 mpp` green (`mpp_smoke`, `mpp_fallback`, `mpp_exec`).
- Existing `aggregate_custom_scan` / `join_custom_scan` regress tests unchanged with `enable_mpp = off`.
- Local 25 M `aggregate_join_groupby` bench completes under 10 s with correct row counts; CI bench on the chain tip (#4807) shows the MPP variants beating DataFusion.