### PR TITLE
fix: Replicate missed v0.23.0 migrations in v0.23.1

### DIFF
--- a/pg_search/sql/pg_search--0.23.0--0.23.1.sql
+++ b/pg_search/sql/pg_search--0.23.0--0.23.1.sql
@@ -1183,7 +1183,7 @@ DO $$
 BEGIN
     IF NOT EXISTS (
         SELECT 1 FROM pg_type t
-        JOIN pg_namespace n ON t.typnamespace == n.oid
+        JOIN pg_namespace n ON t.typnamespace = n.oid
         WHERE n.nspname = 'pdb' AND t.typname = 'edge_ngram'
     ) THEN 
         CREATE TYPE pdb.edge_ngram;

--- a/pg_search/sql/pg_search--0.23.0--0.23.1.sql
+++ b/pg_search/sql/pg_search--0.23.0--0.23.1.sql
@@ -1141,3 +1141,125 @@ AS 'MODULE_PATHNAME', 'lindera_to_const_wrapper';
 CREATE CAST (pdb.lindera AS pdb.const) WITH FUNCTION pdb.lindera_to_const(pdb.lindera, integer, boolean) AS ASSIGNMENT;
 CREATE CAST (pdb.slop AS pdb.const) WITH FUNCTION slop_to_const(pdb.slop, integer, boolean) AS IMPLICIT;
 CREATE CAST (pdb.fuzzy AS pdb.const) WITH FUNCTION fuzzy_to_const(pdb.fuzzy, integer, boolean) AS IMPLICIT;
+
+
+----------------------------------------------------------------------
+-- Begin replicating migrations that accidentally got put in 0.22.5--0.22.6
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pdb."agg_placeholder_agg_placeholder_state"(
+	"this" internal,
+	"arg_one" jsonb
+) RETURNS internal
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_state_wrapper';
+
+-- Ensure the single-arg finalize function exists
+CREATE OR REPLACE FUNCTION pdb."agg_placeholder_agg_placeholder_finalize"(
+	"this" internal
+) RETURNS jsonb
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_finalize_wrapper';
+
+-- Recreate pdb.agg(jsonb) only if it doesn't already exist
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_aggregate a
+		JOIN pg_proc p ON a.aggfnoid = p.oid
+		JOIN pg_namespace n ON p.pronamespace = n.oid
+		WHERE n.nspname = 'pdb' AND p.proname = 'agg' AND p.pronargs = 1
+	) THEN
+		CREATE AGGREGATE pdb.agg (jsonb) (
+			SFUNC = pdb."agg_placeholder_agg_placeholder_state",
+			STYPE = internal,
+			FINALFUNC = pdb."agg_placeholder_agg_placeholder_finalize"
+		);
+	END IF;
+END
+$$;
+
+-- Add edge_ngram tokenizer type, casts, function if it doesn't already exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+        JOIN pg_namespace n ON t.typnamespace == n.oid
+        WHERE n.nspname = 'pdb' AND t.typname = 'edge_ngram'
+    ) THEN 
+        CREATE TYPE pdb.edge_ngram;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_in(cstring) RETURNS pdb.edge_ngram AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_out(pdb.edge_ngram) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_send(pdb.edge_ngram) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_recv(internal) RETURNS pdb.edge_ngram AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE TYPE pdb.edge_ngram (
+            INPUT = pdb.edge_ngram_in,
+            OUTPUT = pdb.edge_ngram_out,
+            SEND = pdb.edge_ngram_send,
+            RECEIVE = pdb.edge_ngram_recv,
+            COLLATABLE = true,
+            CATEGORY = 't',
+            PREFERRED = false,
+            LIKE = text
+        );
+        ALTER TYPE pdb.edge_ngram SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_typmod_out);
+
+        CREATE CAST (text AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
+        CREATE CAST (varchar AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
+
+        CREATE FUNCTION pdb."tokenize_edge_ngram"(
+            "s" pdb.edge_ngram
+        ) RETURNS TEXT[]
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'tokenize_edge_ngram_wrapper';
+
+        CREATE CAST (pdb.edge_ngram AS TEXT[]) WITH FUNCTION pdb.tokenize_edge_ngram AS IMPLICIT;
+
+        CREATE FUNCTION pdb."json_to_edge_ngram"(
+            "json" json
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'json_to_edge_ngram_wrapper';
+
+        CREATE FUNCTION pdb."jsonb_to_edge_ngram"(
+            "jsonb" jsonb
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'jsonb_to_edge_ngram_wrapper';
+
+        CREATE CAST (json AS pdb.edge_ngram) WITH FUNCTION pdb.json_to_edge_ngram AS ASSIGNMENT;
+        CREATE CAST (jsonb AS pdb.edge_ngram) WITH FUNCTION pdb.jsonb_to_edge_ngram AS ASSIGNMENT;
+
+        CREATE FUNCTION pdb."uuid_to_edge_ngram"(
+            "uuid" uuid
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'uuid_to_edge_ngram_wrapper';
+
+        CREATE CAST (uuid AS pdb.edge_ngram) WITH FUNCTION pdb.uuid_to_edge_ngram AS ASSIGNMENT;
+
+        CREATE FUNCTION pdb."text_array_to_edge_ngram"(
+            "arr" text[]
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'text_array_to_edge_ngram_wrapper';
+
+        CREATE FUNCTION pdb."varchar_array_to_edge_ngram"(
+            "arr" varchar[]
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'varchar_array_to_edge_ngram_wrapper';
+
+        CREATE CAST (text[] AS pdb.edge_ngram) WITH FUNCTION pdb.text_array_to_edge_ngram AS ASSIGNMENT;
+        CREATE CAST (varchar[] AS pdb.edge_ngram) WITH FUNCTION pdb.varchar_array_to_edge_ngram AS ASSIGNMENT;
+    END IF;
+END $$;
+----------------------------------------------------------------------
+-- End replicating migrations that accidentally got put in 0.22.5--0.22.6
+----------------------------------------------------------------------
+

--- a/pg_search/sql/pg_search--0.23.0--0.23.1.sql
+++ b/pg_search/sql/pg_search--0.23.0--0.23.1.sql
@@ -1,3 +1,123 @@
+-----------------------------------------------------------------------
+-- Begin replicating migrations that accidentally got put in 0.22.5--0.22.6
+----------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION pdb."agg_placeholder_agg_placeholder_state"(
+	"this" internal,
+	"arg_one" jsonb
+) RETURNS internal
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_state_wrapper';
+
+-- Ensure the single-arg finalize function exists
+CREATE OR REPLACE FUNCTION pdb."agg_placeholder_agg_placeholder_finalize"(
+	"this" internal
+) RETURNS jsonb
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_finalize_wrapper';
+
+-- Recreate pdb.agg(jsonb) only if it doesn't already exist
+DO $$
+BEGIN
+	IF NOT EXISTS (
+		SELECT 1 FROM pg_aggregate a
+		JOIN pg_proc p ON a.aggfnoid = p.oid
+		JOIN pg_namespace n ON p.pronamespace = n.oid
+		WHERE n.nspname = 'pdb' AND p.proname = 'agg' AND p.pronargs = 1
+	) THEN
+		CREATE AGGREGATE pdb.agg (jsonb) (
+			SFUNC = pdb."agg_placeholder_agg_placeholder_state",
+			STYPE = internal,
+			FINALFUNC = pdb."agg_placeholder_agg_placeholder_finalize"
+		);
+	END IF;
+END
+$$;
+
+-- Add edge_ngram tokenizer type, casts, function if it doesn't already exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_type t
+        JOIN pg_namespace n ON t.typnamespace = n.oid
+        WHERE n.nspname = 'pdb' AND t.typname = 'edge_ngram'
+    ) THEN 
+        CREATE TYPE pdb.edge_ngram;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_in(cstring) RETURNS pdb.edge_ngram AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_out(pdb.edge_ngram) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_send(pdb.edge_ngram) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE OR REPLACE FUNCTION pdb.edge_ngram_recv(internal) RETURNS pdb.edge_ngram AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
+        CREATE TYPE pdb.edge_ngram (
+            INPUT = pdb.edge_ngram_in,
+            OUTPUT = pdb.edge_ngram_out,
+            SEND = pdb.edge_ngram_send,
+            RECEIVE = pdb.edge_ngram_recv,
+            COLLATABLE = true,
+            CATEGORY = 't',
+            PREFERRED = false,
+            LIKE = text
+        );
+        ALTER TYPE pdb.edge_ngram SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_typmod_out);
+
+        CREATE CAST (text AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
+        CREATE CAST (varchar AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
+
+        CREATE FUNCTION pdb."tokenize_edge_ngram"(
+            "s" pdb.edge_ngram
+        ) RETURNS TEXT[]
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'tokenize_edge_ngram_wrapper';
+
+        CREATE CAST (pdb.edge_ngram AS TEXT[]) WITH FUNCTION pdb.tokenize_edge_ngram AS IMPLICIT;
+
+        CREATE FUNCTION pdb."json_to_edge_ngram"(
+            "json" json
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'json_to_edge_ngram_wrapper';
+
+        CREATE FUNCTION pdb."jsonb_to_edge_ngram"(
+            "jsonb" jsonb
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'jsonb_to_edge_ngram_wrapper';
+
+        CREATE CAST (json AS pdb.edge_ngram) WITH FUNCTION pdb.json_to_edge_ngram AS ASSIGNMENT;
+        CREATE CAST (jsonb AS pdb.edge_ngram) WITH FUNCTION pdb.jsonb_to_edge_ngram AS ASSIGNMENT;
+
+        CREATE FUNCTION pdb."uuid_to_edge_ngram"(
+            "uuid" uuid
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'uuid_to_edge_ngram_wrapper';
+
+        CREATE CAST (uuid AS pdb.edge_ngram) WITH FUNCTION pdb.uuid_to_edge_ngram AS ASSIGNMENT;
+
+        CREATE FUNCTION pdb."text_array_to_edge_ngram"(
+            "arr" text[]
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'text_array_to_edge_ngram_wrapper';
+
+        CREATE FUNCTION pdb."varchar_array_to_edge_ngram"(
+            "arr" varchar[]
+        ) RETURNS pdb.edge_ngram
+            IMMUTABLE STRICT PARALLEL SAFE
+            LANGUAGE c
+        AS 'MODULE_PATHNAME', 'varchar_array_to_edge_ngram_wrapper';
+
+        CREATE CAST (text[] AS pdb.edge_ngram) WITH FUNCTION pdb.text_array_to_edge_ngram AS ASSIGNMENT;
+        CREATE CAST (varchar[] AS pdb.edge_ngram) WITH FUNCTION pdb.varchar_array_to_edge_ngram AS ASSIGNMENT;
+    END IF;
+END $$;
+----------------------------------------------------------------------
+-- End replicating migrations that accidentally got put in 0.22.5--0.22.6
+----------------------------------------------------------------------
+
 -- pg_search/src/api/operator/fuzzy.rs:241
 -- pg_search::api::operator::fuzzy::fuzzy_to_const
 CREATE  FUNCTION "fuzzy_to_const"(
@@ -1141,125 +1261,3 @@ AS 'MODULE_PATHNAME', 'lindera_to_const_wrapper';
 CREATE CAST (pdb.lindera AS pdb.const) WITH FUNCTION pdb.lindera_to_const(pdb.lindera, integer, boolean) AS ASSIGNMENT;
 CREATE CAST (pdb.slop AS pdb.const) WITH FUNCTION slop_to_const(pdb.slop, integer, boolean) AS IMPLICIT;
 CREATE CAST (pdb.fuzzy AS pdb.const) WITH FUNCTION fuzzy_to_const(pdb.fuzzy, integer, boolean) AS IMPLICIT;
-
-
-----------------------------------------------------------------------
--- Begin replicating migrations that accidentally got put in 0.22.5--0.22.6
-----------------------------------------------------------------------
-CREATE OR REPLACE FUNCTION pdb."agg_placeholder_agg_placeholder_state"(
-	"this" internal,
-	"arg_one" jsonb
-) RETURNS internal
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_state_wrapper';
-
--- Ensure the single-arg finalize function exists
-CREATE OR REPLACE FUNCTION pdb."agg_placeholder_agg_placeholder_finalize"(
-	"this" internal
-) RETURNS jsonb
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'agg_placeholder_agg_placeholder_finalize_wrapper';
-
--- Recreate pdb.agg(jsonb) only if it doesn't already exist
-DO $$
-BEGIN
-	IF NOT EXISTS (
-		SELECT 1 FROM pg_aggregate a
-		JOIN pg_proc p ON a.aggfnoid = p.oid
-		JOIN pg_namespace n ON p.pronamespace = n.oid
-		WHERE n.nspname = 'pdb' AND p.proname = 'agg' AND p.pronargs = 1
-	) THEN
-		CREATE AGGREGATE pdb.agg (jsonb) (
-			SFUNC = pdb."agg_placeholder_agg_placeholder_state",
-			STYPE = internal,
-			FINALFUNC = pdb."agg_placeholder_agg_placeholder_finalize"
-		);
-	END IF;
-END
-$$;
-
--- Add edge_ngram tokenizer type, casts, function if it doesn't already exist
-DO $$
-BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_type t
-        JOIN pg_namespace n ON t.typnamespace = n.oid
-        WHERE n.nspname = 'pdb' AND t.typname = 'edge_ngram'
-    ) THEN 
-        CREATE TYPE pdb.edge_ngram;
-        CREATE OR REPLACE FUNCTION pdb.edge_ngram_in(cstring) RETURNS pdb.edge_ngram AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
-        CREATE OR REPLACE FUNCTION pdb.edge_ngram_out(pdb.edge_ngram) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
-        CREATE OR REPLACE FUNCTION pdb.edge_ngram_send(pdb.edge_ngram) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
-        CREATE OR REPLACE FUNCTION pdb.edge_ngram_recv(internal) RETURNS pdb.edge_ngram AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
-        CREATE TYPE pdb.edge_ngram (
-            INPUT = pdb.edge_ngram_in,
-            OUTPUT = pdb.edge_ngram_out,
-            SEND = pdb.edge_ngram_send,
-            RECEIVE = pdb.edge_ngram_recv,
-            COLLATABLE = true,
-            CATEGORY = 't',
-            PREFERRED = false,
-            LIKE = text
-        );
-        ALTER TYPE pdb.edge_ngram SET (TYPMOD_IN = generic_typmod_in, TYPMOD_OUT = generic_typmod_out);
-
-        CREATE CAST (text AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
-        CREATE CAST (varchar AS pdb.edge_ngram) WITH INOUT AS IMPLICIT;
-
-        CREATE FUNCTION pdb."tokenize_edge_ngram"(
-            "s" pdb.edge_ngram
-        ) RETURNS TEXT[]
-            IMMUTABLE STRICT PARALLEL SAFE
-            LANGUAGE c
-        AS 'MODULE_PATHNAME', 'tokenize_edge_ngram_wrapper';
-
-        CREATE CAST (pdb.edge_ngram AS TEXT[]) WITH FUNCTION pdb.tokenize_edge_ngram AS IMPLICIT;
-
-        CREATE FUNCTION pdb."json_to_edge_ngram"(
-            "json" json
-        ) RETURNS pdb.edge_ngram
-            IMMUTABLE STRICT PARALLEL SAFE
-            LANGUAGE c
-        AS 'MODULE_PATHNAME', 'json_to_edge_ngram_wrapper';
-
-        CREATE FUNCTION pdb."jsonb_to_edge_ngram"(
-            "jsonb" jsonb
-        ) RETURNS pdb.edge_ngram
-            IMMUTABLE STRICT PARALLEL SAFE
-            LANGUAGE c
-        AS 'MODULE_PATHNAME', 'jsonb_to_edge_ngram_wrapper';
-
-        CREATE CAST (json AS pdb.edge_ngram) WITH FUNCTION pdb.json_to_edge_ngram AS ASSIGNMENT;
-        CREATE CAST (jsonb AS pdb.edge_ngram) WITH FUNCTION pdb.jsonb_to_edge_ngram AS ASSIGNMENT;
-
-        CREATE FUNCTION pdb."uuid_to_edge_ngram"(
-            "uuid" uuid
-        ) RETURNS pdb.edge_ngram
-            IMMUTABLE STRICT PARALLEL SAFE
-            LANGUAGE c
-        AS 'MODULE_PATHNAME', 'uuid_to_edge_ngram_wrapper';
-
-        CREATE CAST (uuid AS pdb.edge_ngram) WITH FUNCTION pdb.uuid_to_edge_ngram AS ASSIGNMENT;
-
-        CREATE FUNCTION pdb."text_array_to_edge_ngram"(
-            "arr" text[]
-        ) RETURNS pdb.edge_ngram
-            IMMUTABLE STRICT PARALLEL SAFE
-            LANGUAGE c
-        AS 'MODULE_PATHNAME', 'text_array_to_edge_ngram_wrapper';
-
-        CREATE FUNCTION pdb."varchar_array_to_edge_ngram"(
-            "arr" varchar[]
-        ) RETURNS pdb.edge_ngram
-            IMMUTABLE STRICT PARALLEL SAFE
-            LANGUAGE c
-        AS 'MODULE_PATHNAME', 'varchar_array_to_edge_ngram_wrapper';
-
-        CREATE CAST (text[] AS pdb.edge_ngram) WITH FUNCTION pdb.text_array_to_edge_ngram AS ASSIGNMENT;
-        CREATE CAST (varchar[] AS pdb.edge_ngram) WITH FUNCTION pdb.varchar_array_to_edge_ngram AS ASSIGNMENT;
-    END IF;
-END $$;
-----------------------------------------------------------------------
--- End replicating migrations that accidentally got put in 0.22.5--0.22.6
-----------------------------------------------------------------------
-


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4824 

## What
All of the migration sql between v0.22.6 and v0.23.0 was accidentally added to the v0.22.5->v0.22.6 file. This PR replicates that sql in the v0.23.0->v0.23.1 file to make sure that users who first installed pg_search on v0.22.6 still get those changes.

## Why

## How
All statements were either already `CREATE OR REPLACE`, or they were wrapped in a `DO BEGIN IF NOT EXISTS(...` block to ensure they would not run if they already had ran for that user.

## Tests
Manually verified that the 3 relevant migration paths all end in a state that knows about `pdb.edge_ngram`
- `0.22.5->0.23.1`: Starts in state that does not have these migrations applied, then runs both files that include them.
- `0.22.6->0.23.1`: Starts in a state that does not have these migrations applied, then runs only the second file that includes them.
- `0.23.0->0.23.1`: Starts in a state that already has the end result of these migrations, the runs the second file that includes them.