### PR TITLE
ci: Only save the cache on the nightly run of test-pg_search.yml

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -46,7 +46,6 @@ jobs:
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
-      # Only save cache on non-PR events; PRs restore from the default branch.
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
@@ -54,7 +53,8 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          save-if: ${{ github.event_name != 'pull_request' }}
+          # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
+          save-if: false
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -63,7 +63,8 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          save-if: ${{ github.event_name != 'pull_request' }}
+          # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
+          save-if: false
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -127,8 +127,6 @@ jobs:
       # Cache notes:
       # - Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       #   See test-pg_search.yml for rationale.
-      # Only save cache on non-PR events; PRs restore from the default branch.
-      # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
@@ -136,7 +134,8 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          save-if: ${{ github.event_name != 'pull_request' }}
+          # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
+          save-if: false
 
       - name: Install pgrx
         run: cargo install -j $(nproc) --locked cargo-pgrx --version "${{ steps.pgrx.outputs.version }}" --debug

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -55,8 +55,6 @@ jobs:
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
-      # Only save cache on non-PR events; PRs restore from the default branch.
-      # See test-pg_search.yml for rationale.
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
@@ -64,7 +62,8 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          save-if: ${{ github.event_name != 'pull_request' }}
+          # We don't save the cache here to avoid thrashing. The cache is only saved on the nightly run of test-pg_search.yml
+          save-if: false
 
       - name: Install required system tools
         run: sudo apt-get update && sudo apt-get install -y lsof

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -110,7 +110,7 @@ jobs:
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true
-          save-if: ${{ github.event_name != 'pull_request' }}
+          save-if: ${{ github.event_name == 'schedule' && github.ref_name == github.event.repository.default_branch }}
 
       - name: Install required system tools
         run: |


### PR DESCRIPTION
# Ticket(s) Closed

## What

To prevent cache thrashing we stopped saving the Rust cache on PR events (instead relying on the nightly run). This worked for this repo, but it did not work for enterprise because CI is run on non-PR events there, so those cache entries are still saved. To prevent that, I updated the save-if condition to only run on scheduled runs on main rather than only excluding PRs. This should stop the thrashing.
I also noticed that because the workflows other than test-pg_search.yml only run on PRs, they're never saving their caches (which is fine), so I updated those conditions to `save-if: false`.

## Why

## How

## Tests
