### PR TITLE
fix: Modify upgrade test workflow to also test last-version->this-version only.

### DIFF
--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -122,6 +122,13 @@ runs:
         psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS \$\$ BEGIN IF a <> b THEN RAISE EXCEPTION 'Assertion failed: % <> %', a, b; END IF; RETURN true; END; \$\$;"
         psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "SELECT assert(count(*), 0) FROM (SELECT * FROM pdb.verify_index('search_idx') WHERE NOT passed) failed;"
 
+    # `cargo pgrx regress` rebuilds and reinstalls the extension without sudo,
+    # but the earlier `cargo pgrx install --sudo` left the Postgres extension
+    # directories owned by root.
+    - name: Take ownership of Postgres directories
+      shell: bash
+      run: sudo chown -R $(whoami) /usr/share/postgresql/${{ inputs.pg_version }}/ /usr/lib/postgresql/${{ inputs.pg_version }}/
+
     - name: Run pg_search Regression Tests
       shell: bash
       run: |

--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -122,15 +122,6 @@ runs:
         psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS \$\$ BEGIN IF a <> b THEN RAISE EXCEPTION 'Assertion failed: % <> %', a, b; END IF; RETURN true; END; \$\$;"
         psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "SELECT assert(count(*), 0) FROM (SELECT * FROM pdb.verify_index('search_idx') WHERE NOT passed) failed;"
 
-    # We only run the integration tests since pgrx won't run the #[pg_test] unit tests in an existing database
-    - name: Run pg_search Integration Tests
-      working-directory: tests/
-      shell: bash
-      run: |
-        export DATABASE_URL=postgresql://localhost:288${{ inputs.pg_version }}/postgres
-        export PG_CONFIG=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config
-        RUST_BACKTRACE=1 cargo test --jobs $(nproc)
-
     - name: Run pg_search Regression Tests
       shell: bash
       run: |

--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -131,6 +131,15 @@ runs:
         export PG_CONFIG=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config
         RUST_BACKTRACE=1 cargo test --jobs $(nproc)
 
+    - name: Run pg_search Regression Tests
+      shell: bash
+      run: |
+        set -e
+        if ! cargo pgrx regress --package pg_search pg${{ inputs.pg_version }}; then
+          git diff
+          exit 1
+        fi
+
     - name: Print the Postgres Logs
       if: always()
       shell: bash

--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -122,21 +122,14 @@ runs:
         psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS \$\$ BEGIN IF a <> b THEN RAISE EXCEPTION 'Assertion failed: % <> %', a, b; END IF; RETURN true; END; \$\$;"
         psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "SELECT assert(count(*), 0) FROM (SELECT * FROM pdb.verify_index('search_idx') WHERE NOT passed) failed;"
 
-    # `cargo pgrx regress` rebuilds and reinstalls the extension without sudo,
-    # but the earlier `cargo pgrx install --sudo` left the Postgres extension
-    # directories owned by root.
-    - name: Take ownership of Postgres directories
-      shell: bash
-      run: sudo chown -R $(whoami) /usr/share/postgresql/${{ inputs.pg_version }}/ /usr/lib/postgresql/${{ inputs.pg_version }}/
-
-    - name: Run pg_search Regression Tests
+    # We only run the integration tests since pgrx won't run the #[pg_test] unit tests in an existing database
+    - name: Run pg_search Integration Tests
+      working-directory: tests/
       shell: bash
       run: |
-        set -e
-        if ! cargo pgrx regress --package pg_search pg${{ inputs.pg_version }}; then
-          git diff
-          exit 1
-        fi
+        export DATABASE_URL=postgresql://localhost:288${{ inputs.pg_version }}/postgres
+        export PG_CONFIG=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config
+        RUST_BACKTRACE=1 cargo test --jobs $(nproc)
 
     - name: Print the Postgres Logs
       if: always()

--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -1,0 +1,137 @@
+name: Test pg_search Upgrade
+description: Test that the pg_search extension can upgrade via ALTER EXTENSION from a given prior version
+
+inputs:
+  prior_pg_search_version:
+    description: "The prior pg_search version (git tag) to upgrade from, e.g. v0.21.0"
+    required: true
+  prior_pgrx_version:
+    description: "The pgrx version compatible with the prior pg_search version, e.g. 0.16.1"
+    required: true
+  pg_version:
+    description: "The PostgreSQL major version to test against"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract pgrx Version
+      id: pgrx
+      shell: bash
+      run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+
+    # This is the pgrx version compatible with ParadeDB ${{ inputs.prior_pg_search_version }}
+    - name: Install pgrx for ParadeDB ${{ inputs.prior_pg_search_version }}
+      shell: bash
+      run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ inputs.prior_pgrx_version }} --force --debug
+
+    - name: Initialize pgrx environment for ParadeDB ${{ inputs.prior_pg_search_version }}
+      shell: bash
+      run: cargo pgrx init "--pg${{ inputs.pg_version }}=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Checkout ParadeDB ${{ inputs.prior_pg_search_version }}
+      shell: bash
+      run: |
+        # cleanup any local modifications the above steps may have made
+        git checkout .
+
+        # checkout the prior version of ParadeDB
+        git checkout ${{ inputs.prior_pg_search_version }}
+
+    - name: Compile & install pg_search ${{ inputs.prior_pg_search_version }}
+      working-directory: pg_search/
+      shell: bash
+      run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Start Postgres via pgrx
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        RUST_BACKTRACE=1 cargo pgrx start pg${{ inputs.pg_version }}
+        # Necessary for the ephemeral Postgres test to have proper permissions
+        sudo chown -R $(whoami) /var/run/postgresql/
+
+    - name: Create pg_search Extension
+      working-directory: pg_search/
+      shell: bash
+      run: psql -h localhost -p 288${{ inputs.pg_version }} postgres -c 'CREATE EXTENSION pg_search;'
+
+    # We create and test the BM25 index before and after the upgrade to test for version compatibility
+    - name: Create and Test BM25 Index
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "CREATE INDEX search_idx ON mock_items USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"
+
+    - name: Stop Postgres via pgrx
+      working-directory: pg_search/
+      shell: bash
+      run: RUST_BACKTRACE=1 cargo pgrx stop pg${{ inputs.pg_version }}
+
+    - name: Install the pgrx version for ParadeDB
+      shell: bash
+      run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --force --debug
+
+    - name: Initialize pgrx environment for ParadeDB
+      shell: bash
+      run: cargo pgrx init "--pg${{ inputs.pg_version }}=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Fetch and Checkout PR Head (PR) or Pushed Commit (push)
+      shell: bash
+      run: |
+        set -euo pipefail
+        git checkout .
+
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}
+          git checkout ${{ github.event.pull_request.head.ref }}
+        else
+          # For push (and other non-PR events), use the exact commit that triggered the workflow
+          git fetch origin ${{ github.sha }}:commit-${{ github.sha }}
+          git checkout commit-${{ github.sha }}
+        fi
+
+    - name: Compile & install pg_search
+      working-directory: pg_search/
+      shell: bash
+      run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Start Postgres via pgrx
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        RUST_BACKTRACE=1 cargo pgrx start pg${{ inputs.pg_version }}
+        # Necessary for the ephemeral Postgres test to have proper permissions
+        sudo chown -R $(whoami) /var/run/postgresql/
+
+    - name: Alter pg_search extension to the latest version
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        VERSION=$(grep "^version" ../Cargo.toml | head -1 | awk -F '"' '{print $2}')
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
+
+    # We test the BM25 index before and after the upgrade to test for version compatibility
+    - name: Test BM25 Index
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS \$\$ BEGIN IF a <> b THEN RAISE EXCEPTION 'Assertion failed: % <> %', a, b; END IF; RETURN true; END; \$\$;"
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "SELECT assert(count(*), 0) FROM (SELECT * FROM pdb.verify_index('search_idx') WHERE NOT passed) failed;"
+
+    # We only run the integration tests since pgrx won't run the #[pg_test] unit tests in an existing database
+    - name: Run pg_search Integration Tests
+      working-directory: tests/
+      shell: bash
+      run: |
+        export DATABASE_URL=postgresql://localhost:288${{ inputs.pg_version }}/postgres
+        export PG_CONFIG=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config
+        RUST_BACKTRACE=1 cargo test --jobs $(nproc)
+
+    - name: Print the Postgres Logs
+      if: always()
+      shell: bash
+      run: cat ~/.pgrx/${{ inputs.pg_version }}.log

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -14,16 +14,13 @@ on:
       - moe/** # Temporary: trigger CI on stacked PR chain
     paths:
       - ".github/workflows/test-pg_search-upgrade.yml"
+      - ".github/actions/test-pg_search-upgrade/**"
       - "pg_search/**"
       - "!pg_search/README.md"
       - "tests/**"
       - "tokenizers/**"
       - "Cargo.toml"
   workflow_dispatch:
-
-# This is the first pg_search version that has Postgres 18 support.
-env:
-  PRIOR_PG_SEARCH_VERSION: "v0.21.0"
 
 concurrency:
   group: test-pg_search-upgrade-${{ github.head_ref || github.ref }}
@@ -34,8 +31,15 @@ jobs:
     name: Test upgrading pg_search via ALTER EXTENSION
     runs-on: ubicloud-standard-8-arm-ubuntu-2404
     strategy:
+      fail-fast: false
       matrix:
         pg_version: [18]
+        # Each entry is an upgrade starting point. v0.21.0 is the first pg_search
+        # version that has Postgres 18 support; pgrx_version must match the prior
+        # pg_search version's pgrx dependency.
+        prior:
+          - pg_search_version: "v0.21.0"
+            pgrx_version: "0.16.1"
 
     steps:
       - name: Checkout Git Repository
@@ -48,10 +52,6 @@ jobs:
         with:
           cache: false
           rustflags: "" # Use .cargo/config.toml target-cpu flags
-
-      - name: Extract pgrx Version
-        id: pgrx
-        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
 
       # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
       # See test-pg_search.yml for rationale.
@@ -87,101 +87,9 @@ jobs:
       - name: Install llvm-tools-preview
         run: rustup component add llvm-tools-preview
 
-      # This is the pgrx version compatible with ParadeDB $PRIOR_PG_SEARCH_VERSION
-      - name: Install pgrx for ParadeDB $PRIOR_PG_SEARCH_VERSION
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version 0.16.1 --force --debug
-
-      - name: Initialize pgrx environment for ParadeDB $PRIOR_PG_SEARCH_VERSION
-        run: cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
-
-      - name: Checkout ParadeDB $PRIOR_PG_SEARCH_VERSION
-        run: |
-          # cleanup any local modifications the above steps may have made
-          git checkout .
-
-          # checkout the prior version of ParadeDB
-          git checkout $PRIOR_PG_SEARCH_VERSION
-
-      - name: Compile & install pg_search $PRIOR_PG_SEARCH_VERSION
-        working-directory: pg_search/
-        run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
-
-      - name: Start Postgres via pgrx
-        working-directory: pg_search/
-        run: |
-          RUST_BACKTRACE=1 cargo pgrx start pg${{ matrix.pg_version }}
-          # Necessary for the ephemeral Postgres test to have proper permissions
-          sudo chown -R $(whoami) /var/run/postgresql/
-
-      - name: Create pg_search Extension
-        working-directory: pg_search/
-        run: psql -h localhost -p 288${{ matrix.pg_version }} postgres -c 'CREATE EXTENSION pg_search;'
-
-      # We create and test the BM25 index before and after the upgrade to test for version compatibility
-      - name: Create and Test BM25 Index
-        working-directory: pg_search/
-        run: |
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');"
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "SELECT description, rating, category FROM mock_items LIMIT 3;"
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "CREATE INDEX search_idx ON mock_items USING bm25 (id, description, category, rating, in_stock, created_at, metadata, weight_range) WITH (key_field='id');"
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "SELECT description, rating, category FROM mock_items WHERE description @@@ 'shoes' OR category @@@ 'footwear' AND rating @@@ '>2' ORDER BY description LIMIT 5;"
-
-      - name: Stop Postgres via pgrx
-        working-directory: pg_search/
-        run: RUST_BACKTRACE=1 cargo pgrx stop pg${{ matrix.pg_version }}
-
-      - name: Install the pgrx version for ParadeDB
-        run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --force --debug
-
-      - name: Initialize pgrx environment for ParadeDB
-        run: cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
-
-      - name: Fetch and Checkout PR Head (PR) or Pushed Commit (push)
-        run: |
-          set -euo pipefail
-          git checkout .
-
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}
-            git checkout ${{ github.event.pull_request.head.ref }}
-          else
-            # For push (and other non-PR events), use the exact commit that triggered the workflow
-            git fetch origin ${{ github.sha }}:commit-${{ github.sha }}
-            git checkout commit-${{ github.sha }}
-          fi
-
-      - name: Compile & install pg_search
-        working-directory: pg_search/
-        run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
-
-      - name: Start Postgres via pgrx
-        working-directory: pg_search/
-        run: |
-          RUST_BACKTRACE=1 cargo pgrx start pg${{ matrix.pg_version }}
-          # Necessary for the ephemeral Postgres test to have proper permissions
-          sudo chown -R $(whoami) /var/run/postgresql/
-
-      - name: Alter pg_search extension to the latest version
-        working-directory: pg_search/
-        run: |
-          VERSION=$(grep "^version" ../Cargo.toml | head -1 | awk -F '"' '{print $2}')
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
-
-      # We test the BM25 index before and after the upgrade to test for version compatibility
-      - name: Test BM25 Index
-        working-directory: pg_search/
-        run: |
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "CREATE OR REPLACE FUNCTION assert(a bigint, b bigint) RETURNS bool STABLE STRICT LANGUAGE plpgsql AS \$\$ BEGIN IF a <> b THEN RAISE EXCEPTION 'Assertion failed: % <> %', a, b; END IF; RETURN true; END; \$\$;"
-          psql -h localhost -p 288${{ matrix.pg_version }} postgres -c "SELECT assert(count(*), 0) FROM (SELECT * FROM pdb.verify_index('search_idx') WHERE NOT passed) failed;"
-
-      # We only run the integration tests since pgrx won't run the #[pg_test] unit tests in an existing database
-      - name: Run pg_search Integration Tests
-        working-directory: tests/
-        run: |
-          export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
-          export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-          RUST_BACKTRACE=1 cargo test --jobs $(nproc)
-
-      - name: Print the Postgres Logs
-        if: always()
-        run: cat ~/.pgrx/${{ matrix.pg_version}}.log
+      - name: Test Upgrade from ${{ matrix.prior.pg_search_version }}
+        uses: ./.github/actions/test-pg_search-upgrade
+        with:
+          prior_pg_search_version: ${{ matrix.prior.pg_search_version }}
+          prior_pgrx_version: ${{ matrix.prior.pgrx_version }}
+          pg_version: ${{ matrix.pg_version }}

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -27,19 +27,56 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Resolves the immediately preceding released version on the upgrade path
+  # (the highest semver tag less than the current Cargo.toml version) plus its
+  # matching pgrx version, and emits the full matrix of upgrade starting points.
+  discover-upgrade-starting-points:
+    name: Discover upgrade starting points
+    runs-on: ubuntu-latest
+    outputs:
+      prior_matrix: ${{ steps.compute.outputs.prior_matrix }}
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # Fetch the entire history (required to read tags)
+
+      - name: Compute prior versions
+        id: compute
+        run: |
+          set -euo pipefail
+          CURRENT=$(grep "^version" Cargo.toml | head -1 | awk -F '"' '{print $2}')
+          TAGS=$(git tag -l 'v*' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$')
+          SORTED=$(printf "%s\nv%s\n" "$TAGS" "$CURRENT" | sort -V -u)
+          PRIOR=$(echo "$SORTED" | awk -v cur="v$CURRENT" 'prev != "" && $0 == cur { print prev; exit } { prev = $0 }')
+          if [ -z "$PRIOR" ]; then
+            echo "Could not determine prior version for current=$CURRENT" >&2
+            exit 1
+          fi
+          PRIOR_PGRX=$(git show "$PRIOR:Cargo.toml" | sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' | head -1)
+          if [ -z "$PRIOR_PGRX" ]; then
+            echo "Could not determine pgrx version at $PRIOR" >&2
+            exit 1
+          fi
+          echo "Resolved prior=$PRIOR pgrx=$PRIOR_PGRX (current=$CURRENT)"
+
+          # v0.21.0 is the first pg_search version with Postgres 18 support.
+          # Dedup in case the dynamic prior happens to also be v0.21.0.
+          MATRIX=$(jq -nc --arg p "$PRIOR" --arg pgrx "$PRIOR_PGRX" '[
+            { "pg_search_version": "v0.21.0", "pgrx_version": "0.16.1" },
+            { "pg_search_version": $p, "pgrx_version": $pgrx }
+          ] | unique_by(.pg_search_version)')
+          echo "prior_matrix=$MATRIX" >> $GITHUB_OUTPUT
+
   test-pg_search-upgrade:
     name: Test upgrading pg_search via ALTER EXTENSION
+    needs: discover-upgrade-starting-points
     runs-on: ubicloud-standard-8-arm-ubuntu-2404
     strategy:
       fail-fast: false
       matrix:
         pg_version: [18]
-        # Each entry is an upgrade starting point. v0.21.0 is the first pg_search
-        # version that has Postgres 18 support; pgrx_version must match the prior
-        # pg_search version's pgrx dependency.
-        prior:
-          - pg_search_version: "v0.21.0"
-            pgrx_version: "0.16.1"
+        prior: ${{ fromJSON(needs.discover-upgrade-starting-points.outputs.prior_matrix) }}
 
     steps:
       - name: Checkout Git Repository


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4833 

## What
This PR modifies the sql upgrade check workflow to check both the v0.21.0->current and the last-version->current migration paths. We need to check the initialized-as-last-version->current path specifically to make sure that all of the migration sql we've intended to apply to this version change actually does.

## Why
As long as the changes are covered by the integration tests, this makes sure we are putting migration sql in the right place.

## How
- Extract most of the migration upgrade workflow into its own action that takes pg_search version, and pgrx version as input.
- Add an initial discovery job to find the most recent version before this, as well as its pgrx version, and run the migration upgrade check for it as well as the v0.21.0 path.

## Tests
- Manual run of the workflow to verify it works as expected: https://github.com/paradedb/paradedb/actions/runs/24747974705/
