### PR TITLE
fix: apply sampled/{size}/csv suffix to --data-source in benchmarks

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -133,8 +133,8 @@ struct ExistingArgs {
     #[arg(long)]
     size: String,
 
-    /// Path to external CSV data source (S3 or local). Each table should be a subdirectory
-    /// containing CSV files. Overrides s3_base_path in config.toml.
+    /// Base path to external CSV data source (S3 or local). Overrides s3_base_path in
+    /// config.toml. CSVs are loaded from `{data_source}/sampled/{size}/csv/{table}/`.
     #[arg(long)]
     data_source: Option<String>,
 }
@@ -620,22 +620,20 @@ fn load_external_data(
         .with_context(|| format!("Failed to load config '{config_path}'"))?;
 
     // Determine CSV data source path.
-    let source_path = match data_source {
-        Some(path) => path.trim_end_matches('/').to_string(),
-        None => {
-            let s3_base = config.s3_base_path.as_deref().with_context(|| {
-                format!(
-                    "Dataset '{dataset}' has no S3 base path. Provide --data-source or set \
-                     s3_base_path in datasets/{dataset}/config.toml"
-                )
-            })?;
+    let base_path = match data_source {
+        Some(path) => path,
+        None => config.s3_base_path.as_deref().with_context(|| {
             format!(
-                "{}/sampled/{}/csv",
-                s3_base.trim_end_matches('/'),
-                size_label
+                "Dataset '{dataset}' has no S3 base path. Provide --data-source or set \
+                 s3_base_path in datasets/{dataset}/config.toml"
             )
-        }
+        })?,
     };
+    let source_path = format!(
+        "{}/sampled/{}/csv",
+        base_path.trim_end_matches('/'),
+        size_label
+    );
     println!("Data source: {source_path}");
 
     // Create tables via DDL.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4801 

## What
Makes path construction behavior consistent across both the default and the override.

## Why
This behavior is more intuitive than what was there before.

## How

## Tests
