### PR TITLE
chore: Add baseline metrics to the PgSearch scan.

### DIFF
--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -46,7 +46,9 @@ use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
 use datafusion::physical_plan::filter_pushdown::{
     ChildPushdownResult, FilterPushdownPhase, FilterPushdownPropagation, PushedDown,
 };
-use datafusion::physical_plan::metrics::{ExecutionPlanMetricsSet, MetricBuilder, MetricsSet};
+use datafusion::physical_plan::metrics::{
+    BaselineMetrics, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet, RecordOutput,
+};
 use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::{
     DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
@@ -353,11 +355,13 @@ impl ExecutionPlan for PgSearchScanPlan {
         let rows_pruned = has_dynamic_filters
             .then(|| MetricBuilder::new(&self.metrics).counter("rows_pruned", partition));
 
+        let baseline_metrics = BaselineMetrics::new(&self.metrics, partition);
         let schema = self.properties.eq_properties.schema().clone();
         let dynamic_filters = self.dynamic_filters.clone();
 
         let stream_gen = async_stream::try_stream! {
             loop {
+                let timer = baseline_metrics.elapsed_compute().timer();
                 let pre_filters = build_filters(&dynamic_filters, &schema);
                 let pre_filters_wrapper = if pre_filters.is_empty() {
                     None
@@ -368,13 +372,17 @@ impl ExecutionPlan for PgSearchScanPlan {
                     })
                 };
 
-                match scanner.next(
+                let next_batch = scanner.next(
                     &ffhelper,
                     &mut visibility,
                     pre_filters_wrapper.as_ref(),
-                ) {
+                );
+                timer.done();
+
+                match next_batch {
                     Some(batch) => {
-                        yield batch.to_record_batch(&schema);
+                        let record_batch = batch.to_record_batch(&schema);
+                        yield record_batch.record_output(&baseline_metrics);
                     }
                     None => {
                         // Flush pre-materialization filter stats from Scanner.
@@ -388,6 +396,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                     }
                 }
             }
+            baseline_metrics.done();
         };
 
         // SAFETY: pg_search operates in a single-threaded Tokio executor within Postgres,

--- a/pg_search/tests/pg_regress/expected/join_sort_merge.out
+++ b/pg_search/tests/pg_regress/expected/join_sort_merge.out
@@ -353,8 +353,8 @@ JOIN dyn_filter_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.val ASC
 LIMIT 10;
-                                                                                                                                QUERY PLAN                                                                                                                                
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                      QUERY PLAN                                                                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: t2 INNER t1
@@ -370,9 +370,9 @@ LIMIT 10;
            :           ProjectionExec: expr=[ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, val@4 as val], metrics=[output_rows=20.00 K, output_bytes=1184.8 KB, output_batches=3]
            :             SortMergeJoinExec: join_type=Inner, on=[(t1_id@1, id@1)], metrics=[output_rows=20.00 K, output_bytes=1568.8 KB, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, input_batches=6, input_rows=40.00 K, peak_mem_used=1.20 M]
            :               SortPreservingMergeExec: [t1_id@1 ASC], metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=3]
-           :                 PgSearchScan: segments=2, query="all"
+           :                 PgSearchScan: segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :               SortPreservingMergeExec: [id@1 ASC], metrics=[output_rows=20.00 K, output_bytes=1113.3 KB, output_batches=3]
-           :                 PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[rows_pruned=0, rows_scanned=20.00 K]
+           :                 PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=20.00 K, output_bytes=566.4 KB, output_batches=4, rows_pruned=0, rows_scanned=20.00 K]
 (18 rows)
 
 -- Verify results
@@ -472,8 +472,8 @@ JOIN null_val_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val' OR t1.val IS NULL
 ORDER BY t1.val DESC NULLS FIRST, t1.id
 LIMIT 25;
-                                                                                                                                                                          QUERY PLAN                                                                                                                                                                          
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=25.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=25.00 loops=1)
          Relation Tree: t2 INNER t1
@@ -490,9 +490,9 @@ LIMIT 25;
            :             ProjectionExec: expr=[ctid_1@0 as ctid_1, id@1 as id, val@2 as val, ctid_0@3 as ctid_0], metrics=[output_rows=16.62 K, output_bytes=1292.9 KB, output_batches=3]
            :               SortMergeJoinExec: join_type=Inner, on=[(id@1, t1_id@1)], metrics=[output_rows=16.62 K, output_bytes=1472.6 KB, output_batches=3, spill_count=0, spilled_bytes=0.0 B, spilled_rows=0, input_batches=6, input_rows=36.62 K, peak_mem_used=524.9 K]
            :                 SortPreservingMergeExec: [id@1 ASC], metrics=[output_rows=16.62 K, output_bytes=925.4 KB, output_batches=3]
-           :                   PgSearchScan: segments=2, dynamic_filters=1, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[rows_pruned=3.38 K, rows_scanned=20.00 K]
+           :                   PgSearchScan: segments=2, dynamic_filters=1, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=16.62 K, output_bytes=471.9 KB, output_batches=4, rows_pruned=3.38 K, rows_scanned=20.00 K]
            :                 SortPreservingMergeExec: [t1_id@1 ASC], metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=3]
-           :                   PgSearchScan: segments=2, dynamic_filters=1, query="all", metrics=[rows_pruned=0, rows_scanned=20.00 K]
+           :                   PgSearchScan: segments=2, dynamic_filters=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4, rows_pruned=0, rows_scanned=20.00 K]
 (19 rows)
 
 SELECT t1.id, t1.val

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -164,9 +164,9 @@ LIMIT 3;
            :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=50, output_bytes=1450.0 B, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, build_mem_used=344, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[rows_pruned=50, rows_scanned=100]
+           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=50, rows_scanned=100]
 (16 rows)
 
 -- =============================================================================
@@ -670,9 +670,9 @@ LIMIT 5;
            :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=14.26 K, output_bytes=793.9 KB, output_batches=2]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=14.26 K, output_bytes=827.1 KB, output_batches=2, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=14.26 K, build_mem_used=228, avg_fanout=100% (14.26 K/14.26 K), probe_hit_rate=56% (14.26 K/25.52 K)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[rows_pruned=35.74 K, rows_scanned=50.00 K]
+           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=14.26 K, output_bytes=515.3 KB, output_batches=4, rows_pruned=35.74 K, rows_scanned=50.00 K]
 (16 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -165,9 +165,9 @@ LIMIT 3;
            :     VisibilityFilterExec: tables=[s, p], metrics=[output_rows=6, output_bytes=64.1 KB, output_batches=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, id@4], metrics=[output_rows=6, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=6, build_mem_used=20, avg_fanout=100% (6/6), probe_hit_rate=100% (6/6)]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=16.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[rows_pruned=24, rows_scanned=30]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=6, output_bytes=160.0 B, output_batches=1, rows_pruned=24, rows_scanned=30]
 (15 rows)
 
 -- =============================================================================
@@ -485,9 +485,9 @@ LIMIT 3;
            :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=70, output_bytes=2030.0 B, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, build_mem_used=424, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[rows_pruned=130, rows_scanned=200]
+           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=130, rows_scanned=200]
 (16 rows)
 
 SELECT f.id, f.title
@@ -532,9 +532,9 @@ LIMIT 3;
            :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=10, output_bytes=290.0 B, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, build_mem_used=105, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[rows_pruned=190, rows_scanned=200]
+           :             PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=190, rows_scanned=200]
 (16 rows)
 
 SELECT f.id, f.title


### PR DESCRIPTION
## What

Add BaselineMetrics to the PgSearch scan.

## Why

It gets us output rows/bytes/batches, and in VERBOSE mode it additionally captures elapsed cpu time of the node (not demonstrated in the regress output for obvious reasons).