### PR TITLE
fix: <Tantivy> Optimize single term BooleanQuery to use BMW

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "fd162e25a974daba1755a4dc3c024e390baa7a14", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "3d0b4607eb3162c736634eb8051859a08740ad6d", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.17.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "fd162e25a974daba1755a4dc3c024e390baa7a14" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "3d0b4607eb3162c736634eb8051859a08740ad6d" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-P5mL2iW9wzWM5S7ZTq7JFTD8Qvtug0CDAVnkDnSFuWI=";
+  cargoHash = "sha256-v4Dx04W/XiSfyPjCpSSvLqflHSHmxRnsn22VROg5oSA=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
https://github.com/paradedb/tantivy/commit/32c398897b4a15b0be3fb3ad73a80133459a4b14


> When there is a single term, delegate directly to the child weight's for_each_pruning. This ensures that a BooleanQuery 
wrapping a single TermQuery still benefits from block-max WAND pruning (via TermWeight::for_each_pruning), rather than falling through to the generic for_each_pruning_scorer loop.


