### PR TITLE
fix: <Tantivy> Tighten Block-Max in single-scorer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "fd162e25a974daba1755a4dc3c024e390baa7a14", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "bda3a507b062a05340a7952129295b973001f410", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.17.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "fd162e25a974daba1755a4dc3c024e390baa7a14" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "bda3a507b062a05340a7952129295b973001f410" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-P5mL2iW9wzWM5S7ZTq7JFTD8Qvtug0CDAVnkDnSFuWI=";
+  cargoHash = "sha256-v4Dx04W/XiSfyPjCpSSvLqflHSHmxRnsn22VROg5oSA=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
https://github.com/paradedb/tantivy/commit/ca2ee44f98a49c330007ff27f238afb2d099cccd

> In the Block-Max WAND single-scorer, it uses `block_max_score() < threshold`, whereas the multi-term one uses `block_max_score_upperbound <= threshold`.
> 
> As both of these are guarded later on with if s`core > threshold `we can use the more efficient form in single-scorer.
> 
> - [Single-scorer block skip (<, should be <=)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L231)
> - [Multi-scorer block skip (already <=)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L179)
> - [Single-scorer per-doc guard (>)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L246)
> - [Multi-scorer per-doc guard (>)](https://github.com/quickwit-oss/tantivy/blob/main/src/query/boolean_query/block_wand.rs#L206_)
>
> This will improve performance when there are many identical scores.
> 
