### PR TITLE
fix: convert fuzzy_data_roundtrip to #[pg_test]

### DIFF
--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -99,22 +99,6 @@ pub mod pdb {
         }
     }
 
-    #[test]
-    fn fuzzy_data_roundtrip() {
-        proptest::proptest!(|(distance in 0u8..=255u8, prefix in 0..=1, transposition_cost_one in 0..=1)| {
-            let original = FuzzyData {
-                distance,
-                prefix: prefix == 1,
-                transposition_cost_one: transposition_cost_one == 1,
-            };
-
-            let typmod_repr:i32 = original.clone().into();
-            assert!(typmod_repr >= 0);  // can't be negative
-            let from_typmod:FuzzyData = typmod_repr.into();
-            assert_eq!(original, from_typmod);
-        })
-    }
-
     #[derive(Debug, Deserialize, Serialize, Clone, PartialEq)]
     #[serde(rename_all = "snake_case")]
     pub struct SlopData {
@@ -2012,4 +1996,27 @@ fn exists(field: FieldName, searcher: &Searcher) -> Box<ExistsQuery> {
         .field_type()
         .is_json();
     Box::new(ExistsQuery::new(field.into_inner(), is_json))
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::pdb::FuzzyData;
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn fuzzy_data_roundtrip() {
+        proptest::proptest!(|(distance in 0u8..=255u8, prefix in 0..=1, transposition_cost_one in 0..=1)| {
+            let original = FuzzyData {
+                distance,
+                prefix: prefix == 1,
+                transposition_cost_one: transposition_cost_one == 1,
+            };
+
+            let typmod_repr: i32 = original.clone().into();
+            assert!(typmod_repr >= 0); // can't be negative
+            let from_typmod: FuzzyData = typmod_repr.into();
+            assert_eq!(original, from_typmod);
+        })
+    }
 }


### PR DESCRIPTION
## Summary

- Converts `fuzzy_data_roundtrip` in `pg_search/src/query/pdb_query.rs` from a regular `#[test]` to `#[pg_test]`, per upstream pgrx guidance on [pgcentralfoundation/pgrx#2229](https://github.com/pgcentralfoundation/pgrx/issues/2229).
- The test was the only `#[test]` in the crate living directly inside a `#[pg_schema]`-annotated pgrx module, i.e. "indirectly using a pgrx symbol."
- Moves it out of the inline `pub mod pdb` block into a dedicated `#[cfg(any(test, feature = "pg_test"))] #[pgrx::pg_schema] mod tests` block at the end of the file, matching the convention used elsewhere (e.g. `scan/visibility_ctid_resolver_rule.rs`).

Context: [#3715](https://github.com/paradedb/paradedb/issues/3715) — still relevant after the pgrx 0.18 upgrade. This PR is the cheap half of the guidance; the `OnceLock<BuildFilterQueryFn>` workaround for `FilterQuery` stays in place until upstream lands a fix.

## Test plan

- [x] `cargo check -p pg_search --tests` builds clean
- [x] `cargo check -p pg_search --features pg_test` builds clean
- [x] `cargo pgrx test` picks up `fuzzy_data_roundtrip` and it passes