### PR TITLE
fix: Fix issues with inline tokenizers on non-TEXT types

### DIFF
--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -24,7 +24,7 @@ use std::ffi::CStr;
 pub(crate) mod pdb {
     use crate::api::operator::{boost, const_score, fuzzy, slop};
     use crate::api::tokenizers::{
-        CowString, DatumWrapper, GenericTypeWrapper, JsonMarker, JsonbMarker, SqlNameMarker,
+        tokenize, DatumWrapper, GenericTypeWrapper, JsonMarker, JsonbMarker, SqlNameMarker,
         TextArrayMarker, UuidMarker, VarcharArrayMarker,
     };
     use macros::generate_tokenizer_sql;
@@ -71,7 +71,7 @@ pub(crate) mod pdb {
     /// data, along with proper cleanup when the wrapper is freed. This would make the wrapper
     /// fully self-contained and safe regardless of the input datum's lifetime.
     #[repr(C)]
-    pub struct AliasDatumWithType {
+    pub struct DatumWithType {
         vl_len_: i32,               // varlena header
         magic: u32,                 // magic number to identify wrapped datums
         typoid: pg_sys::Oid,        // original type OID
@@ -82,10 +82,10 @@ pub(crate) mod pdb {
     // PostgreSQL text values cannot contain embedded nulls, making false positives impossible
     const ALIAS_MAGIC: u32 = 0x414C0053; // 'A', 'L', 0x00, 'S'
 
-    impl AliasDatumWithType {
+    impl DatumWithType {
         unsafe fn new(datum: pg_sys::Datum, typoid: pg_sys::Oid) -> *mut Self {
-            let size = std::mem::size_of::<AliasDatumWithType>();
-            let ptr = pg_sys::palloc(size) as *mut AliasDatumWithType;
+            let size = std::mem::size_of::<DatumWithType>();
+            let ptr = pg_sys::palloc(size) as *mut DatumWithType;
 
             // Since pdb.alias is defined as LIKE = text, PostgreSQL treats it as a varlena
             // (variable-length) type. All varlena types must have a valid size header in the
@@ -110,29 +110,52 @@ pub(crate) mod pdb {
             ptr
         }
 
-        /// Check if a datum is a wrapped AliasDatumWithType by verifying size and magic number
+        /// Check if a datum is a wrapped DatumWithType by verifying size and magic number
         pub unsafe fn is_wrapped(wrapper: pg_sys::Datum) -> bool {
-            let ptr = wrapper.cast_mut_ptr::<AliasDatumWithType>();
+            let ptr = wrapper.cast_mut_ptr::<DatumWithType>();
             if ptr.is_null() {
                 return false;
             }
 
             let vl_len = pgrx::varlena::varsize_any(ptr.cast::<pg_sys::varlena>());
-            let expected_size = std::mem::size_of::<AliasDatumWithType>();
+            let expected_size = std::mem::size_of::<DatumWithType>();
 
             // Check both size AND magic number to avoid false positives
-            vl_len == expected_size && (*ptr).magic == ALIAS_MAGIC
+            // NOTE: if ptr is TEXT than ptr.magic could be unaligned
+            vl_len == expected_size
+                && ptr
+                    .byte_add(std::mem::offset_of!(DatumWithType, magic))
+                    .cast::<u32>()
+                    .read_unaligned()
+                    == ALIAS_MAGIC
         }
 
         pub unsafe fn extract_datum(wrapper: pg_sys::Datum) -> pg_sys::Datum {
-            let ptr = wrapper.cast_mut_ptr::<AliasDatumWithType>();
+            let ptr = wrapper.cast_mut_ptr::<DatumWithType>();
             (*ptr).datum_value
         }
 
-        unsafe fn extract_typoid(wrapper: pg_sys::Datum) -> pg_sys::Oid {
-            let ptr = wrapper.cast_mut_ptr::<AliasDatumWithType>();
+        pub unsafe fn extract_typoid(wrapper: pg_sys::Datum) -> pg_sys::Oid {
+            let ptr = wrapper.cast_mut_ptr::<DatumWithType>();
             (*ptr).typoid
         }
+    }
+
+    unsafe fn wrap_generic_type<InTy, InMarker, OutTy, OutMarker>(
+        input: GenericTypeWrapper<InTy, InMarker>,
+    ) -> GenericTypeWrapper<OutTy, OutMarker>
+    where
+        InTy: DatumWrapper,
+        OutTy: DatumWrapper,
+        InMarker: SqlNameMarker,
+        OutMarker: SqlNameMarker,
+    {
+        // Wrap datum and original typoid in a custom structure
+        let wrapper_ptr = unsafe { DatumWithType::new(input.datum, input.typoid) };
+
+        // Return the wrapper with the original typoid preserved
+        // This allows PostgreSQL to track array vs scalar types correctly
+        GenericTypeWrapper::new(pg_sys::Datum::from(wrapper_ptr), input.typoid)
     }
 
     macro_rules! cast_alias {
@@ -146,16 +169,11 @@ pub(crate) mod pdb {
 
                 #[pg_extern(immutable, parallel_safe, requires = [tokenize_alias])]
                 unsafe fn [<$fn_prefix _to_alias>](
-                    arr: GenericTypeWrapper<$rust_ty, [<$marker Marker>]>,
+                    mut arr: GenericTypeWrapper<$rust_ty, [<$marker Marker>]>,
                 ) -> GenericTypeWrapper<Alias, AliasMarker> {
-                    let original_typoid: pg_sys::Oid = $typoid;
-
-                    // Wrap datum and original typoid in a custom structure
-                    let wrapper_ptr = AliasDatumWithType::new(arr.datum, original_typoid);
-
-                    // Return the wrapper with the original typoid preserved
-                    // This allows PostgreSQL to track array vs scalar types correctly
-                    GenericTypeWrapper::new(pg_sys::Datum::from(wrapper_ptr), original_typoid)
+                    // TODO probably not needed but maintains old behavior
+                    arr.typoid = $typoid;
+                    wrap_generic_type(arr)
                 }
             }
         };
@@ -254,19 +272,7 @@ pub(crate) mod pdb {
                     super::super::apply_typmod(&mut tokenizer, typmod);
                 }
 
-                let mut analyzer = tokenizer
-                    .to_tantivy_tokenizer()
-                    .expect("failed to convert tokenizer to tantivy tokenizer");
-
-                let s = s.to_str();
-                let mut stream = analyzer.token_stream(&s);
-
-                let mut tokens = Vec::new();
-                while stream.advance() {
-                    let token = stream.token();
-                    tokens.push(token.text.to_string());
-                }
-                tokens
+                unsafe { tokenize(s, tokenizer) }
             }
 
             paste! {
@@ -299,35 +305,35 @@ pub(crate) mod pdb {
                 fn $json_cast_name(
                     json: GenericTypeWrapper<pgrx::Json, JsonMarker>,
                 ) -> GenericTypeWrapper<$rust_name, [<$rust_name JsonMarker>]> {
-                    GenericTypeWrapper::new(json.datum, json.typoid)
+                    unsafe { wrap_generic_type(json) }
                 }
 
                 #[pg_extern(immutable, parallel_safe, requires = [ $cast_name ])]
                 unsafe fn $jsonb_cast_name(
                     jsonb: GenericTypeWrapper<pgrx::JsonB, JsonbMarker>,
                 ) -> GenericTypeWrapper<$rust_name, [<$rust_name JsonbMarker>]> {
-                    GenericTypeWrapper::new(jsonb.datum, jsonb.typoid)
+                    unsafe { wrap_generic_type(jsonb) }
                 }
 
                 #[pg_extern(immutable, parallel_safe, requires = [ $cast_name ])]
                 unsafe fn $uuid_cast_name(
                     uuid: GenericTypeWrapper<pgrx::datum::Uuid, UuidMarker>,
                 ) -> GenericTypeWrapper<$rust_name, [<$rust_name UuidMarker>]> {
-                    GenericTypeWrapper::new(uuid.datum, uuid.typoid)
+                    unsafe { wrap_generic_type(uuid) }
                 }
 
                 #[pg_extern(immutable, parallel_safe, requires = [ $cast_name ])]
                 unsafe fn $text_array_cast_name(
                     arr: GenericTypeWrapper<Vec<String>, TextArrayMarker>,
                 ) -> GenericTypeWrapper<$rust_name, [<$rust_name TextArrayMarker>]> {
-                    GenericTypeWrapper::new(arr.datum, arr.typoid)
+                    unsafe { wrap_generic_type(arr) }
                 }
 
                 #[pg_extern(immutable, parallel_safe, requires = [ $cast_name ])]
                 unsafe fn $varchar_array_cast_name(
                     arr: GenericTypeWrapper<Vec<String>, VarcharArrayMarker>,
                 ) -> GenericTypeWrapper<$rust_name, [<$rust_name VarcharArrayMarker>]> {
-                    GenericTypeWrapper::new(arr.datum, arr.typoid)
+                    unsafe { wrap_generic_type(arr) }
                 }
 
                 #[pg_extern(immutable, parallel_safe, requires = [ $cast_name ])]
@@ -391,12 +397,12 @@ pub(crate) mod pdb {
         unsafe {
             let wrapper_datum = input.as_datum();
 
-            // Check if this is a wrapped AliasDatumWithType using magic number verification
+            // Check if this is a wrapped DatumWithType using magic number verification
             // For text literals, PostgreSQL might pass them directly without wrapping
             // due to LIKE = text in the type definition
-            if AliasDatumWithType::is_wrapped(wrapper_datum) {
-                let typoid = AliasDatumWithType::extract_typoid(wrapper_datum);
-                let original_datum = AliasDatumWithType::extract_datum(wrapper_datum);
+            if DatumWithType::is_wrapped(wrapper_datum) {
+                let typoid = DatumWithType::extract_typoid(wrapper_datum);
+                let original_datum = DatumWithType::extract_datum(wrapper_datum);
 
                 // Get the output function for the original type
                 let mut typoutput: pg_sys::Oid = pg_sys::InvalidOid;

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::api::tokenizers::definitions::pdb::DatumWithType;
 use crate::postgres::catalog::{
     is_citext_oid, lookup_type_category, lookup_type_name, lookup_typoid,
 };
@@ -24,7 +25,6 @@ use pgrx::pgrx_sql_entity_graph::metadata::{
     ArgumentError, ReturnsError, ReturnsRef, SqlMappingRef, SqlTranslatable, TypeOrigin,
 };
 use pgrx::{pg_sys, set_varsize_4b, FromDatum, IntoDatum};
-use std::borrow::Cow;
 use std::marker::PhantomData;
 use std::ptr::addr_of_mut;
 use tokenizers::chinese_convert::ConvertMode;
@@ -500,10 +500,6 @@ pub fn apply_typmod(tokenizer: &mut SearchTokenizer, typmod: Typmod) {
     }
 }
 
-pub trait CowString {
-    fn to_str(&self) -> Cow<'_, str>;
-}
-
 pub trait DatumWrapper {
     #[allow(dead_code)]
     fn from_datum(datum: pg_sys::Datum) -> Self;
@@ -550,24 +546,58 @@ pub trait DatumWrapper {
     }
 }
 
-impl<T: DatumWrapper> CowString for T {
-    fn to_str(&self) -> Cow<'_, str> {
-        unsafe {
-            let varlena = self.as_datum().cast_mut_ptr::<pg_sys::varlena>();
-            let detoasted = pg_sys::pg_detoast_datum(varlena);
+// SAFETY: to_tokenize must be raw text or a tokenizer type
+unsafe fn tokenize<T>(to_tokenize: T, tokenizer: SearchTokenizer) -> Vec<String>
+where
+    T: DatumWrapper,
+{
+    let mut analyzer = tokenizer
+        .to_tantivy_tokenizer()
+        .expect("failed to convert tokenizer to tantivy tokenizer");
 
-            let s = convert_varlena_to_str_memoized(detoasted);
-            if std::ptr::eq(detoasted, varlena) {
-                // wasn't toasted, can do zero-copy
-                Cow::Borrowed(s)
-            } else {
-                // was toasted, so copy to owned Rust string and free the detoasted memory
-                let s = s.to_string();
-                pg_sys::pfree(detoasted.cast());
-                Cow::Owned(s)
+    let wrapper_datum = to_tokenize.as_datum();
+    let mut tokens = Vec::new();
+    let mut tokenize = |s: &str| {
+        let mut stream = analyzer.token_stream(s);
+
+        while stream.advance() {
+            let token = stream.token();
+            tokens.push(token.text.to_string());
+        }
+    };
+
+    // Check if this is a wrapped DatumWithType using magic number verification
+    // For text literals, PostgreSQL might pass them directly without wrapping
+    // due to LIKE = text in the type definition
+    // TODO is the LIKE doing anything useful if conversion is effectively mandatory?
+    if !DatumWithType::is_wrapped(wrapper_datum) {
+        // Not wrapped, it's raw text (or null)
+        let varlena = wrapper_datum.cast_mut_ptr::<pg_sys::varlena>();
+        let detoasted = pg_sys::pg_detoast_datum(varlena);
+
+        let s = convert_varlena_to_str_memoized(detoasted);
+        tokenize(s);
+        return tokens;
+    }
+
+    let typoid = DatumWithType::extract_typoid(wrapper_datum);
+    let original_datum = DatumWithType::extract_datum(wrapper_datum);
+    match typoid {
+        pg_sys::TEXTARRAYOID | pg_sys::VARCHARARRAYOID => {
+            let strings = <Vec<String> as pgrx::FromDatum>::from_datum(original_datum, false)
+                .expect("must have data");
+            for s in strings {
+                tokenize(&s)
             }
         }
+
+        _ => pgrx::error!(
+            "cannot tokenize a {} inline",
+            lookup_type_name(typoid).unwrap_or_else(|| "<unknown>".to_string())
+        ),
     }
+
+    tokens
 }
 
 struct GenericTypeWrapper<Type: DatumWrapper, SqlName: SqlNameMarker> {
@@ -604,6 +634,8 @@ impl<Type: DatumWrapper, SqlName: SqlNameMarker> IntoDatum for GenericTypeWrappe
 }
 
 impl<Type: DatumWrapper, SqlName: SqlNameMarker> FromDatum for GenericTypeWrapper<Type, SqlName> {
+    const GET_TYPOID: bool = true;
+
     unsafe fn from_polymorphic_datum(
         datum: pg_sys::Datum,
         is_null: bool,

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::api::operator::row_expr_from_indexed_expr;
-use crate::api::tokenizers::definitions::pdb::AliasDatumWithType;
+use crate::api::tokenizers::definitions::pdb::DatumWithType;
 use crate::api::tokenizers::{
     type_can_be_tokenized, type_is_alias, type_is_tokenizer, AliasTypmod, UncheckedTypmod,
 };
@@ -785,10 +785,12 @@ pub unsafe fn row_to_search_document<'a>(
             continue;
         }
 
-        // For pdb.alias types, unwrap the datum first before any processing
-        // The AliasDatumWithType structure wraps the actual datum for all alias types
-        let actual_datum = if type_is_alias(pg_type.value()) {
-            unsafe { AliasDatumWithType::extract_datum(datum) }
+        // For pdb.alias/tokenizer types, unwrap the datum first before any processing
+        // The DatumWithType structure wraps the actual datum for all alias types
+        let actual_datum = if type_is_alias(pg_type.value())
+            || (type_is_tokenizer(pg_type.value()) && DatumWithType::is_wrapped(datum))
+        {
+            unsafe { DatumWithType::extract_datum(datum) }
         } else {
             datum
         };

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
@@ -76,3 +76,11 @@ SELECT 'this is a test. fn foo(arg: String) -> impl Foo<''a> { return 42; }'::pd
  {this,is,a,test,fn,foo,arg,string,impl,foo,a,return,42}
 (1 row)
 
+SELECT ARRAY['this is a test.', 'foo bar baz']::pdb.whitespace::text[];
+             array             
+-------------------------------
+ {this,is,a,test.,foo,bar,baz}
+(1 row)
+
+SELECT '"foo"'::jsonb::pdb.whitespace::text[];
+ERROR:  cannot tokenize a jsonb inline

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
@@ -1,3 +1,4 @@
+
 SELECT 'this is a test.'::pdb.chinese_compatible::text[];
 SELECT 'this is a test.'::pdb.literal::text[];
 SELECT 'this is a test.'::pdb.jieba::text[];
@@ -11,3 +12,7 @@ SELECT 'this is a test.'::pdb.simple::text[];
 SELECT 'this is a test.'::pdb.simple('stemmer=english')::text[];
 SELECT 'this is a test.'::pdb.whitespace::text[];
 SELECT 'this is a test. fn foo(arg: String) -> impl Foo<''a> { return 42; }'::pdb.source_code::text[];
+
+SELECT ARRAY['this is a test.', 'foo bar baz']::pdb.whitespace::text[];
+
+SELECT '"foo"'::jsonb::pdb.whitespace::text[];


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4797

## What

The old tokenization code was performing what was effectively a raw-pointer cast to TEXT, which did not have the correct behavior for non-TEXT types. This commit migrates the tokenization code to use the same polymorphic datum type that alias is using, and the tokenization code handle TEXT and TEXT arrays.

## Why

The old code would crash the DB when given properly crafted input.

## How

Gets the type's `Oid` when `GenericTypeWrapper` is read from fcinfo, and propagates it into `DatumWithType` when casted to a tokenizer type.

## Tests

`tokenizer-types-inline-tokenization.sql` tests both correct array behavior, and that a previously aborting cast now errors gracefully.