### PR TITLE
chore: Add 20m Stack Overflow dataset to benchmark CI and remove logs

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -294,22 +294,6 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
 
-      - name: Benchmark "stackoverflow" Dataset (10M)
-        if: >-
-          github.event_name != 'pull_request' ||
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow"]'), github.event.label.name)
-        uses: ./.github/actions/benchmark-queries
-        with:
-          mode: existing
-          dataset: stackoverflow
-          size: 10m
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
-
       - name: Benchmark "stackoverflow" Dataset (20M)
         if: >-
           github.event_name != 'pull_request' ||

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -52,7 +52,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
-        contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
+        contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
       )
     env:
       pg_version: 18
@@ -64,12 +64,11 @@ jobs:
         uses: actions-ecosystem/action-remove-labels@v1
         if: >-
           github.event_name == 'pull_request' &&
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
         with:
           labels: |
             benchmark
             benchmark-queries
-            benchmark-queries-logs
             benchmark-queries-stackoverflow
             benchmark-queries-docs
 
@@ -114,7 +113,7 @@ jobs:
       - name: Fetch the Latest Composite Actions
         if: >-
           github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
         uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
@@ -126,20 +125,20 @@ jobs:
       - name: Copy latest actions into place
         if: >-
           github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
         run: cp -rv actions-temp/.github/actions .github/
 
       - name: Cleanup temporary checkout
         if: >-
           github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
         run: rm -rf actions-temp
 
       # only fetch the latest from main when, essentially, we're merging to main.  otherwise, use whatever we checked out in the ref we're benchmarking
       - name: Fetch latest benchmark code, suites
         if: >-
           github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
+          !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow", "benchmark-queries-docs"]'), github.event.label.name)
         uses: ./.github/actions/benchmarks-from-main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -320,81 +319,6 @@ jobs:
           mode: existing
           dataset: stackoverflow
           size: 20m
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
-
-      - name: Benchmark "logs" Dataset (10K rows)
-        if: >-
-          github.event_name != 'pull_request' ||
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
-        uses: ./.github/actions/benchmark-queries
-        with:
-          dataset: logs
-          rows: 10000
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
-
-      - name: Benchmark "logs" Dataset (100K rows)
-        if: >-
-          github.event_name != 'pull_request' ||
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
-        uses: ./.github/actions/benchmark-queries
-        with:
-          dataset: logs
-          rows: 100000
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
-
-      - name: Benchmark "logs" Dataset (1M rows)
-        if: >-
-          github.event_name != 'pull_request' ||
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
-        uses: ./.github/actions/benchmark-queries
-        with:
-          dataset: logs
-          rows: 1000000
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
-
-      - name: Benchmark "logs" Dataset (10M rows)
-        if: >-
-          github.event_name != 'pull_request' ||
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
-        uses: ./.github/actions/benchmark-queries
-        with:
-          dataset: logs
-          rows: 10000000
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error || true }}
-
-      - name: Benchmark "logs" Dataset (100M rows)
-        if: >-
-          github.event_name != 'pull_request' ||
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-logs"]'), github.event.label.name)
-        uses: ./.github/actions/benchmark-queries
-        with:
-          dataset: logs
-          rows: 100000000
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -311,6 +311,22 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
 
+      - name: Benchmark "stackoverflow" Dataset (20M)
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-queries-stackoverflow"]'), github.event.label.name)
+        uses: ./.github/actions/benchmark-queries
+        with:
+          mode: existing
+          dataset: stackoverflow
+          size: 20m
+          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+          pr_label: ${{ steps.pr_label.outputs.result }}
+          fail_on_error: ${{ inputs.fail_on_error || true }}
+
       - name: Benchmark "logs" Dataset (10K rows)
         if: >-
           github.event_name != 'pull_request' ||


### PR DESCRIPTION
# Ticket(s) Closed

- Contributes to  #4782 

## What
Adds the 20m Stack Overflow dataset to benchmarking CI and removes all runs of the logs dataset. The 20m dataset is of a similar size to the 100m logs dataset, so we're covering similar ground with it.

The 20m SO dataset takes ~19 minutes to run in CI. (Though this will increase later once the docs queries are ported.)

## Why

## How

## Tests
