### PR TITLE
fix: Improve join planning warnings

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -204,7 +204,7 @@ struct BuiltJoinPath {
 ///
 /// `Quiet` is for the early "this isn't even a candidate join" gates;
 /// `Warn` is for validation failures past the "considered interesting"
-/// boundary, where we owe the planner a `NOTICE`.
+/// boundary, where we owe the planner a `WARNING`.
 enum JoinPathDecline {
     Quiet,
     Warn {
@@ -213,51 +213,32 @@ enum JoinPathDecline {
     },
 }
 
-/// Specific reason a `JoinPathDecline::Warn` was raised. Each variant maps
-/// 1:1 to a planner-warning message we used to emit inline.
-enum JoinDeclineReason {
-    NoEquiKeys,
-    UnsupportedJoinType(Vec<String>),
-    PrunedJoinKey,
-    ActivationFailed,
-    JoinLevelExtractionFailed,
-    OrderByUnavailable,
-    Other(String),
+/// Specific reason a `JoinPathDecline::Warn` was raised. Wraps a specific
+/// warning message and any optional details (e.g., unsupported join types)
+/// to be emitted as a planner warning.
+pub struct JoinDeclineReason {
+    message: String,
+    details: Option<Vec<String>>,
 }
 
 impl JoinDeclineReason {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            details: None,
+        }
+    }
+
+    pub fn with_details(mut self, details: Vec<String>) -> Self {
+        self.details = Some(details);
+        self
+    }
+
     fn emit(&self, aliases: &[String]) {
-        match self {
-            JoinDeclineReason::NoEquiKeys => JoinScan::add_planner_warning(
-                "JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required",
-                aliases,
-            ),
-            JoinDeclineReason::UnsupportedJoinType(types) => {
-                JoinScan::add_detailed_planner_warning(
-                    "JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported",
-                    aliases,
-                    types.clone(),
-                )
-            }
-            JoinDeclineReason::PrunedJoinKey => JoinScan::add_planner_warning(
-                "JoinScan not used: a semi/anti join prunes columns required by an outer join key and no equivalent output-visible column was found",
-                aliases,
-            ),
-            JoinDeclineReason::ActivationFailed => JoinScan::add_planner_warning(
-                "JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates)",
-                aliases,
-            ),
-            JoinDeclineReason::JoinLevelExtractionFailed => JoinScan::add_planner_warning(
-                "JoinScan not used: failed to extract join-level conditions (ensure all referenced columns are fast fields)",
-                aliases,
-            ),
-            JoinDeclineReason::OrderByUnavailable => JoinScan::add_planner_warning(
-                "JoinScan not used: ORDER BY column is not available in the joined output schema",
-                aliases,
-            ),
-            JoinDeclineReason::Other(msg) => {
-                JoinScan::add_planner_warning(msg.clone(), ());
-            }
+        if let Some(details) = &self.details {
+            JoinScan::add_detailed_planner_warning(&self.message, aliases, details.clone());
+        } else {
+            JoinScan::add_planner_warning(&self.message, aliases);
         }
     }
 }
@@ -343,7 +324,7 @@ fn walk_relnode_for_subplan_ids(node: &RelNode, ids: &mut HashSet<i32>) {
 unsafe fn is_limit_pushdown_safe(
     root: *mut pg_sys::PlannerInfo,
     join_clause: &JoinCSClause,
-) -> bool {
+) -> Result<(), JoinDeclineReason> {
     let absorbed_rtis: Vec<pg_sys::Index> = join_clause
         .plan
         .sources()
@@ -362,7 +343,9 @@ unsafe fn is_limit_pushdown_safe(
         absorbed_bms = pg_sys::bms_add_member(absorbed_bms, *rti as i32);
     }
     if !pg_sys::bms_is_subset(all_rels, absorbed_bms) {
-        return false;
+        return Err(JoinDeclineReason::new(
+            "JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations",
+        ));
     }
 
     // 2. Every SubPlan in baserestrictinfo must have been absorbed.
@@ -370,7 +353,9 @@ unsafe fn is_limit_pushdown_safe(
     let absorbed_subplan_ids = collect_absorbed_subplan_ids(&join_clause.plan);
     for id in &all_subplan_ids {
         if !absorbed_subplan_ids.contains(id) {
-            return false;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed SubPlans",
+            ));
         }
     }
 
@@ -381,14 +366,15 @@ unsafe fn is_limit_pushdown_safe(
         for ri in ri_list.iter_ptr() {
             let clause = (*ri).clause as *mut pg_sys::Node;
             if pg_sys::contain_volatile_functions(clause) {
-                return false;
+                return Err(JoinDeclineReason::new(
+                    "JoinScan not used: LIMIT pushdown is unsafe due to volatile functions",
+                ));
             }
         }
     }
 
-    true
+    Ok(())
 }
-
 /// Try to create JoinScan `CustomPath`s for a single base relation that contains
 /// SubPlan-based join opportunities (e.g. `col IN (SELECT ...) OR col IS NULL`).
 ///
@@ -459,9 +445,20 @@ pub unsafe fn try_create_subplan_join_paths(
     // Phase 1: validate + build JoinCSClause.
     let has_distinct = !(*(*root).parse).distinctClause.is_null();
     let (join_clause, limit_offset) =
-        match JoinScan::validate_and_build_clause(root, plan, &join_keys, has_distinct) {
-            Some(res) => res,
-            None => return Vec::new(),
+        match JoinScan::validate_and_build_clause(root, &plan, &join_keys, has_distinct) {
+            Ok(res) => res,
+            Err(reason) => {
+                let aliases: Vec<String> = plan
+                    .sources()
+                    .iter()
+                    .map(|s| {
+                        RelationAlias::new(s.scan_info.alias.as_deref())
+                            .warning_context(s.scan_info.heaprelid)
+                    })
+                    .collect();
+                reason.emit(&aliases);
+                return Vec::new();
+            }
         };
 
     // No join-level predicate extraction needed for SubPlan-based paths.
@@ -477,15 +474,15 @@ impl JoinScan {
     /// Phase 1: Validate a `RelNode` plan against JoinScan activation requirements
     /// and build a `JoinCSClause` with score bubbling and partitioning applied.
     ///
-    /// Returns `None` if any activation check fails. The caller can then optionally
-    /// perform join-level predicate extraction on the returned clause before
-    /// passing it to [`finalize_clause_into_path`].
+    /// Returns `Err` with a descriptive message if any activation check fails.
+    /// The caller can then optionally perform join-level predicate extraction on
+    /// the returned clause before passing it to [`finalize_clause_into_path`].
     unsafe fn validate_and_build_clause(
         root: *mut pg_sys::PlannerInfo,
-        plan: RelNode,
+        plan: &RelNode,
         join_keys: &[build::JoinKeyPair],
         has_distinct: bool,
-    ) -> Option<(JoinCSClause, LimitOffset)> {
+    ) -> Result<(JoinCSClause, LimitOffset), JoinDeclineReason> {
         let all_sources = plan.sources();
 
         // --- Activation checks ---
@@ -497,11 +494,15 @@ impl JoinScan {
             .iter()
             .any(|s| s.scan_info.indexrelid == pg_sys::InvalidOid)
         {
-            return None;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: at least one relation lacks a BM25 index",
+            ));
         }
 
         if (*(*root).parse).hasAggs {
-            return None;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: aggregates are not supported",
+            ));
         }
 
         // Require LIMIT for top-level queries (without it, JoinScan's TopK
@@ -510,7 +511,9 @@ impl JoinScan {
         let limit_offset = LimitOffset::from_root(root);
         let is_subquery = !(*root).parent_root.is_null();
         if limit_offset.limit.is_none() && !is_subquery {
-            return None;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: LIMIT is required for top-level queries",
+            ));
         }
 
         // Empty join_keys are normally a rejection, but a disjunctive Semi/Anti
@@ -524,15 +527,21 @@ impl JoinScan {
             RelNode::Join(j) if matches!(j.join_type, build::JoinType::Semi | build::JoinType::Anti)
         );
         if join_keys.is_empty() && !root_is_semi_anti {
-            return None;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required",
+            ));
         }
 
         if has_distinct && distinct_columns_are_fast_fields(root, &all_sources).is_none() {
-            return None;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: DISTINCT columns must be fast fields",
+            ));
         }
 
         if !order_by_columns_are_fast_fields(root, &all_sources, has_distinct) {
-            return None;
+            return Err(JoinDeclineReason::new(
+                "JoinScan not used: ORDER BY columns must be fast fields",
+            ));
         }
 
         for jk in join_keys {
@@ -553,16 +562,22 @@ impl JoinScan {
                         )
                         .is_none()
                     {
-                        return None;
+                        return Err(JoinDeclineReason::new(
+                            "JoinScan not used: join keys must be fast fields",
+                        ));
                     }
                 }
-                _ => return None,
+                _ => {
+                    return Err(JoinDeclineReason::new(
+                        "JoinScan not used: failed to resolve join keys to base relations",
+                    ))
+                }
             }
         }
 
         // --- Build JoinCSClause ---
 
-        let mut join_clause = JoinCSClause::new(plan)
+        let mut join_clause = JoinCSClause::new(plan.clone())
             .with_limit(limit_offset.limit)
             .with_offset(limit_offset.offset)
             .with_distinct(has_distinct);
@@ -589,25 +604,11 @@ impl JoinScan {
 
         // Safety check: bail out if LIMIT pushdown is unsafe due to
         // un-absorbed relations, un-absorbed SubPlans, or volatile functions.
-        if join_clause.limit_offset.limit.is_some() && !is_limit_pushdown_safe(root, &join_clause) {
-            let aliases: Vec<String> = join_clause
-                .plan
-                .sources()
-                .iter()
-                .map(|s| {
-                    RelationAlias::new(s.scan_info.alias.as_deref())
-                        .warning_context(s.scan_info.heaprelid)
-                })
-                .collect();
-            JoinScan::add_planner_warning(
-                "JoinScan not used: LIMIT pushdown unsafe (un-absorbed \
-                 relations, SubPlans, or volatile functions)",
-                &aliases,
-            );
-            return None;
+        if join_clause.limit_offset.limit.is_some() {
+            is_limit_pushdown_safe(root, &join_clause)?;
         }
 
-        Some((join_clause, limit_offset))
+        Ok((join_clause, limit_offset))
     }
 
     /// Phase 2: Finalize a validated `JoinCSClause` into a `CustomPath` by
@@ -1740,26 +1741,35 @@ impl JoinScan {
             collect_join_sources(root, innerrel).ok_or(JoinPathDecline::Quiet)?;
         join_keys.extend(inner_keys);
 
-        let mut all_sources = outer_node.sources();
-        all_sources.extend(inner_node.sources());
+        let aliases: Vec<String> = {
+            let mut all_sources = outer_node.sources();
+            all_sources.extend(inner_node.sources());
+            all_sources
+                .iter()
+                .map(|s| {
+                    RelationAlias::new(s.scan_info.alias.as_deref())
+                        .warning_context(s.scan_info.heaprelid)
+                })
+                .collect()
+        };
 
-        let aliases: Vec<String> = all_sources
-            .iter()
-            .map(|s| {
-                RelationAlias::new(s.scan_info.alias.as_deref())
-                    .warning_context(s.scan_info.heaprelid)
-            })
-            .collect();
-
-        let join_conditions = extract_join_conditions(extra, &all_sources);
+        let join_conditions = {
+            let mut all_sources = outer_node.sources();
+            all_sources.extend(inner_node.sources());
+            extract_join_conditions(extra, &all_sources)
+        };
 
         // The minimum requirement for considering the join scan is that a
         // search predicate is used — either in a source or in a join-level
         // condition. Below this gate, every Err carries a planner warning.
-        if !all_sources.iter().any(|s| s.scan_info.has_search_predicate)
-            && !join_conditions.has_search_predicate
         {
-            return Err(JoinPathDecline::Quiet);
+            let mut all_sources = outer_node.sources();
+            all_sources.extend(inner_node.sources());
+            if !all_sources.iter().any(|s| s.scan_info.has_search_predicate)
+                && !join_conditions.has_search_predicate
+            {
+                return Err(JoinPathDecline::Quiet);
+            }
         }
 
         let warn = |reason| JoinPathDecline::Warn {
@@ -1777,13 +1787,15 @@ impl JoinScan {
         );
         let has_other_conditions = !join_conditions.other_conditions.is_empty();
         if join_conditions.equi_keys.is_empty() && !(is_semi_anti && has_other_conditions) {
-            return Err(warn(JoinDeclineReason::NoEquiKeys));
+            return Err(warn(JoinDeclineReason::new(
+                "JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required",
+            )));
         }
 
         join_keys.extend(join_conditions.equi_keys.clone());
 
         let parsed_jointype = build::JoinType::try_from(jointype)
-            .map_err(|e| warn(JoinDeclineReason::Other(e.to_string())))?;
+            .map_err(|e| warn(JoinDeclineReason::new(e.to_string())))?;
 
         // For Semi/Anti with additional conditions that cannot ride the
         // MultiTablePredicate pipeline (setrefs would fail to resolve inner-side
@@ -1853,7 +1865,9 @@ impl JoinScan {
         if try_absorb_disjunction
             && (initial_filter.is_none() || !remaining_other_conditions.is_empty())
         {
-            return Err(warn(JoinDeclineReason::NoEquiKeys));
+            return Err(warn(JoinDeclineReason::new(
+                "JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required",
+            )));
         }
 
         let mut plan = RelNode::Join(Box::new(build::JoinNode {
@@ -1867,24 +1881,30 @@ impl JoinScan {
 
         let unsupported = plan.unsupported_join_types();
         if !unsupported.is_empty() {
-            return Err(warn(JoinDeclineReason::UnsupportedJoinType(
-                unsupported
-                    .iter()
-                    .map(|t| t.to_string().to_uppercase())
-                    .collect(),
-            )));
+            return Err(warn(
+                JoinDeclineReason::new(
+                    "JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported",
+                )
+                .with_details(
+                    unsupported
+                        .iter()
+                        .map(|t| t.to_string().to_uppercase())
+                        .collect(),
+                ),
+            ));
         }
 
         if !plan.rewrite_pruned_join_keys(root) {
-            return Err(warn(JoinDeclineReason::PrunedJoinKey));
+            return Err(warn(JoinDeclineReason::new(
+                "JoinScan not used: a semi/anti join prunes columns required by an outer join key and no equivalent output-visible column was found",
+            )));
         }
 
         let has_distinct = !(*(*root).parse).distinctClause.is_null();
 
         // Phase 1: shared activation checks + JoinCSClause construction.
         let (mut join_clause, limit_offset) =
-            Self::validate_and_build_clause(root, plan, &join_keys, has_distinct)
-                .ok_or_else(|| warn(JoinDeclineReason::ActivationFailed))?;
+            Self::validate_and_build_clause(root, &plan, &join_keys, has_distinct).map_err(warn)?;
 
         // --- Join-level predicate extraction (join-hook specific) ---
         // This builds an expression tree that can reference:
@@ -1902,7 +1922,11 @@ impl JoinScan {
             &remaining_other_conditions,
             join_clause.clone(),
         )
-        .map_err(|_| warn(JoinDeclineReason::JoinLevelExtractionFailed))?;
+        .map_err(|_| {
+            warn(JoinDeclineReason::new(
+                "JoinScan not used: failed to extract join-level conditions (ensure all referenced columns are fast fields)",
+            ))
+        })?;
         join_clause = join_clause_updated;
 
         // Post-extraction check: need at least one side predicate OR join-level predicates.
@@ -1926,7 +1950,11 @@ impl JoinScan {
             &limit_offset,
             consider_parallel,
         )
-        .ok_or_else(|| warn(JoinDeclineReason::OrderByUnavailable))?;
+        .ok_or_else(|| {
+            warn(JoinDeclineReason::new(
+                "JoinScan not used: ORDER BY column is not available in the joined output schema",
+            ))
+        })?;
 
         Ok(BuiltJoinPath {
             path,

--- a/pg_search/tests/pg_regress/expected/issue_4529.out
+++ b/pg_search/tests/pg_regress/expected/issue_4529.out
@@ -102,7 +102,7 @@ JOIN typmod_suppliers s ON p.supplier_id = s.id
 WHERE p.description === 'widget'
 ORDER BY s.name
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: DISTINCT columns must be fast fields (tables: p, s)
                                                                QUERY PLAN                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -128,7 +128,7 @@ JOIN typmod_suppliers s ON p.supplier_id = s.id
 WHERE p.description === 'widget'
 ORDER BY s.name
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: DISTINCT columns must be fast fields (tables: p, s)
  name  
 -------
  Alpha

--- a/pg_search/tests/pg_regress/expected/issue_4667.out
+++ b/pg_search/tests/pg_regress/expected/issue_4667.out
@@ -100,6 +100,7 @@ FROM people AS p
 WHERE p.id @@@ pdb.all()
 AND p.seniority_slug IN ('manager', 'director')
 AND (p.company_id IS NULL OR p.company_id IN (SELECT c.id FROM companies AS c));
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: c, p)
                                                                                                                        QUERY PLAN                                                                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique
@@ -127,6 +128,7 @@ FROM people AS p
 WHERE p.id @@@ pdb.all()
 AND p.seniority_slug IN ('manager', 'director')
 AND (p.company_id IS NULL OR p.company_id IN (SELECT c.id FROM companies AS c));
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: c, p)
  id | nameIsNull 
 ----+------------
   1 | f

--- a/pg_search/tests/pg_regress/expected/join_basic.out
+++ b/pg_search/tests/pg_regress/expected/join_basic.out
@@ -60,7 +60,7 @@ FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, s)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -536,7 +536,7 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: DISTINCT columns must be fast fields (tables: p, s)
                                                                                       QUERY PLAN                                                                                       
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -574,7 +574,7 @@ FROM dist_products p
          JOIN dist_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
     LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, s)
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -608,7 +608,7 @@ FROM dist_products p
          JOIN dist_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
     LIMIT 3;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, s)
  count 
 -------
      5
@@ -627,7 +627,7 @@ FROM dist_products p
          JOIN dist_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, s)
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Unique

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -1083,7 +1083,7 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: DISTINCT columns must be fast fields (tables: p, s)
                                                                                     QUERY PLAN                                                                                     
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -1114,7 +1114,7 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: DISTINCT columns must be fast fields (tables: p, s)
  supplier_json |      name       
 ---------------+-----------------
  "TechCorp"    | 

--- a/pg_search/tests/pg_regress/expected/join_execution_limits.out
+++ b/pg_search/tests/pg_regress/expected/join_execution_limits.out
@@ -125,7 +125,7 @@ FROM mem_test_products p
 JOIN mem_test_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 LIMIT 100;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, s)
  match_count 
 -------------
          166
@@ -183,7 +183,7 @@ FROM large_items li
 JOIN large_categories lc ON li.category_id = lc.id
 WHERE li.content @@@ 'wireless'
 LIMIT 500;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: lc, li)
+WARNING:  JoinScan not used: aggregates are not supported (tables: lc, li)
  wireless_count 
 ----------------
             200
@@ -453,7 +453,7 @@ SELECT COUNT(*) AS wireless_count
 FROM hint_test_products hp
 JOIN hint_test_categories hc ON hp.category_id = hc.id
 WHERE hp.description @@@ 'wireless';
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: hc, hp)
+WARNING:  JoinScan not used: aggregates are not supported (tables: hc, hp)
  wireless_count 
 ----------------
              66

--- a/pg_search/tests/pg_regress/expected/join_multi_table.out
+++ b/pg_search/tests/pg_regress/expected/join_multi_table.out
@@ -85,8 +85,8 @@ JOIN categories c ON p.category_id = c.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 5;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: p, s)
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p, s)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: p, s)
+WARNING:  JoinScan not used: join keys must be fast fields (tables: c, p, s)
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -124,8 +124,8 @@ JOIN categories c ON p.category_id = c.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 5;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: p, s)
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p, s)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: p, s)
+WARNING:  JoinScan not used: join keys must be fast fields (tables: c, p, s)
  id  |      name      | supplier_name | category_name 
 -----+----------------+---------------+---------------
  201 | Wireless Mouse | TechCorp      | Electronics
@@ -165,7 +165,7 @@ FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless' OR s.contact_info @@@ 'wireless'
 ORDER BY p.id;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, s)
  id  |      name      | supplier_name 
 -----+----------------+---------------
  201 | Wireless Mouse | TechCorp

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -661,7 +661,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 1 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: c, fr)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -703,7 +703,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY 0 - c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: c, fr)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -745,7 +745,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: c, fr)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -842,7 +842,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0::bigint DESC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, fr)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: c, fr)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/pg_search/tests/pg_regress/expected/join_outer_pathkey.out
+++ b/pg_search/tests/pg_regress/expected/join_outer_pathkey.out
@@ -139,8 +139,7 @@ WHERE c.name @@@ 'Acme OR Globex'
 AND p.description @@@ 'widget OR gadget OR gizmo'
 ORDER BY cat.category_name, p.id
 LIMIT 5;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: c, p)
                                                                                                QUERY PLAN                                                                                               
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -176,8 +175,7 @@ WHERE c.name @@@ 'Acme OR Globex'
 AND p.description @@@ 'widget OR gadget OR gizmo'
 ORDER BY cat.category_name, p.id
 LIMIT 5;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: c, p)
  id  |  description  | category_name 
 -----+---------------+---------------
  100 | A fine widget | Electronics

--- a/pg_search/tests/pg_regress/expected/join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/join_predicates.out
@@ -169,7 +169,7 @@ FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless' OR s.contact_info @@@ 'wireless'
 ORDER BY p.id;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, s)
  id  |      name      | supplier_name 
 -----+----------------+---------------
  201 | Wireless Mouse | TechCorp

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -168,7 +168,7 @@ AND id NOT IN (
 AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: table_a, table_b)
+WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
                                                                                       QUERY PLAN                                                                                      
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -218,7 +218,7 @@ AND id NOT IN (
 AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: table_a, table_b)
+WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
  id  |    category     
 -----+-----------------

--- a/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_sortby_score.out
@@ -86,7 +86,7 @@ WHERE documents.parents @@@ 'project alpha'
   AND pages.content @@@ 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: documents, files, pages)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: documents, files, pages)
                                                                                                                                                QUERY PLAN                                                                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -136,7 +136,7 @@ WHERE documents.parents @@@ 'project alpha'
   AND pages.content @@@ 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: documents, files, pages)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: documents, files, pages)
   id   |       parents       |           content            |   title   |   id   | documentId |        content         |        title        |   id   | fileId |              content              | title  |   score   
 -------+---------------------+------------------------------+-----------+--------+------------+------------------------+---------------------+--------+--------+-----------------------------------+--------+-----------
  doc-1 | project alpha notes | Document about project alpha | Alpha Doc | file-1 | doc-1      | File content for alpha | collab12 alpha file | page-1 | file-1 | Single Number Reach configuration | Page A | 3.2872329

--- a/pg_search/tests/pg_regress/expected/limit_pushdown_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/limit_pushdown_joinscan.out
@@ -149,8 +149,7 @@ SELECT count(*) FROM (
     ORDER BY c.id ASC
     LIMIT 26
 ) sub;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: c, p)
  count 
 -------
     26
@@ -171,8 +170,7 @@ SELECT count(*) FROM (
     ORDER BY c.id ASC
     LIMIT 26
 ) sub;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: c, p)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed SubPlans (tables: c, p)
  count 
 -------
     26
@@ -253,7 +251,7 @@ SELECT count(*) FROM (
     ORDER BY p.id DESC
     LIMIT 26
 ) sub;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: c, p)
  count 
 -------
     26
@@ -275,7 +273,7 @@ WHERE p.id @@@ paradedb.all()
        ))
 ORDER BY p.id DESC
 LIMIT 26;
-WARNING:  JoinScan not used: LIMIT pushdown unsafe (un-absorbed relations, SubPlans, or volatile functions) (tables: c, p)
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: c, p)
                                                                                                                     QUERY PLAN                                                                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -291,7 +291,7 @@ WHERE f.document_id IN (
     SELECT d.id FROM stk_documents d WHERE d.category @@@ 'PROJECT_ALPHA'
 )
 ORDER BY f.title ASC;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: d, f)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, f)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -375,7 +375,7 @@ FROM expr_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY upper(p.category) ASC
     LIMIT 5;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: p, s)
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -406,7 +406,7 @@ FROM expr_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY upper(p.category) ASC
     LIMIT 5;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: p, s)
        name       | supplier_name 
 ------------------+---------------
  Mouse Pad        | CableCo

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -367,7 +367,7 @@ FROM products p
 JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'premium'
 ORDER BY p.id;
-WARNING:  JoinScan not used: activation checks failed (LIMIT / BM25 index / fast fields / aggregates) (tables: p, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, s)
                                                                              QUERY PLAN                                                                             
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort


### PR DESCRIPTION
## What

Convert `JoinDeclineReason` into a struct, and provide ~8 more descriptive planning failure cases.

## Why

To ensure that we get useful warnings for join planning failures.

The `JoinDeclineReason` didn't need to be `enum`: being an enum meant that every new return point in every function needed a unique enum value. While it is still possible for the reason for a return to accidentally be duplicated, that is obvious locally as an error, where the message is not descriptive enough relative to nearby errors.