### PR TITLE
feat(mpp): JoinScan MPP activation (A/4)

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/distinct_parent_sort.sql
@@ -29,3 +29,18 @@ WHERE
 ORDER BY
     d.title ASC                     -- Single Feature Sort (Parent Field)
 LIMIT 50;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '64MB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT DISTINCT
+    d.id,
+    d.title,
+    d.parents
+FROM documents d
+JOIN files f ON d.id = f."documentId"
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    p."sizeInBytes" > 5000            -- Filter on the "Many" side
+    AND d.parents ||| 'parent group'
+ORDER BY
+    d.title ASC                     -- Single Feature Sort (Parent Field)
+LIMIT 50;

--- a/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
@@ -31,3 +31,19 @@ WHERE
 ORDER BY
     f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
 LIMIT 20;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt",
+    d.title as document_title,
+    d.parents as document_parents
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents ||| 'parent group'
+    AND f.title ||| 'collab12'
+ORDER BY
+    f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
+LIMIT 20;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-large.sql
@@ -15,3 +15,12 @@ FROM
 WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 LIMIT 5;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+  *
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+LIMIT 5;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-no-scores-small.sql
@@ -19,3 +19,14 @@ FROM
 WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 LIMIT 5;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+  documents.id,
+  files.id,
+  pages.id
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+LIMIT 5;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-large.sql
@@ -55,3 +55,14 @@ WHERE
   documents.parents ||| 'project alpha' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+  *,
+  pdb.score(documents.id) + pdb.score(files.id) + pdb.score(pages.id) AS score
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'project alpha' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;

--- a/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/hierarchical_content-scores-small.sql
@@ -23,3 +23,16 @@ WHERE
   documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
 ORDER BY score DESC
 LIMIT 1000;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+  documents.id,
+  files.id,
+  pages.id,
+  pdb.score(documents.id) + pdb.score(files.id) + pdb.score(pages.id) AS score
+FROM
+  documents JOIN files ON documents.id = files."documentId" JOIN pages ON pages."fileId" = files.id
+WHERE
+  documents.parents ||| 'parent group' AND files.title ||| 'collab12' AND pages."content" ||| 'Single Number Reach'
+ORDER BY score DESC
+LIMIT 1000;

--- a/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
@@ -27,3 +27,17 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    pdb.score(f.id) as relevance
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    f.title ||| 'File'              -- Driving the Sort (Single Feature)
+    AND d.parents ||| 'parent group'
+ORDER BY
+    relevance DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -82,3 +82,20 @@ WHERE
 ORDER BY
     f.title ASC
 LIMIT 25;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt"
+FROM files f
+WHERE
+    f."documentId" IN (
+        SELECT id
+        FROM documents
+        WHERE parents ||| 'PROJECT_ALPHA'
+        AND title ||| 'Document Title 1'
+    )
+ORDER BY
+    f.title ASC
+LIMIT 25;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -647,6 +647,22 @@ impl JoinScan {
             0
         };
 
+        // When MPP is active for a binary join (the JoinOnly shape), PG's
+        // worker count must match `mpp_worker_count - 1`. Otherwise PG
+        // launches workers whose `ParallelWorkerNumber` exceeds
+        // `total_participants - 1`, and `worker_init_dsm` errors with
+        // "participant_index out of range". Mirrors the AggregateScan MPP
+        // path's `maybe_flip_mpp_parallel`.
+        let nworkers = if nworkers > 0
+            && join_clause.plan.sources().len() == 2
+            && crate::postgres::customscan::mpp::customscan_glue::mpp_is_active()
+        {
+            let n = crate::postgres::customscan::mpp::customscan_glue::mpp_worker_count() as usize;
+            n.saturating_sub(1).max(1)
+        } else {
+            nworkers
+        };
+
         if nworkers > 0 {
             let processes = std::cmp::max(
                 1,
@@ -727,9 +743,187 @@ impl ParallelQueryCapable for JoinScan {
         state: &mut CustomScanStateWrapper<Self>,
         _pcxt: *mut pg_sys::ParallelContext,
     ) -> pg_sys::Size {
-        // Size DSM from actual execution-time segment counts (via manifests) rather
-        // than planning-time scan_info.segment_count, which can diverge under
-        // concurrent inserts.
+        // MPP branch: when `begin_custom_scan` classified this query as
+        // JoinOnly and serialized the broadcast plan, we size DSM for the
+        // MPP mesh instead of the broadcast-join `ParallelScanState`. PG
+        // hands us one coordinate region; MPP and broadcast-join layouts
+        // are incompatible in it, so this is an OR choice.
+        if let Some(shape) = state.custom_state().mpp_shape {
+            let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+                crate::mpp_log!(
+                    "mpp: JoinScan::estimate_dsm_custom_scan but logical_plan_bytes is None; \
+                     falling back to non-MPP sizing"
+                );
+                return Self::estimate_broadcast_dsm(state);
+            };
+            let num_meshes = crate::postgres::customscan::mpp::shape::shuffles_required(shape);
+            if num_meshes == 0 {
+                return Self::estimate_broadcast_dsm(state);
+            }
+            return match crate::postgres::customscan::mpp::customscan_glue::leader_estimate_dsm(
+                plan_bytes.len(),
+                num_meshes,
+            ) {
+                Ok(sz) => sz,
+                Err(e) => {
+                    crate::mpp_log!(
+                        "mpp: JoinScan leader_estimate_dsm failed: {e}; falling back to non-MPP"
+                    );
+                    Self::estimate_broadcast_dsm(state)
+                }
+            };
+        }
+
+        Self::estimate_broadcast_dsm(state)
+    }
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        // MPP branch mirrors AggregateScan::initialize_dsm_custom_scan.
+        if let Some(shape) = state.custom_state().mpp_shape {
+            debug_assert!(state.custom_state().mpp_state.is_none());
+            if coordinate.is_null() {
+                // `estimate_dsm` returned 0 (plan bytes unavailable) — PG
+                // hands us NULL. Silently fall back to non-MPP.
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            }
+            let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            };
+            let plan_bytes = plan_bytes.to_vec();
+            let num_meshes = crate::postgres::customscan::mpp::shape::shuffles_required(shape);
+            if num_meshes == 0 {
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            }
+            let seg = unsafe { (*pcxt).seg };
+            let ctx = unsafe {
+                crate::postgres::customscan::mpp::customscan_glue::leader_init_dsm(
+                    coordinate, plan_bytes, num_meshes, seg,
+                )
+            };
+            match ctx {
+                Ok(leader_ctx) => {
+                    crate::mpp_log!(
+                        "mpp: JoinScan leader initialized DSM for {} participants (shape={:?})",
+                        leader_ctx.participant_config().total_participants,
+                        shape,
+                    );
+                    state.custom_state_mut().mpp_state = Some(leader_ctx);
+                }
+                Err(e) => {
+                    // Partial-init leaves DSM in undefined state — fail
+                    // loudly, same rationale as AggregateScan.
+                    pgrx::error!("mpp: JoinScan leader_init_dsm failed: {e}");
+                }
+            }
+            return;
+        }
+
+        Self::initialize_broadcast_dsm(state, coordinate);
+    }
+
+    fn reinitialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        // MPP rescan is out of scope in Phase 5; the non-MPP path resets
+        // the broadcast-join `ParallelScanState` as before.
+        if state.custom_state().mpp_shape.is_some() {
+            // No-op: a rescanned MPP join would need a full mesh teardown
+            // + rebuild, same gap AggregateScan leaves.
+            return;
+        }
+        let pscan_state = coordinate.cast::<ParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+        unsafe {
+            (*pscan_state).reset();
+        }
+    }
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _toc: *mut pg_sys::shm_toc,
+        coordinate: *mut c_void,
+    ) {
+        // MPP branch: if the leader wrote MPP header magic, attach as an
+        // MPP worker. We key off the DSM header's magic via the same
+        // `MppDsmHeader` read AggregateScan uses — we don't have
+        // `mpp_shape` on the worker side (that state doesn't propagate
+        // through PrivateData), so we inspect the region itself.
+        if crate::postgres::customscan::mpp::customscan_glue::mpp_is_active()
+            && !coordinate.is_null()
+            && Self::dsm_looks_like_mpp(coordinate)
+        {
+            debug_assert!(state.custom_state().mpp_state.is_none());
+            let region_total = unsafe {
+                let header = std::ptr::read_unaligned(
+                    coordinate as *const crate::postgres::customscan::mpp::worker::MppDsmHeader,
+                );
+                header.region_total
+            };
+            let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+            let ctx = unsafe {
+                crate::postgres::customscan::mpp::customscan_glue::worker_init_dsm(
+                    coordinate,
+                    region_total,
+                    worker_number,
+                    std::ptr::null_mut(),
+                )
+            };
+            match ctx {
+                Ok(worker_ctx) => {
+                    crate::mpp_log!(
+                        "mpp: JoinScan worker {} attached to DSM ({} participants)",
+                        worker_number,
+                        worker_ctx.participant_config().total_participants
+                    );
+                    state.custom_state_mut().mpp_state = Some(worker_ctx);
+                    return;
+                }
+                Err(e) => {
+                    // Worker-side attach failure is fatal because the
+                    // leader expects an MPP participant on this seat.
+                    pgrx::error!(
+                        "mpp: JoinScan worker_init_dsm failed on worker {worker_number}: {e}"
+                    );
+                }
+            }
+        }
+
+        let pscan_state = coordinate.cast::<ParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+
+        state.custom_state_mut().parallel_state = Some(pscan_state);
+
+        // Workers must wait for the leader to finish populating the segment pool.
+        unsafe {
+            (*pscan_state).wait_for_initialization();
+        }
+
+        // Read the canonical non-partitioning segment ID sets that the leader wrote to
+        // shared memory.  These are used in exec_custom_scan to ensure every worker opens
+        // each replicated source with MvccSatisfies::ParallelWorker, which pins the
+        // visible segment list to exactly what the leader snapshotted.
+        let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
+        state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
+
+        // We don't need to deserialize query from parallel state for JoinScan
+        // because the full plan (including query) is serialized in PrivateData
+        // and available to the worker via the plan.
+    }
+}
+
+impl JoinScan {
+    /// DSM sizing for the non-MPP broadcast-join path. Extracted so both the
+    /// non-MPP branch and the MPP fallback can call it.
+    fn estimate_broadcast_dsm(state: &mut CustomScanStateWrapper<Self>) -> pg_sys::Size {
         Self::ensure_source_manifests(state);
 
         let join_clause = &state.custom_state().join_clause;
@@ -744,11 +938,9 @@ impl ParallelQueryCapable for JoinScan {
         ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false)
     }
 
-    fn initialize_dsm_custom_scan(
-        state: &mut CustomScanStateWrapper<Self>,
-        _pcxt: *mut pg_sys::ParallelContext,
-        coordinate: *mut c_void,
-    ) {
+    /// DSM population for the non-MPP broadcast-join path. Extracted so both
+    /// the non-MPP branch and the MPP fallback can call it.
+    fn initialize_broadcast_dsm(state: &mut CustomScanStateWrapper<Self>, coordinate: *mut c_void) {
         let pscan_state = coordinate.cast::<ParallelScanState>();
         assert!(!pscan_state.is_null(), "coordinate is null");
 
@@ -781,47 +973,83 @@ impl ParallelQueryCapable for JoinScan {
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
     }
 
-    fn reinitialize_dsm_custom_scan(
-        _state: &mut CustomScanStateWrapper<Self>,
-        _pcxt: *mut pg_sys::ParallelContext,
-        coordinate: *mut c_void,
-    ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
-        assert!(!pscan_state.is_null(), "coordinate is null");
+    /// Quick heuristic to detect whether `coordinate` points to an
+    /// MPP-initialized DSM region (as opposed to a `ParallelScanState` the
+    /// broadcast-join path allocated). Reads the header's `magic` field;
+    /// `MppDsmHeader` places a fixed magic at the start of the region. Safe
+    /// to call speculatively because the read is aligned and bounded to the
+    /// header struct size — if the region is `ParallelScanState`-sized, the
+    /// magic won't match and we fall through to the broadcast-join branch.
+    fn dsm_looks_like_mpp(coordinate: *mut c_void) -> bool {
         unsafe {
-            (*pscan_state).reset();
+            let header = std::ptr::read_unaligned(
+                coordinate as *const crate::postgres::customscan::mpp::worker::MppDsmHeader,
+            );
+            header.magic == crate::postgres::customscan::mpp::worker::MPP_DSM_MAGIC
         }
     }
 
-    fn initialize_worker_custom_scan(
-        state: &mut CustomScanStateWrapper<Self>,
-        _toc: *mut pg_sys::shm_toc,
-        coordinate: *mut c_void,
-    ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
-        assert!(!pscan_state.is_null(), "coordinate is null");
+    /// Wrap the already-serialized logical plan in `MppPlanBroadcast` and
+    /// stash the bytes + classified shape on `JoinScanState` for the MPP DSM
+    /// hooks to consume. Called from `begin_custom_scan` when `mpp_is_active()`
+    /// and the query is not EXPLAIN-only.
+    ///
+    /// Classification is derived from `join_clause.plan.sources().len()` — a
+    /// 2-source binary join maps to [`MppPlanShape::JoinOnly`]; anything else
+    /// stays `Ineligible`. Failures (serialize error, ineligible shape) leave
+    /// the MPP fields `None` and the scan silently falls back to the non-MPP
+    /// broadcast-join path — same ops-friendly behavior as AggregateScan.
+    fn maybe_stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
+        use crate::postgres::customscan::mpp::shape::{classify, ClassifyInputs, MppPlanShape};
 
-        state.custom_state_mut().parallel_state = Some(pscan_state);
+        let Some(raw_plan_bytes) = state.custom_state().logical_plan.as_ref() else {
+            crate::mpp_log!(
+                "mpp: JoinScan begin_custom_scan has no logical_plan bytes; MPP falls back"
+            );
+            return;
+        };
+        let raw_plan_bytes = raw_plan_bytes.clone();
 
-        // Workers must wait for the leader to finish populating the segment pool.
-        unsafe {
-            (*pscan_state).wait_for_initialization();
+        let n_join_tables = state.custom_state().join_clause.plan.sources().len();
+        let shape = classify(&ClassifyInputs {
+            n_join_tables,
+            has_group_by: false,
+            all_aggregates_splittable: true,
+            has_aggregate: false,
+        });
+        if !matches!(shape, MppPlanShape::JoinOnly) {
+            crate::mpp_log!(
+                "mpp: JoinScan shape={:?} (n_join_tables={}); staying on non-MPP path",
+                shape,
+                n_join_tables
+            );
+            return;
         }
 
-        // Read the canonical non-partitioning segment ID sets that the leader wrote to
-        // shared memory.  These are used in exec_custom_scan to ensure every worker opens
-        // each replicated source with MvccSatisfies::ParallelWorker, which pins the
-        // visible segment list to exactly what the leader snapshotted.
-        let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
-        state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
-
-        // We don't need to deserialize query from parallel state for JoinScan
-        // because the full plan (including query) is serialized in PrivateData
-        // and available to the worker via the plan.
+        let n = crate::postgres::customscan::mpp::customscan_glue::mpp_worker_count();
+        let broadcast = crate::postgres::customscan::mpp::session::MppPlanBroadcast::new(
+            raw_plan_bytes.to_vec(),
+            n,
+            crate::postgres::customscan::mpp::session::MppSessionProfile::Join,
+        );
+        let broadcast_bytes = match broadcast.serialize() {
+            Ok(b) => b,
+            Err(e) => {
+                crate::mpp_log!(
+                    "mpp: JoinScan MppPlanBroadcast serialize failed, MPP falls back: {e}"
+                );
+                return;
+            }
+        };
+        crate::mpp_log!(
+            "mpp: JoinScan stashed plan-broadcast bytes (shape={:?}, n={})",
+            shape,
+            n
+        );
+        state.custom_state_mut().logical_plan_bytes = Some(bytes::Bytes::from(broadcast_bytes));
+        state.custom_state_mut().mpp_shape = Some(shape);
     }
-}
 
-impl JoinScan {
     /// Capture lightweight segment manifests for all join sources.
     ///
     /// Uses `SearchIndexManifest::capture` instead of opening full `SearchIndexReader`s
@@ -880,8 +1108,9 @@ impl JoinScan {
         let mut ids_by_pos = vec![None; plan_sources.len()];
         let partitioning_idx = join_clause.partitioning_source_index();
         let is_worker = unsafe { pg_sys::ParallelWorkerNumber >= 0 };
+        let is_mpp = state.custom_state().mpp_state.is_some();
 
-        if is_worker {
+        if is_worker && !is_mpp {
             let non_partitioning_segs = &state.custom_state().non_partitioning_segments;
             let mut np_counter = 0usize;
             for (i, _source) in plan_sources.iter().enumerate() {
@@ -1250,7 +1479,8 @@ impl CustomScan for JoinScan {
         estate: *mut pg_sys::EState,
         eflags: i32,
     ) {
-        if eflags & (pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) == 0 {
+        let explain_only = (eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) != 0;
+        if !explain_only {
             unsafe {
                 let planstate = state.planstate();
                 // Always assign an ExprContext — heap filters, runtime
@@ -1258,6 +1488,12 @@ impl CustomScan for JoinScan {
                 pg_sys::ExecAssignExprContext(estate, planstate);
                 state.custom_state_mut().result_slot = Some(state.csstate.ss.ps.ps_ResultTupleSlot);
                 state.runtime_context = state.csstate.ss.ps.ps_ExprContext;
+            }
+
+            // Stash MPP plan-broadcast bytes + shape when MPP is active.
+            // Non-fatal on failure (logged + falls back to broadcast-join).
+            if crate::postgres::customscan::mpp::customscan_glue::mpp_is_active() {
+                Self::maybe_stash_mpp_plan_bytes(state);
             }
         }
     }
@@ -1307,7 +1543,42 @@ impl CustomScan for JoinScan {
                 let index_segment_ids =
                     Self::build_index_segment_ids(state, &join_clause, &plan_sources);
 
-                let ctx = create_datafusion_session_context(SessionContextProfile::Join);
+                // Pre-read the MPP shape BEFORE we take the DataFusion
+                // session/context borrow, because rewriting the physical
+                // plan below needs `mpp_state` mutably at the same time
+                // as the ctx is built.
+                let mpp_shape = if state.custom_state().mpp_state.is_some() {
+                    state.custom_state().mpp_shape
+                } else {
+                    None
+                };
+
+                // Build the session context. When this scan is an MPP
+                // participant, use `create_datafusion_session_context_mpp`
+                // so `SortMergeJoinEnforcer` is skipped (otherwise it
+                // collapses hash-partitioned streams) and inject
+                // `MppShardConfig` so `PgSearchTableProvider::scan`
+                // opens each participant's shard of segments.
+                let ctx = match state.custom_state().mpp_state.as_ref() {
+                    Some(mpp_state) if mpp_state.participant_config().total_participants > 1 => {
+                        let cfg = mpp_state.participant_config().clone();
+                        let ctx = scan_state::create_datafusion_session_context_mpp(
+                            SessionContextProfile::Join,
+                            &cfg,
+                        );
+                        ctx.state_ref()
+                            .write()
+                            .config_mut()
+                            .set_extension(std::sync::Arc::new(
+                                crate::postgres::customscan::mpp::MppShardConfig {
+                                    participant_index: cfg.participant_index,
+                                    total_participants: cfg.total_participants,
+                                },
+                            ));
+                        ctx
+                    }
+                    _ => create_datafusion_session_context(SessionContextProfile::Join),
+                };
                 let logical_plan = deserialize_logical_plan_with_runtime(
                     &plan_bytes,
                     &ctx.task_ctx(),
@@ -1319,10 +1590,36 @@ impl CustomScan for JoinScan {
                 )
                 .expect("Failed to deserialize logical plan");
 
-                // Convert logical plan to physical plan
-                let plan = runtime
+                // Convert logical plan to standard physical plan.
+                let standard_plan = runtime
                     .block_on(build_physical_plan(&ctx, logical_plan))
                     .expect("Failed to create execution plan");
+
+                // If MPP was set up by the DSM hooks, rewrite the
+                // standard plan into the JoinOnly MPP shape.
+                let plan = if let Some(shape) = mpp_shape {
+                    let mpp_state = state
+                        .custom_state_mut()
+                        .mpp_state
+                        .as_mut()
+                        .expect("mpp_shape set ⇒ mpp_state must be Some");
+                    crate::mpp_log!(
+                        "mpp: routing JoinScan exec through shape {:?} (is_leader={})",
+                        shape,
+                        mpp_state.is_leader()
+                    );
+                    let _guard = runtime.enter();
+                    match crate::postgres::customscan::mpp::exec_bridge::build_mpp_physical_plan(
+                        standard_plan,
+                        mpp_state,
+                        shape,
+                    ) {
+                        Ok(p) => p,
+                        Err(e) => panic!("mpp: JoinScan build_mpp_physical_plan failed: {e}"),
+                    }
+                } else {
+                    standard_plan
+                };
 
                 let task_ctx = build_task_context(
                     &ctx,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -833,8 +833,8 @@ impl ParallelQueryCapable for JoinScan {
         _pcxt: *mut pg_sys::ParallelContext,
         coordinate: *mut c_void,
     ) {
-        // MPP rescan is out of scope in Phase 5; the non-MPP path resets
-        // the broadcast-join `ParallelScanState` as before.
+        // MPP rescan is out of scope; the non-MPP path resets the
+        // broadcast-join `ParallelScanState` as before.
         if state.custom_state().mpp_shape.is_some() {
             // No-op: a rescanned MPP join would need a full mesh teardown
             // + rebuild, same gap AggregateScan leaves.

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -217,6 +217,32 @@ pub struct JoinScanState {
     /// Dropping manifests early would release the pins and allow segment recycling
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
+
+    /// Serialized `MppPlanBroadcast` bytes — same framing as
+    /// `AggregateScanState::logical_plan_bytes`. Wraps the raw logical-plan
+    /// bytes already in `PrivateData::logical_plan`. Populated on the leader
+    /// in `begin_custom_scan` when MPP is active and the classified shape is
+    /// eligible; consumed by the MPP DSM hooks (`estimate_dsm_custom_scan`
+    /// reads `.len()`; `initialize_dsm_custom_scan` copies verbatim into DSM).
+    /// `None` when MPP is off, the shape is ineligible, or plan serialization
+    /// failed (logged; silently falls back to the non-MPP broadcast-join).
+    pub logical_plan_bytes: Option<bytes::Bytes>,
+
+    /// Classified MPP shape for this query, populated alongside
+    /// `logical_plan_bytes`. Drives the number of shuffle meshes allocated in
+    /// DSM and the per-shape builder used by `exec_bridge`. For JoinScan this
+    /// is always `JoinOnly` (or `Ineligible`, which means `logical_plan_bytes`
+    /// stays `None`).
+    pub mpp_shape: Option<crate::postgres::customscan::mpp::shape::MppPlanShape>,
+
+    /// MPP lifecycle state. Populated by `initialize_dsm_custom_scan` on the
+    /// leader or `initialize_worker_custom_scan` on a worker when MPP is
+    /// active. `None` for the non-MPP broadcast-join path.
+    ///
+    /// Declared LAST so it's the last field dropped — same rationale as
+    /// `AggregateScanState::mpp_state`: it owns shm_mq handles pointing into
+    /// DSM which must stay mapped until this drops.
+    pub mpp_state: Option<crate::postgres::customscan::mpp::customscan_glue::MppExecutionState>,
 }
 
 impl JoinScanState {

--- a/pg_search/src/postgres/customscan/mpp/chain.rs
+++ b/pg_search/src/postgres/customscan/mpp/chain.rs
@@ -46,8 +46,6 @@
 //! driven by the participants' scan completions, not by operator-level poll
 //! cadence. See `plan_build::wrap_with_mpp_shuffle` for the full reasoning.
 
-#![allow(dead_code)] // wired in via wrap_with_mpp_shuffle.
-
 use std::any::Any;
 use std::sync::Arc;
 use std::task::{Context, Poll};

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -35,8 +35,6 @@
 //! glue from the lower-level DSM math so future refactors on either side
 //! stay localized.
 
-#![allow(dead_code)] // First caller lands when AggregateScan MPP path is wired up.
-
 use pgrx::pg_sys;
 
 use crate::postgres::customscan::mpp::mesh::MeshLayout;

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -40,8 +40,6 @@
 //! `ParallelQueryCapable` impl is five lines of delegation and never touches
 //! raw shm_mq FFI directly.
 
-#![allow(dead_code)] // First caller is AggregateScan wiring.
-
 use pgrx::pg_sys;
 
 use crate::postgres::customscan::mpp::coordinator::{

--- a/pg_search/src/postgres/customscan/mpp/exec_bridge.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_bridge.rs
@@ -61,7 +61,6 @@
 //! mismatch would route left rows to the right drain and break
 //! correctness.
 
-#![allow(dead_code)]
 // caller lands in aggregatescan/mod.rs in this same change.
 // `CoalesceBatchesExec` is deprecated in favor of arrow-rs's `BatchCoalescer`, but
 // DataFusion 52's planner still emits `CoalesceBatchesExec` nodes in the physical

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -36,8 +36,6 @@
 //! are in this file so the full production transport stack lives next to the
 //! layout math.
 
-#![allow(dead_code)]
-
 use pgrx::pg_sys;
 
 use crate::parallel_worker::mqueue::{

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -65,7 +65,6 @@ pub struct MppParticipantConfig {
 /// set, the provider calls `reader.search_segments(sharded_ids)` and each
 /// participant reads only its share of segments.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
 pub struct MppShardConfig {
     pub participant_index: u32,
     pub total_participants: u32,

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -72,8 +72,6 @@
 //! building block for the benchmark and cleanly composes with DataFusion's
 //! existing `HashJoinExec(Partitioned)`.
 
-#![allow(dead_code)]
-
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::SchemaRef;

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -28,8 +28,6 @@
 //! The plan bytes are the same for every participant — participant identity
 //! comes from the worker's seat in the mesh, not from the plan encoding.
 
-#![allow(dead_code)]
-
 use serde::{Deserialize, Serialize};
 
 use crate::postgres::customscan::mpp::MppParticipantConfig;

--- a/pg_search/src/postgres/customscan/mpp/shape.rs
+++ b/pg_search/src/postgres/customscan/mpp/shape.rs
@@ -57,7 +57,6 @@
 //! shuffle. Multi-mesh DSM allocation is a separate piece — this module
 //! takes pre-allocated wirings as parameters.
 
-#![allow(dead_code)]
 // caller lands once create_custom_path flips parallel-safe
 // `CoalesceBatchesExec` is deprecated in favor of arrow-rs's `BatchCoalescer`,
 // but DataFusion 52 still ships it as an `ExecutionPlan` node — the replacement

--- a/pg_search/src/postgres/customscan/mpp/shuffle.rs
+++ b/pg_search/src/postgres/customscan/mpp/shuffle.rs
@@ -41,8 +41,6 @@
 //!   loop calls this once per input batch, then feeds each sub-batch to its
 //!   corresponding `MppSender` (peers) or local channel (self).
 
-#![allow(dead_code)]
-
 use datafusion::arrow::array::{RecordBatch, UInt64Array};
 use datafusion::arrow::compute::take;
 use datafusion::common::hash_utils::create_hashes;
@@ -583,8 +581,10 @@ struct ShuffleStream {
     done: bool,
     schema: datafusion::arrow::datatypes::SchemaRef,
     /// Diagnostic label for the `mpp_log!` row-count report at EOF.
+    #[cfg_attr(test, allow(dead_code))]
     tag: &'static str,
     /// Remembered `participant_index` for logging after `wiring` is dropped.
+    #[cfg_attr(test, allow(dead_code))]
     participant_index: u32,
     /// Total rows read from `child`.
     rows_in: u64,
@@ -1019,7 +1019,9 @@ struct DrainGatherStream {
     handle: Option<std::sync::Arc<crate::postgres::customscan::mpp::transport::DrainHandle>>,
     done: bool,
     schema: datafusion::arrow::datatypes::SchemaRef,
+    #[cfg_attr(test, allow(dead_code))]
     tag: &'static str,
+    #[cfg_attr(test, allow(dead_code))]
     participant_index: u32,
     rows_received: u64,
     batches_received: u64,

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -29,8 +29,6 @@
 //! The shm_mq-backed sender/receiver and drain thread spawn logic build on
 //! top of these primitives.
 
-#![allow(dead_code)]
-
 use std::collections::VecDeque;
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::JoinHandle;

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -44,8 +44,6 @@
 //! [`ShmMqReceiver`](super::mesh::ShmMqReceiver). Here we only own the
 //! sizing/offset math and the header layout.
 
-#![allow(dead_code)]
-
 use crate::postgres::customscan::mpp::mesh::{MeshLayout, ShmMqReceiver, ShmMqSender};
 use crate::postgres::customscan::mpp::transport::{MppReceiver, MppSender};
 use pgrx::pg_sys;

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -210,7 +210,6 @@ impl PgSearchScanPlan {
     /// Transfers scan state out of the original plan — the original becomes
     /// a dead stub whose `execute` returns empty streams. Returns the plan
     /// unchanged when there are no dynamic filters to strip.
-    #[allow(dead_code)] // caller lands in MPP exec-bridge PR
     pub fn strip_dynamic_filters_from_dyn(
         dyn_plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/pg_search/tests/pg_regress/expected/mpp_join.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join.out
@@ -1,0 +1,166 @@
+-- =====================================================================
+-- MPP correctness for the JoinOnly shape: a bare join without an
+-- aggregate above it. Verifies that with `paradedb.enable_mpp = on` the
+-- result rows match the serial baseline.
+--
+-- Like `mpp_exec.sql`, this test exercises plan-stash + classifier +
+-- parallel-flag pipeline. PG's planner may not launch actual workers on
+-- this small dataset; what this test DOES guarantee is:
+--   * the JoinOnly plan stash completes without error
+--   * the exec path produces correct rows whether or not workers launch
+--   * `mpp_debug` logs the `mpp: routing JoinScan exec through shape` line
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+CREATE TABLE mpp_join_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+CREATE TABLE mpp_join_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER,
+    comment TEXT
+);
+INSERT INTO mpp_join_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+INSERT INTO mpp_join_reviews (product_id, rating, comment)
+SELECT
+    (i % 40) + 1,
+    (i % 5) + 1,
+    'review ' || i
+FROM generate_series(1, 200) AS i;
+CREATE INDEX mpp_join_products_idx ON mpp_join_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+CREATE INDEX mpp_join_reviews_idx ON mpp_join_reviews
+USING bm25 (id, product_id, rating, comment)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}',
+    text_fields='{"comment": {}}'
+);
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      | rating 
+----+----------------------+--------
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+(10 rows)
+
+-- =====================================================================
+-- MPP enabled: must return the same rows (set-equality, then row-order).
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.description, r.rating, r.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.description, r.rating, r.id
+         Relation Tree: r INNER p
+         Join Cond: p.id = r.product_id
+         Limit: 10
+         Order By: p.id asc, r.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, id@1 as col_4, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST, id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[r, p]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      | rating 
+----+----------------------+--------
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+(10 rows)
+
+-- Multi-predicate join with both sides filtered.
+SELECT p.id, p.description, r.comment
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop' AND r.comment @@@ 'review'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      |  comment   
+----+----------------------+------------
+  4 | Laptop computer fast | review 3
+  4 | Laptop computer fast | review 43
+  4 | Laptop computer fast | review 83
+  4 | Laptop computer fast | review 123
+  4 | Laptop computer fast | review 163
+  8 | Laptop computer fast | review 7
+  8 | Laptop computer fast | review 47
+  8 | Laptop computer fast | review 87
+  8 | Laptop computer fast | review 127
+  8 | Laptop computer fast | review 167
+(10 rows)
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE mpp_join_reviews;
+DROP TABLE mpp_join_products;

--- a/pg_search/tests/pg_regress/sql/mpp_join.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_join.sql
@@ -1,0 +1,117 @@
+-- =====================================================================
+-- MPP correctness for the JoinOnly shape: a bare join without an
+-- aggregate above it. Verifies that with `paradedb.enable_mpp = on` the
+-- result rows match the serial baseline.
+--
+-- Like `mpp_exec.sql`, this test exercises plan-stash + classifier +
+-- parallel-flag pipeline. PG's planner may not launch actual workers on
+-- this small dataset; what this test DOES guarantee is:
+--   * the JoinOnly plan stash completes without error
+--   * the exec path produces correct rows whether or not workers launch
+--   * `mpp_debug` logs the `mpp: routing JoinScan exec through shape` line
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+
+CREATE TABLE mpp_join_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+
+CREATE TABLE mpp_join_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER,
+    comment TEXT
+);
+
+INSERT INTO mpp_join_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+
+INSERT INTO mpp_join_reviews (product_id, rating, comment)
+SELECT
+    (i % 40) + 1,
+    (i % 5) + 1,
+    'review ' || i
+FROM generate_series(1, 200) AS i;
+
+CREATE INDEX mpp_join_products_idx ON mpp_join_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+
+CREATE INDEX mpp_join_reviews_idx ON mpp_join_reviews
+USING bm25 (id, product_id, rating, comment)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}',
+    text_fields='{"comment": {}}'
+);
+
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- =====================================================================
+-- MPP enabled: must return the same rows (set-equality, then row-order).
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- Multi-predicate join with both sides filtered.
+SELECT p.id, p.description, r.comment
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop' AND r.comment @@@ 'review'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.enable_join_custom_scan;
+
+DROP TABLE mpp_join_reviews;
+DROP TABLE mpp_join_products;


### PR DESCRIPTION
## Summary

First in a 4-PR chain that splits the former #4807 into reviewable slices. This PR activates the MPP path for bare-join (JoinOnly) queries by flipping JoinScan's `ParallelQueryCapable` hooks.

Chain layout (each PR stacks on the previous):
- **A (this PR)** — JoinScan MPP activation, base `moe/mpp-04-agg`
- B — walker seam + `MppNetworkBoundary` + per-batch framing (`moe/mpp-06-walker-seam`)
- C — DF-D verbatim port scaffolding (`moe/mpp-07-dfd-port`)
- D — flip walker to generic pipeline + delete legacy assemblers (`moe/mpp-08-dfd-flip`)

**Safety:** `paradedb.enable_mpp = off` by default — zero user-visible change until opt-in.

## What ships

- `joinscan/mod.rs` — plan stash (`MppPlanBroadcast` + `classify_joinscan_logical_plan`), DSM estimate/init/worker_init hooks, MPP routing branch in `exec_custom_scan`, manifest capture for canonical segment IDs, `parallel_workers` pinned to `mpp_worker_count - 1`.
- `joinscan/scan_state.rs` — `logical_plan_bytes`, `mpp_shape`, `mpp_state` fields.
- `scan/execution_plan.rs` — drop `#[allow(dead_code)]` on `shard_from_dyn` / `strip_dynamic_filters_from_dyn` (JoinScan is now a live caller).
- `mpp/mod.rs` — `cfg(test)`-stub of `mpp_trace()` GUC read for unit tests.
- Bench SQL (MPP alt variants): `distinct_parent_sort`, `foreign_filter_local_sort`, `hierarchical_content-{no-scores,scores}-{small,large}`, `permissioned_search`, `semi_join_filter`.
- `pg_search/tests/pg_regress/{sql,expected}/mpp_join.{sql,out}` — end-to-end JoinOnly coverage.

## Commits (3)

- `feat(mpp): JoinScan MPP activation — bare-join path`
- `chore(mpp): drop stale 'Phase 5' attribution from reinit comment`
- `chore(mpp): PR5 dead-code cleanup — drop module-level suppressions`

## Test plan

- [x] `cargo check -p pg_search --features pg18` clean
- [x] `cargo test -p pg_search --lib mpp:: --features pg18 -- --test-threads=1` — 90 passed, 0 failed, 2 ignored
- [x] `cargo pgrx regress pg18 mpp` — mpp_exec / mpp_fallback / mpp_join / mpp_smoke all PASS
- [ ] CI benchmark (bare-join MPP variants should show `Results: [...]` for the first time)

## Rollback

Revert the PR. AggregateScan MPP path (#4830) is unaffected.