### PR TITLE
refactor(mpp): DF-D verbatim port scaffolding (C/4)

### DIFF
--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -87,18 +87,20 @@
                       // 52 still emits it as a plan node and we must recognize
                       // + reuse it.
 
+use std::borrow::Borrow;
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::common::{DataFusionError, Result as DfResult};
 use datafusion::physical_expr::expressions::Column;
-use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_expr::{Partitioning, PhysicalExpr};
 use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
 use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::filter::FilterExec;
 use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
 use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
 use datafusion::physical_plan::ExecutionPlan;
 
 use super::customscan_glue::{MppExecutionState, DEFAULT_MPP_QUEUE_BYTES};
@@ -230,6 +232,187 @@ fn validate_shape_matches(classified: MppPlanShape, derived: MppPlanShape) -> Df
              but plan structure implies {derived:?}"
         )))
     }
+}
+
+// ============================================================================
+// Generic cut walker (dead-code scaffolding ported from
+// datafusion-contrib/datafusion-distributed).
+//
+// Port aims to match DF-D's `src/distributed_planner/plan_annotator.rs` and
+// `src/common/children_helpers.rs` as closely as ParadeDB allows. The three
+// deviations are all driven by ParadeDB constraints, not aesthetics:
+//
+//   * DF-D's `PlanOrNetworkBoundary::Broadcast` variant is dropped because
+//     ParadeDB doesn't do broadcast joins.
+//   * DF-D's `AnnotatedPlan::task_count` field is dropped because ParadeDB's
+//     participant count is fixed by `MppParticipantConfig::total_participants`
+//     at plan time — no task estimators, no cardinality scale factors, no
+//     propagation passes needed.
+//   * DF-D's `annotate_plan` / `_annotate_plan` are `async` to accommodate
+//     task-estimator I/O; ParadeDB's are sync because there's nothing to
+//     await.
+//
+// Nothing calls these yet. `distribute_plan` above still dispatches to the
+// three topology assemblers. The follow-up commits wire the pipeline:
+//
+//   * 2b — `insert_mpp_cuts` pre-pass synthesizes the
+//     `RepartitionExec(Hash)` / `CoalescePartitionsExec` markers the DF-D
+//     triggers look for (ParadeDB's serial standard plans don't emit them).
+//   * 2c — `_distribute_plan` consumes `AnnotatedPlan` and emits the
+//     `ShuffleExec` / `DrainGatherExec` pairs via `wrap_with_mpp_shuffle`,
+//     plus ParadeDB-specific post-passes (probe-side dynamic-filter
+//     strip/re-apply, leader-only scalar `FinalPartitioned`, 64 Ki
+//     `CoalesceBatchesExec` for group-by, `VisibilityCtidResolverRule`
+//     re-run).
+//   * 2d — flip `distribute_plan` to route through the generic pipeline.
+//   * 2e — retire the three topology assemblers.
+// ============================================================================
+
+/// Annotation attached to a single [`ExecutionPlan`] that determines the kind
+/// of network boundary needed just below itself. Ported verbatim from DF-D
+/// minus the `Broadcast` variant (not applicable to ParadeDB).
+#[allow(dead_code)]
+pub(super) enum PlanOrNetworkBoundary {
+    Plan(Arc<dyn ExecutionPlan>),
+    Shuffle,
+    Coalesce,
+}
+
+impl std::fmt::Debug for PlanOrNetworkBoundary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Plan(plan) => write!(f, "{}", plan.name()),
+            Self::Shuffle => write!(f, "[NetworkBoundary] Shuffle"),
+            Self::Coalesce => write!(f, "[NetworkBoundary] Coalesce"),
+        }
+    }
+}
+
+impl PlanOrNetworkBoundary {
+    #[allow(dead_code)]
+    pub(super) fn is_network_boundary(&self) -> bool {
+        matches!(self, Self::Shuffle | Self::Coalesce)
+    }
+}
+
+/// Wraps an [`ExecutionPlan`] and annotates it with information about whether
+/// it needs a network boundary below it. Ported from DF-D minus `task_count`
+/// (ParadeDB has a fixed N; no propagation pass).
+#[allow(dead_code)]
+pub(super) struct AnnotatedPlan {
+    /// The annotated [`ExecutionPlan`].
+    pub(super) plan_or_nb: PlanOrNetworkBoundary,
+    /// The annotated children of this [`ExecutionPlan`]. When
+    /// `plan_or_nb == Plan(p)`, this holds the annotated form of
+    /// `p.children()`. When `plan_or_nb` is a network boundary, this holds
+    /// the single node that sits below the boundary.
+    pub(super) children: Vec<AnnotatedPlan>,
+}
+
+impl std::fmt::Debug for AnnotatedPlan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        fn fmt_dbg(
+            f: &mut std::fmt::Formatter<'_>,
+            plan: &AnnotatedPlan,
+            depth: usize,
+        ) -> std::fmt::Result {
+            write!(f, "{}{:?}", " ".repeat(depth * 2), plan.plan_or_nb)?;
+            writeln!(f)?;
+            for child in plan.children.iter() {
+                fmt_dbg(f, child, depth + 1)?;
+            }
+            Ok(())
+        }
+        fmt_dbg(f, self, 0)
+    }
+}
+
+/// Ported verbatim from DF-D's `common/children_helpers.rs`. Used by
+/// `_distribute_plan` (Step 2c) to unwrap the single child beneath a
+/// network-boundary annotation when rewriting plans via `with_new_children`.
+#[allow(dead_code)]
+pub(super) fn require_one_child<L, T>(children: L) -> DfResult<Arc<dyn ExecutionPlan>>
+where
+    L: AsRef<[T]>,
+    T: Borrow<Arc<dyn ExecutionPlan>>,
+{
+    let children = children.as_ref();
+    if children.len() != 1 {
+        return Err(DataFusionError::Plan(format!(
+            "Expected exactly 1 children, got {}",
+            children.len()
+        )));
+    }
+    Ok(children[0].borrow().clone())
+}
+
+/// Annotates recursively an [`ExecutionPlan`] and its children with
+/// information about whether a network boundary is needed below it. Ported
+/// from DF-D's `annotate_plan` minus `async`, `DistributedConfig`,
+/// `TaskEstimator`, `children_isolator_unions`, `propagate_task_count`, and
+/// the `Broadcast` cut trigger (none of which apply to ParadeDB).
+///
+/// The two cut triggers preserved verbatim are:
+///
+/// * `RepartitionExec(Hash)` → annotate with `Shuffle`.
+/// * Any non-leaf plan whose parent is `CoalescePartitionsExec` or
+///   `SortPreservingMergeExec` → annotate with `Coalesce`.
+///
+/// Running this over ParadeDB's serial standard plan (as produced by
+/// `exec_datafusion_aggregate`) yields zero network-boundary annotations
+/// because the serial plan emits neither trigger. Step 2b adds
+/// `insert_mpp_cuts`, a pre-pass that synthesizes the expected markers per
+/// [`MppPlanShape`] before this walker runs.
+#[allow(dead_code)]
+pub(super) fn annotate_plan(plan: Arc<dyn ExecutionPlan>) -> DfResult<AnnotatedPlan> {
+    _annotate_plan(plan, None)
+}
+
+fn _annotate_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    parent: Option<&Arc<dyn ExecutionPlan>>,
+) -> DfResult<AnnotatedPlan> {
+    let annotated_children: Vec<AnnotatedPlan> = plan
+        .children()
+        .into_iter()
+        .map(|child| _annotate_plan(Arc::clone(child), Some(&plan)))
+        .collect::<DfResult<Vec<_>>>()?;
+
+    // Wrap the node with a boundary node if the parent marks it.
+    let mut annotation = AnnotatedPlan {
+        plan_or_nb: PlanOrNetworkBoundary::Plan(Arc::clone(&plan)),
+        children: annotated_children,
+    };
+
+    // Upon reaching a hash repartition, we need to introduce a shuffle right above it.
+    if let Some(r_exec) = plan.as_any().downcast_ref::<RepartitionExec>() {
+        if matches!(r_exec.partitioning(), Partitioning::Hash(_, _)) {
+            annotation = AnnotatedPlan {
+                plan_or_nb: PlanOrNetworkBoundary::Shuffle,
+                children: vec![annotation],
+            };
+        }
+    } else if let Some(parent) = parent {
+        // DF-D expresses this as a single `else if let` + `&&` chain; Rust
+        // 2021 doesn't allow let-chains, so split into nested ifs. Comments
+        // preserved verbatim.
+        //
+        // If this node is a leaf node, putting a network boundary above is a bit wasteful, so
+        // we don't want to do it.
+        // If the parent is trying to coalesce all partitions into one, we need to introduce
+        // a network coalesce right below it (or in other words, above the current node)
+        if !plan.children().is_empty()
+            && (parent.as_any().is::<CoalescePartitionsExec>()
+                || parent.as_any().is::<SortPreservingMergeExec>())
+        {
+            annotation = AnnotatedPlan {
+                plan_or_nb: PlanOrNetworkBoundary::Coalesce,
+                children: vec![annotation],
+            };
+        }
+    }
+
+    Ok(annotation)
 }
 
 // ============================================================================
@@ -1269,4 +1452,180 @@ mod tests {
     // synthetic `ExecutionPlan`s would require wiring up enough of
     // `VisibilityFilterExec` + `ShuffleExec` to make the downcast fire,
     // which duplicates the fixture the bridges already exercise. Skipped.
+
+    // ========================================================================
+    // DF-D generic cut walker tests (dead-path scaffolding — Step 2a).
+    // ========================================================================
+
+    fn mem_source(schema: &SchemaRef) -> Arc<dyn ExecutionPlan> {
+        use datafusion::arrow::array::{Int32Array, RecordBatch};
+        use datafusion::datasource::memory::MemorySourceConfig;
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap()
+    }
+
+    #[test]
+    fn annotate_plan_detects_hash_repartition_as_shuffle() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let key: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 0));
+        let repart: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::Hash(vec![key], 2)).unwrap());
+
+        let annotated = annotate_plan(repart).unwrap();
+        // The trigger sits *above* the RepartitionExec, so the top of the
+        // annotated tree is the Shuffle boundary whose sole child is the
+        // RepartitionExec-as-Plan.
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Shuffle
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_round_robin_repartition_does_not_trigger_shuffle() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let repart: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2)).unwrap());
+
+        let annotated = annotate_plan(repart).unwrap();
+        // Non-hash repartitioning is not a DF-D cut trigger.
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_plain_plan_has_no_boundaries() {
+        fn assert_no_boundary(a: &AnnotatedPlan) {
+            assert!(
+                !a.plan_or_nb.is_network_boundary(),
+                "unexpected boundary: {:?}",
+                a.plan_or_nb
+            );
+            for c in &a.children {
+                assert_no_boundary(c);
+            }
+        }
+
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let annotated = annotate_plan(partial).unwrap();
+        assert_no_boundary(&annotated);
+    }
+
+    #[test]
+    fn annotate_plan_coalesce_parent_triggers_coalesce_boundary() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        // Partial aggregation is non-leaf (children() non-empty) and its
+        // parent is CoalescePartitionsExec — this is the DF-D Coalesce
+        // trigger verbatim.
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
+        let annotated = annotate_plan(coalesced).unwrap();
+
+        // Root is the CoalescePartitionsExec itself (annotated as Plan; the
+        // trigger only wraps the child that sits *under* the coalesce).
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        // The Partial aggregate has its parent as CoalescePartitionsExec, so
+        // the walker wraps it with Coalesce.
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Coalesce
+        ));
+        // Inside the Coalesce annotation, the wrapped plan is the Partial
+        // aggregate.
+        assert_eq!(annotated.children[0].children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_leaf_under_coalesce_is_not_boundaried() {
+        // A true leaf node (no children) underneath CoalescePartitionsExec
+        // must not get a Coalesce boundary — DF-D's comment: "putting a
+        // network boundary above [a leaf] is a bit wasteful".
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(input));
+        let annotated = annotate_plan(coalesced).unwrap();
+
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn require_one_child_accepts_single_child() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let got = require_one_child(vec![Arc::clone(&input)]).unwrap();
+        assert!(Arc::ptr_eq(&got, &input));
+    }
+
+    #[test]
+    fn require_one_child_rejects_zero_children() {
+        let empty: Vec<Arc<dyn ExecutionPlan>> = vec![];
+        let err = require_one_child(empty).unwrap_err();
+        assert!(format!("{err}").contains("Expected exactly 1"));
+    }
+
+    #[test]
+    fn require_one_child_rejects_many_children() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let err = require_one_child(vec![mem_source(&schema), mem_source(&schema)]).unwrap_err();
+        assert!(format!("{err}").contains("Expected exactly 1"));
+    }
 }

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -560,6 +560,113 @@ fn rewrite_with_cuts(
     Ok(plan)
 }
 
+/// Emit an [`ExecutionPlan`] from an [`AnnotatedPlan`], turning every
+/// network-boundary annotation into a concrete MPP rewrite. Ported in spirit
+/// from DF-D's `_distribute_plan`; ParadeDB deviates by having a single
+/// `Shuffle` emit path (no stage tree, no task estimators) and by tagging
+/// cuts with shape-aware labels so benchmark-log grep patterns keep working.
+///
+/// # Step 2c scope — structural traversal only
+///
+/// This iteration wires the `Plan` arm through `with_new_children` recursion,
+/// which is enough to exercise plan-tree round-tripping and cut counting. The
+/// `Shuffle` and `Coalesce` arms return `DataFusionError::Plan(...)` with a
+/// "not yet wired" message; Step 2c-ii replaces those errors with real
+/// [`wrap_with_mpp_shuffle`](crate::postgres::customscan::mpp::plan_build::wrap_with_mpp_shuffle)
+/// calls + ParadeDB post-passes (probe-side dynamic-filter strip, leader-only
+/// scalar `FinalPartitioned`, 64 Ki `CoalesceBatchesExec` insert for GROUP BY,
+/// `VisibilityCtidResolverRule` re-run).
+///
+/// `cut_index` is the bottom-up ordinal of the next boundary the walker
+/// encounters, threaded through the recursion so [`tag_for_cut`] can derive a
+/// byte-exact tag (`scalar_left` / `scalar_right` / `scalar_final`, etc.)
+/// matching the strings the existing topology assemblers emit.
+#[allow(dead_code)]
+pub(super) fn _distribute_plan(
+    plan: AnnotatedPlan,
+    shape: MppPlanShape,
+    cut_index: &mut u32,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    // Recurse bottom-up so descendants' rewrites are in place before the
+    // current node's `with_new_children` call sees them. This matches DF-D's
+    // post-order traversal in `_distribute_plan`.
+    let new_children: Vec<Arc<dyn ExecutionPlan>> = plan
+        .children
+        .into_iter()
+        .map(|c| _distribute_plan(c, shape, cut_index))
+        .collect::<DfResult<Vec<_>>>()?;
+
+    match plan.plan_or_nb {
+        PlanOrNetworkBoundary::Plan(p) => {
+            if new_children.is_empty() {
+                Ok(p)
+            } else {
+                Arc::clone(&p).with_new_children(new_children)
+            }
+        }
+        PlanOrNetworkBoundary::Shuffle => {
+            // Every boundary has exactly one child (the subtree it sits
+            // above). DF-D enforces this with `require_one_child`.
+            let _child = require_one_child(&new_children)?;
+            let tag = tag_for_cut(shape, *cut_index);
+            *cut_index += 1;
+            Err(DataFusionError::Plan(format!(
+                "mpp: _distribute_plan: Shuffle emit for cut {tag} is not yet wired \
+                 (Step 2c-ii will replace this with wrap_with_mpp_shuffle + mesh allocation)"
+            )))
+        }
+        PlanOrNetworkBoundary::Coalesce => {
+            let _child = require_one_child(&new_children)?;
+            let tag = tag_for_cut(shape, *cut_index);
+            *cut_index += 1;
+            Err(DataFusionError::Plan(format!(
+                "mpp: _distribute_plan: Coalesce emit for cut {tag} is not yet wired \
+                 (Step 2c-ii will replace this with wrap_with_mpp_shuffle(FixedTargetPartitioner(0)))"
+            )))
+        }
+    }
+}
+
+/// Map a (shape, bottom-up cut index) pair to the byte-exact tag string the
+/// existing topology assemblers pass to `wrap_with_mpp_shuffle`. Keeps
+/// benchmark-log grep patterns and `mpp_trace` output unchanged across the
+/// generic-walker migration.
+///
+/// The cut ordinals below follow the post-order (children-first) traversal
+/// `_distribute_plan` performs against a plan produced by [`insert_mpp_cuts`]:
+///
+/// * `JoinOnly`: `HashJoinExec` has two children — left subtree first, then
+///   right subtree. After `insert_mpp_cuts` each is wrapped in
+///   `RepartitionExec(Hash)` that `annotate_plan` lifts to a `Shuffle`.
+///   Bottom-up visit order therefore yields indices 0 = `join_left`,
+///   1 = `join_right`.
+///
+/// * `ScalarAggOnBinaryJoin`: same two join-side cuts (0, 1) plus a top
+///   `CoalescePartitionsExec` over the `AggregateExec(Partial)` that
+///   `annotate_plan` lifts to a `Coalesce`. Bottom-up the join-side cuts
+///   come first (descendants visited before parents), then the scalar-final
+///   cut at index 2.
+///
+/// * `GroupByAggOnBinaryJoin`: same two join-side cuts (0, 1) plus a top
+///   `RepartitionExec(Hash(group_keys))` that becomes a `Shuffle` at index 2.
+///
+/// Mis-indexed cuts fall through to `"mpp_unknown_cut"` rather than panic —
+/// this is a dead-code scaffold and callers aren't live yet.
+#[allow(dead_code)]
+fn tag_for_cut(shape: MppPlanShape, cut_index: u32) -> &'static str {
+    match (shape, cut_index) {
+        (MppPlanShape::JoinOnly, 0) => "join_left",
+        (MppPlanShape::JoinOnly, 1) => "join_right",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 0) => "scalar_left",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 1) => "scalar_right",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 2) => "scalar_final",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 0) => "gb_left",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 1) => "gb_right",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 2) => "gb_postagg",
+        _ => "mpp_unknown_cut",
+    }
+}
+
 // ============================================================================
 // Topology assemblers — one per supported shape. Each one owns the full flow:
 // plan walk + mesh allocation + shuffle wiring + final DF operator composition.
@@ -1930,5 +2037,225 @@ mod tests {
         let plan = partial_agg_over_mem_source(vec!["id"]);
         let err = insert_mpp_cuts(plan, MppPlanShape::GroupByAggSingleTable, 2).unwrap_err();
         assert!(format!("{err}").contains("GroupByAggSingleTable"));
+    }
+
+    // ========================================================================
+    // `_distribute_plan` + `tag_for_cut` tests (dead-path scaffolding — Step 2c).
+    //
+    // Step 2c only wires the `Plan` arm (structural traversal via
+    // `with_new_children`). The `Shuffle` and `Coalesce` arms return
+    // `DataFusionError::Plan` with a "not yet wired" message; Step 2c-ii
+    // replaces those errors with real `wrap_with_mpp_shuffle` calls.
+    // ========================================================================
+
+    #[test]
+    fn tag_for_cut_covers_every_live_shape() {
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 0), "join_left");
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 1), "join_right");
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 0),
+            "scalar_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 1),
+            "scalar_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 2),
+            "scalar_final"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 0),
+            "gb_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 1),
+            "gb_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 2),
+            "gb_postagg"
+        );
+    }
+
+    #[test]
+    fn tag_for_cut_unknown_pair_falls_through_to_placeholder() {
+        // Out-of-range indices and Ineligible / SingleTable shapes fall
+        // through to the placeholder rather than panic. Callers are not
+        // live yet; a panic would mask Step 2c-ii regressions.
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 7), "mpp_unknown_cut");
+        assert_eq!(tag_for_cut(MppPlanShape::Ineligible, 0), "mpp_unknown_cut");
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggSingleTable, 0),
+            "mpp_unknown_cut"
+        );
+    }
+
+    #[test]
+    fn distribute_plan_round_trips_boundary_free_plan() {
+        // A plain MemorySourceConfig has no boundary triggers, so the
+        // traversal should emit a tree identical in structure to the input:
+        // one Plan annotation per original node, no errors, no children
+        // collapsed.
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let annotated = annotate_plan(Arc::clone(&input)).unwrap();
+
+        let mut cut_index = 0u32;
+        let rebuilt = _distribute_plan(annotated, MppPlanShape::JoinOnly, &mut cut_index).unwrap();
+
+        // No boundaries ⇒ no cuts consumed.
+        assert_eq!(cut_index, 0);
+        // Leaf plan re-emitted verbatim (same Arc, since `with_new_children`
+        // is skipped when `new_children.is_empty()`).
+        assert!(Arc::ptr_eq(&rebuilt, &input));
+    }
+
+    #[test]
+    fn distribute_plan_recurses_through_plan_arms() {
+        // CoalescePartitionsExec over a Partial aggregate: the root is a
+        // Plan, the child is a Plan (the Partial is leaf-like-ish — it has
+        // a mem_source underneath, which is non-empty), and the grandchild
+        // is a leaf Plan. No boundaries anywhere, so _distribute_plan should
+        // rebuild the tree without errors and without incrementing cut_index.
+        //
+        // Guards against a regression where the `Plan` arm's
+        // `with_new_children` call drops or double-wraps descendants.
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+
+        // Annotate — no boundaries expected (Partial's parent is a Plan
+        // annotation for the Partial itself, not a coalesce-trigger parent).
+        let annotated = annotate_plan(Arc::clone(&partial)).unwrap();
+        let mut cut_index = 0u32;
+        let rebuilt = _distribute_plan(
+            annotated,
+            MppPlanShape::ScalarAggOnBinaryJoin,
+            &mut cut_index,
+        )
+        .unwrap();
+
+        assert_eq!(cut_index, 0);
+        // Root must still be an AggregateExec(Partial). with_new_children
+        // on a single-child plan returns a fresh Arc even if the child is
+        // identical, so don't use Arc::ptr_eq on the root.
+        let rebuilt_agg = rebuilt
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("root is AggregateExec after round trip");
+        assert_eq!(*rebuilt_agg.mode(), AggregateMode::Partial);
+        assert_eq!(rebuilt.children().len(), 1);
+    }
+
+    #[test]
+    fn distribute_plan_shuffle_arm_errors_for_now() {
+        // Step 2c stubs the Shuffle emit path. annotate_plan on a
+        // RepartitionExec(Hash) produces a Shuffle annotation whose
+        // _distribute_plan call must return DataFusionError::Plan mentioning
+        // the tag and "not yet wired" — this pins the error shape so Step
+        // 2c-ii knows what to replace.
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let hash_key: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::new(Column::new("id", 0))];
+        let repart: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::Hash(hash_key, 2)).unwrap());
+        let annotated = annotate_plan(repart).unwrap();
+
+        let mut cut_index = 0u32;
+        let err = _distribute_plan(annotated, MppPlanShape::JoinOnly, &mut cut_index)
+            .expect_err("Shuffle arm stub must return an error");
+        let msg = format!("{err}");
+        assert!(msg.contains("Shuffle emit"), "unexpected error: {msg}");
+        assert!(msg.contains("join_left"), "unexpected error: {msg}");
+        assert!(msg.contains("not yet wired"), "unexpected error: {msg}");
+        // Index advanced exactly once — the `Shuffle` arm consumed a tag
+        // before returning.
+        assert_eq!(cut_index, 1);
+    }
+
+    #[test]
+    fn distribute_plan_coalesce_arm_errors_for_now() {
+        // CoalescePartitionsExec over a non-leaf child is the DF-D Coalesce
+        // trigger. annotate_plan produces a Coalesce annotation on the
+        // child (the Partial aggregate), which _distribute_plan must surface
+        // as a "Coalesce emit ... not yet wired" error tagged `scalar_final`
+        // when the shape is ScalarAggOnBinaryJoin and the only cut encountered
+        // is the final one.
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
+        let annotated = annotate_plan(coalesced).unwrap();
+
+        let mut cut_index = 0u32;
+        let err = _distribute_plan(
+            annotated,
+            MppPlanShape::ScalarAggOnBinaryJoin,
+            &mut cut_index,
+        )
+        .expect_err("Coalesce arm stub must return an error");
+        let msg = format!("{err}");
+        assert!(msg.contains("Coalesce emit"), "unexpected error: {msg}");
+        // The only cut annotation in this tree is the coalesce over the
+        // Partial; with ScalarAggOnBinaryJoin shape it's the `scalar_left`
+        // tag at index 0 (this isn't a full scalar-agg tree — it's a
+        // minimal synthetic shape; the test proves the tag lookup runs,
+        // not that tag-to-shape is semantically correct in isolation).
+        assert!(msg.contains("scalar_left"), "unexpected error: {msg}");
+        assert!(msg.contains("not yet wired"), "unexpected error: {msg}");
+        assert_eq!(cut_index, 1);
+    }
+
+    #[test]
+    fn distribute_plan_cut_index_counts_bottom_up() {
+        // Build a two-Shuffle tree — RepartitionExec(Hash) wrapping
+        // RepartitionExec(Hash) wrapping a mem_source — so annotate_plan
+        // yields Shuffle(Shuffle(Plan(leaf))). Bottom-up traversal must
+        // fail on the *inner* Shuffle first (cut index 0), leaving the
+        // outer Shuffle un-visited. If the walker accidentally goes
+        // top-down, the tag would be `join_right` (index 1) instead of
+        // `join_left` (index 0).
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let k0: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::new(Column::new("id", 0))];
+        let inner: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::Hash(k0, 2)).unwrap());
+        let k1: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::new(Column::new("id", 0))];
+        let outer: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(inner, Partitioning::Hash(k1, 2)).unwrap());
+        let annotated = annotate_plan(outer).unwrap();
+
+        let mut cut_index = 0u32;
+        let err = _distribute_plan(annotated, MppPlanShape::JoinOnly, &mut cut_index)
+            .expect_err("Shuffle stub must error");
+        // Bottom-up ⇒ inner cut first ⇒ `join_left`.
+        assert!(format!("{err}").contains("join_left"));
+        assert_eq!(cut_index, 1);
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -415,6 +415,151 @@ fn _annotate_plan(
     Ok(annotation)
 }
 
+/// Pre-pass: rewrite a ParadeDB "standard" physical plan so it carries the
+/// `RepartitionExec(Hash)` / `CoalescePartitionsExec` markers the DF-D
+/// generic walker treats as cut triggers.
+///
+/// ParadeDB's standard plan (as produced by `exec_datafusion_aggregate`) is
+/// single-partition and emits neither marker: the `HashJoinExec` is
+/// `CollectLeft` with serial left/right scans, there's no upstream
+/// `RepartitionExec`, and the aggregate chain has no `CoalescePartitionsExec`
+/// above the `Partial` because there's only one input partition to begin
+/// with. Running [`annotate_plan`] directly over that plan yields zero
+/// boundary annotations.
+///
+/// This function closes that gap by shape:
+///
+/// * [`MppPlanShape::JoinOnly`] — wrap `HashJoinExec.left()` and `.right()`
+///   in `RepartitionExec(Hash(key))`. Two Shuffle triggers result.
+///
+/// * [`MppPlanShape::ScalarAggOnBinaryJoin`] — the two pre-join
+///   `RepartitionExec(Hash(key))` above, plus a `CoalescePartitionsExec`
+///   wrapping the `AggregateExec(Partial)`. The two pre-join wrappers give
+///   Shuffle triggers; the coalesce wrapper gives a Coalesce trigger above
+///   the Partial whose Step-2c rewrite emits a `FixedTargetPartitioner(0)`
+///   (final-gather to leader).
+///
+/// * [`MppPlanShape::GroupByAggOnBinaryJoin`] — the two pre-join
+///   `RepartitionExec(Hash(key))` above, plus a
+///   `RepartitionExec(Hash(group_keys))` wrapping the `AggregateExec(Partial)`.
+///   Three Shuffle triggers; the post-Partial one drives the postagg shuffle
+///   with a `HashPartitioner` in Step 2c.
+///
+/// The rewrite walks bottom-up so rewrites of descendants compose cleanly
+/// with rewrites of ancestors (e.g. the scalar-agg Partial wrap must see
+/// the already-shuffled join as its grandchild).
+///
+/// Not yet live — nothing calls this. Step 2c will wire
+/// `distribute_plan` through `insert_mpp_cuts` → `annotate_plan` →
+/// `_distribute_plan`.
+#[allow(dead_code)]
+pub(super) fn insert_mpp_cuts(
+    plan: Arc<dyn ExecutionPlan>,
+    shape: MppPlanShape,
+    total_participants: u32,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let kind = match shape {
+        MppPlanShape::ScalarAggOnBinaryJoin => CutKind::ScalarAgg,
+        MppPlanShape::GroupByAggOnBinaryJoin => CutKind::GroupByAgg,
+        MppPlanShape::JoinOnly => CutKind::JoinOnly,
+        MppPlanShape::GroupByAggSingleTable => {
+            return Err(DataFusionError::Plan(
+                "mpp: insert_mpp_cuts: GroupByAggSingleTable not yet supported".into(),
+            ));
+        }
+        MppPlanShape::Ineligible => {
+            return Err(DataFusionError::Plan(
+                "mpp: insert_mpp_cuts invoked on Ineligible shape — caller should have \
+                 routed to the non-MPP serial path"
+                    .into(),
+            ));
+        }
+    };
+    rewrite_with_cuts(plan, kind, total_participants)
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(dead_code)]
+enum CutKind {
+    ScalarAgg,
+    GroupByAgg,
+    JoinOnly,
+}
+
+#[allow(dead_code)]
+fn rewrite_with_cuts(
+    plan: Arc<dyn ExecutionPlan>,
+    kind: CutKind,
+    n: u32,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    // Recurse into children first so rewrites compose bottom-up.
+    let original_children: Vec<Arc<dyn ExecutionPlan>> =
+        plan.children().iter().map(|c| Arc::clone(c)).collect();
+    let new_children: Vec<Arc<dyn ExecutionPlan>> = original_children
+        .iter()
+        .map(|c| rewrite_with_cuts(Arc::clone(c), kind, n))
+        .collect::<DfResult<Vec<_>>>()?;
+
+    let any_child_changed = original_children
+        .iter()
+        .zip(new_children.iter())
+        .any(|(a, b)| !Arc::ptr_eq(a, b));
+    let plan = if any_child_changed {
+        Arc::clone(&plan).with_new_children(new_children)?
+    } else {
+        plan
+    };
+
+    // HashJoinExec — wrap its left / right inputs with RepartitionExec(Hash)
+    // so the DF-D walker sees Shuffle triggers there. Does *not* touch the
+    // join's own node type, mode, or keys — the join itself still runs
+    // locally on each seat, operating on shuffle-gathered inputs.
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        let join_on = hj.on().to_vec();
+        let left_keys: Vec<Arc<dyn PhysicalExpr>> =
+            join_on.iter().map(|(l, _)| Arc::clone(l)).collect();
+        let right_keys: Vec<Arc<dyn PhysicalExpr>> =
+            join_on.iter().map(|(_, r)| Arc::clone(r)).collect();
+
+        let new_left: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
+            Arc::clone(hj.left()),
+            Partitioning::Hash(left_keys, n as usize),
+        )?);
+        let new_right: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
+            Arc::clone(hj.right()),
+            Partitioning::Hash(right_keys, n as usize),
+        )?);
+        return Arc::clone(&plan).with_new_children(vec![new_left, new_right]);
+    }
+
+    // AggregateExec(Partial) — per-shape wrapping. Final/FinalPartitioned
+    // don't get wrapped; they're the stage above the cut.
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial) {
+            let group_exprs = agg.group_expr().expr();
+            match (kind, group_exprs.is_empty()) {
+                (CutKind::ScalarAgg, true) => {
+                    // Scalar agg: Coalesce trigger above the Partial.
+                    return Ok(Arc::new(CoalescePartitionsExec::new(plan)));
+                }
+                (CutKind::GroupByAgg, false) => {
+                    // Group-by agg: Shuffle trigger above the Partial,
+                    // hashed on the group-by keys.
+                    let group_keys: Vec<Arc<dyn PhysicalExpr>> =
+                        group_exprs.iter().map(|(e, _)| Arc::clone(e)).collect();
+                    return Ok(Arc::new(RepartitionExec::try_new(
+                        plan,
+                        Partitioning::Hash(group_keys, n as usize),
+                    )?));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(plan)
+}
+
 // ============================================================================
 // Topology assemblers — one per supported shape. Each one owns the full flow:
 // plan walk + mesh allocation + shuffle wiring + final DF operator composition.
@@ -1627,5 +1772,163 @@ mod tests {
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let err = require_one_child(vec![mem_source(&schema), mem_source(&schema)]).unwrap_err();
         assert!(format!("{err}").contains("Expected exactly 1"));
+    }
+
+    // ========================================================================
+    // `insert_mpp_cuts` tests (dead-path scaffolding — Step 2b).
+    //
+    // These exercise the aggregate-wrapping half of the pre-pass on
+    // synthetic plans built from `MemorySourceConfig` +
+    // `AggregateExec(Partial)`. The `HashJoinExec` half is exercised by
+    // regression tests in Step 2d, when `insert_mpp_cuts` is wired into
+    // `distribute_plan`'s live path — building a synthetic `HashJoinExec`
+    // here would duplicate the fixture the regression tests already
+    // produce from real SQL.
+    // ========================================================================
+
+    fn partial_agg_over_mem_source(group_cols: Vec<&str>) -> Arc<dyn ExecutionPlan> {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let group_by_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = group_cols
+            .into_iter()
+            .map(|c| {
+                (
+                    Arc::new(Column::new(c, 0)) as Arc<dyn PhysicalExpr>,
+                    c.to_string(),
+                )
+            })
+            .collect();
+        Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(group_by_exprs),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn insert_mpp_cuts_scalar_wraps_partial_with_coalesce() {
+        let plan = partial_agg_over_mem_source(vec![]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::ScalarAggOnBinaryJoin, 2).unwrap();
+
+        // Root should be CoalescePartitionsExec; its sole child is the
+        // original Partial aggregate.
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .is_some());
+        assert_eq!(rewritten.children().len(), 1);
+        let partial = rewritten.children()[0]
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("child is AggregateExec");
+        assert_eq!(*partial.mode(), AggregateMode::Partial);
+
+        // Cross-check: annotate_plan should see exactly one Coalesce boundary.
+        let annotated = annotate_plan(Arc::clone(&rewritten)).unwrap();
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Coalesce
+        ));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_groupby_wraps_partial_with_hash_repartition() {
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::GroupByAggOnBinaryJoin, 4).unwrap();
+
+        // Root should be RepartitionExec(Hash(id), 4); its sole child is
+        // the original Partial aggregate.
+        let repart = rewritten
+            .as_any()
+            .downcast_ref::<RepartitionExec>()
+            .expect("root is RepartitionExec");
+        match repart.partitioning() {
+            Partitioning::Hash(keys, n) => {
+                assert_eq!(keys.len(), 1);
+                assert_eq!(*n, 4);
+            }
+            other => panic!("expected Hash partitioning, got {other:?}"),
+        }
+        assert_eq!(rewritten.children().len(), 1);
+        let partial = rewritten.children()[0]
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("child is AggregateExec");
+        assert_eq!(*partial.mode(), AggregateMode::Partial);
+
+        // Cross-check: annotate_plan should see a Shuffle boundary on the
+        // RepartitionExec.
+        let annotated = annotate_plan(Arc::clone(&rewritten)).unwrap();
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Shuffle
+        ));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_scalar_does_not_wrap_groupby_partial() {
+        // A Partial *with* group keys under ScalarAgg shape should not be
+        // wrapped — rewrite_with_cuts matches on (kind, group_exprs.is_empty()).
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::ScalarAggOnBinaryJoin, 2).unwrap();
+
+        // Root is still the Partial — no CoalescePartitionsExec, no RepartitionExec.
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .is_none());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_groupby_does_not_wrap_scalar_partial() {
+        // A Partial *without* group keys under GroupByAgg shape should not
+        // be wrapped. The caller's classifier is responsible for picking
+        // the right shape — rewrite_with_cuts enforces the invariant by
+        // no-op-ing on the mismatched pair.
+        let plan = partial_agg_over_mem_source(vec![]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::GroupByAggOnBinaryJoin, 2).unwrap();
+
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<RepartitionExec>()
+            .is_none());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_join_only_does_not_wrap_partial() {
+        // JoinOnly shape should leave any Partial aggregate alone — the
+        // only rewrite is on HashJoinExec children (exercised in regression).
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::JoinOnly, 2).unwrap();
+
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_rejects_ineligible() {
+        let plan = partial_agg_over_mem_source(vec![]);
+        let err = insert_mpp_cuts(plan, MppPlanShape::Ineligible, 2).unwrap_err();
+        assert!(format!("{err}").contains("Ineligible"));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_rejects_single_table_groupby() {
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let err = insert_mpp_cuts(plan, MppPlanShape::GroupByAggSingleTable, 2).unwrap_err();
+        assert!(format!("{err}").contains("GroupByAggSingleTable"));
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -88,6 +88,7 @@
                       // + reuse it.
 
 use std::borrow::Borrow;
+use std::collections::VecDeque;
 use std::sync::Arc;
 
 use datafusion::arrow::datatypes::SchemaRef;
@@ -560,32 +561,124 @@ fn rewrite_with_cuts(
     Ok(plan)
 }
 
+/// Per-walk state threaded through [`_distribute_plan`]'s recursion. Holds
+/// the pre-extracted scalars the emit arms need (query_id, participant_index,
+/// total_participants, shape) plus the pool of meshes allocated up front so
+/// each boundary visit just `pop_front`s one. Structured as a plain struct so
+/// the walker body stays close to DF-D's — the emit arms are a handful of
+/// lines that all dispatch through [`emit_shuffle_cut`].
+///
+/// Lifetime-free: the walker does not touch [`MppExecutionState`] during
+/// traversal. The caller extracts what the walker needs (via [`take_meshes`]
+/// / [`MppExecutionState::query_id`] / [`MppParticipantConfig`]) and hands it
+/// in. Keeping the walker free of coordinator references is what lets the
+/// unit tests drive it with in-process channels.
+///
+/// [`MppParticipantConfig`]: crate::postgres::customscan::mpp::MppParticipantConfig
+#[allow(dead_code)]
+pub(super) struct CutEmitCtx {
+    /// Shape classification — consumed by [`tag_for_cut`] to derive the
+    /// byte-exact tag string each boundary passes to
+    /// [`wrap_with_mpp_shuffle`].
+    shape: MppPlanShape,
+    /// Bottom-up ordinal of the next boundary the walker will emit. Each
+    /// emit (`Shuffle` or `Coalesce`) increments by 1 after reading
+    /// [`tag_for_cut`].
+    cut_index: u32,
+    /// Mesh pool pre-drained from [`MppExecutionState`]; every emit pops one
+    /// from the front. Must hold exactly [`cut_count_for_shape`] meshes at
+    /// entry — the caller enforces this via [`take_meshes`].
+    meshes: VecDeque<MeshHalves>,
+    /// Per-query stamp used by [`MppStage::new`] for every boundary.
+    query_id: u64,
+    /// Seat ordinal for this participant (0 = leader). Stamped onto
+    /// outbound senders as `task_number` and onto [`ShuffleWiring`] so
+    /// `ShuffleExec` drops the self-partition sender slot.
+    participant_index: u32,
+    /// Total seats in the mesh. Sizes every partitioner (`HashPartitioner`,
+    /// `FixedTargetPartitioner`).
+    total_participants: u32,
+}
+
+#[allow(dead_code)]
+impl CutEmitCtx {
+    /// Construct a context from the pieces of an [`MppExecutionState`] the
+    /// walker actually needs. Pulls the mesh pool out of the state up front
+    /// so the walker itself can stay free of coordinator references.
+    ///
+    /// `expected_cuts` must equal [`cut_count_for_shape`] for the shape —
+    /// [`take_meshes`] panics otherwise, surfacing the leader/worker
+    /// contract mismatch loudly rather than deferring to a walker-side
+    /// error.
+    pub(super) fn from_state(
+        state: &mut MppExecutionState,
+        shape: MppPlanShape,
+        expected_cuts: usize,
+    ) -> Self {
+        let cfg = state.participant_config();
+        let participant_index = cfg.participant_index;
+        let total_participants = cfg.total_participants;
+        let query_id = state.query_id();
+        let meshes: VecDeque<MeshHalves> = take_meshes(state, expected_cuts).into();
+        CutEmitCtx {
+            shape,
+            cut_index: 0,
+            meshes,
+            query_id,
+            participant_index,
+            total_participants,
+        }
+    }
+}
+
 /// Emit an [`ExecutionPlan`] from an [`AnnotatedPlan`], turning every
-/// network-boundary annotation into a concrete MPP rewrite. Ported in spirit
-/// from DF-D's `_distribute_plan`; ParadeDB deviates by having a single
-/// `Shuffle` emit path (no stage tree, no task estimators) and by tagging
-/// cuts with shape-aware labels so benchmark-log grep patterns keep working.
+/// network-boundary annotation into a concrete
+/// [`wrap_with_mpp_shuffle`] call. Ported in spirit from DF-D's
+/// `_distribute_plan`; ParadeDB deviates by having a single `Shuffle` emit
+/// path (no stage tree, no task estimators) and by tagging cuts with
+/// shape-aware labels so benchmark-log grep patterns keep working.
 ///
-/// # Step 2c scope — structural traversal only
+/// # Traversal
 ///
-/// This iteration wires the `Plan` arm through `with_new_children` recursion,
-/// which is enough to exercise plan-tree round-tripping and cut counting. The
-/// `Shuffle` and `Coalesce` arms return `DataFusionError::Plan(...)` with a
-/// "not yet wired" message; Step 2c-ii replaces those errors with real
-/// [`wrap_with_mpp_shuffle`](crate::postgres::customscan::mpp::plan_build::wrap_with_mpp_shuffle)
-/// calls + ParadeDB post-passes (probe-side dynamic-filter strip, leader-only
-/// scalar `FinalPartitioned`, 64 Ki `CoalesceBatchesExec` insert for GROUP BY,
-/// `VisibilityCtidResolverRule` re-run).
+/// Post-order: descendants are emitted first, so the current node's
+/// `with_new_children` call (Plan arm) or its [`emit_shuffle_cut`] call
+/// (Shuffle / Coalesce arms) sees the already-rewritten subtree as its
+/// single child.
 ///
-/// `cut_index` is the bottom-up ordinal of the next boundary the walker
-/// encounters, threaded through the recursion so [`tag_for_cut`] can derive a
-/// byte-exact tag (`scalar_left` / `scalar_right` / `scalar_final`, etc.)
-/// matching the strings the existing topology assemblers emit.
+/// # Shuffle emit
+///
+/// The `Shuffle` boundary sits above a `RepartitionExec(Hash)` that
+/// [`insert_mpp_cuts`] synthesized. The walker extracts the hash-key
+/// column indices, drops the `RepartitionExec` layer, and wraps its
+/// underlying input directly with [`wrap_with_mpp_shuffle`] +
+/// `HashPartitioner`. Keeping the `RepartitionExec` around would add a
+/// redundant in-process partition that `ShuffleExec` already enforces
+/// across seats.
+///
+/// # Coalesce emit
+///
+/// The `Coalesce` boundary sits above the child of a
+/// `CoalescePartitionsExec` or `SortPreservingMergeExec`. The walker
+/// wraps that child with `FixedTargetPartitioner(0)` so every seat ships
+/// its rows to seat 0; the parent coalesce / merge is preserved in the
+/// Plan arm above it and remains responsible for the final single-stream
+/// output shape.
+///
+/// # ParadeDB post-passes
+///
+/// The emitted tree still carries ParadeDB-specific obligations that
+/// this walker deliberately does not handle — probe-side dynamic-filter
+/// strip + re-apply, `HashJoinExec` rebuild via `.builder()`,
+/// `CoalesceBatchesExec(65_536)` insert before the postagg shuffle,
+/// leader-only `AggregateExec(FinalPartitioned)`, and
+/// `VisibilityCtidResolverRule` re-run. Those live in explicit pre/post
+/// passes that the `distribute_plan` dispatcher orchestrates around this
+/// generic walker (Step 2d), keeping `_distribute_plan` itself as close
+/// to DF-D as the Rust 2021 / ParadeDB-constraint deltas allow.
 #[allow(dead_code)]
 pub(super) fn _distribute_plan(
     plan: AnnotatedPlan,
-    shape: MppPlanShape,
-    cut_index: &mut u32,
+    ctx: &mut CutEmitCtx,
 ) -> DfResult<Arc<dyn ExecutionPlan>> {
     // Recurse bottom-up so descendants' rewrites are in place before the
     // current node's `with_new_children` call sees them. This matches DF-D's
@@ -593,7 +686,7 @@ pub(super) fn _distribute_plan(
     let new_children: Vec<Arc<dyn ExecutionPlan>> = plan
         .children
         .into_iter()
-        .map(|c| _distribute_plan(c, shape, cut_index))
+        .map(|c| _distribute_plan(c, ctx))
         .collect::<DfResult<Vec<_>>>()?;
 
     match plan.plan_or_nb {
@@ -607,24 +700,108 @@ pub(super) fn _distribute_plan(
         PlanOrNetworkBoundary::Shuffle => {
             // Every boundary has exactly one child (the subtree it sits
             // above). DF-D enforces this with `require_one_child`.
-            let _child = require_one_child(&new_children)?;
-            let tag = tag_for_cut(shape, *cut_index);
-            *cut_index += 1;
-            Err(DataFusionError::Plan(format!(
-                "mpp: _distribute_plan: Shuffle emit for cut {tag} is not yet wired \
-                 (Step 2c-ii will replace this with wrap_with_mpp_shuffle + mesh allocation)"
-            )))
+            let child = require_one_child(&new_children)?;
+            let tag = tag_for_cut(ctx.shape, ctx.cut_index);
+            let (partitioner, underlying) =
+                shuffle_keys_from_repartition(&child, ctx.total_participants)?;
+            emit_shuffle_cut(ctx, underlying, partitioner, tag)
         }
         PlanOrNetworkBoundary::Coalesce => {
-            let _child = require_one_child(&new_children)?;
-            let tag = tag_for_cut(shape, *cut_index);
-            *cut_index += 1;
-            Err(DataFusionError::Plan(format!(
-                "mpp: _distribute_plan: Coalesce emit for cut {tag} is not yet wired \
-                 (Step 2c-ii will replace this with wrap_with_mpp_shuffle(FixedTargetPartitioner(0)))"
-            )))
+            let child = require_one_child(&new_children)?;
+            let tag = tag_for_cut(ctx.shape, ctx.cut_index);
+            let partitioner: Arc<dyn RowPartitioner> =
+                Arc::new(FixedTargetPartitioner::new(0, ctx.total_participants));
+            emit_shuffle_cut(ctx, child, partitioner, tag)
         }
     }
+}
+
+/// Extract hash-key column indices from the `RepartitionExec(Hash)` marker
+/// that [`insert_mpp_cuts`] sits directly below a `Shuffle` boundary, then
+/// build a [`HashPartitioner`] and return the marker's underlying input.
+/// The walker wraps that input directly, dropping the `RepartitionExec` —
+/// the MPP `ShuffleExec` replaces what the `RepartitionExec` was doing.
+///
+/// Errors (all surface as `DataFusionError::Plan`) when the child is not a
+/// `RepartitionExec(Hash)` or any hash key is not a plain
+/// [`Column`](datafusion::physical_expr::expressions::Column). The second
+/// case is the same constraint the legacy topology assemblers enforce via
+/// [`extract_key_col_indices`] — milestone 1 only supports column-ref join
+/// keys.
+fn shuffle_keys_from_repartition(
+    child: &Arc<dyn ExecutionPlan>,
+    total_participants: u32,
+) -> DfResult<(Arc<dyn RowPartitioner>, Arc<dyn ExecutionPlan>)> {
+    let r_exec = child
+        .as_any()
+        .downcast_ref::<RepartitionExec>()
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "mpp: _distribute_plan: Shuffle boundary expected RepartitionExec child \
+                 synthesized by insert_mpp_cuts"
+                    .into(),
+            )
+        })?;
+    let Partitioning::Hash(exprs, _n) = r_exec.partitioning() else {
+        return Err(DataFusionError::Plan(
+            "mpp: _distribute_plan: Shuffle boundary expected Partitioning::Hash; \
+             insert_mpp_cuts only synthesizes Hash repartitions"
+                .into(),
+        ));
+    };
+    let keys: Vec<usize> = exprs.iter().map(col_index).collect::<DfResult<Vec<_>>>()?;
+    let partitioner: Arc<dyn RowPartitioner> =
+        Arc::new(HashPartitioner::new(keys, total_participants));
+    Ok((partitioner, Arc::clone(r_exec.input())))
+}
+
+/// Pop the next mesh off `ctx.meshes` and stitch up the full drain + sender
+/// + cooperative-drain + frame-stamp wiring that [`wrap_with_mpp_shuffle`]
+///   expects. Shared between the `Shuffle` and `Coalesce` emit arms; the only
+///   difference between them is the `partitioner` choice.
+///
+/// Panics (via `pgrx::error!` inside `take_meshes`) never fire here — the
+/// mesh count is checked up front in [`CutEmitCtx::from_state`]. Downstream
+/// error paths live inside [`wrap_with_mpp_shuffle`] itself and surface as
+/// `DataFusionError`.
+fn emit_shuffle_cut(
+    ctx: &mut CutEmitCtx,
+    child: Arc<dyn ExecutionPlan>,
+    partitioner: Arc<dyn RowPartitioner>,
+    tag: &'static str,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let mesh = ctx.meshes.pop_front().ok_or_else(|| {
+        DataFusionError::Plan(format!(
+            "mpp: _distribute_plan: out of mesh slots at cut {} ({tag}); \
+             insert_mpp_cuts / cut_count_for_shape disagree",
+            ctx.cut_index
+        ))
+    })?;
+    let stage = MppStage::new(ctx.query_id, ctx.cut_index, ctx.total_participants);
+    ctx.cut_index += 1;
+
+    let drain = spawn_drain(mesh.inbound);
+    let task_key = MppTaskKey {
+        query_id: stage.query_id,
+        stage_id: stage.stage_id,
+        task_number: ctx.participant_index,
+    };
+    let outbound = attach_cooperative_drain(stamp_frame_ids(mesh.outbound, task_key), &drain);
+    let wiring = ShuffleWiring {
+        partitioner,
+        outbound_senders: outbound,
+        participant_index: ctx.participant_index,
+        cooperative_drain: Some(Arc::clone(&drain)),
+    };
+    let wrapped_schema = child.schema();
+    wrap_with_mpp_shuffle(MppShuffleInputs {
+        child,
+        wiring,
+        drain_handle: drain,
+        wrapped_schema,
+        tag,
+        stage: Some(stage),
+    })
 }
 
 /// Map a (shape, bottom-up cut index) pair to the byte-exact tag string the
@@ -2040,13 +2217,89 @@ mod tests {
     }
 
     // ========================================================================
-    // `_distribute_plan` + `tag_for_cut` tests (dead-path scaffolding — Step 2c).
-    //
-    // Step 2c only wires the `Plan` arm (structural traversal via
-    // `with_new_children`). The `Shuffle` and `Coalesce` arms return
-    // `DataFusionError::Plan` with a "not yet wired" message; Step 2c-ii
-    // replaces those errors with real `wrap_with_mpp_shuffle` calls.
+    // `_distribute_plan` + `tag_for_cut` tests (dead-path scaffolding — Step
+    // 2c-ii). The `Plan` arm exercises `with_new_children` recursion; the
+    // `Shuffle` and `Coalesce` arms hit `wrap_with_mpp_shuffle` against a
+    // synthetic in-process mesh and verify the resulting tree embeds the
+    // expected number of `ShuffleExec` nodes with stamped `MppStage` ids.
     // ========================================================================
+
+    /// Build `count` empty mesh slots — each mesh has `count` outbound /
+    /// inbound edges per seat, with the self-seat slot left `None` so the
+    /// wiring matches what `take_meshes` would deliver at runtime. Seats
+    /// other than `participant_index` get live `in_proc_channel`s; their
+    /// receiver halves are dropped so the drain thread sees EOF instantly.
+    fn synth_meshes(
+        mesh_count: usize,
+        participant_index: u32,
+        total_participants: u32,
+    ) -> VecDeque<MeshHalves> {
+        let n = total_participants as usize;
+        let mut meshes = VecDeque::with_capacity(mesh_count);
+        for _ in 0..mesh_count {
+            let mut outbound: Vec<Option<MppSender>> = Vec::with_capacity(n);
+            let mut inbound: Vec<Option<MppReceiver>> = Vec::with_capacity(n);
+            for seat in 0..n {
+                if seat as u32 == participant_index {
+                    outbound.push(None);
+                    inbound.push(None);
+                    continue;
+                }
+                let (out_tx, _out_rx) = in_proc_channel(1);
+                outbound.push(Some(MppSender::new(Box::new(out_tx))));
+                let (_in_tx, in_rx) = in_proc_channel(1);
+                inbound.push(Some(MppReceiver::new(Box::new(in_rx))));
+            }
+            meshes.push_back(MeshHalves { outbound, inbound });
+        }
+        meshes
+    }
+
+    /// Construct a synthetic `CutEmitCtx` with `mesh_count` pre-allocated
+    /// in-process meshes — enough for tests to drive `_distribute_plan`
+    /// without wiring up a full `MppExecutionState`.
+    fn synth_ctx(shape: MppPlanShape, mesh_count: usize) -> CutEmitCtx {
+        CutEmitCtx {
+            shape,
+            cut_index: 0,
+            meshes: synth_meshes(mesh_count, 0, 2),
+            query_id: 0xdeadbeef,
+            participant_index: 0,
+            total_participants: 2,
+        }
+    }
+
+    /// Walk `plan` and collect every `ShuffleExec`. Sorted by
+    /// `input_stage.stage_id` so tests can assert tag/stage_id pairings in
+    /// emit order regardless of which subtree the walker descended first.
+    fn collect_shuffle_execs(
+        plan: &Arc<dyn ExecutionPlan>,
+    ) -> Vec<&crate::postgres::customscan::mpp::shuffle::ShuffleExec> {
+        // Emulate a trait-method traversal without writing a full Visitor:
+        // recursively borrow each node, try the downcast, descend into the
+        // node's children. `ShuffleExec` is the only type we care about so
+        // the single-type collector is adequate.
+        fn recurse<'a>(
+            plan: &'a Arc<dyn ExecutionPlan>,
+            out: &mut Vec<&'a crate::postgres::customscan::mpp::shuffle::ShuffleExec>,
+        ) {
+            if let Some(s) = plan
+                .as_any()
+                .downcast_ref::<crate::postgres::customscan::mpp::shuffle::ShuffleExec>()
+            {
+                out.push(s);
+            }
+            for child in plan.children() {
+                // `plan.children()` returns `Vec<&Arc<dyn ExecutionPlan>>`
+                // — each child is a borrow rooted in the parent, so
+                // `recurse(child, out)` is sound.
+                recurse(child, out);
+            }
+        }
+        let mut out = Vec::new();
+        recurse(plan, &mut out);
+        out
+    }
 
     #[test]
     fn tag_for_cut_covers_every_live_shape() {
@@ -2081,8 +2334,8 @@ mod tests {
     #[test]
     fn tag_for_cut_unknown_pair_falls_through_to_placeholder() {
         // Out-of-range indices and Ineligible / SingleTable shapes fall
-        // through to the placeholder rather than panic. Callers are not
-        // live yet; a panic would mask Step 2c-ii regressions.
+        // through to the placeholder rather than panic — a panic in the
+        // dead-code scaffold would mask a real emit-arm regression.
         assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 7), "mpp_unknown_cut");
         assert_eq!(tag_for_cut(MppPlanShape::Ineligible, 0), "mpp_unknown_cut");
         assert_eq!(
@@ -2095,33 +2348,33 @@ mod tests {
     fn distribute_plan_round_trips_boundary_free_plan() {
         // A plain MemorySourceConfig has no boundary triggers, so the
         // traversal should emit a tree identical in structure to the input:
-        // one Plan annotation per original node, no errors, no children
-        // collapsed.
+        // one Plan annotation per original node, no errors, no meshes
+        // consumed.
         let schema: SchemaRef =
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let input = mem_source(&schema);
         let annotated = annotate_plan(Arc::clone(&input)).unwrap();
 
-        let mut cut_index = 0u32;
-        let rebuilt = _distribute_plan(annotated, MppPlanShape::JoinOnly, &mut cut_index).unwrap();
+        let mut ctx = synth_ctx(MppPlanShape::JoinOnly, 0);
+        let rebuilt = _distribute_plan(annotated, &mut ctx).unwrap();
 
-        // No boundaries ⇒ no cuts consumed.
-        assert_eq!(cut_index, 0);
+        // No boundaries ⇒ no cuts consumed, meshes untouched.
+        assert_eq!(ctx.cut_index, 0);
+        assert_eq!(ctx.meshes.len(), 0);
         // Leaf plan re-emitted verbatim (same Arc, since `with_new_children`
         // is skipped when `new_children.is_empty()`).
         assert!(Arc::ptr_eq(&rebuilt, &input));
+        // And no shuffles were emitted.
+        assert_eq!(collect_shuffle_execs(&rebuilt).len(), 0);
     }
 
     #[test]
     fn distribute_plan_recurses_through_plan_arms() {
-        // CoalescePartitionsExec over a Partial aggregate: the root is a
-        // Plan, the child is a Plan (the Partial is leaf-like-ish — it has
-        // a mem_source underneath, which is non-empty), and the grandchild
-        // is a leaf Plan. No boundaries anywhere, so _distribute_plan should
-        // rebuild the tree without errors and without incrementing cut_index.
-        //
-        // Guards against a regression where the `Plan` arm's
-        // `with_new_children` call drops or double-wraps descendants.
+        // A Partial aggregate over a mem_source has no boundary triggers,
+        // so `_distribute_plan` should rebuild the tree without errors and
+        // without consuming any cut slots. Guards against a regression
+        // where the `Plan` arm's `with_new_children` call drops or
+        // double-wraps descendants.
         let schema: SchemaRef =
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let input = mem_source(&schema);
@@ -2137,18 +2390,11 @@ mod tests {
             .unwrap(),
         );
 
-        // Annotate — no boundaries expected (Partial's parent is a Plan
-        // annotation for the Partial itself, not a coalesce-trigger parent).
         let annotated = annotate_plan(Arc::clone(&partial)).unwrap();
-        let mut cut_index = 0u32;
-        let rebuilt = _distribute_plan(
-            annotated,
-            MppPlanShape::ScalarAggOnBinaryJoin,
-            &mut cut_index,
-        )
-        .unwrap();
+        let mut ctx = synth_ctx(MppPlanShape::ScalarAggOnBinaryJoin, 0);
+        let rebuilt = _distribute_plan(annotated, &mut ctx).unwrap();
 
-        assert_eq!(cut_index, 0);
+        assert_eq!(ctx.cut_index, 0);
         // Root must still be an AggregateExec(Partial). with_new_children
         // on a single-child plan returns a fresh Arc even if the child is
         // identical, so don't use Arc::ptr_eq on the root.
@@ -2158,43 +2404,63 @@ mod tests {
             .expect("root is AggregateExec after round trip");
         assert_eq!(*rebuilt_agg.mode(), AggregateMode::Partial);
         assert_eq!(rebuilt.children().len(), 1);
+        assert_eq!(collect_shuffle_execs(&rebuilt).len(), 0);
     }
 
     #[test]
-    fn distribute_plan_shuffle_arm_errors_for_now() {
-        // Step 2c stubs the Shuffle emit path. annotate_plan on a
-        // RepartitionExec(Hash) produces a Shuffle annotation whose
-        // _distribute_plan call must return DataFusionError::Plan mentioning
-        // the tag and "not yet wired" — this pins the error shape so Step
-        // 2c-ii knows what to replace.
+    fn distribute_plan_shuffle_arm_emits_wrap_with_mpp_shuffle() {
+        // `annotate_plan` over a `RepartitionExec(Hash)` produces a Shuffle
+        // annotation; _distribute_plan must emit a live
+        // `wrap_with_mpp_shuffle` tree with tag `join_left` and
+        // input_stage stage_id 0. The underlying `RepartitionExec` layer
+        // is dropped — its purpose was only to carry the hash-key
+        // annotation to the walker.
+        use crate::postgres::customscan::mpp::stage::MppNetworkBoundary;
+
         let schema: SchemaRef =
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let input = mem_source(&schema);
         let hash_key: Vec<Arc<dyn PhysicalExpr>> = vec![Arc::new(Column::new("id", 0))];
-        let repart: Arc<dyn ExecutionPlan> =
-            Arc::new(RepartitionExec::try_new(input, Partitioning::Hash(hash_key, 2)).unwrap());
+        let repart: Arc<dyn ExecutionPlan> = Arc::new(
+            RepartitionExec::try_new(Arc::clone(&input), Partitioning::Hash(hash_key, 2)).unwrap(),
+        );
         let annotated = annotate_plan(repart).unwrap();
 
-        let mut cut_index = 0u32;
-        let err = _distribute_plan(annotated, MppPlanShape::JoinOnly, &mut cut_index)
-            .expect_err("Shuffle arm stub must return an error");
-        let msg = format!("{err}");
-        assert!(msg.contains("Shuffle emit"), "unexpected error: {msg}");
-        assert!(msg.contains("join_left"), "unexpected error: {msg}");
-        assert!(msg.contains("not yet wired"), "unexpected error: {msg}");
-        // Index advanced exactly once — the `Shuffle` arm consumed a tag
-        // before returning.
-        assert_eq!(cut_index, 1);
+        let mut ctx = synth_ctx(MppPlanShape::JoinOnly, 1);
+        let rebuilt = _distribute_plan(annotated, &mut ctx).unwrap();
+
+        assert_eq!(ctx.cut_index, 1);
+        assert_eq!(ctx.meshes.len(), 0, "mesh pool drained by the single cut");
+
+        // Exactly one ShuffleExec emitted, stamped with cut_index 0 and
+        // the JoinOnly 0→"join_left" tag. `input_stage` is proof the
+        // boundary went through the `MppNetworkBoundary::with_input_stage`
+        // seam — i.e. `wrap_with_mpp_shuffle` actually ran.
+        let shuffles = collect_shuffle_execs(&rebuilt);
+        assert_eq!(shuffles.len(), 1, "expected a single ShuffleExec");
+        let stage = shuffles[0].input_stage().expect("stage was stamped");
+        assert_eq!(stage.query_id, 0xdeadbeef);
+        assert_eq!(stage.stage_id, 0);
+        assert_eq!(stage.task_count, 2);
+        // Sanity: the RepartitionExec marker doesn't survive — only
+        // scan-level children should remain below the shuffle.
+        let debug = format!("{rebuilt:?}");
+        assert!(
+            !debug.contains("RepartitionExec"),
+            "RepartitionExec marker should be dropped: {debug}"
+        );
     }
 
     #[test]
-    fn distribute_plan_coalesce_arm_errors_for_now() {
+    fn distribute_plan_coalesce_arm_emits_wrap_with_mpp_shuffle() {
         // CoalescePartitionsExec over a non-leaf child is the DF-D Coalesce
-        // trigger. annotate_plan produces a Coalesce annotation on the
-        // child (the Partial aggregate), which _distribute_plan must surface
-        // as a "Coalesce emit ... not yet wired" error tagged `scalar_final`
-        // when the shape is ScalarAggOnBinaryJoin and the only cut encountered
-        // is the final one.
+        // trigger — `annotate_plan` places the boundary on the child. With
+        // `ScalarAggOnBinaryJoin` shape and the only cut at index 0, the
+        // emit must use tag `scalar_left` (this is a minimal synthetic
+        // tree — the test proves the emit runs, not that the tag is
+        // semantically correct for a real scalar-agg plan).
+        use crate::postgres::customscan::mpp::stage::MppNetworkBoundary;
+
         let schema: SchemaRef =
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let input = mem_source(&schema);
@@ -2212,34 +2478,31 @@ mod tests {
         let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
         let annotated = annotate_plan(coalesced).unwrap();
 
-        let mut cut_index = 0u32;
-        let err = _distribute_plan(
-            annotated,
-            MppPlanShape::ScalarAggOnBinaryJoin,
-            &mut cut_index,
-        )
-        .expect_err("Coalesce arm stub must return an error");
-        let msg = format!("{err}");
-        assert!(msg.contains("Coalesce emit"), "unexpected error: {msg}");
-        // The only cut annotation in this tree is the coalesce over the
-        // Partial; with ScalarAggOnBinaryJoin shape it's the `scalar_left`
-        // tag at index 0 (this isn't a full scalar-agg tree — it's a
-        // minimal synthetic shape; the test proves the tag lookup runs,
-        // not that tag-to-shape is semantically correct in isolation).
-        assert!(msg.contains("scalar_left"), "unexpected error: {msg}");
-        assert!(msg.contains("not yet wired"), "unexpected error: {msg}");
-        assert_eq!(cut_index, 1);
+        let mut ctx = synth_ctx(MppPlanShape::ScalarAggOnBinaryJoin, 1);
+        let rebuilt = _distribute_plan(annotated, &mut ctx).unwrap();
+
+        assert_eq!(ctx.cut_index, 1);
+        assert_eq!(ctx.meshes.len(), 0);
+
+        // The outer CoalescePartitionsExec is preserved in the Plan arm;
+        // the emitted shuffle sits beneath it. That's fine for the
+        // generic walker — the ParadeDB post-pass (Step 2d) strips the
+        // coalesce marker when the shape calls for it.
+        let shuffles = collect_shuffle_execs(&rebuilt);
+        assert_eq!(shuffles.len(), 1, "expected a single ShuffleExec");
+        let stage = shuffles[0].input_stage().expect("stage was stamped");
+        assert_eq!(stage.stage_id, 0);
     }
 
     #[test]
-    fn distribute_plan_cut_index_counts_bottom_up() {
-        // Build a two-Shuffle tree — RepartitionExec(Hash) wrapping
-        // RepartitionExec(Hash) wrapping a mem_source — so annotate_plan
-        // yields Shuffle(Shuffle(Plan(leaf))). Bottom-up traversal must
-        // fail on the *inner* Shuffle first (cut index 0), leaving the
-        // outer Shuffle un-visited. If the walker accidentally goes
-        // top-down, the tag would be `join_right` (index 1) instead of
-        // `join_left` (index 0).
+    fn distribute_plan_cuts_emit_bottom_up() {
+        // Two stacked `RepartitionExec(Hash)` wrap a leaf. `annotate_plan`
+        // yields Shuffle(Plan(RepartitionExec, Shuffle(Plan(RepartitionExec,
+        // Plan(leaf))))). Bottom-up emit assigns cut_index 0 to the inner
+        // shuffle (`join_left`) and cut_index 1 to the outer (`join_right`).
+        // If the walker ever goes top-down, the stage_ids invert.
+        use crate::postgres::customscan::mpp::stage::MppNetworkBoundary;
+
         let schema: SchemaRef =
             Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
         let input = mem_source(&schema);
@@ -2251,11 +2514,54 @@ mod tests {
             Arc::new(RepartitionExec::try_new(inner, Partitioning::Hash(k1, 2)).unwrap());
         let annotated = annotate_plan(outer).unwrap();
 
-        let mut cut_index = 0u32;
-        let err = _distribute_plan(annotated, MppPlanShape::JoinOnly, &mut cut_index)
-            .expect_err("Shuffle stub must error");
-        // Bottom-up ⇒ inner cut first ⇒ `join_left`.
-        assert!(format!("{err}").contains("join_left"));
-        assert_eq!(cut_index, 1);
+        let mut ctx = synth_ctx(MppPlanShape::JoinOnly, 2);
+        let rebuilt = _distribute_plan(annotated, &mut ctx).unwrap();
+
+        assert_eq!(ctx.cut_index, 2);
+        assert_eq!(ctx.meshes.len(), 0);
+
+        let shuffles = collect_shuffle_execs(&rebuilt);
+        assert_eq!(shuffles.len(), 2);
+        // Stage_ids in tree-traversal order (whichever order
+        // `collect_shuffle_execs` produces) must include both 0 and 1.
+        let mut seen_ids: Vec<u32> = shuffles
+            .iter()
+            .map(|s| s.input_stage().unwrap().stage_id)
+            .collect();
+        seen_ids.sort();
+        assert_eq!(seen_ids, vec![0, 1]);
+    }
+
+    #[test]
+    fn distribute_plan_shuffle_arm_rejects_non_repartition_child() {
+        // If a Shuffle annotation somehow sits above something other than
+        // a RepartitionExec(Hash), the emit arm surfaces a
+        // `DataFusionError::Plan` rather than silently wrapping a bogus
+        // partitioner. Covers a malformed pre-pass upstream of the walker.
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        // Build an annotated tree with a Shuffle boundary manually —
+        // `annotate_plan` itself only produces Shuffle boundaries above
+        // RepartitionExec(Hash), but the walker must still defend.
+        let annotated = AnnotatedPlan {
+            plan_or_nb: PlanOrNetworkBoundary::Shuffle,
+            children: vec![AnnotatedPlan {
+                plan_or_nb: PlanOrNetworkBoundary::Plan(Arc::clone(&input)),
+                children: vec![],
+            }],
+        };
+
+        let mut ctx = synth_ctx(MppPlanShape::JoinOnly, 1);
+        let err = _distribute_plan(annotated, &mut ctx)
+            .expect_err("malformed Shuffle child must surface as Plan error");
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("expected RepartitionExec"),
+            "unexpected error: {msg}"
+        );
+        // cut_index did NOT advance — the walker errors out before
+        // consuming a tag slot.
+        assert_eq!(ctx.cut_index, 0);
     }
 }


### PR DESCRIPTION
## Summary

Third in the 4-PR chain. Ports DataFusion-Distributed's `AnnotatedPlan` + `insert_mpp_cuts` pre-pass + `_distribute_plan` walker + `CutEmitCtx` emit arms into `mpp/walker.rs`. **All new code is dead at merge time** — `distribute_plan`'s current bridge-dispatch body is untouched. Reviewers can pattern-match each helper line-for-line against the DF-D counterparts.

Chain context:
- A — JoinScan MPP activation (#4858)
- B — walker seam + network boundary + framing (#4859)
- **C (this PR)** — DF-D verbatim port scaffolding
- D — flip walker + delete legacy assemblers (next)

**Safety:** `paradedb.enable_mpp = off` by default. Zero behavioural change — bridges still dispatch; new helpers have no callers yet.

## What ships

- `PlanOrNetworkBoundary`, `AnnotatedPlan`, `require_one_child` — DF-D port verbatim minus the `Broadcast` variant, the async-ness, the task-count propagation, and Rust-2024 let-chains (deviations documented in commit messages).
- `insert_mpp_cuts(plan, shape, total_participants)` — wraps `HashJoinExec.left()`/`right()` in `RepartitionExec(Hash)` for each shape; wraps `AggregateExec(Partial)` in `CoalescePartitionsExec` (scalar) or `RepartitionExec(Hash(group_keys))` (group-by). Not called yet.
- `_distribute_plan(annotated, ctx)` — bottom-up walker that Plan-arm-recurses via `with_new_children` and, for Shuffle/Coalesce arms, consults `tag_for_cut(shape, bottom_up_cut_index)` and calls `emit_shuffle_cut` via `CutEmitCtx`.
- `CutEmitCtx` + `shuffle_keys_from_repartition` + live `emit_shuffle_cut` arms.
- `tag_for_cut` byte-exact mapping: `join_left`/`join_right`, `scalar_left`/`scalar_right`/`scalar_final`, `gb_left`/`gb_right`/`gb_postagg`.

## Deviations from DF-D (all ParadeDB-constrained)

1. No `Broadcast` variant — ParadeDB has no broadcast-join path.
2. No `AnnotatedPlan::task_count` — ParadeDB's N is fixed by `MppParticipantConfig::total_participants`.
3. Sync, not async — DF-D's `annotate_plan` is `async` for task-estimator I/O; we have nothing to await.
4. Rust 2021 nested `if let` — DF-D's let-chain is split into nested ifs (let-chains require Rust 2024).
5. `CutEmitCtx` pre-pops meshes, holds no `&mut MppExecutionState` — so tests can drive the walker with in-process channels.

## Commits (4)

- Step 2a — port DF-D `PlanOrNetworkBoundary` + `AnnotatedPlan` + `annotate_plan` + `_annotate_plan` + `require_one_child`
- Step 2b — `insert_mpp_cuts` pre-pass + `CutKind` + `rewrite_with_cuts`
- Step 2c — `_distribute_plan` + `tag_for_cut` scaffolding (Shuffle/Coalesce arms still stubbed)
- Step 2c-ii — `CutEmitCtx` + `shuffle_keys_from_repartition` + live `emit_shuffle_cut` arms

## Reference source files (read-only)

- `src/distributed_planner/plan_annotator.rs` in `datafusion-contrib/datafusion-distributed` — verbatim `_annotate_plan` + `PlanOrNetworkBoundary` + `AnnotatedPlan`.
- `src/common/children_helpers.rs` — verbatim `require_one_child`.
- `src/distributed_planner/distribute_plan.rs` — `_distribute_plan`.

## Test plan

- [x] `cargo check -p pg_search --features pg18` clean
- [x] `cargo clippy -p pg_search --features pg18 --all-targets -- -D warnings` clean
- [x] `cargo test -p pg_search --lib mpp:: --features pg18 -- --test-threads=1` — 118 passed, 0 failed, 2 ignored (23 new scaffolding tests)
- [x] `cargo pgrx regress pg18 mpp` — mpp_exec / mpp_fallback / mpp_join / mpp_smoke all PASS (unchanged vs PR B)
- [ ] CI benchmark — no expected change (zero new callers)

## Rollback

Revert drops the DF-D scaffolding; walker falls back to pure bridge dispatch. No user-visible impact.