### PR TITLE
ci: Skip scheduled Antithesis runs on community repo

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -7,6 +7,9 @@
 name: Antithesis - Trigger Test Run
 
 on:
+  # Scheduled runs are only executed on paradedb-enterprise; on paradedb/paradedb
+  # (community) the job-level `if` below short-circuits the schedule trigger. The cron
+  # entry stays here so the same workflow file can be synced between the two repos.
   schedule:
     - cron: "0 2 * * 1-5" # At 02:00 UTC on every day-of-week from Monday through Friday
   pull_request:
@@ -32,7 +35,7 @@ jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
     runs-on: ubicloud-standard-8-ubuntu-2404
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'antithesis')
+    if: (github.event_name == 'schedule' && github.repository == 'paradedb/paradedb-enterprise') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'antithesis')
     strategy:
       matrix:
         pg_version: [18]

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -11,7 +11,7 @@ on:
   # (community) the job-level `if` below short-circuits the schedule trigger. The cron
   # entry stays here so the same workflow file can be synced between the two repos.
   schedule:
-    - cron: "0 2 * * 1-5" # At 02:00 UTC on every day-of-week from Monday through Friday
+    - cron: "0 2 * * 2,4" # At 02:00 UTC on Tuesday and Thursday (Monday night and Wednesday night)
   pull_request:
     types: [labeled]
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Gate the `schedule` trigger on the Antithesis test-run workflow so cron jobs only execute on `paradedb/paradedb-enterprise`, not on community.
- `workflow_dispatch` and the `antithesis` PR label continue to work on both repos.
- Added a comment near the `schedule:` block explaining why the cron entry stays in the file.

## Test plan
- [x] Confirm next scheduled fire on `paradedb/paradedb` shows the job skipped via the `if` guard.
- [x] Confirm `workflow_dispatch` still triggers the job on community.
- [x] Confirm the `antithesis` PR label still triggers the job on community.