### PR TITLE
chore: Change Stack overflow queries to use standard sql where possible

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-filter.sql
@@ -5,7 +5,7 @@ SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascrip
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
 
 -- pdb.agg (under the hood) with GROUP BY
-SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-filter.sql
@@ -4,8 +4,8 @@ SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascrip
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
 
--- pdb.agg with GROUP BY
-SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}') FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
+-- pdb.agg (under the hood) with GROUP BY
+SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-filter.sql
@@ -5,7 +5,7 @@ SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascrip
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
 
 -- pdb.agg (under the hood) with GROUP BY
-SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY post_type_id;
+SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-nofilter.sql
@@ -5,7 +5,7 @@ SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GR
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
 
 -- pdb.agg (under the hood) with GROUP BY
-SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-nofilter.sql
@@ -4,7 +4,7 @@ SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GR
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
 
--- pdb.agg with GROUP BY
+-- pdb.agg (under the hood) with GROUP BY
 SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-numeric-nofilter.sql
@@ -5,7 +5,7 @@ SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GR
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY
-SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}') FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
+SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
@@ -5,7 +5,7 @@ SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name ORDER 
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg (under the hood) with GROUP BY
-SELECT name, COUNT(name) FROM badges WHERE name ||| 'Question' GROUP BY name;
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(name) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
@@ -5,7 +5,7 @@ SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name ORDER 
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg with GROUP BY
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}') FROM badges WHERE name ||| 'Question' GROUP BY name;
+SELECT name, COUNT(name) FROM badges WHERE name ||| 'Question' and id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' GROUP BY name;
+SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' and id @@@ pdb.all() GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
@@ -5,7 +5,7 @@ SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name ORDER 
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg (under the hood) with GROUP BY
-SELECT name, COUNT(name) FROM badges WHERE name ||| 'Question' and id @@@ pdb.all() GROUP BY name;
+SELECT name, COUNT(name) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' and id @@@ pdb.all() GROUP BY name;
+SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-filter.sql
@@ -4,7 +4,7 @@ SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name ORDER 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
--- pdb.agg with GROUP BY
+-- pdb.agg (under the hood) with GROUP BY
 SELECT name, COUNT(name) FROM badges WHERE name ||| 'Question' and id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-nofilter.sql
@@ -4,7 +4,7 @@ SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name ORDER BY 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
 
--- pdb.agg with GROUP BY
+-- pdb.agg (under the hood) with GROUP BY
 SELECT name, COUNT(name) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-nofilter.sql
@@ -5,7 +5,7 @@ SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name ORDER BY 
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg with GROUP BY
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}') FROM badges WHERE id @@@ pdb.all() GROUP BY name;
+SELECT name, COUNT(name) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE id @@@ pdb.all() GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/bucket-string-nofilter.sql
@@ -5,7 +5,7 @@ SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name ORDER BY 
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg (under the hood) with GROUP BY
-SELECT name, COUNT(name) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(name) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
 SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE id @@@ pdb.all() GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -8,16 +8,16 @@ SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id);
 
 -- pdb.agg (under the hood) without GROUP BY
-SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all();
+SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- pdb.agg without GROUP BY (mvcc disabled)
-SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all();
+SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- high-cardinality aggregate scan
-SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY tags;
+SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg
-SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY tags;
+SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
-SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY tags;
+SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -8,16 +8,16 @@ SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id);
 
 -- pdb.agg without GROUP BY
-SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}') FROM stackoverflow_posts WHERE body ||| 'javascript';
+SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all();
 
 -- pdb.agg without GROUP BY (mvcc disabled)
-SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
+SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all();
 
 -- high-cardinality aggregate scan
-SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg
-SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
-SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() GROUP BY tags;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -8,7 +8,7 @@ SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id);
 
 -- pdb.agg (under the hood) without GROUP BY
-SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- pdb.agg without GROUP BY (mvcc disabled)
 SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
@@ -17,7 +17,7 @@ SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackov
 SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg
-SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET paradedb.enable_aggregate_custom_scan TO on; SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
 SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -7,7 +7,7 @@ SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id);
 
--- pdb.agg without GROUP BY
+-- pdb.agg (under the hood) without GROUP BY
 SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all();
 
 -- pdb.agg without GROUP BY (mvcc disabled)

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/count-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/count-filter.sql
@@ -5,7 +5,7 @@ SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
 
 -- pdb.agg (under the hood) without GROUP BY
-SELECT COUNT(ctid) FROM stackoverflow_posts WHERE body ||| 'error';
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(ctid) FROM stackoverflow_posts WHERE body ||| 'error';
 
 -- pdb.agg without GROUP BY (mvcc disabled)
 SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE body ||| 'error';

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/count-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/count-filter.sql
@@ -5,7 +5,7 @@ SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
 
 -- pdb.agg (under the hood) without GROUP BY
-SELECT COUNT(ctid) FROM stackoverflow_posts WHERE body ||| 'error' and id @@@ pdb.all();
+SELECT COUNT(ctid) FROM stackoverflow_posts WHERE body ||| 'error';
 
 -- pdb.agg without GROUP BY (mvcc disabled)
 SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE body ||| 'error';

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/count-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/count-filter.sql
@@ -4,8 +4,8 @@ SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
 
--- pdb.agg without GROUP BY
-SELECT pdb.agg('{"value_count": {"field": "ctid"}}') FROM stackoverflow_posts WHERE body ||| 'error';
+-- pdb.agg (under the hood) without GROUP BY
+SELECT COUNT(ctid) FROM stackoverflow_posts WHERE body ||| 'error' and id @@@ pdb.all();
 
 -- pdb.agg without GROUP BY (mvcc disabled)
 SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE body ||| 'error';

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/count-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/count-nofilter.sql
@@ -4,8 +4,8 @@ SELECT COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 
--- pdb.agg without GROUP BY
-SELECT pdb.agg('{"value_count": {"field": "ctid"}}') FROM stackoverflow_posts WHERE id @@@ pdb.all();
+-- pdb.agg (under the hood) without GROUP BY
+SELECT COUNT(ctid) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 
 -- pdb.agg without GROUP BY (mvcc disabled)
 SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all();

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/count-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/count-nofilter.sql
@@ -5,7 +5,7 @@ SELECT COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 
 -- pdb.agg (under the hood) without GROUP BY
-SELECT COUNT(ctid) FROM stackoverflow_posts WHERE id @@@ pdb.all();
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(ctid) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 
 -- pdb.agg without GROUP BY (mvcc disabled)
 SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all();

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-avg.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-avg.sql
@@ -1,1 +1,1 @@
-SELECT id, title, tags, score, creation_date, AVG(score) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT id, title, tags, score, creation_date, AVG(score) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-avg.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-avg.sql
@@ -1,1 +1,1 @@
-SELECT id, title, tags, score, creation_date, pdb.agg('{"avg": {"field": "score"}}') OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;
+SELECT id, title, tags, score, creation_date, AVG(score) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() ORDER BY creation_date DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-avg.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-avg.sql
@@ -1,1 +1,1 @@
-SELECT id, title, tags, score, creation_date, AVG(score) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() ORDER BY creation_date DESC LIMIT 10;
+SELECT id, title, tags, score, creation_date, AVG(score) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-bucket-string.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-bucket-string.sql
@@ -1,1 +1,1 @@
-SELECT id, title, tags, post_type_id, creation_date, pdb.agg('{"value_count": {"field": "owner_display_name"}}') OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;
+SELECT id, title, tags, post_type_id, creation_date, COUNT(owner_display_name) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() ORDER BY creation_date DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-bucket-string.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-bucket-string.sql
@@ -1,1 +1,1 @@
-SELECT id, title, tags, post_type_id, creation_date, COUNT(owner_display_name) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' and id @@@ pdb.all() ORDER BY creation_date DESC LIMIT 10;
+SELECT id, title, tags, post_type_id, creation_date, COUNT(owner_display_name) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-bucket-string.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-agg-bucket-string.sql
@@ -1,1 +1,1 @@
-SELECT id, title, tags, post_type_id, creation_date, COUNT(owner_display_name) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;
+SET paradedb.enable_aggregate_custom_scan TO on; SELECT id, title, tags, post_type_id, creation_date, COUNT(owner_display_name) OVER () FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY creation_date DESC LIMIT 10;


### PR DESCRIPTION
# Ticket(s) Closed
## What
Change all uses of `pdb.agg` in the stack overflow queries to normal sql where possible.

## Why
It's much easier to read 😄 

## How

## Tests
- benchmarking CI job runs as normal