### PR TITLE
ci: run test-pg_search-docker on amd64 and arm64 in parallel

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -27,8 +27,18 @@ concurrency:
 
 jobs:
   test-paradedb:
-    name: Test ParadeDB Docker Image
-    runs-on: ubicloud-standard-8-arm-ubuntu-2404
+    name: Test ParadeDB Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubicloud-standard-2-ubuntu-2404
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubicloud-standard-2-arm-ubuntu-2404
+            platform: linux/arm64
 
     steps:
       - name: Checkout Git Repository
@@ -82,13 +92,15 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       # We tag the image as `latest` so it can be picked up by `docker-compose.yml` for testing,
-      # and we set `push: false` since this is just a test build.
+      # and we set `push: false` since this is just a test build. Each matrix entry builds its
+      # own arch natively (via a runner on that arch) so `load: true` works and the `docker run`
+      # smoke tests below exercise the image natively — no emulation, no cross-arch shenanigans.
       - name: Build the ParadeDB Docker Image via Depot
         uses: depot/build-push-action@v1
         with:
           context: .
           file: docker/Dockerfile
-          platforms: linux/arm64
+          platforms: ${{ matrix.platform }}
           load: true
           push: false
           tags: paradedb/paradedb:latest


### PR DESCRIPTION
## Summary

Split out from #4805 (unrelated to the pgrx 0.18 upgrade).

Today `test-pg_search-docker` builds a single arch on a single runner and runs a `docker run` smoke test against it. `publish-paradedb-docker` publishes `linux/amd64,linux/arm64`, so an arch-specific runtime regression — entrypoint, extension load, initdb hook, a dependency that only loads on one arch — can ship undetected through a green PR.

This PR converts the job to a matrix over `amd64` / `arm64`:

- Each matrix entry runs on an Ubicloud runner native to its arch (`ubicloud-standard-2-ubuntu-2404` for amd64, `ubicloud-standard-2-arm-ubuntu-2404` for arm64).
- Each builds only its own platform via Depot with `load: true`, then runs the existing `docker run` smoke tests natively on that arch. No emulation, no duplicate build.
- `fail-fast: false` so one arch failing doesn't cancel the other — you see both results on the same PR.

An earlier version of this PR did a multi-arch verify build followed by an amd64-only load; that relied on the Depot cross-build cache being hot on the second call, and still only exercised the `docker run` smoke test on amd64. The matrix approach is simpler and closes both gaps.

## Breaking: required status check name

The job name changes from `Test ParadeDB Docker Image` to `Test ParadeDB Docker Image (amd64)` and `Test ParadeDB Docker Image (arm64)`. If `main` branch protection requires the old name, it needs to be updated (or replaced with both new names) before this can merge cleanly.

## Test plan

- [x] CI: both `Test ParadeDB Docker Image (amd64)` and `Test ParadeDB Docker Image (arm64)` green on this PR
- [x] Confirm the two matrix entries run in parallel (not queued) and wall-clock doesn't regress vs. today's single-arch job
- [x] In a scratch PR, intentionally break arm64 (e.g. an arm64-only `RUN` failure in `docker/Dockerfile`) and confirm only the arm64 matrix entry fails
- [x] Update branch protection to require both new check names before merging this