### PR TITLE
chore: Do not run benchmarks on release branches. (#4868)

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -10,7 +10,6 @@ on:
   push:
     branches:
       - main
-      - 0.*.x # Release branches
     paths:
       - "benchmarks/**"
       - "**/*.rs"

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - main
-      - 0.*.x # Release branches
     paths:
       - "stressgres/suites/**"
       - "**/*.rs"


### PR DESCRIPTION
Backport of #4868 to `0.23.x`.

## What

Do not run benchmarks on release branches.

## Why

We do not have a safe/obvious way to incorporate them into our graphs currently. See #3769 about fixing that.

## Test plan

- [x] CI passes on the backport branch