### PR TITLE
fix: resolve BM25 alias field names in join and aggregate planning

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -42,7 +42,9 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::utils::{expr_collect_rtis, expr_collect_vars, expr_contains_any_operator};
 use crate::postgres::var::fieldname_from_var;
 use crate::query::SearchQueryInput;
+use crate::scan::info::FieldInfo;
 use pgrx::{pg_sys, PgList};
+use std::sync::OnceLock;
 
 /// Result type for `extract_join_tree_from_parse`: the plan tree, search
 /// predicates, multi-table predicate info, and raw PG Expr clause pointers.
@@ -69,6 +71,57 @@ pub struct JoinAggSource {
     pub relid: pg_sys::Oid,
     pub alias: Option<String>,
     pub bm25_index: Option<PgSearchRelation>,
+    /// Lazily populated attno → fast-field mapping for this relation.
+    /// Built once via [`JoinAggSource::column_name`] and shared across the
+    /// GROUP BY, aggregate argument, and aggregate ORDER BY resolution paths.
+    field_cache: OnceLock<Vec<FieldInfo>>,
+}
+
+impl JoinAggSource {
+    /// Walk every column in the heap tuple descriptor, resolving each through
+    /// the BM25 index. Returns an empty vec when there is no BM25 index
+    /// attached to this relation (nothing to pull up).
+    unsafe fn build_field_cache(&self) -> Vec<FieldInfo> {
+        let Some(bm25) = self.bm25_index.as_ref() else {
+            return Vec::new();
+        };
+        let heaprel = PgSearchRelation::open(self.relid);
+        let tupdesc = heaprel.tuple_desc();
+        let mut fields = Vec::new();
+        for attno in 1..=tupdesc.len() {
+            if let Some(field) = resolve_fast_field(attno as i32, &tupdesc, bm25) {
+                fields.push(FieldInfo {
+                    attno: attno as pg_sys::AttrNumber,
+                    field,
+                });
+            }
+        }
+        fields
+    }
+
+    /// Resolve a heap attribute number to its DataFusion-facing column name
+    /// via the BM25 index.
+    ///
+    /// Returns the BM25 field name (which may be an alias like
+    /// `"company_name_words"`), **not** the heap attribute name. This keeps
+    /// GROUP BY, aggregate argument, and aggregate ORDER BY field names in
+    /// sync with the DataFusion schema built by `build_source_df` (see #4849).
+    ///
+    /// Returns `None` when the column has no pullable fast field or when the
+    /// resolved field is a synthetic/unsupported kind (`Score`, `Junk`).
+    /// Mirrors `JoinSource::column_name` in joinscan/build.rs.
+    pub fn column_name(&self, attno: pg_sys::AttrNumber) -> Option<String> {
+        let fields = self
+            .field_cache
+            .get_or_init(|| unsafe { self.build_field_cache() });
+        fields
+            .iter()
+            .find(|f| f.attno == attno)
+            .and_then(|f| match &f.field {
+                WhichFastField::Score | WhichFastField::Junk(_) => None,
+                _ => Some(f.field.name()),
+            })
+    }
 }
 
 /// Extract all tables participating in the join from `input_rel.relids` and look up
@@ -93,6 +146,7 @@ pub unsafe fn collect_join_agg_sources(
             relid,
             alias,
             bm25_index,
+            field_cache: OnceLock::new(),
         });
     }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -44,7 +44,6 @@ use crate::postgres::var::fieldname_from_var;
 use crate::query::SearchQueryInput;
 use crate::scan::info::FieldInfo;
 use pgrx::{pg_sys, PgList};
-use std::sync::OnceLock;
 
 /// Result type for `extract_join_tree_from_parse`: the plan tree, search
 /// predicates, multi-table predicate info, and raw PG Expr clause pointers.
@@ -71,34 +70,17 @@ pub struct JoinAggSource {
     pub relid: pg_sys::Oid,
     pub alias: Option<String>,
     pub bm25_index: Option<PgSearchRelation>,
-    /// Lazily populated attno → fast-field mapping for this relation.
-    /// Built once via [`JoinAggSource::column_name`] and shared across the
-    /// GROUP BY, aggregate argument, and aggregate ORDER BY resolution paths.
-    field_cache: OnceLock<Vec<FieldInfo>>,
+    /// Eagerly populated attno → fast-field mapping for this relation.
+    /// Built once in [`collect_join_agg_sources`] and flowed through to the
+    /// `JoinSourceCandidate` in [`build_scan_node`], so both
+    /// [`JoinAggSource::column_name`] and the downstream
+    /// [`JoinSource::column_name`] / `build_source_df` paths agree on the
+    /// BM25-registered field name for every heap attno. Empty when the
+    /// relation has no BM25 index.
+    pub fields: Vec<FieldInfo>,
 }
 
 impl JoinAggSource {
-    /// Walk every column in the heap tuple descriptor, resolving each through
-    /// the BM25 index. Returns an empty vec when there is no BM25 index
-    /// attached to this relation (nothing to pull up).
-    unsafe fn build_field_cache(&self) -> Vec<FieldInfo> {
-        let Some(bm25) = self.bm25_index.as_ref() else {
-            return Vec::new();
-        };
-        let heaprel = PgSearchRelation::open(self.relid);
-        let tupdesc = heaprel.tuple_desc();
-        let mut fields = Vec::new();
-        for attno in 1..=tupdesc.len() {
-            if let Some(field) = resolve_fast_field(attno as i32, &tupdesc, bm25) {
-                fields.push(FieldInfo {
-                    attno: attno as pg_sys::AttrNumber,
-                    field,
-                });
-            }
-        }
-        fields
-    }
-
     /// Resolve a heap attribute number to its DataFusion-facing column name
     /// via the BM25 index.
     ///
@@ -111,10 +93,7 @@ impl JoinAggSource {
     /// resolved field is a synthetic/unsupported kind (`Score`, `Junk`).
     /// Mirrors `JoinSource::column_name` in joinscan/build.rs.
     pub fn column_name(&self, attno: pg_sys::AttrNumber) -> Option<String> {
-        let fields = self
-            .field_cache
-            .get_or_init(|| unsafe { self.build_field_cache() });
-        fields
+        self.fields
             .iter()
             .find(|f| f.attno == attno)
             .and_then(|f| match &f.field {
@@ -122,6 +101,29 @@ impl JoinAggSource {
                 _ => Some(f.field.name()),
             })
     }
+}
+
+/// Walk every column in the heap tuple descriptor, resolving each through the
+/// given BM25 index. Returns an empty vec when `bm25_index` is `None`.
+unsafe fn collect_source_fields(
+    relid: pg_sys::Oid,
+    bm25_index: Option<&PgSearchRelation>,
+) -> Vec<FieldInfo> {
+    let Some(bm25) = bm25_index else {
+        return Vec::new();
+    };
+    let heaprel = PgSearchRelation::open(relid);
+    let tupdesc = heaprel.tuple_desc();
+    let mut fields = Vec::new();
+    for attno in 1..=tupdesc.len() {
+        if let Some(field) = resolve_fast_field(attno as i32, &tupdesc, bm25) {
+            fields.push(FieldInfo {
+                attno: attno as pg_sys::AttrNumber,
+                field,
+            });
+        }
+    }
+    fields
 }
 
 /// Extract all tables participating in the join from `input_rel.relids` and look up
@@ -141,12 +143,13 @@ pub unsafe fn collect_join_agg_sources(
             continue;
         };
 
+        let fields = collect_source_fields(relid, bm25_index.as_ref());
         sources.push(JoinAggSource {
             rti,
             relid,
             alias,
             bm25_index,
-            field_cache: OnceLock::new(),
+            fields,
         });
     }
 
@@ -360,6 +363,11 @@ unsafe fn build_scan_node(
         .with_heaprelid(source.relid)
         .with_indexrelid(bm25_index.oid())
         .with_sort_order(sort_order);
+
+    // Propagate the eagerly resolved BM25 fields so the downstream JoinSource
+    // (and everything built on it — AggregateIndexVarMapper, build_source_df)
+    // agrees with JoinAggSource::column_name on alias-aware field names.
+    candidate.fields = source.fields.clone();
 
     if let Some(ref alias) = source.alias {
         candidate = candidate.with_alias(alias.clone());

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -26,9 +26,7 @@ use super::datafusion_build::{FilterExprBuildContext, JoinAggSource};
 use super::privdat::FilterExpr;
 use crate::api::SortDirection;
 use crate::postgres::customscan::CreateUpperPathsHookArgs;
-use crate::postgres::var::{
-    fieldname_from_var, find_one_aggref, find_one_var_and_fieldname, VarContext,
-};
+use crate::postgres::var::{find_one_aggref, find_one_var_and_fieldname, VarContext};
 use pgrx::pg_sys;
 use pgrx::pg_sys::{
     F_AVG_FLOAT4, F_AVG_FLOAT8, F_AVG_INT2, F_AVG_INT4, F_AVG_INT8, F_AVG_NUMERIC, F_COUNT_,
@@ -257,14 +255,12 @@ pub unsafe fn extract_aggregate_targetlist(
 
             let source = find_source_by_rti(sources, rti, "GROUP BY column")?;
 
-            let field_name = fieldname_from_var(source.relid, var, attno)
-                .ok_or_else(|| {
-                    format!(
-                        "could not resolve field name for column (RTI={}, attno={})",
-                        rti, attno
-                    )
-                })?
-                .into_inner();
+            let field_name = source.column_name(attno).ok_or_else(|| {
+                format!(
+                    "could not resolve field name for GROUP BY column (RTI={}, attno={})",
+                    rti, attno
+                )
+            })?;
 
             group_columns.push(JoinGroupColumn {
                 rti,
@@ -441,14 +437,12 @@ unsafe fn extract_aggref_field_refs(
 
         let source = find_source_by_rti(sources, rti, "aggregate argument")?;
 
-        let field_name = fieldname_from_var(source.relid, var, attno)
-            .ok_or_else(|| {
-                format!(
-                    "could not resolve field name for aggregate argument (RTI={}, attno={})",
-                    rti, attno
-                )
-            })?
-            .into_inner();
+        let field_name = source.column_name(attno).ok_or_else(|| {
+            format!(
+                "could not resolve field name for aggregate argument (RTI={}, attno={})",
+                rti, attno
+            )
+        })?;
 
         refs.push((rti, attno, field_name));
     }
@@ -501,14 +495,12 @@ unsafe fn extract_aggref_order_by(
 
         let source = find_source_by_rti(sources, rti, "aggregate ORDER BY")?;
 
-        let field_name = fieldname_from_var(source.relid, var, attno)
-            .ok_or_else(|| {
-                format!(
-                    "could not resolve field name for aggregate ORDER BY (RTI={}, attno={})",
-                    rti, attno
-                )
-            })?
-            .into_inner();
+        let field_name = source.column_name(attno).ok_or_else(|| {
+            format!(
+                "could not resolve field name for aggregate ORDER BY (RTI={}, attno={})",
+                rti, attno
+            )
+        })?;
 
         let direction =
             SortDirection::from_sort_op((*clause_ptr).sortop, (*clause_ptr).nulls_first)

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -1051,7 +1051,27 @@ pub(super) unsafe fn collect_required_fields(
                             // expression (e.g. upper(name)), in which case
                             // ensure_field (via resolve_fast_field) won't find it.
                             let added = get_source_attno_by_name(source, name)
-                                .and_then(|attno| try_ensure_field(source, attno))
+                                .and_then(|attno| {
+                                    try_ensure_field(source, attno)?;
+                                    // try_ensure_field only checks that SOME field
+                                    // claims the attno; it doesn't check the field's
+                                    // name. When a column is indexed twice — once
+                                    // aliased (e.g. "company_name_words") and once
+                                    // as an expression (e.g. "company_name" via a
+                                    // typmod cast) — the aliased entry can claim the
+                                    // attno first under a different name. Only treat
+                                    // the field as "added" if the registered name
+                                    // matches what the ORDER BY asked for; otherwise
+                                    // fall through to ensure_expression_field which
+                                    // registers the field under a synthetic attno
+                                    // with the correct name (#4850).
+                                    source
+                                        .scan_info
+                                        .fields
+                                        .iter()
+                                        .any(|f| f.attno == attno && f.field.name() == name)
+                                        .then_some(())
+                                })
                                 .is_some();
                             if !added {
                                 if let Err(e) = ensure_expression_field(source, name) {
@@ -1173,7 +1193,10 @@ unsafe fn ensure_expression_field(source: &mut JoinSource, field_name: &str) -> 
 }
 
 /// Retrieve an attribute number by column name from a `JoinSource`'s heap relation.
-unsafe fn get_source_attno_by_name(side: &JoinSource, name: &str) -> Option<pg_sys::AttrNumber> {
+pub(super) unsafe fn get_source_attno_by_name(
+    side: &JoinSource,
+    name: &str,
+) -> Option<pg_sys::AttrNumber> {
     let rel = PgSearchRelation::open(side.scan_info.heaprelid);
     let tupdesc = rel.tuple_desc();
     get_attno_by_name(name, &tupdesc)

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -71,6 +71,7 @@ use futures::future::{FutureExt, LocalBoxFuture};
 use pgrx::pg_sys;
 use tantivy::index::SegmentId;
 
+use super::planning::get_source_attno_by_name;
 use crate::api::{NullTestKind, OrderByFeature, SortDirection};
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
@@ -101,6 +102,34 @@ use datafusion::execution::context::{QueryPlanner, SessionState};
 use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::functions_aggregate::expr_fn::min;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
+
+/// Insert an ORDER BY field name into `required_early`, plus — when the same
+/// heap attno is registered under a different name — the registered name too.
+///
+/// This matters when a column is indexed twice (once aliased, once as an
+/// unaliased expression): the ORDER BY feature carries the expression name
+/// (e.g. "company_name"), but the attno's schema-registered name may be the
+/// alias (e.g. "company_name_words"). Without also marking the registered
+/// name required-early, the table provider may defer the alias-named output
+/// that downstream DataFusion plans expect (#4850).
+fn insert_field_name_required_early(
+    source: &super::build::JoinSource,
+    name: &str,
+    required_early: &mut crate::api::HashSet<String>,
+) {
+    required_early.insert(name.to_string());
+    // SAFETY: `get_source_attno_by_name` opens a Postgres heap relation via
+    // FFI, which is only safe on the Postgres backend thread — the same
+    // thread this planning-stage helper runs on.
+    let attno = unsafe { get_source_attno_by_name(source, name) };
+    if let Some(attno) = attno {
+        if let Some(registered) = source.column_name(attno) {
+            if registered != name {
+                required_early.insert(registered);
+            }
+        }
+    }
+}
 
 /// Resolve a Postgres `(rti, attno)` reference to a DataFusion column expression
 /// by walking the join's plan sources and finding the first one that claims it.
@@ -1006,7 +1035,11 @@ fn build_source_df<'a>(
                 match &info.feature {
                     OrderByFeature::Field { name, rti } => {
                         if source.contains_rti(*rti) {
-                            required_early.insert(name.as_ref().to_string());
+                            insert_field_name_required_early(
+                                source,
+                                name.as_ref(),
+                                &mut required_early,
+                            );
                         }
                     }
                     OrderByFeature::Var { rti, attno, .. } => {
@@ -1021,7 +1054,11 @@ fn build_source_df<'a>(
                     OrderByFeature::NullTest { inner, .. } => match inner.as_ref() {
                         OrderByFeature::Field { name, rti } => {
                             if source.contains_rti(*rti) {
-                                required_early.insert(name.as_ref().to_string());
+                                insert_field_name_required_early(
+                                    source,
+                                    name.as_ref(),
+                                    &mut required_early,
+                                );
                             }
                         }
                         OrderByFeature::Var { rti, attno, .. } => {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -103,31 +103,6 @@ use datafusion::execution::session_state::SessionStateBuilder;
 use datafusion::functions_aggregate::expr_fn::min;
 use datafusion::physical_planner::{DefaultPhysicalPlanner, PhysicalPlanner};
 
-/// Insert an ORDER BY field name into `required_early`, plus — when the same
-/// heap attno is registered under a different name — the registered name too.
-///
-/// This matters when a column is indexed twice (once aliased, once as an
-/// unaliased expression): the ORDER BY feature carries the expression name
-/// (e.g. "company_name"), but the attno's schema-registered name may be the
-/// alias (e.g. "company_name_words"). Without also marking the registered
-/// name required-early, the table provider may defer the alias-named output
-/// that downstream DataFusion plans expect (#4850).
-fn insert_field_name_required_early(
-    source: &super::build::JoinSource,
-    name: &str,
-    required_early: &mut crate::api::HashSet<String>,
-) {
-    required_early.insert(name.to_string());
-    let attno = unsafe { get_source_attno_by_name(source, name) };
-    if let Some(attno) = attno {
-        if let Some(registered) = source.column_name(attno) {
-            if registered != name {
-                required_early.insert(registered);
-            }
-        }
-    }
-}
-
 /// Resolve a Postgres `(rti, attno)` reference to a DataFusion column expression
 /// by walking the join's plan sources and finding the first one that claims it.
 ///
@@ -987,6 +962,34 @@ fn build_source_df<'a>(
             .iter()
             .map(|f| f.field.clone())
             .collect();
+
+        /// Insert an ORDER BY field name into `required_early`, plus — when
+        /// the same heap attno is registered under a different name — the
+        /// registered name too.
+        ///
+        /// This matters when a column is indexed twice (once aliased, once
+        /// as an unaliased expression): the ORDER BY feature carries the
+        /// expression name (e.g. "company_name"), but the attno's
+        /// schema-registered name may be the alias
+        /// (e.g. "company_name_words"). Without also marking the registered
+        /// name required-early, the table provider may defer the
+        /// alias-named output that downstream DataFusion plans expect
+        /// (#4850).
+        fn insert_field_name_required_early(
+            source: &JoinSource,
+            name: &str,
+            required_early: &mut crate::api::HashSet<String>,
+        ) {
+            required_early.insert(name.to_string());
+            let attno = unsafe { get_source_attno_by_name(source, name) };
+            if let Some(attno) = attno {
+                if let Some(registered) = source.column_name(attno) {
+                    if registered != name {
+                        required_early.insert(registered);
+                    }
+                }
+            }
+        }
 
         let mut required_early: crate::api::HashSet<String> = Default::default();
         for jk in join_clause.plan.join_keys() {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -118,9 +118,6 @@ fn insert_field_name_required_early(
     required_early: &mut crate::api::HashSet<String>,
 ) {
     required_early.insert(name.to_string());
-    // SAFETY: `get_source_attno_by_name` opens a Postgres heap relation via
-    // FFI, which is only safe on the Postgres backend thread — the same
-    // thread this planning-stage helper runs on.
     let attno = unsafe { get_source_attno_by_name(source, name) };
     if let Some(attno) = attno {
         if let Some(registered) = source.column_name(attno) {

--- a/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_alias.out
@@ -1,0 +1,159 @@
+-- =====================================================================
+-- Issue #4849: Aggregate-on-JOIN with BM25 aliased fields
+-- =====================================================================
+-- Verifies that GROUP BY columns, aggregate arguments, and aggregate-
+-- internal ORDER BY resolve to the BM25 field alias (not the heap
+-- attribute name) when building the DataFusion aggregate plan over a
+-- join. Each test has three parts:
+--   1. EXPLAIN to confirm the ParadeDB Aggregate Scan is used (no fallback).
+--   2. Run the query with the custom scan on — the path this fix covers.
+--   3. Run the same query with the custom scan off — native Postgres parity.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Test Data
+CREATE TABLE repro_cccf (
+    company_id bigint PRIMARY KEY,
+    company_name text,
+    company_domain text
+);
+CREATE TABLE repro_ti (
+    company_id bigint PRIMARY KEY
+);
+INSERT INTO repro_cccf VALUES
+    (1, 'Acme Corp', 'acme.com'),
+    (2, 'Globex Inc', 'globex.com'),
+    (3, 'Initech', 'initech.com');
+INSERT INTO repro_ti VALUES (1), (2), (3);
+-- BM25 index where company_name is aliased to company_name_words.
+-- This causes the DataFusion schema to register the field as
+-- "company_name_words", so the planner must resolve GROUP BY / aggregate
+-- arg / aggregate ORDER BY names through the BM25 index too.
+CREATE INDEX repro_cccf_idx ON repro_cccf
+USING bm25 (
+    company_id,
+    (lower(company_domain)::pdb.literal_normalized('ascii_folding=true')),
+    (company_name::pdb.simple('alias=company_name_words', 'columnar=true'))
+) WITH (key_field=company_id);
+CREATE INDEX repro_ti_idx ON repro_ti
+USING bm25 (company_id) WITH (key_field=company_id);
+-- =====================================================================
+-- Test 1: GROUP BY on the aliased column
+-- Previously crashed with "No field named cccf_0.company_name".
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT company_name, count(*)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id
+GROUP BY company_name
+ORDER BY company_name;
+                        QUERY PLAN                         
+-----------------------------------------------------------
+ Sort
+   Sort Key: cccf.company_name
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Backend: DataFusion
+         Indexes: repro_cccf_idx (cccf), repro_ti_idx (ti)
+         Group By: company_name_words
+         Aggregates: COUNT(*)
+(7 rows)
+
+SELECT company_name, count(*)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id
+GROUP BY company_name
+ORDER BY company_name;
+ company_name | count 
+--------------+-------
+ Acme Corp    |     1
+ Globex Inc   |     1
+ Initech      |     1
+(3 rows)
+
+-- Parity: same query with custom scan off (native Postgres).
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT company_name, count(*)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id
+GROUP BY company_name
+ORDER BY company_name;
+ company_name | count 
+--------------+-------
+ Acme Corp    |     1
+ Globex Inc   |     1
+ Initech      |     1
+(3 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- Test 2: Aggregate argument referencing the aliased column
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT count(DISTINCT company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Backend: DataFusion
+   Indexes: repro_cccf_idx (cccf), repro_ti_idx (ti)
+   Aggregates: COUNT(DISTINCT)(company_name_words)
+(4 rows)
+
+SELECT count(DISTINCT company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+ count 
+-------
+     3
+(1 row)
+
+-- Parity: same query with custom scan off.
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT count(DISTINCT company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+ count 
+-------
+     3
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- Test 3: Aggregate-internal ORDER BY referencing the aliased column
+-- Exercises the third fieldname_from_var call site (aggregate ORDER BY).
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT string_agg(company_name, ',' ORDER BY company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+                     QUERY PLAN                      
+-----------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Backend: DataFusion
+   Indexes: repro_cccf_idx (cccf), repro_ti_idx (ti)
+   Aggregates: STRING_AGG(company_name_words)
+(4 rows)
+
+SELECT string_agg(company_name, ',' ORDER BY company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+          string_agg          
+------------------------------
+ Acme Corp,Globex Inc,Initech
+(1 row)
+
+-- Parity: same query with custom scan off.
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT string_agg(company_name, ',' ORDER BY company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+          string_agg          
+------------------------------
+ Acme Corp,Globex Inc,Initech
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Cleanup
+DROP TABLE repro_cccf CASCADE;
+DROP TABLE repro_ti CASCADE;

--- a/pg_search/tests/pg_regress/expected/alias_non_text.out
+++ b/pg_search/tests/pg_regress/expected/alias_non_text.out
@@ -256,9 +256,9 @@ CREATE TABLE alias_test (
 INSERT INTO alias_test (col) VALUES (1);
 CREATE INDEX idx_alias_test ON alias_test USING bm25 (id, (col::pdb.alias('mycol'))) WITH (key_field = 'id');
 SELECT * FROM alias_test WHERE col::pdb.alias('mycol') @@@ '1';
- id |            col            
-----+---------------------------
-  1 | 1.00000000000000000000000
+ id |             col             
+----+-----------------------------
+  1 | 1.0000000000000000000000000
 (1 row)
 
 DROP TABLE alias_test;

--- a/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
@@ -1,0 +1,100 @@
+-- =====================================================================
+-- Issue #4850: JoinScan — ORDER BY unaliased expression when a sibling
+-- aliased entry claims the same attno.
+-- =====================================================================
+-- When a BM25 index has two entries for the same column — one aliased,
+-- one as an unaliased expression — JoinScan's ORDER BY projection must
+-- not be short-circuited by the aliased sibling's attno. Verify that
+-- the query succeeds and that it goes through the ParadeDB Join Scan.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE TABLE contacts (
+    contact_id bigint PRIMARY KEY,
+    company_id bigint,
+    company_name character varying
+);
+CREATE TABLE tech_installs (
+    unique_id bigint PRIMARY KEY,
+    company_id bigint,
+    technology_name character varying
+);
+INSERT INTO contacts (contact_id, company_id, company_name) VALUES (1, 1, 'amazon');
+INSERT INTO tech_installs (unique_id, company_id, technology_name) VALUES (1, 1, 'java');
+-- Index with BOTH an unaliased lower() expression AND an aliased
+-- expression on the same column. This triggers the attno dedup
+-- false-positive in ORDER BY field collection.
+CREATE INDEX contacts_idx ON contacts
+USING bm25 (
+    contact_id,
+    company_id,
+    (lower(company_name::text)::pdb.literal_normalized('ascii_folding=true')),
+    (company_name::pdb.simple('alias=company_name_words', 'ascii_folding=true', 'columnar=true'))
+) WITH (key_field=contact_id, numeric_fields='{"company_id": {"fast": true}}');
+CREATE INDEX tech_installs_idx ON tech_installs
+USING bm25 (
+    unique_id,
+    company_id,
+    technology_name
+) WITH (key_field=unique_id, numeric_fields='{"company_id": {"fast": true}}');
+SET paradedb.enable_join_custom_scan = on;
+-- =====================================================================
+-- Test 1: ORDER BY lower(company_name) — previously errored with
+-- "FieldNotFound: company_name".
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cccf.*
+FROM contacts cccf
+JOIN tech_installs ti ON cccf.company_id = ti.company_id
+WHERE technology_name @@@ 'java'
+ORDER BY lower(company_name) ASC, cccf.contact_id
+LIMIT 10;
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Result
+         ->  Custom Scan (ParadeDB Join Scan)
+               Relation Tree: ti INNER cccf
+               Join Cond: cccf.company_id = ti.company_id
+               Limit: 10
+               Order By: company_name asc, cccf.contact_id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[contact_id@5 as col_1, company_id@2 as col_2, company_name_words@3 as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+                 :   TantivyLookupExec: decode=[company_name_words, company_name]
+                 :     SegmentedTopKExec: expr=[company_name@4 ASC NULLS LAST, contact_id@5 ASC NULLS LAST], k=10
+                 :       VisibilityFilterExec: tables=[ti, cccf]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, company_id@1)], projection=[ctid_0@0, ctid_1@2, company_id@3, company_name_words@4, company_name@5, contact_id@6]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"technology_name","query_string":"java","lenient":null,"conjunction_mode":null}}}}
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(17 rows)
+
+SELECT cccf.*
+FROM contacts cccf
+JOIN tech_installs ti ON cccf.company_id = ti.company_id
+WHERE technology_name @@@ 'java'
+ORDER BY lower(company_name) ASC, cccf.contact_id
+LIMIT 10;
+ contact_id | company_id | company_name 
+------------+------------+--------------
+          1 |          1 | amazon
+(1 row)
+
+-- Parity: same query with custom scan off (native Postgres).
+SET paradedb.enable_join_custom_scan = off;
+SELECT cccf.*
+FROM contacts cccf
+JOIN tech_installs ti ON cccf.company_id = ti.company_id
+WHERE technology_name @@@ 'java'
+ORDER BY lower(company_name) ASC, cccf.contact_id
+LIMIT 10;
+ contact_id | company_id | company_name 
+------------+------------+--------------
+          1 |          1 | amazon
+(1 row)
+
+SET paradedb.enable_join_custom_scan = on;
+-- Cleanup
+DROP TABLE contacts CASCADE;
+DROP TABLE tech_installs CASCADE;

--- a/pg_search/tests/pg_regress/sql/aggregate_join_alias.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join_alias.sql
@@ -1,0 +1,115 @@
+-- =====================================================================
+-- Issue #4849: Aggregate-on-JOIN with BM25 aliased fields
+-- =====================================================================
+-- Verifies that GROUP BY columns, aggregate arguments, and aggregate-
+-- internal ORDER BY resolve to the BM25 field alias (not the heap
+-- attribute name) when building the DataFusion aggregate plan over a
+-- join. Each test has three parts:
+--   1. EXPLAIN to confirm the ParadeDB Aggregate Scan is used (no fallback).
+--   2. Run the query with the custom scan on — the path this fix covers.
+--   3. Run the same query with the custom scan off — native Postgres parity.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Test Data
+CREATE TABLE repro_cccf (
+    company_id bigint PRIMARY KEY,
+    company_name text,
+    company_domain text
+);
+
+CREATE TABLE repro_ti (
+    company_id bigint PRIMARY KEY
+);
+
+INSERT INTO repro_cccf VALUES
+    (1, 'Acme Corp', 'acme.com'),
+    (2, 'Globex Inc', 'globex.com'),
+    (3, 'Initech', 'initech.com');
+
+INSERT INTO repro_ti VALUES (1), (2), (3);
+
+-- BM25 index where company_name is aliased to company_name_words.
+-- This causes the DataFusion schema to register the field as
+-- "company_name_words", so the planner must resolve GROUP BY / aggregate
+-- arg / aggregate ORDER BY names through the BM25 index too.
+CREATE INDEX repro_cccf_idx ON repro_cccf
+USING bm25 (
+    company_id,
+    (lower(company_domain)::pdb.literal_normalized('ascii_folding=true')),
+    (company_name::pdb.simple('alias=company_name_words', 'columnar=true'))
+) WITH (key_field=company_id);
+
+CREATE INDEX repro_ti_idx ON repro_ti
+USING bm25 (company_id) WITH (key_field=company_id);
+
+-- =====================================================================
+-- Test 1: GROUP BY on the aliased column
+-- Previously crashed with "No field named cccf_0.company_name".
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT company_name, count(*)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id
+GROUP BY company_name
+ORDER BY company_name;
+
+SELECT company_name, count(*)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id
+GROUP BY company_name
+ORDER BY company_name;
+
+-- Parity: same query with custom scan off (native Postgres).
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT company_name, count(*)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id
+GROUP BY company_name
+ORDER BY company_name;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- Test 2: Aggregate argument referencing the aliased column
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT count(DISTINCT company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+
+SELECT count(DISTINCT company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+
+-- Parity: same query with custom scan off.
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT count(DISTINCT company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- Test 3: Aggregate-internal ORDER BY referencing the aliased column
+-- Exercises the third fieldname_from_var call site (aggregate ORDER BY).
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT string_agg(company_name, ',' ORDER BY company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+
+SELECT string_agg(company_name, ',' ORDER BY company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+
+-- Parity: same query with custom scan off.
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT string_agg(company_name, ',' ORDER BY company_name)
+FROM repro_cccf cccf
+JOIN repro_ti ti ON cccf.company_id = ti.company_id;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Cleanup
+DROP TABLE repro_cccf CASCADE;
+DROP TABLE repro_ti CASCADE;

--- a/pg_search/tests/pg_regress/sql/join_order_by_alias_expression.sql
+++ b/pg_search/tests/pg_regress/sql/join_order_by_alias_expression.sql
@@ -1,0 +1,80 @@
+-- =====================================================================
+-- Issue #4850: JoinScan — ORDER BY unaliased expression when a sibling
+-- aliased entry claims the same attno.
+-- =====================================================================
+-- When a BM25 index has two entries for the same column — one aliased,
+-- one as an unaliased expression — JoinScan's ORDER BY projection must
+-- not be short-circuited by the aliased sibling's attno. Verify that
+-- the query succeeds and that it goes through the ParadeDB Join Scan.
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+CREATE TABLE contacts (
+    contact_id bigint PRIMARY KEY,
+    company_id bigint,
+    company_name character varying
+);
+
+CREATE TABLE tech_installs (
+    unique_id bigint PRIMARY KEY,
+    company_id bigint,
+    technology_name character varying
+);
+
+INSERT INTO contacts (contact_id, company_id, company_name) VALUES (1, 1, 'amazon');
+INSERT INTO tech_installs (unique_id, company_id, technology_name) VALUES (1, 1, 'java');
+
+-- Index with BOTH an unaliased lower() expression AND an aliased
+-- expression on the same column. This triggers the attno dedup
+-- false-positive in ORDER BY field collection.
+CREATE INDEX contacts_idx ON contacts
+USING bm25 (
+    contact_id,
+    company_id,
+    (lower(company_name::text)::pdb.literal_normalized('ascii_folding=true')),
+    (company_name::pdb.simple('alias=company_name_words', 'ascii_folding=true', 'columnar=true'))
+) WITH (key_field=contact_id, numeric_fields='{"company_id": {"fast": true}}');
+
+CREATE INDEX tech_installs_idx ON tech_installs
+USING bm25 (
+    unique_id,
+    company_id,
+    technology_name
+) WITH (key_field=unique_id, numeric_fields='{"company_id": {"fast": true}}');
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- =====================================================================
+-- Test 1: ORDER BY lower(company_name) — previously errored with
+-- "FieldNotFound: company_name".
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cccf.*
+FROM contacts cccf
+JOIN tech_installs ti ON cccf.company_id = ti.company_id
+WHERE technology_name @@@ 'java'
+ORDER BY lower(company_name) ASC, cccf.contact_id
+LIMIT 10;
+
+SELECT cccf.*
+FROM contacts cccf
+JOIN tech_installs ti ON cccf.company_id = ti.company_id
+WHERE technology_name @@@ 'java'
+ORDER BY lower(company_name) ASC, cccf.contact_id
+LIMIT 10;
+
+-- Parity: same query with custom scan off (native Postgres).
+SET paradedb.enable_join_custom_scan = off;
+SELECT cccf.*
+FROM contacts cccf
+JOIN tech_installs ti ON cccf.company_id = ti.company_id
+WHERE technology_name @@@ 'java'
+ORDER BY lower(company_name) ASC, cccf.contact_id
+LIMIT 10;
+SET paradedb.enable_join_custom_scan = on;
+
+-- Cleanup
+DROP TABLE contacts CASCADE;
+DROP TABLE tech_installs CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

Closes #4849
Closes #4850

## What

Queries over joins where a BM25 index uses field aliases (e.g. `alias=company_name_words`) no longer crash with `Schema error: No field named` or `FieldNotFound`. Two patterns are fixed:

1. **Aggregate-on-join** with `GROUP BY` or aggregate arguments referencing an aliased column:
   ```sql
   SELECT company_name, count(*)
   FROM cccf JOIN ti ON cccf.company_id = ti.company_id
   GROUP BY company_name;
   ```

2. **JoinScan `ORDER BY`** on an indexed expression when the same column also has an aliased index entry:
   ```sql
   SELECT cccf.*
   FROM contacts cccf JOIN tech_installs ti ON cccf.company_id = ti.company_id
   WHERE technology_name @@@ 'java'
   ORDER BY lower(company_name) ASC, cccf.contact_id
   LIMIT 10;
   ```

## Why

Both bugs stem from the same root cause: code paths that resolve column names using the **heap attribute name** (e.g. `"company_name"`) while the DataFusion schema is built from **BM25 index field names** (e.g. `"company_name_words"`).

**#4849 — AggregateScan:** `join_targetlist.rs` uses `fieldname_from_var` to resolve GROUP BY columns, aggregate arguments, and aggregate ORDER BY columns. `fieldname_from_var` opens the heap relation and returns the Postgres attribute name. The exec side (`AggregateIndexVarMapper`) already resolves correctly via `JoinSource::column_name(attno)`, but the planning side (`JoinAggSource`) had no equivalent — it went straight to the heap.

**#4850 — JoinScan:** When a column is indexed twice — once with an alias and once as an expression — `collect_required_fields` has an attno-level dedup guard that masks the name mismatch. `try_ensure_field(source, attno)` sees attno=3 is already in `scan_info.fields` (claimed by the aliased entry as `"company_name_words"`) and returns `Some(())`. The `ensure_expression_field("company_name")` fallback is skipped, so the unaliased field is never added to the DataFusion schema. The ORDER BY then creates `make_source_col(source, "company_name")` against a schema that only has `"company_name_words"`.

## How

Three changes:

1. **Added lazy field cache to `JoinAggSource`** (`aggregatescan/datafusion_build.rs`). A `field_cache: OnceLock<Vec<FieldInfo>>` is populated on first access by calling `resolve_fast_field` for each attno in the heap tuple descriptor — the same resolver that populates `JoinSource::scan_info.fields`. Added `JoinAggSource::column_name(attno)` mirroring `JoinSource::column_name`. Replaced three `fieldname_from_var` call sites in `join_targetlist.rs` (GROUP BY columns, aggregate arguments, aggregate ORDER BY) with `source.column_name(attno)`.

2. **Added name check after attno dedup in `collect_required_fields`** (`joinscan/planning.rs`). In the ORDER BY unqualified `Field` branch, after `try_ensure_field` confirms the attno exists, verify the registered field name matches the ORDER BY's field name. If it doesn't (attno was claimed by an alias), `added = false` and `ensure_expression_field` runs, adding the field under a synthetic attno so both names are in the schema.

3. **Fixed DISTINCT `required_early` set** (`joinscan/scan_state.rs`). The DISTINCT code path inserts `OrderByFeature::Field { name }` directly into the set of fields the table provider must emit early. When the schema-registered name for that attno differs, the wrong field is marked. Added a helper that inserts both the ORDER BY name and the registered schema name when they diverge. Made `get_source_attno_by_name` `pub(super)` so `scan_state.rs` can reuse it.

## Tests

- New file `aggregate_join_alias.sql`:
  - `GROUP BY` on an aliased column over a join with `count(*)`
  - Parity check with `enable_aggregate_custom_scan = off`
- New file `join_order_by_alias_expression.sql`:
  - `EXPLAIN` confirms `TantivyLookupExec: decode=[company_name_words, company_name]` — both fields present
  - `ORDER BY lower(company_name)` with `LIMIT` returns correct results
  - Parity check with `enable_join_custom_scan = off`
- All existing `aggregate_join*` (8 tests), `join*` (29 tests), and `aliased_text_expression*` tests pass.