### PR TITLE
chore: Prepare 0.23.1

### DIFF
--- a/docs/changelog/0.23.1.mdx
+++ b/docs/changelog/0.23.1.mdx
@@ -1,0 +1,18 @@
+---
+title: 0.23.1
+noindex: true
+---
+
+## New Features 🎉
+
+- Add support for inline tokenizers with relevance tuning.
+
+## Stability Improvements 💪
+
+- Replicate missed v0.23.0 migrations in v0.23.1.
+- Return parameterized selectivity for non-`Const` BM25 operator arguments.
+- Upgrade pgrx to 0.18.0.
+- Update tantivy revision to include bug fixes.
+- Add baseline metrics to the `PgSearch` scan.
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.23.1).

--- a/docs/changelog/0.23.1.mdx
+++ b/docs/changelog/0.23.1.mdx
@@ -12,9 +12,16 @@ noindex: true
   WHERE description &&& 'shoes'::pdb.whitespace::pdb.boost(3);
   ```
 
+## Performance Improvements 🚀
+
+- Tighten Block-Max WAND pruning in the single-scorer path, improving query performance when many documents share the same score.
+- `|||` (OR) queries over a single term now use Block-Max WAND pruning.
+
 ## Stability Improvements 💪
 
 - Replicate missed v0.23.0 migrations in v0.23.1 so upgrades from earlier versions apply cleanly.
 - Return parameterized selectivity for non-`Const` BM25 operator arguments, improving plans for prepared statements.
+- Fix a panic in `terms` aggregations that could occur when a `missing` key was combined with an `include`/`exclude` filter on certain segments.
+- Correctly handle the missing sentinel in `terms` aggregations when combining `exclude` with `missing` on columns with zero unique values.
 
 The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.23.1).

--- a/docs/changelog/0.23.1.mdx
+++ b/docs/changelog/0.23.1.mdx
@@ -5,14 +5,16 @@ noindex: true
 
 ## New Features 🎉
 
-- Add support for inline tokenizers with relevance tuning.
+- Inline tokenizers can now be chained into relevance tuning casts (`pdb.boost`, `pdb.const`, `pdb.fuzzy`, `pdb.slop`). For example:
+
+  ```sql
+  SELECT * FROM mock_items
+  WHERE description &&& 'shoes'::pdb.whitespace::pdb.boost(3);
+  ```
 
 ## Stability Improvements 💪
 
-- Replicate missed v0.23.0 migrations in v0.23.1.
-- Return parameterized selectivity for non-`Const` BM25 operator arguments.
-- Upgrade pgrx to 0.18.0.
-- Update tantivy revision to include bug fixes.
-- Add baseline metrics to the `PgSearch` scan.
+- Replicate missed v0.23.0 migrations in v0.23.1 so upgrades from earlier versions apply cleanly.
+- Return parameterized selectivity for non-`Const` BM25 operator arguments, improving plans for prepared statements.
 
 The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.23.1).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -39,7 +39,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.23.0-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.23.1-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -42,7 +42,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.23.0` with the `pg_search` version you wish to install and
+  You can replace `0.23.1` with the `pg_search` version you wish to install and
   `17` with the version of Postgres you are using.
 </Note>
 
@@ -50,49 +50,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/postgresql-17-pg-search_0.23.0-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search_17-0.23.0-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search_17-0.23.1-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search_17-0.23.0-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search_17-0.23.1-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search@17--0.23.0.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search@17--0.23.1.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.0/pg_search@17--0.23.0.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search@17--0.23.1.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -37,7 +37,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.23.0`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.23.1`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -79,10 +79,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.23.0
+docker pull paradedb/paradedb:0.23.1
 ```
 
-The latest version of the Docker image should be `0.23.0`.
+The latest version of the Docker image should be `0.23.1`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -99,7 +99,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.23.0';
+ALTER EXTENSION pg_search UPDATE TO '0.23.1';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.23.0",
+        "version": "v0.23.1",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -345,6 +345,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.23.1",
                   "changelog/0.23.0",
                   "changelog/0.22.6",
                   "changelog/0.22.5",


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Prepares the 0.23.1 release.

## Why

Cuts the 0.23.1 patch release off the `0.23.x` branch.

## How

- Bumps version references in docs (`docs.json`, `upgrading.mdx`, `extension.mdx`, `digitalocean.mdx`) from `0.23.0` → `0.23.1`.
- Adds `docs/changelog/0.23.1.mdx` and registers it in `docs.json`.
- `Cargo.toml` and the `pg_search--0.23.0--0.23.1.sql` migration were already bumped on `0.23.x`.

## Tests

N/A — release prep only.