### PR TITLE
fix: Increase worker mem for large agg queries in SO benchmark suite

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -16,6 +16,7 @@ SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackov
 -- high-cardinality aggregate scan
 SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
+SET work_mem = 4GB;
 -- high-cardinality aggregate scan using pdb.agg
 SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -16,7 +16,7 @@ SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackov
 -- high-cardinality aggregate scan
 SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
-SET work_mem = 4GB;
+SET work_mem = '4GB';
 -- high-cardinality aggregate scan using pdb.agg
 SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/cardinality.sql
@@ -16,9 +16,8 @@ SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackov
 -- high-cardinality aggregate scan
 SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
-SET work_mem = '4GB';
 -- high-cardinality aggregate scan using pdb.agg
-SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}') as count, pdb.agg('{"min": {"field": "score"}}') as min, pdb.agg('{"max": {"field": "score"}}') as max, pdb.agg('{"sum": {"field": "score"}}') as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
-SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;


### PR DESCRIPTION
# Ticket(s) Closed
## What
Increase the worker mem

## Why
So our benchmark runs stop failing

## How

## Tests
Successful run of SO queries: https://github.com/paradedb/paradedb/actions/runs/24851333874
