### PR TITLE
ci: Cascade release push to downstream publish workflows

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -147,9 +147,16 @@ jobs:
           fi
 
       # The tag_name will have "-rc.X" suffix and be marked as a prerelease for beta releases,
-      # and no suffix and marked as a full release for prod releases
+      # and no suffix and marked as a full release for prod releases.
+      #
+      # Pinned to v2.4.2: versions >= v2.5.0 create the tag ref in a way that does not
+      # propagate our PARADEDB_BOT_GITHUB_TOKEN PAT, so the resulting tag push is attributed
+      # to the default GITHUB_TOKEN. GitHub intentionally suppresses cascading workflow runs
+      # from GITHUB_TOKEN, which means the downstream `publish-*` workflows (triggered on
+      # `push: tags: v*`) never fire. v2.4.2 preserves the PAT on tag creation, so the tag
+      # push cascades correctly. Do not bump without verifying downstream workflows fire.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2.6.1
+        uses: softprops/action-gh-release@v2.4.2
         with:
           tag_name: v${{ github.event.inputs.version }}
           target_commitish: ${{ github.ref_name }} # Deploy the branch that this workflow is being run from

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -146,17 +146,29 @@ jobs:
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
+      # Create the tag ref ourselves, using the PARADEDB_BOT_GITHUB_TOKEN PAT, BEFORE
+      # calling softprops/action-gh-release. Since v2.5.0, that action publishes releases
+      # via a draft-first flow where the tag ref is created as a side effect of the
+      # publish API call, which does not emit a cascading `push` event — so our downstream
+      # `publish-*` workflows (triggered on `push: tags: v*`) never fire. Pushing the tag
+      # ref directly with the PAT here ensures the push event is attributed to the PAT and
+      # cascades to the downstream workflows. The subsequent release-creation step then
+      # attaches the release to the already-existing tag.
+      - name: Create Tag
+        env:
+          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+        run: |
+          sha=$(git rev-parse HEAD)
+          echo "Creating tag v${{ github.event.inputs.version }} pointing at $sha"
+          gh api -X POST "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/tags/v${{ github.event.inputs.version }}" \
+            -f sha="$sha"
+
       # The tag_name will have "-rc.X" suffix and be marked as a prerelease for beta releases,
-      # and no suffix and marked as a full release for prod releases.
-      #
-      # Pinned to v2.4.2: versions >= v2.5.0 create the tag ref in a way that does not
-      # propagate our PARADEDB_BOT_GITHUB_TOKEN PAT, so the resulting tag push is attributed
-      # to the default GITHUB_TOKEN. GitHub intentionally suppresses cascading workflow runs
-      # from GITHUB_TOKEN, which means the downstream `publish-*` workflows (triggered on
-      # `push: tags: v*`) never fire. v2.4.2 preserves the PAT on tag creation, so the tag
-      # push cascades correctly. Do not bump without verifying downstream workflows fire.
+      # and no suffix and marked as a full release for prod releases. The tag has already been
+      # created in the step above, so this step just attaches the release to it.
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2.4.2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ github.event.inputs.version }}
           target_commitish: ${{ github.ref_name }} # Deploy the branch that this workflow is being run from


### PR DESCRIPTION
## Summary
- Create the `v<version>` tag ref explicitly with `PARADEDB_BOT_GITHUB_TOKEN` **before** calling `softprops/action-gh-release`.
- Bump the action to `@v3` (latest) now that it no longer has to own tag creation.

## Why
Since `softprops/action-gh-release` v2.5.0, the action uses a draft-first publish flow: it creates a draft release, uploads assets, then `PATCH`es it to published. The tag ref is created as a side effect of that publish call, and that path does not emit a cascading `push` event — regardless of whether a PAT or `GITHUB_TOKEN` is supplied. That's why our downstream `publish-*` workflows (all triggered on `push: tags: v*`) stopped firing for v0.23.0 and v0.23.1, while v0.20.11 (still on `v2.4.2`, pre-draft-first) cascaded correctly.

Pushing the tag ourselves via `gh api` with the PAT attributes the push event to the PAT, which GitHub does propagate, so every downstream `publish-*` workflow cascades again. The `Create GitHub Release` step then just attaches the release to the already-existing tag, letting us stay on the latest action (`@v3`).

## Test plan
- [ ] After merge, cut a beta release (`-rc.X`) and confirm all 7 downstream `publish-*` workflows (Debian / Ubuntu / RHEL / macOS / Docker / PGXN / Docs) are triggered by the tag `push` event, not by `workflow_dispatch`.
- [ ] Cherry-pick onto `0.23.x` so the next 0.23.x patch release also cascades.