### PR TITLE
fix: Make sampling actually determinstic

### DIFF
--- a/benchmarks/datasets/sample_config.toml
+++ b/benchmarks/datasets/sample_config.toml
@@ -1,9 +1,9 @@
-root_table = "orders"
 sampling_seed = 723                                          # sum of the characters in "ParadeDB" as ascii
 s3_base_path = "s3://paradedb-ci-benchmarks/datasets/sample" # does not exist, replace with your own path
 
-[[tables]]
+[root_table]
 name = "orders"
+primary_key = "id"
 
 [[tables]]
 name = "lineitem"

--- a/benchmarks/datasets/stackoverflow/config.toml
+++ b/benchmarks/datasets/stackoverflow/config.toml
@@ -1,9 +1,9 @@
-root_table = "stackoverflow_posts"
 sampling_seed = 723                                                 # sum of the characters in "ParadeDB" as ascii
 s3_base_path = "s3://paradedb-ci-benchmarks/datasets/stackoverflow"
 
-[[tables]]
+[root_table]
 name = "stackoverflow_posts"
+primary_key = "id"
 
 [[tables]]
 name = "badges"

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -31,7 +31,7 @@ pub struct DatasetConfig {
 #[derive(Deserialize)]
 pub struct RootTableConfig {
     pub name: String,
-    pub _primary_key: String,
+    pub primary_key: String,
 }
 
 #[derive(Deserialize, Clone)]
@@ -104,7 +104,7 @@ mod tests {
         DatasetConfig {
             root_table: RootTableConfig {
                 name: root_table.to_string(),
-                _primary_key: format!("{root_table}_pk"),
+                primary_key: format!("{root_table}_pk"),
             },
             sampling_seed: 42,
             tables,

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -30,7 +30,7 @@ pub struct DatasetConfig {
 
 impl DatasetConfig {
     /// Returns an iterator containing the root table name, then all of the other table names
-    pub fn all_table_names(&self) -> impl Iterator<Item = &str> {
+    pub(crate) fn all_table_names(&self) -> impl Iterator<Item = &str> {
         let tables_iter = self.tables.iter().map(|t| t.name.as_str());
         let root_iter = std::iter::once(self.root_table.name.as_str());
         root_iter.chain(tables_iter)
@@ -52,13 +52,15 @@ pub struct TableConfig {
     pub join_col: String,
 }
 
-pub fn load_dataset_config(path: &str) -> Result<DatasetConfig> {
+/// Returns the dataset config, and the topological order for the non-root tables
+pub fn load_dataset_config(path: &str) -> Result<(DatasetConfig, Vec<usize>)> {
     let content =
         std::fs::read_to_string(path).with_context(|| format!("Failed to read config '{path}'"))?;
     let config: DatasetConfig =
         toml::from_str(&content).with_context(|| format!("Failed to parse config '{path}'"))?;
     validate_config(&config).with_context(|| format!("Invalid config '{path}'"))?;
-    Ok(config)
+    let order = topological_order(&config)?;
+    Ok((config, order))
 }
 
 fn validate_config(config: &DatasetConfig) -> Result<()> {
@@ -73,7 +75,7 @@ fn validate_config(config: &DatasetConfig) -> Result<()> {
 }
 
 /// Returns table indices in topological order (children only, excludes root).
-pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
+fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
     let mut order = Vec::with_capacity(config.tables.len());
     let mut processed: HashSet<&str> = HashSet::new();
 

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -27,7 +27,9 @@ pub struct DatasetConfig {
     #[serde(default)]
     pub s3_base_path: Option<String>,
 }
+
 impl DatasetConfig {
+    /// Returns an iterator containing the root table name, then all of the other table names
     pub fn all_table_names(&self) -> impl Iterator<Item = &str> {
         let tables_iter = self.tables.iter().map(|t| t.name.as_str());
         let root_iter = std::iter::once(self.root_table.name.as_str());
@@ -35,10 +37,10 @@ impl DatasetConfig {
     }
 }
 
-/// For deterministic sampling, `primary_key` must reference a column with unique, non-null values for all rows
 #[derive(Deserialize)]
 pub struct RootTableConfig {
     pub name: String,
+    /// For deterministic sampling, `primary_key` must reference a column with unique, non-null values for all rows
     pub primary_key: String,
 }
 
@@ -55,17 +57,19 @@ pub fn load_dataset_config(path: &str) -> Result<DatasetConfig> {
         std::fs::read_to_string(path).with_context(|| format!("Failed to read config '{path}'"))?;
     let config: DatasetConfig =
         toml::from_str(&content).with_context(|| format!("Failed to parse config '{path}'"))?;
-    if config
-        .tables
-        .iter()
-        .any(|t| t.name == config.root_table.name)
-    {
-        bail!(
-            "Multiple tables with root table name '{}' defined in config '{path}'",
-            config.root_table.name,
-        );
-    }
+    validate_config(&config).with_context(|| format!("Invalid config '{path}'"))?;
     Ok(config)
+}
+
+fn validate_config(config: &DatasetConfig) -> Result<()> {
+    let mut seen_names: HashSet<&str> = HashSet::new();
+    seen_names.insert(config.root_table.name.as_str());
+    for table in &config.tables {
+        if !seen_names.insert(table.name.as_str()) {
+            bail!("Duplicate table name '{}'", table.name);
+        }
+    }
+    Ok(())
 }
 
 /// Returns table indices in topological order (children only, excludes root).
@@ -192,5 +196,23 @@ mod tests {
     fn error_missing_parent_reference() {
         let config = make_config("orders", vec![make_table("line_items", "nonexistent")]);
         assert!(topological_order(&config).is_err());
+    }
+
+    #[test]
+    fn error_duplicate_of_root_in_tables() {
+        let config = make_config("orders", vec![make_table("orders", "orders")]);
+        assert!(validate_config(&config).is_err());
+    }
+
+    #[test]
+    fn error_duplicate_within_tables() {
+        let config = make_config(
+            "orders",
+            vec![
+                make_table("line_items", "orders"),
+                make_table("line_items", "orders"),
+            ],
+        );
+        assert!(validate_config(&config).is_err());
     }
 }

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -27,9 +27,16 @@ pub struct DatasetConfig {
     #[serde(default)]
     pub s3_base_path: Option<String>,
 }
+impl DatasetConfig {
+    pub fn all_table_names(&self) -> impl Iterator<Item = &str> {
+        let tables_iter = self.tables.iter().map(|t| t.name.as_str());
+        let root_iter = std::iter::once(self.root_table.name.as_str());
+        root_iter.chain(tables_iter)
+    }
+}
 
-#[derive(Deserialize)]
 /// For deterministic sampling, `primary_key` must reference a column with unique, non-null values for all rows
+#[derive(Deserialize)]
 pub struct RootTableConfig {
     pub name: String,
     pub primary_key: String,
@@ -46,7 +53,19 @@ pub struct TableConfig {
 pub fn load_dataset_config(path: &str) -> Result<DatasetConfig> {
     let content =
         std::fs::read_to_string(path).with_context(|| format!("Failed to read config '{path}'"))?;
-    toml::from_str(&content).with_context(|| format!("Failed to parse config '{path}'"))
+    let config: DatasetConfig =
+        toml::from_str(&content).with_context(|| format!("Failed to parse config '{path}'"))?;
+    if config
+        .tables
+        .iter()
+        .any(|t| t.name == config.root_table.name)
+    {
+        bail!(
+            "Multiple tables with root table name '{}' defined in config '{path}'",
+            config.root_table.name,
+        );
+    }
+    Ok(config)
 }
 
 /// Returns table indices in topological order (children only, excludes root).
@@ -77,8 +96,9 @@ pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
     for table in &config.tables {
         if !processed.contains(table.name.as_str()) {
             bail!(
-                "Table '{}' could not be processed. Its parent '{}' is not in the config or there is a cycle.",
+                "Table '{}' could not be processed. Its parent '{}' is not the root table '{}', or is not in the config, or there is a cycle.",
                 table.name,
+                config.root_table.name,
                 table.parent,
             );
         }

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -17,11 +17,11 @@
 
 use anyhow::{bail, Context, Result};
 use serde::Deserialize;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 #[derive(Deserialize)]
 pub struct DatasetConfig {
-    pub root_table: String,
+    pub root_table: RootTableConfig,
     pub sampling_seed: u64,
     pub tables: Vec<TableConfig>,
     #[serde(default)]
@@ -29,11 +29,17 @@ pub struct DatasetConfig {
 }
 
 #[derive(Deserialize)]
+pub struct RootTableConfig {
+    pub name: String,
+    pub _primary_key: String,
+}
+
+#[derive(Deserialize, Clone)]
 pub struct TableConfig {
     pub name: String,
-    pub parent: Option<String>,
-    pub parent_join_col: Option<String>,
-    pub join_col: Option<String>,
+    pub parent: String,
+    pub parent_join_col: String,
+    pub join_col: String,
 }
 
 pub fn load_dataset_config(path: &str) -> Result<DatasetConfig> {
@@ -42,35 +48,13 @@ pub fn load_dataset_config(path: &str) -> Result<DatasetConfig> {
     toml::from_str(&content).with_context(|| format!("Failed to parse config '{path}'"))
 }
 
-/// Returns table indices in topological order (root first, then children).
+/// Returns table indices in topological order (children only, excludes root).
 pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
-    let name_to_idx: HashMap<&str, usize> = config
-        .tables
-        .iter()
-        .enumerate()
-        .map(|(i, t)| (t.name.as_str(), i))
-        .collect();
-
-    let mut order = Vec::with_capacity(config.tables.len());
+    let mut order = Vec::with_capacity(config.tables.len() + 1);
     let mut processed: HashSet<&str> = HashSet::new();
 
     // Start with the root table.
-    let root_idx = *name_to_idx
-        .get(config.root_table.as_str())
-        .with_context(|| {
-            format!(
-                "Root table '{}' not found in tables list",
-                config.root_table
-            )
-        })?;
-    if config.tables[root_idx].parent.is_some() {
-        bail!(
-            "Root table '{}' cannot have a parent table.",
-            config.root_table
-        )
-    }
-    order.push(root_idx);
-    processed.insert(&config.root_table);
+    processed.insert(&config.root_table.name);
 
     // Iteratively add tables whose parent has been processed. Repeat until no progress is made
     let mut progress = true;
@@ -80,26 +64,11 @@ pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
             if processed.contains(table.name.as_str()) {
                 continue;
             }
-            if let Some(parent) = &table.parent {
-                if processed.contains(parent.as_str()) {
-                    // Validate that child tables have the required keys.
-                    if table.parent_join_col.is_none() || table.join_col.is_none() {
-                        bail!(
-                            "Table '{}' has a parent '{}' but is missing parent_join_col or join_col",
-                            table.name,
-                            parent
-                        );
-                    }
-                    order.push(i);
-                    processed.insert(&table.name);
-                    progress = true;
-                }
-            } else if table.name != config.root_table {
-                bail!(
-                    "Table '{}' has no parent and is not the root table '{}'",
-                    table.name,
-                    config.root_table
-                );
+            if processed.contains(table.parent.as_str()) {
+                // Validate that child tables have the required keys.
+                order.push(i);
+                processed.insert(&table.name);
+                progress = true;
             }
         }
     }
@@ -110,7 +79,7 @@ pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
             bail!(
                 "Table '{}' could not be processed. Its parent '{}' is not in the config or there is a cycle.",
                 table.name,
-                table.parent.as_deref().unwrap_or("(none)")
+                table.parent,
             );
         }
     }
@@ -122,18 +91,21 @@ pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
 mod tests {
     use super::*;
 
-    fn make_table(name: &str, parent: Option<&str>) -> TableConfig {
+    fn make_table(name: &str, parent: &str) -> TableConfig {
         TableConfig {
             name: name.to_string(),
-            parent: parent.map(|s| s.to_string()),
-            parent_join_col: parent.map(|_| "parent_id".to_string()),
-            join_col: parent.map(|_| "id".to_string()),
+            parent: parent.to_string(),
+            parent_join_col: "parent_id".to_string(),
+            join_col: "id".to_string(),
         }
     }
 
     fn make_config(root_table: &str, tables: Vec<TableConfig>) -> DatasetConfig {
         DatasetConfig {
-            root_table: root_table.to_string(),
+            root_table: RootTableConfig {
+                name: root_table.to_string(),
+                _primary_key: format!("{root_table}_pk"),
+            },
             sampling_seed: 42,
             tables,
             s3_base_path: None,
@@ -142,22 +114,16 @@ mod tests {
 
     #[test]
     fn single_root_table() {
-        let config = make_config("orders", vec![make_table("orders", None)]);
+        let config = make_config("orders", vec![]);
         let order = topological_order(&config).unwrap();
-        assert_eq!(order, vec![0]);
+        assert_eq!(order, Vec::<usize>::new());
     }
 
     #[test]
     fn root_with_one_child() {
-        let config = make_config(
-            "orders",
-            vec![
-                make_table("orders", None),
-                make_table("line_items", Some("orders")),
-            ],
-        );
+        let config = make_config("orders", vec![make_table("line_items", "orders")]);
         let order = topological_order(&config).unwrap();
-        assert_eq!(order, vec![0, 1]);
+        assert_eq!(order, vec![0]);
     }
 
     #[test]
@@ -165,15 +131,13 @@ mod tests {
         let config = make_config(
             "orders",
             vec![
-                make_table("orders", None),
-                make_table("line_items", Some("orders")),
-                make_table("payments", Some("orders")),
+                make_table("line_items", "orders"),
+                make_table("payments", "orders"),
             ],
         );
         let order = topological_order(&config).unwrap();
-        assert_eq!(order[0], 0); // root first
-        let rest: HashSet<usize> = order[1..].iter().copied().collect();
-        assert_eq!(rest, HashSet::from([1, 2]));
+        let rest: HashSet<usize> = order[..].iter().copied().collect();
+        assert_eq!(rest, HashSet::from([0, 1]));
     }
 
     #[test]
@@ -182,13 +146,12 @@ mod tests {
         let config = make_config(
             "orders",
             vec![
-                make_table("orders", None),
-                make_table("line_items", Some("orders")),
-                make_table("shipments", Some("line_items")),
+                make_table("line_items", "orders"),
+                make_table("shipments", "line_items"),
             ],
         );
         let order = topological_order(&config).unwrap();
-        assert_eq!(order, vec![0, 1, 2]);
+        assert_eq!(order, vec![0, 1]);
     }
 
     #[test]
@@ -197,63 +160,18 @@ mod tests {
         let config = make_config(
             "orders",
             vec![
-                make_table("shipments", Some("line_items")),
-                make_table("line_items", Some("orders")),
-                make_table("orders", None),
+                make_table("shipments", "line_items"),
+                make_table("line_items", "orders"),
             ],
         );
         let order = topological_order(&config).unwrap();
         // Root (orders=idx2) must come first, then line_items(idx1), then shipments(idx0).
-        assert_eq!(order, vec![2, 1, 0]);
-    }
-
-    #[test]
-    fn error_root_table_not_in_list() {
-        let config = make_config("missing", vec![make_table("orders", None)]);
-        assert!(topological_order(&config).is_err());
-    }
-
-    #[test]
-    fn error_root_table_has_parent() {
-        let config = make_config("orders", vec![make_table("orders", Some("something"))]);
-        assert!(topological_order(&config).is_err());
-    }
-
-    #[test]
-    fn error_non_root_without_parent() {
-        let config = make_config(
-            "orders",
-            vec![make_table("orders", None), make_table("orphan", None)],
-        );
-        assert!(topological_order(&config).is_err());
+        assert_eq!(order, vec![1, 0]);
     }
 
     #[test]
     fn error_missing_parent_reference() {
-        let config = make_config(
-            "orders",
-            vec![
-                make_table("orders", None),
-                make_table("line_items", Some("nonexistent")),
-            ],
-        );
-        assert!(topological_order(&config).is_err());
-    }
-
-    #[test]
-    fn error_child_missing_join_cols() {
-        let config = make_config(
-            "orders",
-            vec![
-                make_table("orders", None),
-                TableConfig {
-                    name: "line_items".to_string(),
-                    parent: Some("orders".to_string()),
-                    parent_join_col: None,
-                    join_col: None,
-                },
-            ],
-        );
+        let config = make_config("orders", vec![make_table("line_items", "nonexistent")]);
         assert!(topological_order(&config).is_err());
     }
 }

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -58,12 +58,12 @@ pub fn load_dataset_config(path: &str) -> Result<(DatasetConfig, Vec<usize>)> {
         std::fs::read_to_string(path).with_context(|| format!("Failed to read config '{path}'"))?;
     let config: DatasetConfig =
         toml::from_str(&content).with_context(|| format!("Failed to parse config '{path}'"))?;
-    validate_config(&config).with_context(|| format!("Invalid config '{path}'"))?;
-    let order = topological_order(&config)?;
+    let order = validate_config_and_table_order(&config)
+        .with_context(|| format!("Invalid config '{path}'"))?;
     Ok((config, order))
 }
 
-fn validate_config(config: &DatasetConfig) -> Result<()> {
+fn validate_config_and_table_order(config: &DatasetConfig) -> Result<Vec<usize>> {
     let mut seen_names: HashSet<&str> = HashSet::new();
     seen_names.insert(config.root_table.name.as_str());
     for table in &config.tables {
@@ -71,7 +71,8 @@ fn validate_config(config: &DatasetConfig) -> Result<()> {
             bail!("Duplicate table name '{}'", table.name);
         }
     }
-    Ok(())
+    let order = topological_order(config)?;
+    Ok(order)
 }
 
 /// Returns table indices in topological order (children only, excludes root).
@@ -141,14 +142,14 @@ mod tests {
     #[test]
     fn single_root_table() {
         let config = make_config("orders", vec![]);
-        let order = topological_order(&config).unwrap();
+        let order = validate_config_and_table_order(&config).unwrap();
         assert_eq!(order, Vec::<usize>::new());
     }
 
     #[test]
     fn root_with_one_child() {
         let config = make_config("orders", vec![make_table("line_items", "orders")]);
-        let order = topological_order(&config).unwrap();
+        let order = validate_config_and_table_order(&config).unwrap();
         assert_eq!(order, vec![0]);
     }
 
@@ -161,7 +162,7 @@ mod tests {
                 make_table("payments", "orders"),
             ],
         );
-        let order = topological_order(&config).unwrap();
+        let order = validate_config_and_table_order(&config).unwrap();
         let rest: HashSet<usize> = order[..].iter().copied().collect();
         assert_eq!(rest, HashSet::from([0, 1]));
     }
@@ -176,7 +177,7 @@ mod tests {
                 make_table("shipments", "line_items"),
             ],
         );
-        let order = topological_order(&config).unwrap();
+        let order = validate_config_and_table_order(&config).unwrap();
         assert_eq!(order, vec![0, 1]);
     }
 
@@ -190,7 +191,7 @@ mod tests {
                 make_table("line_items", "orders"),
             ],
         );
-        let order = topological_order(&config).unwrap();
+        let order = validate_config_and_table_order(&config).unwrap();
         assert_eq!(order, vec![1, 0]);
     }
 
@@ -203,7 +204,7 @@ mod tests {
     #[test]
     fn error_duplicate_of_root_in_tables() {
         let config = make_config("orders", vec![make_table("orders", "orders")]);
-        assert!(validate_config(&config).is_err());
+        assert!(validate_config_and_table_order(&config).is_err());
     }
 
     #[test]
@@ -215,6 +216,6 @@ mod tests {
                 make_table("line_items", "orders"),
             ],
         );
-        assert!(validate_config(&config).is_err());
+        assert!(validate_config_and_table_order(&config).is_err());
     }
 }

--- a/benchmarks/src/config.rs
+++ b/benchmarks/src/config.rs
@@ -29,12 +29,13 @@ pub struct DatasetConfig {
 }
 
 #[derive(Deserialize)]
+/// For deterministic sampling, `primary_key` must reference a column with unique, non-null values for all rows
 pub struct RootTableConfig {
     pub name: String,
     pub primary_key: String,
 }
 
-#[derive(Deserialize, Clone)]
+#[derive(Deserialize)]
 pub struct TableConfig {
     pub name: String,
     pub parent: String,
@@ -50,7 +51,7 @@ pub fn load_dataset_config(path: &str) -> Result<DatasetConfig> {
 
 /// Returns table indices in topological order (children only, excludes root).
 pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
-    let mut order = Vec::with_capacity(config.tables.len() + 1);
+    let mut order = Vec::with_capacity(config.tables.len());
     let mut processed: HashSet<&str> = HashSet::new();
 
     // Start with the root table.
@@ -65,7 +66,6 @@ pub fn topological_order(config: &DatasetConfig) -> Result<Vec<usize>> {
                 continue;
             }
             if processed.contains(table.parent.as_str()) {
-                // Validate that child tables have the required keys.
                 order.push(i);
                 processed.insert(&table.name);
                 progress = true;
@@ -165,7 +165,6 @@ mod tests {
             ],
         );
         let order = topological_order(&config).unwrap();
-        // Root (orders=idx2) must come first, then line_items(idx1), then shipments(idx0).
         assert_eq!(order, vec![1, 0]);
     }
 

--- a/benchmarks/src/convert.rs
+++ b/benchmarks/src/convert.rs
@@ -48,9 +48,8 @@ pub fn run_convert(args: ConvertArgs) -> Result<()> {
     let input = args.input.trim_end_matches('/');
     let output = args.output.trim_end_matches('/');
 
-    let tables: Vec<&str> = args.tables.iter().map(|t| t.as_ref()).collect();
-    validate_input(&tables, &conn, input)?;
-    validate_output(&tables, &conn, output)?;
+    let tables_iter = args.tables.iter().map(|t| t.as_ref());
+    validate_input(tables_iter.clone(), &conn, input)?;
 
     if args.dry_run {
         println!("\nDry run: counting planned conversions...");
@@ -70,6 +69,8 @@ pub fn run_convert(args: ConvertArgs) -> Result<()> {
         println!("\nDry run complete. No files were converted.");
         return Ok(());
     }
+
+    validate_output(tables_iter, &conn, output)?;
 
     // Conversion phase: one COPY per table, DuckDB handles parallelism internally.
     println!("\nConverting parquet to CSV...");

--- a/benchmarks/src/convert.rs
+++ b/benchmarks/src/convert.rs
@@ -18,7 +18,7 @@
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 
-use crate::utils::{open_duckdb_conn, validate_input_output};
+use crate::utils::{open_duckdb_conn, validate_input, validate_output};
 
 #[derive(Parser)]
 pub struct ConvertArgs {
@@ -49,7 +49,8 @@ pub fn run_convert(args: ConvertArgs) -> Result<()> {
     let output = args.output.trim_end_matches('/');
 
     let tables: Vec<&str> = args.tables.iter().map(|t| t.as_ref()).collect();
-    validate_input_output(&tables, &conn, input, output)?;
+    validate_input(&tables, &conn, input)?;
+    validate_output(&tables, &conn, output)?;
 
     if args.dry_run {
         println!("\nDry run: counting planned conversions...");

--- a/benchmarks/src/convert.rs
+++ b/benchmarks/src/convert.rs
@@ -48,7 +48,8 @@ pub fn run_convert(args: ConvertArgs) -> Result<()> {
     let input = args.input.trim_end_matches('/');
     let output = args.output.trim_end_matches('/');
 
-    validate_input_output(&args.tables, &conn, input, output)?;
+    let tables: Vec<&str> = args.tables.iter().map(|t| t.as_ref()).collect();
+    validate_input_output(&tables, &conn, input, output)?;
 
     if args.dry_run {
         println!("\nDry run: counting planned conversions...");

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -616,7 +616,7 @@ fn load_external_data(
 ) -> anyhow::Result<()> {
     // Read dataset config for table names and S3 path.
     let config_path = format!("datasets/{dataset}/config.toml");
-    let config = config::load_dataset_config(&config_path)
+    let (config, _) = config::load_dataset_config(&config_path)
         .with_context(|| format!("Failed to load config '{config_path}'"))?;
 
     // Determine CSV data source path.

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -124,8 +124,8 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     };
     let sql = format!(
         "CREATE TABLE sampled_{name} AS \
-        (SELECT * FROM  read_parquet('{local_path}') ORDER BY {pk}) \
-         USING SAMPLE {sample_arg} REPEATABLE({seed})",
+        WITH ordered AS (SELECT * FROM  read_parquet('{local_path}') ORDER BY {pk}) \
+        SELECT * FROM ordered USING SAMPLE {sample_arg} REPEATABLE({seed})",
         name = root.name,
         local_path = local_glob,
         pk = root.primary_key,

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -124,7 +124,7 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     };
     let sql = format!(
         "CREATE TABLE sampled_{name} AS \
-         SELECT * FROM  read_parquet('{local_path}') ORDER BY {pk} \
+        (SELECT * FROM  read_parquet('{local_path}') ORDER BY {pk}) \
          USING SAMPLE {sample_arg} REPEATABLE({seed})",
         name = root.name,
         local_path = local_glob,

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -160,14 +160,11 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     // Sample child tables by joining against their sampled parent.
     for &idx in &order[1..] {
         let table = &config.tables[idx];
-        let parent = table.parent.as_ref().unwrap();
-        let parent_join_key = table.parent_join_col.as_ref().unwrap();
-        let join_key = table.join_col.as_ref().unwrap();
         let glob = parquet_glob_pattern(input, &table.name);
 
         println!(
-            "Sampling child table '{}' (parent: '{parent}')...",
-            table.name
+            "Sampling child table '{}' (parent: '{}')...",
+            table.name, table.parent,
         );
 
         let sql = format!(
@@ -177,9 +174,9 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
              WHERE c.\"{jk}\" IN 
                 (SELECT {pk} from sampled_{parent})",
             name = table.name,
-            parent = parent,
-            jk = join_key,
-            pk = parent_join_key,
+            parent = table.parent,
+            jk = table.join_col,
+            pk = table.parent_join_col,
         );
         conn.execute_batch(&sql)
             .with_context(|| format!("Failed to sample child table '{}'", table.name))?;

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -160,7 +160,7 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     println!("  {} sampled: {sampled_root_count} rows", root.name);
 
     // Sample child tables by joining against their sampled parent.
-    for &idx in &order[1..] {
+    for &idx in &order[..] {
         let table = &config.tables[idx];
         let glob = parquet_glob_pattern(input, &table.name);
 
@@ -200,6 +200,19 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
 
     // Write output.
     println!("\nWriting sampled parquet files...");
+    // root
+    let table_name = root.name;
+    println!("  Writing '{}'...", table_name);
+    let sql = format!(
+        "COPY sampled_{name} TO '{output}/{name}' (FORMAT PARQUET, PER_THREAD_OUTPUT true)",
+        name = table_name,
+        output = output,
+    );
+    conn.execute_batch(&sql)
+        .with_context(|| format!("Failed to write sampled table '{}'", table_name))?;
+    println!("  {}: done", table_name);
+
+    // others
     for &idx in &order {
         let table = &config.tables[idx];
         println!("  Writing '{}'...", table.name);

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -68,11 +68,9 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     let input = args.input.trim_end_matches('/');
     let output = args.output.trim_end_matches('/');
 
-    let mut table_names: Vec<&str> = config.tables.iter().map(|t| t.name.as_str()).collect();
-    table_names.push(&config.root_table.name);
-    validate_input(&table_names, &conn, input)?;
+    validate_input(config.all_table_names(), &conn, input)?;
     if !args.dry_run {
-        validate_output(&table_names, &conn, output)?;
+        validate_output(config.all_table_names(), &conn, output)?;
     }
 
     // Determine processing order.
@@ -176,12 +174,12 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
             "CREATE TABLE sampled_{name} AS \
              SELECT DISTINCT c.* \
              FROM read_parquet('{glob}') c \
-             WHERE c.\"{jk}\" IN 
-                (SELECT {pk} from sampled_{parent})",
+             WHERE c.\"{child_col}\" IN 
+                (SELECT {parent_col} from sampled_{parent})",
             name = table.name,
             parent = table.parent,
-            jk = table.join_col,
-            pk = table.parent_join_col,
+            child_col = table.join_col,
+            parent_col = table.parent_join_col,
         );
         conn.execute_batch(&sql)
             .with_context(|| format!("Failed to sample child table '{}'", table.name))?;
@@ -204,7 +202,6 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     // Write output.
     println!("\nWriting sampled parquet files...");
     write_sample_table(&conn, &root.name, output)?;
-    // others
     for &idx in &order {
         write_sample_table(&conn, &config.tables[idx].name, output)?;
     }

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -21,7 +21,7 @@ use duckdb::Connection;
 use std::time::Instant;
 
 use crate::config::{load_dataset_config, topological_order};
-use crate::utils::{open_duckdb_conn, validate_input_output};
+use crate::utils::{open_duckdb_conn, validate_input, validate_output};
 
 #[derive(Parser)]
 pub struct SampleArgs {
@@ -70,7 +70,10 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
 
     let mut table_names: Vec<&str> = config.tables.iter().map(|t| t.name.as_str()).collect();
     table_names.push(&config.root_table.name);
-    validate_input_output(&table_names, &conn, input, output)?;
+    validate_input(&table_names, &conn, input)?;
+    if !args.dry_run {
+        validate_output(&table_names, &conn, output)?;
+    }
 
     // Determine processing order.
     let order = topological_order(&config)?;

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -76,7 +76,7 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     let order = topological_order(&config)?;
 
     // Sample the root table.
-    let root = config.root_table;
+    let root = &config.root_table;
     let root_glob = parquet_glob_pattern(input, &root.name);
     let total_rows = count_rows(&conn, &root_glob)?;
 
@@ -124,7 +124,7 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     };
     let sql = format!(
         "CREATE TABLE sampled_{name} AS \
-        WITH ordered AS (SELECT * FROM  read_parquet('{local_path}') ORDER BY {pk}) \
+        WITH ordered AS (SELECT * FROM  read_parquet('{local_path}') ORDER BY \"{pk}\") \
         SELECT * FROM ordered USING SAMPLE {sample_arg} REPEATABLE({seed})",
         name = root.name,
         local_path = local_glob,
@@ -160,7 +160,7 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     println!("  {} sampled: {sampled_root_count} rows", root.name);
 
     // Sample child tables by joining against their sampled parent.
-    for &idx in &order[..] {
+    for &idx in &order {
         let table = &config.tables[idx];
         let glob = parquet_glob_pattern(input, &table.name);
 
@@ -200,8 +200,21 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
 
     // Write output.
     println!("\nWriting sampled parquet files...");
-    // root
-    let table_name = root.name;
+    write_sample_table(&conn, &root.name, output)?;
+    // others
+    for &idx in &order {
+        write_sample_table(&conn, &config.tables[idx].name, output)?;
+    }
+
+    println!("\nSampling complete.");
+    Ok(())
+}
+
+fn write_sample_table(
+    conn: &duckdb::Connection,
+    table_name: &str,
+    output: &str,
+) -> anyhow::Result<()> {
     println!("  Writing '{}'...", table_name);
     let sql = format!(
         "COPY sampled_{name} TO '{output}/{name}' (FORMAT PARQUET, PER_THREAD_OUTPUT true)",
@@ -211,21 +224,5 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     conn.execute_batch(&sql)
         .with_context(|| format!("Failed to write sampled table '{}'", table_name))?;
     println!("  {}: done", table_name);
-
-    // others
-    for &idx in &order {
-        let table = &config.tables[idx];
-        println!("  Writing '{}'...", table.name);
-        let sql = format!(
-            "COPY sampled_{name} TO '{output}/{name}' (FORMAT PARQUET, PER_THREAD_OUTPUT true)",
-            name = table.name,
-            output = output,
-        );
-        conn.execute_batch(&sql)
-            .with_context(|| format!("Failed to write sampled table '{}'", table.name))?;
-        println!("  {}: done", table.name);
-    }
-
-    println!("\nSampling complete.");
     Ok(())
 }

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -210,11 +210,7 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     Ok(())
 }
 
-fn write_sample_table(
-    conn: &duckdb::Connection,
-    table_name: &str,
-    output: &str,
-) -> anyhow::Result<()> {
+fn write_sample_table(conn: &duckdb::Connection, table_name: &str, output: &str) -> Result<()> {
     println!("  Writing '{}'...", table_name);
     let sql = format!(
         "COPY sampled_{name} TO '{output}/{name}' (FORMAT PARQUET, PER_THREAD_OUTPUT true)",

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -20,7 +20,7 @@ use clap::Parser;
 use duckdb::Connection;
 use std::time::Instant;
 
-use crate::config::{load_dataset_config, topological_order};
+use crate::config::load_dataset_config;
 use crate::utils::{open_duckdb_conn, validate_input, validate_output};
 
 #[derive(Parser)]
@@ -61,7 +61,7 @@ fn count_rows(conn: &Connection, glob: &str) -> Result<u64> {
 }
 
 pub fn run_sample(args: SampleArgs) -> Result<()> {
-    let config = load_dataset_config(&args.config)?;
+    let (config, order) = load_dataset_config(&args.config)?;
 
     let conn = open_duckdb_conn()?;
 
@@ -74,7 +74,6 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     }
 
     // Determine processing order.
-    let order = topological_order(&config)?;
 
     // Sample the root table.
     let root = &config.root_table;
@@ -201,11 +200,9 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
 
     // Write output.
     println!("\nWriting sampled parquet files...");
-    write_sample_table(&conn, &root.name, output)?;
-    for &idx in &order {
-        write_sample_table(&conn, &config.tables[idx].name, output)?;
+    for table_name in config.all_table_names() {
+        write_sample_table(&conn, table_name, output)?;
     }
-
     println!("\nSampling complete.");
     Ok(())
 }

--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -68,14 +68,15 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     let input = args.input.trim_end_matches('/');
     let output = args.output.trim_end_matches('/');
 
-    let table_names: Vec<String> = config.tables.iter().map(|t| t.name.clone()).collect();
+    let mut table_names: Vec<&str> = config.tables.iter().map(|t| t.name.as_str()).collect();
+    table_names.push(&config.root_table.name);
     validate_input_output(&table_names, &conn, input, output)?;
 
     // Determine processing order.
     let order = topological_order(&config)?;
 
     // Sample the root table.
-    let root = &config.tables[order[0]];
+    let root = config.root_table;
     let root_glob = parquet_glob_pattern(input, &root.name);
     let total_rows = count_rows(&conn, &root_glob)?;
 
@@ -123,10 +124,11 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
     };
     let sql = format!(
         "CREATE TABLE sampled_{name} AS \
-         SELECT * FROM  read_parquet('{local_path}') \
+         SELECT * FROM  read_parquet('{local_path}') ORDER BY {pk} \
          USING SAMPLE {sample_arg} REPEATABLE({seed})",
         name = root.name,
         local_path = local_glob,
+        pk = root.primary_key,
         sample_arg = sample_arg,
         seed = config.sampling_seed,
     );

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -44,7 +44,7 @@ pub fn open_duckdb_conn() -> Result<Connection> {
 /// check that each table has at least one parquet file, and that the output location for each
 /// table is empty
 pub fn validate_input_output(
-    tables: &[String],
+    tables: &[&str],
     conn: &Connection,
     input: &str,
     output: &str,
@@ -76,11 +76,11 @@ pub fn validate_input_output(
 
         if !input_exists {
             println!("  {table}: no parquet files found at '{input_glob}'");
-            missing_tables.push(table.clone());
+            missing_tables.push(table.to_string());
         }
         if !output_empty {
             println!("  {table}: output directory not empty '{output_glob}'");
-            filled_outputs.push(table.clone());
+            filled_outputs.push(table.to_string());
         }
         if input_exists && output_empty {
             println!("  {table}: ok");

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -110,7 +110,7 @@ pub fn validate_output<'a>(
 
     if !filled_outputs.is_empty() {
         bail!(
-            "Output directories not empty for {} table(s): {} Aborting before doing any work.",
+            "Output directories not empty for {} table(s): {}. Aborting before doing any work.",
             filled_outputs.len(),
             filled_outputs.join(", "),
         );

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -67,7 +67,7 @@ pub fn validate_input(tables: &[&str], conn: &Connection, input: &str) -> Result
 
     if !missing_tables.is_empty() {
         bail!(
-            "No parquet files found for {} table(s): {}. Aborting before any conversion work.",
+            "No parquet files found for {} table(s): {}. Aborting before doing any work.",
             missing_tables.len(),
             missing_tables.join(", ")
         );
@@ -102,7 +102,7 @@ pub fn validate_output(tables: &[&str], conn: &Connection, output: &str) -> Resu
 
     if !filled_outputs.is_empty() {
         bail!(
-            "Output directories not empty for {} table(s): {} Aborting before any conversion work.",
+            "Output directories not empty for {} table(s): {} Aborting before doing any work.",
             filled_outputs.len(),
             filled_outputs.join(", "),
         );

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -41,17 +41,10 @@ pub fn open_duckdb_conn() -> Result<Connection> {
     Ok(conn)
 }
 
-/// check that each table has at least one parquet file, and that the output location for each
-/// table is empty
-pub fn validate_input_output(
-    tables: &[&str],
-    conn: &Connection,
-    input: &str,
-    output: &str,
-) -> Result<()> {
-    println!("Validating input and output paths...");
+/// check that each table has at least one parquet file at the input location
+pub fn validate_input(tables: &[&str], conn: &Connection, input: &str) -> Result<()> {
+    println!("Validating input path...");
     let mut missing_tables: Vec<String> = Vec::new();
-    let mut filled_outputs: Vec<String> = Vec::new();
 
     for table in tables.iter() {
         let input_glob = format!("{input}/{table}/*.parquet");
@@ -64,6 +57,31 @@ pub fn validate_input_output(
             .with_context(|| format!("Failed to check parquet files for table '{table}'"))?;
         let input_exists = input_file_count > 0;
 
+        if !input_exists {
+            println!("  {table}: no parquet files found at '{input_glob}'");
+            missing_tables.push(table.to_string());
+        } else {
+            println!("  {table}: ok");
+        }
+    }
+
+    if !missing_tables.is_empty() {
+        bail!(
+            "No parquet files found for {} table(s): {}. Aborting before any conversion work.",
+            missing_tables.len(),
+            missing_tables.join(", ")
+        );
+    }
+
+    Ok(())
+}
+
+/// check that the output location for each table is empty
+pub fn validate_output(tables: &[&str], conn: &Connection, output: &str) -> Result<()> {
+    println!("Validating output path...");
+    let mut filled_outputs: Vec<String> = Vec::new();
+
+    for table in tables.iter() {
         let output_glob = format!("{output}/{table}/*");
         let output_file_count: usize = conn
             .query_row(
@@ -74,38 +92,20 @@ pub fn validate_input_output(
             .with_context(|| format!("Failed to check output files for table '{table}'"))?;
         let output_empty = output_file_count == 0;
 
-        if !input_exists {
-            println!("  {table}: no parquet files found at '{input_glob}'");
-            missing_tables.push(table.to_string());
-        }
         if !output_empty {
             println!("  {table}: output directory not empty '{output_glob}'");
             filled_outputs.push(table.to_string());
-        }
-        if input_exists && output_empty {
+        } else {
             println!("  {table}: ok");
         }
     }
 
-    match (missing_tables.is_empty(), filled_outputs.is_empty()) {
-        (false, false) => bail!(
-            "No parquet files found for {} table(s): {}.\nOutput directories not empty for {} table(s): {}\nAborting before any conversion work.",
-            filled_outputs.len(),
-            filled_outputs.join(", "),
-            missing_tables.len(),
-            missing_tables.join(", ")
-        ),
-        (false, true) => bail!(
-            "No parquet files found for {} table(s): {}. Aborting before any conversion work.",
-            missing_tables.len(),
-            missing_tables.join(", ")
-        ),
-        (true, false) => bail!(
+    if !filled_outputs.is_empty() {
+        bail!(
             "Output directories not empty for {} table(s): {} Aborting before any conversion work.",
             filled_outputs.len(),
             filled_outputs.join(", "),
-        ),
-        (true, true) => {}
+        );
     }
 
     Ok(())

--- a/benchmarks/src/utils.rs
+++ b/benchmarks/src/utils.rs
@@ -42,11 +42,15 @@ pub fn open_duckdb_conn() -> Result<Connection> {
 }
 
 /// check that each table has at least one parquet file at the input location
-pub fn validate_input(tables: &[&str], conn: &Connection, input: &str) -> Result<()> {
+pub fn validate_input<'a>(
+    tables: impl Iterator<Item = &'a str>,
+    conn: &Connection,
+    input: &str,
+) -> Result<()> {
     println!("Validating input path...");
     let mut missing_tables: Vec<String> = Vec::new();
 
-    for table in tables.iter() {
+    for table in tables {
         let input_glob = format!("{input}/{table}/*.parquet");
         let input_file_count: usize = conn
             .query_row(
@@ -77,11 +81,15 @@ pub fn validate_input(tables: &[&str], conn: &Connection, input: &str) -> Result
 }
 
 /// check that the output location for each table is empty
-pub fn validate_output(tables: &[&str], conn: &Connection, output: &str) -> Result<()> {
+pub fn validate_output<'a>(
+    tables: impl Iterator<Item = &'a str>,
+    conn: &Connection,
+    output: &str,
+) -> Result<()> {
     println!("Validating output path...");
     let mut filled_outputs: Vec<String> = Vec::new();
 
-    for table in tables.iter() {
+    for table in tables {
         let output_glob = format!("{output}/{table}/*");
         let output_file_count: usize = conn
             .query_row(


### PR DESCRIPTION
## What
Enforce sampling determinism by controlling the read order of the sampling query by sorting the input. (That adds ~30-50% more time spent sampling in my experiments, but unfortunately that's necessary.) This necessitated defining a primary key for the root table, hence the change to the config file structure.

This will necessitate re-sampling for all our existing sampled datasets, which means our benchmarks will probably end up with slightly different numbers.

## Why
When I first added the `sample` command back in #4700, I thought I had provided a setup sufficient for sampling, and my experiments using didn't provide any evidence to the contrary. Fast forward to now, and new experiments show that that is not the case. This fixes that.

## How
- Control the read order of the sampling query by sorting the input stream by primary key. This, along with single-threaded sampling, should be sufficient make sampling deterministic
- Make the root table config distinct from the other tables, and add a primary key
- Do a couple other cleanups while here:
  - Move the code to derive topological order into the config loading code so that all of the config validation is done at the same time.
  - Separate input & output path validation so that dry-runs are not blocked by non-empty output paths.

## Tests
- Existing tests were modified to fit, and a few additional tests were written.
- Manually ran sampling of the 100k stack overflow dataset multiple times to gain evidence this is _actually_ deterministic.