### PR TITLE
fix: Cap memory consumption during merge

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -508,6 +508,22 @@ pub fn adjust_maintenance_work_mem(nlaunched: usize) -> NonZeroUsize {
     NonZeroUsize::new(per_worker_budget * nlaunched).unwrap()
 }
 
+/// Hardcoded estimate of in-memory bytes consumed per doc during a merge.
+///
+/// Used to convert `maintenance_work_mem` into a doc-count budget, so we can cap
+/// how many docs are pulled into a single merge candidate without OOMing.  The
+/// value is intentionally conservative: tantivy's merge keeps per-field readers
+/// and posting buffers in memory, and 1 KB/doc is a rough floor that empirically
+/// keeps peak RSS near `maintenance_work_mem` on text-heavy workloads.
+const MERGE_BYTES_PER_DOC: usize = 1024;
+
+/// Returns the maximum number of docs that should participate in a single merge,
+/// derived from `maintenance_work_mem` and the [`MERGE_BYTES_PER_DOC`] estimate.
+pub fn merge_doc_budget() -> usize {
+    let mwm_as_bytes = unsafe { pg_sys::maintenance_work_mem as usize } * 1024;
+    (mwm_as_bytes / MERGE_BYTES_PER_DOC).max(1)
+}
+
 pub fn adjust_work_mem() -> NonZeroUsize {
     let wm_as_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
     let wm_as_bytes = wm_as_bytes.clamp(

--- a/pg_search/src/index/merge_policy.rs
+++ b/pg_search/src/index/merge_policy.rs
@@ -33,6 +33,10 @@ pub struct LayeredMergePolicy {
     n: usize,
     layer_sizes: Vec<u64>,
     min_merge_count: usize,
+    /// Maximum number of docs allowed in a single merge candidate.  When a
+    /// candidate would exceed this, we close it off and start a new one in the
+    /// same layer.  This caps peak merge memory regardless of byte-size layers.
+    doc_budget: usize,
     enable_logging: bool,
 
     mergeable_segments: HashMap<SegmentId, SegmentMetaEntry>,
@@ -54,11 +58,12 @@ impl MergePolicy for LayeredMergePolicy {
 }
 
 impl LayeredMergePolicy {
-    pub fn new(layer_sizes: Vec<u64>) -> LayeredMergePolicy {
+    pub fn new(layer_sizes: Vec<u64>, doc_budget: usize) -> LayeredMergePolicy {
         Self {
             n: crate::available_parallelism(),
             layer_sizes,
             min_merge_count: 2,
+            doc_budget: doc_budget.max(1),
             enable_logging: unsafe { pg_sys::message_level_is_interesting(pg_sys::DEBUG1 as _) },
 
             mergeable_segments: Default::default(),
@@ -261,6 +266,7 @@ impl LayeredMergePolicy {
             let segments =
                 self.collect_mergeable_segments(original_segments, &merged_segments, avg_doc_size);
             let mut candidate_byte_size = 0;
+            let mut candidate_doc_count: usize = 0;
             candidates.push((layer_size, MergeCandidate(vec![])));
 
             for segment in segments {
@@ -274,21 +280,45 @@ impl LayeredMergePolicy {
                     continue;
                 }
 
+                let segment_doc_count = segment.num_docs() as usize;
+
+                // if this segment alone would exceed the doc budget there's no way to fit it; skip
+                // it rather than rolling a degenerate single-segment candidate that blows past the
+                // memory cap.  The next layer (or a future merge cycle) can deal with it.
+                if segment_doc_count > self.doc_budget {
+                    continue;
+                }
+
+                // if appending this segment would push the in-progress candidate over the doc
+                // budget, close the current candidate (if it has anything) and start a new one
+                if !candidates.last().unwrap().1 .0.is_empty()
+                    && candidate_doc_count + segment_doc_count > self.doc_budget
+                {
+                    candidate_byte_size = 0;
+                    candidate_doc_count = 0;
+                    candidates.push((layer_size, MergeCandidate(vec![])));
+                }
+
                 // add this segment as a candidate
                 let segment_byte_size =
                     actual_byte_size(segment, &self.mergeable_segments, avg_doc_size);
                 candidate_byte_size += segment_byte_size;
+                candidate_doc_count += segment_doc_count;
                 candidates.last_mut().unwrap().1 .0.push(segment.id());
 
                 if candidate_byte_size >= extended_layer_size {
                     // the candidate now exceeds the layer size so we start a new candidate
                     candidate_byte_size = 0;
+                    candidate_doc_count = 0;
                     candidates.push((layer_size, MergeCandidate(vec![])));
                 }
             }
 
-            if candidate_byte_size < extended_layer_size {
-                // the last candidate isn't full, so throw it away
+            if candidate_byte_size < extended_layer_size && candidate_doc_count < self.doc_budget {
+                // the last candidate isn't full by either threshold, so throw it away.
+                // we keep candidates that hit the doc budget even if they're under the byte
+                // threshold — the budget exists to cap memory, and a half-full byte merge is a
+                // better outcome than OOMing.
                 candidates.pop();
             }
 
@@ -459,7 +489,7 @@ mod tests {
 
     #[pg_test]
     fn test_layered_merge_policy_eagerly_merges_mutable_segment() {
-        let mut policy = LayeredMergePolicy::new(vec![1000]);
+        let mut policy = LayeredMergePolicy::new(vec![1000], usize::MAX);
         // min_merge_count is 2 by default, but the single mutable segment should still be merged
         let segments = vec![create_mutable_segment_meta_entry(100, 0, false)];
         let segment_ids: Vec<_> = segments.iter().map(|s| s.segment_id()).collect();
@@ -479,7 +509,7 @@ mod tests {
 
     #[pg_test]
     fn test_layered_merge_policy_simple() {
-        let mut policy = LayeredMergePolicy::new(vec![1000]);
+        let mut policy = LayeredMergePolicy::new(vec![1000], usize::MAX);
         let segments = vec![
             create_segment_meta_entry(700, 70, 0),
             create_segment_meta_entry(700, 70, 0),
@@ -499,7 +529,7 @@ mod tests {
 
     #[pg_test]
     fn test_layered_merge_policy_not_full_enough() {
-        let mut policy = LayeredMergePolicy::new(vec![1000]);
+        let mut policy = LayeredMergePolicy::new(vec![1000], usize::MAX);
         let segments = vec![
             create_segment_meta_entry(400, 40, 0),
             create_segment_meta_entry(400, 40, 0),
@@ -515,7 +545,7 @@ mod tests {
 
     #[pg_test]
     fn test_layered_merge_policy_min_merge_count() {
-        let mut policy = LayeredMergePolicy::new(vec![1000]);
+        let mut policy = LayeredMergePolicy::new(vec![1000], usize::MAX);
         policy.min_merge_count = 3;
         let segments = vec![
             create_segment_meta_entry(700, 70, 0),
@@ -531,7 +561,7 @@ mod tests {
 
     #[pg_test]
     fn test_layered_merge_policy_multiple_layers() {
-        let mut policy = LayeredMergePolicy::new(vec![1000, 10000]);
+        let mut policy = LayeredMergePolicy::new(vec![1000, 10000], usize::MAX);
         let segments = vec![
             create_segment_meta_entry(700, 70, 0),
             create_segment_meta_entry(700, 70, 0),
@@ -558,5 +588,65 @@ mod tests {
             assert_eq!(candidate2_ids, small_segment_ids);
         }
         assert_eq!(largest_layer_size, 10000);
+    }
+
+    /// Four 30-doc segments with byte sizes that comfortably fill the 1000-byte
+    /// layer should all merge into one candidate when there's no doc budget,
+    /// but split into two 2-segment candidates when the budget is 60 docs (so
+    /// 3 segments wouldn't fit but 2 do).
+    #[pg_test]
+    fn test_layered_merge_policy_doc_budget_splits_candidate() {
+        let mut policy = LayeredMergePolicy::new(vec![1000], 60);
+        let segments = vec![
+            create_segment_meta_entry(400, 30, 0),
+            create_segment_meta_entry(400, 30, 0),
+            create_segment_meta_entry(400, 30, 0),
+            create_segment_meta_entry(400, 30, 0),
+        ];
+
+        policy.set_mergeable_segments_for_test(segments);
+        let (candidates, largest_layer_size) = policy.simulate();
+
+        // expect two candidates of 2 segments each (60 docs each, exactly at budget)
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].0.len(), 2);
+        assert_eq!(candidates[1].0.len(), 2);
+        assert_eq!(largest_layer_size, 1000);
+    }
+
+    /// A doc budget that's smaller than any single segment should drop those
+    /// over-budget segments rather than emitting a degenerate single-segment
+    /// candidate that would blow past the memory cap.
+    #[pg_test]
+    fn test_layered_merge_policy_doc_budget_skips_oversized_segments() {
+        let mut policy = LayeredMergePolicy::new(vec![10_000], 50);
+        let segments = vec![
+            create_segment_meta_entry(7000, 100, 0), // exceeds budget alone
+            create_segment_meta_entry(7000, 100, 0), // exceeds budget alone
+        ];
+
+        policy.set_mergeable_segments_for_test(segments);
+        let (candidates, largest_layer_size) = policy.simulate();
+
+        assert_eq!(candidates.len(), 0);
+        assert_eq!(largest_layer_size, 0);
+    }
+
+    /// With a generous doc budget, behavior should match the no-budget case:
+    /// two segments that fit the layer get merged into one candidate.
+    #[pg_test]
+    fn test_layered_merge_policy_doc_budget_loose_matches_unbounded() {
+        let mut policy = LayeredMergePolicy::new(vec![1000], 1_000_000);
+        let segments = vec![
+            create_segment_meta_entry(700, 70, 0),
+            create_segment_meta_entry(700, 70, 0),
+        ];
+
+        policy.set_mergeable_segments_for_test(segments);
+        let (candidates, largest_layer_size) = policy.simulate();
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].0.len(), 2);
+        assert_eq!(largest_layer_size, 1000);
     }
 }

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -432,8 +432,41 @@ impl WorkerBuildState {
             };
 
             self.unmerged_metas.sort_by_key(|entry| entry.max_doc());
+
+            // cap the chunk by the per-merge doc budget so a single merge can't
+            // pull in more docs than `maintenance_work_mem` can hold (sized by
+            // [`gucs::MERGE_BYTES_PER_DOC`]).  We walk the sorted prefix and stop
+            // once adding the next segment would exceed the budget; we always
+            // include at least 2 segments so progress is guaranteed.
+            let doc_budget = gucs::merge_doc_budget();
+            let mut bounded_chunk_size = 0usize;
+            let mut running_docs: usize = 0;
+            for entry in self.unmerged_metas.iter().take(chunk_size) {
+                let next_docs = running_docs.saturating_add(entry.max_doc() as usize);
+                if bounded_chunk_size >= 2 && next_docs > doc_budget {
+                    break;
+                }
+                running_docs = next_docs;
+                bounded_chunk_size += 1;
+            }
+
+            if bounded_chunk_size < 2 {
+                pgrx::debug1!(
+                    "try_merge: skipping merge because the smallest two segments ({} docs) already exceed merge_doc_budget {}",
+                    running_docs,
+                    doc_budget
+                );
+                return Ok(());
+            }
+
+            if bounded_chunk_size < chunk_size {
+                pgrx::debug1!(
+                    "try_merge: trimming chunk_size from {chunk_size} to {bounded_chunk_size} to fit merge_doc_budget {doc_budget} (running_docs: {running_docs})"
+                );
+            }
+
             self.unmerged_metas
-                .drain(..chunk_size)
+                .drain(..bounded_chunk_size)
                 .map(|entry| entry.id())
                 .collect::<Vec<_>>()
         };

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -432,41 +432,8 @@ impl WorkerBuildState {
             };
 
             self.unmerged_metas.sort_by_key(|entry| entry.max_doc());
-
-            // cap the chunk by the per-merge doc budget so a single merge can't
-            // pull in more docs than `maintenance_work_mem` can hold (sized by
-            // [`gucs::MERGE_BYTES_PER_DOC`]).  We walk the sorted prefix and stop
-            // once adding the next segment would exceed the budget; we always
-            // include at least 2 segments so progress is guaranteed.
-            let doc_budget = gucs::merge_doc_budget();
-            let mut bounded_chunk_size = 0usize;
-            let mut running_docs: usize = 0;
-            for entry in self.unmerged_metas.iter().take(chunk_size) {
-                let next_docs = running_docs.saturating_add(entry.max_doc() as usize);
-                if bounded_chunk_size >= 2 && next_docs > doc_budget {
-                    break;
-                }
-                running_docs = next_docs;
-                bounded_chunk_size += 1;
-            }
-
-            if bounded_chunk_size < 2 {
-                pgrx::debug1!(
-                    "try_merge: skipping merge because the smallest two segments ({} docs) already exceed merge_doc_budget {}",
-                    running_docs,
-                    doc_budget
-                );
-                return Ok(());
-            }
-
-            if bounded_chunk_size < chunk_size {
-                pgrx::debug1!(
-                    "try_merge: trimming chunk_size from {chunk_size} to {bounded_chunk_size} to fit merge_doc_budget {doc_budget} (running_docs: {running_docs})"
-                );
-            }
-
             self.unmerged_metas
-                .drain(..bounded_chunk_size)
+                .drain(..chunk_size)
                 .map(|entry| entry.id())
                 .collect::<Vec<_>>()
         };
@@ -797,6 +764,19 @@ mod plan {
                 "heap byte size ({byte_size}) is less than 15MB, creating a single segment"
             );
             return 1;
+        }
+
+        // Floor the target segment count by what `maintenance_work_mem` can actually merge in
+        // one shot.  If the user asked for fewer segments than the doc budget allows, the
+        // per-worker chunking math would eventually try to merge more docs than fit in memory;
+        // bumping the target up means each chunk naturally stays under [`gucs::merge_doc_budget`].
+        let doc_budget = gucs::merge_doc_budget();
+        let min_segments_for_budget = (reltuples / doc_budget as f64).ceil() as usize;
+        if min_segments_for_budget > target_segment_count {
+            pgrx::debug1!(
+                "bumping target_segment_count from {target_segment_count} to {min_segments_for_budget} to keep per-merge docs under merge_doc_budget ({doc_budget}); reltuples: {reltuples}"
+            );
+            return min_segments_for_budget;
         }
 
         target_segment_count

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::gucs;
 use crate::index::merge_policy::LayeredMergePolicy;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::writer::index::{Mergeable, SearchIndexMerger};
@@ -258,7 +259,8 @@ pub unsafe fn do_merge(
         if layer_sizes.user_configured_background_layers() {
             let combined_layers = layer_sizes.combined();
             let merger = SearchIndexMerger::open(MvccSatisfies::Mergeable.directory(index))?;
-            let mut background_merge_policy = LayeredMergePolicy::new(combined_layers);
+            let mut background_merge_policy =
+                LayeredMergePolicy::new(combined_layers, gucs::merge_doc_budget());
 
             background_merge_policy.set_mergeable_segment_entries(&metadata, &merge_lock, &merger);
             let (merge_candidates, largest_layer_size) = background_merge_policy.simulate();
@@ -283,7 +285,8 @@ pub unsafe fn do_merge(
         } else {
             foreground_layer_sizes
         };
-        let foreground_merge_policy = LayeredMergePolicy::new(foreground_layer_sizes);
+        let foreground_merge_policy =
+            LayeredMergePolicy::new(foreground_layer_sizes, gucs::merge_doc_budget());
         merge_index(
             index,
             foreground_merge_policy,
@@ -374,7 +377,8 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
         let metadata = MetaPage::open(&index);
 
         let layer_sizes = IndexLayerSizes::from(&index);
-        let merge_policy = LayeredMergePolicy::new(layer_sizes.combined());
+        let merge_policy =
+            LayeredMergePolicy::new(layer_sizes.combined(), gucs::merge_doc_budget());
 
         let cleanup_lock = metadata.cleanup_lock_shared();
         // this ensures there's only one merge running at a time for the given index,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Twice in prod now we've seen situations where very few segments get created because the target segment count defaults to CPU count. Once, this led to a very skewed index (where one segment contained most of the matches for a particularly query) and another time it led to OOM because merging down to a few huge segments consumes more memory.

The solution is to try and cap merges to `maintenance_work_mem`. It's not a perfect heuristic, but during `CREATE INDEX` we can set the target segment count such that merges don't exceed the memory budget, and during normal merge we can skip merging segments that exceed the budget.

## Why

## How

## Tests
