### PR TITLE
ci: remove Depot from test-pg_search-docker, build directly on bumped runner

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -117,9 +117,17 @@ jobs:
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
-      # Cross-compilation is incredibly slow, so we use an external service called Depot to
-      # speed up container builds for universal images. We could eventually replace this with
-      # Docker Build Cloud once they add support for multiple concurrent builders.
+      # Official releases need a single universal image so that the same tag (e.g. `paradedb:latest`)
+      # works on both amd64 and arm64 hosts — pulling clients pick the right manifest entry for their
+      # arch. That requires producing both arches under one tag, which means cross-compiling at least
+      # one of them. Cross-compilation via `docker buildx` (under QEMU emulation) is prohibitively
+      # slow for a build this size, so we offload to Depot, which provides native builders on both
+      # arches and stitches them into a single multi-arch manifest. (We could eventually replace this
+      # with Docker Build Cloud once it supports multiple concurrent builders.)
+      #
+      # Note: this is why `test-pg_search-docker.yml` doesn't use Depot — that workflow only smoke-tests
+      # per-arch, so it can build natively in parallel via a matrix and skip Depot (and the secrets
+      # Depot requires, which forks don't have access to).
       - name: Configure Depot CLI
         uses: depot/setup-action@v1
 

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -124,10 +124,6 @@ jobs:
       # slow for a build this size, so we offload to Depot, which provides native builders on both
       # arches and stitches them into a single multi-arch manifest. (We could eventually replace this
       # with Docker Build Cloud once it supports multiple concurrent builders.)
-      #
-      # Note: this is why `test-pg_search-docker.yml` doesn't use Depot — that workflow only smoke-tests
-      # per-arch, so it can build natively in parallel via a matrix and skip Depot (and the secrets
-      # Depot requires, which forks don't have access to).
       - name: Configure Depot CLI
         uses: depot/setup-action@v1
 

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -27,18 +27,8 @@ concurrency:
 
 jobs:
   test-paradedb:
-    name: Test ParadeDB Docker Image (${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - arch: amd64
-            runner: ubicloud-standard-2-ubuntu-2404
-            platform: linux/amd64
-          - arch: arm64
-            runner: ubicloud-standard-2-arm-ubuntu-2404
-            platform: linux/arm64
+    name: Test ParadeDB Docker Image
+    runs-on: ubicloud-standard-16-arm-ubuntu-2404
 
     steps:
       - name: Checkout Git Repository
@@ -82,30 +72,22 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
-      # Cross-compilation is incredibly slow, so we use an external service called Depot to
-      # speed up container builds for universal images. We could eventually replace this with
-      # Docker Build Cloud once they add support for multiple concurrent builders.
-      - name: Configure Depot CLI
-        uses: depot/setup-action@v1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # We tag the image as `latest` so it can be picked up by `docker-compose.yml` for testing,
-      # and we set `push: false` since this is just a test build. Each matrix entry builds its
-      # own arch natively (via a runner on that arch) so `load: true` works and the `docker run`
-      # smoke tests below exercise the image natively — no emulation, no cross-arch shenanigans.
-      - name: Build the ParadeDB Docker Image via Depot
-        uses: depot/build-push-action@v1
-        with:
-          context: .
-          file: docker/Dockerfile
-          platforms: ${{ matrix.platform }}
-          load: true
-          push: false
-          tags: paradedb/paradedb:latest
-          project: ${{ secrets.DEPOT_PROJECT }}
-          token: ${{ secrets.DEPOT_TOKEN }}
+      # Build the image natively for the runner's arch (linux/arm64) and load it into the local
+      # Docker daemon so the `docker run` smoke tests below can exercise it. We tag it `latest`
+      # to match the tag used by the smoke tests, and skip pushing since this is just a test build.
+      # Building directly (rather than via Depot) avoids requiring repo secrets, which would block
+      # community-contributor PRs from running this workflow.
+      - name: Build the ParadeDB Docker Image
+        run: |
+          docker buildx build \
+            --platform linux/arm64 \
+            --file docker/Dockerfile \
+            --tag paradedb/paradedb:latest \
+            --load \
+            .
 
       # Start the ParadeDB Docker image using `docker run` to test the standalone Docker image.
       # We add a --tmpfs mount as a test of compatibility with the upstream `postgres` image.

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -6,8 +6,12 @@
 # Note: unlike `publish-paradedb-docker.yml`, this workflow cannot use Depot to
 # accelerate the build. Depot requires the `DEPOT_PROJECT` / `DEPOT_TOKEN` repo
 # secrets, which GitHub does not expose to PRs from forks — so any Depot-based
-# step would fail on community-contributor PRs. We build directly with
-# `docker buildx build` instead, which works without secrets.
+# step would fail on community-contributor PRs. That's fine here because, unlike
+# the publish workflow, we don't need to produce a single universal image — we
+# only need to smoke-test that the image builds and runs on each arch. So we
+# skip cross-compilation entirely: the matrix below builds amd64 and arm64 in
+# parallel, each natively on a runner of its own arch via `docker buildx build`,
+# which works without secrets.
 
 name: Test pg_search (Docker)
 

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -27,8 +27,18 @@ concurrency:
 
 jobs:
   test-paradedb:
-    name: Test ParadeDB Docker Image
-    runs-on: ubicloud-standard-16-arm-ubuntu-2404
+    name: Test ParadeDB Docker Image (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: amd64
+            runner: ubicloud-standard-16-ubuntu-2404
+            platform: linux/amd64
+          - arch: arm64
+            runner: ubicloud-standard-16-arm-ubuntu-2404
+            platform: linux/arm64
 
     steps:
       - name: Checkout Git Repository
@@ -75,15 +85,15 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      # Build the image natively for the runner's arch (linux/arm64) and load it into the local
-      # Docker daemon so the `docker run` smoke tests below can exercise it. We tag it `latest`
-      # to match the tag used by the smoke tests, and skip pushing since this is just a test build.
-      # Building directly (rather than via Depot) avoids requiring repo secrets, which would block
-      # community-contributor PRs from running this workflow.
+      # Each matrix entry builds its own arch natively (via a runner on that arch) so `--load`
+      # works and the `docker run` smoke tests below exercise the image natively — no emulation,
+      # no cross-arch shenanigans. We tag the image `latest` to match the tag used by the smoke
+      # tests, and skip pushing since this is just a test build. Building directly (rather than
+      # via Depot) avoids requiring repo secrets, which would block community-contributor PRs.
       - name: Build the ParadeDB Docker Image
         run: |
           docker buildx build \
-            --platform linux/arm64 \
+            --platform ${{ matrix.platform }} \
             --file docker/Dockerfile \
             --tag paradedb/paradedb:latest \
             --load \

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -2,6 +2,12 @@
 #
 # Test pg_search (Docker)
 # Test building and running the ParadeDB Docker Image.
+#
+# Note: unlike `publish-paradedb-docker.yml`, this workflow cannot use Depot to
+# accelerate the build. Depot requires the `DEPOT_PROJECT` / `DEPOT_TOKEN` repo
+# secrets, which GitHub does not expose to PRs from forks — so any Depot-based
+# step would fail on community-contributor PRs. We build directly with
+# `docker buildx build` instead, which works without secrets.
 
 name: Test pg_search (Docker)
 


### PR DESCRIPTION
## Summary

- The `test-pg_search-docker` workflow used Depot, which requires the `DEPOT_PROJECT` / `DEPOT_TOKEN` repo secrets. Those secrets are not exposed to forks, so the workflow failed on community-contributor PRs.
- Drop the Depot setup and build the image directly with `docker buildx build --load` so the workflow runs without secrets.
- The pre-Depot setup built via `docker-compose.dev.yml` on `ubicloud-standard-8-arm-ubuntu-2404` and ran out of memory. The compose file has since been removed, so this builds with `buildx` directly and bumps the runner one tier to `ubicloud-standard-16-arm-ubuntu-2404`.

## Test plan

- [ ] CI: this workflow runs and passes on this PR.
- [ ] Confirm the build completes within the bumped runner's memory budget (no OOM).
- [ ] Verify the smoke tests (`docker run`, `pg_isready`, `CREATE EXTENSION pg_search`, `barman-cloud-wal-archive --help`, Docker Scout compare) still pass end-to-end.