### PR TITLE
chore: Improve top-k-score queries for in-tree benchmarking

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-asc-high-selectivity.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-asc-high-selectivity.sql
@@ -1,0 +1,4 @@
+SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'help' ORDER BY pdb.score(id) LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'help' ORDER BY pdb.score(id) LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-asc-medium-selectivity.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-asc-medium-selectivity.sql
@@ -1,0 +1,4 @@
+SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'why' ORDER BY pdb.score(id) LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'why' ORDER BY pdb.score(id) LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-asc.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-asc.sql
@@ -1,1 +1,4 @@
 SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-desc-high-selectivity.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-desc-high-selectivity.sql
@@ -1,0 +1,4 @@
+SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'help' ORDER BY pdb.score(id) DESC LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'help' ORDER BY pdb.score(id) DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-desc-medium-selectivity.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-desc-medium-selectivity.sql
@@ -1,0 +1,4 @@
+SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'why' ORDER BY pdb.score(id) DESC LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'why' ORDER BY pdb.score(id) DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-desc.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-desc.sql
@@ -1,1 +1,4 @@
 SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) DESC LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) DESC LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-multi-term-asc.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-multi-term-asc.sql
@@ -1,1 +1,4 @@
 SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript python react angular typescript' ORDER BY pdb.score(id) LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript python react angular typescript' ORDER BY pdb.score(id) LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-multi-term-desc.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/top_k-score-multi-term-desc.sql
@@ -1,1 +1,4 @@
 SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript python react angular typescript' ORDER BY pdb.score(id) DESC LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript python react angular typescript' ORDER BY pdb.score(id) DESC LIMIT 10;


### PR DESCRIPTION
For Stackoverflow dataset, top_k-score queries:

- add in variants with workers set to 0
- add in selectivity levels (as new queries)
  - default (low) -> javascript = 4%
  - medium -> why = 60%
  - high -> help = 85%

Perhaps we should add in selectivity settings across queries automtically, but for now this will help a lot.