### PR TITLE
fix: Handle parameterized LIMIT, OFFSET, and snippet args in GENERIC plans

### DIFF
--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -61,8 +61,8 @@ const MORE_LIKE_THIS_SELECTIVITY: f64 = 0.01;
 const DEFAULT_STARTUP_COST: f64 = 10.0;
 
 /// Planning-time row estimate used when LIMIT is parameterized (resolved only at
-/// execution time). Substitutes for an unknown LIMIT in cost/cardinality math so
-/// downstream decisions like worker count don't collapse — see issue #4665.
+/// execution time). Substitutes for an unknown LIMIT in cost/cardinality math
+/// so downstream decisions like worker count don't collapse.
 const DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE: f64 = 1000.0;
 
 pgrx::pg_module_magic!();

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -60,6 +60,11 @@ const MORE_LIKE_THIS_SELECTIVITY: f64 = 0.01;
 /// meaningless but we should be honest that do _something_.
 const DEFAULT_STARTUP_COST: f64 = 10.0;
 
+/// Planning-time row estimate used when LIMIT is parameterized (resolved only at
+/// execution time). Substitutes for an unknown LIMIT in cost/cardinality math so
+/// downstream decisions like worker count don't collapse — see issue #4665.
+const DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE: f64 = 1000.0;
+
 pgrx::pg_module_magic!();
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -160,7 +160,13 @@ impl AggregateType {
                     .expect("invalid JSON in pdb.agg")
                     .0
             } else {
-                panic!("pdb.agg argument must be a constant");
+                // Parameterized pdb.agg() can't be lowered into the aggregate
+                // pushdown plan because we need the JSON spec at planning time
+                // to validate fields and choose a strategy. Return Err so the
+                // AggregateScan path declines and PG falls back to standard
+                // aggregate processing — same behaviour as a query without
+                // pdb.agg() pushdown.
+                return Err("pdb.agg argument must be a constant for aggregate pushdown".into());
             };
 
             // Extract solve_mvcc bool argument (second arg) if using the two-arg overload

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -90,7 +90,7 @@ pub struct AggregateOrderBy {
 pub struct AggregateCSClause {
     targetlist: TargetList,
     orderby: OrderByClause,
-    limit_offset: LimitOffset,
+    limit_offset: Option<LimitOffset>,
     quals: SearchQueryClause,
     indexrelid: pg_sys::Oid,
     is_execution_time: bool,
@@ -409,7 +409,7 @@ impl CustomScanClause<AggregateScan> for AggregateCSClause {
         };
 
         let topk_output: Vec<(String, String)> = if let (true, Some(ref agg_order)) =
-            (self.limit_offset.limit().is_some(), &self.aggregate_orderby)
+            (self.limit_offset.is_some(), &self.aggregate_orderby)
         {
             let dir = match agg_order.direction {
                 SortDirection::DescNullsFirst | SortDirection::DescNullsLast => "DESC",
@@ -450,7 +450,7 @@ impl CustomScanClause<AggregateScan> for AggregateCSClause {
                 }
             }
         };
-        // LimitOffset is optional
+        // LimitOffset is optional - returns None when there is no LIMIT clause.
         let limit_offset = unsafe { LimitOffset::from_parse(args.root().parse) };
         let quals = SearchQueryClause::from_pg(args, heap_rti, index)?;
 
@@ -614,19 +614,18 @@ impl CollectNested<GroupedKey> for AggregateCSClause {
         // The only optimization is `size = K` limiting the merged output.
         // Postgres still adds Sort + Limit above us for final ordering.
         let size = {
-            let limit = self.limit_offset.limit();
-            let offset = self.limit_offset.offset();
-
             // We can use LIMIT-based size optimization when:
             // 1. There's exactly one grouping column (multiple columns need all combinations)
             // 2. Either no ORDER BY, or ORDER BY targets COUNT (the only safe aggregate
             //    for TopK — see detect_aggregate_orderby for why non-COUNT is excluded)
+            // 3. The LIMIT is statically known — parameterized LIMIT can't be
+            //    folded into bucket size at planning time.
             let can_limit_buckets = grouping_columns.len() == 1
                 && (!self.orderby.has_orderby() || self.aggregate_orderby.is_some());
 
             if can_limit_buckets {
-                if let Some(limit) = limit {
-                    (limit + offset.unwrap_or(0)).min(max_buckets)
+                if let Some(fetch) = self.limit_offset.as_ref().and_then(|lo| lo.static_fetch()) {
+                    (fetch as u32).min(max_buckets)
                 } else {
                     max_buckets
                 }

--- a/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
@@ -25,7 +25,7 @@ use crate::postgres::customscan::CustomScan;
 use crate::postgres::rel::PgSearchRelation;
 use pgrx::pg_sys;
 
-impl CustomScanClause<AggregateScan> for LimitOffset {
+impl CustomScanClause<AggregateScan> for Option<LimitOffset> {
     type Args = <AggregateScan as CustomScan>::Args;
 
     fn add_to_custom_path(
@@ -37,15 +37,12 @@ impl CustomScanClause<AggregateScan> for LimitOffset {
 
     fn explain_output(&self) -> Box<dyn Iterator<Item = (String, String)>> {
         let mut output = Vec::new();
-
-        if let Some(limit) = self.limit() {
-            output.push((String::from("Limit"), limit.to_string()));
+        if let Some(lo) = self {
+            output.push((String::from("Limit"), lo.limit.to_string()));
+            if let Some(off) = &lo.offset {
+                output.push((String::from("Offset"), off.to_string()));
+            }
         }
-
-        if let Some(offset) = self.offset() {
-            output.push((String::from("Offset"), offset.to_string()));
-        }
-
         Box::new(output.into_iter())
     }
 
@@ -57,11 +54,19 @@ impl CustomScanClause<AggregateScan> for LimitOffset {
         let parse = args.root().parse;
         let limit_offset = unsafe { LimitOffset::from_parse(parse) };
 
-        unsafe {
-            if !(*parse).groupClause.is_null()
-                && limit_offset.fetch().unwrap_or(0) > gucs::max_term_agg_buckets() as usize
-            {
-                return Err("limit + offset exceeds max_term_agg_buckets".into());
+        // Bucket-limit guard only applies when the row count is statically
+        // known. Parameterized LIMIT/OFFSET values flow through unchecked at
+        // planning time; the bucket cap is enforced lazily by Tantivy at
+        // execution time.
+        if let Some(ref lo) = limit_offset {
+            if let Some(fetch) = lo.static_fetch() {
+                unsafe {
+                    if !(*parse).groupClause.is_null()
+                        && fetch > gucs::max_term_agg_buckets() as usize
+                    {
+                        return Err("limit + offset exceeds max_term_agg_buckets".into());
+                    }
+                }
             }
         }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
@@ -58,8 +58,7 @@ impl CustomScanClause<AggregateScan> for Option<LimitOffset> {
         // known. Parameterized LIMIT/OFFSET values flow through unchecked at
         // planning time; the bucket cap is enforced lazily by Tantivy at
         // execution time.
-        if let Some(ref lo) = limit_offset {
-            if let Some(fetch) = lo.static_fetch() {
+        if let Some(fetch) = limit_offset.as_ref().and_then(|lo| lo.static_fetch()) {
                 unsafe {
                     if !(*parse).groupClause.is_null()
                         && fetch > gucs::max_term_agg_buckets() as usize

--- a/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/limit_offset.rs
@@ -59,12 +59,10 @@ impl CustomScanClause<AggregateScan> for Option<LimitOffset> {
         // planning time; the bucket cap is enforced lazily by Tantivy at
         // execution time.
         if let Some(fetch) = limit_offset.as_ref().and_then(|lo| lo.static_fetch()) {
-                unsafe {
-                    if !(*parse).groupClause.is_null()
-                        && fetch > gucs::max_term_agg_buckets() as usize
-                    {
-                        return Err("limit + offset exceeds max_term_agg_buckets".into());
-                    }
+            unsafe {
+                if !(*parse).groupClause.is_null() && fetch > gucs::max_term_agg_buckets() as usize
+                {
+                    return Err("limit + offset exceeds max_term_agg_buckets".into());
                 }
             }
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1288,11 +1288,12 @@ unsafe fn detect_join_aggregate_topk(
         return None;
     }
 
-    // Must have a LIMIT for TopK to matter
-    let limit_offset = LimitOffset::from_parse(parse);
-    let limit = limit_offset.limit()? as usize;
-    let offset = limit_offset.offset().unwrap_or(0) as usize;
-    let k = limit + offset;
+    // Must have a LIMIT for TopK to matter. We require a STATIC value here
+    // because DataFusion's TopK rule needs a concrete K at planning time.
+    // Parameterized LIMIT is left as a regular sort+limit pipeline.
+    let limit_offset = LimitOffset::from_parse(parse)?;
+    let static_fetch = limit_offset.static_fetch()?;
+    let k = static_fetch;
 
     // Only single sort clause for TopK
     let sort_clauses = PgList::<pg_sys::SortGroupClause>::from_pg((*parse).sortClause);

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -28,10 +28,11 @@ use crate::api::HashMap;
 use crate::index::fast_fields_helper::{build_arrow_schema, FFHelper, WhichFastField};
 use crate::nodecast;
 use crate::postgres::customscan::basescan::exec_methods::{ExecMethod, ExecState};
-use crate::postgres::customscan::basescan::privdat::Limit;
 use crate::postgres::customscan::basescan::scan_state::BaseScanState;
 use crate::postgres::customscan::builders::custom_path::ExecMethodType;
+use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::parallel::checkout_segment;
+use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::SortByField;
 use crate::postgres::rel::PgSearchRelation;
@@ -321,7 +322,7 @@ impl ColumnarExecState {
     pub fn new(
         which_fast_fields: Vec<WhichFastField>,
         extra_fast_fields: Vec<WhichFastField>,
-        limit: Option<usize>,
+        limit_offset: Option<LimitOffset>,
         sort_order: Option<SortByField>,
     ) -> Self {
         // Build scanner fields: projected + extra + [Ctid]
@@ -356,9 +357,13 @@ impl ColumnarExecState {
             None => ColumnarExecStrategy::Unsorted,
         };
 
-        // If there is a limit, then we use a batch size hint which is a small multiple of the
-        // limit, in case of dead tuples.
-        let batch_size_hint = limit.map(|limit| limit * 2);
+        // If there is a static limit, use a batch size hint that is a small
+        // multiple of the limit (in case of dead tuples). For parameterized
+        // limits, we resolve the hint in `init` once `EState` is available.
+        let batch_size_hint = limit_offset
+            .as_ref()
+            .and_then(|lo| lo.static_fetch())
+            .map(|fetch| fetch * 2);
         Self {
             inner: Inner::new(which_fast_fields),
             scanner_fast_fields,
@@ -597,15 +602,27 @@ impl ExecMethod for ColumnarExecState {
     /// * `state` - The current scan state containing query information
     /// * `cstate` - PostgreSQL's custom scan state pointer
     fn init(&mut self, state: &mut BaseScanState, cstate: *mut pg_sys::CustomScanState) {
-        // Resolve parameterized limit for batch size hint
+        // Resolve parameterized LIMIT/OFFSET for batch size hint at execution time.
         if self.batch_size_hint.is_none() {
-            if let ExecMethodType::Columnar { ref mut limit, .. } = state.exec_method_type {
-                if let Some(param_limit) = limit.as_ref().filter(|l| l.static_value().is_none()) {
+            if let ExecMethodType::Columnar {
+                ref mut limit_offset,
+                ..
+            } = state.exec_method_type
+            {
+                let needs_resolve = limit_offset
+                    .as_ref()
+                    .map(|lo| !lo.has_static_limit())
+                    .unwrap_or(false);
+                if needs_resolve {
+                    let lo = limit_offset.as_mut().unwrap();
                     unsafe {
                         let estate = (*cstate).ss.ps.state;
-                        let resolved = param_limit.resolve(estate);
-                        self.batch_size_hint = Some(resolved * 2);
-                        *limit = Some(Limit::Static(resolved));
+                        if let Some(resolved) = lo.fetch(estate) {
+                            self.batch_size_hint = Some(resolved * 2);
+                            // Mirror back so EXPLAIN sees a static value.
+                            lo.limit = ParameterizedValue::Static(resolved as i64);
+                            lo.offset = None;
+                        }
                     }
                 }
             }

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -30,9 +30,7 @@ use crate::nodecast;
 use crate::postgres::customscan::basescan::exec_methods::{ExecMethod, ExecState};
 use crate::postgres::customscan::basescan::scan_state::BaseScanState;
 use crate::postgres::customscan::builders::custom_path::ExecMethodType;
-use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::parallel::checkout_segment;
-use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::SortByField;
 use crate::postgres::rel::PgSearchRelation;
@@ -322,7 +320,6 @@ impl ColumnarExecState {
     pub fn new(
         which_fast_fields: Vec<WhichFastField>,
         extra_fast_fields: Vec<WhichFastField>,
-        limit_offset: Option<LimitOffset>,
         sort_order: Option<SortByField>,
     ) -> Self {
         // Build scanner fields: projected + extra + [Ctid]
@@ -357,17 +354,12 @@ impl ColumnarExecState {
             None => ColumnarExecStrategy::Unsorted,
         };
 
-        // If there is a static limit, use a batch size hint that is a small
-        // multiple of the limit (in case of dead tuples). For parameterized
-        // limits, we resolve the hint in `init` once `EState` is available.
-        let batch_size_hint = limit_offset
-            .as_ref()
-            .and_then(|lo| lo.static_fetch())
-            .map(|fetch| fetch * 2);
+        // batch_size_hint is computed in `init` from the resolved LIMIT/OFFSET,
+        // when EState is available.
         Self {
             inner: Inner::new(which_fast_fields),
             scanner_fast_fields,
-            batch_size_hint,
+            batch_size_hint: None,
             strategy,
             runtime: None,
             stream: None,
@@ -602,28 +594,18 @@ impl ExecMethod for ColumnarExecState {
     /// * `state` - The current scan state containing query information
     /// * `cstate` - PostgreSQL's custom scan state pointer
     fn init(&mut self, state: &mut BaseScanState, cstate: *mut pg_sys::CustomScanState) {
-        // Resolve parameterized LIMIT/OFFSET for batch size hint at execution time.
-        if self.batch_size_hint.is_none() {
-            if let ExecMethodType::Columnar {
-                ref mut limit_offset,
-                ..
-            } = state.exec_method_type
-            {
-                let needs_resolve = limit_offset
-                    .as_ref()
-                    .map(|lo| !lo.has_static_limit())
-                    .unwrap_or(false);
-                if needs_resolve {
-                    let lo = limit_offset.as_mut().unwrap();
-                    unsafe {
-                        let estate = (*cstate).ss.ps.state;
-                        if let Some(resolved) = lo.fetch(estate) {
-                            self.batch_size_hint = Some(resolved * 2);
-                            // Mirror back so EXPLAIN sees a static value.
-                            lo.limit = ParameterizedValue::Static(resolved as i64);
-                            lo.offset = None;
-                        }
-                    }
+        // Resolve LIMIT/OFFSET for the batch size hint. `resolve_mut`
+        // converts each Param → Static in place, so the LimitOffset stored
+        // on ExecMethodType ends up holding resolved values for EXPLAIN.
+        if let ExecMethodType::Columnar {
+            limit_offset: Some(ref mut lo),
+            ..
+        } = state.exec_method_type
+        {
+            unsafe {
+                let estate = (*cstate).ss.ps.state;
+                if let Some(fetch) = lo.resolve_mut(estate).and_then(|lo| lo.static_fetch()) {
+                    self.batch_size_hint = Some(fetch * 2);
                 }
             }
         }

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -26,11 +26,12 @@ use crate::index::reader::index::{
 use crate::postgres::customscan::aggregatescan::exec::AggregationResults;
 use crate::postgres::customscan::aggregatescan::AggregateType;
 use crate::postgres::customscan::basescan::exec_methods::{ExecMethod, ExecState};
-use crate::postgres::customscan::basescan::privdat::Limit;
 use crate::postgres::customscan::basescan::projections::window_agg::WindowAggregateInfo;
 use crate::postgres::customscan::basescan::scan_state::BaseScanState;
 use crate::postgres::customscan::builders::custom_path::ExecMethodType;
+use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::parallel::checkout_segment;
+use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::ParallelScanState;
 use crate::query::SearchQueryInput;
@@ -55,7 +56,14 @@ struct PreparedAggregations {
 }
 
 pub struct TopKScanExecState {
+    /// Resolved value of `LIMIT + OFFSET` (the K our scan must produce so PG's
+    /// outer Limit node can apply OFFSET and return LIMIT). Populated either
+    /// at construction time (when both LIMIT and OFFSET are static) or in
+    /// `init` (when either is parameterized).
     limit: Option<usize>,
+    /// Source description of the LIMIT/OFFSET. Held until execution time so we
+    /// can resolve parameterized values from `EState::es_param_list_info`.
+    limit_offset_source: LimitOffset,
     orderby_info: Option<Vec<OrderByInfo>>,
 
     // set during init
@@ -82,7 +90,7 @@ pub struct TopKScanExecState {
 impl TopKScanExecState {
     pub fn new(
         heaprelid: pg_sys::Oid,
-        limit: Option<usize>,
+        limit_offset: LimitOffset,
         orderby_info: Option<Vec<OrderByInfo>>,
     ) -> Self {
         if matches!(&orderby_info, Some(orderby_info) if orderby_info.len() > MAX_TOPK_FEATURES) {
@@ -108,8 +116,13 @@ impl TopKScanExecState {
             1.0 + ((1.0 + n_dead as f64) / (1.0 + n_live as f64))
         } * crate::gucs::limit_fetch_multiplier();
 
+        // If both LIMIT and OFFSET are static, we can resolve K (= limit + offset)
+        // at construction time. Otherwise leave it as None and resolve in `init`.
+        let limit = limit_offset.static_fetch();
+
         Self {
             limit,
+            limit_offset_source: limit_offset,
             orderby_info,
             search_query_input: None,
             search_reader: None,
@@ -270,14 +283,27 @@ impl TopKScanExecState {
 impl ExecMethod for TopKScanExecState {
     /// Initialize the exec method with data from the scan state
     fn init(&mut self, state: &mut BaseScanState, cstate: *mut pg_sys::CustomScanState) {
-        // Resolve parameterized limit from executor params
+        // Resolve parameterized LIMIT/OFFSET from executor params. K = LIMIT + OFFSET
+        // because PG's outer Limit node will skip OFFSET rows from our output.
         if self.limit.is_none() {
-            if let ExecMethodType::TopK { ref mut limit, .. } = state.exec_method_type {
-                unsafe {
-                    let estate = (*cstate).ss.ps.state;
-                    let resolved = limit.resolve(estate);
-                    self.limit = Some(resolved);
-                    *limit = Limit::Static(resolved);
+            unsafe {
+                let estate = (*cstate).ss.ps.state;
+                let resolved = self
+                    .limit_offset_source
+                    .fetch(estate)
+                    .expect("LIMIT must be resolvable from EState (param missing or NULL)");
+                self.limit = Some(resolved);
+
+                // Mirror the resolved value back into the planning-time
+                // ExecMethodType so anything that introspects later (EXPLAIN
+                // ANALYZE, validation) sees a Static value.
+                if let ExecMethodType::TopK {
+                    ref mut limit_offset,
+                    ..
+                } = state.exec_method_type
+                {
+                    limit_offset.limit = ParameterizedValue::Static(resolved as i64);
+                    limit_offset.offset = None;
                 }
             }
         }

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -31,7 +31,6 @@ use crate::postgres::customscan::basescan::scan_state::BaseScanState;
 use crate::postgres::customscan::builders::custom_path::ExecMethodType;
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::parallel::checkout_segment;
-use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::ParallelScanState;
 use crate::query::SearchQueryInput;
@@ -57,13 +56,10 @@ struct PreparedAggregations {
 
 pub struct TopKScanExecState {
     /// Resolved value of `LIMIT + OFFSET` (the K our scan must produce so PG's
-    /// outer Limit node can apply OFFSET and return LIMIT). Populated either
-    /// at construction time (when both LIMIT and OFFSET are static) or in
-    /// `init` (when either is parameterized).
+    /// outer Limit node can apply OFFSET and return LIMIT). `Some` when both
+    /// sides are static at construction; otherwise resolved in `init` from
+    /// the `LimitOffset` carried on `ExecMethodType::TopK`.
     limit: Option<usize>,
-    /// Source description of the LIMIT/OFFSET. Held until execution time so we
-    /// can resolve parameterized values from `EState::es_param_list_info`.
-    limit_offset_source: LimitOffset,
     orderby_info: Option<Vec<OrderByInfo>>,
 
     // set during init
@@ -90,7 +86,7 @@ pub struct TopKScanExecState {
 impl TopKScanExecState {
     pub fn new(
         heaprelid: pg_sys::Oid,
-        limit_offset: LimitOffset,
+        limit_offset: &LimitOffset,
         orderby_info: Option<Vec<OrderByInfo>>,
     ) -> Self {
         if matches!(&orderby_info, Some(orderby_info) if orderby_info.len() > MAX_TOPK_FEATURES) {
@@ -116,13 +112,11 @@ impl TopKScanExecState {
             1.0 + ((1.0 + n_dead as f64) / (1.0 + n_live as f64))
         } * crate::gucs::limit_fetch_multiplier();
 
-        // If both LIMIT and OFFSET are static, we can resolve K (= limit + offset)
-        // at construction time. Otherwise leave it as None and resolve in `init`.
-        let limit = limit_offset.static_fetch();
-
+        // Resolve K eagerly when both sides are static; otherwise leave it as
+        // None and resolve in `init` from the LimitOffset carried on
+        // ExecMethodType::TopK.
         Self {
-            limit,
-            limit_offset_source: limit_offset,
+            limit: limit_offset.static_fetch(),
             orderby_info,
             search_query_input: None,
             search_reader: None,
@@ -283,27 +277,22 @@ impl TopKScanExecState {
 impl ExecMethod for TopKScanExecState {
     /// Initialize the exec method with data from the scan state
     fn init(&mut self, state: &mut BaseScanState, cstate: *mut pg_sys::CustomScanState) {
-        // Resolve parameterized LIMIT/OFFSET from executor params. K = LIMIT + OFFSET
-        // because PG's outer Limit node will skip OFFSET rows from our output.
+        // Resolve K = LIMIT + OFFSET from EState when not already known.
+        // `fetch_mut` converts each `Param` → `Static` in place on the
+        // `LimitOffset` carried by `ExecMethodType::TopK`, so EXPLAIN ANALYZE
+        // sees resolved values without us holding a separate copy.
         if self.limit.is_none() {
             unsafe {
                 let estate = (*cstate).ss.ps.state;
-                let resolved = self
-                    .limit_offset_source
-                    .fetch(estate)
-                    .expect("LIMIT must be resolvable from EState (param missing or NULL)");
-                self.limit = Some(resolved);
-
-                // Mirror the resolved value back into the planning-time
-                // ExecMethodType so anything that introspects later (EXPLAIN
-                // ANALYZE, validation) sees a Static value.
                 if let ExecMethodType::TopK {
                     ref mut limit_offset,
                     ..
                 } = state.exec_method_type
                 {
-                    limit_offset.limit = ParameterizedValue::Static(resolved as i64);
-                    limit_offset.offset = None;
+                    self.limit = limit_offset
+                        .resolve_mut(estate)
+                        .expect("LIMIT must be resolvable from EState (param missing or NULL)")
+                        .static_fetch();
                 }
             }
         }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -197,8 +197,8 @@ impl BaseScan {
                         std::ptr::NonNull::new(expr_context),
                     );
 
-                let estate = unsafe { (*csstate).ss.ps.state };
                 unsafe {
+                    let estate = (*csstate).ss.ps.state;
                     snippet_type.configure_generator(&mut new_generator.1, estate);
                 }
 
@@ -2447,19 +2447,19 @@ fn is_range_query_string(query_string: &str) -> bool {
 /// Project configured snippets (if any).
 ///
 /// Must be called inside the per-tuple `MemoryContext`.
-unsafe fn maybe_project_snippets(
-    state: &BaseScanState,
-    ctid: u64,
-    estate: *mut pg_sys::EState,
-) {
+unsafe fn maybe_project_snippets(state: &BaseScanState, ctid: u64, estate: *mut pg_sys::EState) {
     if !state.need_snippets() {
         return;
     }
 
     for (snippet_type, const_snippet_nodes) in &state.const_snippet_nodes {
         match snippet_type {
-            SnippetType::SingleText(_, _, _) => {
-                let snippet = state.make_snippet(ctid, snippet_type, estate);
+            SnippetType::SingleText(_, config, _) => {
+                // Resolve start/end tags once per snippet type; for Static
+                // values this avoids cloning the String per tuple.
+                let start_tag = config.resolve_start_tag(estate);
+                let end_tag = config.resolve_end_tag(estate);
+                let snippet = state.make_snippet(ctid, snippet_type, &start_tag, &end_tag);
 
                 for const_ in const_snippet_nodes {
                     match &snippet {
@@ -2474,8 +2474,10 @@ unsafe fn maybe_project_snippets(
                     }
                 }
             }
-            SnippetType::MultipleText(_, _, _, _) => {
-                let snippets = state.make_snippets(ctid, snippet_type, estate);
+            SnippetType::MultipleText(_, config, _, _) => {
+                let start_tag = config.resolve_start_tag(estate);
+                let end_tag = config.resolve_end_tag(estate);
+                let snippets = state.make_snippets(ctid, snippet_type, &start_tag, &end_tag);
 
                 for const_ in const_snippet_nodes {
                     match &snippets {

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -36,7 +36,7 @@ use crate::index::reader::index::{SearchIndexReader, MAX_TOPK_FEATURES};
 use crate::postgres::customscan::basescan::exec_methods::{
     fast_fields, normal::NormalScanExecState, ExecState,
 };
-use crate::postgres::customscan::basescan::privdat::{Limit, PrivateData};
+use crate::postgres::customscan::basescan::privdat::PrivateData;
 use crate::postgres::customscan::basescan::projections::score::uses_scores;
 use crate::postgres::customscan::basescan::projections::snippet::{
     snippet_funcoids, snippet_positions_funcoids, snippets_funcoids, uses_snippets, SnippetType,
@@ -82,7 +82,7 @@ use crate::schema::SearchIndexSchema;
 use crate::{nodecast, DEFAULT_STARTUP_COST, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
 use crate::{FULL_RELATION_SELECTIVITY, UNASSIGNED_SELECTIVITY};
 
-use crate::postgres::customscan::limit_offset::extract_const_i64;
+use crate::postgres::customscan::limit_offset::LimitOffset;
 use pgrx::{pg_sys, FromDatum, IntoDatum, PgList, PgMemoryContexts};
 use tantivy::snippet::SnippetGenerator;
 use tantivy::Index;
@@ -409,52 +409,64 @@ unsafe fn query_has_window_agg_functions(root: *mut pg_sys::PlannerInfo) -> bool
     false
 }
 
-/// Check if the query's target list contains only set-returning functions (e.g. `unnest()`) which
-/// are safe for use with our LIMIT optimization, and if so, then return the LIMIT from the parse.
+/// Returns true if the target list contains a set-returning function that we
+/// cannot prove is safe to push LIMIT through. Only `unnest` is recognized as
+/// limit-safe (it produces at least as many rows as it consumes).
 ///
-/// Only set returning functions which produce at least as many rows as they consume are safe.
-unsafe fn maybe_limit_from_parse(root: *mut pg_sys::PlannerInfo) -> Option<f64> {
+/// Used as a guard alongside `has_non_pushable_predicates` to decide whether
+/// pushing a LIMIT into the scan would silently produce fewer rows than
+/// PostgreSQL's outer Limit node expects.
+unsafe fn has_unsafe_srf(root: *mut pg_sys::PlannerInfo) -> bool {
     if root.is_null() || (*root).parse.is_null() || (*(*root).parse).targetList.is_null() {
-        return None;
+        return false;
     }
     let parse = *(*root).parse;
-    // non-Const LIMIT is not a thing we can handle here
-    let limit = extract_const_i64(parse.limitCount).map(|v| v as f64)?;
-
-    let offset = if parse.limitOffset.is_null() {
-        0.0
-    } else if let Some(offset_const) = nodecast!(Const, T_Const, parse.limitOffset) {
-        i64::from_datum((*offset_const).constvalue, (*offset_const).constisnull)
-            .map(|v| v as f64)?
-    } else {
-        // non-Const OFFSET is not a thing we can handle here
-        return None;
-    };
-
-    let mut found_limit_safe_srf = false;
     let target_list = PgList::<pg_sys::TargetEntry>::from_pg(parse.targetList);
     for te in target_list.iter_ptr() {
-        if !(*te).expr.is_null() && pg_sys::expression_returns_set((*te).expr.cast()) {
-            // It's a set-returning function, is it one we approve of?
-            if let Some(func_expr) = nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
-                if is_unnest_func((*func_expr).funcid) {
-                    found_limit_safe_srf = true;
-                } else {
-                    // We don't recognize this SRF, and can't vouch for it.
-                    return None;
-                }
+        if (*te).expr.is_null() {
+            continue;
+        }
+        if !pg_sys::expression_returns_set((*te).expr.cast()) {
+            continue;
+        }
+        // SRF found — only `unnest` is known to be safe.
+        if let Some(func_expr) = nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
+            if !is_unnest_func((*func_expr).funcid) {
+                return true;
+            }
+        } else {
+            // Some other SRF expression we can't classify.
+            return true;
+        }
+    }
+    false
+}
+
+/// Returns true if the target list contains an `unnest` set-returning function.
+/// PG sets `limit_tuples == -1.0` whenever a SRF is present (it can't predict
+/// how many input rows produce K output rows), so we need this independent
+/// signal to know that a SRF-driven LIMIT pushdown is still safe through the
+/// row-preserving `unnest` semantics.
+unsafe fn has_safe_srf(root: *mut pg_sys::PlannerInfo) -> bool {
+    if root.is_null() || (*root).parse.is_null() || (*(*root).parse).targetList.is_null() {
+        return false;
+    }
+    let parse = *(*root).parse;
+    let target_list = PgList::<pg_sys::TargetEntry>::from_pg(parse.targetList);
+    for te in target_list.iter_ptr() {
+        if (*te).expr.is_null() {
+            continue;
+        }
+        if !pg_sys::expression_returns_set((*te).expr.cast()) {
+            continue;
+        }
+        if let Some(func_expr) = nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
+            if is_unnest_func((*func_expr).funcid) {
+                return true;
             }
         }
     }
-
-    // A LIMIT was applied in the parse for our node, but is being handled elsewhere
-    // due to a set-returning-function that we know produces at least as many tuples as
-    // it is given.
-    if found_limit_safe_srf {
-        Some(limit + offset)
-    } else {
-        None
-    }
+    false
 }
 
 /// Returns `true` if any predicate in `baserestrictinfo` cannot be fully
@@ -484,6 +496,34 @@ unsafe fn has_non_pushable_predicates(
     }
 
     false
+}
+
+/// Returns true if the query's LIMIT can safely be pushed into this scan node.
+///
+/// Three conditions must hold:
+///   1. This rel bounds the output cardinality (single rel, partitioned, or
+///      the driving side of a LEFT LATERAL join). Without this, pushing LIMIT
+///      to the inner side of a join would silently truncate results.
+///   2. No non-pushable predicates sit between this scan and the LIMIT.
+///   3. No unsafe SRFs (anything other than `unnest`) in the target list.
+///
+/// Independent of whether PG's `limit_tuples` is set or the LIMIT involves a
+/// `Param` — that's the caller's policy decision.
+unsafe fn is_limit_pushdown_safe(
+    root: *mut pg_sys::PlannerInfo,
+    rel: *mut pg_sys::RelOptInfo,
+    baserels: *mut pg_sys::Bitmapset,
+    rti: pg_sys::Index,
+    quals: &Option<Qual>,
+) -> bool {
+    let rel_is_single_or_partitioned = pg_sys::bms_equal((*rel).relids, baserels)
+        || range_table::is_partitioned_table_setup(root, (*rel).relids, baserels);
+    let is_left_driven_lateral =
+        is_left_join_lateral(root, rel) && where_clause_only_references_left(root, rti);
+
+    (rel_is_single_or_partitioned || is_left_driven_lateral)
+        && !has_non_pushable_predicates(rel, quals)
+        && !has_unsafe_srf(root)
 }
 
 impl CustomScan for BaseScan {
@@ -673,44 +713,31 @@ impl CustomScan for BaseScan {
             // If so, we want to be aggressive with parallelism to enable Parallel Hash Join
             let is_join_context = pg_sys::bms_num_members(baserels) > 1;
 
-            let limit = if (*builder.args().root).limit_tuples > -1.0 {
-                // Check if this is a single relation or a partitioned table setup
-                let rel_is_single_or_partitioned = pg_sys::bms_equal((*rel).relids, baserels)
-                    || range_table::is_partitioned_table_setup(
+            // Push the LIMIT/OFFSET into this scan when one of:
+            //   - PG already proved it safe (`limit_tuples > -1.0`)
+            //   - The value is a Param (PG can't evaluate at plan time but we
+            //     can at exec time — issue #4665)
+            //   - The target list contains a row-preserving SRF like `unnest`
+            //     (PG zeroed out `limit_tuples` because of the SRF, but the
+            //     SRF doesn't drop input rows so `limit + offset` rows
+            //     fetched here is still enough)
+            // Local safety checks (topology, predicates, unsafe SRFs) gate all
+            // three cases.
+            let raw_limit_offset = LimitOffset::from_root(builder.args().root);
+            let limit_offset = raw_limit_offset.filter(|lo| {
+                let pg_says_pushable = (*builder.args().root).limit_tuples > -1.0;
+                let has_param = lo.has_any_param();
+                let has_safe_srf_override = has_safe_srf(builder.args().root);
+
+                (pg_says_pushable || has_param || has_safe_srf_override)
+                    && is_limit_pushdown_safe(
                         builder.args().root,
-                        (*rel).relids,
+                        rel,
                         baserels,
-                    );
-
-                // Check for LEFT JOIN LATERAL where left side drives the query
-                let is_left_driven_lateral = is_left_join_lateral(builder.args().root, rel)
-                    && where_clause_only_references_left(builder.args().root, rti);
-
-                if rel_is_single_or_partitioned || is_left_driven_lateral {
-                    if has_non_pushable_predicates(rel, &Some(quals.clone())) {
-                        None
-                    } else {
-                        Some((*builder.args().root).limit_tuples)
-                    }
-                } else {
-                    None
-                }
-            } else {
-                let raw = maybe_limit_from_parse(builder.args().root);
-                if raw.is_some() && has_non_pushable_predicates(rel, &Some(quals.clone())) {
-                    None
-                } else {
-                    raw
-                }
-            };
-
-            let limit = if let Some(l) = limit {
-                Some(Limit::Static(l.round() as usize))
-            } else if !(*builder.args().root).parse.is_null() {
-                Limit::from_param((*(*builder.args().root).parse).limitCount)
-            } else {
-                None
-            };
+                        rti,
+                        &Some(quals.clone()),
+                    )
+            });
 
             // Get all columns referenced by this RTE throughout the entire query
             let referenced_columns = collect_maybe_fast_field_referenced_columns(rti, rel);
@@ -718,7 +745,7 @@ impl CustomScan for BaseScan {
             // Save the count of referenced columns for decision-making
             custom_private.set_referenced_columns_count(referenced_columns.len());
 
-            let has_any_limit = limit.is_some();
+            let has_any_limit = limit_offset.is_some();
             let is_maybe_topk = has_any_limit && topk_pathkey_info.is_usable();
 
             // When collecting which_fast_fields, analyze the entire set of referenced columns,
@@ -760,16 +787,17 @@ impl CustomScan for BaseScan {
                 estimate_selectivity(&bm25_index, query.clone()).unwrap_or(UNKNOWN_SELECTIVITY)
             };
 
-            let float_limit = match &limit {
-                Some(Limit::Static(n)) => Some(*n as f64),
-                _ => None,
-            };
+            // For costing/parallelism: prefer a real planning estimate over a
+            // missing one when LIMIT is parameterized. Without this, GENERIC
+            // prepared plans produce float_limit=None and the parallel-worker
+            // estimator collapses (issue #4665).
+            let float_limit = limit_offset.as_ref().map(|lo| lo.planning_estimate());
 
             custom_private.set_heaprelid(table.oid());
             custom_private.set_indexrelid(bm25_index.oid());
             custom_private.set_range_table_index(rti);
             custom_private.set_query(query);
-            custom_private.set_limit(limit);
+            custom_private.set_limit_offset(limit_offset.clone());
             custom_private.set_segment_count(segment_count);
 
             // Determine whether we might be able to sort.
@@ -1669,7 +1697,7 @@ fn validate_topk_expectation(
     }
 
     // Check if this query should be using Top K
-    let has_limit = privdata.limit().is_some();
+    let has_limit = privdata.limit_offset().is_some();
     let has_search_query = privdata.query().is_some();
     let no_group_by = privdata.window_aggregates().is_empty();
 
@@ -1685,7 +1713,7 @@ fn validate_topk_expectation(
     }
 
     // At this point: should_use_topk is true AND we're not using Top K - emit warning
-    let limit = privdata.limit().as_ref().unwrap();
+    let limit = privdata.limit_offset().as_ref().unwrap().limit.to_string();
     let method_name = match chosen_method {
         ExecMethodType::Normal => "Normal",
         ExecMethodType::Columnar { .. } => "Columnar",
@@ -1776,11 +1804,11 @@ fn choose_exec_method(
 ) -> Vec<ExecMethodType> {
     // See if we can use Top K.
     // A known limit value or a parameterized limit (value resolved at execution time) both qualify.
-    if let Some(limit) = privdata.limit().clone() {
+    if let Some(lo) = privdata.limit_offset().clone() {
         if let Some(orderby_info) = privdata.maybe_orderby_info() {
             let method = ExecMethodType::TopK {
                 heaprelid: privdata.heaprelid().expect("heaprelid must be set"),
-                limit: limit.clone(),
+                limit_offset: lo.clone(),
                 orderby_info: Some(orderby_info.clone()),
                 window_aggregates: privdata.window_aggregates().clone(),
             };
@@ -1796,7 +1824,7 @@ fn choose_exec_method(
         if matches!(topk_pathkey_info, PathKeyInfo::None) {
             let method = ExecMethodType::TopK {
                 heaprelid: privdata.heaprelid().expect("heaprelid must be set"),
-                limit,
+                limit_offset: lo,
                 orderby_info: None,
                 window_aggregates: privdata.window_aggregates().clone(),
             };
@@ -1816,12 +1844,12 @@ fn choose_exec_method(
     if is_capable {
         let mut methods = Vec::new();
 
-        let limit = privdata.limit().clone();
+        let lo = privdata.limit_offset().clone();
 
         // Always create the Unsorted variant
         methods.push(ExecMethodType::Columnar {
             which_fast_fields: privdata.planned_which_fast_fields().clone().unwrap(),
-            limit: limit.clone(),
+            limit_offset: lo.clone(),
             sort_order: None,
         });
 
@@ -1839,7 +1867,7 @@ fn choose_exec_method(
             if let Some(sort_order) = sort_order {
                 methods.push(ExecMethodType::Columnar {
                     which_fast_fields: privdata.planned_which_fast_fields().clone().unwrap(),
-                    limit,
+                    limit_offset: lo,
                     sort_order: Some(sort_order),
                 });
             }
@@ -1883,21 +1911,17 @@ fn assign_exec_method(builder: &mut CustomScanStateBuilder<BaseScan, PrivateData
             .assign_exec_method(NormalScanExecState::default(), Some(ExecMethodType::Normal)),
         ExecMethodType::TopK {
             heaprelid,
-            limit,
+            limit_offset,
             orderby_info,
             window_aggregates: _,
         } => builder.custom_state().assign_exec_method(
-            exec_methods::top_k::TopKScanExecState::new(
-                heaprelid,
-                limit.static_value(),
-                orderby_info,
-            ),
+            exec_methods::top_k::TopKScanExecState::new(heaprelid, limit_offset, orderby_info),
             None,
         ),
 
         ExecMethodType::Columnar {
             which_fast_fields,
-            limit,
+            limit_offset,
             sort_order,
         } => {
             // Compute effective sort_order at execution time from PrivateData's use_sorted_path().
@@ -1954,7 +1978,7 @@ fn assign_exec_method(builder: &mut CustomScanStateBuilder<BaseScan, PrivateData
                     exec_methods::fast_fields::columnar::ColumnarExecState::new(
                         which_fast_fields,
                         extra_fast_fields,
-                        limit.as_ref().and_then(Limit::static_value),
+                        limit_offset,
                         effective_sort_order,
                     ),
                     None,

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -197,7 +197,10 @@ impl BaseScan {
                         std::ptr::NonNull::new(expr_context),
                     );
 
-                snippet_type.configure_generator(&mut new_generator.1);
+                let estate = unsafe { (*csstate).ss.ps.state };
+                unsafe {
+                    snippet_type.configure_generator(&mut new_generator.1, estate);
+                }
 
                 *generator = Some(new_generator.1);
             }
@@ -1567,7 +1570,8 @@ impl CustomScan for BaseScan {
                                 // that we could use a wider tuple slot to fetch the extra columns that
                                 // we need during our initial lookup above (but then we'd need to copy
                                 // into the correctly shaped slot for this scan).
-                                maybe_project_snippets(state.custom_state(), ctid);
+                                let estate = state.csstate.ss.ps.state;
+                                maybe_project_snippets(state.custom_state(), ctid, estate);
 
                                 let planstate = state.planstate();
 
@@ -2443,7 +2447,11 @@ fn is_range_query_string(query_string: &str) -> bool {
 /// Project configured snippets (if any).
 ///
 /// Must be called inside the per-tuple `MemoryContext`.
-unsafe fn maybe_project_snippets(state: &BaseScanState, ctid: u64) {
+unsafe fn maybe_project_snippets(
+    state: &BaseScanState,
+    ctid: u64,
+    estate: *mut pg_sys::EState,
+) {
     if !state.need_snippets() {
         return;
     }
@@ -2451,7 +2459,7 @@ unsafe fn maybe_project_snippets(state: &BaseScanState, ctid: u64) {
     for (snippet_type, const_snippet_nodes) in &state.const_snippet_nodes {
         match snippet_type {
             SnippetType::SingleText(_, _, _) => {
-                let snippet = state.make_snippet(ctid, snippet_type);
+                let snippet = state.make_snippet(ctid, snippet_type, estate);
 
                 for const_ in const_snippet_nodes {
                     match &snippet {
@@ -2467,7 +2475,7 @@ unsafe fn maybe_project_snippets(state: &BaseScanState, ctid: u64) {
                 }
             }
             SnippetType::MultipleText(_, _, _, _) => {
-                let snippets = state.make_snippets(ctid, snippet_type);
+                let snippets = state.make_snippets(ctid, snippet_type, estate);
 
                 for const_ in const_snippet_nodes {
                     match &snippets {

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -412,64 +412,49 @@ unsafe fn query_has_window_agg_functions(root: *mut pg_sys::PlannerInfo) -> bool
     false
 }
 
-/// Returns true if the target list contains a set-returning function that we
-/// cannot prove is safe to push LIMIT through. Only `unnest` is recognized as
-/// limit-safe (it produces at least as many rows as it consumes).
-///
-/// Used as a guard alongside `has_non_pushable_predicates` to decide whether
-/// pushing a LIMIT into the scan would silently produce fewer rows than
-/// PostgreSQL's outer Limit node expects.
-unsafe fn has_unsafe_srf(root: *mut pg_sys::PlannerInfo) -> bool {
-    if root.is_null() || (*root).parse.is_null() || (*(*root).parse).targetList.is_null() {
-        return false;
-    }
-    let parse = *(*root).parse;
-    let target_list = PgList::<pg_sys::TargetEntry>::from_pg(parse.targetList);
-    for te in target_list.iter_ptr() {
-        if (*te).expr.is_null() {
-            continue;
-        }
-        if !pg_sys::expression_returns_set((*te).expr.cast()) {
-            continue;
-        }
-        // SRF found — only `unnest` is known to be safe.
-        if let Some(func_expr) = nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
-            if !is_unnest_func((*func_expr).funcid) {
-                return true;
-            }
-        } else {
-            // Some other SRF expression we can't classify.
-            return true;
-        }
-    }
-    false
+/// Classification of any set-returning function found in the target list,
+/// used to decide whether pushing LIMIT through this scan is safe. PG sets
+/// `limit_tuples == -1.0` whenever any SRF is present, so we walk once and
+/// distinguish between "no SRF / safe (unnest only) / unsafe".
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TargetListSrf {
+    None,
+    Safe,
+    Unsafe,
 }
 
-/// Returns true if the target list contains an `unnest` set-returning function.
-/// PG sets `limit_tuples == -1.0` whenever a SRF is present (it can't predict
-/// how many input rows produce K output rows), so we need this independent
-/// signal to know that a SRF-driven LIMIT pushdown is still safe through the
-/// row-preserving `unnest` semantics.
-unsafe fn has_safe_srf(root: *mut pg_sys::PlannerInfo) -> bool {
+impl TargetListSrf {
+    fn is_safe(self) -> bool {
+        matches!(self, TargetListSrf::Safe)
+    }
+    fn is_unsafe(self) -> bool {
+        matches!(self, TargetListSrf::Unsafe)
+    }
+}
+
+/// Walk the target list once and classify any SRFs. Only `unnest` is
+/// row-preserving (and therefore limit-safe); everything else is treated as
+/// unsafe so LIMIT pushdown stops above the scan.
+unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetListSrf {
     if root.is_null() || (*root).parse.is_null() || (*(*root).parse).targetList.is_null() {
-        return false;
+        return TargetListSrf::None;
     }
-    let parse = *(*root).parse;
-    let target_list = PgList::<pg_sys::TargetEntry>::from_pg(parse.targetList);
+    let target_list = PgList::<pg_sys::TargetEntry>::from_pg((*(*root).parse).targetList);
+    let mut found_safe = false;
     for te in target_list.iter_ptr() {
-        if (*te).expr.is_null() {
+        if (*te).expr.is_null() || !pg_sys::expression_returns_set((*te).expr.cast()) {
             continue;
         }
-        if !pg_sys::expression_returns_set((*te).expr.cast()) {
-            continue;
-        }
-        if let Some(func_expr) = nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
-            if is_unnest_func((*func_expr).funcid) {
-                return true;
-            }
+        match nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
+            Some(func_expr) if is_unnest_func((*func_expr).funcid) => found_safe = true,
+            _ => return TargetListSrf::Unsafe,
         }
     }
-    false
+    if found_safe {
+        TargetListSrf::Safe
+    } else {
+        TargetListSrf::None
+    }
 }
 
 /// Returns `true` if any predicate in `baserestrictinfo` cannot be fully
@@ -526,7 +511,7 @@ unsafe fn is_limit_pushdown_safe(
 
     (rel_is_single_or_partitioned || is_left_driven_lateral)
         && !has_non_pushable_predicates(rel, quals)
-        && !has_unsafe_srf(root)
+        && !classify_target_list_srf(root).is_unsafe()
 }
 
 impl CustomScan for BaseScan {
@@ -718,21 +703,19 @@ impl CustomScan for BaseScan {
 
             // Push the LIMIT/OFFSET into this scan when one of:
             //   - PG already proved it safe (`limit_tuples > -1.0`)
-            //   - The value is a Param (PG can't evaluate at plan time but we
-            //     can at exec time — issue #4665)
-            //   - The target list contains a row-preserving SRF like `unnest`
-            //     (PG zeroed out `limit_tuples` because of the SRF, but the
-            //     SRF doesn't drop input rows so `limit + offset` rows
-            //     fetched here is still enough)
-            // Local safety checks (topology, predicates, unsafe SRFs) gate all
-            // three cases.
+            //   - The value is a Param (PG can't evaluate at plan time but
+            //     we can at exec time)
+            //   - A row-preserving `unnest` SRF zeroed PG's `limit_tuples`,
+            //     but `limit + offset` rows here is still enough
+            // `is_limit_pushdown_safe` then gates on topology + predicates +
+            // unsafe SRFs.
             let raw_limit_offset = LimitOffset::from_root(builder.args().root);
             let limit_offset = raw_limit_offset.filter(|lo| {
                 let pg_says_pushable = (*builder.args().root).limit_tuples > -1.0;
-                let has_param = lo.has_any_param();
-                let has_safe_srf_override = has_safe_srf(builder.args().root);
+                let unnest_override =
+                    classify_target_list_srf(builder.args().root).is_safe();
 
-                (pg_says_pushable || has_param || has_safe_srf_override)
+                (pg_says_pushable || lo.has_any_param() || unnest_override)
                     && is_limit_pushdown_safe(
                         builder.args().root,
                         rel,
@@ -790,10 +773,9 @@ impl CustomScan for BaseScan {
                 estimate_selectivity(&bm25_index, query.clone()).unwrap_or(UNKNOWN_SELECTIVITY)
             };
 
-            // For costing/parallelism: prefer a real planning estimate over a
-            // missing one when LIMIT is parameterized. Without this, GENERIC
-            // prepared plans produce float_limit=None and the parallel-worker
-            // estimator collapses (issue #4665).
+            // Use planning_estimate for costing so parameterized limits still
+            // contribute a non-zero row estimate (otherwise the parallel-worker
+            // estimator collapses).
             let float_limit = limit_offset.as_ref().map(|lo| lo.planning_estimate());
 
             custom_private.set_heaprelid(table.oid());

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -712,8 +712,7 @@ impl CustomScan for BaseScan {
             let raw_limit_offset = LimitOffset::from_root(builder.args().root);
             let limit_offset = raw_limit_offset.filter(|lo| {
                 let pg_says_pushable = (*builder.args().root).limit_tuples > -1.0;
-                let unnest_override =
-                    classify_target_list_srf(builder.args().root).is_safe();
+                let unnest_override = classify_target_list_srf(builder.args().root).is_safe();
 
                 (pg_says_pushable || lo.has_any_param() || unnest_override)
                     && is_limit_pushdown_safe(

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -1900,13 +1900,13 @@ fn assign_exec_method(builder: &mut CustomScanStateBuilder<BaseScan, PrivateData
             orderby_info,
             window_aggregates: _,
         } => builder.custom_state().assign_exec_method(
-            exec_methods::top_k::TopKScanExecState::new(heaprelid, limit_offset, orderby_info),
+            exec_methods::top_k::TopKScanExecState::new(heaprelid, &limit_offset, orderby_info),
             None,
         ),
 
         ExecMethodType::Columnar {
             which_fast_fields,
-            limit_offset,
+            limit_offset: _,
             sort_order,
         } => {
             // Compute effective sort_order at execution time from PrivateData's use_sorted_path().
@@ -1963,7 +1963,6 @@ fn assign_exec_method(builder: &mut CustomScanStateBuilder<BaseScan, PrivateData
                     exec_methods::fast_fields::columnar::ColumnarExecState::new(
                         which_fast_fields,
                         extra_fast_fields,
-                        limit_offset,
                         effective_sort_order,
                     ),
                     None,

--- a/pg_search/src/postgres/customscan/basescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/basescan/privdat.rs
@@ -15,116 +15,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::fmt;
-
 use crate::api::{AsCStr, FieldName, HashMap, HashSet, OrderByInfo, Varno};
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::postgres::customscan::basescan::projections::window_agg::WindowAggregateInfo;
 use crate::postgres::customscan::basescan::ExecMethodType;
 use crate::postgres::customscan::builders::custom_path::OrderByStyle;
+use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::query::SearchQueryInput;
 
 use pgrx::pg_sys::AsPgCStr;
-use pgrx::{pg_sys, FromDatum, PgList};
+use pgrx::{pg_sys, PgList};
 use serde::{Deserialize, Serialize};
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum Limit {
-    Static(usize),
-    Parameterized { limit_param_id: i32 },
-}
-
-impl fmt::Display for Limit {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Limit::Static(n) => write!(f, "{n}"),
-            Limit::Parameterized { .. } => write!(f, "<parameterized>"),
-        }
-    }
-}
-
-impl Limit {
-    pub unsafe fn from_param(node: *mut pg_sys::Node) -> Option<Self> {
-        use crate::nodecast;
-
-        if node.is_null() {
-            return None;
-        }
-
-        if let Some(param) = nodecast!(Param, T_Param, node) {
-            if (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN {
-                return Some(Limit::Parameterized {
-                    limit_param_id: (*param).paramid,
-                });
-            }
-            return None;
-        }
-
-        if let Some(func_expr) = nodecast!(FuncExpr, T_FuncExpr, node) {
-            let args = PgList::<pg_sys::Node>::from_pg((*func_expr).args);
-            if args.len() == 1 {
-                return Limit::from_param(args.get_ptr(0).unwrap());
-            }
-        }
-
-        if let Some(relabel) = nodecast!(RelabelType, T_RelabelType, node) {
-            return Limit::from_param((*relabel).arg.cast());
-        }
-
-        if let Some(coerce) = nodecast!(CoerceViaIO, T_CoerceViaIO, node) {
-            return Limit::from_param((*coerce).arg.cast());
-        }
-
-        None
-    }
-
-    pub fn param_id(&self) -> Option<i32> {
-        match self {
-            Limit::Parameterized { limit_param_id } => Some(*limit_param_id),
-            Limit::Static(_) => None,
-        }
-    }
-
-    pub fn static_value(&self) -> Option<usize> {
-        match self {
-            Limit::Static(n) => Some(*n),
-            Limit::Parameterized { .. } => None,
-        }
-    }
-
-    pub unsafe fn resolve(&self, estate: *mut pg_sys::EState) -> usize {
-        match self {
-            Limit::Static(n) => *n,
-            Limit::Parameterized { limit_param_id } => {
-                let param_list = (*estate).es_param_list_info;
-                assert!(
-                    !param_list.is_null(),
-                    "es_param_list_info is NULL but we have a parameterized LIMIT"
-                );
-
-                let idx = (*limit_param_id - 1) as usize;
-                assert!(
-                    idx < (*param_list).numParams as usize,
-                    "LIMIT param_id {} out of range (numParams={})",
-                    limit_param_id,
-                    (*param_list).numParams
-                );
-
-                let param_data = &(*param_list)
-                    .params
-                    .as_slice((*param_list).numParams as usize)[idx];
-                assert!(
-                    !param_data.isnull,
-                    "LIMIT parameter ${} is NULL",
-                    limit_param_id
-                );
-
-                i64::from_datum(param_data.value, param_data.isnull)
-                    .expect("LIMIT parameter should be convertible to i64") as usize
-            }
-        }
-    }
-}
 
 #[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct PrivateData {
@@ -132,7 +33,7 @@ pub struct PrivateData {
     indexrelid: Option<pg_sys::Oid>,
     range_table_index: Option<pg_sys::Index>,
     query: Option<SearchQueryInput>,
-    limit: Option<Limit>,
+    limit_offset: Option<LimitOffset>,
     // ORDER-BY info that will be used iff the appropriate ExecMethodType is chosen.
     maybe_orderby_info: Option<Vec<OrderByInfo>>,
     #[serde(with = "var_attname_lookup_serializer")]
@@ -276,8 +177,8 @@ impl PrivateData {
         self.query = Some(query);
     }
 
-    pub fn set_limit(&mut self, limit: Option<Limit>) {
-        self.limit = limit;
+    pub fn set_limit_offset(&mut self, limit_offset: Option<LimitOffset>) {
+        self.limit_offset = limit_offset;
     }
 
     pub fn set_maybe_orderby_info(&mut self, style: Option<&Vec<OrderByStyle>>) {
@@ -356,12 +257,14 @@ impl PrivateData {
         &self.query
     }
 
-    pub fn limit(&self) -> &Option<Limit> {
-        &self.limit
+    pub fn limit_offset(&self) -> &Option<LimitOffset> {
+        &self.limit_offset
     }
 
     pub fn static_limit(&self) -> Option<usize> {
-        self.limit.as_ref().and_then(Limit::static_value)
+        self.limit_offset
+            .as_ref()
+            .and_then(|lo| lo.static_limit().map(|v| v.max(0) as usize))
     }
 
     pub fn maybe_orderby_info(&self) -> &Option<Vec<OrderByInfo>> {

--- a/pg_search/src/postgres/customscan/basescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/basescan/privdat.rs
@@ -264,7 +264,8 @@ impl PrivateData {
     pub fn static_limit(&self) -> Option<usize> {
         self.limit_offset
             .as_ref()
-            .and_then(|lo| lo.static_limit().map(|v| v.max(0) as usize))
+            .and_then(|lo| lo.limit.static_value())
+            .map(|v| (*v).max(0) as usize)
     }
 
     pub fn maybe_orderby_info(&self) -> &Option<Vec<OrderByInfo>> {

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -110,23 +110,14 @@ pub struct SnippetConfig {
 }
 
 impl SnippetConfig {
-    /// Resolve `start_tag` at execution time, falling back to the default when
-    /// the parameter resolves to NULL.
     pub unsafe fn resolve_start_tag(&self, estate: *mut pg_sys::EState) -> String {
-        self.start_tag
-            .resolve(estate)
-            .unwrap_or_else(|| DEFAULT_SNIPPET_PREFIX.to_string())
+        resolve_tag_or_default(&self.start_tag, estate, DEFAULT_SNIPPET_PREFIX)
     }
 
-    /// Resolve `end_tag` at execution time, falling back to the default when
-    /// the parameter resolves to NULL.
     pub unsafe fn resolve_end_tag(&self, estate: *mut pg_sys::EState) -> String {
-        self.end_tag
-            .resolve(estate)
-            .unwrap_or_else(|| DEFAULT_SNIPPET_POSTFIX.to_string())
+        resolve_tag_or_default(&self.end_tag, estate, DEFAULT_SNIPPET_POSTFIX)
     }
 
-    /// Resolve `max_num_chars` at execution time, falling back to the default.
     pub unsafe fn resolve_max_num_chars(&self, estate: *mut pg_sys::EState) -> usize {
         let v = self
             .max_num_chars
@@ -135,6 +126,14 @@ impl SnippetConfig {
         assert!(v >= 0, "max_num_chars must not be negative");
         v as usize
     }
+}
+
+unsafe fn resolve_tag_or_default(
+    tag: &ParameterizedValue<String>,
+    estate: *mut pg_sys::EState,
+    default: &str,
+) -> String {
+    tag.resolve(estate).unwrap_or_else(|| default.to_string())
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -588,6 +587,23 @@ pub unsafe fn uses_snippets(
     context.snippet_type
 }
 
+/// Resolve the field arg (always arg 0) of a snippet function to its
+/// indexed `FieldName`. Returns `None` if the arg isn't a single Var.
+#[inline]
+unsafe fn extract_snippet_field_attname(
+    args: &PgList<pg_sys::Node>,
+    planning_rti: pg_sys::Index,
+    attname_lookup: &HashMap<(Varno, pg_sys::AttrNumber), FieldName>,
+) -> Option<FieldName> {
+    let field_arg = find_one_var(args.get_ptr(0).unwrap())?;
+    Some(
+        attname_lookup
+            .get(&(planning_rti as _, (*field_arg).varattno as _))
+            .cloned()
+            .expect("Var attname should be in lookup"),
+    )
+}
+
 #[inline(always)]
 pub unsafe fn extract_snippet(
     func: *mut pg_sys::FuncExpr,
@@ -601,11 +617,7 @@ pub unsafe fn extract_snippet(
     let args = PgList::<pg_sys::Node>::from_pg((*func).args);
     assert!(args.len() == 6);
 
-    let field_arg = find_one_var(args.get_ptr(0).unwrap())?;
-    let attname = attname_lookup
-        .get(&(planning_rti as _, (*field_arg).varattno as _))
-        .cloned()
-        .expect("Var attname should be in lookup");
+    let attname = extract_snippet_field_attname(&args, planning_rti, attname_lookup)?;
 
     // All formatting/limit args may be either Const (resolved at planning
     // time) or extern Param (resolved at execution time in GENERIC plan
@@ -643,11 +655,7 @@ pub unsafe fn extract_snippets(
     let args = PgList::<pg_sys::Node>::from_pg((*func).args);
     assert!(args.len() == 7);
 
-    let field_arg = find_one_var(args.get_ptr(0).unwrap())?;
-    let attname = attname_lookup
-        .get(&(planning_rti as _, (*field_arg).varattno as _))
-        .cloned()
-        .expect("Var attname should be in lookup");
+    let attname = extract_snippet_field_attname(&args, planning_rti, attname_lookup)?;
 
     let start_tag = ParameterizedValue::<String>::from_node(args.get_ptr(1).unwrap())
         .unwrap_or_else(|| ParameterizedValue::Static(DEFAULT_SNIPPET_PREFIX.to_string()));
@@ -691,11 +699,7 @@ pub unsafe fn extract_snippet_positions(
     let args = PgList::<pg_sys::Node>::from_pg((*func).args);
     assert!(args.len() == 3);
 
-    let field_arg = find_one_var(args.get_ptr(0).unwrap())?;
-    let attname = attname_lookup
-        .get(&(planning_rti as _, (*field_arg).varattno as _))
-        .cloned()
-        .expect("Var attname should be in lookup");
+    let attname = extract_snippet_field_attname(&args, planning_rti, attname_lookup)?;
 
     let limit = ParameterizedValue::<i32>::from_node(args.get_ptr(1).unwrap());
     let offset = ParameterizedValue::<i32>::from_node(args.get_ptr(2).unwrap());

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -154,7 +154,7 @@ pub enum SnippetType {
 /// Parse a `sort_by` string into a `SnippetSortOrder`. NULL falls back to the
 /// default (`Score`); any other value reports a SQL error at execution time
 /// (parameterized values can't be validated at planning time).
-unsafe fn parse_sort_order(s: Option<&str>) -> SnippetSortOrder {
+fn parse_sort_order(s: Option<&str>) -> SnippetSortOrder {
     match s {
         None | Some("score") => SnippetSortOrder::Score,
         Some("position") => SnippetSortOrder::Position,
@@ -217,7 +217,7 @@ impl SnippetType {
                 generator.set_snippets_offset(positions_config.resolve_offset_or_default(estate));
                 generator.set_max_num_chars(config.resolve_max_num_chars(estate));
                 let resolved = sort_by.resolve(estate);
-                generator.set_sort_order(unsafe { parse_sort_order(resolved.as_deref()) });
+                generator.set_sort_order(parse_sort_order(resolved.as_deref()));
             }
             SnippetType::Positions(_, positions_config) => {
                 // Positions are expected to be fairly small, so we always render all of them by

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -19,12 +19,13 @@ use std::ptr::addr_of_mut;
 
 use crate::api::{FieldName, HashMap, Varno};
 use crate::nodecast;
+use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::var::find_one_var;
 
 use pgrx::pg_sys::expression_tree_walker;
 use pgrx::{
     default, direct_function_call, extension_sql, pg_extern, pg_guard, pg_sys, AnyElement,
-    FromDatum, IntoDatum, PgList,
+    IntoDatum, PgList,
 };
 use std::sync::OnceLock;
 use tantivy::snippet::{SnippetGenerator, SnippetSortOrder};
@@ -36,24 +37,35 @@ const DEFAULT_SNIPPET_LIMIT: i32 = 5;
 const DEFAULT_SNIPPET_OFFSET: i32 = 0;
 
 /// The limit and offset for "fragments" (essentially, matches with a small amount of context).
+///
+/// Both fields are wrapped in `ParameterizedValue` so they can carry either a
+/// planning-time `Const` or an extern `Param` resolved at execution time.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct FragmentPositionsConfig {
-    pub limit: Option<i32>,
-    pub offset: Option<i32>,
+    pub limit: Option<ParameterizedValue<i32>>,
+    pub offset: Option<ParameterizedValue<i32>>,
 }
 
 impl FragmentPositionsConfig {
-    pub fn limit(&self) -> Option<usize> {
-        self.limit.map(|v| {
-            assert!(v >= 0, "limit must not be negative");
-            v as usize
+    /// Resolve the LIMIT against the executor state. Returns `None` if there is
+    /// no LIMIT or the parameter resolves to NULL.
+    pub unsafe fn resolve_limit(&self, estate: *mut pg_sys::EState) -> Option<usize> {
+        self.limit.as_ref().and_then(|v| {
+            v.resolve(estate).map(|raw| {
+                assert!(raw >= 0, "limit must not be negative");
+                raw as usize
+            })
         })
     }
 
-    pub fn offset(&self) -> Option<usize> {
-        self.offset.map(|v| {
-            assert!(v >= 0, "offset must not be negative");
-            v as usize
+    /// Resolve the OFFSET against the executor state. Returns `None` if there is
+    /// no OFFSET or the parameter resolves to NULL.
+    pub unsafe fn resolve_offset(&self, estate: *mut pg_sys::EState) -> Option<usize> {
+        self.offset.as_ref().and_then(|v| {
+            v.resolve(estate).map(|raw| {
+                assert!(raw >= 0, "offset must not be negative");
+                raw as usize
+            })
         })
     }
 }
@@ -62,19 +74,29 @@ impl FragmentPositionsConfig {
 /// size limit).
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct SnippetPositionsConfig {
-    pub limit: Option<i32>,
-    pub offset: Option<i32>,
+    pub limit: Option<ParameterizedValue<i32>>,
+    pub offset: Option<ParameterizedValue<i32>>,
 }
 
 impl SnippetPositionsConfig {
-    pub fn limit_or_default(&self) -> usize {
-        let limit = self.limit.unwrap_or(DEFAULT_SNIPPET_LIMIT);
+    /// Resolve the LIMIT, falling back to `DEFAULT_SNIPPET_LIMIT` when absent or NULL.
+    pub unsafe fn resolve_limit_or_default(&self, estate: *mut pg_sys::EState) -> usize {
+        let limit = self
+            .limit
+            .as_ref()
+            .and_then(|v| v.resolve(estate))
+            .unwrap_or(DEFAULT_SNIPPET_LIMIT);
         assert!(limit >= 0, "limit must not be negative");
         limit as usize
     }
 
-    pub fn offset_or_default(&self) -> usize {
-        let offset = self.offset.unwrap_or(DEFAULT_SNIPPET_OFFSET);
+    /// Resolve the OFFSET, falling back to `DEFAULT_SNIPPET_OFFSET` when absent or NULL.
+    pub unsafe fn resolve_offset_or_default(&self, estate: *mut pg_sys::EState) -> usize {
+        let offset = self
+            .offset
+            .as_ref()
+            .and_then(|v| v.resolve(estate))
+            .unwrap_or(DEFAULT_SNIPPET_OFFSET);
         assert!(offset >= 0, "offset must not be negative");
         offset as usize
     }
@@ -82,9 +104,37 @@ impl SnippetPositionsConfig {
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub struct SnippetConfig {
-    pub start_tag: String,
-    pub end_tag: String,
-    pub max_num_chars: usize,
+    pub start_tag: ParameterizedValue<String>,
+    pub end_tag: ParameterizedValue<String>,
+    pub max_num_chars: ParameterizedValue<i32>,
+}
+
+impl SnippetConfig {
+    /// Resolve `start_tag` at execution time, falling back to the default when
+    /// the parameter resolves to NULL.
+    pub unsafe fn resolve_start_tag(&self, estate: *mut pg_sys::EState) -> String {
+        self.start_tag
+            .resolve(estate)
+            .unwrap_or_else(|| DEFAULT_SNIPPET_PREFIX.to_string())
+    }
+
+    /// Resolve `end_tag` at execution time, falling back to the default when
+    /// the parameter resolves to NULL.
+    pub unsafe fn resolve_end_tag(&self, estate: *mut pg_sys::EState) -> String {
+        self.end_tag
+            .resolve(estate)
+            .unwrap_or_else(|| DEFAULT_SNIPPET_POSTFIX.to_string())
+    }
+
+    /// Resolve `max_num_chars` at execution time, falling back to the default.
+    pub unsafe fn resolve_max_num_chars(&self, estate: *mut pg_sys::EState) -> usize {
+        let v = self
+            .max_num_chars
+            .resolve(estate)
+            .unwrap_or(DEFAULT_SNIPPET_MAX_NUM_CHARS);
+        assert!(v >= 0, "max_num_chars must not be negative");
+        v as usize
+    }
 }
 
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
@@ -94,9 +144,24 @@ pub enum SnippetType {
         FieldName,
         SnippetConfig,
         SnippetPositionsConfig,
-        SnippetSortOrder,
+        // Sort order is held as a string so a parameterized `sort_by` arg can
+        // reach execution time before being converted to `SnippetSortOrder`.
+        ParameterizedValue<String>,
     ),
     Positions(FieldName, FragmentPositionsConfig),
+}
+
+/// Parse a `sort_by` string into a `SnippetSortOrder`. NULL falls back to the
+/// default (`Score`); any other value reports a SQL error at execution time
+/// (parameterized values can't be validated at planning time).
+unsafe fn parse_sort_order(s: Option<&str>) -> SnippetSortOrder {
+    match s {
+        None | Some("score") => SnippetSortOrder::Score,
+        Some("position") => SnippetSortOrder::Position,
+        Some(_) => {
+            pgrx::error!("invalid sort_by value for pdb.snippets: must be 'score' or 'position'")
+        }
+    }
 }
 
 impl SnippetType {
@@ -116,10 +181,16 @@ impl SnippetType {
         }
     }
 
-    pub fn configure_generator(&self, generator: &mut SnippetGenerator) {
+    pub unsafe fn configure_generator(
+        &self,
+        generator: &mut SnippetGenerator,
+        estate: *mut pg_sys::EState,
+    ) {
         match self {
             SnippetType::SingleText(_, config, positions_config) => {
-                if positions_config.limit().is_some() || positions_config.offset().is_some() {
+                let limit = positions_config.resolve_limit(estate);
+                let offset = positions_config.resolve_offset(estate);
+                if limit.is_some() || offset.is_some() {
                     pg_sys::panic::ErrorReport::new(
                         pgrx::PgSqlErrorCode::ERRCODE_WARNING_DEPRECATED_FEATURE,
                         "using `limit` or `offset` with `pdb.snippet` is deprecated",
@@ -131,30 +202,31 @@ impl SnippetType {
                 }
                 // Do not use a limit or offset unless they have been specified: otherwise we might
                 // not highlight all matches in the configured `max_num_chars`.
-                if let Some(limit) = positions_config.limit() {
-                    generator.set_matches_limit(limit as usize);
+                if let Some(limit) = limit {
+                    generator.set_matches_limit(limit);
                 }
-                if let Some(offset) = positions_config.offset() {
-                    generator.set_matches_offset(offset as usize);
+                if let Some(offset) = offset {
+                    generator.set_matches_offset(offset);
                 }
-                generator.set_max_num_chars(config.max_num_chars);
+                generator.set_max_num_chars(config.resolve_max_num_chars(estate));
             }
-            SnippetType::MultipleText(_, config, positions_config, sort_order) => {
+            SnippetType::MultipleText(_, config, positions_config, sort_by) => {
                 // We always use a (default) limit and offset for positions, as we might
                 // potentially produce a huge array otherwise.
-                generator.set_snippets_limit(positions_config.limit_or_default());
-                generator.set_snippets_offset(positions_config.offset_or_default());
-                generator.set_max_num_chars(config.max_num_chars);
-                generator.set_sort_order(*sort_order);
+                generator.set_snippets_limit(positions_config.resolve_limit_or_default(estate));
+                generator.set_snippets_offset(positions_config.resolve_offset_or_default(estate));
+                generator.set_max_num_chars(config.resolve_max_num_chars(estate));
+                let resolved = sort_by.resolve(estate);
+                generator.set_sort_order(unsafe { parse_sort_order(resolved.as_deref()) });
             }
             SnippetType::Positions(_, positions_config) => {
                 // Positions are expected to be fairly small, so we always render all of them by
                 // default.
-                if let Some(limit) = positions_config.limit() {
-                    generator.set_matches_limit(limit as usize);
+                if let Some(limit) = positions_config.resolve_limit(estate) {
+                    generator.set_matches_limit(limit);
                 }
-                if let Some(offset) = positions_config.offset() {
-                    generator.set_matches_offset(offset as usize);
+                if let Some(offset) = positions_config.resolve_offset(estate) {
+                    generator.set_matches_offset(offset);
                 }
                 // If SnippetType::Positions, set max_num_chars to u32::MAX because the entire doc must be considered
                 // This assumes text fields can be no more than u32::MAX bytes.
@@ -529,53 +601,33 @@ pub unsafe fn extract_snippet(
     let args = PgList::<pg_sys::Node>::from_pg((*func).args);
     assert!(args.len() == 6);
 
-    let field_arg = find_one_var(args.get_ptr(0).unwrap());
-    let start_arg = nodecast!(Const, T_Const, args.get_ptr(1).unwrap());
-    let end_arg = nodecast!(Const, T_Const, args.get_ptr(2).unwrap());
-    let max_num_chars_arg = nodecast!(Const, T_Const, args.get_ptr(3).unwrap());
-    let limit_arg = nodecast!(Const, T_Const, args.get_ptr(4).unwrap());
-    let offset_arg = nodecast!(Const, T_Const, args.get_ptr(5).unwrap());
+    let field_arg = find_one_var(args.get_ptr(0).unwrap())?;
+    let attname = attname_lookup
+        .get(&(planning_rti as _, (*field_arg).varattno as _))
+        .cloned()
+        .expect("Var attname should be in lookup");
 
-    if let (
-        Some(field_arg),
-        Some(start_arg),
-        Some(end_arg),
-        Some(max_num_chars_arg),
-        Some(limit_arg),
-        Some(offset_arg),
-    ) = (
-        field_arg,
-        start_arg,
-        end_arg,
-        max_num_chars_arg,
-        limit_arg,
-        offset_arg,
-    ) {
-        let attname = attname_lookup
-            .get(&(planning_rti as _, (*field_arg).varattno as _))
-            .cloned()
-            .expect("Var attname should be in lookup");
-        let start_tag = String::from_datum((*start_arg).constvalue, (*start_arg).constisnull);
-        let end_tag = String::from_datum((*end_arg).constvalue, (*end_arg).constisnull);
-        let max_num_chars = i32::from_datum(
-            (*max_num_chars_arg).constvalue,
-            (*max_num_chars_arg).constisnull,
-        );
-        let limit = i32::from_datum((*limit_arg).constvalue, (*limit_arg).constisnull);
-        let offset = i32::from_datum((*offset_arg).constvalue, (*offset_arg).constisnull);
+    // All formatting/limit args may be either Const (resolved at planning
+    // time) or extern Param (resolved at execution time in GENERIC plan
+    // mode). The legacy code panicked on Param here.
+    let start_tag = ParameterizedValue::<String>::from_node(args.get_ptr(1).unwrap())
+        .unwrap_or_else(|| ParameterizedValue::Static(DEFAULT_SNIPPET_PREFIX.to_string()));
+    let end_tag = ParameterizedValue::<String>::from_node(args.get_ptr(2).unwrap())
+        .unwrap_or_else(|| ParameterizedValue::Static(DEFAULT_SNIPPET_POSTFIX.to_string()));
+    let max_num_chars = ParameterizedValue::<i32>::from_node(args.get_ptr(3).unwrap())
+        .unwrap_or(ParameterizedValue::Static(DEFAULT_SNIPPET_MAX_NUM_CHARS));
+    let limit = ParameterizedValue::<i32>::from_node(args.get_ptr(4).unwrap());
+    let offset = ParameterizedValue::<i32>::from_node(args.get_ptr(5).unwrap());
 
-        Some(SnippetType::SingleText(
-            attname,
-            SnippetConfig {
-                start_tag: start_tag.unwrap_or_else(|| DEFAULT_SNIPPET_PREFIX.to_string()),
-                end_tag: end_tag.unwrap_or_else(|| DEFAULT_SNIPPET_POSTFIX.to_string()),
-                max_num_chars: max_num_chars.unwrap_or(DEFAULT_SNIPPET_MAX_NUM_CHARS) as usize,
-            },
-            FragmentPositionsConfig { limit, offset },
-        ))
-    } else {
-        panic!("`pdb.snippets()`'s arguments must be literals")
-    }
+    Some(SnippetType::SingleText(
+        attname,
+        SnippetConfig {
+            start_tag,
+            end_tag,
+            max_num_chars,
+        },
+        FragmentPositionsConfig { limit, offset },
+    ))
 }
 
 #[inline(always)]
@@ -591,65 +643,36 @@ pub unsafe fn extract_snippets(
     let args = PgList::<pg_sys::Node>::from_pg((*func).args);
     assert!(args.len() == 7);
 
-    let field_arg = find_one_var(args.get_ptr(0).unwrap());
-    let start_arg = nodecast!(Const, T_Const, args.get_ptr(1).unwrap());
-    let end_arg = nodecast!(Const, T_Const, args.get_ptr(2).unwrap());
-    let max_num_chars_arg = nodecast!(Const, T_Const, args.get_ptr(3).unwrap());
-    let limit_arg = nodecast!(Const, T_Const, args.get_ptr(4).unwrap());
-    let offset_arg = nodecast!(Const, T_Const, args.get_ptr(5).unwrap());
-    let sort_by_arg = nodecast!(Const, T_Const, args.get_ptr(6).unwrap());
+    let field_arg = find_one_var(args.get_ptr(0).unwrap())?;
+    let attname = attname_lookup
+        .get(&(planning_rti as _, (*field_arg).varattno as _))
+        .cloned()
+        .expect("Var attname should be in lookup");
 
-    if let (
-        Some(field_arg),
-        Some(start_arg),
-        Some(end_arg),
-        Some(max_num_chars_arg),
-        Some(limit_arg),
-        Some(offset_arg),
-        Some(sort_by_arg),
-    ) = (
-        field_arg,
-        start_arg,
-        end_arg,
-        max_num_chars_arg,
-        limit_arg,
-        offset_arg,
-        sort_by_arg,
-    ) {
-        let attname = attname_lookup
-            .get(&(planning_rti as _, (*field_arg).varattno as _))
-            .cloned()
-            .expect("Var attname should be in lookup");
-        let start_tag = String::from_datum((*start_arg).constvalue, (*start_arg).constisnull);
-        let end_tag = String::from_datum((*end_arg).constvalue, (*end_arg).constisnull);
-        let max_num_chars = i32::from_datum(
-            (*max_num_chars_arg).constvalue,
-            (*max_num_chars_arg).constisnull,
-        );
-        let limit = i32::from_datum((*limit_arg).constvalue, (*limit_arg).constisnull);
-        let offset = i32::from_datum((*offset_arg).constvalue, (*offset_arg).constisnull);
-        let sort_by = String::from_datum((*sort_by_arg).constvalue, (*sort_by_arg).constisnull)
-            .unwrap_or_else(|| "score".to_string());
+    let start_tag = ParameterizedValue::<String>::from_node(args.get_ptr(1).unwrap())
+        .unwrap_or_else(|| ParameterizedValue::Static(DEFAULT_SNIPPET_PREFIX.to_string()));
+    let end_tag = ParameterizedValue::<String>::from_node(args.get_ptr(2).unwrap())
+        .unwrap_or_else(|| ParameterizedValue::Static(DEFAULT_SNIPPET_POSTFIX.to_string()));
+    let max_num_chars = ParameterizedValue::<i32>::from_node(args.get_ptr(3).unwrap())
+        .unwrap_or(ParameterizedValue::Static(DEFAULT_SNIPPET_MAX_NUM_CHARS));
+    let limit = ParameterizedValue::<i32>::from_node(args.get_ptr(4).unwrap());
+    let offset = ParameterizedValue::<i32>::from_node(args.get_ptr(5).unwrap());
+    // sort_by is a String at the SQL level; we defer the conversion to
+    // SnippetSortOrder until execution time so a parameterized value can
+    // also flow through.
+    let sort_by = ParameterizedValue::<String>::from_node(args.get_ptr(6).unwrap())
+        .unwrap_or_else(|| ParameterizedValue::Static("score".to_string()));
 
-        let sort_order = match sort_by.as_str() {
-            "score" => SnippetSortOrder::Score,
-            "position" => SnippetSortOrder::Position,
-            _ => panic!("invalid sort_by value for pdb.snippets: must be 'score' or 'position'"),
-        };
-
-        Some(SnippetType::MultipleText(
-            attname,
-            SnippetConfig {
-                start_tag: start_tag.unwrap_or_else(|| DEFAULT_SNIPPET_PREFIX.to_string()),
-                end_tag: end_tag.unwrap_or_else(|| DEFAULT_SNIPPET_POSTFIX.to_string()),
-                max_num_chars: max_num_chars.unwrap_or(DEFAULT_SNIPPET_MAX_NUM_CHARS) as usize,
-            },
-            SnippetPositionsConfig { limit, offset },
-            sort_order,
-        ))
-    } else {
-        panic!("`pdb.snippets()`'s arguments must be literals")
-    }
+    Some(SnippetType::MultipleText(
+        attname,
+        SnippetConfig {
+            start_tag,
+            end_tag,
+            max_num_chars,
+        },
+        SnippetPositionsConfig { limit, offset },
+        sort_by,
+    ))
 }
 
 #[inline(always)]
@@ -668,25 +691,17 @@ pub unsafe fn extract_snippet_positions(
     let args = PgList::<pg_sys::Node>::from_pg((*func).args);
     assert!(args.len() == 3);
 
-    let field_arg = find_one_var(args.get_ptr(0).unwrap());
-    let limit_arg = nodecast!(Const, T_Const, args.get_ptr(1).unwrap());
-    let offset_arg = nodecast!(Const, T_Const, args.get_ptr(2).unwrap());
+    let field_arg = find_one_var(args.get_ptr(0).unwrap())?;
+    let attname = attname_lookup
+        .get(&(planning_rti as _, (*field_arg).varattno as _))
+        .cloned()
+        .expect("Var attname should be in lookup");
 
-    if let (Some(field_arg), Some(limit_arg), Some(offset_arg)) = (field_arg, limit_arg, offset_arg)
-    {
-        let attname = attname_lookup
-            .get(&(planning_rti as _, (*field_arg).varattno as _))
-            .cloned()
-            .expect("Var attname should be in lookup");
+    let limit = ParameterizedValue::<i32>::from_node(args.get_ptr(1).unwrap());
+    let offset = ParameterizedValue::<i32>::from_node(args.get_ptr(2).unwrap());
 
-        let limit = i32::from_datum((*limit_arg).constvalue, (*limit_arg).constisnull);
-        let offset = i32::from_datum((*offset_arg).constvalue, (*offset_arg).constisnull);
-
-        Some(SnippetType::Positions(
-            attname,
-            FragmentPositionsConfig { limit, offset },
-        ))
-    } else {
-        panic!("`pdb.extract_snippet_positions()`'s arguments must be literals")
-    }
+    Some(SnippetType::Positions(
+        attname,
+        FragmentPositionsConfig { limit, offset },
+    ))
 }

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -136,6 +136,13 @@ unsafe fn resolve_tag_or_default(
     tag.resolve(estate).unwrap_or_else(|| default.to_string())
 }
 
+// TODO: `SnippetType` is used as a `HashMap` key, so `SnippetConfig` fields
+// (which contain `ParameterizedValue<String>`) cannot use `resolve_mut` to
+// convert Param → Static in place — mutating a key would corrupt the map.
+// The clean fix is to separate identity (field name + param IDs → key) from
+// mutable config (resolved tags, generator, const nodes → value) into a
+// single `HashMap<SnippetId, SnippetState>`. Until then, snippet resolution
+// uses `resolve()` (clones per call) instead of `resolve_mut()`.
 #[derive(Debug, Clone, Eq, Hash, PartialEq)]
 pub enum SnippetType {
     SingleText(FieldName, SnippetConfig, FragmentPositionsConfig),

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -318,7 +318,7 @@ impl BaseScanState {
 
     pub fn limit(&self) -> Option<usize> {
         match &self.exec_method_type {
-            ExecMethodType::TopK { limit, .. } => limit.static_value(),
+            ExecMethodType::TopK { limit_offset, .. } => limit_offset.static_fetch(),
             _ => None,
         }
     }

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -256,12 +256,20 @@ impl BaseScanState {
         self.visibility_checker.as_mut().unwrap()
     }
 
-    pub fn make_snippet(&self, ctid: u64, snippet_type: &SnippetType) -> Option<String> {
+    pub fn make_snippet(
+        &self,
+        ctid: u64,
+        snippet_type: &SnippetType,
+        estate: *mut pg_sys::EState,
+    ) -> Option<String> {
         let text = unsafe { self.doc_from_heap(ctid, snippet_type.field())? };
         let generator = self.snippet_generators.get(snippet_type)?.as_ref()?;
         let mut snippet = generator.snippet(&text);
         if let SnippetType::SingleText(_, config, _) = snippet_type {
-            snippet.set_snippet_prefix_postfix(&config.start_tag, &config.end_tag);
+            // start_tag/end_tag may be parameterized — resolve from EState here.
+            let start_tag = unsafe { config.resolve_start_tag(estate) };
+            let end_tag = unsafe { config.resolve_end_tag(estate) };
+            snippet.set_snippet_prefix_postfix(&start_tag, &end_tag);
         }
 
         let html = snippet.to_html();
@@ -272,15 +280,27 @@ impl BaseScanState {
         }
     }
 
-    pub fn make_snippets(&self, ctid: u64, snippet_type: &SnippetType) -> Option<Vec<String>> {
+    pub fn make_snippets(
+        &self,
+        ctid: u64,
+        snippet_type: &SnippetType,
+        estate: *mut pg_sys::EState,
+    ) -> Option<Vec<String>> {
         let text = unsafe { self.doc_from_heap(ctid, snippet_type.field())? };
         let generator = self.snippet_generators.get(snippet_type)?.as_ref()?;
+        // Resolve once outside the per-snippet loop — the values are constant
+        // for the lifetime of this query execution.
+        let resolved_tags = if let SnippetType::MultipleText(_, config, _, _) = snippet_type {
+            unsafe { Some((config.resolve_start_tag(estate), config.resolve_end_tag(estate))) }
+        } else {
+            None
+        };
         let snippets: Vec<_> = generator
             .snippets(&text)
             .into_iter()
             .flat_map(|mut snippet| {
-                if let SnippetType::MultipleText(_, config, _, _) = snippet_type {
-                    snippet.set_snippet_prefix_postfix(&config.start_tag, &config.end_tag);
+                if let Some((start, end)) = &resolved_tags {
+                    snippet.set_snippet_prefix_postfix(start, end);
                 }
 
                 let html = snippet.to_html();

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -260,16 +260,14 @@ impl BaseScanState {
         &self,
         ctid: u64,
         snippet_type: &SnippetType,
-        estate: *mut pg_sys::EState,
+        resolved_start_tag: &str,
+        resolved_end_tag: &str,
     ) -> Option<String> {
         let text = unsafe { self.doc_from_heap(ctid, snippet_type.field())? };
         let generator = self.snippet_generators.get(snippet_type)?.as_ref()?;
         let mut snippet = generator.snippet(&text);
-        if let SnippetType::SingleText(_, config, _) = snippet_type {
-            // start_tag/end_tag may be parameterized — resolve from EState here.
-            let start_tag = unsafe { config.resolve_start_tag(estate) };
-            let end_tag = unsafe { config.resolve_end_tag(estate) };
-            snippet.set_snippet_prefix_postfix(&start_tag, &end_tag);
+        if matches!(snippet_type, SnippetType::SingleText(_, _, _)) {
+            snippet.set_snippet_prefix_postfix(resolved_start_tag, resolved_end_tag);
         }
 
         let html = snippet.to_html();
@@ -284,23 +282,18 @@ impl BaseScanState {
         &self,
         ctid: u64,
         snippet_type: &SnippetType,
-        estate: *mut pg_sys::EState,
+        resolved_start_tag: &str,
+        resolved_end_tag: &str,
     ) -> Option<Vec<String>> {
         let text = unsafe { self.doc_from_heap(ctid, snippet_type.field())? };
         let generator = self.snippet_generators.get(snippet_type)?.as_ref()?;
-        // Resolve once outside the per-snippet loop — the values are constant
-        // for the lifetime of this query execution.
-        let resolved_tags = if let SnippetType::MultipleText(_, config, _, _) = snippet_type {
-            unsafe { Some((config.resolve_start_tag(estate), config.resolve_end_tag(estate))) }
-        } else {
-            None
-        };
+        let apply_tags = matches!(snippet_type, SnippetType::MultipleText(_, _, _, _));
         let snippets: Vec<_> = generator
             .snippets(&text)
             .into_iter()
             .flat_map(|mut snippet| {
-                if let Some((start, end)) = &resolved_tags {
-                    snippet.set_snippet_prefix_postfix(start, end);
+                if apply_tags {
+                    snippet.set_snippet_prefix_postfix(resolved_start_tag, resolved_end_tag);
                 }
 
                 let html = snippet.to_html();

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -17,8 +17,8 @@
 
 use crate::api::{Cardinality, FieldName, HashSet, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::WhichFastField;
-use crate::postgres::customscan::basescan::privdat::Limit;
 use crate::postgres::customscan::basescan::projections::window_agg::WindowAggregateInfo;
+use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::CustomScan;
 use crate::postgres::options::SortByField;
 use pgrx::{pg_sys, PgList};
@@ -116,13 +116,13 @@ pub enum ExecMethodType {
     Normal,
     TopK {
         heaprelid: pg_sys::Oid,
-        limit: Limit,
+        limit_offset: LimitOffset,
         orderby_info: Option<Vec<OrderByInfo>>,
         window_aggregates: Vec<WindowAggregateInfo>,
     },
     Columnar {
         which_fast_fields: HashSet<WhichFastField>,
-        limit: Option<Limit>,
+        limit_offset: Option<LimitOffset>,
         sort_order: Option<SortByField>,
     },
 }

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -1197,8 +1197,10 @@ impl Default for RelNode {
 pub struct JoinCSClause {
     /// The root of the relational execution tree.
     pub plan: RelNode,
-    /// The LIMIT and OFFSET value from the query, if any.
-    pub limit_offset: LimitOffset,
+    /// The LIMIT and OFFSET value from the query, if any. Held in
+    /// `LimitOffset` form so parameterized values are resolved at execution
+    /// time rather than dropped at planning time.
+    pub limit_offset: Option<LimitOffset>,
     /// Join-level search predicates (Tantivy queries to execute).
     pub join_level_predicates: Vec<JoinLevelSearchPredicate>,
     /// Heap conditions (PostgreSQL expressions referencing both sides).
@@ -1217,7 +1219,7 @@ impl JoinCSClause {
     pub fn new(plan: RelNode) -> Self {
         let mut clause = Self {
             plan,
-            limit_offset: Default::default(),
+            limit_offset: None,
             join_level_predicates: Vec::new(),
             multi_table_predicates: Vec::new(),
             order_by: Vec::new(),
@@ -1231,13 +1233,8 @@ impl JoinCSClause {
         clause
     }
 
-    pub fn with_limit(mut self, limit: Option<u32>) -> Self {
-        self.limit_offset.limit = limit;
-        self
-    }
-
-    pub fn with_offset(mut self, offset: Option<u32>) -> Self {
-        self.limit_offset.offset = offset;
+    pub fn with_limit_offset(mut self, lo: Option<LimitOffset>) -> Self {
+        self.limit_offset = lo;
         self
     }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -178,11 +178,13 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::parallel::compute_nworkers;
+use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::customscan::{CustomScan, JoinPathlistHookArgs};
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::{deserialize_logical_plan_with_runtime, serialize_logical_plan};
+use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
@@ -482,7 +484,7 @@ impl JoinScan {
         plan: &RelNode,
         join_keys: &[build::JoinKeyPair],
         has_distinct: bool,
-    ) -> Result<(JoinCSClause, LimitOffset), JoinDeclineReason> {
+    ) -> Result<(JoinCSClause, Option<LimitOffset>), JoinDeclineReason> {
         let all_sources = plan.sources();
 
         // --- Activation checks ---
@@ -507,10 +509,12 @@ impl JoinScan {
 
         // Require LIMIT for top-level queries (without it, JoinScan's TopK
         // optimization has no bound). Subqueries are exempt because the parent
-        // plan provides the cardinality constraint.
+        // plan provides the cardinality constraint. Either a static or
+        // parameterized LIMIT is sufficient — the latter is resolved at
+        // execution time from EState::es_param_list_info.
         let limit_offset = LimitOffset::from_root(root);
         let is_subquery = !(*root).parent_root.is_null();
-        if limit_offset.limit.is_none() && !is_subquery {
+        if limit_offset.is_none() && !is_subquery {
             return Err(JoinDeclineReason::new(
                 "JoinScan not used: LIMIT is required for top-level queries",
             ));
@@ -578,8 +582,7 @@ impl JoinScan {
         // --- Build JoinCSClause ---
 
         let mut join_clause = JoinCSClause::new(plan.clone())
-            .with_limit(limit_offset.limit)
-            .with_offset(limit_offset.offset)
+            .with_limit_offset(limit_offset.clone())
             .with_distinct(has_distinct);
 
         for source in join_clause.plan.sources_mut() {
@@ -604,7 +607,7 @@ impl JoinScan {
 
         // Safety check: bail out if LIMIT pushdown is unsafe due to
         // un-absorbed relations, un-absorbed SubPlans, or volatile functions.
-        if join_clause.limit_offset.limit.is_some() {
+        if join_clause.limit_offset.is_some() {
             is_limit_pushdown_safe(root, &join_clause)?;
         }
 
@@ -620,7 +623,7 @@ impl JoinScan {
         root: *mut pg_sys::PlannerInfo,
         rel: *mut pg_sys::RelOptInfo,
         mut join_clause: JoinCSClause,
-        limit_offset: &LimitOffset,
+        limit_offset: &Option<LimitOffset>,
         consider_parallel: bool,
     ) -> Option<pg_sys::CustomPath> {
         let output_rtis = join_clause.plan.output_rtis();
@@ -637,7 +640,12 @@ impl JoinScan {
 
         let startup_cost = crate::DEFAULT_STARTUP_COST;
         let total_cost = startup_cost + 1.0;
-        let mut result_rows = limit_offset.limit.map(|l| l as f64).unwrap_or(1000.0);
+        // Parameterized LIMIT/OFFSET still get a planning_estimate so we don't
+        // collapse the worker estimate (issue #4665).
+        let mut result_rows = limit_offset
+            .as_ref()
+            .map(|lo| lo.planning_estimate())
+            .unwrap_or(DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE);
 
         let (segment_count, row_estimate) = {
             let src = join_clause.partitioning_source();
@@ -648,7 +656,7 @@ impl JoinScan {
             let declares_sorted_output = !join_clause.order_by.is_empty();
             compute_nworkers(
                 declares_sorted_output,
-                limit_offset.limit.map(|l| l as f64),
+                limit_offset.as_ref().map(|lo| lo.planning_estimate()),
                 row_estimate,
                 segment_count,
                 false,
@@ -1150,13 +1158,14 @@ impl CustomScan for JoinScan {
             explainer.add_text("Join Predicate", format_join_level_expr(expr, join_clause));
         }
 
-        if let Some(limit) = join_clause.limit_offset.limit {
-            explainer.add_text("Limit", limit.to_string());
-        }
-
-        if let Some(offset) = join_clause.limit_offset.offset {
-            if offset > 0 {
-                explainer.add_text("Offset", offset.to_string());
+        if let Some(lo) = &join_clause.limit_offset {
+            explainer.add_text("Limit", lo.limit.to_string());
+            if let Some(off) = &lo.offset {
+                // Suppress an explicit "0" OFFSET to match prior EXPLAIN output.
+                let suppress = matches!(off, ParameterizedValue::Static(0));
+                if !suppress {
+                    explainer.add_text("Offset", off.to_string());
+                }
             }
         }
 
@@ -1330,6 +1339,32 @@ impl CustomScan for JoinScan {
                     index_segment_ids,
                 )
                 .expect("Failed to deserialize logical plan");
+
+                // For parameterized LIMIT/OFFSET, the planning-time logical
+                // plan has no Limit node. Inject one now (before physical
+                // planning) so SegmentedTopKRule can detect SortExec(fetch=K)
+                // and apply its TopK optimization. Static cases were already
+                // pushed in `build_clause_df`.
+                let needs_runtime_limit = join_clause
+                    .limit_offset
+                    .as_ref()
+                    .map(|lo| !lo.has_static_limit())
+                    .unwrap_or(false);
+                let logical_plan = if needs_runtime_limit {
+                    use datafusion::logical_expr::LogicalPlanBuilder;
+                    let lo = join_clause.limit_offset.as_ref().unwrap();
+                    let estate = state.csstate.ss.ps.state;
+                    let fetch = lo
+                        .fetch(estate)
+                        .expect("LIMIT must be resolvable from EState");
+                    LogicalPlanBuilder::from(logical_plan)
+                        .limit(0, Some(fetch))
+                        .expect("failed to add Limit to logical plan")
+                        .build()
+                        .expect("failed to build logical plan with Limit")
+                } else {
+                    logical_plan
+                };
 
                 // Convert logical plan to physical plan
                 let plan = runtime

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -640,8 +640,6 @@ impl JoinScan {
 
         let startup_cost = crate::DEFAULT_STARTUP_COST;
         let total_cost = startup_cost + 1.0;
-        // Parameterized LIMIT/OFFSET still get a planning_estimate so we don't
-        // collapse the worker estimate (issue #4665).
         let mut result_rows = limit_offset
             .as_ref()
             .map(|lo| lo.planning_estimate())

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1291,7 +1291,7 @@ impl CustomScan for JoinScan {
                 let runtime = tokio::runtime::Builder::new_current_thread()
                     .build()
                     .unwrap();
-                let join_clause = state.custom_state().join_clause.clone();
+                let mut join_clause = state.custom_state().join_clause.clone();
                 let snapshot = state.csstate.ss.ps.state.as_ref().unwrap().es_snapshot;
 
                 let plan_sources = join_clause.plan.sources();
@@ -1346,15 +1346,17 @@ impl CustomScan for JoinScan {
                 let needs_runtime_limit = join_clause
                     .limit_offset
                     .as_ref()
-                    .map(|lo| !lo.has_static_limit())
+                    .map(|lo| lo.has_any_param())
                     .unwrap_or(false);
                 let logical_plan = if needs_runtime_limit {
                     use datafusion::logical_expr::LogicalPlanBuilder;
-                    let lo = join_clause.limit_offset.as_ref().unwrap();
+                    let lo = join_clause.limit_offset.as_mut().unwrap();
                     let estate = state.csstate.ss.ps.state;
                     let fetch = lo
-                        .fetch(estate)
-                        .expect("LIMIT must be resolvable from EState");
+                        .resolve_mut(estate)
+                        .expect("LIMIT must be resolvable from EState")
+                        .static_fetch()
+                        .expect("static_fetch must succeed after resolve_mut");
                     LogicalPlanBuilder::from(logical_plan)
                         .limit(0, Some(fetch))
                         .expect("failed to add Limit to logical plan")

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -639,9 +639,15 @@ fn build_clause_df<'a>(
         // 5. Apply Sort
         let df = apply_sort(df, join_clause, &distinct_col_map)?;
 
-        // 6. Apply Limit
-        let df = if let Some(fetch) = join_clause.limit_offset.fetch() {
-            df.limit(0, Some(fetch))?
+        // 6. Apply Limit (only when the value is statically known at planning
+        // time). Parameterized LIMIT/OFFSET are injected at execution time in
+        // `JoinScan::exec_custom_scan` after `EState` becomes available.
+        let df = if let Some(lo) = &join_clause.limit_offset {
+            if let Some(fetch) = lo.static_fetch() {
+                df.limit(0, Some(fetch))?
+            } else {
+                df
+            }
         } else {
             df
         };

--- a/pg_search/src/postgres/customscan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/limit_offset.rs
@@ -16,75 +16,162 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::nodecast;
+use crate::postgres::customscan::parameterized_value::ParameterizedValue;
+use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 use pgrx::{pg_sys, FromDatum};
 use serde::{Deserialize, Serialize};
 
-/// Parsed LIMIT and OFFSET from a query's parse tree.
+/// LIMIT and OFFSET extracted from a query, with values that may be either
+/// `Const` (resolved at planning time) or extern `Param` (resolved at
+/// execution time from `EState::es_param_list_info`).
 ///
-/// Both fields are `Option<u32>` mirroring PostgreSQL's native representation.
-/// Callers decide how to handle absence — JoinScan bails out when `limit`
-/// is `None`, while AggregateScan proceeds normally.
-#[derive(Default, Debug, Clone, Serialize, Deserialize)]
+/// The struct only exists when a LIMIT clause is present. Callers that need to
+/// represent "no LIMIT" hold an `Option<LimitOffset>` instead.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LimitOffset {
-    pub limit: Option<u32>,
-    pub offset: Option<u32>,
+    pub limit: ParameterizedValue<i64>,
+    pub offset: Option<ParameterizedValue<i64>>,
 }
 
 impl LimitOffset {
     /// Extract LIMIT and OFFSET from the parse tree.
     ///
-    /// Reads `limitCount` and `limitOffset` directly from `parse` as Const nodes.
-    /// Use this for AggregateScan and other callers that don't need `limit_tuples`.
-    pub unsafe fn from_parse(parse: *mut pg_sys::Query) -> Self {
-        Self {
-            limit: extract_const_u32((*parse).limitCount),
-            offset: extract_const_u32((*parse).limitOffset),
+    /// Returns `None` if there is no LIMIT clause. Handles both `Const` and
+    /// extern `Param` nodes (the latter for GENERIC prepared plans).
+    pub unsafe fn from_parse(parse: *mut pg_sys::Query) -> Option<Self> {
+        if parse.is_null() {
+            return None;
         }
+        let limit = ParameterizedValue::<i64>::from_node((*parse).limitCount)?;
+        let offset = ParameterizedValue::<i64>::from_node((*parse).limitOffset);
+        Some(Self { limit, offset })
     }
 
-    /// Extract LIMIT and OFFSET from the planner root.
+    /// Extract LIMIT and OFFSET from the planner root, prefering PG's combined
+    /// `limit_tuples` when available (subtracting any static OFFSET to recover
+    /// the original LIMIT) and otherwise falling back to the parse tree.
     ///
-    /// When `limit_tuples > -1.0`, PostgreSQL has already baked `limit + offset`
-    /// into it. We subtract the offset to recover the true limit value.
-    /// Use this for JoinScan where `limit_tuples` may be set by the planner.
-    pub unsafe fn from_root(root: *mut pg_sys::PlannerInfo) -> Self {
+    /// This mirrors PG's planner intent loosely; callers that need to respect
+    /// `limit_tuples == -1` as a "do not push" signal (e.g., BaseScan beneath
+    /// a GROUP BY) should consult `(*root).limit_tuples` themselves and gate
+    /// usage of the returned `LimitOffset` accordingly.
+    pub unsafe fn from_root(root: *mut pg_sys::PlannerInfo) -> Option<Self> {
+        if root.is_null() {
+            return None;
+        }
         let parse = (*root).parse;
-        let offset = extract_const_u32((*parse).limitOffset);
+        if parse.is_null() {
+            return None;
+        }
 
-        let limit = if (*root).limit_tuples > -1.0 {
-            let combined = (*root).limit_tuples as u32;
-            Some(combined - offset.unwrap_or(0))
-        } else {
-            extract_const_u32((*parse).limitCount)
-        };
+        if (*root).limit_tuples > -1.0 {
+            let limit_pv = ParameterizedValue::<i64>::from_node((*parse).limitCount);
+            let offset_pv = ParameterizedValue::<i64>::from_node((*parse).limitOffset);
 
-        Self { limit, offset }
+            if let (Some(ParameterizedValue::Static(_)), maybe_offset) = (&limit_pv, &offset_pv) {
+                let combined = (*root).limit_tuples as i64;
+                let offset_val = match offset_pv {
+                    Some(ParameterizedValue::Static(o)) => o,
+                    _ => 0,
+                };
+                let limit_val = (combined - offset_val).max(0);
+                return Some(Self {
+                    limit: ParameterizedValue::Static(limit_val),
+                    offset: maybe_offset.clone(),
+                });
+            }
+        }
+
+        Self::from_parse(parse)
     }
 
-    pub fn limit(&self) -> Option<u32> {
-        self.limit
+    /// Returns the static LIMIT value if known at planning time; `None` if
+    /// the LIMIT is parameterized.
+    pub fn static_limit(&self) -> Option<i64> {
+        self.limit.static_value().copied()
     }
 
-    pub fn offset(&self) -> Option<u32> {
+    /// Returns the static OFFSET value if known at planning time; `None` if
+    /// there is no OFFSET or it is parameterized.
+    pub fn static_offset(&self) -> Option<i64> {
+        self.offset.as_ref().and_then(|o| o.static_value()).copied()
+    }
+
+    /// Returns true if both LIMIT and OFFSET (or just LIMIT, if no OFFSET) are
+    /// known at planning time.
+    pub fn has_static_limit(&self) -> bool {
+        self.static_limit().is_some()
+    }
+
+    /// Returns true if either LIMIT or OFFSET is a Param (i.e., this came from
+    /// a GENERIC prepared plan where PG couldn't fold the value to a Const).
+    pub fn has_any_param(&self) -> bool {
+        matches!(self.limit, ParameterizedValue::Param { .. })
+            || self
+                .offset
+                .as_ref()
+                .is_some_and(|o| matches!(o, ParameterizedValue::Param { .. }))
+    }
+
+    /// Resolves the LIMIT at execution time. Returns `None` if the value
+    /// cannot be resolved (null param, missing param list).
+    pub unsafe fn resolve_limit(&self, estate: *mut pg_sys::EState) -> Option<usize> {
+        self.limit.resolve(estate).map(|v| v.max(0) as usize)
+    }
+
+    /// Resolves the OFFSET at execution time. Returns 0 when there is no
+    /// OFFSET clause or the resolved value is null.
+    pub unsafe fn resolve_offset(&self, estate: *mut pg_sys::EState) -> usize {
         self.offset
+            .as_ref()
+            .and_then(|o| o.resolve(estate))
+            .map(|v| v.max(0) as usize)
+            .unwrap_or(0)
     }
 
-    /// Returns limit + offset as usize, which is the total number of rows DataFusion
-    /// must produce before PostgreSQL's outer Limit node applies the skip.
-    pub fn fetch(&self) -> Option<usize> {
-        self.limit.map(|l| (l + self.offset.unwrap_or(0)) as usize)
+    /// Returns `LIMIT + OFFSET` resolved at execution time. This is the number
+    /// of rows our scan must produce so PostgreSQL's outer Limit node has
+    /// enough rows to apply OFFSET and return LIMIT.
+    pub unsafe fn fetch(&self, estate: *mut pg_sys::EState) -> Option<usize> {
+        self.resolve_limit(estate)
+            .map(|l| l + self.resolve_offset(estate))
+    }
+
+    /// Returns `LIMIT + OFFSET` only when both are statically known. Used at
+    /// planning time by callers that need a value usable in serializable
+    /// guards (e.g., aggregate bucket-limit checks). Returns `None` when
+    /// either side is parameterized — those values must be resolved at
+    /// execution time via `fetch(estate)`.
+    pub fn static_fetch(&self) -> Option<usize> {
+        let limit = self.static_limit()?;
+        // If an OFFSET clause exists, it MUST be statically known too;
+        // otherwise we cannot compute the fetch count without an EState.
+        let offset = match &self.offset {
+            None => 0,
+            Some(_) => self.static_offset()?,
+        };
+        Some((limit + offset).max(0) as usize)
+    }
+
+    /// Planning-time row estimate. Uses static values when available, falls
+    /// back to `DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE` for parameterized values.
+    pub fn planning_estimate(&self) -> f64 {
+        let limit = self
+            .static_limit()
+            .map(|v| v as f64)
+            .unwrap_or(DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE);
+        let offset = self.static_offset().map(|v| v as f64).unwrap_or(0.0);
+        limit + offset
     }
 }
 
-/// Extract a `Const` node's value as `u32`.
-/// Returns `None` if the node is null, not a Const, or the datum is null.
-pub unsafe fn extract_const_u32(node: *mut pg_sys::Node) -> Option<u32> {
-    let const_node = nodecast!(Const, T_Const, node)?;
-    u32::from_datum((*const_node).constvalue, (*const_node).constisnull)
-}
-
-/// Extract a `Const` node's value as `i64`.
-/// Returns `None` if the node is null, not a Const, or the datum is null.
+/// Extract a `Const` node's value as `i64`. Returns `None` if the node is null,
+/// not a `Const`, or the datum is null.
+///
+/// Retained for callers that intentionally reject non-Const inputs (e.g.,
+/// `is_minmax_implicit_limit`, which only matches PG's MIN/MAX rewrite where
+/// the LIMIT 1 is always a Const).
+#[allow(dead_code)]
 pub unsafe fn extract_const_i64(node: *mut pg_sys::Node) -> Option<i64> {
     let const_node = nodecast!(Const, T_Const, node)?;
     i64::from_datum((*const_node).constvalue, (*const_node).constisnull)

--- a/pg_search/src/postgres/customscan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/limit_offset.rs
@@ -15,10 +15,9 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::nodecast;
 use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
-use pgrx::{pg_sys, FromDatum};
+use pgrx::pg_sys;
 use serde::{Deserialize, Serialize};
 
 /// LIMIT and OFFSET extracted from a query, with values that may be either
@@ -106,11 +105,7 @@ impl LimitOffset {
     /// Returns true if either LIMIT or OFFSET is a Param (i.e., this came from
     /// a GENERIC prepared plan where PG couldn't fold the value to a Const).
     pub fn has_any_param(&self) -> bool {
-        matches!(self.limit, ParameterizedValue::Param { .. })
-            || self
-                .offset
-                .as_ref()
-                .is_some_and(|o| matches!(o, ParameterizedValue::Param { .. }))
+        self.limit.is_param() || self.offset.as_ref().is_some_and(|o| o.is_param())
     }
 
     /// Resolves the LIMIT at execution time. Returns `None` if the value
@@ -165,14 +160,3 @@ impl LimitOffset {
     }
 }
 
-/// Extract a `Const` node's value as `i64`. Returns `None` if the node is null,
-/// not a `Const`, or the datum is null.
-///
-/// Retained for callers that intentionally reject non-Const inputs (e.g.,
-/// `is_minmax_implicit_limit`, which only matches PG's MIN/MAX rewrite where
-/// the LIMIT 1 is always a Const).
-#[allow(dead_code)]
-pub unsafe fn extract_const_i64(node: *mut pg_sys::Node) -> Option<i64> {
-    let const_node = nodecast!(Const, T_Const, node)?;
-    i64::from_datum((*const_node).constvalue, (*const_node).constisnull)
-}

--- a/pg_search/src/postgres/customscan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/limit_offset.rs
@@ -24,8 +24,18 @@ use serde::{Deserialize, Serialize};
 /// `Const` (resolved at planning time) or extern `Param` (resolved at
 /// execution time from `EState::es_param_list_info`).
 ///
-/// The struct only exists when a LIMIT clause is present. Callers that need to
-/// represent "no LIMIT" hold an `Option<LimitOffset>` instead.
+/// The struct only exists when a LIMIT clause is present — callers hold
+/// `Option<LimitOffset>` to represent "no LIMIT".
+///
+/// # Resolution patterns
+///
+/// - **Exec method init (TopK, Columnar, JoinScan):** call `resolve_mut(estate)`
+///   once, then use `static_fetch()` / `limit.static_value()` freely.
+/// - **Planning time cost math:** call `planning_estimate()` — returns a
+///   real value for Static, a default (1000.0) for Param.
+/// - **Planning time guards:** call `has_any_param()` and `static_fetch()`.
+/// - **Immutable context (snippets):** call `resolve(estate)` — clones on
+///   each call, acceptable when dominated by heavier per-row work.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LimitOffset {
     pub limit: ParameterizedValue<i64>,
@@ -84,78 +94,63 @@ impl LimitOffset {
         Self::from_parse(parse)
     }
 
-    /// Returns the static LIMIT value if known at planning time; `None` if
-    /// the LIMIT is parameterized.
-    pub fn static_limit(&self) -> Option<i64> {
-        self.limit.static_value().copied()
-    }
-
-    /// Returns the static OFFSET value if known at planning time; `None` if
-    /// there is no OFFSET or it is parameterized.
-    pub fn static_offset(&self) -> Option<i64> {
-        self.offset.as_ref().and_then(|o| o.static_value()).copied()
-    }
-
-    /// Returns true if both LIMIT and OFFSET (or just LIMIT, if no OFFSET) are
-    /// known at planning time.
-    pub fn has_static_limit(&self) -> bool {
-        self.static_limit().is_some()
-    }
-
     /// Returns true if either LIMIT or OFFSET is a Param (i.e., this came from
     /// a GENERIC prepared plan where PG couldn't fold the value to a Const).
     pub fn has_any_param(&self) -> bool {
         self.limit.is_param() || self.offset.as_ref().is_some_and(|o| o.is_param())
     }
 
-    /// Resolves the LIMIT at execution time. Returns `None` if the value
-    /// cannot be resolved (null param, missing param list).
-    pub unsafe fn resolve_limit(&self, estate: *mut pg_sys::EState) -> Option<usize> {
-        self.limit.resolve(estate).map(|v| v.max(0) as usize)
-    }
-
-    /// Resolves the OFFSET at execution time. Returns 0 when there is no
-    /// OFFSET clause or the resolved value is null.
-    pub unsafe fn resolve_offset(&self, estate: *mut pg_sys::EState) -> usize {
-        self.offset
-            .as_ref()
-            .and_then(|o| o.resolve(estate))
-            .map(|v| v.max(0) as usize)
-            .unwrap_or(0)
-    }
-
-    /// Returns `LIMIT + OFFSET` resolved at execution time. This is the number
-    /// of rows our scan must produce so PostgreSQL's outer Limit node has
-    /// enough rows to apply OFFSET and return LIMIT.
-    pub unsafe fn fetch(&self, estate: *mut pg_sys::EState) -> Option<usize> {
-        self.resolve_limit(estate)
-            .map(|l| l + self.resolve_offset(estate))
-    }
-
     /// Returns `LIMIT + OFFSET` only when both are statically known. Used at
-    /// planning time by callers that need a value usable in serializable
-    /// guards (e.g., aggregate bucket-limit checks). Returns `None` when
-    /// either side is parameterized — those values must be resolved at
-    /// execution time via `fetch(estate)`.
+    /// planning time and as the chained call after `resolve_mut` to read the
+    /// now-static sum.
     pub fn static_fetch(&self) -> Option<usize> {
-        let limit = self.static_limit()?;
-        // If an OFFSET clause exists, it MUST be statically known too;
-        // otherwise we cannot compute the fetch count without an EState.
+        let limit = *self.limit.static_value()? as usize;
         let offset = match &self.offset {
             None => 0,
-            Some(_) => self.static_offset()?,
+            Some(o) => *o.static_value()? as usize,
         };
-        Some((limit + offset).max(0) as usize)
+        Some(limit.saturating_add(offset))
     }
 
     /// Planning-time row estimate. Uses static values when available, falls
     /// back to `DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE` for parameterized values.
     pub fn planning_estimate(&self) -> f64 {
         let limit = self
-            .static_limit()
-            .map(|v| v as f64)
+            .limit
+            .static_value()
+            .map(|v| *v as f64)
             .unwrap_or(DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE);
-        let offset = self.static_offset().map(|v| v as f64).unwrap_or(0.0);
+        let offset = self
+            .offset
+            .as_ref()
+            .and_then(|o| o.static_value())
+            .map(|v| *v as f64)
+            .unwrap_or(0.0);
         limit + offset
+    }
+
+    /// Returns `LIMIT + OFFSET` resolved at execution time. This is the number
+    /// of rows our scan must produce so PostgreSQL's outer Limit node has
+    /// enough rows to apply OFFSET and return LIMIT.
+    pub unsafe fn resolve(&self, estate: *mut pg_sys::EState) -> Option<usize> {
+        let limit = self.limit.resolve(estate)?.max(0) as usize;
+        let offset = self
+            .offset
+            .as_ref()
+            .and_then(|o| o.resolve(estate))
+            .map(|v| v.max(0) as usize)
+            .unwrap_or(0);
+        Some(limit + offset)
+    }
+
+    /// Resolve both LIMIT and OFFSET `Param`s to `Static` in place. Returns
+    /// `&mut Self` on success so callers can chain `.static_fetch()` to read
+    /// the now-static sum.
+    pub unsafe fn resolve_mut(&mut self, estate: *mut pg_sys::EState) -> Option<&mut Self> {
+        self.limit.resolve_mut(estate)?;
+        if let Some(ref mut o) = self.offset {
+            o.resolve_mut(estate);
+        }
+        Some(self)
     }
 }

--- a/pg_search/src/postgres/customscan/limit_offset.rs
+++ b/pg_search/src/postgres/customscan/limit_offset.rs
@@ -46,7 +46,7 @@ impl LimitOffset {
         Some(Self { limit, offset })
     }
 
-    /// Extract LIMIT and OFFSET from the planner root, prefering PG's combined
+    /// Extract LIMIT and OFFSET from the planner root, preferring PG's combined
     /// `limit_tuples` when available (subtracting any static OFFSET to recover
     /// the original LIMIT) and otherwise falling back to the parse tree.
     ///
@@ -159,4 +159,3 @@ impl LimitOffset {
         limit + offset
     }
 }
-

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -42,6 +42,7 @@ pub mod mpp;
 pub mod opexpr;
 pub mod orderby;
 pub mod parallel;
+pub mod parameterized_value;
 mod path;
 pub(crate) mod pg_expr_udf;
 pub mod projections;

--- a/pg_search/src/postgres/customscan/parameterized_value.rs
+++ b/pg_search/src/postgres/customscan/parameterized_value.rs
@@ -26,6 +26,7 @@ use crate::nodecast;
 use pgrx::{pg_sys, FromDatum, PgList};
 use serde::{Deserialize, Serialize};
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ParameterizedValue<T>
@@ -105,6 +106,39 @@ where
         match self {
             ParameterizedValue::Static(v) => Some(v),
             _ => None,
+        }
+    }
+}
+
+// Manual Hash/Eq/PartialEq impls (rather than `derive`) so each trait bound is
+// only required when the concrete `T` actually needs it. Several callers store
+// `ParameterizedValue<T>` inside a `HashMap` key (e.g., snippet configs in
+// `SnippetType`), so this is required for the type to be usable in those
+// contexts. Two `Param { param_id: N }` values compare equal regardless of T,
+// because the param ID is the only identity at planning time.
+impl<T: Clone + PartialEq> PartialEq for ParameterizedValue<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Static(a), Self::Static(b)) => a == b,
+            (Self::Param { param_id: a }, Self::Param { param_id: b }) => a == b,
+            _ => false,
+        }
+    }
+}
+
+impl<T: Clone + Eq> Eq for ParameterizedValue<T> {}
+
+impl<T: Clone + Hash> Hash for ParameterizedValue<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Static(v) => {
+                0u8.hash(state);
+                v.hash(state);
+            }
+            Self::Param { param_id } => {
+                1u8.hash(state);
+                param_id.hash(state);
+            }
         }
     }
 }

--- a/pg_search/src/postgres/customscan/parameterized_value.rs
+++ b/pg_search/src/postgres/customscan/parameterized_value.rs
@@ -1,0 +1,143 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! A value that is either known at planning time (a SQL `Const`) or deferred to
+//! execution time (a SQL `Param` extracted from `EState::es_param_list_info`).
+//!
+//! Used for LIMIT and OFFSET so that GENERIC prepared plans (where Params survive
+//! into the planner) and CUSTOM prepared plans (where Params are folded to Consts
+//! before planning) produce equivalent results.
+
+use crate::nodecast;
+use pgrx::{pg_sys, FromDatum, PgList};
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ParameterizedValue<T>
+where
+    T: Clone,
+{
+    Static(T),
+    Param { param_id: i32 },
+}
+
+impl<T> fmt::Display for ParameterizedValue<T>
+where
+    T: Clone + fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ParameterizedValue::Static(v) => write!(f, "{v}"),
+            ParameterizedValue::Param { param_id } => write!(f, "${param_id}"),
+        }
+    }
+}
+
+impl<T> ParameterizedValue<T>
+where
+    T: Clone + FromDatum,
+{
+    /// Extract a `ParameterizedValue<T>` from a Postgres expression node.
+    ///
+    /// Returns `None` if the node is null or cannot be interpreted as either
+    /// a `Const` of type `T` or an extern `Param`.
+    ///
+    /// Recurses through `FuncExpr` (single arg), `RelabelType`, and
+    /// `CoerceViaIO` wrappers — these are commonly inserted by the parser
+    /// around LIMIT/OFFSET expressions for type coercion.
+    pub unsafe fn from_node(node: *mut pg_sys::Node) -> Option<Self> {
+        if node.is_null() {
+            return None;
+        }
+
+        if let Some(const_node) = nodecast!(Const, T_Const, node) {
+            let value = T::from_datum((*const_node).constvalue, (*const_node).constisnull)?;
+            return Some(ParameterizedValue::Static(value));
+        }
+
+        unwrap_to_extern_param_id(node).map(|param_id| ParameterizedValue::Param { param_id })
+    }
+
+    /// Resolve at execution time using the executor's parameter list.
+    ///
+    /// `Static(v)` returns `Some(v.clone())`.
+    /// `Param { param_id }` looks up `estate.es_param_list_info.params[param_id - 1]`.
+    /// Returns `None` if the parameter is null or out of range.
+    pub unsafe fn resolve(&self, estate: *mut pg_sys::EState) -> Option<T> {
+        match self {
+            ParameterizedValue::Static(v) => Some(v.clone()),
+            ParameterizedValue::Param { param_id } => {
+                if estate.is_null() {
+                    return None;
+                }
+                let param_list = (*estate).es_param_list_info;
+                if param_list.is_null() {
+                    return None;
+                }
+                let num_params = (*param_list).numParams as usize;
+                let idx = (*param_id - 1) as usize;
+                if idx >= num_params {
+                    return None;
+                }
+                let param_data = &(*param_list).params.as_slice(num_params)[idx];
+                T::from_datum(param_data.value, param_data.isnull)
+            }
+        }
+    }
+
+    /// Returns the static value if this is `Static`, otherwise `None`.
+    pub fn static_value(&self) -> Option<&T> {
+        match self {
+            ParameterizedValue::Static(v) => Some(v),
+            _ => None,
+        }
+    }
+}
+
+/// Walk through commonly-inserted coercion wrappers to find an extern Param's
+/// `paramid`. Returns `None` if the node is not (or does not wrap) a Param of
+/// kind `PARAM_EXTERN`.
+pub unsafe fn unwrap_to_extern_param_id(node: *mut pg_sys::Node) -> Option<i32> {
+    if node.is_null() {
+        return None;
+    }
+
+    if let Some(param) = nodecast!(Param, T_Param, node) {
+        if (*param).paramkind == pg_sys::ParamKind::PARAM_EXTERN {
+            return Some((*param).paramid);
+        }
+        return None;
+    }
+
+    if let Some(func_expr) = nodecast!(FuncExpr, T_FuncExpr, node) {
+        let args = PgList::<pg_sys::Node>::from_pg((*func_expr).args);
+        if args.len() == 1 {
+            return unwrap_to_extern_param_id(args.get_ptr(0).unwrap());
+        }
+    }
+
+    if let Some(relabel) = nodecast!(RelabelType, T_RelabelType, node) {
+        return unwrap_to_extern_param_id((*relabel).arg.cast());
+    }
+
+    if let Some(coerce) = nodecast!(CoerceViaIO, T_CoerceViaIO, node) {
+        return unwrap_to_extern_param_id((*coerce).arg.cast());
+    }
+
+    None
+}

--- a/pg_search/src/postgres/customscan/parameterized_value.rs
+++ b/pg_search/src/postgres/customscan/parameterized_value.rs
@@ -108,6 +108,11 @@ where
             _ => None,
         }
     }
+
+    /// Returns true if this value is a `Param` (deferred to execution time).
+    pub fn is_param(&self) -> bool {
+        matches!(self, ParameterizedValue::Param { .. })
+    }
 }
 
 // Manual Hash/Eq/PartialEq impls (rather than `derive`) so each trait bound is

--- a/pg_search/src/postgres/customscan/parameterized_value.rs
+++ b/pg_search/src/postgres/customscan/parameterized_value.rs
@@ -15,12 +15,45 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! A value that is either known at planning time (a SQL `Const`) or deferred to
-//! execution time (a SQL `Param` extracted from `EState::es_param_list_info`).
+//! A value that is either known at planning time (a SQL `Const`) or deferred
+//! to execution time (a SQL `Param` from `EState::es_param_list_info`).
 //!
-//! Used for LIMIT and OFFSET so that GENERIC prepared plans (where Params survive
-//! into the planner) and CUSTOM prepared plans (where Params are folded to Consts
-//! before planning) produce equivalent results.
+//! # When to use which method
+//!
+//! | Situation | Method | Why |
+//! |-----------|--------|-----|
+//! | You own the value (`&mut self`) and will read it again later | `resolve_mut` | Converts Param → Static in place. All subsequent reads are zero-cost borrows. |
+//! | You don't own the value (HashMap key, shared reference) | `resolve` | Returns an owned clone. Costs a heap alloc for String/complex types per call. |
+//! | Planning time only, need the value if it's known | `static_value` | No EState needed. Returns `None` for Params — use `planning_estimate()` on `LimitOffset` for cost math. |
+//!
+//! # Rules of thumb
+//!
+//! 1. **Prefer `resolve_mut` in exec method `init()`.** TopK, Columnar,
+//!    and JoinScan all have `&mut` access to their `LimitOffset`. Call
+//!    `resolve_mut` once during init — every later access (EXPLAIN,
+//!    iteration, batch sizing) gets the cached Static value for free.
+//!
+//! 2. **Use `resolve` only when `&mut` is unavailable.** The main case
+//!    is `SnippetType` used as a HashMap key — you can't mutate a key.
+//!    For everything else, prefer `resolve_mut`.
+//!
+//! 3. **Never call `resolve` in a per-tuple loop if you can help it.**
+//!    For types like `String`, each call clones. If you're in a loop,
+//!    either resolve once before the loop, or restructure so `resolve_mut`
+//!    is viable.
+//!
+//! 4. **At planning time, don't try to resolve Params.** There's no
+//!    EState yet. Use `static_value()` / `static_fetch()` and handle
+//!    the `None` case (parameterized) with a fallback like
+//!    `planning_estimate()`.
+//!
+//! 5. **Watch out for `nodecast!(Const, T_Const, ...)` in new code.**
+//!    If you're extracting a value from a PG expression node at planning
+//!    time, ask: "will this work in GENERIC mode?" If the node could be a
+//!    `Param`, use `ParameterizedValue::from_node` instead of `nodecast!`.
+//!    If you genuinely need a compile-time constant (like
+//!    `is_minmax_implicit_limit` checking for PG's `LIMIT 1` rewrite),
+//!    `nodecast!` is correct — document why.
 
 use crate::nodecast;
 use pgrx::{pg_sys, FromDatum, PgList};
@@ -112,6 +145,22 @@ where
     /// Returns true if this value is a `Param` (deferred to execution time).
     pub fn is_param(&self) -> bool {
         matches!(self, ParameterizedValue::Param { .. })
+    }
+
+    /// Resolve and convert `Param` → `Static` in place. Returns `&T`.
+    ///
+    /// On first call for a `Param`, resolves from `EState` and replaces
+    /// `self` with `Static(value)`. Subsequent calls hit the static path
+    /// at zero cost. Use this when `&mut self` is available (TopK,
+    /// Columnar, JoinScan). Snippet configs use `resolve()` instead
+    /// because `SnippetType` is a `HashMap` key and only `&self` is
+    /// available there.
+    pub unsafe fn resolve_mut(&mut self, estate: *mut pg_sys::EState) -> Option<&T> {
+        if self.is_param() {
+            let value = self.resolve(estate)?;
+            *self = ParameterizedValue::Static(value);
+        }
+        self.static_value()
     }
 }
 

--- a/pg_search/src/postgres/customscan/parameterized_value.rs
+++ b/pg_search/src/postgres/customscan/parameterized_value.rs
@@ -151,7 +151,7 @@ impl<T: Clone + Hash> Hash for ParameterizedValue<T> {
 /// Walk through commonly-inserted coercion wrappers to find an extern Param's
 /// `paramid`. Returns `None` if the node is not (or does not wrap) a Param of
 /// kind `PARAM_EXTERN`.
-pub unsafe fn unwrap_to_extern_param_id(node: *mut pg_sys::Node) -> Option<i32> {
+unsafe fn unwrap_to_extern_param_id(node: *mut pg_sys::Node) -> Option<i32> {
     if node.is_null() {
         return None;
     }

--- a/pg_search/tests/pg_regress/expected/custom-agg.out
+++ b/pg_search/tests/pg_regress/expected/custom-agg.out
@@ -2311,3 +2311,69 @@ SELECT
 (2 rows)
 
 DROP TABLE test_window_order;
+-- =====================================================================
+-- Parameterized pdb.agg() (issue: panic on 6th EXECUTE)
+--
+-- Pre-fix: pdb.agg() requires a Const JSON spec at planning time so the
+-- AggregateScan can build the Tantivy aggregation plan. In GENERIC plan
+-- mode (the 6th+ EXECUTE), the Param survived into the planner and the
+-- extractor panicked with "pdb.agg argument must be a constant",
+-- crashing the backend.
+--
+-- Post-fix: AggregateScan declines pushdown via Err (NOTICE emitted),
+-- and PostgreSQL falls back to the placeholder pdb.agg which returns a
+-- normal SQL error. The contract this test enforces is "no backend
+-- crash" — the connection survives and a follow-up query works.
+-- =====================================================================
+\echo '--- Parameterized pdb.agg() must not crash the backend ---'
+--- Parameterized pdb.agg() must not crash the backend ---
+CREATE TABLE agg_param_test (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+INSERT INTO agg_param_test (description, category)
+SELECT 'document ' || i, (ARRAY['a','b','c'])[1 + (i % 3)]
+FROM generate_series(1, 100) AS i;
+CREATE INDEX agg_param_test_idx ON agg_param_test
+USING bm25 (id, description, category)
+WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
+-- Baseline: constant JSON literal pushes through AggregateScan.
+SELECT pdb.agg('{"terms":{"field":"category"}}'::jsonb) IS NOT NULL AS got_result
+FROM agg_param_test
+WHERE description ||| 'document';
+ got_result 
+------------
+ t
+(1 row)
+
+-- GENERIC plan with parameterized JSON. Run several times to land on the
+-- generic plan (PG switches to GENERIC after the 5th execute by default
+-- under `force_generic_plan` it is immediate). The query is expected to
+-- ERROR (XX000 from the placeholder), but the backend must stay alive.
+SET plan_cache_mode = force_generic_plan;
+PREPARE agg_param_g(jsonb) AS
+SELECT pdb.agg($1)
+FROM agg_param_test
+WHERE description ||| 'document';
+\set VERBOSITY terse
+SELECT 'expecting error from placeholder pdb.agg in GENERIC mode:';
+                         ?column?                          
+-----------------------------------------------------------
+ expecting error from placeholder pdb.agg in GENERIC mode:
+(1 row)
+
+EXECUTE agg_param_g('{"terms":{"field":"category"}}');
+WARNING:  Aggregate Scan not used: pdb.agg argument must be a constant for aggregate pushdown (table: agg_param_test)
+ERROR:  pdb.agg() must be handled by ParadeDB's custom scan. This error usually means the query syntax is not supported. Try adding '@@@ pdb.all()' to your WHERE clause to force custom scan usage, or file an issue at https://github.com/paradedb/paradedb/issues if this should be supported.
+\set VERBOSITY default
+-- Sanity check: backend is still alive.
+SELECT 1 AS backend_still_alive;
+ backend_still_alive 
+---------------------
+                   1
+(1 row)
+
+DEALLOCATE agg_param_g;
+RESET plan_cache_mode;
+DROP TABLE agg_param_test;

--- a/pg_search/tests/pg_regress/expected/issue_4665.out
+++ b/pg_search/tests/pg_regress/expected/issue_4665.out
@@ -214,6 +214,119 @@ EXECUTE issue_4665_generic_plim('technology', 10);
 (10 rows)
 
 DEALLOCATE issue_4665_generic_plim;
+-- ============================================================================
+-- Parameterized OFFSET: LIMIT 5 OFFSET $2 in both modes (must match)
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+PREPARE issue_4665_off_custom(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 5 OFFSET $2;
+EXECUTE issue_4665_off_custom('technology', 5);
+  id  
+------
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(5 rows)
+
+DEALLOCATE issue_4665_off_custom;
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_4665_off_generic(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 5 OFFSET $2;
+EXECUTE issue_4665_off_generic('technology', 5);
+  id  
+------
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(5 rows)
+
+DEALLOCATE issue_4665_off_generic;
+-- ============================================================================
+-- Parameterized LIMIT + OFFSET: LIMIT $2 OFFSET $3 in both modes (must match)
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+PREPARE issue_4665_both_custom(text, int, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET $3;
+EXECUTE issue_4665_both_custom('technology', 5, 5);
+  id  
+------
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(5 rows)
+
+DEALLOCATE issue_4665_both_custom;
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_4665_both_generic(text, int, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET $3;
+EXECUTE issue_4665_both_generic('technology', 5, 5);
+  id  
+------
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(5 rows)
+
+DEALLOCATE issue_4665_both_generic;
+-- ============================================================================
+-- Parameterized LIMIT + Const OFFSET: LIMIT $2 OFFSET 5
+-- The pre-fix bug: GENERIC mode returned 0 rows because TopK fetched only
+-- LIMIT rows and then PG's outer Limit OFFSET 5 skipped all of them.
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+PREPARE issue_4665_plimcoff_custom(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET 5;
+EXECUTE issue_4665_plimcoff_custom('technology', 5);
+  id  
+------
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(5 rows)
+
+DEALLOCATE issue_4665_plimcoff_custom;
+SET plan_cache_mode = force_generic_plan;
+PREPARE issue_4665_plimcoff_generic(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET 5;
+EXECUTE issue_4665_plimcoff_generic('technology', 5);
+  id  
+------
+ 5028
+ 5034
+ 5040
+ 5046
+ 5052
+(5 rows)
+
+DEALLOCATE issue_4665_plimcoff_generic;
 -- Cleanup
 DROP TABLE issue_4665_test CASCADE;
 RESET max_parallel_workers_per_gather;

--- a/pg_search/tests/pg_regress/expected/issue_4665.out
+++ b/pg_search/tests/pg_regress/expected/issue_4665.out
@@ -215,23 +215,23 @@ EXECUTE issue_4665_generic_plim('technology', 10);
 
 DEALLOCATE issue_4665_generic_plim;
 -- ============================================================================
--- Parameterized OFFSET: LIMIT 5 OFFSET $2 in both modes (must match)
+-- Parameterized OFFSET: LIMIT 3 OFFSET $2 in both modes (must match).
+-- OFFSET 7 > LIMIT 3 so the pre-fix TopK-undercount bug returns 0 rows
+-- unambiguously.
 -- ============================================================================
 SET plan_cache_mode = force_custom_plan;
 PREPARE issue_4665_off_custom(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT 5 OFFSET $2;
-EXECUTE issue_4665_off_custom('technology', 5);
+LIMIT 3 OFFSET $2;
+EXECUTE issue_4665_off_custom('technology', 7);
   id  
 ------
- 5028
- 5034
  5040
  5046
  5052
-(5 rows)
+(3 rows)
 
 DEALLOCATE issue_4665_off_custom;
 SET plan_cache_mode = force_generic_plan;
@@ -239,16 +239,14 @@ PREPARE issue_4665_off_generic(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT 5 OFFSET $2;
-EXECUTE issue_4665_off_generic('technology', 5);
+LIMIT 3 OFFSET $2;
+EXECUTE issue_4665_off_generic('technology', 7);
   id  
 ------
- 5028
- 5034
  5040
  5046
  5052
-(5 rows)
+(3 rows)
 
 DEALLOCATE issue_4665_off_generic;
 -- ============================================================================
@@ -260,15 +258,13 @@ SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
 LIMIT $2 OFFSET $3;
-EXECUTE issue_4665_both_custom('technology', 5, 5);
+EXECUTE issue_4665_both_custom('technology', 3, 7);
   id  
 ------
- 5028
- 5034
  5040
  5046
  5052
-(5 rows)
+(3 rows)
 
 DEALLOCATE issue_4665_both_custom;
 SET plan_cache_mode = force_generic_plan;
@@ -277,37 +273,33 @@ SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
 LIMIT $2 OFFSET $3;
-EXECUTE issue_4665_both_generic('technology', 5, 5);
+EXECUTE issue_4665_both_generic('technology', 3, 7);
   id  
 ------
- 5028
- 5034
  5040
  5046
  5052
-(5 rows)
+(3 rows)
 
 DEALLOCATE issue_4665_both_generic;
 -- ============================================================================
--- Parameterized LIMIT + Const OFFSET: LIMIT $2 OFFSET 5
+-- Parameterized LIMIT + Const OFFSET: LIMIT $2 OFFSET 7
 -- The pre-fix bug: GENERIC mode returned 0 rows because TopK fetched only
--- LIMIT rows and then PG's outer Limit OFFSET 5 skipped all of them.
+-- LIMIT (=3) rows and then PG's outer Limit OFFSET 7 skipped all of them.
 -- ============================================================================
 SET plan_cache_mode = force_custom_plan;
 PREPARE issue_4665_plimcoff_custom(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT $2 OFFSET 5;
-EXECUTE issue_4665_plimcoff_custom('technology', 5);
+LIMIT $2 OFFSET 7;
+EXECUTE issue_4665_plimcoff_custom('technology', 3);
   id  
 ------
- 5028
- 5034
  5040
  5046
  5052
-(5 rows)
+(3 rows)
 
 DEALLOCATE issue_4665_plimcoff_custom;
 SET plan_cache_mode = force_generic_plan;
@@ -315,16 +307,14 @@ PREPARE issue_4665_plimcoff_generic(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT $2 OFFSET 5;
-EXECUTE issue_4665_plimcoff_generic('technology', 5);
+LIMIT $2 OFFSET 7;
+EXECUTE issue_4665_plimcoff_generic('technology', 3);
   id  
 ------
- 5028
- 5034
  5040
  5046
  5052
-(5 rows)
+(3 rows)
 
 DEALLOCATE issue_4665_plimcoff_generic;
 -- Cleanup

--- a/pg_search/tests/pg_regress/expected/snippets.out
+++ b/pg_search/tests/pg_regress/expected/snippets.out
@@ -233,5 +233,121 @@ SELECT id, pdb.snippets(content, max_num_chars => 20, sort_by => 'position') FRO
 -- Test with an invalid sort_by value
 SELECT id, pdb.snippets(content, sort_by => 'invalid') FROM snippets_test WHERE content @@@ 'lazy' AND id = 1;
 ERROR:  invalid sort_by value for pdb.snippets: must be 'score' or 'position'
+-- =====================================================================
+-- Parameterized snippet arguments (issue: snippet panics on 6th EXECUTE)
+--
+-- Pre-fix: every formatting argument (start_tag, end_tag, max_num_chars,
+-- limit, offset, sort_by) had to be a Const. In GENERIC plan mode (the
+-- 6th+ EXECUTE of a prepared statement), Params survive into the planner
+-- and the snippet extractor panicked with "arguments must be literals".
+--
+-- We exercise both CUSTOM and GENERIC modes against the same table so
+-- the expected output proves they produce identical results.
+-- =====================================================================
+\echo '--- Parameterized snippet arguments (CUSTOM vs GENERIC) ---'
+--- Parameterized snippet arguments (CUSTOM vs GENERIC) ---
+-- pdb.snippet with parameterized start_tag and end_tag
+SET plan_cache_mode = force_custom_plan;
+PREPARE snip_param_c(text, text, text) AS
+SELECT id, pdb.snippet(content, $2, $3)
+FROM snippets_test
+WHERE content @@@ $1
+ORDER BY id;
+EXECUTE snip_param_c('lazy', '[', ']');
+ id |                                         snippet                                         
+----+-----------------------------------------------------------------------------------------
+  1 | The quick brown fox jumps over the [lazy] dog. The dog is very [lazy]. The fox is quick
+  2 | A [lazy] dog is a happy dog. Dogs are the best, especially a [lazy] one
+  5 | The [lazy] brown dog, and the quick red fox. The dog and fox are here
+(3 rows)
+
+DEALLOCATE snip_param_c;
+SET plan_cache_mode = force_generic_plan;
+PREPARE snip_param_g(text, text, text) AS
+SELECT id, pdb.snippet(content, $2, $3)
+FROM snippets_test
+WHERE content @@@ $1
+ORDER BY id;
+EXECUTE snip_param_g('lazy', '[', ']');
+ id |                                         snippet                                         
+----+-----------------------------------------------------------------------------------------
+  1 | The quick brown fox jumps over the [lazy] dog. The dog is very [lazy]. The fox is quick
+  2 | A [lazy] dog is a happy dog. Dogs are the best, especially a [lazy] one
+  5 | The [lazy] brown dog, and the quick red fox. The dog and fox are here
+(3 rows)
+
+DEALLOCATE snip_param_g;
+-- pdb.snippets with parameterized sort_by + max_num_chars
+SET plan_cache_mode = force_custom_plan;
+PREPARE snips_param_c(text, int, text) AS
+SELECT id, pdb.snippets(content, max_num_chars => $2, sort_by => $3)
+FROM snippets_test
+WHERE content @@@ $1 AND id = 8
+ORDER BY id;
+EXECUTE snips_param_c('term1 OR term2', 20, 'position');
+ id |                                          snippets                                          
+----+--------------------------------------------------------------------------------------------
+  8 | {"<b>term1</b> <b>term2</b>. some","other text. <b>term1</b>","<b>term1</b> <b>term2</b>"}
+(1 row)
+
+DEALLOCATE snips_param_c;
+SET plan_cache_mode = force_generic_plan;
+PREPARE snips_param_g(text, int, text) AS
+SELECT id, pdb.snippets(content, max_num_chars => $2, sort_by => $3)
+FROM snippets_test
+WHERE content @@@ $1 AND id = 8
+ORDER BY id;
+EXECUTE snips_param_g('term1 OR term2', 20, 'position');
+ id |                                          snippets                                          
+----+--------------------------------------------------------------------------------------------
+  8 | {"<b>term1</b> <b>term2</b>. some","other text. <b>term1</b>","<b>term1</b> <b>term2</b>"}
+(1 row)
+
+DEALLOCATE snips_param_g;
+-- pdb.snippet_positions with parameterized limit and offset.
+-- The point of this test is "doesn't panic on 6th EXECUTE in GENERIC mode".
+SET plan_cache_mode = force_custom_plan;
+PREPARE snip_pos_c(text, int, int) AS
+SELECT id, pdb.snippet_positions(content, $2, $3) IS NOT NULL AS has_positions
+FROM snippets_test
+WHERE content @@@ $1 AND id = 1;
+EXECUTE snip_pos_c('lazy', 5, 0);
+ id | has_positions 
+----+---------------
+  1 | t
+(1 row)
+
+DEALLOCATE snip_pos_c;
+SET plan_cache_mode = force_generic_plan;
+PREPARE snip_pos_g(text, int, int) AS
+SELECT id, pdb.snippet_positions(content, $2, $3) IS NOT NULL AS has_positions
+FROM snippets_test
+WHERE content @@@ $1 AND id = 1;
+EXECUTE snip_pos_g('lazy', 5, 0);
+ id | has_positions 
+----+---------------
+  1 | t
+(1 row)
+
+DEALLOCATE snip_pos_g;
+-- Parameterized sort_by with an invalid value must still error at exec time
+-- (validation moved from planning to execution to support Param values).
+SET plan_cache_mode = force_generic_plan;
+PREPARE snips_bad_sort_g(text, text) AS
+SELECT id, pdb.snippets(content, sort_by => $2)
+FROM snippets_test
+WHERE content @@@ $1 AND id = 1;
+\set VERBOSITY terse
+SELECT 'expecting error from pdb.snippets sort_by validation:';
+                       ?column?                        
+-------------------------------------------------------
+ expecting error from pdb.snippets sort_by validation:
+(1 row)
+
+EXECUTE snips_bad_sort_g('lazy', 'invalid');
+ERROR:  invalid sort_by value for pdb.snippets: must be 'score' or 'position'
+\set VERBOSITY default
+DEALLOCATE snips_bad_sort_g;
+RESET plan_cache_mode;
 -- Cleanup
 DROP TABLE snippets_test;

--- a/pg_search/tests/pg_regress/sql/custom-agg.sql
+++ b/pg_search/tests/pg_regress/sql/custom-agg.sql
@@ -1265,3 +1265,59 @@ SELECT
   LIMIT 25;
 
 DROP TABLE test_window_order;
+
+-- =====================================================================
+-- Parameterized pdb.agg() (issue: panic on 6th EXECUTE)
+--
+-- Pre-fix: pdb.agg() requires a Const JSON spec at planning time so the
+-- AggregateScan can build the Tantivy aggregation plan. In GENERIC plan
+-- mode (the 6th+ EXECUTE), the Param survived into the planner and the
+-- extractor panicked with "pdb.agg argument must be a constant",
+-- crashing the backend.
+--
+-- Post-fix: AggregateScan declines pushdown via Err (NOTICE emitted),
+-- and PostgreSQL falls back to the placeholder pdb.agg which returns a
+-- normal SQL error. The contract this test enforces is "no backend
+-- crash" — the connection survives and a follow-up query works.
+-- =====================================================================
+
+\echo '--- Parameterized pdb.agg() must not crash the backend ---'
+
+CREATE TABLE agg_param_test (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+INSERT INTO agg_param_test (description, category)
+SELECT 'document ' || i, (ARRAY['a','b','c'])[1 + (i % 3)]
+FROM generate_series(1, 100) AS i;
+CREATE INDEX agg_param_test_idx ON agg_param_test
+USING bm25 (id, description, category)
+WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
+
+-- Baseline: constant JSON literal pushes through AggregateScan.
+SELECT pdb.agg('{"terms":{"field":"category"}}'::jsonb) IS NOT NULL AS got_result
+FROM agg_param_test
+WHERE description ||| 'document';
+
+-- GENERIC plan with parameterized JSON. Run several times to land on the
+-- generic plan (PG switches to GENERIC after the 5th execute by default
+-- under `force_generic_plan` it is immediate). The query is expected to
+-- ERROR (XX000 from the placeholder), but the backend must stay alive.
+SET plan_cache_mode = force_generic_plan;
+PREPARE agg_param_g(jsonb) AS
+SELECT pdb.agg($1)
+FROM agg_param_test
+WHERE description ||| 'document';
+
+\set VERBOSITY terse
+SELECT 'expecting error from placeholder pdb.agg in GENERIC mode:';
+EXECUTE agg_param_g('{"terms":{"field":"category"}}');
+\set VERBOSITY default
+
+-- Sanity check: backend is still alive.
+SELECT 1 AS backend_still_alive;
+
+DEALLOCATE agg_param_g;
+RESET plan_cache_mode;
+DROP TABLE agg_param_test;

--- a/pg_search/tests/pg_regress/sql/issue_4665.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4665.sql
@@ -126,6 +126,89 @@ EXECUTE issue_4665_generic_plim('technology', 10);
 
 DEALLOCATE issue_4665_generic_plim;
 
+-- ============================================================================
+-- Parameterized OFFSET: LIMIT 5 OFFSET $2 in both modes (must match)
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+
+PREPARE issue_4665_off_custom(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 5 OFFSET $2;
+
+EXECUTE issue_4665_off_custom('technology', 5);
+
+DEALLOCATE issue_4665_off_custom;
+
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_4665_off_generic(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT 5 OFFSET $2;
+
+EXECUTE issue_4665_off_generic('technology', 5);
+
+DEALLOCATE issue_4665_off_generic;
+
+-- ============================================================================
+-- Parameterized LIMIT + OFFSET: LIMIT $2 OFFSET $3 in both modes (must match)
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+
+PREPARE issue_4665_both_custom(text, int, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET $3;
+
+EXECUTE issue_4665_both_custom('technology', 5, 5);
+
+DEALLOCATE issue_4665_both_custom;
+
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_4665_both_generic(text, int, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET $3;
+
+EXECUTE issue_4665_both_generic('technology', 5, 5);
+
+DEALLOCATE issue_4665_both_generic;
+
+-- ============================================================================
+-- Parameterized LIMIT + Const OFFSET: LIMIT $2 OFFSET 5
+-- The pre-fix bug: GENERIC mode returned 0 rows because TopK fetched only
+-- LIMIT rows and then PG's outer Limit OFFSET 5 skipped all of them.
+-- ============================================================================
+SET plan_cache_mode = force_custom_plan;
+
+PREPARE issue_4665_plimcoff_custom(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET 5;
+
+EXECUTE issue_4665_plimcoff_custom('technology', 5);
+
+DEALLOCATE issue_4665_plimcoff_custom;
+
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE issue_4665_plimcoff_generic(text, int) AS
+SELECT id FROM issue_4665_test
+WHERE content ||| $1
+ORDER BY pdb.score(id) DESC
+LIMIT $2 OFFSET 5;
+
+EXECUTE issue_4665_plimcoff_generic('technology', 5);
+
+DEALLOCATE issue_4665_plimcoff_generic;
+
 -- Cleanup
 DROP TABLE issue_4665_test CASCADE;
 RESET max_parallel_workers_per_gather;

--- a/pg_search/tests/pg_regress/sql/issue_4665.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4665.sql
@@ -127,7 +127,9 @@ EXECUTE issue_4665_generic_plim('technology', 10);
 DEALLOCATE issue_4665_generic_plim;
 
 -- ============================================================================
--- Parameterized OFFSET: LIMIT 5 OFFSET $2 in both modes (must match)
+-- Parameterized OFFSET: LIMIT 3 OFFSET $2 in both modes (must match).
+-- OFFSET 7 > LIMIT 3 so the pre-fix TopK-undercount bug returns 0 rows
+-- unambiguously.
 -- ============================================================================
 SET plan_cache_mode = force_custom_plan;
 
@@ -135,9 +137,9 @@ PREPARE issue_4665_off_custom(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT 5 OFFSET $2;
+LIMIT 3 OFFSET $2;
 
-EXECUTE issue_4665_off_custom('technology', 5);
+EXECUTE issue_4665_off_custom('technology', 7);
 
 DEALLOCATE issue_4665_off_custom;
 
@@ -147,9 +149,9 @@ PREPARE issue_4665_off_generic(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT 5 OFFSET $2;
+LIMIT 3 OFFSET $2;
 
-EXECUTE issue_4665_off_generic('technology', 5);
+EXECUTE issue_4665_off_generic('technology', 7);
 
 DEALLOCATE issue_4665_off_generic;
 
@@ -164,7 +166,7 @@ WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
 LIMIT $2 OFFSET $3;
 
-EXECUTE issue_4665_both_custom('technology', 5, 5);
+EXECUTE issue_4665_both_custom('technology', 3, 7);
 
 DEALLOCATE issue_4665_both_custom;
 
@@ -176,14 +178,14 @@ WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
 LIMIT $2 OFFSET $3;
 
-EXECUTE issue_4665_both_generic('technology', 5, 5);
+EXECUTE issue_4665_both_generic('technology', 3, 7);
 
 DEALLOCATE issue_4665_both_generic;
 
 -- ============================================================================
--- Parameterized LIMIT + Const OFFSET: LIMIT $2 OFFSET 5
+-- Parameterized LIMIT + Const OFFSET: LIMIT $2 OFFSET 7
 -- The pre-fix bug: GENERIC mode returned 0 rows because TopK fetched only
--- LIMIT rows and then PG's outer Limit OFFSET 5 skipped all of them.
+-- LIMIT (=3) rows and then PG's outer Limit OFFSET 7 skipped all of them.
 -- ============================================================================
 SET plan_cache_mode = force_custom_plan;
 
@@ -191,9 +193,9 @@ PREPARE issue_4665_plimcoff_custom(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT $2 OFFSET 5;
+LIMIT $2 OFFSET 7;
 
-EXECUTE issue_4665_plimcoff_custom('technology', 5);
+EXECUTE issue_4665_plimcoff_custom('technology', 3);
 
 DEALLOCATE issue_4665_plimcoff_custom;
 
@@ -203,9 +205,9 @@ PREPARE issue_4665_plimcoff_generic(text, int) AS
 SELECT id FROM issue_4665_test
 WHERE content ||| $1
 ORDER BY pdb.score(id) DESC
-LIMIT $2 OFFSET 5;
+LIMIT $2 OFFSET 7;
 
-EXECUTE issue_4665_plimcoff_generic('technology', 5);
+EXECUTE issue_4665_plimcoff_generic('technology', 3);
 
 DEALLOCATE issue_4665_plimcoff_generic;
 

--- a/pg_search/tests/pg_regress/sql/snippets.sql
+++ b/pg_search/tests/pg_regress/sql/snippets.sql
@@ -110,5 +110,90 @@ SELECT id, pdb.snippets(content, max_num_chars => 20, sort_by => 'position') FRO
 -- Test with an invalid sort_by value
 SELECT id, pdb.snippets(content, sort_by => 'invalid') FROM snippets_test WHERE content @@@ 'lazy' AND id = 1;
 
+-- =====================================================================
+-- Parameterized snippet arguments (issue: snippet panics on 6th EXECUTE)
+--
+-- Pre-fix: every formatting argument (start_tag, end_tag, max_num_chars,
+-- limit, offset, sort_by) had to be a Const. In GENERIC plan mode (the
+-- 6th+ EXECUTE of a prepared statement), Params survive into the planner
+-- and the snippet extractor panicked with "arguments must be literals".
+--
+-- We exercise both CUSTOM and GENERIC modes against the same table so
+-- the expected output proves they produce identical results.
+-- =====================================================================
+
+\echo '--- Parameterized snippet arguments (CUSTOM vs GENERIC) ---'
+
+-- pdb.snippet with parameterized start_tag and end_tag
+SET plan_cache_mode = force_custom_plan;
+PREPARE snip_param_c(text, text, text) AS
+SELECT id, pdb.snippet(content, $2, $3)
+FROM snippets_test
+WHERE content @@@ $1
+ORDER BY id;
+EXECUTE snip_param_c('lazy', '[', ']');
+DEALLOCATE snip_param_c;
+
+SET plan_cache_mode = force_generic_plan;
+PREPARE snip_param_g(text, text, text) AS
+SELECT id, pdb.snippet(content, $2, $3)
+FROM snippets_test
+WHERE content @@@ $1
+ORDER BY id;
+EXECUTE snip_param_g('lazy', '[', ']');
+DEALLOCATE snip_param_g;
+
+-- pdb.snippets with parameterized sort_by + max_num_chars
+SET plan_cache_mode = force_custom_plan;
+PREPARE snips_param_c(text, int, text) AS
+SELECT id, pdb.snippets(content, max_num_chars => $2, sort_by => $3)
+FROM snippets_test
+WHERE content @@@ $1 AND id = 8
+ORDER BY id;
+EXECUTE snips_param_c('term1 OR term2', 20, 'position');
+DEALLOCATE snips_param_c;
+
+SET plan_cache_mode = force_generic_plan;
+PREPARE snips_param_g(text, int, text) AS
+SELECT id, pdb.snippets(content, max_num_chars => $2, sort_by => $3)
+FROM snippets_test
+WHERE content @@@ $1 AND id = 8
+ORDER BY id;
+EXECUTE snips_param_g('term1 OR term2', 20, 'position');
+DEALLOCATE snips_param_g;
+
+-- pdb.snippet_positions with parameterized limit and offset.
+-- The point of this test is "doesn't panic on 6th EXECUTE in GENERIC mode".
+SET plan_cache_mode = force_custom_plan;
+PREPARE snip_pos_c(text, int, int) AS
+SELECT id, pdb.snippet_positions(content, $2, $3) IS NOT NULL AS has_positions
+FROM snippets_test
+WHERE content @@@ $1 AND id = 1;
+EXECUTE snip_pos_c('lazy', 5, 0);
+DEALLOCATE snip_pos_c;
+
+SET plan_cache_mode = force_generic_plan;
+PREPARE snip_pos_g(text, int, int) AS
+SELECT id, pdb.snippet_positions(content, $2, $3) IS NOT NULL AS has_positions
+FROM snippets_test
+WHERE content @@@ $1 AND id = 1;
+EXECUTE snip_pos_g('lazy', 5, 0);
+DEALLOCATE snip_pos_g;
+
+-- Parameterized sort_by with an invalid value must still error at exec time
+-- (validation moved from planning to execution to support Param values).
+SET plan_cache_mode = force_generic_plan;
+PREPARE snips_bad_sort_g(text, text) AS
+SELECT id, pdb.snippets(content, sort_by => $2)
+FROM snippets_test
+WHERE content @@@ $1 AND id = 1;
+\set VERBOSITY terse
+SELECT 'expecting error from pdb.snippets sort_by validation:';
+EXECUTE snips_bad_sort_g('lazy', 'invalid');
+\set VERBOSITY default
+DEALLOCATE snips_bad_sort_g;
+
+RESET plan_cache_mode;
+
 -- Cleanup
 DROP TABLE snippets_test;

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -584,3 +584,145 @@ fn joinscan_survives_parameterized_limit(mut conn: PgConnection) {
     "RESET max_parallel_workers_per_gather".execute(&mut conn);
     "RESET enable_indexscan".execute(&mut conn);
 }
+
+/// Snippet functions must not panic when formatting arguments are
+/// parameterized in GENERIC plan mode. Pre-fix: panicked with
+/// "pdb.snippets()'s arguments must be literals" on the 6th execution.
+#[rstest]
+fn snippet_with_parameterized_args(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS snippet_param_test CASCADE;
+    CREATE TABLE snippet_param_test (
+        id SERIAL PRIMARY KEY,
+        content TEXT
+    );
+    INSERT INTO snippet_param_test (content) VALUES
+    ('the quick brown fox jumps over the lazy dog'),
+    ('a technology document about computers and technology advances'),
+    ('science is great for learning new things about the world');
+    CREATE INDEX snippet_param_idx ON snippet_param_test
+    USING bm25 (id, content) WITH (key_field = 'id');
+    "#
+    .execute(&mut conn);
+
+    // Baseline: constant args
+    let baseline = r#"
+    SELECT id, pdb.snippet(content, '<b>', '</b>')
+    FROM snippet_param_test
+    WHERE content ||| 'technology'
+    ORDER BY pdb.score(id) DESC
+    "#
+    .fetch::<(i32, String)>(&mut conn);
+    assert!(!baseline.is_empty(), "baseline should have matches");
+
+    // CUSTOM plan with parameterized start/end tags
+    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
+    "PREPARE snip_c(text, text, text) AS
+     SELECT id, pdb.snippet(content, $2, $3)
+     FROM snippet_param_test
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC"
+        .execute(&mut conn);
+    let custom = "EXECUTE snip_c('technology', '<b>', '</b>')".fetch::<(i32, String)>(&mut conn);
+    "DEALLOCATE snip_c".execute(&mut conn);
+
+    // GENERIC plan — this was panicking before the fix
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE snip_g(text, text, text) AS
+     SELECT id, pdb.snippet(content, $2, $3)
+     FROM snippet_param_test
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC"
+        .execute(&mut conn);
+    let generic = "EXECUTE snip_g('technology', '<b>', '</b>')".fetch::<(i32, String)>(&mut conn);
+    "DEALLOCATE snip_g".execute(&mut conn);
+
+    assert_eq!(custom, baseline, "CUSTOM with param tags must match baseline");
+    assert_eq!(generic, baseline, "GENERIC with param tags must match baseline");
+
+    // Also test pdb.snippet_positions with parameterized limit/offset
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE snip_pos_g(text, int, int) AS
+     SELECT id, pdb.snippet_positions(content, $2, $3)
+     FROM snippet_param_test
+     WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC"
+        .execute(&mut conn);
+    let pos_result = "EXECUTE snip_pos_g('technology', 5, 0)".execute_result(&mut conn);
+    assert!(
+        pos_result.is_ok(),
+        "snippet_positions with param args must not error in GENERIC mode: {pos_result:?}"
+    );
+    "DEALLOCATE snip_pos_g".execute(&mut conn);
+
+    "RESET plan_cache_mode".execute(&mut conn);
+}
+
+/// pdb.agg() must not panic when the JSON argument is parameterized.
+///
+/// Pre-fix: panicked with "pdb.agg argument must be a constant" — a Rust
+/// panic that crashes the backend.
+///
+/// Post-fix: AggregateScan declines pushdown (NOTICE) and PG attempts the
+/// standard aggregate path. Because `pdb.agg` is a custom-scan-only
+/// placeholder it then returns a normal SQL error rather than crashing,
+/// and the connection stays alive. That's the contract this test enforces.
+#[rstest]
+fn pdb_agg_with_parameterized_json(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS agg_param_test CASCADE;
+    CREATE TABLE agg_param_test (
+        id SERIAL PRIMARY KEY,
+        content TEXT,
+        category TEXT
+    );
+    INSERT INTO agg_param_test (content, category)
+    SELECT 'document ' || i, (ARRAY['a','b','c'])[1 + (i % 3)]
+    FROM generate_series(1, 100) AS i;
+    CREATE INDEX agg_param_idx ON agg_param_test
+    USING bm25 (id, content, category) WITH (
+        key_field = 'id',
+        text_fields = '{"category": {"fast": true}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    // Baseline: constant JSON literal pushes through the custom aggregate scan.
+    let baseline = r#"
+    SELECT pdb.agg('{"terms":{"field":"category"}}'::jsonb)
+    FROM agg_param_test
+    WHERE content ||| 'document'
+    "#
+    .fetch::<(serde_json::Value,)>(&mut conn);
+    assert!(!baseline.is_empty(), "baseline should produce agg results");
+
+    // GENERIC plan with parameterized JSON. The bug was a Rust panic; the
+    // fix returns Err so aggregate pushdown is skipped. PG then tries the
+    // placeholder `pdb.agg` and surfaces a controlled SQL error (XX000)
+    // instead of crashing the backend.
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE agg_g(jsonb) AS
+     SELECT pdb.agg($1)
+     FROM agg_param_test
+     WHERE content ||| 'document'"
+        .execute(&mut conn);
+
+    // Repeat enough times to land on the GENERIC plan (>= 6th execute).
+    let mut last_result: Result<(), sqlx::Error> = Ok(());
+    for _ in 0..7 {
+        last_result = "EXECUTE agg_g('{\"terms\":{\"field\":\"category\"}}')"
+            .execute_result(&mut conn);
+    }
+
+    // The connection must still be alive and the error (if any) must be a
+    // normal SQL error, not a backend crash.
+    let still_alive = "SELECT 1".execute_result(&mut conn);
+    assert!(
+        still_alive.is_ok(),
+        "backend must still be alive after parameterized pdb.agg in GENERIC mode \
+         (last error: {last_result:?}, post-check error: {still_alive:?})"
+    );
+
+    "DEALLOCATE agg_g".execute(&mut conn);
+    "RESET plan_cache_mode".execute(&mut conn);
+}

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -393,3 +393,194 @@ fn generic_plan_natural_transition_issue_4665(mut conn: PgConnection) {
 
     "DEALLOCATE stmt_nat".execute(&mut conn);
 }
+
+/// Parameterized OFFSET must produce correct results in GENERIC mode.
+///
+/// Pre-fix bugs:
+///   - LIMIT 5 OFFSET $2: GENERIC fell back to ColumnarExecState (full scan
+///     + Sort), producing a different row order than CUSTOM.
+///   - LIMIT $1 OFFSET 5: GENERIC's TopK fetched only `LIMIT` rows; PG's outer
+///     Limit OFFSET 5 then skipped them all, returning **0 rows**.
+///   - LIMIT $1 OFFSET $2: same TopK undercount bug.
+///
+/// All three cases must now return identical rows to the unprepared baseline.
+#[rstest]
+fn generic_plan_parameterized_offset(mut conn: PgConnection) {
+    r#"
+    DROP TABLE IF EXISTS param_offset_test CASCADE;
+    CREATE TABLE param_offset_test (
+        id SERIAL PRIMARY KEY,
+        content TEXT
+    );
+    INSERT INTO param_offset_test (content)
+    SELECT 'document about technology number ' || i
+    FROM generate_series(1, 200) AS i;
+    CREATE INDEX param_offset_idx ON param_offset_test
+    USING bm25 (id, content) WITH (key_field = 'id');
+    "#
+    .execute(&mut conn);
+
+    // Baseline: constant LIMIT + constant OFFSET
+    let baseline = "SELECT id FROM param_offset_test
+                    WHERE content ||| 'technology'
+                    ORDER BY pdb.score(id) DESC
+                    LIMIT 5 OFFSET 5"
+        .fetch::<(i32,)>(&mut conn);
+    assert_eq!(baseline.len(), 5, "baseline should return 5 rows");
+
+    // --- Case 1: Const LIMIT + Param OFFSET ---
+    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
+    "PREPARE off1_c(text, int) AS
+     SELECT id FROM param_offset_test WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC LIMIT 5 OFFSET $2"
+        .execute(&mut conn);
+    let custom_1 = "EXECUTE off1_c('technology', 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off1_c".execute(&mut conn);
+
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE off1_g(text, int) AS
+     SELECT id FROM param_offset_test WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC LIMIT 5 OFFSET $2"
+        .execute(&mut conn);
+    let generic_1 = "EXECUTE off1_g('technology', 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off1_g".execute(&mut conn);
+
+    assert_eq!(custom_1, baseline, "Case 1 CUSTOM must match baseline");
+    assert_eq!(generic_1, baseline, "Case 1 GENERIC must match baseline");
+
+    // --- Case 2: Param LIMIT + Const OFFSET (was returning 0 rows) ---
+    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
+    "PREPARE off2_c(text, int) AS
+     SELECT id FROM param_offset_test WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET 5"
+        .execute(&mut conn);
+    let custom_2 = "EXECUTE off2_c('technology', 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off2_c".execute(&mut conn);
+
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE off2_g(text, int) AS
+     SELECT id FROM param_offset_test WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET 5"
+        .execute(&mut conn);
+    let generic_2 = "EXECUTE off2_g('technology', 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off2_g".execute(&mut conn);
+
+    assert_eq!(custom_2, baseline, "Case 2 CUSTOM must match baseline");
+    assert_eq!(
+        generic_2, baseline,
+        "Case 2 GENERIC must match baseline (was returning 0 rows pre-fix)"
+    );
+
+    // --- Case 3: Param LIMIT + Param OFFSET ---
+    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
+    "PREPARE off3_c(text, int, int) AS
+     SELECT id FROM param_offset_test WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET $3"
+        .execute(&mut conn);
+    let custom_3 = "EXECUTE off3_c('technology', 5, 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off3_c".execute(&mut conn);
+
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE off3_g(text, int, int) AS
+     SELECT id FROM param_offset_test WHERE content ||| $1
+     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET $3"
+        .execute(&mut conn);
+    let generic_3 = "EXECUTE off3_g('technology', 5, 5)".fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off3_g".execute(&mut conn);
+
+    assert_eq!(custom_3, baseline, "Case 3 CUSTOM must match baseline");
+    assert_eq!(generic_3, baseline, "Case 3 GENERIC must match baseline");
+
+    "RESET plan_cache_mode".execute(&mut conn);
+}
+
+/// JoinScan must survive parameterized LIMIT (was previously disabled with
+/// NOTICE: "JoinScan not used: activation checks failed (LIMIT / ...)").
+#[rstest]
+fn joinscan_survives_parameterized_limit(mut conn: PgConnection) {
+    "SET paradedb.enable_join_custom_scan = on".execute(&mut conn);
+    "SET max_parallel_workers_per_gather = 0".execute(&mut conn);
+    "SET enable_indexscan TO OFF".execute(&mut conn);
+
+    r#"
+    DROP TABLE IF EXISTS js_prods CASCADE;
+    DROP TABLE IF EXISTS js_cats CASCADE;
+    CREATE TABLE js_prods (
+        id SERIAL PRIMARY KEY,
+        name TEXT,
+        cat_id INT
+    );
+    CREATE TABLE js_cats (
+        id SERIAL PRIMARY KEY,
+        label TEXT
+    );
+    INSERT INTO js_cats (label) VALUES ('electronics'), ('clothing'), ('food');
+    INSERT INTO js_prods (name, cat_id)
+    SELECT 'product ' || i || ' in electronics', 1 + (i % 3)
+    FROM generate_series(1, 100) AS i;
+    CREATE INDEX js_prods_idx ON js_prods
+    USING bm25 (id, name, cat_id) WITH (key_field = 'id');
+    CREATE INDEX js_cats_idx ON js_cats
+    USING bm25 (id, label) WITH (key_field = 'id');
+    "#
+    .execute(&mut conn);
+
+    // CUSTOM mode with parameterized LIMIT
+    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
+    "PREPARE js_c(text, int) AS
+     SELECT p.id, p.name FROM js_prods p
+     JOIN js_cats c ON p.cat_id = c.id
+     WHERE p.name ||| $1
+     ORDER BY pdb.score(p.id) DESC
+     LIMIT $2"
+        .execute(&mut conn);
+    let mut custom_results = "EXECUTE js_c('electronics', 10)".fetch::<(i32, String)>(&mut conn);
+    "DEALLOCATE js_c".execute(&mut conn);
+
+    // GENERIC mode with parameterized LIMIT
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE js_g(text, int) AS
+     SELECT p.id, p.name FROM js_prods p
+     JOIN js_cats c ON p.cat_id = c.id
+     WHERE p.name ||| $1
+     ORDER BY pdb.score(p.id) DESC
+     LIMIT $2"
+        .execute(&mut conn);
+    let mut generic_results = "EXECUTE js_g('electronics', 10)".fetch::<(i32, String)>(&mut conn);
+    "DEALLOCATE js_g".execute(&mut conn);
+
+    // All `electronics` matches share identical scores, so the ORDER BY tie is
+    // unstable. Compare the *set* of rows by sorting first — what matters is
+    // that JoinScan produces a correct top-10 in both modes.
+    custom_results.sort_by_key(|r| r.0);
+    generic_results.sort_by_key(|r| r.0);
+    assert_eq!(
+        custom_results, generic_results,
+        "JoinScan with param LIMIT must return the same set of rows in both modes"
+    );
+    assert!(!custom_results.is_empty(), "should have join results");
+    assert_eq!(custom_results.len(), 10, "LIMIT $2=10 must be respected");
+
+    // GENERIC plan must actually use JoinScan (not fall back to NestedLoop).
+    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
+    "PREPARE js_g_explain(text, int) AS
+     SELECT p.id, p.name FROM js_prods p
+     JOIN js_cats c ON p.cat_id = c.id
+     WHERE p.name ||| $1
+     ORDER BY pdb.score(p.id) DESC
+     LIMIT $2"
+        .execute(&mut conn);
+    let (plan,) = "EXPLAIN (FORMAT JSON) EXECUTE js_g_explain('electronics', 10)"
+        .fetch_one::<(Value,)>(&mut conn);
+    let plan_text = format!("{plan:#}");
+    assert!(
+        plan_text.contains("ParadeDB Join Scan"),
+        "GENERIC mode with param LIMIT must keep JoinScan: {plan_text}"
+    );
+    "DEALLOCATE js_g_explain".execute(&mut conn);
+
+    "RESET plan_cache_mode".execute(&mut conn);
+    "RESET paradedb.enable_join_custom_scan".execute(&mut conn);
+    "RESET max_parallel_workers_per_gather".execute(&mut conn);
+    "RESET enable_indexscan".execute(&mut conn);
+}

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -699,7 +699,8 @@ fn pdb_agg_with_parameterized_json(mut conn: PgConnection) {
     // GENERIC plan with parameterized JSON. The bug was a Rust panic; the
     // fix returns Err so aggregate pushdown is skipped. PG then tries the
     // placeholder `pdb.agg` and surfaces a controlled SQL error (XX000)
-    // instead of crashing the backend.
+    // instead of crashing the backend. With force_generic_plan the GENERIC
+    // path is used immediately — no need to burn through CUSTOM executes.
     "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
     "PREPARE agg_g(jsonb) AS
      SELECT pdb.agg($1)
@@ -707,12 +708,8 @@ fn pdb_agg_with_parameterized_json(mut conn: PgConnection) {
      WHERE content ||| 'document'"
         .execute(&mut conn);
 
-    // Repeat enough times to land on the GENERIC plan (>= 6th execute).
-    let mut last_result: Result<(), sqlx::Error> = Ok(());
-    for _ in 0..7 {
-        last_result = "EXECUTE agg_g('{\"terms\":{\"field\":\"category\"}}')"
-            .execute_result(&mut conn);
-    }
+    let last_result =
+        "EXECUTE agg_g('{\"terms\":{\"field\":\"category\"}}')".execute_result(&mut conn);
 
     // The connection must still be alive and the error (if any) must be a
     // normal SQL error, not a backend crash.

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -455,12 +455,7 @@ fn generic_plan_parameterized_offset(
 /// JoinScan must survive parameterized LIMIT/OFFSET (previously disabled
 /// with NOTICE: "JoinScan not used: activation checks failed (LIMIT / ...)").
 #[rstest]
-#[case::param_limit_only(
-    "text, int",
-    "LIMIT $2",
-    "'electronics', 10",
-    10
-)]
+#[case::param_limit_only("text, int", "LIMIT $2", "'electronics', 10", 10)]
 #[case::param_limit_param_offset(
     "text, int, int",
     "LIMIT $2 OFFSET $3",

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -637,8 +637,14 @@ fn snippet_with_parameterized_args(mut conn: PgConnection) {
     let generic = "EXECUTE snip_g('technology', '<b>', '</b>')".fetch::<(i32, String)>(&mut conn);
     "DEALLOCATE snip_g".execute(&mut conn);
 
-    assert_eq!(custom, baseline, "CUSTOM with param tags must match baseline");
-    assert_eq!(generic, baseline, "GENERIC with param tags must match baseline");
+    assert_eq!(
+        custom, baseline,
+        "CUSTOM with param tags must match baseline"
+    );
+    assert_eq!(
+        generic, baseline,
+        "GENERIC with param tags must match baseline"
+    );
 
     // Also test pdb.snippet_positions with parameterized limit/offset
     "SET plan_cache_mode = force_generic_plan".execute(&mut conn);

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -396,16 +396,20 @@ fn generic_plan_natural_transition_issue_4665(mut conn: PgConnection) {
 
 /// Parameterized OFFSET must produce correct results in GENERIC mode.
 ///
-/// Pre-fix bugs:
-///   - LIMIT 5 OFFSET $2: GENERIC fell back to ColumnarExecState (full scan
-///     + Sort), producing a different row order than CUSTOM.
-///   - LIMIT $1 OFFSET 5: GENERIC's TopK fetched only `LIMIT` rows; PG's outer
-///     Limit OFFSET 5 then skipped them all, returning **0 rows**.
-///   - LIMIT $1 OFFSET $2: same TopK undercount bug.
-///
-/// All three cases must now return identical rows to the unprepared baseline.
+/// Pre-fix: GENERIC TopK fetched K=LIMIT (ignoring OFFSET), so PG's outer
+/// `Limit OFFSET` skipped too many rows. With OFFSET > LIMIT the bug
+/// returned **0 rows** unambiguously — chosen here so partial results
+/// can't mask the regression.
 #[rstest]
-fn generic_plan_parameterized_offset(mut conn: PgConnection) {
+#[case::const_limit_param_offset("text, int", "LIMIT 3 OFFSET $2", "'technology', 7")]
+#[case::param_limit_const_offset("text, int", "LIMIT $2 OFFSET 7", "'technology', 3")]
+#[case::param_limit_param_offset("text, int, int", "LIMIT $2 OFFSET $3", "'technology', 3, 7")]
+fn generic_plan_parameterized_offset(
+    mut conn: PgConnection,
+    #[case] param_types: &str,
+    #[case] limit_clause: &str,
+    #[case] execute_args: &str,
+) {
     r#"
     DROP TABLE IF EXISTS param_offset_test CASCADE;
     CREATE TABLE param_offset_test (
@@ -420,84 +424,56 @@ fn generic_plan_parameterized_offset(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    // Baseline: constant LIMIT + constant OFFSET
     let baseline = "SELECT id FROM param_offset_test
                     WHERE content ||| 'technology'
                     ORDER BY pdb.score(id) DESC
-                    LIMIT 5 OFFSET 5"
+                    LIMIT 3 OFFSET 7"
         .fetch::<(i32,)>(&mut conn);
-    assert_eq!(baseline.len(), 5, "baseline should return 5 rows");
+    assert_eq!(baseline.len(), 3, "baseline should return 3 rows");
 
-    // --- Case 1: Const LIMIT + Param OFFSET ---
-    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
-    "PREPARE off1_c(text, int) AS
-     SELECT id FROM param_offset_test WHERE content ||| $1
-     ORDER BY pdb.score(id) DESC LIMIT 5 OFFSET $2"
-        .execute(&mut conn);
-    let custom_1 = "EXECUTE off1_c('technology', 5)".fetch::<(i32,)>(&mut conn);
-    "DEALLOCATE off1_c".execute(&mut conn);
-
-    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
-    "PREPARE off1_g(text, int) AS
-     SELECT id FROM param_offset_test WHERE content ||| $1
-     ORDER BY pdb.score(id) DESC LIMIT 5 OFFSET $2"
-        .execute(&mut conn);
-    let generic_1 = "EXECUTE off1_g('technology', 5)".fetch::<(i32,)>(&mut conn);
-    "DEALLOCATE off1_g".execute(&mut conn);
-
-    assert_eq!(custom_1, baseline, "Case 1 CUSTOM must match baseline");
-    assert_eq!(generic_1, baseline, "Case 1 GENERIC must match baseline");
-
-    // --- Case 2: Param LIMIT + Const OFFSET (was returning 0 rows) ---
-    "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
-    "PREPARE off2_c(text, int) AS
-     SELECT id FROM param_offset_test WHERE content ||| $1
-     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET 5"
-        .execute(&mut conn);
-    let custom_2 = "EXECUTE off2_c('technology', 5)".fetch::<(i32,)>(&mut conn);
-    "DEALLOCATE off2_c".execute(&mut conn);
-
-    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
-    "PREPARE off2_g(text, int) AS
-     SELECT id FROM param_offset_test WHERE content ||| $1
-     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET 5"
-        .execute(&mut conn);
-    let generic_2 = "EXECUTE off2_g('technology', 5)".fetch::<(i32,)>(&mut conn);
-    "DEALLOCATE off2_g".execute(&mut conn);
-
-    assert_eq!(custom_2, baseline, "Case 2 CUSTOM must match baseline");
-    assert_eq!(
-        generic_2, baseline,
-        "Case 2 GENERIC must match baseline (was returning 0 rows pre-fix)"
+    let prepare_template = format!(
+        "SELECT id FROM param_offset_test WHERE content ||| $1
+         ORDER BY pdb.score(id) DESC {limit_clause}"
     );
 
-    // --- Case 3: Param LIMIT + Param OFFSET ---
     "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
-    "PREPARE off3_c(text, int, int) AS
-     SELECT id FROM param_offset_test WHERE content ||| $1
-     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET $3"
-        .execute(&mut conn);
-    let custom_3 = "EXECUTE off3_c('technology', 5, 5)".fetch::<(i32,)>(&mut conn);
-    "DEALLOCATE off3_c".execute(&mut conn);
+    format!("PREPARE off_c({param_types}) AS {prepare_template}").execute(&mut conn);
+    let custom = format!("EXECUTE off_c({execute_args})").fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off_c".execute(&mut conn);
 
     "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
-    "PREPARE off3_g(text, int, int) AS
-     SELECT id FROM param_offset_test WHERE content ||| $1
-     ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET $3"
-        .execute(&mut conn);
-    let generic_3 = "EXECUTE off3_g('technology', 5, 5)".fetch::<(i32,)>(&mut conn);
-    "DEALLOCATE off3_g".execute(&mut conn);
+    format!("PREPARE off_g({param_types}) AS {prepare_template}").execute(&mut conn);
+    let generic = format!("EXECUTE off_g({execute_args})").fetch::<(i32,)>(&mut conn);
+    "DEALLOCATE off_g".execute(&mut conn);
 
-    assert_eq!(custom_3, baseline, "Case 3 CUSTOM must match baseline");
-    assert_eq!(generic_3, baseline, "Case 3 GENERIC must match baseline");
+    assert_eq!(custom, baseline, "CUSTOM must match baseline");
+    assert_eq!(generic, baseline, "GENERIC must match baseline");
 
     "RESET plan_cache_mode".execute(&mut conn);
 }
 
-/// JoinScan must survive parameterized LIMIT (was previously disabled with
-/// NOTICE: "JoinScan not used: activation checks failed (LIMIT / ...)").
+/// JoinScan must survive parameterized LIMIT/OFFSET (previously disabled
+/// with NOTICE: "JoinScan not used: activation checks failed (LIMIT / ...)").
 #[rstest]
-fn joinscan_survives_parameterized_limit(mut conn: PgConnection) {
+#[case::param_limit_only(
+    "text, int",
+    "LIMIT $2",
+    "'electronics', 10",
+    10
+)]
+#[case::param_limit_param_offset(
+    "text, int, int",
+    "LIMIT $2 OFFSET $3",
+    "'electronics', 10, 0",
+    10
+)]
+fn joinscan_survives_parameterized_limit(
+    mut conn: PgConnection,
+    #[case] param_types: &str,
+    #[case] limit_clause: &str,
+    #[case] execute_args: &str,
+    #[case] expected_rows: usize,
+) {
     "SET paradedb.enable_join_custom_scan = on".execute(&mut conn);
     "SET max_parallel_workers_per_gather = 0".execute(&mut conn);
     "SET enable_indexscan TO OFF".execute(&mut conn);
@@ -525,59 +501,48 @@ fn joinscan_survives_parameterized_limit(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    // CUSTOM mode with parameterized LIMIT
+    let prepare_template = format!(
+        "SELECT p.id, p.name FROM js_prods p
+         JOIN js_cats c ON p.cat_id = c.id
+         WHERE p.name ||| $1
+         ORDER BY pdb.score(p.id) DESC
+         {limit_clause}"
+    );
+
     "SET plan_cache_mode = force_custom_plan".execute(&mut conn);
-    "PREPARE js_c(text, int) AS
-     SELECT p.id, p.name FROM js_prods p
-     JOIN js_cats c ON p.cat_id = c.id
-     WHERE p.name ||| $1
-     ORDER BY pdb.score(p.id) DESC
-     LIMIT $2"
-        .execute(&mut conn);
-    let mut custom_results = "EXECUTE js_c('electronics', 10)".fetch::<(i32, String)>(&mut conn);
+    format!("PREPARE js_c({param_types}) AS {prepare_template}").execute(&mut conn);
+    let mut custom_results =
+        format!("EXECUTE js_c({execute_args})").fetch::<(i32, String)>(&mut conn);
     "DEALLOCATE js_c".execute(&mut conn);
 
-    // GENERIC mode with parameterized LIMIT
     "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
-    "PREPARE js_g(text, int) AS
-     SELECT p.id, p.name FROM js_prods p
-     JOIN js_cats c ON p.cat_id = c.id
-     WHERE p.name ||| $1
-     ORDER BY pdb.score(p.id) DESC
-     LIMIT $2"
-        .execute(&mut conn);
-    let mut generic_results = "EXECUTE js_g('electronics', 10)".fetch::<(i32, String)>(&mut conn);
-    "DEALLOCATE js_g".execute(&mut conn);
+    format!("PREPARE js_g({param_types}) AS {prepare_template}").execute(&mut conn);
+    let mut generic_results =
+        format!("EXECUTE js_g({execute_args})").fetch::<(i32, String)>(&mut conn);
 
-    // All `electronics` matches share identical scores, so the ORDER BY tie is
-    // unstable. Compare the *set* of rows by sorting first — what matters is
-    // that JoinScan produces a correct top-10 in both modes.
+    // All `electronics` matches share identical scores, so the ORDER BY tie
+    // is unstable. Compare the row set, not the order.
     custom_results.sort_by_key(|r| r.0);
     generic_results.sort_by_key(|r| r.0);
     assert_eq!(
         custom_results, generic_results,
         "JoinScan with param LIMIT must return the same set of rows in both modes"
     );
-    assert!(!custom_results.is_empty(), "should have join results");
-    assert_eq!(custom_results.len(), 10, "LIMIT $2=10 must be respected");
+    assert_eq!(
+        custom_results.len(),
+        expected_rows,
+        "LIMIT must be respected"
+    );
 
     // GENERIC plan must actually use JoinScan (not fall back to NestedLoop).
-    "SET plan_cache_mode = force_generic_plan".execute(&mut conn);
-    "PREPARE js_g_explain(text, int) AS
-     SELECT p.id, p.name FROM js_prods p
-     JOIN js_cats c ON p.cat_id = c.id
-     WHERE p.name ||| $1
-     ORDER BY pdb.score(p.id) DESC
-     LIMIT $2"
-        .execute(&mut conn);
-    let (plan,) = "EXPLAIN (FORMAT JSON) EXECUTE js_g_explain('electronics', 10)"
+    let (plan,) = format!("EXPLAIN (FORMAT JSON) EXECUTE js_g({execute_args})")
         .fetch_one::<(Value,)>(&mut conn);
     let plan_text = format!("{plan:#}");
     assert!(
         plan_text.contains("ParadeDB Join Scan"),
         "GENERIC mode with param LIMIT must keep JoinScan: {plan_text}"
     );
-    "DEALLOCATE js_g_explain".execute(&mut conn);
+    "DEALLOCATE js_g".execute(&mut conn);
 
     "RESET plan_cache_mode".execute(&mut conn);
     "RESET paradedb.enable_join_custom_scan".execute(&mut conn);


### PR DESCRIPTION
# Ticket(s) Closed

Related to #4665

## What

Prepared statements with parameterized LIMIT, OFFSET, WHERE, or snippet arguments now produce correct, consistent results in both CUSTOM and GENERIC plan modes. Previously, the 6th+ execution of a prepared statement could return wrong results, lose parallelism, disable JoinScan, or crash the backend.

## Why

PostgreSQL switches from CUSTOM to GENERIC plans after 5 executions. In GENERIC mode, `$1`, `$2` etc. survive as `Param` nodes instead of being folded to constants. Throughout `pg_search`, planning-time code extracted values using `nodecast!(Const, ...)`, which silently returned `None` for Param nodes. This caused six distinct failures:

1. `query_input_restrict` returned selectivity 0.00001 instead of 0.10 for parameterized WHERE, collapsing parallel worker estimates to 0.
2. `LIMIT $1 OFFSET 5` fetched only 5 rows (TopK K=5 instead of K=10), then PostgreSQL's OFFSET skipped all 5 — **returning 0 rows**.
3. JoinScan refused to activate with `LIMIT $1`, falling back to nested loop joins silently.
4. `float_limit` became `None`, producing inflated cost estimates.
5. `pdb.snippet(content, $2, $3)` panicked with "arguments must be literals" on the 6th execution.
6. `pdb.agg($1)` crashed the backend with a Rust panic.

## How

**1. `ParameterizedValue<T>` enum.** New generic type (`Static(T)` / `Param { param_id }`) that extracts from PG expression nodes and resolves at execution time from `EState`. Replaces all `nodecast!(Const, ...)` patterns where Param support was missing.

**2. Unified `LimitOffset` struct.** Replaced the old Const-only `LimitOffset` and the separate `Limit` enum with a single struct using `ParameterizedValue<i64>` for both limit and offset. `fetch(estate)` resolves both at execution time and returns `limit + offset`. `planning_estimate()` provides a fallback (1000.0) for cost math when values are parameterized.

**3. Limit pushdown refactor.** Replaced the three-path resolution in BaseScan with `LimitOffset::from_root` + `is_limit_pushdown_safe`. Extracted `classify_target_list_srf` to handle the `unnest` SRF case separately from limit extraction.

**4. JoinScan parameterized LIMIT.** Static limits are baked into the DataFusion plan at planning time (unchanged). Parameterized limits are injected at execution time by wrapping the deserialized logical plan with a Limit node before `build_physical_plan` — `SegmentedTopKRule` still fires correctly.

**5. Snippet param support.** All snippet config fields (`start_tag`, `end_tag`, `max_num_chars`, `limit`, `offset`, `sort_by`) changed to `ParameterizedValue<T>`, resolved from `EState` at execution time. All `panic!` calls removed.

**6. `pdb.agg` graceful degradation.** Panic replaced with `Err` — AggregateScan declines pushdown, PostgreSQL falls back to standard processing, backend survives.

**7. Selectivity fix.** `query_input_restrict` returns `PARAMETERIZED_SELECTIVITY` (0.10) for `PARAM_EXTERN` RHS instead of `UNKNOWN_SELECTIVITY` (0.00001).

### Queries fixed

```sql
-- Was: 0 rows in GENERIC mode (TopK fetched K=5, OFFSET skipped all 5)
PREPARE stmt(text, int) AS
  SELECT id FROM t WHERE content ||| $1 ORDER BY pdb.score(id) DESC LIMIT $2 OFFSET 5;

-- Was: JoinScan disabled, fell back to nested loop
PREPARE stmt(text, int) AS
  SELECT p.id FROM products p JOIN categories c ON p.cat_id = c.id
  WHERE p.name ||| $1 ORDER BY pdb.score(p.id) DESC LIMIT $2;

-- Was: parallelism dropped to 0 workers in GENERIC mode
PREPARE stmt(text) AS
  SELECT id FROM t WHERE content ||| $1 ORDER BY pdb.score(id) DESC LIMIT 10;

-- Was: panic on 6th execution — "arguments must be literals"
PREPARE stmt(text, text, text) AS
  SELECT pdb.snippet(content, $2, $3) FROM t WHERE content ||| $1;

-- Was: backend crash — Rust panic
PREPARE stmt(jsonb) AS
  SELECT pdb.agg($1) FROM t WHERE content ||| 'test';
```

## Tests

**Regression tests:**
- Updated `issue_4665.sql` — parameterized OFFSET: `LIMIT 5 OFFSET $2`, `LIMIT $2 OFFSET $3`, `LIMIT $2 OFFSET 5`. CUSTOM and GENERIC side-by-side.
- New cases in `snippets.sql` — parameterized `pdb.snippet` tags, `pdb.snippets` sort_by/max_num_chars, `pdb.snippet_positions` limit/offset, invalid parameterized sort_by.
- New cases in `custom-agg.sql` — parameterized `pdb.agg`, backend survival check.

**Integration tests (`parameterized_queries.rs`):**
- `generic_plan_consistent_results_issue_4665` — WHERE param, Workers Planned > 0.
- `generic_plan_parameterized_limit_issue_4665` — LIMIT $2 matches constant baseline.
- `generic_plan_natural_transition_issue_4665` — 7 executions, stable results across CUSTOM→GENERIC.
- `generic_plan_parameterized_offset` — all three LIMIT×OFFSET param combinations.
- `joinscan_survives_parameterized_limit` — EXPLAIN confirms JoinScan with LIMIT $2.
- `snippet_with_parameterized_args` — param tags, CUSTOM=GENERIC=baseline.
- `pdb_agg_with_parameterized_json` — backend survives.

All 261 regression tests and integration suites pass. Existing `parallel_with_subselect` passes (`PARAM_EXEC` unaffected).