### PR TITLE
fix: Issues with text casts and memory layout for tokenizer types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "anyhow",
  "approx",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -8030,7 +8030,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -8418,7 +8418,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "anyhow",
  "approx",
@@ -8597,7 +8597,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "anyhow",
  "emoji",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.4"
+version = "0.23.5"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/macros/src/generate_tokenizer_sql.rs
+++ b/macros/src/generate_tokenizer_sql.rs
@@ -25,6 +25,7 @@ use syn::{parse_macro_input, Error, Ident, LitBool, LitStr, Result, Token};
 pub fn generate_tokenizer_sql(input: TokenStream) -> TokenStream {
     let mut args = parse_macro_input!(input as NamedArgs);
 
+    let def_name = args.take_str("def_name").unwrap();
     let rust_name = args.take_ident("rust_name").unwrap();
     let sql_name = args.take_str("sql_name").unwrap();
     let cast_name = args.take_ident("cast_name").unwrap();
@@ -36,30 +37,29 @@ pub fn generate_tokenizer_sql(input: TokenStream) -> TokenStream {
     let uuid_cast_name = args.take_ident("uuid_cast_name").unwrap();
     let text_array_cast_name = args.take_ident("text_array_cast_name").unwrap();
     let varchar_array_cast_name = args.take_ident("varchar_array_cast_name").unwrap();
+    let input_name = quote::format_ident!("{}_in", sql_name.value());
+    let output_name: Ident = quote::format_ident!("{}_out", sql_name.value());
     let to_boost_name = quote::format_ident!("{}_to_boost", sql_name.value());
     let to_const_name = quote::format_ident!("{}_to_const", sql_name.value());
     let to_fuzzy_name = quote::format_ident!("{}_to_fuzzy", sql_name.value());
     let to_slop_name = quote::format_ident!("{}_to_slop", sql_name.value());
     let pgrx_name = format!("{}_definition", sql_name.value());
 
+    let create_type_stub_sql = format!(
+        "CREATE TYPE {schema}.{sql_name};",
+        sql_name = sql_name.value()
+    );
     let create_type_sql = format!(
         r#"
-            CREATE TYPE {schema}.{sql_name};
-
-            CREATE OR REPLACE FUNCTION {schema}.{sql_name}_in(cstring) RETURNS {schema}.{sql_name} AS 'textin' LANGUAGE internal IMMUTABLE STRICT;
-            CREATE OR REPLACE FUNCTION {schema}.{sql_name}_out({schema}.{sql_name}) RETURNS cstring AS 'textout' LANGUAGE internal IMMUTABLE STRICT;
-            CREATE OR REPLACE FUNCTION {schema}.{sql_name}_send({schema}.{sql_name}) RETURNS bytea AS 'textsend' LANGUAGE internal IMMUTABLE STRICT;
-            CREATE OR REPLACE FUNCTION {schema}.{sql_name}_recv(internal) RETURNS {schema}.{sql_name} AS 'textrecv' LANGUAGE internal IMMUTABLE STRICT;
-
             CREATE TYPE {schema}.{sql_name} (
-                INPUT = {schema}.{sql_name}_in,
-                OUTPUT = {schema}.{sql_name}_out,
-                SEND = {schema}.{sql_name}_send,
-                RECEIVE = {schema}.{sql_name}_recv,
+                INPUT = {schema}.{input_name},
+                OUTPUT = {schema}.{output_name},
                 COLLATABLE = true,
                 CATEGORY = 't', -- 't' is for tokenizer
                 PREFERRED = {preferred},
-                LIKE = text
+                INTERNALLENGTH = -1,
+                ALIGNMENT = double,
+                STORAGE = extended
             );
          "#,
         sql_name = sql_name.value(),
@@ -166,10 +166,17 @@ pub fn generate_tokenizer_sql(input: TokenStream) -> TokenStream {
     };
 
     quote! {
+
+        extension_sql!(
+            #create_type_stub_sql,
+            name = #def_name,
+        );
+
         extension_sql!(
             #create_type_sql,
             name = #pgrx_name,
             creates = [Type(#rust_name)],
+            requires = [#input_name, #output_name],
         );
 
         #typmod

--- a/pg_search/sql/pg_search--0.23.4--0.23.5.sql
+++ b/pg_search/sql/pg_search--0.23.4--0.23.5.sql
@@ -1,0 +1,422 @@
+ALTER TYPE pdb.ngram SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.ngram_send(pdb.ngram);
+DROP FUNCTION IF EXISTS pdb.ngram_recv(internal);
+
+ALTER TYPE pdb.chinese_compatible SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.chinese_compatible_send(pdb.chinese_compatible);
+DROP FUNCTION IF EXISTS pdb.chinese_compatible_recv(internal);
+
+ALTER TYPE pdb.regex_pattern SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.regex_pattern_send(pdb.regex_pattern);
+DROP FUNCTION IF EXISTS pdb.regex_pattern_recv(internal);
+
+ALTER TYPE pdb.source_code SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.source_code_send(pdb.source_code);
+DROP FUNCTION IF EXISTS pdb.source_code_recv(internal);
+
+ALTER TYPE pdb.icu SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.icu_send(pdb.icu);
+DROP FUNCTION IF EXISTS pdb.icu_recv(internal);
+
+ALTER TYPE pdb.alias SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.alias_send(pdb.alias);
+DROP FUNCTION IF EXISTS pdb.alias_recv(internal);
+
+ALTER TYPE pdb.unicode_words SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.unicode_words_send(pdb.unicode_words);
+DROP FUNCTION IF EXISTS pdb.unicode_words_recv(internal);
+
+ALTER TYPE pdb.lindera SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.lindera_send(pdb.lindera);
+DROP FUNCTION IF EXISTS pdb.lindera_recv(internal);
+
+ALTER TYPE pdb.literal SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.literal_send(pdb.literal);
+DROP FUNCTION IF EXISTS pdb.literal_recv(internal);
+
+ALTER TYPE pdb.simple SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.simple_send(pdb.simple);
+DROP FUNCTION IF EXISTS pdb.simple_recv(internal);
+
+ALTER TYPE pdb.literal_normalized SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.literal_normalized_send(pdb.literal_normalized);
+DROP FUNCTION IF EXISTS pdb.literal_normalized_recv(internal);
+
+ALTER TYPE pdb.jieba SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.jieba_send(pdb.jieba);
+DROP FUNCTION IF EXISTS pdb.jieba_recv(internal);
+
+ALTER TYPE pdb.edge_ngram SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.edge_ngram_send(pdb.edge_ngram);
+DROP FUNCTION IF EXISTS pdb.edge_ngram_recv(internal);
+
+ALTER TYPE pdb.whitespace SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
+DROP FUNCTION IF EXISTS pdb.whitespace_send(pdb.whitespace);
+DROP FUNCTION IF EXISTS pdb.whitespace_recv(internal);
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:647
+-- pg_search::api::tokenizers::definitions::pdb::chinese_compatible_in
+-- requires:
+--   ChineseCompatibleDef
+CREATE OR REPLACE FUNCTION pdb."chinese_compatible_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.chinese_compatible /* GenericTypeWrapper < ChineseCompatible, ChineseCompatibleTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'chinese_compatible_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:750
+-- pg_search::api::tokenizers::definitions::pdb::edge_ngram_in
+-- requires:
+--   EdgeNgramDef
+CREATE OR REPLACE FUNCTION pdb."edge_ngram_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.edge_ngram /* GenericTypeWrapper < EdgeNgram, EdgeNgramTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'edge_ngram_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:647
+-- pg_search::api::tokenizers::definitions::pdb::chinese_compatible_out
+-- requires:
+--   ChineseCompatibleDef
+CREATE OR REPLACE FUNCTION pdb."chinese_compatible_out"(
+	"s" pdb.chinese_compatible /* ChineseCompatible */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'chinese_compatible_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:662
+-- pg_search::api::tokenizers::definitions::pdb::lindera_in
+-- requires:
+--   LinderaDef
+CREATE OR REPLACE FUNCTION pdb."lindera_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.lindera /* GenericTypeWrapper < Lindera, LinderaTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'lindera_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:662
+-- pg_search::api::tokenizers::definitions::pdb::lindera_out
+-- requires:
+--   LinderaDef
+CREATE OR REPLACE FUNCTION pdb."lindera_out"(
+	"s" pdb.lindera /* Lindera */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'lindera_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:770
+-- pg_search::api::tokenizers::definitions::pdb::regex_pattern_in
+-- requires:
+--   RegexDef
+CREATE OR REPLACE FUNCTION pdb."regex_pattern_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.regex_pattern /* GenericTypeWrapper < Regex, RegexTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'regex_pattern_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:729
+-- pg_search::api::tokenizers::definitions::pdb::ngram_in
+-- requires:
+--   NgramDef
+CREATE OR REPLACE FUNCTION pdb."ngram_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.ngram /* GenericTypeWrapper < Ngram, NgramTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'ngram_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:729
+-- pg_search::api::tokenizers::definitions::pdb::ngram_out
+-- requires:
+--   NgramDef
+CREATE OR REPLACE FUNCTION pdb."ngram_out"(
+	"s" pdb.ngram /* Ngram */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'ngram_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:770
+-- pg_search::api::tokenizers::definitions::pdb::regex_pattern_out
+-- requires:
+--   RegexDef
+CREATE OR REPLACE FUNCTION pdb."regex_pattern_out"(
+	"s" pdb.regex_pattern /* Regex */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'regex_pattern_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:617
+-- pg_search::api::tokenizers::definitions::pdb::literal_in
+-- requires:
+--   LiteralDef
+CREATE OR REPLACE FUNCTION pdb."literal_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.literal /* GenericTypeWrapper < Literal, LiteralTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'literal_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:617
+-- pg_search::api::tokenizers::definitions::pdb::literal_out
+-- requires:
+--   LiteralDef
+CREATE OR REPLACE FUNCTION pdb."literal_out"(
+	"s" pdb.literal /* Literal */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'literal_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:532
+-- pg_search::api::tokenizers::definitions::pdb::alias_in
+-- requires:
+--   AliasDef
+CREATE OR REPLACE FUNCTION pdb."alias_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.alias /* GenericTypeWrapper < Alias, AliasTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'alias_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:632
+-- pg_search::api::tokenizers::definitions::pdb::literal_normalized_in
+-- requires:
+--   LiteralNormalizedDef
+CREATE OR REPLACE FUNCTION pdb."literal_normalized_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.literal_normalized /* GenericTypeWrapper < LiteralNormalized, LiteralNormalizedTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'literal_normalized_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:587
+-- pg_search::api::tokenizers::definitions::pdb::simple_in
+-- requires:
+--   SimpleDef
+CREATE OR REPLACE FUNCTION pdb."simple_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.simple /* GenericTypeWrapper < Simple, SimpleTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'simple_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:602
+-- pg_search::api::tokenizers::definitions::pdb::whitespace_in
+-- requires:
+--   WhitespaceDef
+CREATE OR REPLACE FUNCTION pdb."whitespace_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.whitespace /* GenericTypeWrapper < Whitespace, WhitespaceTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'whitespace_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:602
+-- pg_search::api::tokenizers::definitions::pdb::whitespace_out
+-- requires:
+--   WhitespaceDef
+CREATE OR REPLACE FUNCTION pdb."whitespace_out"(
+	"s" pdb.whitespace /* Whitespace */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'whitespace_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:632
+-- pg_search::api::tokenizers::definitions::pdb::literal_normalized_out
+-- requires:
+--   LiteralNormalizedDef
+CREATE OR REPLACE FUNCTION pdb."literal_normalized_out"(
+	"s" pdb.literal_normalized /* LiteralNormalized */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'literal_normalized_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:750
+-- pg_search::api::tokenizers::definitions::pdb::edge_ngram_out
+-- requires:
+--   EdgeNgramDef
+CREATE OR REPLACE FUNCTION pdb."edge_ngram_out"(
+	"s" pdb.edge_ngram /* EdgeNgram */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'edge_ngram_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:788
+-- pg_search::api::tokenizers::definitions::pdb::unicode_words_in
+-- requires:
+--   UnicodeWordsDef
+CREATE OR REPLACE FUNCTION pdb."unicode_words_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.unicode_words /* GenericTypeWrapper < UnicodeWords, UnicodeWordsTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'unicode_words_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:788
+-- pg_search::api::tokenizers::definitions::pdb::unicode_words_out
+-- requires:
+--   UnicodeWordsDef
+CREATE OR REPLACE FUNCTION pdb."unicode_words_out"(
+	"s" pdb.unicode_words /* UnicodeWords */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'unicode_words_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:532
+-- pg_search::api::tokenizers::definitions::pdb::alias_out
+-- requires:
+--   AliasDef
+CREATE OR REPLACE FUNCTION pdb."alias_out"(
+	"s" pdb.alias /* Alias */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'alias_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:681
+-- pg_search::api::tokenizers::definitions::pdb::jieba_in
+-- requires:
+--   JiebaDef
+CREATE OR REPLACE FUNCTION pdb."jieba_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.jieba /* GenericTypeWrapper < Jieba, JiebaTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'jieba_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:681
+-- pg_search::api::tokenizers::definitions::pdb::jieba_out
+-- requires:
+--   JiebaDef
+CREATE OR REPLACE FUNCTION pdb."jieba_out"(
+	"s" pdb.jieba /* Jieba */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'jieba_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:699
+-- pg_search::api::tokenizers::definitions::pdb::source_code_in
+-- requires:
+--   SourceCodeDef
+CREATE OR REPLACE FUNCTION pdb."source_code_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.source_code /* GenericTypeWrapper < SourceCode, SourceCodeTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'source_code_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:699
+-- pg_search::api::tokenizers::definitions::pdb::source_code_out
+-- requires:
+--   SourceCodeDef
+CREATE OR REPLACE FUNCTION pdb."source_code_out"(
+	"s" pdb.source_code /* SourceCode */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'source_code_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:714
+-- pg_search::api::tokenizers::definitions::pdb::icu_in
+-- requires:
+--   IcuDef
+CREATE OR REPLACE FUNCTION pdb."icu_in"(
+	"s" cstring /* & std :: ffi :: CStr */
+) RETURNS pdb.icu /* GenericTypeWrapper < Icu, IcuTextMarker > */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'icu_in_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:714
+-- pg_search::api::tokenizers::definitions::pdb::icu_out
+-- requires:
+--   IcuDef
+CREATE OR REPLACE FUNCTION pdb."icu_out"(
+	"s" pdb.icu /* Icu */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'icu_out_wrapper';
+/* </end connected objects> */
+
+/* <begin connected objects> */
+-- pg_search/src/api/tokenizers/definitions.rs:587
+-- pg_search::api::tokenizers::definitions::pdb::simple_out
+-- requires:
+--   SimpleDef
+CREATE OR REPLACE FUNCTION pdb."simple_out"(
+	"s" pdb.simple /* Simple */
+) RETURNS cstring /* & '_ std :: ffi :: CStr */
+IMMUTABLE STRICT PARALLEL SAFE
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'simple_out_wrapper';
+
+DROP FUNCTION IF EXISTS pdb."alias_out_safe"(pdb.alias);
+

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -43,101 +43,159 @@ pub(crate) mod pdb {
         fn make_search_tokenizer() -> SearchTokenizer;
     }
 
-    /// Internal structure to store both the datum and its original type OID
-    /// This allows the output function to properly convert any type to text
-    ///
-    /// # IMPORTANT: Lifetime and Memory Safety Assumptions
-    ///
-    /// This structure stores a raw `pg_sys::Datum` value. For pass-by-value types (integers,
-    /// booleans, etc.), the datum contains the actual value and is safe to copy. However, for
-    /// varlena types (text, arrays, etc.), the datum is a **pointer** to memory that may be:
-    ///
-    /// - In a temporary memory context that could be freed
-    /// - TOASTed data whose detoasted copy could be freed
-    /// - Part of a tuple that gets freed after a function returns
-    ///
-    /// **Current Assumption**: We assume the input datum's lifetime extends beyond the wrapper's
-    /// lifetime. This holds true for:
-    /// - Index expressions: the datum comes from heap tuples during index build/insert
-    /// - Query execution: datums are in memory contexts that outlive the expression evaluation
-    ///
-    /// **Potential Issue**: If a wrapper is created with a datum from a temporary context and
-    /// then used after that context is destroyed, we'll have a dangling pointer leading to:
-    /// - Use-after-free bugs
-    /// - Segfaults when the output function tries to dereference the datum
-    /// - Heap corruption if the freed memory is reused
-    ///
-    /// **TODO**: Consider using `pg_sys::datumCopy()` for varlena types to ensure we own the
-    /// data, along with proper cleanup when the wrapper is freed. This would make the wrapper
-    /// fully self-contained and safe regardless of the input datum's lifetime.
+    /// Internal structure to store bytes from any type along with the info
+    /// needed to recover what type it is.
     #[repr(C)]
     pub struct DatumWithType {
-        vl_len_: i32,               // varlena header
-        magic: u32,                 // magic number to identify wrapped datums
-        typoid: pg_sys::Oid,        // original type OID
-        datum_value: pg_sys::Datum, // the actual datum value (RAW POINTER for varlena types!)
+        // varlena header
+        vl_len_: pg_sys::varlena,
+        // contents, separate for convenience with vardata functions.
+        contents: DatumWithTypeContents,
     }
 
-    // Magic number: "AL\0S" - includes a null byte to ensure no valid text string can match
-    // PostgreSQL text values cannot contain embedded nulls, making false positives impossible
-    const ALIAS_MAGIC: u32 = 0x414C0053; // 'A', 'L', 0x00, 'S'
+    #[repr(C)]
+    struct DatumWithTypeContents {
+        // magic number to identify wrapped datums
+        magic: u32,
+        // Metadata needed when extracting the wrapped data
+        elem_length: i16,
+        elem_by_val: bool,
+        // Reserved padding; always written as 0.
+        _padding: u8,
+        // original type OID
+        typoid: pg_sys::Oid,
+        // underlying types data goes here
+    }
+
+    // Check that there's no extra padding
+    const _: () = assert!(
+        std::mem::size_of::<DatumWithType>()
+            == std::mem::size_of::<i32>()
+                + std::mem::size_of::<u32>()
+                + std::mem::size_of::<i16>()
+                + std::mem::size_of::<bool>()
+                + std::mem::size_of::<u8>()
+                + std::mem::size_of::<pg_sys::Oid>()
+    );
+
+    // Magic number: "err\0" - includes null bytes to ensure no valid text string can match
+    // (PostgreSQL text values cannot contain embedded nulls). Prints as the string "err" if
+    // interpreted as TEXT, making it a bit easier to catch.
+    const ALIAS_MAGIC: u32 = u32::from_ne_bytes([b'e', b'r', b'r', b'\0']);
 
     impl DatumWithType {
-        unsafe fn new(datum: pg_sys::Datum, typoid: pg_sys::Oid) -> *mut Self {
-            let size = std::mem::size_of::<DatumWithType>();
-            let ptr = pg_sys::palloc(size) as *mut DatumWithType;
+        unsafe fn new(mut datum: pg_sys::Datum, typoid: pg_sys::Oid) -> *mut Self {
+            use pgrx::varlena::varsize_any;
+            use std::mem::size_of;
 
-            // Since pdb.alias is defined as LIKE = text, PostgreSQL treats it as a varlena
-            // (variable-length) type. All varlena types must have a valid size header in the
-            // first 4 bytes (vl_len_). This header includes:
-            //   1. The total size of the structure (including the header itself)
-            //   2. Special bit flags used by PostgreSQL for TOAST and compression
-            //
-            // set_varsize_4b encodes this information correctly. Without it:
-            //   - PostgreSQL wouldn't know where our data ends (memory corruption)
-            //   - TOAST (oversized-attribute storage) would fail
-            //   - Copying/serializing the datum would cause segfaults
-            pgrx::set_varsize_4b(ptr.cast(), size as i32);
+            // load metadata about the underlying type.
+            let mut elem_length = 0;
+            let mut elem_by_val = false;
+            // Check that the data section is sufficiently aligned to store any
+            // type. So we don't need to use `elem_align`
+            const _: () = assert!(std::mem::size_of::<DatumWithType>().is_multiple_of(8));
+            let mut _elem_align = 0;
+            pg_sys::get_typlenbyvalalign(
+                typoid,
+                &mut elem_length,
+                &mut elem_by_val,
+                &mut _elem_align,
+            );
 
-            // Set the magic number to identify this as a wrapped datum
-            // This prevents false positives when text happens to be the same size
-            (*ptr).magic = ALIAS_MAGIC;
+            // Ensure that the data isn't TOASTed.
+            if elem_length == -1 {
+                datum = pg_sys::pg_detoast_datum(datum.cast_mut_ptr()).into();
+            }
 
-            // set the original type OID and the actual datum value
-            (*ptr).typoid = typoid;
-            (*ptr).datum_value = datum;
+            // based on Postgres's `att_addlength_datum`
+            // (specifically `att_addlength_pointer` which it calls)
+            let data_len = if elem_length > 0 {
+                elem_length as usize
+            } else if elem_length == -1 {
+                varsize_any(datum.cast_mut_ptr::<pg_sys::varlena>())
+            } else {
+                unreachable!("tried to pass a C string as a tokenizer")
+            };
+
+            // DatumWithType is a multiple of 8bytes (the largest alignment
+            // postgres uses) so we don't need any additional aligning.
+            let size = size_of::<DatumWithType>() + data_len;
+            let ptr = pg_sys::palloc(size).cast::<DatumWithType>();
+
+            *ptr = DatumWithType {
+                vl_len_: pg_sys::varlena::default(),
+                contents: DatumWithTypeContents {
+                    // Set the magic number to identify this as a wrapped datum
+                    // This prevents false positives when text happens to be the same size
+                    magic: ALIAS_MAGIC,
+                    elem_length,
+                    elem_by_val,
+                    _padding: 0,
+                    // set the original type OID and the actual datum value
+                    typoid,
+                },
+            };
+
+            // Set the varlena header so Postgres knows the length.
+            pgrx::set_varsize_4b(&mut (*ptr).vl_len_, size as i32);
+
+            // Copy in the data for the underlying type
+            // (based on Postgres's `ArrayCastAndSet()`).
+            let data_ptr = ptr.add(1).cast::<u8>();
+            if elem_by_val {
+                crate::postgres::utils::store_att_byval(
+                    data_ptr.cast(),
+                    datum,
+                    data_len.try_into().unwrap(),
+                );
+            } else {
+                data_ptr.copy_from(datum.cast_mut_ptr(), data_len);
+            }
 
             ptr
         }
 
-        /// Check if a datum is a wrapped DatumWithType by verifying size and magic number
-        pub unsafe fn is_wrapped(wrapper: pg_sys::Datum) -> bool {
-            let ptr = wrapper.cast_mut_ptr::<DatumWithType>();
-            if ptr.is_null() {
-                return false;
-            }
+        /// Returns the a Datum for the underlying type,
+        /// along with its type Oid if it isn't a text type
+        /// SAFETY: datum must be a pointer to a valid `DatumWithType`
+        pub unsafe fn get_underlying_type(
+            this: pg_sys::Datum,
+        ) -> (pg_sys::Datum, Option<pg_sys::Oid>) {
+            use std::mem::offset_of;
+
+            // It would be nice to use pg_detoast_datum_packed(), but then if the
+            // stored type was using the 4B header reading it could be unaligned.
+            let ptr = pg_sys::pg_detoast_datum(this.cast_mut_ptr());
+            debug_assert!(!ptr.is_null());
 
             let vl_len = pgrx::varlena::varsize_any(ptr.cast::<pg_sys::varlena>());
-            let expected_size = std::mem::size_of::<DatumWithType>();
+            let minimum_size = std::mem::size_of::<DatumWithTypeContents>();
 
-            // Check both size AND magic number to avoid false positives
-            // NOTE: if ptr is TEXT than ptr.magic could be unaligned
-            vl_len == expected_size
-                && ptr
-                    .byte_add(std::mem::offset_of!(DatumWithType, magic))
+            // Check both size AND magic number to avoid false positives.
+            // NOTE: False negatives are less risky than false positives since
+            //       any element of this type is prefixed with the valid C string
+            //       `err`
+            if vl_len < minimum_size
+                || pgrx::varlena::vardata_any(ptr)
+                    .byte_add(offset_of!(DatumWithTypeContents, magic))
                     .cast::<u32>()
                     .read_unaligned()
-                    == ALIAS_MAGIC
-        }
+                    != ALIAS_MAGIC
+            {
+                // Must have been a text type, return the detoasted value as-is
+                return (pg_sys::Datum::from(ptr), None);
+            }
 
-        pub unsafe fn extract_datum(wrapper: pg_sys::Datum) -> pg_sys::Datum {
-            let ptr = wrapper.cast_mut_ptr::<DatumWithType>();
-            (*ptr).datum_value
-        }
+            let contents_ptr = pgrx::varlena::vardata_any(ptr).cast::<DatumWithTypeContents>();
+            let contents = contents_ptr.read();
 
-        pub unsafe fn extract_typoid(wrapper: pg_sys::Datum) -> pg_sys::Oid {
-            let ptr = wrapper.cast_mut_ptr::<DatumWithType>();
-            (*ptr).typoid
+            let data_ptr = contents_ptr.add(1).cast();
+            let underlying = crate::postgres::utils::fetch_att(
+                data_ptr,
+                contents.elem_by_val,
+                contents.elem_length.into(),
+            );
+            (underlying, Some(contents.typoid))
         }
     }
 
@@ -180,7 +238,7 @@ pub(crate) mod pdb {
     }
 
     macro_rules! define_tokenizer_type {
-        ($rust_name:ident, $tokenizer_conf:expr, $cast_name:ident, $json_cast_name:ident, $jsonb_cast_name:ident, $uuid_cast_name:ident, $text_array_cast_name:ident, $varchar_array_cast_name:ident, $sql_name:literal, preferred = $preferred:literal, custom_typmod = $custom_typmod:literal) => {
+        ($def_name:literal, $rust_name:ident, $tokenizer_conf:expr, $cast_name:ident, $json_cast_name:ident, $jsonb_cast_name:ident, $uuid_cast_name:ident, $text_array_cast_name:ident, $varchar_array_cast_name:ident, $sql_name:literal, preferred = $preferred:literal, custom_typmod = $custom_typmod:literal) => {
             pub struct $rust_name(pg_sys::Datum);
 
             impl TokenizerCtor for $rust_name {
@@ -276,6 +334,12 @@ pub(crate) mod pdb {
             }
 
             paste! {
+
+                struct [<$rust_name TextMarker>];
+                impl SqlNameMarker for [<$rust_name TextMarker>] {
+                    const SQL_NAME: &'static str = concat!("pdb.", $sql_name);
+                }
+
                 struct [<$rust_name JsonMarker>];
                 impl SqlNameMarker for [<$rust_name JsonMarker>] {
                     const SQL_NAME: &'static str = concat!("pdb.", $sql_name);
@@ -299,6 +363,42 @@ pub(crate) mod pdb {
                 struct [<$rust_name UuidMarker>];
                 impl SqlNameMarker for [<$rust_name UuidMarker>] {
                     const SQL_NAME: &'static str = concat!("pdb.", $sql_name);
+                }
+
+                #[pg_extern(immutable, strict, parallel_safe, requires = [$def_name])] // TODO handle typmod
+                fn [<$sql_name _in>](s: &std::ffi::CStr) -> GenericTypeWrapper<$rust_name, [<$rust_name TextMarker>]> {
+                    // TEXT and bytea share the same underlying layout,
+                    // so the bytea functions provide a convenient way to create
+                    // TEXT without UTF-8 conversion
+                    let text = pgrx::rust_byte_slice_to_bytea(s.to_bytes());
+                    let wrapper_ptr = unsafe { DatumWithType::new(text.into_datum().unwrap(), pg_sys::TEXTOID) };
+
+                    GenericTypeWrapper::new(pg_sys::Datum::from(wrapper_ptr), pg_sys::TEXTOID)
+                }
+
+                #[pg_extern(immutable, strict, parallel_safe, requires = [$def_name])]
+                fn [<$sql_name _out>](s: $rust_name) -> &'static std::ffi::CStr  {
+                    let wrapper_datum = s.as_datum();
+                    unsafe {
+                        let (underlying, typ) = DatumWithType::get_underlying_type(wrapper_datum);
+                        match typ {
+                            None => {
+                                    let ptr = underlying.cast_mut_ptr();
+                                    let cstr = pgrx::pg_sys::text_to_cstring(ptr);
+                                    std::ffi::CStr::from_ptr(cstr)
+                            }
+                            Some(typoid) => {
+                                let mut typoutput = 0.into();
+                                let mut typ_is_varlena = true;
+                                pg_sys::getTypeOutputInfo(
+                                    typoid,
+                                    &mut typoutput,
+                                    &mut typ_is_varlena);
+                                let cstr = pg_sys::OidOutputFunctionCall(typoutput, underlying);
+                                std::ffi::CStr::from_ptr(cstr)
+                            },
+                        }
+                    }
                 }
 
                 #[pg_extern(immutable, parallel_safe, requires = [ $cast_name ])]
@@ -362,6 +462,7 @@ pub(crate) mod pdb {
             }
 
             generate_tokenizer_sql!(
+                def_name = $def_name,
                 rust_name = $rust_name,
                 sql_name = $sql_name,
                 cast_name = $cast_name,
@@ -378,6 +479,7 @@ pub(crate) mod pdb {
     }
 
     define_tokenizer_type!(
+        "AliasDef",
         Alias,
         SearchTokenizer::Simple(SearchTokenizerFilters::default()),
         tokenize_alias,
@@ -391,58 +493,8 @@ pub(crate) mod pdb {
         custom_typmod = false
     );
 
-    /// Output function for pdb.alias that unwraps the stored datum and converts to text
-    #[pg_extern(immutable, strict, parallel_safe)]
-    fn alias_out_safe(input: Alias) -> std::ffi::CString {
-        unsafe {
-            let wrapper_datum = input.as_datum();
-
-            // Check if this is a wrapped DatumWithType using magic number verification
-            // For text literals, PostgreSQL might pass them directly without wrapping
-            // due to LIKE = text in the type definition
-            if DatumWithType::is_wrapped(wrapper_datum) {
-                let typoid = DatumWithType::extract_typoid(wrapper_datum);
-                let original_datum = DatumWithType::extract_datum(wrapper_datum);
-
-                // Get the output function for the original type
-                let mut typoutput: pg_sys::Oid = pg_sys::InvalidOid;
-                let mut is_varlena: bool = false;
-                pg_sys::getTypeOutputInfo(typoid, &mut typoutput, &mut is_varlena);
-
-                // Call the type's output function to get the C string
-                let cstring_ptr = pg_sys::OidOutputFunctionCall(typoutput, original_datum);
-                std::ffi::CStr::from_ptr(cstring_ptr).to_owned()
-            } else {
-                // Not wrapped, it's raw text (or null)
-                let ptr = wrapper_datum.cast_mut_ptr::<pg_sys::varlena>();
-                if ptr.is_null() {
-                    return std::ffi::CString::new("").unwrap();
-                }
-
-                // Convert the text varlena to a string using pgrx utilities
-                let text_len = pgrx::varlena::varsize_any_exhdr(ptr);
-                let text_data = pgrx::varlena::vardata_any(ptr);
-                #[allow(clippy::unnecessary_cast)]
-                let text_slice = std::slice::from_raw_parts(text_data as *const u8, text_len);
-                let text_str = std::str::from_utf8_unchecked(text_slice);
-                std::ffi::CString::new(text_str)
-                    .unwrap_or_else(|_| std::ffi::CString::new("").unwrap())
-            }
-        }
-    }
-
-    extension_sql!(
-        r#"
-        -- Override the output function for pdb.alias
-        CREATE OR REPLACE FUNCTION pdb.alias_out(pdb.alias) RETURNS cstring
-            AS 'MODULE_PATHNAME', 'alias_out_safe_wrapper'
-            LANGUAGE c IMMUTABLE STRICT PARALLEL SAFE;
-        "#,
-        name = "alias_out_safe_override",
-        requires = [tokenize_alias, alias_out_safe]
-    );
-
     define_tokenizer_type!(
+        "SimpleDef",
         Simple,
         SearchTokenizer::Simple(SearchTokenizerFilters::default()),
         tokenize_simple,
@@ -457,6 +509,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "WhitespaceDef",
         Whitespace,
         SearchTokenizer::WhiteSpace(SearchTokenizerFilters::default()),
         tokenize_whitespace,
@@ -471,6 +524,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "LiteralDef",
         Literal,
         SearchTokenizer::Keyword,
         tokenize_literal,
@@ -485,6 +539,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "LiteralNormalizedDef",
         LiteralNormalized,
         SearchTokenizer::LiteralNormalized(SearchTokenizerFilters::default()),
         tokenize_literal_normalized,
@@ -499,6 +554,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "ChineseCompatibleDef",
         ChineseCompatible,
         SearchTokenizer::ChineseCompatible(SearchTokenizerFilters::default()),
         tokenize_chinese_compatible,
@@ -513,6 +569,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "LinderaDef",
         Lindera,
         SearchTokenizer::Lindera {
             language: LinderaLanguage::Chinese,
@@ -531,6 +588,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "JiebaDef",
         Jieba,
         SearchTokenizer::Jieba {
             chinese_convert: None,
@@ -548,6 +606,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "SourceCodeDef",
         SourceCode,
         SearchTokenizer::SourceCode(SearchTokenizerFilters::default()),
         tokenize_source_code,
@@ -562,6 +621,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "IcuDef",
         Icu,
         SearchTokenizer::ICUTokenizer(SearchTokenizerFilters::default()),
         tokenize_icu,
@@ -576,6 +636,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "NgramDef",
         Ngram,
         SearchTokenizer::Ngram {
             min_gram: 1,
@@ -596,6 +657,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "EdgeNgramDef",
         EdgeNgram,
         SearchTokenizer::EdgeNgram {
             min_gram: 1,
@@ -615,6 +677,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "RegexDef",
         Regex,
         SearchTokenizer::RegexTokenizer {
             pattern: ".*".to_string(),
@@ -632,6 +695,7 @@ pub(crate) mod pdb {
     );
 
     define_tokenizer_type!(
+        "UnicodeWordsDef",
         UnicodeWords,
         SearchTokenizer::UnicodeWords {
             remove_emojis: false,

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -555,7 +555,6 @@ where
         .to_tantivy_tokenizer()
         .expect("failed to convert tokenizer to tantivy tokenizer");
 
-    let wrapper_datum = to_tokenize.as_datum();
     let mut tokens = Vec::new();
     let mut tokenize = |s: &str| {
         let mut stream = analyzer.token_stream(s);
@@ -568,23 +567,28 @@ where
 
     // Check if this is a wrapped DatumWithType using magic number verification
     // For text literals, PostgreSQL might pass them directly without wrapping
-    // due to LIKE = text in the type definition
-    // TODO is the LIKE doing anything useful if conversion is effectively mandatory?
-    if !DatumWithType::is_wrapped(wrapper_datum) {
-        // Not wrapped, it's raw text (or null)
-        let varlena = wrapper_datum.cast_mut_ptr::<pg_sys::varlena>();
-        let detoasted = pg_sys::pg_detoast_datum(varlena);
+    // due to the binary casts
+    let wrapper_datum = to_tokenize.as_datum();
+    let (underlying, typ) = DatumWithType::get_underlying_type(wrapper_datum);
+    let typoid = match typ {
+        Some(typoid) => typoid,
+        None => {
+            // Not wrapped, it's raw text (or null)
+            let varlena = wrapper_datum.cast_mut_ptr::<pg_sys::varlena>();
+            let s = convert_varlena_to_str_memoized(varlena);
+            tokenize(s);
+            return tokens;
+        }
+    };
 
-        let s = convert_varlena_to_str_memoized(detoasted);
-        tokenize(s);
-        return tokens;
-    }
-
-    let typoid = DatumWithType::extract_typoid(wrapper_datum);
-    let original_datum = DatumWithType::extract_datum(wrapper_datum);
     match typoid {
+        pg_sys::TEXTOID => {
+            let detoasted = pg_sys::pg_detoast_datum(underlying.cast_mut_ptr::<pg_sys::varlena>());
+            let s = convert_varlena_to_str_memoized(detoasted);
+            tokenize(s)
+        }
         pg_sys::TEXTARRAYOID | pg_sys::VARCHARARRAYOID => {
-            let strings = <Vec<String> as pgrx::FromDatum>::from_datum(original_datum, false)
+            let strings = <Vec<String> as pgrx::FromDatum>::from_datum(underlying, false)
                 .expect("must have data");
             for s in strings {
                 tokenize(&s)
@@ -742,7 +746,8 @@ datum_wrapper_for!(
     Vec<pgrx::datum::Timestamp>,
     Vec<pgrx::datum::TimestampWithTimeZone>,
     Vec<pgrx::datum::TimeWithTimeZone>,
-    Vec<pgrx::datum::AnyNumeric>
+    Vec<pgrx::datum::AnyNumeric>,
+    pgrx::PgBox<pg_sys::bytea>
 );
 
 pub trait SqlNameMarker {

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -764,12 +764,9 @@ pub unsafe fn row_to_search_document<'a>(
             continue;
         }
 
-        // For pdb.alias/tokenizer types, unwrap the datum first before any processing
-        // The DatumWithType structure wraps the actual datum for all alias types
-        let actual_datum = if type_is_alias(pg_type.value())
-            || (type_is_tokenizer(pg_type.value()) && DatumWithType::is_wrapped(datum))
-        {
-            unsafe { DatumWithType::extract_datum(datum) }
+        // For pdb.alias/tokenizer types, get the underlying type if it's not a text type.
+        let actual_datum = if type_is_alias(pg_type.value()) || type_is_tokenizer(pg_type.value()) {
+            unsafe { DatumWithType::get_underlying_type(datum).0 }
         } else {
             datum
         };
@@ -993,6 +990,65 @@ pub fn extract_numeric_precision_scale(typmod: i32) -> (u16, Option<i16>) {
     let scale = (stored_scale ^ 1024) - 1024;
 
     (precision, Some(scale))
+}
+
+// Backport of `store_att_byval()` that works on pg15
+// Writes a datum `arg_newdatum` into memory pointed to by `arg_t`
+// SAFETY: `arg_t` must point at writable memory of sufficient size to store the
+//         Postgres value represented by `arg_newdatum`.
+//         `arg_newdatum` must be a valid postgres value with the specified attlen.
+pub unsafe fn store_att_byval(
+    arg_t: *mut std::ffi::c_void,
+    arg_newdatum: pg_sys::Datum,
+    arg_attlen: std::ffi::c_int,
+) {
+    #[cfg(not(feature = "pg15"))]
+    unsafe {
+        pg_sys::store_att_byval(arg_t, arg_newdatum, arg_attlen)
+    }
+
+    #[cfg(feature = "pg15")]
+    unsafe {
+        match arg_attlen {
+            1 => arg_t.cast::<i8>().write(arg_newdatum.value() as i8),
+            2 => arg_t.cast::<i16>().write(arg_newdatum.value() as i16),
+            4 => arg_t.cast::<i32>().write(arg_newdatum.value() as i32),
+            8 => arg_t.cast::<i64>().write(arg_newdatum.value() as i64),
+            _ => unreachable!(),
+        }
+    }
+}
+
+// Backport of `fetch_att_byval()` that works on pg15
+// Returns a Datum representation of the Postgres value stored in `arg_t`
+// SAFETY: The value stored in `arg_t` must be a valid Postgres value with
+//         the specified by-val and att-len.
+//         If the type is not by-val the provided pointer must live as long as
+//         the Datum.
+pub unsafe fn fetch_att(
+    arg_t: *const ::core::ffi::c_void,
+    arg_attbyval: bool,
+    arg_attlen: ::core::ffi::c_int,
+) -> pg_sys::Datum {
+    #[cfg(not(feature = "pg15"))]
+    unsafe {
+        pg_sys::fetch_att(arg_t, arg_attbyval, arg_attlen)
+    }
+
+    #[cfg(feature = "pg15")]
+    if arg_attbyval {
+        unsafe {
+            match arg_attlen {
+                1 => pg_sys::Datum::from(arg_t.cast::<i8>().read()),
+                2 => pg_sys::Datum::from(arg_t.cast::<i16>().read()),
+                4 => pg_sys::Datum::from(arg_t.cast::<i32>().read()),
+                8 => pg_sys::Datum::from(arg_t.cast::<i64>().read()),
+                _ => unreachable!(),
+            }
+        }
+    } else {
+        pg_sys::Datum::from(arg_t)
+    }
 }
 
 type IsArray = bool;

--- a/pg_search/tests/pg_regress/expected/composite.out
+++ b/pg_search/tests/pg_regress/expected/composite.out
@@ -1395,6 +1395,86 @@ SELECT COUNT(*) AS default_no_stem FROM stemmer_test WHERE id @@@ pdb.parse('con
 (1 row)
 
 ------------------------------------------------------------
+-- TEST: Non-TEXT tokenizer casts in composite ROW (#5033)
+-- Pre-fix, the wrapper used by `text[]::pdb.tokenizer(...)` casts was
+-- short-form-packed by heap_form_tuple inside ROW(...)::composite, and
+-- recognition failed -> ERROR: cache lookup failed for type 0.
+------------------------------------------------------------
+-- text[] field with typmod
+CREATE TYPE arr_search AS (b pdb.literal_normalized('fieldnorms=false'));
+CREATE TABLE arr_test (id int PRIMARY KEY, b text[]);
+CREATE INDEX arr_idx ON arr_test USING bm25 (
+    id,
+    (ROW((b)::pdb.literal_normalized('fieldnorms=false'))::arr_search)
+) WITH (key_field='id');
+INSERT INTO arr_test VALUES (1, ARRAY['x']), (2, ARRAY['y','z']);
+SELECT id FROM arr_test WHERE id @@@ 'b:x' ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+SELECT id FROM arr_test WHERE id @@@ 'b:y' ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+SELECT id FROM arr_test WHERE id @@@ 'b:nope';
+ id 
+----
+(0 rows)
+
+-- Implicit cast (no explicit cast in ROW; PG inserts it from composite type)
+CREATE TYPE arr_search_imp AS (b pdb.literal_normalized('fieldnorms=false'));
+CREATE TABLE arr_test_imp (id int PRIMARY KEY, b text[]);
+CREATE INDEX arr_idx_imp ON arr_test_imp USING bm25 (
+    id, (ROW(b)::arr_search_imp)
+) WITH (key_field='id');
+INSERT INTO arr_test_imp VALUES (1, ARRAY['hello']);
+SELECT id FROM arr_test_imp WHERE id @@@ 'b:hello';
+ id 
+----
+  1
+(1 row)
+
+-- Multi-field composite mixing text, text[], and bigint casts
+CREATE TYPE multi_search AS (
+    txt pdb.simple,
+    arr pdb.literal_normalized('fieldnorms=false'),
+    n   bigint
+);
+CREATE TABLE multi_test (id int PRIMARY KEY, txt text, arr text[], n int);
+CREATE INDEX multi_idx ON multi_test USING bm25 (
+    id,
+    (ROW(
+        (txt)::pdb.simple,
+        (arr)::pdb.literal_normalized('fieldnorms=false'),
+        (n)::bigint
+    )::multi_search)
+) WITH (key_field='id');
+INSERT INTO multi_test VALUES
+    (1, 'hello world', ARRAY['action','adventure'], 10),
+    (2, 'foo bar',     ARRAY['comedy'],             20);
+SELECT id FROM multi_test WHERE id @@@ 'txt:hello'  ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+SELECT id FROM multi_test WHERE id @@@ 'arr:action' ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+SELECT id FROM multi_test WHERE id @@@ 'arr:comedy' ORDER BY id;
+ id 
+----
+  2
+(1 row)
+
+------------------------------------------------------------
 -- SMOKE TESTS: Comprehensive feature coverage
 ------------------------------------------------------------
 -- Create composite type for smoke tests (using pdb tokenizer types)

--- a/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-types-inline-tokenization.out
@@ -84,3 +84,57 @@ SELECT ARRAY['this is a test.', 'foo bar baz']::pdb.whitespace::text[];
 
 SELECT '"foo"'::jsonb::pdb.whitespace::text[];
 ERROR:  cannot tokenize a jsonb inline
+SELECT '"foo"'::jsonb::pdb.whitespace::text;
+ text  
+-------
+ "foo"
+(1 row)
+
+SELECT ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace::text[];
+       array       
+-------------------
+ {foo,bar,baz,qux}
+(1 row)
+
+SELECT ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace::text;
+         array          
+------------------------
+ {"foo bar",baz," qux"}
+(1 row)
+
+-- Expression realloc function. Causes Postgres to reallocate the returned value
+CREATE FUNCTION realloc (anyelement) RETURNS anyelement
+AS 'SELECT $1 FROM random();'
+LANGUAGE SQL VOLATILE;
+SELECT realloc('foo'::pdb.whitespace)::text[];
+ realloc 
+---------
+ {foo}
+(1 row)
+
+SELECT realloc('foo'::pdb.whitespace)::text;
+ realloc 
+---------
+ foo
+(1 row)
+
+SELECT realloc('"foo"'::jsonb::pdb.whitespace)::text[];
+ERROR:  cannot tokenize a jsonb inline
+SELECT realloc('"foo"'::jsonb::pdb.whitespace)::text;
+ realloc 
+---------
+ "foo"
+(1 row)
+
+SELECT realloc(ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace)::text[];
+      realloc      
+-------------------
+ {foo,bar,baz,qux}
+(1 row)
+
+SELECT realloc(ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace)::text;
+        realloc         
+------------------------
+ {"foo bar",baz," qux"}
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/composite.sql
+++ b/pg_search/tests/pg_regress/sql/composite.sql
@@ -812,6 +812,56 @@ SELECT COUNT(*) AS default_no_stem FROM stemmer_test WHERE id @@@ pdb.parse('con
 SELECT COUNT(*) AS default_no_stem FROM stemmer_test WHERE id @@@ pdb.parse('content:run');
 
 ------------------------------------------------------------
+-- TEST: Non-TEXT tokenizer casts in composite ROW (#5033)
+-- Pre-fix, the wrapper used by `text[]::pdb.tokenizer(...)` casts was
+-- short-form-packed by heap_form_tuple inside ROW(...)::composite, and
+-- recognition failed -> ERROR: cache lookup failed for type 0.
+------------------------------------------------------------
+
+-- text[] field with typmod
+CREATE TYPE arr_search AS (b pdb.literal_normalized('fieldnorms=false'));
+CREATE TABLE arr_test (id int PRIMARY KEY, b text[]);
+CREATE INDEX arr_idx ON arr_test USING bm25 (
+    id,
+    (ROW((b)::pdb.literal_normalized('fieldnorms=false'))::arr_search)
+) WITH (key_field='id');
+INSERT INTO arr_test VALUES (1, ARRAY['x']), (2, ARRAY['y','z']);
+SELECT id FROM arr_test WHERE id @@@ 'b:x' ORDER BY id;
+SELECT id FROM arr_test WHERE id @@@ 'b:y' ORDER BY id;
+SELECT id FROM arr_test WHERE id @@@ 'b:nope';
+
+-- Implicit cast (no explicit cast in ROW; PG inserts it from composite type)
+CREATE TYPE arr_search_imp AS (b pdb.literal_normalized('fieldnorms=false'));
+CREATE TABLE arr_test_imp (id int PRIMARY KEY, b text[]);
+CREATE INDEX arr_idx_imp ON arr_test_imp USING bm25 (
+    id, (ROW(b)::arr_search_imp)
+) WITH (key_field='id');
+INSERT INTO arr_test_imp VALUES (1, ARRAY['hello']);
+SELECT id FROM arr_test_imp WHERE id @@@ 'b:hello';
+
+-- Multi-field composite mixing text, text[], and bigint casts
+CREATE TYPE multi_search AS (
+    txt pdb.simple,
+    arr pdb.literal_normalized('fieldnorms=false'),
+    n   bigint
+);
+CREATE TABLE multi_test (id int PRIMARY KEY, txt text, arr text[], n int);
+CREATE INDEX multi_idx ON multi_test USING bm25 (
+    id,
+    (ROW(
+        (txt)::pdb.simple,
+        (arr)::pdb.literal_normalized('fieldnorms=false'),
+        (n)::bigint
+    )::multi_search)
+) WITH (key_field='id');
+INSERT INTO multi_test VALUES
+    (1, 'hello world', ARRAY['action','adventure'], 10),
+    (2, 'foo bar',     ARRAY['comedy'],             20);
+SELECT id FROM multi_test WHERE id @@@ 'txt:hello'  ORDER BY id;
+SELECT id FROM multi_test WHERE id @@@ 'arr:action' ORDER BY id;
+SELECT id FROM multi_test WHERE id @@@ 'arr:comedy' ORDER BY id;
+
+------------------------------------------------------------
 -- SMOKE TESTS: Comprehensive feature coverage
 ------------------------------------------------------------
 

--- a/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql
@@ -16,3 +16,19 @@ SELECT 'this is a test. fn foo(arg: String) -> impl Foo<''a> { return 42; }'::pd
 SELECT ARRAY['this is a test.', 'foo bar baz']::pdb.whitespace::text[];
 
 SELECT '"foo"'::jsonb::pdb.whitespace::text[];
+SELECT '"foo"'::jsonb::pdb.whitespace::text;
+SELECT ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace::text[];
+SELECT ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace::text;
+
+
+-- Expression realloc function. Causes Postgres to reallocate the returned value
+CREATE FUNCTION realloc (anyelement) RETURNS anyelement
+AS 'SELECT $1 FROM random();'
+LANGUAGE SQL VOLATILE;
+
+SELECT realloc('foo'::pdb.whitespace)::text[];
+SELECT realloc('foo'::pdb.whitespace)::text;
+SELECT realloc('"foo"'::jsonb::pdb.whitespace)::text[];
+SELECT realloc('"foo"'::jsonb::pdb.whitespace)::text;
+SELECT realloc(ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace)::text[];
+SELECT realloc(ARRAY['foo bar', 'baz', ' qux']::pdb.whitespace)::text;


### PR DESCRIPTION
# Ticket(s) Closed

- fixes https://github.com/paradedb/paradedb/issues/5033

## What

Changes the tokenizer and alias types to function as regular SQL types (writable to disk, reallocatable in memory contexts etc).

## Why

When used incorrectly (eg. within a non-optimized function call) the previous versions would access freed memory.

## How

The tokenizer format is changed from `(header, magic_num, Oid, padding Datum)` to `(header, magic_num, metadata, padding, Oid, data_bytes)` where the `data_bytes` are the bytes from the original value (the `Datum` for by-value types, and the bytes pointed-at by the `Datum` for by-ref types). This lets us create a new `Datum` for that type (pointing at the inner bytes if needed).

NOTE: Since the old version of the type was storing `Datum`s directly, any values stored to disk with the old code is broken unless they were in text format (the others store dangling pointers). In the updated version such values will be output as meaningless text instead.

## Tests

- in `pg_search/tests/pg_regress/sql/tokenizer-types-inline-tokenization.sql`
