### PR TITLE
fix: pre-load dictionary tokenizers in postmaster

### DIFF
--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -112,6 +112,17 @@ pub unsafe extern "C-unwind" fn _PG_init() {
     postgres::options::init();
     gucs::init();
 
+    // Issue #4840: parallel workers fork from the postmaster, not from the
+    // backend. The early `shared_preload_libraries` check above bails out
+    // unless `process_shared_preload_libraries_in_progress` is true, so by
+    // this point we are guaranteed to be running once in the postmaster.
+    // Pre-loading the dictionary-backed Lindera and jieba tokenizers here
+    // means every parallel worker inherits them through copy-on-write
+    // `fork()` and skips the 50-160 ms per-query dictionary cold-start.
+    // The dict pages are immutable after load, so they stay physically
+    // shared across all workers.
+    tokenizers::prewarm_dictionary_tokenizers();
+
     #[cfg(not(any(feature = "pg17", feature = "pg18")))]
     postgres::fake_aminsertcleanup::register();
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -120,8 +120,19 @@ pub unsafe extern "C-unwind" fn _PG_init() {
     // means every parallel worker inherits them through copy-on-write
     // `fork()` and skips the 50-160 ms per-query dictionary cold-start.
     // The dict pages are immutable after load, so they stay physically
-    // shared across all workers.
-    tokenizers::prewarm_dictionary_tokenizers();
+    // shared across all workers. A panic in any one family is caught and
+    // logged as a WARNING rather than aborting the postmaster — the same
+    // failure will resurface on first per-query use of that family, so
+    // visibility is preserved.
+    for failure in tokenizers::prewarm_dictionary_tokenizers() {
+        pgrx::warning!(
+            "pg_search: dictionary tokenizer prewarm failed for `{}`; queries \
+             using this family will pay per-query dictionary cold-start and \
+             will hit the same failure on first use. Cause: {}",
+            failure.family,
+            failure.cause
+        );
+    }
 
     #[cfg(not(any(feature = "pg17", feature = "pg18")))]
     postgres::fake_aminsertcleanup::register();

--- a/tokenizers/src/chinese_convert.rs
+++ b/tokenizers/src/chinese_convert.rs
@@ -42,6 +42,11 @@ pub enum ConvertMode {
 /// Global OpenCC converter instance (lazy-loaded)
 static OPENCC: Lazy<Mutex<OpenCC>> = Lazy::new(|| Mutex::new(OpenCC::new()));
 
+/// Force the OpenCC converter for `jieba + chinese_convert`.
+pub fn prewarm() {
+    Lazy::force(&OPENCC);
+}
+
 /// Get the conversion mode string for the specified mode
 fn get_mode_str(mode: ConvertMode) -> &'static str {
     match mode {

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -32,6 +32,21 @@ use tracing::debug;
 
 pub use manager::{SearchNormalizer, SearchTokenizer};
 
+/// Force-load every dictionary-backed tokenizer so postmaster-forked workers
+/// inherit them via COW.
+pub fn prewarm_dictionary_tokenizers() {
+    lindera::prewarm();
+
+    // Constructing a JiebaTokenizer is a no-op; only token_stream() forces
+    // the embedded JIEBA lazy_static.
+    use tantivy::tokenizer::{TokenStream, Tokenizer};
+    let mut t = tantivy_jieba::JiebaTokenizer::with_ordinal_position_mode(true);
+    let mut stream = t.token_stream("warm");
+    while stream.advance() {}
+
+    chinese_convert::prewarm();
+}
+
 pub fn create_tokenizer_manager(search_tokenizers: Vec<SearchTokenizer>) -> TokenizerManager {
     let tokenizer_manager = TokenizerManager::default();
 
@@ -59,4 +74,52 @@ pub fn create_normalizer_manager() -> TokenizerManager {
     tokenizer_manager.register("raw", raw_tokenizer);
     tokenizer_manager.register("lowercase", lower_case_tokenizer);
     tokenizer_manager
+}
+
+#[cfg(test)]
+mod prewarm_4840_tests {
+    /// Catches the regression class where someone "simplifies"
+    /// `prewarm_dictionary_tokenizers` and silently drops a dictionary
+    /// family — for example by deleting the `token_stream("warm")` call
+    /// (constructing a `JiebaTokenizer` alone is a no-op and was the
+    /// original jieba bug review found).
+    #[test]
+    fn prewarm_body_covers_every_dict_tokenizer_family() {
+        let src = include_str!("lib.rs");
+        // Slice exactly the function body, not the rest of the file. If we
+        // scanned a fixed window we'd cover this test's own assertion
+        // string literals and the test would pass even when the prewarm
+        // calls had been deleted.
+        let header_pos = src
+            .find("pub fn prewarm_dictionary_tokenizers()")
+            .expect("prewarm_dictionary_tokenizers must exist");
+        let body_open = header_pos
+            + src[header_pos..]
+                .find('{')
+                .expect("function body must open with {");
+        let body_end = {
+            let mut depth = 0i32;
+            let mut found = None;
+            for (i, c) in src[body_open..].char_indices() {
+                match c {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            found = Some(body_open + i);
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            found.expect("function body must have a matching closing brace")
+        };
+        let body = &src[body_open..body_end];
+
+        assert!(body.contains("lindera::prewarm()"));
+        assert!(body.contains("tantivy_jieba::JiebaTokenizer"));
+        assert!(body.contains("token_stream"));
+        assert!(body.contains("chinese_convert::prewarm()"));
+    }
 }

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -32,19 +32,58 @@ use tracing::debug;
 
 pub use manager::{SearchNormalizer, SearchTokenizer};
 
-/// Force-load every dictionary-backed tokenizer so postmaster-forked workers
-/// inherit them via COW.
-pub fn prewarm_dictionary_tokenizers() {
-    lindera::prewarm();
+/// A dictionary tokenizer family that failed to prewarm. Caller-side
+/// reports each entry so operators see a clear log line per failure
+/// instead of the postmaster aborting.
+pub struct PrewarmFailure {
+    pub family: &'static str,
+    pub cause: String,
+}
 
-    // Constructing a JiebaTokenizer is a no-op; only token_stream() forces
-    // the embedded JIEBA lazy_static.
-    use tantivy::tokenizer::{TokenStream, Tokenizer};
-    let mut t = tantivy_jieba::JiebaTokenizer::with_ordinal_position_mode(true);
-    let mut stream = t.token_stream("warm");
-    while stream.advance() {}
+/// Force-load every dictionary-backed tokenizer so postmaster-forked
+/// workers inherit them via COW. Each family is wrapped in `catch_unwind`
+/// so a failure in one (e.g. OOM, corrupt embedded asset, CPU issue)
+/// doesn't prevent the others from loading or take down the postmaster.
+/// The same failure will surface again on first per-query use of the
+/// affected family, so we don't lose visibility — we just stop turning
+/// it into a cluster-down event at startup. Returns one entry per family
+/// that panicked; an empty Vec means full success.
+pub fn prewarm_dictionary_tokenizers() -> Vec<PrewarmFailure> {
+    let mut failures = Vec::new();
 
-    chinese_convert::prewarm();
+    let try_family = |family: &'static str, f: &dyn Fn()| -> Option<PrewarmFailure> {
+        match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+            Ok(()) => None,
+            Err(payload) => {
+                let cause = payload
+                    .downcast_ref::<&'static str>()
+                    .map(|s| s.to_string())
+                    .or_else(|| payload.downcast_ref::<String>().cloned())
+                    .unwrap_or_else(|| "<non-string panic payload>".to_string());
+                Some(PrewarmFailure { family, cause })
+            }
+        }
+    };
+
+    if let Some(f) = try_family("lindera", &|| lindera::prewarm()) {
+        failures.push(f);
+    }
+
+    if let Some(f) = try_family("jieba", &|| {
+        // Constructing a JiebaTokenizer is a no-op; only token_stream()
+        // forces the embedded JIEBA lazy_static.
+        use tantivy::tokenizer::Tokenizer;
+        let mut t = tantivy_jieba::JiebaTokenizer::with_ordinal_position_mode(true);
+        let _ = t.token_stream("warm");
+    }) {
+        failures.push(f);
+    }
+
+    if let Some(f) = try_family("opencc", &|| chinese_convert::prewarm()) {
+        failures.push(f);
+    }
+
+    failures
 }
 
 pub fn create_tokenizer_manager(search_tokenizers: Vec<SearchTokenizer>) -> TokenizerManager {
@@ -78,20 +117,20 @@ pub fn create_normalizer_manager() -> TokenizerManager {
 
 #[cfg(test)]
 mod prewarm_4840_tests {
-    /// Catches the regression class where someone "simplifies"
-    /// `prewarm_dictionary_tokenizers` and silently drops a dictionary
-    /// family — for example by deleting the `token_stream("warm")` call
-    /// (constructing a `JiebaTokenizer` alone is a no-op and was the
-    /// original jieba bug review found).
+    use super::*;
+
+    /// Structural lint. Catches the regression class where someone
+    /// "simplifies" `prewarm_dictionary_tokenizers` and silently drops
+    /// a dictionary family or the per-family panic guard.
     #[test]
     fn prewarm_body_covers_every_dict_tokenizer_family() {
         let src = include_str!("lib.rs");
-        // Slice exactly the function body, not the rest of the file. If we
-        // scanned a fixed window we'd cover this test's own assertion
+        // Slice exactly the function body, not the rest of the file. If
+        // we scanned a fixed window we'd cover this test's own assertion
         // string literals and the test would pass even when the prewarm
         // calls had been deleted.
         let header_pos = src
-            .find("pub fn prewarm_dictionary_tokenizers()")
+            .find("pub fn prewarm_dictionary_tokenizers")
             .expect("prewarm_dictionary_tokenizers must exist");
         let body_open = header_pos
             + src[header_pos..]
@@ -121,5 +160,28 @@ mod prewarm_4840_tests {
         assert!(body.contains("tantivy_jieba::JiebaTokenizer"));
         assert!(body.contains("token_stream"));
         assert!(body.contains("chinese_convert::prewarm()"));
+        // Every family must be wrapped in catch_unwind so a panic in one
+        // doesn't take down the postmaster or skip the others.
+        assert!(body.contains("catch_unwind"));
+    }
+
+    /// Behavioral test. Exercises every dict-load path so CI catches
+    /// upstream API drift or corrupt embedded assets before deployment.
+    /// catch_unwind in the production code means this returns Vec instead
+    /// of panicking, so a green build still requires the Vec to be empty.
+    #[test]
+    fn prewarm_succeeds_and_is_idempotent() {
+        let failures = prewarm_dictionary_tokenizers();
+        assert!(
+            failures.is_empty(),
+            "prewarm reported failures: {:?}",
+            failures
+                .iter()
+                .map(|f| format!("{}: {}", f.family, f.cause))
+                .collect::<Vec<_>>()
+        );
+        // Second call must be a cheap no-op once the Lazy values are set.
+        let failures = prewarm_dictionary_tokenizers();
+        assert!(failures.is_empty());
     }
 }

--- a/tokenizers/src/lindera.rs
+++ b/tokenizers/src/lindera.rs
@@ -77,6 +77,18 @@ static KOR_TOKENIZER: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
     ))
 });
 
+/// Force all six Lindera tokenizers. Each language loads its dict twice
+/// (keep_whitespace variants don't share — `Data::Vec` is deep-copied on
+/// clone), pending an upstream lindera fix.
+pub fn prewarm() {
+    Lazy::force(&CMN_TOKENIZER);
+    Lazy::force(&CMN_TOKENIZER_KEEP_WHITESPACE);
+    Lazy::force(&JPN_TOKENIZER);
+    Lazy::force(&JPN_TOKENIZER_KEEP_WHITESPACE);
+    Lazy::force(&KOR_TOKENIZER);
+    Lazy::force(&KOR_TOKENIZER_KEEP_WHITESPACE);
+}
+
 #[derive(Clone, Default)]
 pub struct LinderaChineseTokenizer {
     keep_whitespace: bool,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4840

## What

Pre-loads the dictionary-backed tokenizers (Lindera Chinese / Japanese / Korean, jieba, OpenCC) once in the postmaster process via `_PG_init`. Every parallel worker forked from the postmaster thereafter inherits the loaded dictionaries via `fork()` copy-on-write, eliminating the per-query dictionary cold-start that issue #4840 measured at 50–160 ms.

## Why

Issue #4840 reports that parallel queries against indexes using `korean_lindera`, `japanese_lindera`, `chinese_lindera`, or `jieba` tokenizers pay a fixed 50–160 ms per query, independent of corpus size or matching doc count. Root cause: every dictionary tokenizer is wrapped in a `Lazy<Arc<...>>` process-local static, so each ephemeral parallel worker reloads its dictionary from scratch on first `token_stream()` call.

PostgreSQL parallel workers fork from the **postmaster**, not from the leader backend, so warming the leader's session-level cache doesn't help. The cheapest fix is to ensure the postmaster's heap holds the loaded dictionaries before any backend or worker forks — Linux/macOS COW then makes them free for every child.

## How

`pg_search/src/lib.rs::_PG_init` runs once in the postmaster when `pg_search` is in `shared_preload_libraries` (post-#4914 this is enforced unconditionally — the early `process_shared_preload_libraries_in_progress` check at the top of `_PG_init` errors out otherwise). Inside that path, force every dictionary-backed `Lazy` static once:

- `lindera::prewarm()` calls `Lazy::force` on the six existing `Lazy<Arc<LinderaTokenizer>>` statics (3 languages × `keep_whitespace` ∈ {true,false}).
- For `tantivy_jieba`, the embedded `JIEBA: lazy_static!` is private and *only* dereferenced inside `token_stream()` — constructing a `JiebaTokenizer` is a no-op. The prewarm therefore actually runs `tokenizer.token_stream("warm").advance()` to force the load.
- `chinese_convert::prewarm()` forces the separate `OPENCC` lazy used by `jieba + chinese_convert`.

### Known limitations

- Each Lindera language currently loads its dictionary twice (once per `keep_whitespace` variant) because `Segmenter::new` takes `Dictionary` by value and lindera's `Data::Vec` deep-copies on clone. Documented inline; not solvable here without an upstream lindera change.
- Windows / `EXEC_BACKEND` builds don't truly fork; on those platforms the prewarm runs in the postmaster but child processes don't inherit the heap. A follow-up using mmap-backed on-disk dict cache or Postgres DSM would cover that case.

## Tests

`cargo test -p tokenizers prewarm_4840` (~0 ms) — a structural regression test that asserts the prewarm body still references every dictionary tokenizer family. Verified empirically that:

- Test passes when the prewarm code is intact.
- Test fails when any single required call (`lindera::prewarm()`, `tantivy_jieba::JiebaTokenizer`, `token_stream`, `chinese_convert::prewarm()`) is deleted from the function body.

The test extracts the function body via brace-counting (rather than a fixed-byte window) so it does not self-fulfill from its own assertion strings.

Pre-commit hooks: rustfmt ✓ · clippy ✓ · cargo-machete ✓ · taplo ✓