### PR TITLE
fix(mpp): force pg_search load in mpp_smoke before first GUC SHOW

### DIFF
--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -8,6 +8,12 @@
 -- in the GUC surface so a future accidental rename breaks loudly.
 -- =====================================================================
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- `CREATE EXTENSION` runs the SQL script but doesn't always trigger the
+-- `.so` dlopen + `_PG_init` (which registers our GUCs) before the next
+-- statement. Other regress tests don't notice because their setup runs
+-- a `SET paradedb.<guc>` that forces the load; this test goes straight
+-- to `SHOW` and would race. `LOAD` is the canonical force-load.
+LOAD 'pg_search';
 -- GUCs must be visible after the extension loads.
 SHOW paradedb.enable_mpp;
  paradedb.enable_mpp 

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -9,6 +9,12 @@
 -- =====================================================================
 
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- `CREATE EXTENSION` runs the SQL script but doesn't always trigger the
+-- `.so` dlopen + `_PG_init` (which registers our GUCs) before the next
+-- statement. Other regress tests don't notice because their setup runs
+-- a `SET paradedb.<guc>` that forces the load; this test goes straight
+-- to `SHOW` and would race. `LOAD` is the canonical force-load.
+LOAD 'pg_search';
 
 -- GUCs must be visible after the extension loads.
 SHOW paradedb.enable_mpp;


### PR DESCRIPTION
## Summary

`mpp_smoke.sql` ran `CREATE EXTENSION IF NOT EXISTS pg_search;` and went straight into `SHOW paradedb.enable_mpp;`. `CREATE EXTENSION` runs the extension SQL script but doesn't always trigger the `.so` dlopen + `_PG_init` (where our GUCs are registered) before the next statement. Other regress tests dodge this by running a `SET paradedb.<guc>` in their setup, which forces the load; mpp_smoke jumps straight to `SHOW` and races.

Add an explicit `LOAD 'pg_search';` right after `CREATE EXTENSION`. That's the canonical SQL command to force a backend dlopen + init. Idempotent: if the .so was already loaded by some prior session event, `LOAD` is a no-op.

## Why

Triggered by the report: "`cargo pgrx regress -p pg_search --auto -- pg18 mpp_smoke` seems to be unstable on `origin/main`: it doesn't look like things are registered." Repros only intermittently in CI; locally I cannot reproduce. The fix is precautionary — `LOAD` is the right tool for "I'm about to read a GUC and need to be sure init has run", and adding it removes the dependency on `CREATE EXTENSION`'s lazy-load timing.

## Test plan

- [x] `cargo pgrx regress -p pg_search --auto pg18 mpp_smoke` passes locally
- [x] CI `test-pg_search.yml` runs the full regress suite — should pick up the fix