### PR TITLE
ci: Publish pg_search to Postgres.app via PR from paradedb-bot

### DIFF
--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -11,9 +11,6 @@ on:
   push:
     tags:
       - "v*"
-    # TEMPORARY: enable branch push trigger to test this workflow on the PR. Revert before merge.
-    branches:
-      - add-publish-pg_search-postgresapp-workflow
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -138,6 +138,39 @@ jobs:
           export PATH="/opt/homebrew/bin:$PATH"
           cargo pgrx package --pg-config $PG_CONFIG_PATH
 
+      # Import the Developer ID Application + Installer certificates into a dedicated
+      # temporary keychain so codesign/pkgbuild can sign with them. The keychain is the
+      # only one on the user search list for the rest of the job, so the partial
+      # "Developer ID Application"/"Developer ID Installer" identity strings used below
+      # match unambiguously. Mirrors GitHub's "Installing an Apple certificate on macOS
+      # runners" guide.
+      - name: Import Apple Developer ID Certificates
+        env:
+          APPLE_DEVELOPER_ID_APPLICATION_CERT: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT }}
+          APPLE_DEVELOPER_ID_INSTALLER_CERT: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_CERT }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+
+          # Create, configure, and unlock a throwaway keychain for the job.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Decode and import both Developer ID certificates (.p12), then wipe the files.
+          echo "$APPLE_DEVELOPER_ID_APPLICATION_CERT" | base64 --decode > "$RUNNER_TEMP/application.p12"
+          echo "$APPLE_DEVELOPER_ID_INSTALLER_CERT" | base64 --decode > "$RUNNER_TEMP/installer.p12"
+          security import "$RUNNER_TEMP/application.p12" -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/installer.p12" -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          rm -f "$RUNNER_TEMP/application.p12" "$RUNNER_TEMP/installer.p12"
+
+          # Allow the signing tools to use the private keys without an interactive prompt,
+          # and make this the keychain that codesign/pkgbuild search.
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
       - name: Create .pkg Package
         run: |
           # Retrieve the built pg_search extension
@@ -171,6 +204,11 @@ jobs:
           # alongside the Homebrew install prefix.
           cp LICENSE ${package_dir}/LICENSE
 
+          # Sign the loadable library with the Developer ID Application identity before
+          # packaging, so the notarized pkg does not contain an unsigned binary (which
+          # would fail notarization).
+          codesign --force --sign "Developer ID Application" --timestamp ${package_dir}/${lib_path}/*
+
           # Create postinstall script
           mkdir -p ~/tmp/pg_search_postinstall_script/
           postinstall_file=~/tmp/pg_search_postinstall_script/postinstall
@@ -195,7 +233,29 @@ jobs:
                   --version ${tag_version} \
                   --install-location /opt/homebrew/opt/paradedb \
                   --scripts ~/tmp/pg_search_postinstall_script/ \
+                  --sign "Developer ID Installer" \
                   pg_search@${{ matrix.pg_version }}--${tag_version}.arm64_${{ steps.version.outputs.os_version }}.pkg
+
+      # Submit the signed pkg to Apple's notary service and staple the ticket onto it
+      # so Gatekeeper accepts the installer on first open, even offline. Authenticates
+      # with an App Store Connect API key (notarytool --key). Runs before attestation
+      # and upload so the artifact we attest and ship is the stapled one.
+      - name: Notarize and Staple Installer Package
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          PKG="pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg"
+          echo "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          xcrun notarytool submit "$PKG" \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "$PKG"
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v4

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -11,6 +11,9 @@ on:
   push:
     tags:
       - "v*"
+    # TEMPORARY: enable branch push trigger to test this workflow on the PR. Revert before merge.
+    branches:
+      - add-publish-pg_search-postgresapp-workflow
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -153,12 +153,12 @@ jobs:
           EXTENSION_VERSION=${{ steps.version.outputs.tag_version }}
           PG_MAJOR_VERSION=${{ matrix.pg_version }}
           PREFIX=/Applications/Postgres.app/Contents/Versions/$PG_MAJOR_VERSION
-          INSTALL_ROOT="${GITHUB_WORKSPACE}/pg_search/target/release/${EXTENSION_NAME}-pg${PG_MAJOR_VERSION}${PREFIX}"
+          INSTALL_ROOT="${GITHUB_WORKSPACE}/target/release/${EXTENSION_NAME}-pg${PG_MAJOR_VERSION}${PREFIX}"
           UPSTREAM=/tmp/postgresapp-extensions/pg_search
 
           if [ ! -d "$INSTALL_ROOT/lib/postgresql" ] || [ ! -d "$INSTALL_ROOT/share/postgresql/extension" ]; then
             echo "Expected pgrx package layout not found under $INSTALL_ROOT"
-            ls -R "${GITHUB_WORKSPACE}/pg_search/target/release" || true
+            ls -R "${GITHUB_WORKSPACE}/target/release" || true
             exit 1
           fi
 

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -248,8 +248,12 @@ jobs:
           set -euo pipefail
 
           UPSTREAM=PostgresApp/PostgresApp
+          # The fork lives under the paradedb org (so the existing PARADEDB_BOT_GITHUB_TOKEN,
+          # whose resource owner is the paradedb org, can push to it). PR authorship still
+          # comes from paradedb-bot since that's the user the token belongs to.
+          FORK_OWNER=paradedb
+          FORK="${FORK_OWNER}/PostgresApp"
           BOT_LOGIN=$(gh api user --jq .login)
-          BOT_FORK="${BOT_LOGIN}/PostgresApp"
           BRANCH="update-pg_search-${TAG_VERSION}-pg${PG_MAJOR_VERSION}"
           DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v${TAG_VERSION}/${PKG_NAME}"
 
@@ -262,26 +266,13 @@ jobs:
               --delete-branch=false
           done
 
-          # Ensure the bot has a fork of PostgresApp/PostgresApp. If the fork already
-          # exists, skip creation — fine-grained PATs cannot fork external repos, so
-          # the fork must be pre-created manually as a one-time step (log in as the
-          # bot and fork the repo via the GitHub UI).
-          if gh api "repos/${BOT_FORK}" >/dev/null 2>&1; then
-            echo "Fork ${BOT_FORK} already exists; skipping creation."
-          else
-            echo "Fork ${BOT_FORK} not found; attempting to create it..."
-            if ! gh repo fork "$UPSTREAM" --clone=false; then
-              echo "ERROR: Failed to fork ${UPSTREAM}. The bot's PAT likely lacks fork permissions"
-              echo "       (common with fine-grained PATs). Pre-create the fork manually by"
-              echo "       logging in as ${BOT_LOGIN} and forking ${UPSTREAM} via the GitHub UI."
-              exit 1
-            fi
-            # The fork can take a moment to become available after creation.
-            for i in $(seq 1 30); do
-              if gh api "repos/${BOT_FORK}" >/dev/null 2>&1; then break; fi
-              echo "Waiting for fork ${BOT_FORK} to be available..."
-              sleep 2
-            done
+          # The fork at ${FORK} is pre-created and maintained as a one-time setup —
+          # fine-grained PATs cannot fork external repos into an org, so we don't try
+          # to create it from the workflow. Just verify it exists with a clear error.
+          if ! gh api "repos/${FORK}" >/dev/null 2>&1; then
+            echo "ERROR: Fork ${FORK} not found. Create it once via the GitHub UI by forking" >&2
+            echo "       ${UPSTREAM} into the ${FORK_OWNER} org." >&2
+            exit 1
           fi
 
           UPSTREAM_DEFAULT_BRANCH=$(gh api "repos/${UPSTREAM}" --jq .default_branch)
@@ -290,7 +281,7 @@ jobs:
           git config --global user.email "developers@paradedb.com"
 
           WORK=$(mktemp -d)
-          git clone "https://x-access-token:${GH_TOKEN}@github.com/${BOT_FORK}.git" "$WORK"
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${FORK}.git" "$WORK"
           cd "$WORK"
           git remote add upstream "https://github.com/${UPSTREAM}.git"
           git fetch upstream "$UPSTREAM_DEFAULT_BRANCH"
@@ -351,7 +342,7 @@ jobs:
           gh pr create \
             --repo "$UPSTREAM" \
             --base "$UPSTREAM_DEFAULT_BRANCH" \
-            --head "${BOT_LOGIN}:${BRANCH}" \
+            --head "${FORK_OWNER}:${BRANCH}" \
             --title "Update pg_search to ${TAG_VERSION} for PostgreSQL ${PG_MAJOR_VERSION}" \
             --body "$BODY"
 

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -240,7 +240,11 @@ jobs:
       # so that only one update is ever pending review upstream.
       - name: Open PR to PostgresApp/PostgresApp
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          # Classic PAT with `repo` scope — required because fine-grained PATs cannot
+          # invoke createPullRequest (or pr list/close) against repos outside their
+          # resource owner, and PostgresApp/PostgresApp lives outside the paradedb org.
+          # Reuses the existing enterprise-sync token, which already has `repo` scope.
+          GH_TOKEN: ${{ secrets.PARADEDB_BOT_ENTERPRISE_SYNC_GITHUB_TOKEN }}
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
           PG_MAJOR_VERSION: ${{ matrix.pg_version }}
           PKG_NAME: ${{ steps.pkg.outputs.pkg_name }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -263,7 +263,8 @@ jobs:
           done
 
           # Ensure the bot has a fork of PostgresApp/PostgresApp; this is a no-op if it already exists.
-          gh repo fork "$UPSTREAM" --clone=false --remote=false || true
+          # Note: `--remote` is only valid for the current-repo form; it's rejected when a repo argument is passed.
+          gh repo fork "$UPSTREAM" --clone=false || true
           # The fork can take a moment to become available after the first call.
           for i in $(seq 1 30); do
             if gh api "repos/${BOT_FORK}" >/dev/null 2>&1; then break; fi

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -1,0 +1,422 @@
+# workflows/publish-pg_search-postgresapp.yml
+#
+# Publish pg_search (Postgres.app)
+# Build and publish the pg_search extension for Postgres.app as a .pkg installer to
+# GitHub Releases, then open a PR to PostgresApp/PostgresApp updating the download
+# link on https://postgresapp.com/extensions/. Triggered on creation of a GitHub
+# Tag, but beta releases get filtered out by the `if` condition of the job.
+#
+# The PR is raised by `paradedb-bot` from a fork. If a previous PR from the bot is
+# still open in PostgresApp/PostgresApp, it is closed in favour of the new one so
+# that only the latest release is ever pending review upstream.
+
+name: Publish pg_search (Postgres.app)
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to set for the pg_search release (e.g. 0.22.0). This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
+        required: true
+        default: ""
+
+concurrency:
+  group: publish-pg_search-postgresapp-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# Used by actions/attest-build-provenance to sign the builds
+permissions:
+  contents: write
+  id-token: write
+  attestations: write
+
+jobs:
+  publish-pg_search:
+    name: Publish pg_search for Postgres.app PostgreSQL ${{ matrix.pg_version }} arm64
+    runs-on: macos-15
+    if: ${{ !contains(github.ref, '-rc.') }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Postgres.app only supports loadable extensions installed in Application Support
+        # starting with PostgreSQL 18. Earlier versions require extensions to be bundled,
+        # which is out of scope for this workflow.
+        pg_version: [18]
+
+    steps:
+      # We force reinstall git to make sure it is in PATH
+      - name: Install Dependencies
+        run: brew reinstall git
+
+      - name: Checkout Git Repository
+        uses: actions/checkout@v6
+
+      # Used to query/update the GitHub Release and open the PostgresApp/PostgresApp PR.
+      - name: Install GitHub CLI
+        run: |
+          brew reinstall gh
+          gh --version
+
+      - name: Retrieve GitHub Tag Version
+        id: version
+        run: |
+          # If no workflow_dispatch version is provided, we use workflow tag trigger version
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            if [[ $GITHUB_REF == refs/tags/v* ]]; then
+              VERSION=${GITHUB_REF#refs/tags/v}
+            else
+              # If there is no tag and no provided version, it's a test run and we set a default version
+              VERSION="0.0.0"
+            fi
+          else
+            VERSION=${{ github.event.inputs.version }}
+          fi
+          echo "GitHub Tag Version: $VERSION"
+          echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      # Postgres.app ships its own PostgreSQL build. We install it into /Applications
+      # so that we can build pg_search against its pg_config and link against the
+      # exact libpq/server headers that ship with Postgres.app.
+      - name: Install Postgres.app
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ASSET=$(gh release view --repo PostgresApp/PostgresApp --json assets \
+            --jq '.assets[] | select(.name | test("Postgres-.*-${{ matrix.pg_version }}\\.dmg$")) | .name' | head -1)
+          if [ -z "$ASSET" ]; then
+            echo "Could not find a Postgres.app DMG for PostgreSQL ${{ matrix.pg_version }}"
+            exit 1
+          fi
+          echo "Downloading $ASSET"
+          gh release download --repo PostgresApp/PostgresApp --pattern "$ASSET" --output postgres.dmg
+          MOUNT=$(hdiutil attach -nobrowse -noverify -noautoopen postgres.dmg | tail -1 | awk '{print $3}')
+          cp -R "$MOUNT/Postgres.app" /Applications/Postgres.app
+          hdiutil detach "$MOUNT"
+          PG_BIN=/Applications/Postgres.app/Contents/Versions/${{ matrix.pg_version }}/bin
+          echo "$PG_BIN" >> $GITHUB_PATH
+          "$PG_BIN/pg_config" --version
+
+      - name: Extract pgrx Version
+        id: pgrx
+        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+
+      - name: Cache pgrx binary
+        id: cache-pgrx
+        uses: actions/cache@v5
+        with:
+          path: ~/.cargo/bin/cargo-pgrx
+          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-postgresapp-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Install pgrx
+        if: steps.cache-pgrx.outputs.cache-hit != 'true'
+        run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
+
+      - name: Initialize pgrx environment
+        working-directory: pg_search/
+        run: |
+          PG_CONFIG=/Applications/Postgres.app/Contents/Versions/${{ matrix.pg_version }}/bin/pg_config
+          cargo pgrx init --pg${{ matrix.pg_version }}=$PG_CONFIG
+
+      - name: Package pg_search Extension with pgrx
+        working-directory: pg_search/
+        env:
+          COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
+          PARADEDB_VERSION: ${{ steps.version.outputs.tag_version }}
+        run: |
+          PG_CONFIG=/Applications/Postgres.app/Contents/Versions/${{ matrix.pg_version }}/bin/pg_config
+          # Workaround for inttypes.h not being found under the default sysroot
+          export BINDGEN_EXTRA_CLANG_ARGS="$(xcrun --show-sdk-path | xargs -I{} echo -isysroot {})"
+          cargo pgrx package --pg-config $PG_CONFIG
+
+      # Build a Postgres.app installer pkg. This mirrors the layout used by
+      # PostgresApp/Extensions (see https://github.com/PostgresApp/Extensions/blob/main/pg_search/build.zsh)
+      # so that the pkg installs into ~/Library/Application Support/Postgres/Extensions/<pg>/pg_search,
+      # which is the search path Postgres.app configures automatically for PostgreSQL 18+.
+      - name: Build Postgres.app Installer Package
+        id: pkg
+        run: |
+          set -euo pipefail
+          EXTENSION_NAME=pg_search
+          EXTENSION_VERSION=${{ steps.version.outputs.tag_version }}
+          PG_MAJOR_VERSION=${{ matrix.pg_version }}
+          PREFIX=/Applications/Postgres.app/Contents/Versions/$PG_MAJOR_VERSION
+          INSTALL_ROOT="target/release/${EXTENSION_NAME}-pg${PG_MAJOR_VERSION}${PREFIX}"
+
+          if [ ! -d "$INSTALL_ROOT/lib/postgresql" ] || [ ! -d "$INSTALL_ROOT/share/postgresql/extension" ]; then
+            echo "Expected pgrx package layout not found under $INSTALL_ROOT"
+            ls -R target/release || true
+            exit 1
+          fi
+
+          # Stage installer resources. We inline these here (rather than checking them
+          # into the repo) since they're small, templated, and only used by this workflow.
+          mkdir -p Build/Resources Build/Scripts
+
+          cat > Build/Resources/welcome.html <<'HTML'
+          <!DOCTYPE html>
+          <html>
+          <head><meta charset="utf-8"><title>Welcome</title>
+          <style>body{font-family:-apple-system;font-size:13px;margin:20px;line-height:1.5}h1{font-size:18px;font-weight:600;margin-top:0}p{margin-bottom:1em}</style>
+          </head>
+          <body>
+            <h1>pg_search __EXTENSION_VERSION__ for PostgreSQL __PG_MAJOR_VERSION__</h1>
+            <p>You are about to install the pg_search extension from <a href="https://paradedb.com">ParadeDB</a>.</p>
+            <p>This installer package is compatible with <strong>Postgres.app 2.8.3 or later</strong>.</p>
+            <p>After completing the installation, please stop and restart the PostgreSQL server to use the extension.</p>
+          </body>
+          </html>
+          HTML
+
+          cat > Build/Resources/conclusion.html <<'HTML'
+          <!DOCTYPE html>
+          <html>
+          <head><meta charset="utf-8"><title>Installation Complete</title>
+          <style>body{font-family:-apple-system;font-size:13px;margin:20px;line-height:1.5}h1{font-size:18px;font-weight:600;margin-top:0}p{margin-bottom:1em}tt{font-family:Menlo,monospace}</style>
+          </head>
+          <body>
+            <h1>Please restart the PostgreSQL server!</h1>
+            <p>pg_search __EXTENSION_VERSION__ for PostgreSQL __PG_MAJOR_VERSION__ has been installed successfully.</p>
+            <p>If this is a new install, please stop and restart your PostgreSQL server before using the extension. After restarting the server, you can enable the extension in a database by running the SQL command <tt>CREATE EXTENSION pg_search;</tt></p>
+            <p>If you are upgrading from a previous version of the extension, you do not need to restart the server. Please execute the command <tt>ALTER EXTENSION pg_search UPDATE;</tt> on every database that uses the extension.</p>
+          </body>
+          </html>
+          HTML
+
+          cat > Build/distribution.xml <<'XML'
+          <?xml version="1.0" encoding="utf-8"?>
+          <installer-gui-script minSpecVersion="1">
+            <title>pg_search for Postgres.app</title>
+            <welcome file="welcome.html"/>
+            <license file="license.txt"/>
+            <conclusion file="conclusion.html"/>
+            <pkg-ref id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search"/>
+            <options customize="never" require-scripts="false" hostArchitectures="arm64"/>
+            <domains enable_currentUserHome="true"/>
+            <choices-outline>
+              <line choice="default"><line choice="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search"/></line>
+            </choices-outline>
+            <choice id="default"/>
+            <choice id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search" visible="false">
+              <pkg-ref id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search"/>
+            </choice>
+            <pkg-ref id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search" version="0" onConclusion="none">pg_search-__PG_MAJOR_VERSION__.pkg</pkg-ref>
+          </installer-gui-script>
+          XML
+
+          # Preinstall script removes any previous install of the extension at the
+          # destination so that upgrades don't leave stale files behind.
+          cat > Build/Scripts/preinstall <<'SH'
+          #!/bin/zsh
+          INSTALL_PATH="$2"
+          if [[ "$INSTALL_PATH" == *"Application Support"/Postgres/Extensions/*/* ]]; then
+            if [[ -d "$INSTALL_PATH" ]]; then
+              echo "Deleting directory: $INSTALL_PATH"
+              rm -rf -- "$INSTALL_PATH"
+            fi
+          else
+            echo "Error: Install path does not match expected pattern. Aborting." >&2
+            exit 1
+          fi
+          SH
+          chmod +x Build/Scripts/preinstall
+
+          # Substitute templated values
+          for f in Build/Resources/welcome.html Build/Resources/conclusion.html Build/distribution.xml; do
+            sed -i '' \
+              -e "s|__EXTENSION_VERSION__|${EXTENSION_VERSION}|g" \
+              -e "s|__PG_MAJOR_VERSION__|${PG_MAJOR_VERSION}|g" \
+              "$f"
+          done
+
+          cp LICENSE Build/Resources/license.txt
+
+          COMPONENT_PKG="pg_search-${PG_MAJOR_VERSION}.pkg"
+          FINAL_PKG="pg_search-pg${PG_MAJOR_VERSION}-${EXTENSION_VERSION}.postgresapp.pkg"
+
+          pkgbuild \
+            --root "$INSTALL_ROOT" \
+            --install-location "/Library/Application Support/Postgres/Extensions/${PG_MAJOR_VERSION}/pg_search" \
+            --identifier "com.paradedb.postgresapp.${PG_MAJOR_VERSION}.pg_search" \
+            --version "${EXTENSION_VERSION}" \
+            --scripts Build/Scripts \
+            "${COMPONENT_PKG}"
+
+          productbuild \
+            --distribution Build/distribution.xml \
+            --resources Build/Resources \
+            --package-path . \
+            "${FINAL_PKG}"
+
+          rm -f "${COMPONENT_PKG}"
+          ls -lh "${FINAL_PKG}"
+          echo "pkg_path=${FINAL_PKG}" >> $GITHUB_OUTPUT
+          echo "pkg_name=${FINAL_PKG}" >> $GITHUB_OUTPUT
+
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ./${{ steps.pkg.outputs.pkg_path }}
+
+      - name: Retrieve GitHub Release Upload URL
+        id: upload_url
+        env:
+          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+        run: |
+          RESPONSE=$(gh api \
+            -H "Authorization: token $GH_TOKEN" \
+            /repos/paradedb/paradedb/releases/tags/v${{ steps.version.outputs.tag_version }})
+          UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url' | sed 's/{.*}//')
+          echo "GitHub Release Upload URL is: $UPLOAD_URL"
+          echo "upload_url=$UPLOAD_URL" >> $GITHUB_OUTPUT
+
+      - name: Upload pg_search .pkg to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./${{ steps.pkg.outputs.pkg_path }}
+          asset_name: ${{ steps.pkg.outputs.pkg_name }}
+          overwrite: true
+
+      # Open a PR to PostgresApp/PostgresApp updating the pg_search download URL on
+      # https://postgresapp.com/extensions/. The PR is raised from paradedb-bot's
+      # fork; any previous open PR from the bot is closed first so that only one
+      # update is ever pending review upstream.
+      - name: Open PR to PostgresApp/PostgresApp
+        env:
+          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          TAG_VERSION: ${{ steps.version.outputs.tag_version }}
+          PG_MAJOR_VERSION: ${{ matrix.pg_version }}
+          PKG_NAME: ${{ steps.pkg.outputs.pkg_name }}
+        run: |
+          set -euo pipefail
+
+          UPSTREAM=PostgresApp/PostgresApp
+          BOT_LOGIN=$(gh api user --jq .login)
+          BOT_FORK="${BOT_LOGIN}/PostgresApp"
+          BRANCH="update-pg_search-${TAG_VERSION}-pg${PG_MAJOR_VERSION}"
+          DOWNLOAD_URL="https://github.com/paradedb/paradedb/releases/download/v${TAG_VERSION}/${PKG_NAME}"
+
+          # Close any existing open PRs from the bot so the new one supersedes them.
+          EXISTING_PRS=$(gh pr list --repo "$UPSTREAM" --author "$BOT_LOGIN" --state open --json number --jq '.[].number' || true)
+          for pr in $EXISTING_PRS; do
+            echo "Closing superseded PR #$pr in $UPSTREAM"
+            gh pr close "$pr" --repo "$UPSTREAM" \
+              --comment "Superseded by the pg_search v${TAG_VERSION} release. Closing in favour of the new PR." \
+              --delete-branch=false
+          done
+
+          # Ensure the bot has a fork of PostgresApp/PostgresApp; this is a no-op if it already exists.
+          gh repo fork "$UPSTREAM" --clone=false --remote=false || true
+          # The fork can take a moment to become available after the first call.
+          for i in $(seq 1 30); do
+            if gh api "repos/${BOT_FORK}" >/dev/null 2>&1; then break; fi
+            echo "Waiting for fork ${BOT_FORK} to be available..."
+            sleep 2
+          done
+
+          UPSTREAM_DEFAULT_BRANCH=$(gh api "repos/${UPSTREAM}" --jq .default_branch)
+
+          git config --global user.name "paradedb[bot]"
+          git config --global user.email "developers@paradedb.com"
+
+          WORK=$(mktemp -d)
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${BOT_FORK}.git" "$WORK"
+          cd "$WORK"
+          git remote add upstream "https://github.com/${UPSTREAM}.git"
+          git fetch upstream "$UPSTREAM_DEFAULT_BRANCH"
+          # Make sure the bot's fork default branch is in sync before branching.
+          git checkout "$UPSTREAM_DEFAULT_BRANCH"
+          git reset --hard "upstream/${UPSTREAM_DEFAULT_BRANCH}"
+          git push origin "$UPSTREAM_DEFAULT_BRANCH" --force-with-lease
+          git checkout -B "$BRANCH"
+
+          # Update the pg_search version line and the download URL inside the
+          # `<h1>pg_search (ParadeDB)</h1>` block of docs/extensions/index.md. We
+          # restrict the substitutions to that block so other extensions are not
+          # touched.
+          python3 - <<'PY'
+          import os, pathlib, re
+
+          version = os.environ["TAG_VERSION"]
+          pg_major = os.environ["PG_MAJOR_VERSION"]
+          url = (
+              f"https://github.com/paradedb/paradedb/releases/download/"
+              f"v{version}/{os.environ['PKG_NAME']}"
+          )
+
+          path = pathlib.Path("docs/extensions/index.md")
+          text = path.read_text()
+
+          # Anchor on the pg_search (ParadeDB) heading and the unique closing anchor of
+          # the download link so we capture the entire outer <div class="extension"> block,
+          # not the inner extension-description <div>.
+          block_re = re.compile(
+              r'<div class="extension">\s*<h1>pg_search \(ParadeDB\)</h1>'
+              r'.*?Download for Postgres\.app</a>\s*</div>',
+              re.DOTALL,
+          )
+          match = block_re.search(text)
+          if not match:
+              raise SystemExit("Could not locate the pg_search (ParadeDB) extension block in docs/extensions/index.md")
+
+          block = match.group(0)
+          updated = re.sub(
+              r"pg_search \d+\.\d+\.\d+(?:-[A-Za-z0-9.\-]+)?",
+              f"pg_search {version}",
+              block,
+          )
+          updated = re.sub(
+              r"built for PostgreSQL \d+",
+              f"built for PostgreSQL {pg_major}",
+              updated,
+          )
+          updated = re.sub(
+              r'href="https://[^"]*pg_search[^"]*\.pkg"',
+              f'href="{url}"',
+              updated,
+          )
+
+          if updated == block:
+              raise SystemExit("pg_search block matched but no fields were updated; refusing to open an empty PR")
+
+          path.write_text(text[: match.start()] + updated + text[match.end():])
+          PY
+
+          if git diff --quiet; then
+            echo "No changes to docs/extensions/index.md; nothing to PR."
+            exit 0
+          fi
+
+          git add docs/extensions/index.md
+          git commit -m "Update pg_search to v${TAG_VERSION} for PostgreSQL ${PG_MAJOR_VERSION}"
+          git push origin "$BRANCH" --force-with-lease
+
+          BODY=$(cat <<EOF
+          This PR updates the [pg_search](https://github.com/paradedb/paradedb) download link on https://postgresapp.com/extensions/ to point at the v${TAG_VERSION} release.
+
+          - **Version**: ${TAG_VERSION}
+          - **PostgreSQL**: ${PG_MAJOR_VERSION}
+          - **Installer**: <${DOWNLOAD_URL}>
+
+          Opened automatically by \`paradedb-bot\` from the [publish-pg_search-postgresapp](https://github.com/paradedb/paradedb/blob/main/.github/workflows/publish-pg_search-postgresapp.yml) workflow. See [PostgresApp/PostgresApp#799](https://github.com/PostgresApp/PostgresApp/issues/799) for context.
+          EOF
+          )
+
+          gh pr create \
+            --repo "$UPSTREAM" \
+            --base "$UPSTREAM_DEFAULT_BRANCH" \
+            --head "${BOT_LOGIN}:${BRANCH}" \
+            --title "Update pg_search to ${TAG_VERSION} for PostgreSQL ${PG_MAJOR_VERSION}" \
+            --body "$BODY"
+
+      - name: Notify Slack on Failure
+        if: failure()
+        run: |
+          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE="<!here> \`publish-pg_search-postgresapp\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -13,9 +13,6 @@ on:
   push:
     tags:
       - "v*"
-    # TEMPORARY: enable branch push trigger to test this workflow on the PR. Revert before merge.
-    branches:
-      - add-publish-pg_search-postgresapp-workflow
   workflow_dispatch:
     inputs:
       version:
@@ -328,8 +325,6 @@ jobs:
           - **Version**: ${TAG_VERSION}
           - **PostgreSQL**: ${PG_MAJOR_VERSION}
           - **Installer**: <${DOWNLOAD_URL}>
-
-          The pkg is built from the upstream [PostgresApp/Extensions/pg_search](https://github.com/PostgresApp/Extensions/tree/main/pg_search) build assets (Resources, Scripts, distribution.xml) so layout and install behavior match other Postgres.app extensions.
 
           Opened automatically by \`paradedb-bot\` from the [publish-pg_search-postgresapp](https://github.com/paradedb/paradedb/blob/main/.github/workflows/publish-pg_search-postgresapp.yml) workflow. See [PostgresApp/PostgresApp#799](https://github.com/PostgresApp/PostgresApp/issues/799) for context.
           EOF

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-postgresapp-${{ runner.os }}-${{ runner.arch }}
+          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
 
       - name: Install pgrx
         if: steps.cache-pgrx.outputs.cache-hit != 'true'

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -286,16 +286,11 @@ jobs:
           cd "$WORK"
           git remote add upstream "https://github.com/${UPSTREAM}.git"
           git fetch upstream "$UPSTREAM_DEFAULT_BRANCH"
-          # Treat the bot's fork as throwaway state: hard-reset its default branch to
-          # upstream and force-push, so we never get tripped up by stale commits left
-          # behind on the fork. Any local changes are intentionally overridden.
-          git checkout "$UPSTREAM_DEFAULT_BRANCH"
-          git reset --hard "upstream/${UPSTREAM_DEFAULT_BRANCH}"
-          git push origin "$UPSTREAM_DEFAULT_BRANCH" --force
-          # Delete any pre-existing PR branch on the fork so the new branch creation
-          # always starts from a clean slate.
+          # Branch directly off upstream's tip — we don't need the fork's default
+          # branch to mirror upstream for a PR to work. This also avoids ambiguity
+          # when origin and upstream both have the same branch name.
           git push origin --delete "$BRANCH" 2>/dev/null || true
-          git checkout -B "$BRANCH"
+          git checkout -B "$BRANCH" "upstream/${UPSTREAM_DEFAULT_BRANCH}"
 
           # Update only `version` and `download_url` in the per-PG-version JSON,
           # preserving the rest of the file (title, description, info_url) and the

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -6,15 +6,6 @@
 # and download URL recorded in docs/_data/extensions/<pg>/pg_search.json (the source
 # for https://postgresapp.com/extensions/). Triggered on creation of a GitHub Tag,
 # but beta releases get filtered out by the `if` condition of the job.
-#
-# The pkg is built using the upstream build assets from PostgresApp/Extensions
-# (https://github.com/PostgresApp/Extensions/tree/main/pg_search) — Resources/,
-# Scripts/, and distribution.xml — so that pkg layout, identifiers, and behavior
-# match what Postgres.app maintainers ship for other extensions.
-#
-# The PR is raised by `paradedb-bot` from a fork. If a previous PR from the bot is
-# still open in PostgresApp/PostgresApp, it is closed in favour of the new one so
-# that only the latest release is ever pending review upstream.
 
 name: Publish pg_search (Postgres.app)
 
@@ -149,11 +140,11 @@ jobs:
           export BINDGEN_EXTRA_CLANG_ARGS="$(xcrun --show-sdk-path | xargs -I{} echo -isysroot {})"
           cargo pgrx package --pg-config $PG_CONFIG
 
-      # Build a Postgres.app installer pkg using the upstream build assets so layout,
-      # identifiers, install location, and pre/post-install behavior match what
-      # PostgresApp/Extensions ships. We skip the codesign/notarize steps from
-      # upstream's build.zsh because we don't have an Apple Developer cert wired up
-      # in CI yet — installers will trigger a Gatekeeper warning on first install.
+      # TODO: wire up Apple Developer codesigning + notarytool before merging this
+      # PR. Upstream's build.zsh runs `codesign --sign "Developer ID Application"`
+      # on the dylibs and signs the pkg with `Developer ID Installer`, then submits
+      # to `xcrun notarytool` using a `postgresapp` keychain profile. Without those,
+      # the produced pkg trips Gatekeeper on first install.
       - name: Build Postgres.app Installer Package
         id: pkg
         run: |

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -18,7 +18,6 @@ on:
       version:
         description: "The version to set for the pg_search release (e.g. 0.22.0). This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
         required: true
-        default: "0.0.0"
 
 concurrency:
   group: publish-pg_search-postgresapp-${{ github.head_ref || github.ref }}
@@ -261,7 +260,7 @@ jobs:
             echo "Closing superseded PR #$pr in $UPSTREAM"
             gh pr close "$pr" --repo "$UPSTREAM" \
               --comment "Superseded by the pg_search v${TAG_VERSION} release. Closing in favour of the new PR." \
-              --delete-branch=false
+              --delete-branch=true
           done
 
           # The fork at ${FORK} is pre-created and maintained as a one-time setup —

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -294,10 +294,15 @@ jobs:
           cd "$WORK"
           git remote add upstream "https://github.com/${UPSTREAM}.git"
           git fetch upstream "$UPSTREAM_DEFAULT_BRANCH"
-          # Make sure the bot's fork default branch is in sync before branching.
+          # Treat the bot's fork as throwaway state: hard-reset its default branch to
+          # upstream and force-push, so we never get tripped up by stale commits left
+          # behind on the fork. Any local changes are intentionally overridden.
           git checkout "$UPSTREAM_DEFAULT_BRANCH"
           git reset --hard "upstream/${UPSTREAM_DEFAULT_BRANCH}"
-          git push origin "$UPSTREAM_DEFAULT_BRANCH" --force-with-lease
+          git push origin "$UPSTREAM_DEFAULT_BRANCH" --force
+          # Delete any pre-existing PR branch on the fork so the new branch creation
+          # always starts from a clean slate.
+          git push origin --delete "$BRANCH" 2>/dev/null || true
           git checkout -B "$BRANCH"
 
           # Update only `version` and `download_url` in the per-PG-version JSON,
@@ -328,7 +333,7 @@ jobs:
 
           git add "$JSON_PATH"
           git commit -m "Update pg_search to v${TAG_VERSION} for PostgreSQL ${PG_MAJOR_VERSION}"
-          git push origin "$BRANCH" --force-with-lease
+          git push origin "$BRANCH" --force
 
           BODY=$(cat <<EOF
           This PR updates the [pg_search](https://github.com/paradedb/paradedb) entry on https://postgresapp.com/extensions/ to point at the v${TAG_VERSION} release.

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -262,15 +262,27 @@ jobs:
               --delete-branch=false
           done
 
-          # Ensure the bot has a fork of PostgresApp/PostgresApp; this is a no-op if it already exists.
-          # Note: `--remote` is only valid for the current-repo form; it's rejected when a repo argument is passed.
-          gh repo fork "$UPSTREAM" --clone=false || true
-          # The fork can take a moment to become available after the first call.
-          for i in $(seq 1 30); do
-            if gh api "repos/${BOT_FORK}" >/dev/null 2>&1; then break; fi
-            echo "Waiting for fork ${BOT_FORK} to be available..."
-            sleep 2
-          done
+          # Ensure the bot has a fork of PostgresApp/PostgresApp. If the fork already
+          # exists, skip creation — fine-grained PATs cannot fork external repos, so
+          # the fork must be pre-created manually as a one-time step (log in as the
+          # bot and fork the repo via the GitHub UI).
+          if gh api "repos/${BOT_FORK}" >/dev/null 2>&1; then
+            echo "Fork ${BOT_FORK} already exists; skipping creation."
+          else
+            echo "Fork ${BOT_FORK} not found; attempting to create it..."
+            if ! gh repo fork "$UPSTREAM" --clone=false; then
+              echo "ERROR: Failed to fork ${UPSTREAM}. The bot's PAT likely lacks fork permissions"
+              echo "       (common with fine-grained PATs). Pre-create the fork manually by"
+              echo "       logging in as ${BOT_LOGIN} and forking ${UPSTREAM} via the GitHub UI."
+              exit 1
+            fi
+            # The fork can take a moment to become available after creation.
+            for i in $(seq 1 30); do
+              if gh api "repos/${BOT_FORK}" >/dev/null 2>&1; then break; fi
+              echo "Waiting for fork ${BOT_FORK} to be available..."
+              sleep 2
+            done
+          fi
 
           UPSTREAM_DEFAULT_BRANCH=$(gh api "repos/${UPSTREAM}" --jq .default_branch)
 

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -266,7 +266,7 @@ jobs:
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
@@ -278,7 +278,7 @@ jobs:
       - name: Upload pg_search .pkg to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1
         with:
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./${{ steps.pkg.outputs.pkg_path }}
           asset_name: ${{ steps.pkg.outputs.pkg_name }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -22,12 +22,15 @@ on:
   push:
     tags:
       - "v*"
+    # TEMPORARY: enable branch push trigger to test this workflow on the PR. Revert before merge.
+    branches:
+      - add-publish-pg_search-postgresapp-workflow
   workflow_dispatch:
     inputs:
       version:
         description: "The version to set for the pg_search release (e.g. 0.22.0). This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
         required: true
-        default: ""
+        default: "0.0.0"
 
 concurrency:
   group: publish-pg_search-postgresapp-${{ github.head_ref || github.ref }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -18,6 +18,7 @@ on:
       version:
         description: "The version to set for the pg_search release (e.g. 0.22.0). This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
         required: true
+        default: ""
 
 concurrency:
   group: publish-pg_search-postgresapp-${{ github.head_ref || github.ref }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -2,9 +2,15 @@
 #
 # Publish pg_search (Postgres.app)
 # Build and publish the pg_search extension for Postgres.app as a .pkg installer to
-# GitHub Releases, then open a PR to PostgresApp/PostgresApp updating the download
-# link on https://postgresapp.com/extensions/. Triggered on creation of a GitHub
-# Tag, but beta releases get filtered out by the `if` condition of the job.
+# GitHub Releases, then open a PR to PostgresApp/PostgresApp updating the version
+# and download URL recorded in docs/_data/extensions/<pg>/pg_search.json (the source
+# for https://postgresapp.com/extensions/). Triggered on creation of a GitHub Tag,
+# but beta releases get filtered out by the `if` condition of the job.
+#
+# The pkg is built using the upstream build assets from PostgresApp/Extensions
+# (https://github.com/PostgresApp/Extensions/tree/main/pg_search) — Resources/,
+# Scripts/, and distribution.xml — so that pkg layout, identifiers, and behavior
+# match what Postgres.app maintainers ship for other extensions.
 #
 # The PR is raised by `paradedb-bot` from a fork. If a previous PR from the bot is
 # still open in PostgresApp/PostgresApp, it is closed in favour of the new one so
@@ -100,6 +106,14 @@ jobs:
           echo "$PG_BIN" >> $GITHUB_PATH
           "$PG_BIN/pg_config" --version
 
+      # Pull the upstream Postgres.app build assets (Resources/, Scripts/, distribution.xml)
+      # so the produced pkg matches what PostgresApp/Extensions ships for other extensions.
+      # See https://github.com/PostgresApp/Extensions/tree/main/pg_search.
+      - name: Fetch Postgres.app Extensions Build Assets
+        run: |
+          git clone --depth=1 https://github.com/PostgresApp/Extensions.git /tmp/postgresapp-extensions
+          ls -la /tmp/postgresapp-extensions/pg_search
+
       - name: Extract pgrx Version
         id: pgrx
         run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
@@ -132,10 +146,11 @@ jobs:
           export BINDGEN_EXTRA_CLANG_ARGS="$(xcrun --show-sdk-path | xargs -I{} echo -isysroot {})"
           cargo pgrx package --pg-config $PG_CONFIG
 
-      # Build a Postgres.app installer pkg. This mirrors the layout used by
-      # PostgresApp/Extensions (see https://github.com/PostgresApp/Extensions/blob/main/pg_search/build.zsh)
-      # so that the pkg installs into ~/Library/Application Support/Postgres/Extensions/<pg>/pg_search,
-      # which is the search path Postgres.app configures automatically for PostgreSQL 18+.
+      # Build a Postgres.app installer pkg using the upstream build assets so layout,
+      # identifiers, install location, and pre/post-install behavior match what
+      # PostgresApp/Extensions ships. We skip the codesign/notarize steps from
+      # upstream's build.zsh because we don't have an Apple Developer cert wired up
+      # in CI yet — installers will trigger a Gatekeeper warning on first install.
       - name: Build Postgres.app Installer Package
         id: pkg
         run: |
@@ -144,115 +159,57 @@ jobs:
           EXTENSION_VERSION=${{ steps.version.outputs.tag_version }}
           PG_MAJOR_VERSION=${{ matrix.pg_version }}
           PREFIX=/Applications/Postgres.app/Contents/Versions/$PG_MAJOR_VERSION
-          INSTALL_ROOT="target/release/${EXTENSION_NAME}-pg${PG_MAJOR_VERSION}${PREFIX}"
+          INSTALL_ROOT="${GITHUB_WORKSPACE}/pg_search/target/release/${EXTENSION_NAME}-pg${PG_MAJOR_VERSION}${PREFIX}"
+          UPSTREAM=/tmp/postgresapp-extensions/pg_search
 
           if [ ! -d "$INSTALL_ROOT/lib/postgresql" ] || [ ! -d "$INSTALL_ROOT/share/postgresql/extension" ]; then
             echo "Expected pgrx package layout not found under $INSTALL_ROOT"
-            ls -R target/release || true
+            ls -R "${GITHUB_WORKSPACE}/pg_search/target/release" || true
             exit 1
           fi
 
-          # Stage installer resources. We inline these here (rather than checking them
-          # into the repo) since they're small, templated, and only used by this workflow.
-          mkdir -p Build/Resources Build/Scripts
+          BUILD=$(mktemp -d)
+          mkdir -p "$BUILD/Resources" "$BUILD/Scripts"
 
-          cat > Build/Resources/welcome.html <<'HTML'
-          <!DOCTYPE html>
-          <html>
-          <head><meta charset="utf-8"><title>Welcome</title>
-          <style>body{font-family:-apple-system;font-size:13px;margin:20px;line-height:1.5}h1{font-size:18px;font-weight:600;margin-top:0}p{margin-bottom:1em}</style>
-          </head>
-          <body>
-            <h1>pg_search __EXTENSION_VERSION__ for PostgreSQL __PG_MAJOR_VERSION__</h1>
-            <p>You are about to install the pg_search extension from <a href="https://paradedb.com">ParadeDB</a>.</p>
-            <p>This installer package is compatible with <strong>Postgres.app 2.8.3 or later</strong>.</p>
-            <p>After completing the installation, please stop and restart the PostgreSQL server to use the extension.</p>
-          </body>
-          </html>
-          HTML
-
-          cat > Build/Resources/conclusion.html <<'HTML'
-          <!DOCTYPE html>
-          <html>
-          <head><meta charset="utf-8"><title>Installation Complete</title>
-          <style>body{font-family:-apple-system;font-size:13px;margin:20px;line-height:1.5}h1{font-size:18px;font-weight:600;margin-top:0}p{margin-bottom:1em}tt{font-family:Menlo,monospace}</style>
-          </head>
-          <body>
-            <h1>Please restart the PostgreSQL server!</h1>
-            <p>pg_search __EXTENSION_VERSION__ for PostgreSQL __PG_MAJOR_VERSION__ has been installed successfully.</p>
-            <p>If this is a new install, please stop and restart your PostgreSQL server before using the extension. After restarting the server, you can enable the extension in a database by running the SQL command <tt>CREATE EXTENSION pg_search;</tt></p>
-            <p>If you are upgrading from a previous version of the extension, you do not need to restart the server. Please execute the command <tt>ALTER EXTENSION pg_search UPDATE;</tt> on every database that uses the extension.</p>
-          </body>
-          </html>
-          HTML
-
-          cat > Build/distribution.xml <<'XML'
-          <?xml version="1.0" encoding="utf-8"?>
-          <installer-gui-script minSpecVersion="1">
-            <title>pg_search for Postgres.app</title>
-            <welcome file="welcome.html"/>
-            <license file="license.txt"/>
-            <conclusion file="conclusion.html"/>
-            <pkg-ref id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search"/>
-            <options customize="never" require-scripts="false" hostArchitectures="arm64"/>
-            <domains enable_currentUserHome="true"/>
-            <choices-outline>
-              <line choice="default"><line choice="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search"/></line>
-            </choices-outline>
-            <choice id="default"/>
-            <choice id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search" visible="false">
-              <pkg-ref id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search"/>
-            </choice>
-            <pkg-ref id="com.paradedb.postgresapp.__PG_MAJOR_VERSION__.pg_search" version="0" onConclusion="none">pg_search-__PG_MAJOR_VERSION__.pkg</pkg-ref>
-          </installer-gui-script>
-          XML
-
-          # Preinstall script removes any previous install of the extension at the
-          # destination so that upgrades don't leave stale files behind.
-          cat > Build/Scripts/preinstall <<'SH'
-          #!/bin/zsh
-          INSTALL_PATH="$2"
-          if [[ "$INSTALL_PATH" == *"Application Support"/Postgres/Extensions/*/* ]]; then
-            if [[ -d "$INSTALL_PATH" ]]; then
-              echo "Deleting directory: $INSTALL_PATH"
-              rm -rf -- "$INSTALL_PATH"
-            fi
-          else
-            echo "Error: Install path does not match expected pattern. Aborting." >&2
-            exit 1
-          fi
-          SH
-          chmod +x Build/Scripts/preinstall
-
-          # Substitute templated values
-          for f in Build/Resources/welcome.html Build/Resources/conclusion.html Build/distribution.xml; do
-            sed -i '' \
-              -e "s|__EXTENSION_VERSION__|${EXTENSION_VERSION}|g" \
-              -e "s|__PG_MAJOR_VERSION__|${PG_MAJOR_VERSION}|g" \
-              "$f"
+          # Substitute templated values into the upstream Resources and distribution.xml.
+          # Mirrors the sed pipeline in https://github.com/PostgresApp/Extensions/blob/main/pg_search/build.zsh.
+          for file in "$UPSTREAM"/Resources/*.html "$UPSTREAM"/distribution.xml; do
+            base=$(basename "$file")
+            case "$file" in
+              *.html) out="$BUILD/Resources/$base" ;;
+              *) out="$BUILD/$base" ;;
+            esac
+            sed -e "s|@EXTENSION_VERSION@|${EXTENSION_VERSION}|g" \
+                -e "s|@PG_MAJOR_VERSION@|${PG_MAJOR_VERSION}|g" \
+                -e "s|@EXTENSION_NAME@|${EXTENSION_NAME}|g" \
+                "$file" > "$out"
           done
 
-          cp LICENSE Build/Resources/license.txt
+          cp "$UPSTREAM"/Scripts/* "$BUILD/Scripts/"
+          chmod +x "$BUILD/Scripts/"*
+          cp "${GITHUB_WORKSPACE}/LICENSE" "$BUILD/Resources/license.txt"
 
-          COMPONENT_PKG="pg_search-${PG_MAJOR_VERSION}.pkg"
-          FINAL_PKG="pg_search-pg${PG_MAJOR_VERSION}-${EXTENSION_VERSION}.postgresapp.pkg"
+          COMPONENT_PKG="${EXTENSION_NAME}-${PG_MAJOR_VERSION}.pkg"
+          FINAL_PKG="${EXTENSION_NAME}-pg${PG_MAJOR_VERSION}-${EXTENSION_VERSION}.pkg"
 
+          cd "$BUILD"
           pkgbuild \
             --root "$INSTALL_ROOT" \
-            --install-location "/Library/Application Support/Postgres/Extensions/${PG_MAJOR_VERSION}/pg_search" \
-            --identifier "com.paradedb.postgresapp.${PG_MAJOR_VERSION}.pg_search" \
+            --install-location "/Library/Application Support/Postgres/Extensions/${PG_MAJOR_VERSION}/${EXTENSION_NAME}" \
+            --identifier "com.postgresapp.extension.${PG_MAJOR_VERSION}.${EXTENSION_NAME}" \
             --version "${EXTENSION_VERSION}" \
-            --scripts Build/Scripts \
+            --scripts Scripts \
             "${COMPONENT_PKG}"
 
           productbuild \
-            --distribution Build/distribution.xml \
-            --resources Build/Resources \
+            --distribution distribution.xml \
+            --resources Resources \
             --package-path . \
             "${FINAL_PKG}"
 
-          rm -f "${COMPONENT_PKG}"
-          ls -lh "${FINAL_PKG}"
+          rm "${COMPONENT_PKG}"
+          mv "$BUILD/${FINAL_PKG}" "${GITHUB_WORKSPACE}/${FINAL_PKG}"
+          ls -lh "${GITHUB_WORKSPACE}/${FINAL_PKG}"
           echo "pkg_path=${FINAL_PKG}" >> $GITHUB_OUTPUT
           echo "pkg_name=${FINAL_PKG}" >> $GITHUB_OUTPUT
 
@@ -283,9 +240,10 @@ jobs:
           overwrite: true
 
       # Open a PR to PostgresApp/PostgresApp updating the pg_search download URL on
-      # https://postgresapp.com/extensions/. The PR is raised from paradedb-bot's
-      # fork; any previous open PR from the bot is closed first so that only one
-      # update is ever pending review upstream.
+      # https://postgresapp.com/extensions/. The page is generated from per-version
+      # JSON files at docs/_data/extensions/<pg>/pg_search.json. The PR is raised
+      # from paradedb-bot's fork; any previous open PR from the bot is closed first
+      # so that only one update is ever pending review upstream.
       - name: Open PR to PostgresApp/PostgresApp
         env:
           GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
@@ -335,73 +293,44 @@ jobs:
           git push origin "$UPSTREAM_DEFAULT_BRANCH" --force-with-lease
           git checkout -B "$BRANCH"
 
-          # Update the pg_search version line and the download URL inside the
-          # `<h1>pg_search (ParadeDB)</h1>` block of docs/extensions/index.md. We
-          # restrict the substitutions to that block so other extensions are not
-          # touched.
+          # Update only `version` and `download_url` in the per-PG-version JSON,
+          # preserving the rest of the file (title, description, info_url) and the
+          # existing 4-space indentation used upstream.
+          JSON_PATH="docs/_data/extensions/${PG_MAJOR_VERSION}/pg_search.json"
+          if [ ! -f "$JSON_PATH" ]; then
+            echo "Expected $JSON_PATH to exist upstream; aborting." >&2
+            exit 1
+          fi
+
+          JSON_PATH="$JSON_PATH" \
+          NEW_VERSION="$TAG_VERSION" \
+          NEW_URL="$DOWNLOAD_URL" \
           python3 - <<'PY'
-          import os, pathlib, re
-
-          version = os.environ["TAG_VERSION"]
-          pg_major = os.environ["PG_MAJOR_VERSION"]
-          url = (
-              f"https://github.com/paradedb/paradedb/releases/download/"
-              f"v{version}/{os.environ['PKG_NAME']}"
-          )
-
-          path = pathlib.Path("docs/extensions/index.md")
-          text = path.read_text()
-
-          # Anchor on the pg_search (ParadeDB) heading and the unique closing anchor of
-          # the download link so we capture the entire outer <div class="extension"> block,
-          # not the inner extension-description <div>.
-          block_re = re.compile(
-              r'<div class="extension">\s*<h1>pg_search \(ParadeDB\)</h1>'
-              r'.*?Download for Postgres\.app</a>\s*</div>',
-              re.DOTALL,
-          )
-          match = block_re.search(text)
-          if not match:
-              raise SystemExit("Could not locate the pg_search (ParadeDB) extension block in docs/extensions/index.md")
-
-          block = match.group(0)
-          updated = re.sub(
-              r"pg_search \d+\.\d+\.\d+(?:-[A-Za-z0-9.\-]+)?",
-              f"pg_search {version}",
-              block,
-          )
-          updated = re.sub(
-              r"built for PostgreSQL \d+",
-              f"built for PostgreSQL {pg_major}",
-              updated,
-          )
-          updated = re.sub(
-              r'href="https://[^"]*pg_search[^"]*\.pkg"',
-              f'href="{url}"',
-              updated,
-          )
-
-          if updated == block:
-              raise SystemExit("pg_search block matched but no fields were updated; refusing to open an empty PR")
-
-          path.write_text(text[: match.start()] + updated + text[match.end():])
+          import json, os, pathlib
+          path = pathlib.Path(os.environ["JSON_PATH"])
+          data = json.loads(path.read_text())
+          data["version"] = os.environ["NEW_VERSION"]
+          data["download_url"] = os.environ["NEW_URL"]
+          path.write_text(json.dumps(data, indent=4) + "\n")
           PY
 
           if git diff --quiet; then
-            echo "No changes to docs/extensions/index.md; nothing to PR."
+            echo "No changes to ${JSON_PATH}; nothing to PR."
             exit 0
           fi
 
-          git add docs/extensions/index.md
+          git add "$JSON_PATH"
           git commit -m "Update pg_search to v${TAG_VERSION} for PostgreSQL ${PG_MAJOR_VERSION}"
           git push origin "$BRANCH" --force-with-lease
 
           BODY=$(cat <<EOF
-          This PR updates the [pg_search](https://github.com/paradedb/paradedb) download link on https://postgresapp.com/extensions/ to point at the v${TAG_VERSION} release.
+          This PR updates the [pg_search](https://github.com/paradedb/paradedb) entry on https://postgresapp.com/extensions/ to point at the v${TAG_VERSION} release.
 
           - **Version**: ${TAG_VERSION}
           - **PostgreSQL**: ${PG_MAJOR_VERSION}
           - **Installer**: <${DOWNLOAD_URL}>
+
+          The pkg is built from the upstream [PostgresApp/Extensions/pg_search](https://github.com/PostgresApp/Extensions/tree/main/pg_search) build assets (Resources, Scripts, distribution.xml) so layout and install behavior match other Postgres.app extensions.
 
           Opened automatically by \`paradedb-bot\` from the [publish-pg_search-postgresapp](https://github.com/paradedb/paradedb/blob/main/.github/workflows/publish-pg_search-postgresapp.yml) workflow. See [PostgresApp/PostgresApp#799](https://github.com/PostgresApp/PostgresApp/issues/799) for context.
           EOF

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -135,11 +135,39 @@ jobs:
           export BINDGEN_EXTRA_CLANG_ARGS="$(xcrun --show-sdk-path | xargs -I{} echo -isysroot {})"
           cargo pgrx package --pg-config $PG_CONFIG
 
-      # TODO: wire up Apple Developer codesigning + notarytool before merging this
-      # PR. Upstream's build.zsh runs `codesign --sign "Developer ID Application"`
-      # on the dylibs and signs the pkg with `Developer ID Installer`, then submits
-      # to `xcrun notarytool` using a `postgresapp` keychain profile. Without those,
-      # the produced pkg trips Gatekeeper on first install.
+      # Import the Developer ID Application + Installer certificates into a dedicated
+      # temporary keychain so codesign/pkgbuild/productbuild can sign with them. The
+      # keychain is the only one on the user search list for the rest of the job, so
+      # the partial "Developer ID Application"/"Developer ID Installer" identity
+      # strings used below match unambiguously. Mirrors GitHub's "Installing an Apple
+      # certificate on macOS runners" guide.
+      - name: Import Apple Developer ID Certificates
+        env:
+          APPLE_DEVELOPER_ID_APPLICATION_CERT: ${{ secrets.APPLE_DEVELOPER_ID_APPLICATION_CERT }}
+          APPLE_DEVELOPER_ID_INSTALLER_CERT: ${{ secrets.APPLE_DEVELOPER_ID_INSTALLER_CERT }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+
+          # Create, configure, and unlock a throwaway keychain for the job.
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Decode and import both Developer ID certificates (.p12), then wipe the files.
+          echo "$APPLE_DEVELOPER_ID_APPLICATION_CERT" | base64 --decode > "$RUNNER_TEMP/application.p12"
+          echo "$APPLE_DEVELOPER_ID_INSTALLER_CERT" | base64 --decode > "$RUNNER_TEMP/installer.p12"
+          security import "$RUNNER_TEMP/application.p12" -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security import "$RUNNER_TEMP/installer.p12" -P "$APPLE_CERT_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          rm -f "$RUNNER_TEMP/application.p12" "$RUNNER_TEMP/installer.p12"
+
+          # Allow the signing tools to use the private keys without an interactive prompt,
+          # and make this the keychain that codesign/pkgbuild/productbuild search.
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychain -d user -s "$KEYCHAIN_PATH"
+
       - name: Build Postgres.app Installer Package
         id: pkg
         run: |
@@ -156,6 +184,11 @@ jobs:
             ls -R "${GITHUB_WORKSPACE}/target/release" || true
             exit 1
           fi
+
+          # Sign the loadable library with the Developer ID Application identity before
+          # packaging, matching upstream build.zsh. Without this the notarized pkg would
+          # contain an unsigned dylib and fail notarization.
+          codesign --force --sign "Developer ID Application" --timestamp "$INSTALL_ROOT"/lib/postgresql/*.dylib
 
           BUILD=$(mktemp -d)
           mkdir -p "$BUILD/Resources" "$BUILD/Scripts"
@@ -188,12 +221,14 @@ jobs:
             --identifier "com.postgresapp.extension.${PG_MAJOR_VERSION}.${EXTENSION_NAME}" \
             --version "${EXTENSION_VERSION}" \
             --scripts Scripts \
+            --sign "Developer ID Installer" \
             "${COMPONENT_PKG}"
 
           productbuild \
             --distribution distribution.xml \
             --resources Resources \
             --package-path . \
+            --sign "Developer ID Installer" \
             "${FINAL_PKG}"
 
           rm "${COMPONENT_PKG}"
@@ -201,6 +236,26 @@ jobs:
           ls -lh "${GITHUB_WORKSPACE}/${FINAL_PKG}"
           echo "pkg_path=${FINAL_PKG}" >> $GITHUB_OUTPUT
           echo "pkg_name=${FINAL_PKG}" >> $GITHUB_OUTPUT
+
+      # Submit the signed pkg to Apple's notary service and staple the ticket onto it
+      # so Gatekeeper accepts the installer on first open, even offline. Authenticates
+      # with an App Store Connect API key (notarytool --key). Runs before attestation
+      # and upload so the artifact we attest and ship is the stapled one.
+      - name: Notarize and Staple Installer Package
+        env:
+          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ secrets.APPLE_API_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          echo "$APPLE_API_KEY_P8" | base64 --decode > "$RUNNER_TEMP/AuthKey.p8"
+          xcrun notarytool submit "${{ steps.pkg.outputs.pkg_path }}" \
+            --key "$RUNNER_TEMP/AuthKey.p8" \
+            --key-id "$APPLE_API_KEY_ID" \
+            --issuer "$APPLE_API_ISSUER_ID" \
+            --wait
+          xcrun stapler staple "${{ steps.pkg.outputs.pkg_path }}"
+          rm -f "$RUNNER_TEMP/AuthKey.p8"
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v4

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -13,15 +13,11 @@ on:
   push:
     tags:
       - "v*"
-    # TEMPORARY: enable branch push trigger to test this workflow on the PR. Revert before merge.
-    branches:
-      - add-publish-pg_search-postgresapp-workflow
   workflow_dispatch:
     inputs:
       version:
         description: "The version to set for the pg_search release (e.g. 0.22.0). This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
         required: true
-        default: "0.0.0"
 
 concurrency:
   group: publish-pg_search-postgresapp-${{ github.head_ref || github.ref }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -13,11 +13,15 @@ on:
   push:
     tags:
       - "v*"
+    # TEMPORARY: enable branch push trigger to test this workflow on the PR. Revert before merge.
+    branches:
+      - add-publish-pg_search-postgresapp-workflow
   workflow_dispatch:
     inputs:
       version:
         description: "The version to set for the pg_search release (e.g. 0.22.0). This publishes the latest commit of the chosen branch and uploads it to the pre-existing GitHub Release of the provided version."
         required: true
+        default: "0.0.0"
 
 concurrency:
   group: publish-pg_search-postgresapp-${{ github.head_ref || github.ref }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -35,7 +35,6 @@ jobs:
     runs-on: macos-15
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
-      fail-fast: false
       matrix:
         # Postgres.app only supports loadable extensions installed in Application Support
         # starting with PostgreSQL 18. Earlier versions require extensions to be bundled,

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -35,7 +35,7 @@ permissions:
 
 jobs:
   publish-pg_search:
-    name: Publish pg_search for Postgres.app PostgreSQL ${{ matrix.pg_version }} arm64
+    name: Publish pg_search for Postgres.app (PostgreSQL ${{ matrix.pg_version }}, arm64)
     runs-on: macos-15
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
@@ -236,8 +236,8 @@ jobs:
       # Open a PR to PostgresApp/PostgresApp updating the pg_search download URL on
       # https://postgresapp.com/extensions/. The page is generated from per-version
       # JSON files at docs/_data/extensions/<pg>/pg_search.json. The PR is raised
-      # from paradedb-bot's fork; any previous open PR from the bot is closed first
-      # so that only one update is ever pending review upstream.
+      # from the paradedb/PostgresApp fork; any previous open PR from the bot is
+      # closed first so that only one update is ever pending review upstream.
       - name: Open PR to PostgresApp/PostgresApp
         env:
           # Classic PAT with `repo` scope — required because fine-grained PATs cannot
@@ -252,9 +252,6 @@ jobs:
           set -euo pipefail
 
           UPSTREAM=PostgresApp/PostgresApp
-          # The fork lives under the paradedb org (so the existing PARADEDB_BOT_GITHUB_TOKEN,
-          # whose resource owner is the paradedb org, can push to it). PR authorship still
-          # comes from paradedb-bot since that's the user the token belongs to.
           FORK_OWNER=paradedb
           FORK="${FORK_OWNER}/PostgresApp"
           BOT_LOGIN=$(gh api user --jq .login)

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -92,6 +92,12 @@ sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 
 </CodeGroup>
 
+<Note>
+  On macOS, if you run [Postgres.app](https://postgresapp.com) (PostgreSQL 18+),
+  you can also install `pg_search` directly from the
+  [Postgres.app extensions page](https://postgresapp.com/extensions/).
+</Note>
+
 ### ParadeDB Enterprise
 
 If you are a [ParadeDB Enterprise](/deploy/enterprise) user, you should have received a copy of the enterprise binaries. Please [contact sales](mailto:sales@paradedb.com) for access.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -27,6 +27,7 @@ ParadeDB provides prebuilt binaries of our extension for Postgres 15+ on:
 - Debian 12 (Bookworm) and 13 (Trixie)
 - Ubuntu 22.04 (Jammy) and 24.04 (Noble)
 - macOS 14 (Sonoma) and 15 (Sequoia)
+- macOS via [Postgres.app](https://postgresapp.com/extensions/) (PostgreSQL 18)
 - Red Hat Enterprise Linux 9 and 10
 
 If you are using a different version of Postgres or a different operating system, you will need to build the extension from source.
@@ -91,12 +92,6 @@ sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 </CodeGroup>
-
-<Note>
-  On macOS, if you run [Postgres.app](https://postgresapp.com) (PostgreSQL 18+),
-  you can also install `pg_search` directly from the
-  [Postgres.app extensions page](https://postgresapp.com/extensions/).
-</Note>
 
 ### ParadeDB Enterprise
 


### PR DESCRIPTION
## Summary

Closes #4630 

- Adds `.github/workflows/publish-pg_search-postgresapp.yml` that builds a Postgres.app installer `.pkg` for pg_search on each release tag (PG 18 only — earlier versions don't support extensions installed in Application Support).
- The pkg is uploaded to the existing GitHub Release at `v<version>` and named `pg_search-pg18-<version>.pkg`, matching the naming convention used by [PostgresApp/Extensions](https://github.com/PostgresApp/Extensions/tree/main/pg_search).
- The pkg is built using the upstream build assets (`Resources/`, `Scripts/`, `distribution.xml`) cloned from `PostgresApp/Extensions` at workflow time, so the installer layout, identifiers, install location, and pre/post-install behavior match what Postgres.app maintainers ship for other extensions.
- The workflow then opens a PR from `paradedb-bot`'s fork to [PostgresApp/PostgresApp](https://github.com/PostgresApp/PostgresApp) updating `version` and `download_url` in `docs/_data/extensions/18/pg_search.json` (the source for https://postgresapp.com/extensions/), per [Jakob's guidance](https://github.com/paradedb/paradedb/issues/4630#issuecomment-4342493949) that download metadata is now stored as JSON.
- Any previous open PR authored by `paradedb-bot` upstream is closed with a "Superseded" comment before the new one is opened, so only the latest release is ever pending review.

See [PostgresApp/PostgresApp#799](https://github.com/PostgresApp/PostgresApp/issues/799) for the upstream conversation that motivated this.

## Notes

- The pkg is now codesigned + notarized, matching upstream's `build.zsh`: the loadable library is signed with `Developer ID Application`, the pkg is signed with `Developer ID Installer`, then submitted to Apple's notary service via `notarytool` (App Store Connect API key) and stapled. The same was added to `publish-pg_search-macos.yml` in this PR. This requires the following repo secrets to be configured:
    - `APPLE_DEVELOPER_ID_APPLICATION_CERT` — base64 of the Developer ID Application cert exported as `.p12`
    - `APPLE_DEVELOPER_ID_INSTALLER_CERT` — base64 of the Developer ID Installer cert exported as `.p12`
    - `APPLE_CERT_PASSWORD` — the export password used for both `.p12` files
    - `APPLE_API_KEY_P8` — base64 of the App Store Connect API key (`AuthKey_XXXX.p8`)
    - `APPLE_API_KEY_ID` — the API key's Key ID
    - `APPLE_API_ISSUER_ID` — the API key's Issuer ID
- `paradedb-bot` does not yet have a fork of `PostgresApp/PostgresApp` — `gh repo fork` creates it on first run.
- `PARADEDB_BOT_GITHUB_TOKEN` needs `public_repo` scope to fork and open PRs against the public upstream (already required by other publish workflows).

## Test plan

- [x] Trigger the workflow via `workflow_dispatch` against an existing release tag and confirm the pkg is uploaded to the release.
- [x] Verify a PR is opened against `PostgresApp/PostgresApp` from `paradedb-bot:update-pg_search-<version>-pg18` updating `version` and `download_url` in `docs/_data/extensions/18/pg_search.json`.
- [x] Re-run the workflow with a different version and confirm the prior open bot PR is closed before the new one is opened.
- [x] Install the resulting `.pkg` on a Mac with Postgres.app PG 18 and run `CREATE EXTENSION pg_search;` to confirm the layout is correct.
