### PR TITLE
chore: require pg_search in shared_preload_libraries unconditionally

### DIFF
--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -43,6 +43,11 @@ runs:
       shell: bash
       run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
 
+    - name: Add pg_search to shared_preload_libraries
+      working-directory: /home/runner/.pgrx/data-${{ inputs.pg_version }}/
+      shell: bash
+      run: echo "shared_preload_libraries = 'pg_search'" >> postgresql.conf
+
     - name: Start Postgres via pgrx
       working-directory: pg_search/
       shell: bash
@@ -98,6 +103,11 @@ runs:
       working-directory: pg_search/
       shell: bash
       run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Add pg_search to shared_preload_libraries
+      working-directory: /home/runner/.pgrx/data-${{ inputs.pg_version }}/
+      shell: bash
+      run: echo "shared_preload_libraries = 'pg_search'" >> postgresql.conf
 
     - name: Start Postgres via pgrx
       working-directory: pg_search/

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -105,9 +105,7 @@ pub unsafe extern "C-unwind" fn _PG_init() {
         let _ = env_logger::try_init();
     }
 
-    if cfg!(not(any(feature = "pg17", feature = "pg18")))
-        && !pg_sys::process_shared_preload_libraries_in_progress
-    {
+    if !pg_sys::process_shared_preload_libraries_in_progress {
         error!("pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to shared_preload_libraries in postgresql.conf and restart Postgres.");
     }
 
@@ -170,13 +168,6 @@ pub mod pg_test {
 
     pub fn postgresql_conf_options() -> Vec<&'static str> {
         // return any postgresql.conf settings that are required for your tests
-
-        let mut options: Vec<&'static str> = Vec::new();
-
-        if cfg!(not(any(feature = "pg17", feature = "pg18"))) {
-            options.push("shared_preload_libraries='pg_search'");
-        }
-
-        options
+        vec!["shared_preload_libraries='pg_search'"]
     }
 }


### PR DESCRIPTION
## Summary
- Drop the `pg17`/`pg18` cfg gate around the `shared_preload_libraries` check in `_PG_init`, so `pg_search` errors out on every supported Postgres version when it isn't preloaded.
- Mirror the change in `pg_test::postgresql_conf_options()` so the pgrx test harness always preloads `pg_search`.

## Test plan
- [ ] `cargo pgrx test pg14` (and other supported versions) still pass with the unconditional preload requirement.
- [ ] Manually starting Postgres without `pg_search` in `shared_preload_libraries` errors out at load time on every version.