### PR TITLE
fix: route legacy F64 NUMERIC indexes through F64 conversion

### DIFF
--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -907,6 +907,37 @@ impl TantivyValue {
             })
             .collect()
     }
+
+    /// Convert a PostgreSQL NUMERIC datum to a TantivyValue with F64 storage.
+    /// Used only for legacy indexes (pre-v0.22.0) whose tantivy schema stored
+    /// NUMERIC fields as F64. Subject to f64 precision loss for values that
+    /// don't round-trip through a double.
+    pub unsafe fn try_from_numeric_f64(datum: Datum) -> Result<Self, TantivyValueError> {
+        let numeric =
+            pgrx::AnyNumeric::from_datum(datum, false).ok_or(TantivyValueError::DatumDeref)?;
+        Ok(TantivyValue(tantivy::schema::OwnedValue::F64(
+            numeric.try_into()?,
+        )))
+    }
+
+    /// Convert a PostgreSQL NUMERIC[] array to TantivyValues with F64 storage.
+    /// Legacy-only counterpart to `try_from_numeric_f64`.
+    pub unsafe fn try_from_numeric_array_f64(datum: Datum) -> Result<Vec<Self>, TantivyValueError> {
+        let array: pgrx::Array<Datum> =
+            pgrx::Array::from_datum(datum, false).ok_or(TantivyValueError::DatumDeref)?;
+
+        array
+            .iter()
+            .flatten()
+            .map(|element_datum| {
+                let numeric = pgrx::AnyNumeric::from_datum(element_datum, false)
+                    .ok_or(TantivyValueError::DatumDeref)?;
+                Ok(TantivyValue(tantivy::schema::OwnedValue::F64(
+                    numeric.try_into()?,
+                )))
+            })
+            .collect()
+    }
 }
 
 impl TryFrom<TantivyValue> for pgrx::AnyNumeric {

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -816,6 +816,16 @@ pub unsafe fn row_to_search_document<'a>(
                         document.add_field_value(search_field.field(), &OwnedValue::from(value));
                     }
                 }
+                // Legacy pre-v0.22.0 indexes stored NUMERIC arrays as F64 in the tantivy schema.
+                SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
+                    for value in TantivyValue::try_from_numeric_array_f64(actual_datum)
+                        .unwrap_or_else(|e| {
+                            panic!("could not parse field `{}`: {e}", search_field.field_name())
+                        })
+                    {
+                        document.add_field_value(search_field.field(), &OwnedValue::from(value));
+                    }
+                }
                 _ => {
                     for value in TantivyValue::try_from_datum_array(actual_datum, *base_oid)
                         .unwrap_or_else(|e| {
@@ -842,6 +852,10 @@ pub unsafe fn row_to_search_document<'a>(
                 }
                 SearchFieldType::NumericBytes(..) => {
                     TantivyValue::try_from_numeric_bytes(actual_datum)
+                }
+                // Legacy pre-v0.22.0 indexes stored NUMERIC as F64 in the tantivy schema.
+                SearchFieldType::F64(oid) if oid == pg_sys::NUMERICOID => {
+                    TantivyValue::try_from_numeric_f64(actual_datum)
                 }
                 _ => TantivyValue::try_from_datum(actual_datum, *base_oid),
             }


### PR DESCRIPTION
## Summary

Restores the backwards-compatibility promise of #3997: legacy indexes (pre-v0.22.0) that stored `NUMERIC` columns as F64 in the tantivy schema error when read with

```
ERROR:  Failed to index mutable segment.: Schema error:
        'Expected a F64 for field "<col>"'
```