### PR TITLE
docs: bump default Postgres version from 17 to 18

### DIFF
--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -43,56 +43,56 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 <Note>
   You can replace `0.23.1` with the `pg_search` version you wish to install and
-  `17` with the version of Postgres you are using.
+  `18` with the version of Postgres you are using.
 </Note>
 
 <CodeGroup>
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-18-pg-search_0.23.1-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-18-pg-search_0.23.1-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-18-pg-search_0.23.1-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-17-pg-search_0.23.1-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/postgresql-18-pg-search_0.23.1-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search_17-0.23.1-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search_18-0.23.1-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search_17-0.23.1-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search_18-0.23.1-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search@17--0.23.1.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search@18--0.23.1.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search@17--0.23.1.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.1/pg_search@18--0.23.1.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/third-party-extensions.mdx
+++ b/docs/deploy/third-party-extensions.mdx
@@ -72,7 +72,7 @@ Most popular Postgres extensions can be installed with `apt-get install`.
 
 ```bash
 apt-get update
-apt-get install -y --no-install-recommends postgresql-17-partman
+apt-get install -y --no-install-recommends postgresql-18-partman
 ```
 
 <Note>


### PR DESCRIPTION
## Summary
- Update `docs/deploy/self-hosted/extension.mdx` install snippets and the `Note` to use Postgres 18 as the default version.
- Update `docs/deploy/third-party-extensions.mdx` `apt-get` example to `postgresql-18-partman` to match the current default ParadeDB image (`PG_VERSION_MAJOR=18` in `docker/Dockerfile`).

## Test plan
- [x] Verify the rendered docs show `18` everywhere the default is referenced.
- [x] Confirm the v0.23.1 release artifacts referenced (deb/rpm/pkg for pg18) exist on GitHub Releases.