### PR TITLE
chore(deps): bump Cargo, GitHub Actions to latest compatible versions

### DIFF
--- a/.github/workflows/assign-github-issue.yml
+++ b/.github/workflows/assign-github-issue.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Notify of Assignment Failure
         if: steps.check_assignee.outputs.can_assign == 'false'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Fire Benchmark & Stressgres for ${{ matrix.sha }}
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -144,7 +144,7 @@ jobs:
 
       - name: Resolve git ref to PR
         id: pr_label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           # ← Set this to whatever ref you’re resolving:
           # • a SHA:            ${{ github.sha }}

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -114,7 +114,7 @@ jobs:
 
       - name: Resolve git ref to PR
         id: pr_label
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         env:
           # ← Set this to whatever ref you’re resolving:
           # • a SHA:            ${{ github.sha }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1137,12 +1137,6 @@ name = "census"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cexpr"
@@ -1526,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -1839,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "dary_heap"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06d2e3287df1c007e74221c49ca10a95d557349e54b3a75dc2fb14712c751f04"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
 name = "dashmap"
@@ -3033,23 +3027,9 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05de7d48f37cd6730705cbca900770cab77a89f413d23e100ad7fad7795a0ab"
-dependencies = [
- "fax_derive",
-]
-
-[[package]]
-name = "fax_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -3691,9 +3671,9 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -3943,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -4001,9 +3981,9 @@ dependencies = [
 
 [[package]]
 name = "imgref"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "include-flate"
@@ -4233,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
  "log",
@@ -4246,9 +4226,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4257,27 +4237,32 @@ dependencies = [
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror 2.0.18",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4317,9 +4302,9 @@ checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4442,9 +4427,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libduckdb-sys"
@@ -4601,7 +4586,7 @@ dependencies = [
  "csv",
  "lindera-dictionary",
  "once_cell",
- "rkyv 0.8.15",
+ "rkyv 0.8.16",
  "serde_json",
  "tokio",
 ]
@@ -4628,8 +4613,8 @@ dependencies = [
  "once_cell",
  "rand 0.9.4",
  "regex",
- "reqwest 0.13.2",
- "rkyv 0.8.15",
+ "reqwest 0.13.3",
+ "rkyv 0.8.16",
  "serde",
  "serde_json",
  "strum",
@@ -4651,7 +4636,7 @@ dependencies = [
  "csv",
  "lindera-dictionary",
  "once_cell",
- "rkyv 0.8.15",
+ "rkyv 0.8.16",
  "serde_json",
  "tokio",
 ]
@@ -4667,7 +4652,7 @@ dependencies = [
  "csv",
  "lindera-dictionary",
  "once_cell",
- "rkyv 0.8.15",
+ "rkyv 0.8.16",
  "serde_json",
  "tokio",
 ]
@@ -4683,7 +4668,7 @@ dependencies = [
  "csv",
  "lindera-dictionary",
  "once_cell",
- "rkyv 0.8.15",
+ "rkyv 0.8.16",
  "serde_json",
  "tokio",
 ]
@@ -4699,7 +4684,7 @@ dependencies = [
  "csv",
  "lindera-dictionary",
  "once_cell",
- "rkyv 0.8.15",
+ "rkyv 0.8.16",
  "serde_json",
  "tokio",
 ]
@@ -5017,7 +5002,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -5199,9 +5184,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.77"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
  "bitflags 2.11.1",
  "cfg-if",
@@ -5231,9 +5216,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.113"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -5346,9 +5331,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
+checksum = "4500030c302e4af1d423f36f3b958d1aecb6c04184356ed5a833bf6b60435777"
 dependencies = [
  "rustc_version",
 ]
@@ -5726,7 +5711,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5955,9 +5940,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -6269,9 +6254,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "qoi"
@@ -6402,9 +6387,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6502,7 +6487,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6732,9 +6717,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
+checksum = "62e0021ea2c22aed41653bc7e1419abb2c97e038ff2c33d0e1309e49a97deec0"
 dependencies = [
  "base64",
  "bytes",
@@ -6805,19 +6790,19 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a30e631b7f4a03dee9056b8ef6982e8ba371dd5bedb74d3ec86df4499132c70"
+checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
 dependencies = [
  "bytecheck 0.8.2",
  "bytes",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "indexmap",
  "munge",
  "ptr_meta 0.3.1",
  "rancor",
  "rend 0.5.3",
- "rkyv_derive 0.8.15",
+ "rkyv_derive 0.8.16",
  "tinyvec",
  "uuid",
 ]
@@ -6835,9 +6820,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.15"
+version = "0.8.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100bb34c0a1d0f907143db3149e6b4eea3c33b9ee8b189720168e818303986f"
+checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6921,7 +6906,7 @@ dependencies = [
  "bytes",
  "num-traits",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv 0.7.46",
  "serde",
  "serde_json",
@@ -6985,9 +6970,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -7012,9 +6997,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7022,9 +7007,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
@@ -7049,9 +7034,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7347,6 +7332,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simd_helpers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7578,7 +7573,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -7621,7 +7616,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -8263,9 +8258,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -8323,7 +8318,7 @@ dependencies = [
  "socket2 0.6.3",
  "tokio",
  "tokio-util",
- "whoami 2.1.1",
+ "whoami 2.1.2",
 ]
 
 [[package]]
@@ -8438,7 +8433,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -8447,7 +8442,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -8565,9 +8560,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typetag"
@@ -8727,9 +8722,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8866,11 +8861,11 @@ dependencies = [
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -8879,7 +8874,7 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -8899,9 +8894,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8913,9 +8908,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8923,9 +8918,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8933,9 +8928,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8946,9 +8941,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -8989,9 +8984,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9009,18 +9004,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9043,9 +9038,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
  "libc",
  "libredox",
@@ -9279,15 +9274,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
@@ -9329,21 +9315,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -9405,12 +9376,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -9429,12 +9394,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -9450,12 +9409,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9489,12 +9442,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -9510,12 +9457,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -9537,12 +9478,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -9558,12 +9493,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -9594,9 +9523,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -9618,6 +9547,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -4,7 +4,7 @@ version = { workspace = true }
 edition = { workspace = true }
 
 [dependencies]
-clap = { version = "4.5.53", features = ["derive", "env"] }
+clap = { version = "4.6.1", features = ["derive", "env"] }
 anyhow = "1.0"
 serde_json = "1.0"
 sqlx = { version = "0.8.6", features = [
@@ -16,11 +16,11 @@ sqlx = { version = "0.8.6", features = [
   "chrono",
 ] }
 pretty_assertions = "1.4.1"
-tokio = { version = "1.48", features = ["full"] }
+tokio = { version = "1.52", features = ["full"] }
 serde = { version = "1.0.228", features = ["derive"] }
 toml = "0.8"
-futures = "0.3.31"
-duckdb = { version = "1.10501.0", features = ["bundled"] }
+futures = "0.3.32"
+duckdb = { version = "1.10502.0", features = ["bundled"] }
 
 [lib]
 name = "paradedb"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -9,7 +9,7 @@ license.workspace = true
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.103"
-syn = { version = "2.0.111", features = ["full"] }
-uuid = { version = "1.19.0", features = ["v4"] }
-quote = "1.0.42"
+proc-macro2 = "1.0.106"
+syn = { version = "2.0.117", features = ["full"] }
+uuid = { version = "1.23.1", features = ["v4"] }
+quote = "1.0.45"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-BgsxJzPe0iEKNnylTS09hz+SxdsBcOo3Re+wwsAWexE=";
+  cargoHash = "sha256-Qs+EXx3QYjpF1UlO0zqYckUwXzbDW+ATdLIjDRfjTSQ=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -25,43 +25,43 @@ debug-logging = [
 [dependencies]
 async-trait = "0.1.89"
 stable_deref_trait = "1.2.1"
-anyhow = { version = "1.0.100", features = ["backtrace"] }
-arrow-array = "58.0.0"
-arrow-buffer = "58.0.0"
-arrow-schema = "58.0.0"
-arrow-select = "58.0.0"
-bitpacking = "0.9.2"
-chrono = "0.4.42"
-time = "0.3.44"
-derive_more = { version = "2.1.0", features = ["full"] }
-env_logger = { version = "0.11.8", optional = true }
+anyhow = { version = "1.0.102", features = ["backtrace"] }
+arrow-array = "58.1.0"
+arrow-buffer = "58.1.0"
+arrow-schema = "58.1.0"
+arrow-select = "58.1.0"
+bitpacking = "0.9.3"
+chrono = "0.4.44"
+time = "0.3.47"
+derive_more = { version = "2.1.1", features = ["full"] }
+env_logger = { version = "0.11.10", optional = true }
 json5 = "0.4.1"
 memoffset = "0.9.1"
-once_cell = "1.21.3"
+once_cell = "1.21.4"
 parking_lot = "0.12.5"
 tokenizers = { path = "../tokenizers" }
 pgrx.workspace = true
-rustc-hash = "2.1.1"
+rustc-hash = "2.1.2"
 serde = "1.0.228"
-serde_json = { version = "1.0.145", features = ["preserve_order"] }
+serde_json = { version = "1.0.149", features = ["preserve_order"] }
 serde_cbor = "0.11.2"
 tantivy.workspace = true
-thiserror = "2.0.17"
-ordered-float = "5.1.0"
-uuid = "1.19.0"
+thiserror = "2.0.18"
+ordered-float = "5.3.0"
+uuid = "1.23.1"
 strum = { version = "0.27.2" }
 serde_path_to_error = "0.1.20"
 bincode = { version = "2.0.1", features = [
   "serde",
   "std",
 ], default-features = false }
-rand = "0.9.2"
-proptest = { version = "1.9.0", optional = true }
+rand = "0.9.4"
+proptest = { version = "1.11.0", optional = true }
 postcard = { version = "1.1.3", features = [
   "use-std",
 ], default-features = false }
 # same version as tantivy uses
-regex = { version = "1.12.2", default-features = false, features = [
+regex = { version = "1.12.3", default-features = false, features = [
   "std",
   "perf",
   "unicode",
@@ -70,7 +70,7 @@ tantivy-fst = { git = "https://github.com/paradedb/fst.git" }
 lazy_static = "1.5.0"
 macros = { path = "../macros" }
 half = "2.7.1"
-bytemuck = { version = "1.24.0", features = ["derive", "min_const_generics"] }
+bytemuck = { version = "1.25.0", features = ["derive", "min_const_generics"] }
 decimal-bytes = "0.4.2"
 paste = "1.0.15"
 typetag = "0.2"
@@ -85,11 +85,11 @@ prost = "0.14.3"
 [dev-dependencies]
 pgrx-tests.workspace = true
 rstest = "0.25.0"
-proptest = "1.9.0"
+proptest = "1.11.0"
 
 [build-dependencies]
-vergen = { version = "9.0.6", features = ["build", "cargo", "rustc", "si"] }
-vergen-git2 = "9.0"
+vergen = { version = "9.1.0", features = ["build", "cargo", "rustc", "si"] }
+vergen-git2 = "9.1"
 
 [package.metadata.cargo-machete]
 ignored = ["indexmap", "libc", "tantivy-common"]

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -6,8 +6,8 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
-anyhow = "1.0.100"
-clap = { version = "4.5", features = ["derive"] }
+anyhow = "1.0.102"
+clap = { version = "4.6", features = ["derive"] }
 csv = "1.4.0"
 cursive = { version = "0.21.1" }
 cursive-multiplex = "0.7.0"
@@ -16,20 +16,20 @@ cursive_table_view = "0.15.0"
 human_bytes = "0.4.3"
 humantime = "2.3.0"
 image = "0.25.9"
-libc = "0.2.178"
+libc = "0.2.186"
 parking_lot = "0.12.5"
 pgrx-pg-config = "0.13.1"
 plotters = "0.3.7"
-postgres = "0.19.12"
-rust_decimal = { version = "1.39.0", features = ["db-postgres"] }
+postgres = "0.19.13"
+rust_decimal = { version = "1.41.0", features = ["db-postgres"] }
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = { version = "1.0.145", features = [
+serde_json = { version = "1.0.149", features = [
   "preserve_order",
   "arbitrary_precision",
 ] }
 shutdown_hooks = "0.1.0"
 sysinfo = "0.33.1"
 toml = "0.8.23"
-url = "2.5.7"
-postgres-openssl = "0.5.2"
-openssl = "0.10.75"
+url = "2.5.8"
+postgres-openssl = "0.5.3"
+openssl = "0.10.78"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,23 +13,23 @@ crate-type = ["rlib"]
 
 [dev-dependencies]
 approx = "0.5.1"
-anyhow = "1.0.100"
+anyhow = "1.0.102"
 async-std = { version = "1.13.2", features = ["attributes"] }
 benchmarks = { path = "../benchmarks" }
-bigdecimal = { version = "0.4.9", features = ["serde"] }
-bytes = "1.11.0"
-chrono = { version = "0.4.42", features = ["clock", "alloc"] }
+bigdecimal = { version = "0.4.10", features = ["serde"] }
+bytes = "1.11.1"
+chrono = { version = "0.4.44", features = ["clock", "alloc"] }
 cmd_lib = "1.9.6"
 dotenvy = "0.15.7"
-futures = "0.3.31"
+futures = "0.3.32"
 lockfree-object-pool = "0.1.6"
 pgvector = { version = "0.4.1", features = ["sqlx"] }
 pretty_assertions = "1.4.1"
-rand = "0.9.2"
+rand = "0.9.4"
 rstest = "0.25.0"
-rustc-hash = "2.1.1"
+rustc-hash = "2.1.2"
 serde = "1.0.228"
-serde_json = "1.0.145"
+serde_json = "1.0.149"
 soa_derive = "0.14.0"
 sqlx = { version = "0.8.6", features = [
   "postgres",
@@ -42,12 +42,12 @@ sqlx = { version = "0.8.6", features = [
 strum = "0.27.2"
 strum_macros = "0.27.2"
 tantivy.workspace = true
-tempfile = "3.23.0"
-time = { version = "0.3.44", features = ["serde"] }
+tempfile = "3.27.0"
+time = { version = "0.3.47", features = ["serde"] }
 tokenizers = { path = "../tokenizers" }
-tokio = { version = "1.48.0", features = ["rt-multi-thread", "macros"] }
-uuid = "1.19.0"
+tokio = { version = "1.52.1", features = ["rt-multi-thread", "macros"] }
+uuid = "1.23.1"
 num-traits = "0.2.19"
-proptest = "1.9.0"
+proptest = "1.11.0"
 proptest-derive = "0.6.0"
-env_logger = "0.11.8"
+env_logger = "0.11.10"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -5,25 +5,25 @@ edition = { workspace = true }
 
 
 [dependencies]
-anyhow = "1.0.100"
-lindera = { version = "1.4.1", features = [
+anyhow = "1.0.102"
+lindera = { version = "1.5.1", features = [
   "embedded-cc-cedict",
   "embedded-ipadic",
   "embedded-ko-dic",
   "compress",
 ] }
-once_cell = "1.21.3"
+once_cell = "1.21.4"
 serde = "1.0.228"
-serde_json = "1.0.145"
+serde_json = "1.0.149"
 tantivy.workspace = true
-tracing = "0.1.43"
+tracing = "0.1.44"
 strum_macros = "0.27.2"
 strum = { version = "0.27.2", features = ["derive"] }
 tantivy-jieba = { workspace = true }
 emoji = "0.2.1"
-icu_properties = "2.1.2"
-unicode-segmentation = "1.12.0"
-icu_segmenter = "2.1.1"
+icu_properties = "2.2.0"
+unicode-segmentation = "1.13.2"
+icu_segmenter = "2.2.0"
 opencc-jieba-rs = "0.7.2"
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

### Cargo (workspace)
- Ran `cargo update` for Cargo.lock — patch-level bumps across the tree (rustls 0.23.40, reqwest 0.13.3, tokio 1.52.1, openssl 0.10.78, wasm-bindgen 0.2.120, jiff 0.2.24, rkyv 0.8.16, jni 0.22.4, etc.).
- Pinned `cargo-platform` at 0.3.2 because 0.3.3 requires rustc 1.91 and `rust-toolchain.toml` is at 1.90.0.
- Ran `cargo upgrade` to bring the version constraints in every Cargo.toml in line with the lockfile (arrow-* 58.1.0, anyhow 1.0.102, chrono 0.4.44, clap 4.6, derive_more 2.1.1, ordered-float 5.3.0, postgres 0.19.13, proptest 1.11.0, rust_decimal 1.41.0, serde_json 1.0.149, tempfile 3.27.0, tokio 1.52, uuid 1.23.1, vergen 9.1.0, etc.).
- Held back: `image` at 0.25.9 (0.25.10 wants rayon ≥1.11 which conflicts with `opencc-jieba-rs`'s `=1.10` pin), `opencc-jieba-rs` at 0.7.2 (0.7.4 pulls in libflate 2.1.0 with a yanked `core2 0.4.0` transitive).

### GitHub Actions
- Bumped `actions/github-script@v8` → `@v9`. The breaking change in v9 only affects scripts that do `require('@actions/github')` or shadow the injected `getOctokit`; ours use only `github.rest.*`, `github.request`, `context.*`, and `core.*`.
- Every other action is already at its latest major (checkout v6, cache v5, setup-node v6, setup-python v6, upload-artifact v7, download-artifact v8, codecov v6, all `docker/*` latest, swatinem/rust-cache v2, aws-actions/configure-aws-credentials v6, ...). Dependabot is configured for github-actions on a monthly cadence.
- Intentionally skipped `astral-sh/setup-uv@v7` → `@v8`: v8 drops major and minor tags entirely (must pin to a full version tag or githash), which is a separate pinning-convention change.

### Out of scope
- `flake.lock` — would need `nix flake update`; nix isn't installed in this dev shell.
- `package.json` (`mintlify`) — already at latest after `npm update`.
- Docker base images — `postgres:${PG_VERSION_MAJOR}-trixie` is parameterized (PG18 default landed in #4916); `rust:1.94-slim` is current.

## Test plan
- [x] `cargo check --workspace --all-targets`
- [ ] CI passes