### PR TITLE
ci: migrate to runs-on and tune runner sizing

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -35,6 +35,7 @@ jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
     runs-on:
+      # General-purpose m-family — orchestrates remote test infra, not CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -35,7 +35,6 @@ jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
     runs-on:
-      # 8 vCPU / 32 GB x64.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -35,7 +35,7 @@ jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
     runs-on:
-      # General-purpose m-family — orchestrates remote test infra, not CPU-bound.
+      # General-purpose m-family — Docker buildx is RAM-heavy.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -35,7 +35,7 @@ jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
     runs-on:
-      # Sized to match ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB RAM, x64, Ubuntu 24.04).
+      # 8 vCPU / 32 GB x64.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -34,7 +34,14 @@ on:
 jobs:
   antithesis-trigger-test-run:
     name: Test pg_search via Antithesis
-    runs-on: ubicloud-standard-8-ubuntu-2404
+    runs-on:
+      # Sized to match ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB RAM, x64, Ubuntu 24.04).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=8
+      - ram=32
+      - image=ubuntu24-full-x64
+      - extras=s3-cache
     if: (github.event_name == 'schedule' && github.repository == 'paradedb/paradedb-enterprise') || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'antithesis')
     strategy:
       matrix:

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -38,6 +38,7 @@ jobs:
       # Sized to match ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB RAM, x64, Ubuntu 24.04).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7a+m7i
       - cpu=8
       - ram=32
       - image=ubuntu24-full-x64

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -22,7 +22,7 @@ jobs:
   lint-rust:
     name: Lint Rust Files
     runs-on:
-      # Compute-optimized c-family — clippy/fmt is CPU-bound, RAM-light.
+      # Compute-optimized c-family — Rust clippy/fmt is CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -21,7 +21,14 @@ concurrency:
 jobs:
   lint-rust:
     name: Lint Rust Files
-    runs-on: ubicloud-standard-4-arm
+    runs-on:
+      # Sized to match ubicloud-standard-4-arm (4 vCPU, 16 GB RAM, ARM).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=4
+      - ram=16
+      - image=ubuntu22-full-arm64
+      - extras=s3-cache
     strategy:
       matrix:
         pg_version: [18]

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -23,7 +23,6 @@ jobs:
     name: Lint Rust Files
     runs-on:
       # 4 vCPU / 8 GB ARM, compute-optimized — clippy/fmt is CPU-bound, RAM-light.
-      # Originally ran on ubicloud-standard-4-arm (4 vCPU, 16 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -29,7 +29,7 @@ jobs:
       - family=c7g+c8g
       - cpu=4
       - ram=8
-      - image=ubuntu22-base-arm64
+      - image=ubuntu24-full-arm64
       - extras=s3-cache
     strategy:
       matrix:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -22,7 +22,6 @@ jobs:
   lint-rust:
     name: Lint Rust Files
     runs-on:
-      # 4 vCPU / 8 GB ARM, compute-optimized — clippy/fmt is CPU-bound, RAM-light.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y build-essential libfontconfig1-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y libfontconfig1-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -22,13 +22,14 @@ jobs:
   lint-rust:
     name: Lint Rust Files
     runs-on:
-      # Sized to match ubicloud-standard-4-arm (4 vCPU, 16 GB RAM, ARM).
+      # 4 vCPU / 8 GB ARM, compute-optimized — clippy/fmt is CPU-bound, RAM-light.
+      # Originally ran on ubicloud-standard-4-arm (4 vCPU, 16 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
-      - family=m7g+m8g
+      - family=c7g+c8g
       - cpu=4
-      - ram=16
-      - image=ubuntu22-full-arm64
+      - ram=8
+      - image=ubuntu22-base-arm64
       - extras=s3-cache
     strategy:
       matrix:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -25,6 +25,7 @@ jobs:
       # Sized to match ubicloud-standard-4-arm (4 vCPU, 16 GB RAM, ARM).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7g+m8g
       - cpu=4
       - ram=16
       - image=ubuntu22-full-arm64

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -22,6 +22,7 @@ jobs:
   lint-rust:
     name: Lint Rust Files
     runs-on:
+      # Compute-optimized c-family — clippy/fmt is CPU-bound, RAM-light.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y libfontconfig1-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y build-essential libfontconfig1-dev postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -52,7 +52,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:12-slim
             pg_version: 15
             arch: amd64
@@ -60,7 +60,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:12-slim
             pg_version: 15
             arch: arm64
@@ -68,7 +68,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:12-slim
             pg_version: 16
             arch: amd64
@@ -76,7 +76,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:12-slim
             pg_version: 16
             arch: arm64
@@ -84,7 +84,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:12-slim
             pg_version: 17
             arch: amd64
@@ -92,7 +92,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:12-slim
             pg_version: 17
             arch: arm64
@@ -100,7 +100,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:12-slim
             pg_version: 18
             arch: amd64
@@ -108,7 +108,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:12-slim
             pg_version: 18
             arch: arm64
@@ -117,7 +117,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:13-slim
             pg_version: 15
             arch: amd64
@@ -125,7 +125,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:13-slim
             pg_version: 15
             arch: arm64
@@ -133,7 +133,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:13-slim
             pg_version: 16
             arch: amd64
@@ -141,7 +141,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:13-slim
             pg_version: 16
             arch: arm64
@@ -149,7 +149,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:13-slim
             pg_version: 17
             arch: amd64
@@ -157,7 +157,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:13-slim
             pg_version: 17
             arch: arm64
@@ -165,7 +165,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: debian:13-slim
             pg_version: 18
             arch: amd64
@@ -173,7 +173,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: debian:13-slim
             pg_version: 18
             arch: arm64

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -31,7 +31,16 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
+    # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB, x64) and
+    # ubicloud-standard-4-arm (4 vCPU, 16 GB, ARM). matrix.image is the build
+    # container; matrix.runner_image is the runs-on host AMI.
+    # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=${{ matrix.cpu }}
+      - ram=${{ matrix.ram }}
+      - image=${{ matrix.runner_image }}
+      - extras=s3-cache
     container:
       image: ${{ matrix.image }}
     if: ${{ !contains(github.ref, '-rc.') }}
@@ -40,83 +49,115 @@ jobs:
         include:
           # Debian 12 (Bookworm)
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 15
             arch: amd64
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 15
             arch: arm64
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 16
             arch: amd64
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 16
             arch: arm64
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 17
             arch: amd64
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 17
             arch: arm64
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 18
             arch: amd64
           - name: Debian 12 (Bookworm)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 18
             arch: arm64
           # Debian 13 (Trixie)
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 15
             arch: amd64
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 15
             arch: arm64
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 16
             arch: amd64
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 16
             arch: arm64
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 17
             arch: amd64
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 17
             arch: arm64
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 18
             arch: amd64
           - name: Debian 13 (Trixie)
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 18
             arch: arm64

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -31,9 +31,9 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB, x64) and
-    # ubicloud-standard-4-arm (4 vCPU, 16 GB, ARM). matrix.image is the build
-    # container; matrix.runner_image is the runs-on host AMI.
+    # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
+    # build is CPU-bound). matrix.image is the build container; matrix.runner_image
+    # is the runs-on host AMI. Originally ran on ubicloud-standard-8 / -4-arm.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -41,7 +41,6 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
-      - extras=s3-cache
     container:
       image: ${{ matrix.image }}
     if: ${{ !contains(github.ref, '-rc.') }}
@@ -51,130 +50,130 @@ jobs:
           # Debian 12 (Bookworm)
           - name: Debian 12 (Bookworm)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:12-slim
             pg_version: 15
             arch: amd64
           - name: Debian 12 (Bookworm)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:12-slim
             pg_version: 15
             arch: arm64
           - name: Debian 12 (Bookworm)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:12-slim
             pg_version: 16
             arch: amd64
           - name: Debian 12 (Bookworm)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:12-slim
             pg_version: 16
             arch: arm64
           - name: Debian 12 (Bookworm)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:12-slim
             pg_version: 17
             arch: amd64
           - name: Debian 12 (Bookworm)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:12-slim
             pg_version: 17
             arch: arm64
           - name: Debian 12 (Bookworm)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:12-slim
             pg_version: 18
             arch: amd64
           - name: Debian 12 (Bookworm)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:12-slim
             pg_version: 18
             arch: arm64
           # Debian 13 (Trixie)
           - name: Debian 13 (Trixie)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:13-slim
             pg_version: 15
             arch: amd64
           - name: Debian 13 (Trixie)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:13-slim
             pg_version: 15
             arch: arm64
           - name: Debian 13 (Trixie)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:13-slim
             pg_version: 16
             arch: amd64
           - name: Debian 13 (Trixie)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:13-slim
             pg_version: 16
             arch: arm64
           - name: Debian 13 (Trixie)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:13-slim
             pg_version: 17
             arch: amd64
           - name: Debian 13 (Trixie)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:13-slim
             pg_version: 17
             arch: arm64
           - name: Debian 13 (Trixie)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: debian:13-slim
             pg_version: 18
             arch: amd64
           - name: Debian 13 (Trixie)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: debian:13-slim
             pg_version: 18
             arch: arm64

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -37,6 +37,7 @@ jobs:
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
+      - family=${{ matrix.runner_family }}
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
@@ -51,6 +52,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 15
@@ -58,6 +60,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 15
@@ -65,6 +68,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 16
@@ -72,6 +76,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 16
@@ -79,6 +84,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 17
@@ -86,6 +92,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 17
@@ -93,6 +100,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:12-slim
             pg_version: 18
@@ -100,6 +108,7 @@ jobs:
           - name: Debian 12 (Bookworm)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:12-slim
             pg_version: 18
@@ -108,6 +117,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 15
@@ -115,6 +125,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 15
@@ -122,6 +133,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 16
@@ -129,6 +141,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 16
@@ -136,6 +149,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 17
@@ -143,6 +157,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 17
@@ -150,6 +165,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: debian:13-slim
             pg_version: 18
@@ -157,6 +173,7 @@ jobs:
           - name: Debian 13 (Trixie)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: debian:13-slim
             pg_version: 18

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -33,7 +33,7 @@ jobs:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
     # build is CPU-bound). matrix.image is the build container; matrix.runner_image
-    # is the runs-on host AMI. Originally ran on ubicloud-standard-8 / -4-arm.
+    # is the runs-on host AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
+    # Compute-optimized c-family — Rust release build inside matrix.image container is CPU-bound.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -31,9 +31,6 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
-    # build is CPU-bound). matrix.image is the build container; matrix.runner_image
-    # is the runs-on host AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -54,8 +54,8 @@ jobs:
             pg_version: 15
             arch: amd64
           - name: Debian 12 (Bookworm)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:12-slim
@@ -70,8 +70,8 @@ jobs:
             pg_version: 16
             arch: amd64
           - name: Debian 12 (Bookworm)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:12-slim
@@ -86,8 +86,8 @@ jobs:
             pg_version: 17
             arch: amd64
           - name: Debian 12 (Bookworm)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:12-slim
@@ -102,8 +102,8 @@ jobs:
             pg_version: 18
             arch: amd64
           - name: Debian 12 (Bookworm)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:12-slim
@@ -119,8 +119,8 @@ jobs:
             pg_version: 15
             arch: amd64
           - name: Debian 13 (Trixie)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:13-slim
@@ -135,8 +135,8 @@ jobs:
             pg_version: 16
             arch: amd64
           - name: Debian 13 (Trixie)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:13-slim
@@ -151,8 +151,8 @@ jobs:
             pg_version: 17
             arch: amd64
           - name: Debian 13 (Trixie)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:13-slim
@@ -167,8 +167,8 @@ jobs:
             pg_version: 18
             arch: amd64
           - name: Debian 13 (Trixie)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: debian:13-slim

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -31,9 +31,9 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB, x64) and
-    # ubicloud-standard-4-arm (4 vCPU, 16 GB, ARM). matrix.image is the build
-    # container; matrix.runner_image is the runs-on host AMI.
+    # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
+    # build is CPU-bound). matrix.image is the build container; matrix.runner_image
+    # is the runs-on host AMI. Originally ran on ubicloud-standard-8 / -4-arm.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -41,7 +41,6 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
-      - extras=s3-cache
     container:
       image: ${{ matrix.image }}
     if: ${{ !contains(github.ref, '-rc.') }}
@@ -51,130 +50,130 @@ jobs:
           # Red Hat Enterprise Linux 9
           - name: Red Hat Enterprise Linux 9
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi9:latest
             pg_version: 15
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi9:latest
             pg_version: 15
             arch: aarch64
           - name: Red Hat Enterprise Linux 9
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi9:latest
             pg_version: 16
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi9:latest
             pg_version: 16
             arch: aarch64
           - name: Red Hat Enterprise Linux 9
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi9:latest
             pg_version: 17
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi9:latest
             pg_version: 17
             arch: aarch64
           - name: Red Hat Enterprise Linux 9
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi9:latest
             pg_version: 18
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi9:latest
             pg_version: 18
             arch: aarch64
           # Red Hat Enterprise Linux 10
           - name: Red Hat Enterprise Linux 10
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi10:latest
             pg_version: 15
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi10:latest
             pg_version: 15
             arch: aarch64
           - name: Red Hat Enterprise Linux 10
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi10:latest
             pg_version: 16
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi10:latest
             pg_version: 16
             arch: aarch64
           - name: Red Hat Enterprise Linux 10
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi10:latest
             pg_version: 17
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi10:latest
             pg_version: 17
             arch: aarch64
           - name: Red Hat Enterprise Linux 10
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             image: redhat/ubi10:latest
             pg_version: 18
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             image: redhat/ubi10:latest
             pg_version: 18
             arch: aarch64

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -37,6 +37,7 @@ jobs:
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
+      - family=${{ matrix.runner_family }}
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
@@ -51,6 +52,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 15
@@ -58,6 +60,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 15
@@ -65,6 +68,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 16
@@ -72,6 +76,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 16
@@ -79,6 +84,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 17
@@ -86,6 +92,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 17
@@ -93,6 +100,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 18
@@ -100,6 +108,7 @@ jobs:
           - name: Red Hat Enterprise Linux 9
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 18
@@ -108,6 +117,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 15
@@ -115,6 +125,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 15
@@ -122,6 +133,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 16
@@ -129,6 +141,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 16
@@ -136,6 +149,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 17
@@ -143,6 +157,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 17
@@ -150,6 +165,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 18
@@ -157,6 +173,7 @@ jobs:
           - name: Red Hat Enterprise Linux 10
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 18

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -33,7 +33,7 @@ jobs:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
     # build is CPU-bound). matrix.image is the build container; matrix.runner_image
-    # is the runs-on host AMI. Originally ran on ubicloud-standard-8 / -4-arm.
+    # is the runs-on host AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -54,8 +54,8 @@ jobs:
             pg_version: 15
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
@@ -70,8 +70,8 @@ jobs:
             pg_version: 16
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
@@ -86,8 +86,8 @@ jobs:
             pg_version: 17
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
@@ -102,8 +102,8 @@ jobs:
             pg_version: 18
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
@@ -119,8 +119,8 @@ jobs:
             pg_version: 15
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest
@@ -135,8 +135,8 @@ jobs:
             pg_version: 16
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest
@@ -151,8 +151,8 @@ jobs:
             pg_version: 17
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest
@@ -167,8 +167,8 @@ jobs:
             pg_version: 18
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -52,7 +52,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi9:latest
             pg_version: 15
             arch: x86_64
@@ -60,7 +60,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
             pg_version: 15
             arch: aarch64
@@ -68,7 +68,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi9:latest
             pg_version: 16
             arch: x86_64
@@ -76,7 +76,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
             pg_version: 16
             arch: aarch64
@@ -84,7 +84,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi9:latest
             pg_version: 17
             arch: x86_64
@@ -92,7 +92,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
             pg_version: 17
             arch: aarch64
@@ -100,7 +100,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi9:latest
             pg_version: 18
             arch: x86_64
@@ -108,7 +108,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi9:latest
             pg_version: 18
             arch: aarch64
@@ -117,7 +117,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi10:latest
             pg_version: 15
             arch: x86_64
@@ -125,7 +125,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest
             pg_version: 15
             arch: aarch64
@@ -133,7 +133,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi10:latest
             pg_version: 16
             arch: x86_64
@@ -141,7 +141,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest
             pg_version: 16
             arch: aarch64
@@ -149,7 +149,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi10:latest
             pg_version: 17
             arch: x86_64
@@ -157,7 +157,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest
             pg_version: 17
             arch: aarch64
@@ -165,7 +165,7 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             image: redhat/ubi10:latest
             pg_version: 18
             arch: x86_64
@@ -173,7 +173,7 @@ jobs:
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             image: redhat/ubi10:latest
             pg_version: 18
             arch: aarch64

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -31,7 +31,16 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
+    # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB, x64) and
+    # ubicloud-standard-4-arm (4 vCPU, 16 GB, ARM). matrix.image is the build
+    # container; matrix.runner_image is the runs-on host AMI.
+    # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=${{ matrix.cpu }}
+      - ram=${{ matrix.ram }}
+      - image=${{ matrix.runner_image }}
+      - extras=s3-cache
     container:
       image: ${{ matrix.image }}
     if: ${{ !contains(github.ref, '-rc.') }}
@@ -40,83 +49,115 @@ jobs:
         include:
           # Red Hat Enterprise Linux 9
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 15
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 15
             arch: aarch64
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 16
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 16
             arch: aarch64
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 17
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 17
             arch: aarch64
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi9:latest
             pg_version: 18
             arch: x86_64
           - name: Red Hat Enterprise Linux 9
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi9:latest
             pg_version: 18
             arch: aarch64
           # Red Hat Enterprise Linux 10
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 15
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 15
             arch: aarch64
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 16
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 16
             arch: aarch64
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 17
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 17
             arch: aarch64
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-8
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             image: redhat/ubi10:latest
             pg_version: 18
             arch: x86_64
           - name: Red Hat Enterprise Linux 10
-            runner: ubicloud-standard-4-arm
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             image: redhat/ubi10:latest
             pg_version: 18
             arch: aarch64

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
+    # Compute-optimized c-family — Rust release build inside matrix.image container is CPU-bound.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -31,9 +31,6 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
-    # build is CPU-bound). matrix.image is the build container; matrix.runner_image
-    # is the runs-on host AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y build-essential postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }}
           echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -24,7 +24,14 @@ concurrency:
 jobs:
   publish-pg_search-schema:
     name: Publish pg_search Schema
-    runs-on: ubicloud-standard-8-ubuntu-2404
+    runs-on:
+      # Sized to match ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB RAM, x64, Ubuntu 24.04).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=8
+      - ram=32
+      - image=ubuntu24-full-x64
+      - extras=s3-cache
     if: ${{ !contains(github.ref, '-rc.') }}
     defaults:
       run:

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -25,7 +25,6 @@ jobs:
   publish-pg_search-schema:
     name: Publish pg_search Schema
     runs-on:
-      # 8 vCPU / 16 GB x64, compute-optimized — Rust schema generation is CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7a+c7i

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -25,14 +25,14 @@ jobs:
   publish-pg_search-schema:
     name: Publish pg_search Schema
     runs-on:
-      # Sized to match ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB RAM, x64, Ubuntu 24.04).
+      # 8 vCPU / 16 GB x64, compute-optimized — Rust schema generation is CPU-bound.
+      # Originally ran on ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
-      - family=m7a+m7i
+      - family=c7a+c7i
       - cpu=8
-      - ram=32
-      - image=ubuntu24-full-x64
-      - extras=s3-cache
+      - ram=16
+      - image=ubuntu24-base-x64
     if: ${{ !contains(github.ref, '-rc.') }}
     defaults:
       run:

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }}
+          sudo apt-get update && sudo apt-get install -y build-essential postgresql-${{ env.pg_version }} postgresql-server-dev-${{ env.pg_version }}
           echo "/usr/lib/postgresql/${{ env.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pgrx

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -28,6 +28,7 @@ jobs:
       # Sized to match ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB RAM, x64, Ubuntu 24.04).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7a+m7i
       - cpu=8
       - ram=32
       - image=ubuntu24-full-x64

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -32,7 +32,7 @@ jobs:
       - family=c7a+c7i
       - cpu=8
       - ram=16
-      - image=ubuntu24-base-x64
+      - image=ubuntu24-full-x64
     if: ${{ !contains(github.ref, '-rc.') }}
     defaults:
       run:

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -26,7 +26,6 @@ jobs:
     name: Publish pg_search Schema
     runs-on:
       # 8 vCPU / 16 GB x64, compute-optimized — Rust schema generation is CPU-bound.
-      # Originally ran on ubicloud-standard-8-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7a+c7i

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -25,6 +25,7 @@ jobs:
   publish-pg_search-schema:
     name: Publish pg_search Schema
     runs-on:
+      # Compute-optimized c-family — Rust schema generation is CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7a+c7i

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -31,6 +31,7 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
+    # Compute-optimized c-family — Rust release build is CPU-bound.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -31,8 +31,6 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
-    # build is CPU-bound); matrix.runner_image picks the matching Ubuntu release.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -33,7 +33,6 @@ jobs:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
     # build is CPU-bound); matrix.runner_image picks the matching Ubuntu release.
-    # Originally ran on ubicloud-standard-8 / -4-arm.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -50,56 +50,56 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu22-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu22-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 18
             arch: arm64
           # Ubuntu 24.04

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y build-essential wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
+        run: DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
 
       - name: Checkout Git Repository
         uses: actions/checkout@v6

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -51,8 +51,8 @@ jobs:
             pg_version: 15
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 15
@@ -65,8 +65,8 @@ jobs:
             pg_version: 16
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 16
@@ -79,8 +79,8 @@ jobs:
             pg_version: 17
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 17
@@ -93,8 +93,8 @@ jobs:
             pg_version: 18
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 18
@@ -108,8 +108,8 @@ jobs:
             pg_version: 15
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 15
@@ -122,8 +122,8 @@ jobs:
             pg_version: 16
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 16
@@ -136,8 +136,8 @@ jobs:
             pg_version: 17
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 17
@@ -150,8 +150,8 @@ jobs:
             pg_version: 18
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            cpu: 4
-            ram: 8
+            cpu: 8
+            ram: 16
             runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             pg_version: 18

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -37,6 +37,7 @@ jobs:
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
+      - family=${{ matrix.runner_family }}
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
@@ -49,48 +50,56 @@ jobs:
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu22-full-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu22-full-arm64
             pg_version: 18
             arch: arm64
@@ -98,48 +107,56 @@ jobs:
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 16
+            runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             pg_version: 18
             arch: arm64

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -31,75 +31,116 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    runs-on: ${{ matrix.runner }}
+    # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB, x64) and
+    # ubicloud-standard-4-arm (4 vCPU, 16 GB, ARM); matrix.runner_image picks
+    # the matching Ubuntu release.
+    # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=${{ matrix.cpu }}
+      - ram=${{ matrix.ram }}
+      - image=${{ matrix.runner_image }}
+      - extras=s3-cache
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
       matrix:
         include:
           # Ubuntu 22.04
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-8-ubuntu-2204
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-4-arm-ubuntu-2204
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-8-ubuntu-2204
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-4-arm-ubuntu-2204
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-8-ubuntu-2204
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-4-arm-ubuntu-2204
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-8-ubuntu-2204
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu22-full-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
-            runner: ubicloud-standard-4-arm-ubuntu-2204
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu22-full-arm64
             pg_version: 18
             arch: arm64
           # Ubuntu 24.04
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-8-ubuntu-2404
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu24-full-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-4-arm-ubuntu-2404
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu24-full-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-8-ubuntu-2404
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu24-full-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-4-arm-ubuntu-2404
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu24-full-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-8-ubuntu-2404
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu24-full-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-4-arm-ubuntu-2404
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu24-full-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-8-ubuntu-2404
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu24-full-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
-            runner: ubicloud-standard-4-arm-ubuntu-2404
+            cpu: 4
+            ram: 16
+            runner_image: ubuntu24-full-arm64
             pg_version: 18
             arch: arm64
 

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -107,56 +107,56 @@ jobs:
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu24-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu24-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu24-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-base-x64
+            runner_image: ubuntu24-full-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
             ram: 8
             runner_family: c7g+c8g
-            runner_image: ubuntu24-base-arm64
+            runner_image: ubuntu24-full-arm64
             pg_version: 18
             arch: arm64
 

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -31,9 +31,9 @@ permissions:
 jobs:
   publish-pg_search:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
-    # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB, x64) and
-    # ubicloud-standard-4-arm (4 vCPU, 16 GB, ARM); matrix.runner_image picks
-    # the matching Ubuntu release.
+    # 8 vCPU / 16 GB x64 + 4 vCPU / 8 GB ARM, compute-optimized (Rust release
+    # build is CPU-bound); matrix.runner_image picks the matching Ubuntu release.
+    # Originally ran on ubicloud-standard-8 / -4-arm.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -41,7 +41,6 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
-      - extras=s3-cache
     if: ${{ !contains(github.ref, '-rc.') }}
     strategy:
       matrix:
@@ -49,115 +48,115 @@ jobs:
           # Ubuntu 22.04
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu22-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu22-base-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu22-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu22-base-arm64
             pg_version: 18
             arch: arm64
           # Ubuntu 24.04
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu24-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu24-base-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu24-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu24-base-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu24-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu24-base-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu24-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu24-base-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu24-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu24-base-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu24-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu24-base-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
-            runner_image: ubuntu24-full-x64
+            ram: 16
+            runner_family: c7a+c7i
+            runner_image: ubuntu24-base-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
             cpu: 4
-            ram: 16
-            runner_family: m7g+m8g
-            runner_image: ubuntu24-full-arm64
+            ram: 8
+            runner_family: c7g+c8g
+            runner_image: ubuntu24-base-arm64
             pg_version: 18
             arch: arm64
 

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -162,7 +162,7 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
+        run: DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y build-essential wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
 
       - name: Checkout Git Repository
         uses: actions/checkout@v6

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -24,7 +24,7 @@ jobs:
       - family=m7a+m7i
       - cpu=8
       - ram=32
-      - image=ubuntu22-base-x64
+      - image=ubuntu24-full-x64
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -17,14 +17,14 @@ jobs:
   publish-stressgres-docker:
     name: Publish Stressgres Docker Image to Docker Hub
     runs-on:
-      # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB RAM, x64, Ubuntu 22.04 default).
+      # 8 vCPU / 32 GB x64 — Docker buildx via Depot, m-family for buildx headroom.
+      # Originally ran on ubicloud-standard-8 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i
       - cpu=8
       - ram=32
-      - image=ubuntu22-full-x64
-      - extras=s3-cache
+      - image=ubuntu22-base-x64
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -17,7 +17,6 @@ jobs:
   publish-stressgres-docker:
     name: Publish Stressgres Docker Image to Docker Hub
     runs-on:
-      # 8 vCPU / 32 GB x64 — Docker buildx via Depot, m-family for buildx headroom.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -18,7 +18,6 @@ jobs:
     name: Publish Stressgres Docker Image to Docker Hub
     runs-on:
       # 8 vCPU / 32 GB x64 — Docker buildx via Depot, m-family for buildx headroom.
-      # Originally ran on ubicloud-standard-8 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -17,6 +17,7 @@ jobs:
   publish-stressgres-docker:
     name: Publish Stressgres Docker Image to Docker Hub
     runs-on:
+      # General-purpose m-family for Docker buildx layer headroom.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -20,6 +20,7 @@ jobs:
       # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB RAM, x64, Ubuntu 22.04 default).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7a+m7i
       - cpu=8
       - ram=32
       - image=ubuntu22-full-x64

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -16,7 +16,14 @@ concurrency:
 jobs:
   publish-stressgres-docker:
     name: Publish Stressgres Docker Image to Docker Hub
-    runs-on: ubicloud-standard-8
+    runs-on:
+      # Sized to match ubicloud-standard-8 (8 vCPU, 32 GB RAM, x64, Ubuntu 22.04 default).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=8
+      - ram=32
+      - image=ubuntu22-full-x64
+      - extras=s3-cache
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -17,7 +17,7 @@ jobs:
   publish-stressgres-docker:
     name: Publish Stressgres Docker Image to Docker Hub
     runs-on:
-      # General-purpose m-family for Docker buildx layer headroom.
+      # General-purpose m-family — Docker buildx is RAM-heavy.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7a+m7i

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -27,7 +27,6 @@ jobs:
   schemabot-generate-diff:
     name: SchemaBot
     runs-on:
-      # 8 vCPU / 16 GB ARM, compute-optimized — Rust schema generation is CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -26,7 +26,14 @@ concurrency:
 jobs:
   schemabot-generate-diff:
     name: SchemaBot
-    runs-on: ubicloud-standard-8-arm-ubuntu-2404
+    runs-on:
+      # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=8
+      - ram=32
+      - image=ubuntu24-full-arm64
+      - extras=s3-cache
     defaults:
       run:
         shell: bash -eo pipefail {0}

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -28,7 +28,6 @@ jobs:
     name: SchemaBot
     runs-on:
       # 8 vCPU / 16 GB ARM, compute-optimized — Rust schema generation is CPU-bound.
-      # Originally ran on ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y build-essential postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pg-schema-diff and its Required Dependencies

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -30,6 +30,7 @@ jobs:
       # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7g+m8g
       - cpu=8
       - ram=32
       - image=ubuntu24-full-arm64

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -34,7 +34,7 @@ jobs:
       - family=c7g+c8g
       - cpu=8
       - ram=16
-      - image=ubuntu24-base-arm64
+      - image=ubuntu24-full-arm64
       - extras=s3-cache
     defaults:
       run:

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -27,13 +27,14 @@ jobs:
   schemabot-generate-diff:
     name: SchemaBot
     runs-on:
-      # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
+      # 8 vCPU / 16 GB ARM, compute-optimized — Rust schema generation is CPU-bound.
+      # Originally ran on ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
-      - family=m7g+m8g
+      - family=c7g+c8g
       - cpu=8
-      - ram=32
-      - image=ubuntu24-full-arm64
+      - ram=16
+      - image=ubuntu24-base-arm64
       - extras=s3-cache
     defaults:
       run:

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -27,6 +27,7 @@ jobs:
   schemabot-generate-diff:
     name: SchemaBot
     runs-on:
+      # Compute-optimized c-family — Rust schema generation is CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
           sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
-          sudo apt-get update && sudo apt-get install -y build-essential postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
+          sudo apt-get update && sudo apt-get install -y postgresql-${{ matrix.pg_version }} postgresql-server-dev-${{ matrix.pg_version }}
           echo "/usr/lib/postgresql/${{ matrix.pg_version }}/bin" >> $GITHUB_PATH
 
       - name: Install pg-schema-diff and its Required Dependencies

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -28,7 +28,6 @@ jobs:
     runs-on:
       # 8 vCPU / 16 GB ARM, compute-optimized — Mintlify is JS, RAM-light. Image
       # stays on -full- because Mintlify CLI is installed via npm (Node preinstalled).
-      # Originally ran on ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -26,8 +26,6 @@ jobs:
   test-docs:
     name: Test Docs for Broken Links, SEO Issues, and Code Snippets
     runs-on:
-      # 8 vCPU / 16 GB ARM, compute-optimized — Mintlify is JS, RAM-light. Image
-      # stays on -full- because Mintlify CLI is installed via npm (Node preinstalled).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -26,12 +26,14 @@ jobs:
   test-docs:
     name: Test Docs for Broken Links, SEO Issues, and Code Snippets
     runs-on:
-      # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
+      # 8 vCPU / 16 GB ARM, compute-optimized — Mintlify is JS, RAM-light. Image
+      # stays on -full- because Mintlify CLI is installed via npm (Node preinstalled).
+      # Originally ran on ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
-      - family=m7g+m8g
+      - family=c7g+c8g
       - cpu=8
-      - ram=32
+      - ram=16
       - image=ubuntu24-full-arm64
       - extras=s3-cache
     strategy:

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -26,7 +26,7 @@ jobs:
   test-docs:
     name: Test Docs for Broken Links, SEO Issues, and Code Snippets
     runs-on:
-      # Compute-optimized c-family — Mintlify is JS, RAM-light.
+      # Compute-optimized c-family — Rust + Postgres tests are CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -29,6 +29,7 @@ jobs:
       # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7g+m8g
       - cpu=8
       - ram=32
       - image=ubuntu24-full-arm64

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -25,7 +25,14 @@ concurrency:
 jobs:
   test-docs:
     name: Test Docs for Broken Links, SEO Issues, and Code Snippets
-    runs-on: ubicloud-standard-8-arm-ubuntu-2404
+    runs-on:
+      # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=8
+      - ram=32
+      - image=ubuntu24-full-arm64
+      - extras=s3-cache
     strategy:
       matrix:
         pg_version: [18]

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -26,6 +26,7 @@ jobs:
   test-docs:
     name: Test Docs for Broken Links, SEO Issues, and Code Snippets
     runs-on:
+      # Compute-optimized c-family — Mintlify is JS, RAM-light.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -38,16 +38,28 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image (${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
+    # Sized to match ubicloud-standard-16-ubuntu-2404 / ubicloud-standard-16-arm-ubuntu-2404
+    # (16 vCPU, 64 GB, Ubuntu 24.04). matrix.runner_image picks the matching arch AMI.
+    # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=${{ matrix.cpu }}
+      - ram=${{ matrix.ram }}
+      - image=${{ matrix.runner_image }}
+      - extras=s3-cache
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: amd64
-            runner: ubicloud-standard-16-ubuntu-2404
+            cpu: 16
+            ram: 64
+            runner_image: ubuntu24-full-x64
             platform: linux/amd64
           - arch: arm64
-            runner: ubicloud-standard-16-arm-ubuntu-2404
+            cpu: 16
+            ram: 64
+            runner_image: ubuntu24-full-arm64
             platform: linux/arm64
 
     steps:

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -38,7 +38,6 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image (${{ matrix.arch }})
-    # 16 vCPU / 64 GB Ubuntu 24.04. matrix.runner_image picks the matching arch AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -38,8 +38,7 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image (${{ matrix.arch }})
-    # Sized to match ubicloud-standard-16-ubuntu-2404 / ubicloud-standard-16-arm-ubuntu-2404
-    # (16 vCPU, 64 GB, Ubuntu 24.04). matrix.runner_image picks the matching arch AMI.
+    # 16 vCPU / 64 GB Ubuntu 24.04. matrix.runner_image picks the matching arch AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -38,6 +38,7 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image (${{ matrix.arch }})
+    # General-purpose m-family for Docker buildx layer headroom.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -59,7 +59,7 @@ jobs:
             platform: linux/amd64
           - arch: arm64
             cpu: 16
-            ram: 32
+            ram: 64
             runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             platform: linux/arm64

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -58,7 +58,7 @@ jobs:
             runner_image: ubuntu24-full-x64
             platform: linux/amd64
           - arch: arm64
-            cpu: 8
+            cpu: 16
             ram: 32
             runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
@@ -114,12 +114,18 @@ jobs:
       # no cross-arch shenanigans. We tag the image `latest` to match the tag used by the smoke
       # tests, and skip pushing since this is just a test build. Building directly (rather than
       # via Depot) avoids requiring repo secrets, which would block community-contributor PRs.
+      #
+      # The BuildKit `type=gha` cache is transparently backed by runs-on's S3 cache (via the
+      # `extras=s3-cache` runner label above), so it works without configuring a separate
+      # registry cache. Scoped per-arch so amd64 and arm64 don't evict each other.
       - name: Build the ParadeDB Docker Image
         run: |
           docker buildx build \
             --platform ${{ matrix.platform }} \
             --file docker/Dockerfile \
             --tag paradedb/paradedb:latest \
+            --cache-from type=gha,scope=paradedb-docker-${{ matrix.arch }} \
+            --cache-to type=gha,mode=max,scope=paradedb-docker-${{ matrix.arch }} \
             --load \
             .
 

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -38,7 +38,7 @@ concurrency:
 jobs:
   test-paradedb:
     name: Test ParadeDB Docker Image (${{ matrix.arch }})
-    # General-purpose m-family for Docker buildx layer headroom.
+    # General-purpose m-family — Docker buildx is RAM-heavy.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -52,14 +52,14 @@ jobs:
       matrix:
         include:
           - arch: amd64
-            cpu: 16
-            ram: 64
+            cpu: 8
+            ram: 32
             runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             platform: linux/amd64
           - arch: arm64
-            cpu: 16
-            ram: 64
+            cpu: 8
+            ram: 32
             runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             platform: linux/arm64

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -43,6 +43,7 @@ jobs:
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
+      - family=${{ matrix.runner_family }}
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
@@ -54,11 +55,13 @@ jobs:
           - arch: amd64
             cpu: 16
             ram: 64
+            runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             platform: linux/amd64
           - arch: arm64
             cpu: 16
             ram: 64
+            runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             platform: linux/arm64
 

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -75,6 +75,7 @@ jobs:
       # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7g+m8g
       - cpu=8
       - ram=32
       - image=ubuntu24-full-arm64

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -72,13 +72,14 @@ jobs:
     name: Test upgrading pg_search via ALTER EXTENSION
     needs: discover-upgrade-starting-points
     runs-on:
-      # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
+      # 8 vCPU / 16 GB ARM, compute-optimized — Rust + Postgres tests are CPU-bound.
+      # Originally ran on ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
-      - family=m7g+m8g
+      - family=c7g+c8g
       - cpu=8
-      - ram=32
-      - image=ubuntu24-full-arm64
+      - ram=16
+      - image=ubuntu24-base-arm64
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -71,7 +71,14 @@ jobs:
   test-pg_search-upgrade:
     name: Test upgrading pg_search via ALTER EXTENSION
     needs: discover-upgrade-starting-points
-    runs-on: ubicloud-standard-8-arm-ubuntu-2404
+    runs-on:
+      # Sized to match ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB RAM, ARM, Ubuntu 24.04).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=8
+      - ram=32
+      - image=ubuntu24-full-arm64
+      - extras=s3-cache
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -73,7 +73,6 @@ jobs:
     needs: discover-upgrade-starting-points
     runs-on:
       # 8 vCPU / 16 GB ARM, compute-optimized — Rust + Postgres tests are CPU-bound.
-      # Originally ran on ubicloud-standard-8-arm-ubuntu-2404 (8 vCPU, 32 GB).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -72,6 +72,7 @@ jobs:
     name: Test upgrading pg_search via ALTER EXTENSION
     needs: discover-upgrade-starting-points
     runs-on:
+      # Compute-optimized c-family — Rust + Postgres tests are CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -112,7 +112,7 @@ jobs:
           save-if: false
 
       - name: Install required system tools
-        run: sudo apt-get update && sudo apt-get install -y lsof
+        run: sudo apt-get update && sudo apt-get install -y build-essential lsof
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -79,7 +79,7 @@ jobs:
       - family=c7g+c8g
       - cpu=8
       - ram=16
-      - image=ubuntu24-base-arm64
+      - image=ubuntu24-full-arm64
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -72,7 +72,6 @@ jobs:
     name: Test upgrading pg_search via ALTER EXTENSION
     needs: discover-upgrade-starting-points
     runs-on:
-      # 8 vCPU / 16 GB ARM, compute-optimized — Rust + Postgres tests are CPU-bound.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=c7g+c8g

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -112,7 +112,7 @@ jobs:
           save-if: false
 
       - name: Install required system tools
-        run: sudo apt-get update && sudo apt-get install -y build-essential lsof
+        run: sudo apt-get update && sudo apt-get install -y lsof
 
       - name: Install & Configure Supported PostgreSQL Version
         run: |

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -50,16 +50,26 @@ jobs:
 
   test-pg_search:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} (${{ matrix.pg_impl }} - ${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
+    # Sized to match ubicloud-standard-8-arm-ubuntu-2404 / ubicloud-standard-8-ubuntu-2404
+    # (8 vCPU, 32 GB, Ubuntu 24.04). matrix.runner_image picks the matching arch AMI.
+    # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - cpu=${{ matrix.cpu }}
+      - ram=${{ matrix.ram }}
+      - image=${{ matrix.runner_image }}
+      - extras=s3-cache
     if: ${{ !cancelled() }}
     needs: set-matrix
     strategy:
       fail-fast: false
       matrix:
-        # Base: system Postgres on regular runner for all versions
+        # Base: system Postgres on ARM Ubuntu 24.04 for all versions
         pg_version: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
         pg_impl: [system]
-        runner: [ubicloud-standard-8-arm-ubuntu-2404]
+        cpu: [8]
+        ram: [32]
+        runner_image: [ubuntu24-full-arm64]
         arch: [arm64]
         include:
           # pgrx compiles Postgres from source with --enable-cassert and --enable-debug,
@@ -70,12 +80,16 @@ jobs:
           # only. This run is the only way we get Postgres assertion coverage in CI.
           - pg_version: 18
             pg_impl: pgrx
-            runner: ubicloud-standard-8-arm-ubuntu-2404
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu24-full-arm64
             arch: arm64
           # Add AMD run for PG 18 (system Postgres)
           - pg_version: 18
             pg_impl: system
-            runner: ubicloud-standard-8-ubuntu-2404
+            cpu: 8
+            ram: 32
+            runner_image: ubuntu24-full-x64
             arch: amd64
 
     steps:

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -50,6 +50,7 @@ jobs:
 
   test-pg_search:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} (${{ matrix.pg_impl }} - ${{ matrix.arch }})
+    # Compute-optimized c-family for system Postgres jobs; pgrx variant uses m-family because it compiles Postgres from source.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -50,7 +50,7 @@ jobs:
 
   test-pg_search:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} (${{ matrix.pg_impl }} - ${{ matrix.arch }})
-    # Compute-optimized c-family for system Postgres jobs; pgrx variant uses m-family because it compiles Postgres from source.
+    # Compute-optimized c-family — Rust + Postgres tests are CPU-bound.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -65,9 +65,6 @@ jobs:
       fail-fast: false
       matrix:
         # Base: system Postgres on ARM Ubuntu 24.04 for all versions.
-        # Compute-optimized c-family (cpu:ram = 1:2) for cargo build/test, which is
-        # CPU-bound. The pgrx variant below stays on m-family (1:4) because it
-        # compiles Postgres from source and needs more headroom.
         pg_version: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
         pg_impl: [system]
         cpu: [8]
@@ -85,8 +82,8 @@ jobs:
           - pg_version: 18
             pg_impl: pgrx
             cpu: 8
-            ram: 32
-            runner_family: m7g+m8g
+            ram: 16
+            runner_family: c7g+c8g
             runner_image: ubuntu24-full-arm64
             arch: arm64
           # Add AMD run for PG 18 (system Postgres)

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -242,10 +242,11 @@ jobs:
         working-directory: pg_search/
         run: cargo pgrx install --sudo --features block_tracker --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 
-      # Coverage instrumentation only runs on schedule + push-to-main; PRs run
-      # plain cargo test for ~30-40% wall-clock reduction.
+      # Coverage instrumentation runs on schedule + push-to-main, plus PG 18
+      # entries on PRs (so Codecov has fresh data per PR). Older-version PR
+      # entries run plain cargo test for ~30-40% wall-clock reduction.
       - name: Source LLVM coverage environment (pgrx)
-        if: matrix.pg_impl == 'pgrx' && github.event_name != 'pull_request'
+        if: matrix.pg_impl == 'pgrx' && (github.event_name != 'pull_request' || matrix.pg_version == 18)
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           cargo llvm-cov clean --workspace
@@ -280,7 +281,7 @@ jobs:
         run: |
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.pg_version }}" != "18" ]]; then
             RUST_BACKTRACE=1 cargo test --jobs $(nproc) --package tests --package tokenizers
           else
             RUST_BACKTRACE=1 cargo llvm-cov --jobs $(nproc) --package tests --package tokenizers --lcov --output-path coverage-integration-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}.lcov
@@ -292,7 +293,7 @@ jobs:
         run: |
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.pg_version }}" != "18" ]]; then
             RUST_BACKTRACE=1 cargo test --jobs $(nproc) --features pg${{ matrix.pg_version }} --no-default-features
           else
             RUST_BACKTRACE=1 cargo llvm-cov --jobs $(nproc) --features pg${{ matrix.pg_version }} --no-default-features --lcov --output-path ../coverage-unit-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}.lcov
@@ -317,7 +318,7 @@ jobs:
         run: cargo pgrx stop pg${{ matrix.pg_version }}
 
       - name: Generate combined LCOV report (pgrx)
-        if: matrix.pg_impl == 'pgrx' && github.event_name != 'pull_request' && always()
+        if: matrix.pg_impl == 'pgrx' && (github.event_name != 'pull_request' || matrix.pg_version == 18) && always()
         run: cargo llvm-cov report --lcov --output-path coverage-combined-pgrx-${{ matrix.pg_version }}.lcov
 
       # runs-on's extras=s3-cache proxies ACTIONS_RESULTS_URL to its local cache
@@ -326,7 +327,7 @@ jobs:
       # env vars back to GitHub's canonical artifact endpoint just for this step
       # so the upload bypasses the proxy.
       - name: Upload Coverage Artifact
-        if: github.event_name != 'pull_request' && always()
+        if: (github.event_name != 'pull_request' || matrix.pg_version == 18) && always()
         env:
           ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
           ACTIONS_CACHE_SERVICE_V2: ""
@@ -344,7 +345,7 @@ jobs:
     name: Upload Combined Coverage to Codecov
     runs-on: ubuntu-latest
     needs: test-pg_search
-    if: success() && github.event_name != 'pull_request'
+    if: success()
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v6

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -243,8 +243,10 @@ jobs:
         working-directory: pg_search/
         run: cargo pgrx install --sudo --features block_tracker --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 
+      # Coverage instrumentation only runs on schedule + push-to-main; PRs run
+      # plain cargo test for ~30-40% wall-clock reduction.
       - name: Source LLVM coverage environment (pgrx)
-        if: matrix.pg_impl == 'pgrx'
+        if: matrix.pg_impl == 'pgrx' && github.event_name != 'pull_request'
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           cargo llvm-cov clean --workspace
@@ -279,7 +281,11 @@ jobs:
         run: |
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
-          RUST_BACKTRACE=1 cargo llvm-cov --jobs $(nproc) --package tests --package tokenizers --lcov --output-path coverage-integration-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}.lcov
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            RUST_BACKTRACE=1 cargo test --jobs $(nproc) --package tests --package tokenizers
+          else
+            RUST_BACKTRACE=1 cargo llvm-cov --jobs $(nproc) --package tests --package tokenizers --lcov --output-path coverage-integration-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}.lcov
+          fi
 
       - name: Run pg_search Unit Tests (system)
         if: matrix.pg_impl == 'system'
@@ -287,7 +293,11 @@ jobs:
         run: |
           sudo chown -R $(whoami) /usr/share/postgresql/${{ matrix.pg_version }}/ /usr/lib/postgresql/${{ matrix.pg_version }}/
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
-          RUST_BACKTRACE=1 cargo llvm-cov --jobs $(nproc) --features pg${{ matrix.pg_version }} --no-default-features --lcov --output-path ../coverage-unit-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}.lcov
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            RUST_BACKTRACE=1 cargo test --jobs $(nproc) --features pg${{ matrix.pg_version }} --no-default-features
+          else
+            RUST_BACKTRACE=1 cargo llvm-cov --jobs $(nproc) --features pg${{ matrix.pg_version }} --no-default-features --lcov --output-path ../coverage-unit-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}.lcov
+          fi
 
       - name: Run pg_search Integration Tests (pgrx-managed)
         if: matrix.pg_impl == 'pgrx'
@@ -308,7 +318,7 @@ jobs:
         run: cargo pgrx stop pg${{ matrix.pg_version }}
 
       - name: Generate combined LCOV report (pgrx)
-        if: matrix.pg_impl == 'pgrx' && always()
+        if: matrix.pg_impl == 'pgrx' && github.event_name != 'pull_request' && always()
         run: cargo llvm-cov report --lcov --output-path coverage-combined-pgrx-${{ matrix.pg_version }}.lcov
 
       # runs-on's extras=s3-cache proxies ACTIONS_RESULTS_URL to its local cache
@@ -317,7 +327,7 @@ jobs:
       # env vars back to GitHub's canonical artifact endpoint just for this step
       # so the upload bypasses the proxy.
       - name: Upload Coverage Artifact
-        if: always()
+        if: github.event_name != 'pull_request' && always()
         env:
           ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
           ACTIONS_CACHE_SERVICE_V2: ""

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -50,7 +50,6 @@ jobs:
 
   test-pg_search:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} (${{ matrix.pg_impl }} - ${{ matrix.arch }})
-    # matrix.runner_image picks the matching arch AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -52,6 +52,10 @@ jobs:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} (${{ matrix.pg_impl }} - ${{ matrix.arch }})
     # Sized to match ubicloud-standard-8-arm-ubuntu-2404 / ubicloud-standard-8-ubuntu-2404
     # (8 vCPU, 32 GB, Ubuntu 24.04). matrix.runner_image picks the matching arch AMI.
+    # extras=s3-cache is intentionally omitted: runs-on's magic cache sets
+    # ACTIONS_CACHE_SERVICE_V2 + proxies ACTIONS_RESULTS_URL, which breaks
+    # actions/upload-artifact@v7 (the artifact action shares that URL and ends up
+    # POSTing to the cache proxy, getting non-JSON back).
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -59,7 +63,6 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
-      - extras=s3-cache
     if: ${{ !cancelled() }}
     needs: set-matrix
     strategy:

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -50,8 +50,7 @@ jobs:
 
   test-pg_search:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} (${{ matrix.pg_impl }} - ${{ matrix.arch }})
-    # Sized to match ubicloud-standard-8-arm-ubuntu-2404 / ubicloud-standard-8-ubuntu-2404
-    # (8 vCPU, 32 GB, Ubuntu 24.04). matrix.runner_image picks the matching arch AMI.
+    # matrix.runner_image picks the matching arch AMI.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -52,10 +52,6 @@ jobs:
     name: Test pg_search on PostgreSQL ${{ matrix.pg_version }} (${{ matrix.pg_impl }} - ${{ matrix.arch }})
     # Sized to match ubicloud-standard-8-arm-ubuntu-2404 / ubicloud-standard-8-ubuntu-2404
     # (8 vCPU, 32 GB, Ubuntu 24.04). matrix.runner_image picks the matching arch AMI.
-    # extras=s3-cache is intentionally omitted: runs-on's magic cache sets
-    # ACTIONS_CACHE_SERVICE_V2 + proxies ACTIONS_RESULTS_URL, which breaks
-    # actions/upload-artifact@v7 (the artifact action shares that URL and ends up
-    # POSTing to the cache proxy, getting non-JSON back).
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
@@ -63,6 +59,7 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
+      - extras=s3-cache
     if: ${{ !cancelled() }}
     needs: set-matrix
     strategy:
@@ -314,8 +311,16 @@ jobs:
         if: matrix.pg_impl == 'pgrx' && always()
         run: cargo llvm-cov report --lcov --output-path coverage-combined-pgrx-${{ matrix.pg_version }}.lcov
 
+      # runs-on's extras=s3-cache proxies ACTIONS_RESULTS_URL to its local cache
+      # server (for s3-backed actions/cache), but actions/upload-artifact@v4+ uses
+      # the same env var and ends up POSTing artifacts to the cache proxy. Pin the
+      # env vars back to GitHub's canonical artifact endpoint just for this step
+      # so the upload bypasses the proxy.
       - name: Upload Coverage Artifact
         if: always()
+        env:
+          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
+          ACTIONS_CACHE_SERVICE_V2: ""
         uses: actions/upload-artifact@v7
         with:
           name: coverage-${{ matrix.pg_version }}-${{ matrix.pg_impl }}-${{ matrix.arch }}

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -65,12 +65,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Base: system Postgres on ARM Ubuntu 24.04 for all versions
+        # Base: system Postgres on ARM Ubuntu 24.04 for all versions.
+        # Compute-optimized c-family (cpu:ram = 1:2) for cargo build/test, which is
+        # CPU-bound. The pgrx variant below stays on m-family (1:4) because it
+        # compiles Postgres from source and needs more headroom.
         pg_version: ${{ fromJson(needs.set-matrix.outputs.matrix) }}
         pg_impl: [system]
         cpu: [8]
-        ram: [32]
-        runner_family: [m7g+m8g]
+        ram: [16]
+        runner_family: [c7g+c8g]
         runner_image: [ubuntu24-full-arm64]
         arch: [arm64]
         include:
@@ -91,8 +94,8 @@ jobs:
           - pg_version: 18
             pg_impl: system
             cpu: 8
-            ram: 32
-            runner_family: m7a+m7i
+            ram: 16
+            runner_family: c7a+c7i
             runner_image: ubuntu24-full-x64
             arch: amd64
 
@@ -345,7 +348,7 @@ jobs:
     name: Upload Combined Coverage to Codecov
     runs-on: ubuntu-latest
     needs: test-pg_search
-    if: success()
+    if: success() && github.event_name != 'pull_request'
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v6

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -55,6 +55,7 @@ jobs:
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
     runs-on:
       - runs-on=${{ github.run_id }}
+      - family=${{ matrix.runner_family }}
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
@@ -69,6 +70,7 @@ jobs:
         pg_impl: [system]
         cpu: [8]
         ram: [32]
+        runner_family: [m7g+m8g]
         runner_image: [ubuntu24-full-arm64]
         arch: [arm64]
         include:
@@ -82,6 +84,7 @@ jobs:
             pg_impl: pgrx
             cpu: 8
             ram: 32
+            runner_family: m7g+m8g
             runner_image: ubuntu24-full-arm64
             arch: arm64
           # Add AMD run for PG 18 (system Postgres)
@@ -89,6 +92,7 @@ jobs:
             pg_impl: system
             cpu: 8
             ram: 32
+            runner_family: m7a+m7i
             runner_image: ubuntu24-full-x64
             arch: amd64
 

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -24,6 +24,7 @@ jobs:
   test-stressgres-docker:
     name: Test Stressgres Docker Image
     runs-on:
+      # General-purpose m-family for Docker buildx layer headroom.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7g+m8g

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -24,7 +24,6 @@ jobs:
   test-stressgres-docker:
     name: Test Stressgres Docker Image
     runs-on:
-      # 8 vCPU / 32 GB ARM.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7g+m8g

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -23,7 +23,14 @@ concurrency:
 jobs:
   test-stressgres-docker:
     name: Test Stressgres Docker Image
-    runs-on: ubicloud-standard-8-arm
+    runs-on:
+      # Sized to match ubicloud-standard-8-arm (8 vCPU, 32 GB RAM, ARM, Ubuntu 22.04 default).
+      # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+      - runs-on=${{ github.run_id }}
+      - cpu=8
+      - ram=32
+      - image=ubuntu22-full-arm64
+      - extras=s3-cache
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -30,7 +30,7 @@ jobs:
       - family=m7g+m8g
       - cpu=8
       - ram=32
-      - image=ubuntu22-full-arm64
+      - image=ubuntu24-full-arm64
       - extras=s3-cache
 
     steps:

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -27,6 +27,7 @@ jobs:
       # Sized to match ubicloud-standard-8-arm (8 vCPU, 32 GB RAM, ARM, Ubuntu 22.04 default).
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
+      - family=m7g+m8g
       - cpu=8
       - ram=32
       - image=ubuntu22-full-arm64

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -24,7 +24,7 @@ jobs:
   test-stressgres-docker:
     name: Test Stressgres Docker Image
     runs-on:
-      # General-purpose m-family for Docker buildx layer headroom.
+      # General-purpose m-family — Docker buildx is RAM-heavy.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7g+m8g

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -24,7 +24,7 @@ jobs:
   test-stressgres-docker:
     name: Test Stressgres Docker Image
     runs-on:
-      # Sized to match ubicloud-standard-8-arm (8 vCPU, 32 GB RAM, ARM, Ubuntu 22.04 default).
+      # 8 vCPU / 32 GB ARM.
       # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
       - runs-on=${{ github.run_id }}
       - family=m7g+m8g


### PR DESCRIPTION
## Summary

Migrates GitHub Actions self-hosted runners from ubicloud to [runs-on](https://runs-on.com) (AWS spot in us-east-1), and tunes sizing/coverage along the way.

## Runner image / family

- All workflows now use `ubuntu24-full-{x64,arm64}` (the only `ubuntu24-base-*` image runs-on doesn't publish; the `ubuntu22-base-*` we briefly used was a transitional choice).
- Compute-optimized **c-family** (`c7g+c8g`, `c7a+c7i`) for CPU-bound Rust workloads: lint-rust, schemabot, publish-pg_search-{schema,ubuntu,rhel,debian}, test-pg_search, test-pg_search-upgrade, test-docs.
- General-purpose **m-family** (`m7g+m8g`, `m7a+m7i`) for Docker buildx workloads (RAM-heavy): test/publish-stressgres-docker, test-pg_search-docker, antithesis-trigger-test-run.
- Each `runs-on:` block has a one-liner explaining the family choice plus the runs-on doc link.

## Sizing

- **c-family Rust jobs**: 8 vCPU / 16 GB (4 vCPU / 8 GB for the lint-only path).
- **m-family Docker jobs**: 8 vCPU / 32 GB across test-pg_search-docker, test-stressgres-docker, publish-stressgres-docker (was 16/64 on the ParadeDB Docker test).
- ARM publish entries promoted from 4 vCPU / 8 GB to 8 vCPU / 16 GB to match x64; Graviton per-core perf is comparable to x86 c-family on AWS, so the asymmetric ubicloud sizing was no longer earning its keep.

## Coverage gating

`test-pg_search` LLVM-cov instrumentation now runs on:
- All matrix entries on `schedule` + push to `main`.
- PG 18 entries (system arm64, system amd64, pgrx arm64) on PRs — keeps Codecov data fresh per PR.
- PG 15/16/17 entries on PRs run plain `cargo test` instead, for ~30-40% wall-clock savings.

Codecov upload job runs unconditionally and consumes whatever artifacts the matrix produced.

## Test plan

- [x] CI green on this PR
- [x] Confirm cache-miss pgrx PG 18 build doesn't OOM at 16 GB (cassert-enabled compile is the peak case)
- [x] Confirm test-pg_search-docker doesn't OOM at 8/32 (was previously 16/64 for the full ParadeDB image build)
- [x] Spot-check Codecov PR comment shows up with PG 18 data