### PR TITLE
docs: update Render deploy guide for new blueprint

### DIFF
--- a/docs/deploy/cloud-platforms/render.mdx
+++ b/docs/deploy/cloud-platforms/render.mdx
@@ -12,26 +12,37 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/render
   [Kubernetes](/deploy/self-hosted/kubernetes) or [BYOC](/deploy/byoc).
 </Note>
 
-[Render](https://render.com) is a cloud platform that makes it easy to deploy and manage applications. The
-[ParadeDB Render Blueprint](https://github.com/paradedb/render-blueprint) provides a one-click deployment
-that runs ParadeDB Community as a private service with persistent SSD storage.
+[Render](https://render.com) is a cloud platform that makes it easy to deploy and manage applications. Render
+provides [official documentation for deploying ParadeDB](https://render.com/docs/deploy-paradedb) using a
+[Render Blueprint](https://render.com/docs/blueprint-spec) that runs ParadeDB Community as a private service
+with persistent SSD storage.
+
+There are two blueprints available:
+
+- The [official blueprint](https://github.com/render-examples/paradedb) maintained by Render
+- The [ParadeDB-maintained blueprint](https://github.com/paradedb/render-blueprint)
 
 ## One-Click Deploy
 
-The fastest way to get started is to click the button below, which will fork the template repository and deploy
-ParadeDB to your Render account.
+The fastest way to get started is to click the button below, which uses the ParadeDB-maintained blueprint to
+deploy ParadeDB to your Render account.
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/paradedb/render-blueprint)
+
+This will:
+
+1. Create a private service named `paradedb` running the [official ParadeDB Docker image](https://hub.docker.com/r/paradedb/paradedb).
+2. Attach a 10 GB persistent disk for your database data, mounted at `/var/lib/postgresql`.
+3. Set up `POSTGRES_USER`, `POSTGRES_PASSWORD`, and `POSTGRES_DB` environment variables automatically.
 
 ## Manual Setup
 
 If you prefer to configure the deployment yourself:
 
-1. Fork the [deployment-render](https://github.com/paradedb/render-blueprint) repository
-2. In the Render dashboard, create a new **Private Service** and connect your forked repository
-3. Select **Docker** as the runtime
-4. Attach a **Disk** of at least 10 GB mounted at `/var/lib/postgresql`
-5. Set the following environment variables:
+1. Click **Use this template** at the top of the [render-blueprint](https://github.com/paradedb/render-blueprint) repository to create your own copy (or fork it).
+2. In the Render dashboard, create a new **Private Service** using the **Existing Image** runtime, pointing at `docker.io/paradedb/paradedb:latest` (or your preferred [tag](https://hub.docker.com/r/paradedb/paradedb/tags)).
+3. Attach a **Disk** of at least 10 GB mounted at `/var/lib/postgresql`.
+4. Set the following environment variables:
 
 | Variable            | Description       | Default        |
 | ------------------- | ----------------- | -------------- |
@@ -41,15 +52,23 @@ If you prefer to configure the deployment yourself:
 
 ## Connecting to ParadeDB
 
-ParadeDB runs as a **private service** on Render, which means it is not exposed to the public internet. You can
-connect from other services on your Render account via the internal network:
+ParadeDB runs as a **private service** on Render, which means it is not exposed to the public internet.
+
+### From another Render service
+
+Connect from any other service in your Render private network using the service name as the host:
 
 ```bash
 psql -h paradedb -U postgres -d paradedb
 ```
 
-To connect from your local machine, set up [Render SSH](https://docs.render.com/ssh) and then run:
+### From your local machine
+
+Since the service isn't exposed publicly, [SSH into the service](https://render.com/docs/ssh) and run `psql` from inside the container:
 
 ```bash
-psql -U postgres paradedb
+ssh srv-XXXXXXXXXXXXX@ssh.<region>.render.com
+psql -U postgres -d paradedb
 ```
+
+Replace `srv-XXXXXXXXXXXXX` with your service ID from the Render dashboard, and make sure you've added an SSH key to your Render account first.

--- a/docs/deploy/cloud-platforms/render.mdx
+++ b/docs/deploy/cloud-platforms/render.mdx
@@ -12,20 +12,17 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/render
   [Kubernetes](/deploy/self-hosted/kubernetes) or [BYOC](/deploy/byoc).
 </Note>
 
-[Render](https://render.com) is a cloud platform that makes it easy to deploy and manage applications. Render
-provides [official documentation for deploying ParadeDB](https://render.com/docs/deploy-paradedb) using a
-[Render Blueprint](https://render.com/docs/blueprint-spec) that runs ParadeDB Community as a private service
-with persistent SSD storage.
+[Render](https://render.com) is a cloud platform that makes it easy to deploy and manage applications. The
+[ParadeDB Render Blueprint](https://github.com/paradedb/render-blueprint) provides a one-click deployment
+that runs ParadeDB Community as a [private service](https://render.com/docs/private-services) with persistent
+SSD storage.
 
-There are two blueprints available:
-
-- The [official blueprint](https://github.com/render-examples/paradedb) maintained by Render
-- The [ParadeDB-maintained blueprint](https://github.com/paradedb/render-blueprint)
+You can either follow [Render's official ParadeDB deployment guide](https://render.com/docs/deploy-paradedb)
+or use the steps below.
 
 ## One-Click Deploy
 
-The fastest way to get started is to click the button below, which uses the ParadeDB-maintained blueprint to
-deploy ParadeDB to your Render account.
+The fastest way to get started is to click the button below, which deploys ParadeDB to your Render account.
 
 [![Deploy to Render](https://render.com/images/deploy-to-render-button.svg)](https://render.com/deploy?repo=https://github.com/paradedb/render-blueprint)
 


### PR DESCRIPTION
## Summary

Updates the Render cloud-platform deploy doc to reflect recent changes in the [paradedb/render-blueprint](https://github.com/paradedb/render-blueprint) repo and to link out to the official Render docs.

- Add a link to [render.com/docs/deploy-paradedb](https://render.com/docs/deploy-paradedb) and call out both the official Render-maintained blueprint ([render-examples/paradedb](https://github.com/render-examples/paradedb)) and the ParadeDB-maintained one.
- Update Manual Setup to match the current blueprint: lead with **Use this template**, switch from the Docker runtime to **Existing Image** pointing at `docker.io/paradedb/paradedb:latest`, and fix the broken "deployment-render" link.
- Rework the Connecting section to split internal vs. local access. The previous local-machine instructions were ambiguous about whether you SSH in and run `psql` inside or run `psql` locally — now it's explicit that you SSH into the service and run `psql` from the container, which is what actually works for a private service.
- Add a one-click deploy summary describing what the blueprint provisions.

## Test plan

- [X ] Confirm the rendered Mintlify page links resolve and the new SSH-in-and-psql flow works end-to-end against a deployed instance.