### PR TITLE
feat(mpp): AggregateScan + JoinScan activation (5/5)

### DIFF
--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*)
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
@@ -19,3 +19,14 @@ JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section'
 GROUP BY f.title
 ORDER BY f.title;
+
+-- MPP aggregate scan (Phase 7: N=4 — the default `paradedb.mpp_worker_count`
+-- — after the Phase 8 coalesce + hash-partition fix stabilised the 4-way
+-- mesh for GROUP BY. The earlier N=2 pin is removed; other bench queries
+-- already run at N=4.)
+SET statement_timeout TO '600s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT f.title, COUNT(*), SUM(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section'
+GROUP BY f.title
+ORDER BY f.title;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*), MIN(p."sizeInB
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
@@ -31,3 +31,17 @@ GROUP BY
 ORDER BY
     COUNT(*) DESC
 LIMIT 10;
+
+-- MPP TopK aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.title,
+    COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'
+GROUP BY
+    f.title
+ORDER BY
+    COUNT(*) DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
@@ -29,3 +29,18 @@ GROUP BY
 ORDER BY
     last_activity DESC            -- Single Feature Sort (Computed Aggregate)
 LIMIT 10;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    MAX(p."createdAt") as last_activity
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'       -- Search Term
+GROUP BY
+    f.id, f.title
+ORDER BY
+    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
@@ -31,3 +31,19 @@ WHERE
 ORDER BY
     f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
 LIMIT 20;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt",
+    d.title as document_title,
+    d.parents as document_parents
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents ||| 'parent group'
+    AND f.title ||| 'collab12'
+ORDER BY
+    f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
+LIMIT 20;

--- a/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
@@ -27,3 +27,17 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    pdb.score(f.id) as relevance
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    f.title ||| 'File'              -- Driving the Sort (Single Feature)
+    AND d.parents ||| 'parent group'
+ORDER BY
+    relevance DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -82,3 +82,20 @@ WHERE
 ORDER BY
     f.title ASC
 LIMIT 25;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt"
+FROM files f
+WHERE
+    f."documentId" IN (
+        SELECT id
+        FROM documents
+        WHERE parents ||| 'PROJECT_ALPHA'
+        AND title ||| 'Document Title 1'
+    )
+ORDER BY
+    f.title ASC
+LIMIT 25;

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -178,6 +178,12 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
     GucSetting::<i32>::new(16_000);
 
+/// Cost gate for binary-join MPP shapes (JoinOnly, ScalarAggOnBinaryJoin,
+/// GroupByAggOnBinaryJoin). If the smaller side's row estimate is below this
+/// threshold, skip MPP — the non-MPP broadcast-join path is cheaper when the
+/// small side fits in memory. Single-table shapes are unaffected.
+static MPP_MIN_JOIN_ROWS: GucSetting<i32> = GucSetting::<i32>::new(10_000);
+
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -535,6 +541,22 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_min_join_rows",
+        c"Minimum smaller-side rows before binary-join MPP shapes kick in",
+        c"Cost gate for binary-join MPP shapes: JoinOnly and aggregate-on- \
+          binary-join (both scalar and group-by). If the smaller side's \
+          planner row estimate is below this threshold, skip MPP — the \
+          non-MPP broadcast-join path is cheaper when the small side fits \
+          in memory. Single-table aggregate shapes have no broadcast \
+          candidate and are not gated. Set to 0 to disable the gate.",
+        &MPP_MIN_JOIN_ROWS,
+        0,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -735,6 +757,10 @@ pub fn hash_join_inlist_pushdown_max_size() -> i32 {
 
 pub fn hash_join_inlist_pushdown_max_distinct_values() -> i32 {
     HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES.get()
+}
+
+pub fn mpp_min_join_rows() -> i32 {
+    MPP_MIN_JOIN_ROWS.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -130,6 +130,14 @@ pub unsafe extern "C-unwind" fn _PG_init() {
 
     // Initialize the filter query builder
     customscan::aggregatescan::filterquery::init_filter_query_builder();
+
+    // Install MPP walker's runtime indirection for `PgSearchScanPlan::strip_dynamic_filters_from_dyn`.
+    // See `mpp::walker::STRIP_DYNAMIC_FILTERS_FN` for why this cannot be called statically.
+    customscan::mpp::walker::init_mpp_strip_dynamic_filters();
+
+    // Register an extractor with the datafusion-distributed fork so its
+    // NetworkBoundaryExt::as_network_boundary recognizes MppShuffleExec.
+    customscan::mpp::walker::init_mpp_network_boundary_extractor();
 }
 
 #[pg_extern]

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -38,8 +38,10 @@ use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, JoinSource, RelNode, RelationAlias,
 };
 use crate::postgres::customscan::joinscan::scan_state::{
-    create_datafusion_session_context, register_source_table, SessionContextProfile,
+    create_datafusion_session_context, create_datafusion_session_context_mpp,
+    register_source_table, SessionContextProfile,
 };
+use crate::postgres::customscan::mpp::MppParticipantConfig;
 use crate::scan::info::RowEstimate;
 use crate::scan::PgSearchTableProvider;
 use datafusion::common::{DataFusionError, Result};
@@ -49,12 +51,15 @@ use datafusion::functions_aggregate::expr_fn::{
     array_agg, avg, bool_and, bool_or, count, max, min, stddev, stddev_pop, sum, var_pop,
     var_sample,
 };
-use datafusion::functions_aggregate::string_agg::string_agg_udaf;
+use datafusion::functions_aggregate::string_agg::{string_agg, string_agg_udaf};
 use datafusion::logical_expr::expr::{AggregateFunction, Sort};
-use datafusion::logical_expr::{lit, Expr};
-use datafusion::prelude::{DataFrame, SessionContext};
+use datafusion::logical_expr::{lit, BinaryExpr, Expr, LogicalPlan, Operator};
+use datafusion::prelude::{col, DataFrame, SessionContext};
 use futures::future::{FutureExt, LocalBoxFuture};
 use pgrx::pg_sys;
+use pgrx::PgList;
+
+use crate::api::{HashMap, HashSet};
 
 /// Creates a DataFusion [`SessionContext`] for aggregate-on-join workloads.
 ///
@@ -65,6 +70,15 @@ use pgrx::pg_sys;
 /// specific session setup ever appears, this is the place to put it.
 pub fn create_aggregate_session_context() -> SessionContext {
     create_datafusion_session_context(SessionContextProfile::Aggregate)
+}
+
+/// MPP-aware variant. Applies the join-layer bug fixes required when the
+/// aggregate path runs as part of an MPP pipeline: skip `SortMergeJoinEnforcer`
+/// and disable `enable_join_dynamic_filter_pushdown`. Without this, the
+/// probe-side scan races with the exchange producer and silently drops rows
+/// before the dynamic filter stabilizes.
+pub fn create_aggregate_session_context_mpp(mpp: &MppParticipantConfig) -> SessionContext {
+    create_datafusion_session_context_mpp(SessionContextProfile::Aggregate, mpp)
 }
 
 /// Build the complete DataFusion logical plan for an aggregate-on-join query:
@@ -79,7 +93,7 @@ pub async fn build_join_aggregate_plan(
     custom_scan_tlist: *mut pg_sys::List,
     having_filter: Option<&FilterExpr>,
     ctx: &SessionContext,
-) -> Result<datafusion::logical_expr::LogicalPlan> {
+) -> Result<LogicalPlan> {
     // Step 1: Build the join DataFrame from the RelNode tree
     let df = build_relnode_df(
         ctx,
@@ -146,9 +160,7 @@ pub async fn build_join_aggregate_plan(
                     let col_expr = agg_field_col(agg, plan)?;
                     let sep_lit = lit(sep.clone());
                     if agg.order_by.is_empty() {
-                        Ok(datafusion::functions_aggregate::string_agg::string_agg(
-                            col_expr, sep_lit,
-                        ))
+                        Ok(string_agg(col_expr, sep_lit))
                     } else {
                         Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
                             string_agg_udaf(),
@@ -214,8 +226,8 @@ pub async fn build_join_aggregate_plan(
     // bounded TopK heap.
     if let Some(topk) = topk {
         let sort_col_name = topk.sort_target.resolve_sort_col_name(targetlist, plan);
-        let sort_expr = datafusion::prelude::col(&sort_col_name)
-            .sort(topk.direction.is_asc(), topk.direction.is_nulls_first());
+        let sort_expr =
+            col(&sort_col_name).sort(topk.direction.is_asc(), topk.direction.is_nulls_first());
         let df = df.sort(vec![sort_expr])?;
         let df = df.limit(0, Some(topk.k))?;
         return df.into_optimized_plan();
@@ -290,13 +302,13 @@ fn build_relnode_df<'a>(
                 // in the table provider schema. After aliasing, it's accessible
                 // as `<alias>.ctid`.
                 let sources = filter.input.sources();
-                let ctid_map: crate::api::HashMap<pg_sys::Index, Expr> = sources
+                let ctid_map: HashMap<pg_sys::Index, Expr> = sources
                     .iter()
                     .map(|s| (s.plan_position as pg_sys::Index, make_source_col(s, "ctid")))
                     .collect();
 
                 // No deferred positions in aggregate path (no VisibilityFilterExec)
-                let deferred_positions = crate::api::HashSet::default();
+                let deferred_positions = HashSet::default();
 
                 // Translate custom_exprs (non-@@@ cross-table predicates) using
                 // PredicateTranslator, mirroring JoinScan's scan_state.rs:562-576.
@@ -312,7 +324,7 @@ fn build_relnode_df<'a>(
                     let translator =
                         PredicateTranslator::new(&sources).with_mapper(Box::new(mapper));
                     unsafe {
-                        let expr_list = pgrx::PgList::<pg_sys::Node>::from_pg(custom_exprs);
+                        let expr_list = PgList::<pg_sys::Node>::from_pg(custom_exprs);
                         for (i, expr_node) in expr_list.iter_ptr().enumerate() {
                             let expr = translator.translate(expr_node).ok_or_else(|| {
                                 DataFusionError::Internal(format!(
@@ -357,7 +369,7 @@ impl<'a> ColumnMapper for AggregateIndexVarMapper<'a> {
             // INDEX_VAR: look up the original Var from custom_scan_tlist.
             // varattno is 1-indexed into the target list.
             unsafe {
-                let tlist = pgrx::PgList::<pg_sys::TargetEntry>::from_pg(self.custom_scan_tlist);
+                let tlist = PgList::<pg_sys::TargetEntry>::from_pg(self.custom_scan_tlist);
                 let idx = (varattno - 1) as usize;
                 let te = tlist.get_ptr(idx)?;
                 if (*(*te).expr).type_ != pg_sys::NodeTag::T_Var {
@@ -394,18 +406,16 @@ impl FilterExpr {
     ///
     /// Used for both HAVING (pass `targetlist`) and per-aggregate FILTER (pass `plan`).
     fn to_datafusion(&self, ctx: &FilterExprExecContext<'_>) -> Option<Expr> {
-        use datafusion::logical_expr::Operator;
-
         match self {
             FilterExpr::AggRef(idx) => {
                 let tl = ctx.targetlist?;
                 if *idx < tl.aggregates.len() {
-                    Some(datafusion::prelude::col(format!("agg_{}", idx)))
+                    Some(col(format!("agg_{}", idx)))
                 } else {
                     None
                 }
             }
-            FilterExpr::GroupRef(field_name) => Some(datafusion::prelude::col(field_name.as_str())),
+            FilterExpr::GroupRef(field_name) => Some(col(field_name.as_str())),
             FilterExpr::ColumnRef { rti, field_name } => {
                 let plan = ctx.plan?;
                 Some(make_rti_col(plan, *rti, field_name))
@@ -425,7 +435,7 @@ impl FilterExpr {
                     CompareOp::Gt => Operator::Gt,
                     CompareOp::GtEq => Operator::GtEq,
                 };
-                Some(Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
+                Some(Expr::BinaryExpr(BinaryExpr::new(
                     Box::new(l),
                     df_op,
                     Box::new(r),
@@ -539,7 +549,7 @@ async fn build_source_df(
 /// Thin wrapper around the shared [`make_source_col`] that walks the plan to
 /// find the source claiming `rti` first. Use this instead of resolving the
 /// source manually at every aggregate-on-join call site.
-fn make_rti_col(plan: &RelNode, rti: pgrx::pg_sys::Index, field_name: &str) -> Expr {
+fn make_rti_col(plan: &RelNode, rti: pg_sys::Index, field_name: &str) -> Expr {
     let source = plan
         .source_for_rti_in_subtree(rti)
         .unwrap_or_else(|| panic!("make_rti_col: RTI {rti} not found in plan sources"));

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -39,6 +39,7 @@ pub use targetlist::TargetListEntry;
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
 use crate::gucs;
+use crate::mpp_log;
 
 use crate::aggregate::{NULL_SENTINEL_MAX, NULL_SENTINEL_MIN};
 use crate::customscan::aggregatescan::build::AggregateCSClause;
@@ -47,6 +48,7 @@ use crate::postgres::customscan::aggregatescan::datafusion_build::{
 };
 use crate::postgres::customscan::aggregatescan::datafusion_exec::{
     build_join_aggregate_plan, create_aggregate_session_context,
+    create_aggregate_session_context_mpp,
 };
 use crate::postgres::customscan::aggregatescan::datafusion_project::project_aggregate_row_to_slot;
 use crate::postgres::customscan::aggregatescan::exec::{
@@ -63,9 +65,24 @@ use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
 };
+use crate::postgres::customscan::dsm as mpp_dsm;
+use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::scan_state::{build_physical_plan, build_task_context};
 use crate::postgres::customscan::limit_offset::LimitOffset;
+use crate::postgres::customscan::mpp::customscan_glue::{
+    leader_estimate_dsm, leader_init_dsm, mpp_is_active, mpp_worker_count as mpp_glue_worker_count,
+    worker_init_dsm,
+};
+use crate::postgres::customscan::mpp::session::{
+    derive_query_id, MppPlanBroadcast, MppSessionProfile,
+};
+use crate::postgres::customscan::mpp::shape::{
+    broadcast_side_gate, classify as classify_shape, ClassifyInputs, MppPlanShape,
+};
+use crate::postgres::customscan::mpp::walker::{cut_count_for_shape, distribute_plan};
+use crate::postgres::customscan::mpp::worker::{MppDsmHeader, MPP_DSM_MAGIC};
+use crate::postgres::customscan::mpp::MppShardConfig;
 use crate::postgres::customscan::projections::{create_placeholder_targetlist, placeholder_procid};
 use crate::postgres::customscan::solve_expr::SolvePostgresExpressions;
 use crate::postgres::customscan::{range_table, CreateUpperPathsHookArgs, CustomScan};
@@ -74,9 +91,17 @@ use crate::postgres::types::{is_datetime_type, TantivyValue};
 use crate::postgres::utils::{add_vars_to_tlist, is_unnest_func, make_text_const};
 use crate::postgres::PgSearchRelation;
 use chrono::{DateTime as ChronoDateTime, Utc};
+use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+use datafusion::common::Result as DFResult;
+use datafusion::logical_expr::LogicalPlan;
 use pgrx::{pg_sys, PgList, PgMemoryContexts, PgTupleDesc};
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
+use std::ptr;
+use std::sync::Arc;
 use tantivy::schema::OwnedValue;
+
+use crate::scan::codec::serialize_logical_plan;
+use crate::scan::info::RowEstimate;
 
 #[derive(Default)]
 pub struct AggregateScan;
@@ -142,10 +167,13 @@ impl CustomScan for AggregateScan {
             ReScanCustomScan: Some(crate::postgres::customscan::exec::rescan_custom_scan::<Self>),
             MarkPosCustomScan: None,
             RestrPosCustomScan: None,
-            EstimateDSMCustomScan: None,
-            InitializeDSMCustomScan: None,
-            ReInitializeDSMCustomScan: None,
-            InitializeWorkerCustomScan: None,
+            // MPP DSM slots. These are only invoked when the path is flagged
+            // parallel-safe in `create_custom_path`; they wire the MPP
+            // lifecycle when `customscan_glue::mpp_is_active()`.
+            EstimateDSMCustomScan: Some(mpp_dsm::estimate_dsm_custom_scan::<Self>),
+            InitializeDSMCustomScan: Some(mpp_dsm::initialize_dsm_custom_scan::<Self>),
+            ReInitializeDSMCustomScan: Some(mpp_dsm::reinitialize_dsm_custom_scan::<Self>),
+            InitializeWorkerCustomScan: Some(mpp_dsm::initialize_worker_custom_scan::<Self>),
             ShutdownCustomScan: Some(
                 crate::postgres::customscan::exec::shutdown_custom_scan::<Self>,
             ),
@@ -231,7 +259,8 @@ impl CustomScan for AggregateScan {
             // For join aggregates, scanrelid=0 (no single base relation)
             builder.set_scanrelid(0);
 
-            // Check if the query has pathkeys (ORDER BY) before consuming builder.
+            // Check if the query has pathkeys (e.g. GROUP BY emits group_pathkeys
+            // into query_pathkeys) before consuming builder.
             let root = builder.args().root;
             let has_pathkeys = unsafe {
                 !(*root).query_pathkeys.is_null() && pg_sys::list_length((*root).query_pathkeys) > 0
@@ -280,14 +309,24 @@ impl CustomScan for AggregateScan {
                     cscan.custom_exprs = custom_exprs_list.into_pg();
                 }
 
-                if !has_pathkeys {
-                    // No ORDER BY: safe to replace Aggrefs at plan time.
+                let parallel_aware = (*best_path).path.parallel_aware;
+                if !has_pathkeys && !parallel_aware {
+                    // Non-MPP, no-pathkeys case: replace Aggrefs at plan
+                    // time with `pdb.agg_fn(...)` placeholders. The non-MPP
+                    // CustomScan executes aggregation internally (without
+                    // a Gather above), so placing FuncExprs here is fine —
+                    // they never get evaluated because our ExecCustomScan
+                    // produces finished tuples directly.
                     let plan = &mut cscan.scan.plan;
                     replace_aggrefs_in_target_list(plan);
                 }
-                // When has_pathkeys: aggrefs stay in plan.targetlist so Postgres's
-                // make_sort_from_pathkeys can find them. Replacement is deferred to
-                // create_custom_scan_state (execution time).
+                // MPP path: leave Aggrefs in `plan.targetlist`. Gather /
+                // Sort / Result tlists above us carry the same Aggrefs from
+                // `rel->reltarget`; setrefs uses `equal()`-matching to
+                // rewrite them. Replacing here breaks every one of those
+                // matches under ORDER BY. The non-MPP `has_pathkeys` ORDER BY
+                // path also keeps Aggrefs (for `make_sort_from_pathkeys`),
+                // and defers replacement to `create_custom_scan_state`.
                 cscan
             }
         }
@@ -450,7 +489,7 @@ impl CustomScan for AggregateScan {
     fn begin_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
         estate: *mut pg_sys::EState,
-        _eflags: i32,
+        eflags: i32,
     ) {
         if state.custom_state().is_datafusion_backend() {
             // DataFusion backend: create scan slot for result projection
@@ -461,6 +500,13 @@ impl CustomScan for AggregateScan {
                     &pg_sys::TTSOpsVirtual,
                 );
                 state.custom_state_mut().scan_slot = Some(scan_slot);
+            }
+
+            // Stash plan bytes for the MPP DSM hooks; skip bare EXPLAIN to
+            // avoid plan-build cost that's purely for parallel init.
+            let explain_only = (eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) != 0;
+            if !explain_only && mpp_is_active() {
+                Self::maybe_stash_mpp_plan_bytes(state);
             }
             return;
         }
@@ -611,6 +657,275 @@ pub trait CustomScanClause<CS: CustomScan> {
 }
 
 impl AggregateScan {
+    /// Build the DataFusion logical plan, serialize it, and stash the bytes
+    /// on `AggregateScanState` for the MPP DSM hooks. Failures fall silently
+    /// back to the non-MPP path (a misconfigured GUC shouldn't kill the
+    /// query). Pays the plan-build cost twice (here + at exec); caching is
+    /// possible but not yet worth the cross-worker sync complexity.
+    fn maybe_stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
+        let Some(df_state) = state.custom_state().datafusion_state.as_ref() else {
+            return;
+        };
+        let plan = df_state.plan.clone();
+        let targetlist = df_state.targetlist.clone();
+        let topk = df_state.topk.clone();
+        let jlp = df_state.join_level_predicates.clone();
+        let custom_exprs = df_state.custom_exprs;
+        let custom_scan_tlist = df_state.custom_scan_tlist;
+        let having = df_state.having_filter.clone();
+        // Snapshot source row estimates for the broadcast-side cost gate
+        // below. Harvested here (cheaply, from the PG-side join tree) so we
+        // don't have to walk the DataFusion logical plan to recover them
+        // after it's built.
+        let source_estimates: Vec<RowEstimate> = plan
+            .sources()
+            .iter()
+            .map(|s| s.scan_info.estimate)
+            .collect();
+
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                mpp_log!("mpp: failed to build tokio runtime for plan stash: {e}");
+                return;
+            }
+        };
+
+        let ctx = create_aggregate_session_context();
+        let plan_and_shape: DFResult<(bytes::Bytes, MppPlanShape)> = rt.block_on(async {
+            let logical = build_join_aggregate_plan(
+                &plan,
+                &targetlist,
+                topk.as_ref(),
+                &jlp,
+                custom_exprs,
+                custom_scan_tlist,
+                having.as_ref(),
+                &ctx,
+            )
+            .await?;
+            let shape = Self::classify_logical_plan(&logical);
+            let bytes = serialize_logical_plan(&logical)?;
+            Ok((bytes, shape))
+        });
+
+        match plan_and_shape {
+            Ok((bytes, shape)) => {
+                // Cost gate: for binary-join shapes (Scalar / GroupBy agg on
+                // binary join), if the smallest source is small enough to
+                // broadcast-join cheaply, skip MPP's pre-join shuffle and let
+                // the non-MPP path run. Single-table shapes
+                // (GroupByAggSingleTable) have no broadcast candidate and are
+                // not gated.
+                if shape.is_binary_join() {
+                    let min_rows = gucs::mpp_min_join_rows();
+                    if let Some(gated_rows) = broadcast_side_gate(&source_estimates, min_rows) {
+                        mpp_log!(
+                            "mpp: AggregateScan {:?} gated — smallest side \
+                             estimated_rows={} < mpp_min_join_rows={}; staying on \
+                             non-MPP path",
+                            shape,
+                            gated_rows,
+                            min_rows
+                        );
+                        return;
+                    }
+                }
+                // Pre-wrap in `MppPlanBroadcast` so `logical_plan_bytes.len()`
+                // matches the bytes copied into DSM exactly. Re-wrapping at
+                // DSM-init time would inflate past `estimate_dsm_custom_scan`,
+                // overrun the `shm_toc` region, and corrupt adjacent DSA
+                // control blocks.
+                let n = mpp_glue_worker_count();
+                let query_id = derive_query_id();
+                let broadcast = MppPlanBroadcast::new(
+                    bytes.to_vec(),
+                    n,
+                    MppSessionProfile::Aggregate,
+                    query_id,
+                );
+                let broadcast_bytes = match broadcast.serialize() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        mpp_log!("mpp: MppPlanBroadcast serialize failed, MPP will fall back: {e}");
+                        return;
+                    }
+                };
+                mpp_log!(
+                    "mpp: stashed plan-broadcast bytes (shape={shape:?}) on AggregateScanState"
+                );
+                state.custom_state_mut().logical_plan_bytes =
+                    Some(bytes::Bytes::from(broadcast_bytes));
+                state.custom_state_mut().mpp_shape = Some(shape);
+            }
+            Err(e) => {
+                mpp_log!(
+                    "mpp: plan build/serialize failed, MPP will fall back to serial path: {e}"
+                );
+            }
+        }
+    }
+
+    /// Walk a built `LogicalPlan` tree and derive [`MppPlanShape`] inputs.
+    /// Counts table scans, detects GROUP BY / aggregate presence, and
+    /// inspects aggregate function names for splittability. Runs once per
+    /// MPP-eligible query; keep side-effect free so it can be called during
+    /// plan-stash.
+    fn classify_logical_plan(plan: &LogicalPlan) -> MppPlanShape {
+        let mut n_table_scans: usize = 0;
+        let mut has_aggregate = false;
+        let mut has_group_by = false;
+        let mut all_aggregates_splittable = true;
+
+        plan.apply(|node| {
+            match node {
+                LogicalPlan::TableScan(_) => {
+                    n_table_scans += 1;
+                }
+                LogicalPlan::Aggregate(a) => {
+                    has_aggregate = true;
+                    if !a.group_expr.is_empty() {
+                        has_group_by = true;
+                    }
+                    for expr in &a.aggr_expr {
+                        if !Self::is_splittable_aggregate_expr(expr) {
+                            all_aggregates_splittable = false;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            Ok(TreeNodeRecursion::Continue)
+        })
+        .ok();
+
+        classify_shape(&ClassifyInputs {
+            n_join_tables: n_table_scans,
+            has_group_by,
+            all_aggregates_splittable,
+            has_aggregate,
+        })
+    }
+
+    /// Early-path classification used at `create_custom_path` time, before
+    /// we have a DataFusion logical plan. Mirrors [`Self::classify_logical_plan`]
+    /// but reads from the PG-side `sources` + `JoinAggregateTargetList` that
+    /// are already available at this stage.
+    ///
+    /// Returns the cheap-but-correct shape input triple; feeds directly into
+    /// [`mpp::shape::classify`]. Conservative: any aggregate not on the
+    /// partial-safe allow-list downgrades the whole query to `Ineligible`.
+    fn classify_path_shape(
+        sources: &[crate::postgres::customscan::aggregatescan::datafusion_build::JoinAggSource],
+        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+    ) -> MppPlanShape {
+        use crate::postgres::customscan::aggregatescan::join_targetlist::AggKind;
+        let n_join_tables = sources.len();
+        let has_group_by = !targetlist.group_columns.is_empty();
+        let has_aggregate = !targetlist.aggregates.is_empty();
+        let all_aggregates_splittable = targetlist.aggregates.iter().all(|a| {
+            matches!(
+                a.agg_kind,
+                AggKind::CountStar
+                    | AggKind::Count
+                    | AggKind::Sum
+                    | AggKind::Avg
+                    | AggKind::Min
+                    | AggKind::Max
+                    | AggKind::BoolAnd
+                    | AggKind::BoolOr
+                    | AggKind::StddevSamp
+                    | AggKind::StddevPop
+                    | AggKind::VarSamp
+                    | AggKind::VarPop
+            ) && !a.distinct
+        });
+        classify_shape(&ClassifyInputs {
+            n_join_tables,
+            has_group_by,
+            all_aggregates_splittable,
+            has_aggregate,
+        })
+    }
+
+    /// If the query is MPP-eligible, flip the path's `parallel_safe` /
+    /// `parallel_aware` / `parallel_workers` on the builder so PG launches
+    /// workers for this scan. Called from `try_build_datafusion_aggregate_path`
+    /// just before `.build(...)`.
+    ///
+    /// Returns the builder unchanged when MPP is off, the worker count is
+    /// below 2, or the shape classifies as `Ineligible`.
+    fn maybe_flip_mpp_parallel(
+        builder: CustomPathBuilder<Self>,
+        sources: &[crate::postgres::customscan::aggregatescan::datafusion_build::JoinAggSource],
+        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+    ) -> CustomPathBuilder<Self> {
+        use MppPlanShape;
+        if !mpp_is_active() {
+            return builder;
+        }
+        let shape = Self::classify_path_shape(sources, targetlist);
+
+        // `GroupByAggSingleTable` and `JoinOnly` shapes' bridges haven't
+        // landed yet; they still classify correctly but fall through to
+        // the serial path here.
+        let activate = matches!(
+            shape,
+            MppPlanShape::ScalarAggOnBinaryJoin | MppPlanShape::GroupByAggOnBinaryJoin
+        );
+        if !activate {
+            return builder;
+        }
+        let n = mpp_glue_worker_count() as usize;
+        // `mpp_worker_count` clamps to >= 2, but be defensive.
+        let nworkers = n.saturating_sub(1).max(1);
+        mpp_log!(
+            "mpp: flipping AggregateScan path parallel_workers={} for shape {:?}",
+            nworkers,
+            shape
+        );
+        builder.set_parallel(nworkers)
+    }
+
+    /// Conservative allow-list of aggregate function names that are safe to
+    /// split into Partial/FinalPartitioned. Anything outside this list marks
+    /// the shape Ineligible so MPP falls back to the serial path.
+    ///
+    /// The outer expression may be wrapped in `Alias` (e.g., `COUNT(*) AS cnt`)
+    /// — unwrap before checking. Any other wrapping (casts, arithmetic) is
+    /// treated as unsafe to be conservative.
+    fn is_splittable_aggregate_expr(expr: &datafusion::logical_expr::Expr) -> bool {
+        use datafusion::logical_expr::Expr;
+        let unwrapped = match expr {
+            Expr::Alias(a) => a.expr.as_ref(),
+            other => other,
+        };
+        let name = match unwrapped {
+            Expr::AggregateFunction(af) => af.func.name().to_ascii_lowercase(),
+            // Non-aggregate in the aggr_expr slot — assume unsafe.
+            _ => return false,
+        };
+        matches!(
+            name.as_str(),
+            "count"
+                | "sum"
+                | "min"
+                | "max"
+                | "avg"
+                | "bool_and"
+                | "bool_or"
+                | "stddev"
+                | "stddev_samp"
+                | "stddev_pop"
+                | "var"
+                | "var_samp"
+                | "var_pop"
+        )
+    }
+
     /// Existing single-table Tantivy aggregate path.
     fn build_tantivy_aggregate_path(
         builder: CustomPathBuilder<Self>,
@@ -771,6 +1086,17 @@ impl AggregateScan {
             }
         };
 
+        // Flip parallel-safe with the configured worker count when the
+        // shape is MPP-eligible. Uses a cheap pre-classification based on
+        // `sources` + `targetlist` — the authoritative shape is re-derived
+        // from the DataFusion logical plan in `maybe_stash_mpp_plan_bytes`,
+        // but we must commit to parallel-safe here (before `.build()`)
+        // because PG's path-builder freezes the parallel flags at this
+        // point. Downstream failure to stash the plan falls back to the
+        // serial path via the `mpp_state.is_none()` guard in
+        // `exec_datafusion_aggregate`.
+        let builder = Self::maybe_flip_mpp_parallel(builder, &sources, &targetlist);
+
         // Build the custom path with DataFusion private data
         let multi_table_clause_count = multi_table_clauses.len();
         let mut custom_path = builder.build(PrivateData::DataFusion {
@@ -807,7 +1133,7 @@ impl AggregateScan {
         state: &mut CustomScanStateWrapper<Self>,
     ) -> *mut pg_sys::TupleTableSlot {
         let Some(row) = Self::advance_tantivy_state(state) else {
-            return std::ptr::null_mut();
+            return ptr::null_mut();
         };
 
         unsafe {
@@ -969,47 +1295,137 @@ impl AggregateScan {
     fn exec_datafusion_aggregate(
         state: &mut CustomScanStateWrapper<Self>,
     ) -> *mut pg_sys::TupleTableSlot {
+        // Correctness fence: if we're a parallel worker and `mpp_state` is
+        // None even though MPP is supposed to be active, the worker DSM
+        // attach didn't run. Silently running the non-MPP path here would
+        // double-count at the final gather. Abort loudly instead.
+        // `IsParallelWorker` is a C macro (`ParallelWorkerNumber >= 0`);
+        // pgrx exposes the underlying int but not the macro, so inline it.
+        let is_parallel_worker = unsafe { pg_sys::ParallelWorkerNumber } >= 0;
+        if is_parallel_worker && mpp_is_active() && state.custom_state().mpp_state.is_none() {
+            pgrx::error!(
+                "mpp: parallel worker reached exec_datafusion_aggregate without \
+                 MppExecutionState — worker DSM attach did not run. Wrong-result \
+                 scenario averted via loud abort."
+            );
+        }
+
         // Grab the scan_slot pointer before entering the mutable borrow
         let scan_slot = state
             .custom_state()
             .scan_slot
             .expect("scan_slot must be initialized in begin_custom_scan");
 
-        let df_state = state
-            .custom_state_mut()
-            .datafusion_state
-            .as_mut()
-            .expect("DataFusion state must be initialized");
+        // Pre-read shape so the MPP branch doesn't alias the
+        // `custom_state_mut()` borrow taken below for `datafusion_state`.
+        let mpp_shape = if state.custom_state().mpp_state.is_some() {
+            Some(match state.custom_state().mpp_shape {
+                Some(s) => s,
+                None => pgrx::error!(
+                    "mpp: exec_datafusion_aggregate has mpp_state but no mpp_shape — \
+                     begin_custom_scan must populate both or neither"
+                ),
+            })
+        } else {
+            None
+        };
 
-        // First call: build and execute the DataFusion plan
-        if df_state.runtime.is_none() {
+        // First call: build + execute. Both `datafusion_state` and
+        // `mpp_state` need `custom_state_mut`; we take short-lived borrows
+        // instead of one long-lived alias.
+        let runtime_is_none = state
+            .custom_state()
+            .datafusion_state
+            .as_ref()
+            .map(|d| d.runtime.is_none())
+            .unwrap_or(false);
+        if runtime_is_none {
+            // PG FFI is single-threaded; the lazy scan reaches into PG, so
+            // a multi-thread runtime would trigger pgrx's `thread_id_check`.
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e));
 
-            let ctx = create_aggregate_session_context();
+            // MPP needs the join-layer-fixed session; see
+            // `create_aggregate_session_context_mpp` for the rationale.
+            let ctx = match state.custom_state().mpp_state.as_ref() {
+                Some(mpp_state) if mpp_state.participant_config().total_participants > 1 => {
+                    let cfg = mpp_state.participant_config();
+                    let ctx = create_aggregate_session_context_mpp(cfg);
+                    ctx.state_ref()
+                        .write()
+                        .config_mut()
+                        .set_extension(Arc::new(MppShardConfig {
+                            participant_index: cfg.participant_index,
+                            total_participants: cfg.total_participants,
+                        }));
+                    ctx
+                }
+                _ => create_aggregate_session_context(),
+            };
 
-            let custom_exprs = df_state.custom_exprs;
-            let custom_scan_tlist = df_state.custom_scan_tlist;
-            let physical_plan = runtime.block_on(async {
-                let logical = build_join_aggregate_plan(
-                    &df_state.plan,
-                    &df_state.targetlist,
-                    df_state.topk.as_ref(),
-                    &df_state.join_level_predicates,
-                    custom_exprs,
-                    custom_scan_tlist,
-                    df_state.having_filter.as_ref(),
-                    &ctx,
-                )
-                .await?;
-                build_physical_plan(&ctx, logical).await
-            });
+            // Short borrow so `mpp_state` can be taken below.
+            let standard_plan = {
+                let df_state = state
+                    .custom_state_mut()
+                    .datafusion_state
+                    .as_mut()
+                    .expect("DataFusion state must be initialized");
+                let custom_exprs = df_state.custom_exprs;
+                let custom_scan_tlist = df_state.custom_scan_tlist;
+                let result = runtime.block_on(async {
+                    let logical = build_join_aggregate_plan(
+                        &df_state.plan,
+                        &df_state.targetlist,
+                        df_state.topk.as_ref(),
+                        &df_state.join_level_predicates,
+                        custom_exprs,
+                        custom_scan_tlist,
+                        df_state.having_filter.as_ref(),
+                        &ctx,
+                    )
+                    .await?;
+                    build_physical_plan(&ctx, logical).await
+                });
+                match result {
+                    Ok(p) => p,
+                    Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+                }
+            };
 
-            let physical_plan = match physical_plan {
-                Ok(p) => p,
-                Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+            // If MPP state was wired up by the DSM hooks, rewrite the
+            // standard plan into a shape-specific MPP plan. The non-MPP
+            // branch stays byte-identical to the previous behavior.
+            let physical_plan = if let Some(shape) = mpp_shape {
+                let mpp_state = state
+                    .custom_state_mut()
+                    .mpp_state
+                    .as_mut()
+                    .expect("mpp_shape set ⇒ mpp_state must also be Some");
+                mpp_log!(
+                    "mpp: routing exec_datafusion_aggregate through shape {:?} (is_leader={})",
+                    shape,
+                    mpp_state.is_leader()
+                );
+                let _guard = runtime.enter();
+                let standard_fallback = Arc::clone(&standard_plan);
+                match distribute_plan(standard_plan, mpp_state, shape) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        // The dispatcher couldn't handle this plan shape
+                        // (e.g. TopK / Sort + Limit above the agg). Fall
+                        // back to the un-rewritten standard plan rather
+                        // than aborting; the query still runs, just
+                        // without MPP acceleration.
+                        pgrx::warning!(
+                            "mpp: distribute_plan failed ({e}); running serial DataFusion plan"
+                        );
+                        standard_fallback
+                    }
+                }
+            } else {
+                standard_plan
             };
 
             let task_ctx = build_task_context(
@@ -1026,9 +1442,20 @@ impl AggregateScan {
                 }
             };
 
+            let df_state = state
+                .custom_state_mut()
+                .datafusion_state
+                .as_mut()
+                .expect("DataFusion state must be initialized");
             df_state.runtime = Some(runtime);
             df_state.stream = Some(stream);
         }
+
+        let df_state = state
+            .custom_state_mut()
+            .datafusion_state
+            .as_mut()
+            .expect("DataFusion state must be initialized");
 
         // Consume batches row-by-row
         loop {
@@ -1069,7 +1496,7 @@ impl AggregateScan {
                 }
                 None => {
                     // Stream exhausted — no more results
-                    return std::ptr::null_mut();
+                    return ptr::null_mut();
                 }
             }
         }
@@ -1370,56 +1797,54 @@ unsafe fn detect_join_aggregate_topk(
 /// Replace any T_Aggref expressions in the target list with T_FuncExpr placeholders
 /// This is called at execution time to avoid "Aggref found in non-Agg plan node" errors
 /// Uses expression_tree_mutator to handle nested Aggrefs (e.g., COALESCE(COUNT(*), 0))
-unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
-    use pgrx::pg_guard;
-
-    if (*plan).targetlist.is_null() {
-        return;
+/// Mutator that replaces Aggref nodes with a placeholder FuncExpr and UNNEST
+/// FuncExprs with a generic placeholder of their result type. Used to clean
+/// up Plan targetlists (see [`replace_aggrefs_in_target_list`]) on the
+/// non-parallel path — the MPP path keeps Aggrefs intact so PG's setrefs
+/// matches them structurally between Gather/Sort/Result and the CustomScan.
+#[pgrx::pg_guard]
+pub(crate) unsafe extern "C-unwind" fn aggref_mutator(
+    node: *mut pg_sys::Node,
+    context: *mut core::ffi::c_void,
+) -> *mut pg_sys::Node {
+    if node.is_null() {
+        return ptr::null_mut();
     }
 
-    // Mutator function to replace Aggref nodes with placeholder FuncExpr
-    #[pg_guard]
-    unsafe extern "C-unwind" fn aggref_mutator(
-        node: *mut pg_sys::Node,
-        context: *mut core::ffi::c_void,
-    ) -> *mut pg_sys::Node {
-        if node.is_null() {
-            return std::ptr::null_mut();
-        }
+    if (*node).type_ == pg_sys::NodeTag::T_Aggref {
+        let aggref = node as *mut pg_sys::Aggref;
+        return make_placeholder_func_expr(aggref) as *mut pg_sys::Node;
+    }
 
-        // If this is an Aggref, replace it with a placeholder FuncExpr
-        if (*node).type_ == pg_sys::NodeTag::T_Aggref {
-            let aggref = node as *mut pg_sys::Aggref;
-            return make_placeholder_func_expr(aggref) as *mut pg_sys::Node;
+    if (*node).type_ == pg_sys::NodeTag::T_FuncExpr {
+        let func_expr = node as *mut pg_sys::FuncExpr;
+        if is_unnest_func((*func_expr).funcid) {
+            return make_placeholder_func_expr_internal(
+                (*func_expr).funcresulttype,
+                (*func_expr).inputcollid,
+                (*func_expr).location,
+                "UNNEST",
+            ) as *mut pg_sys::Node;
         }
+    }
 
-        // If this is an UNNEST FuncExpr, replace it with a placeholder FuncExpr of its result type.
-        // This is safe because AggregateScan handles the unnesting via Tantivy's terms aggregation.
-        if (*node).type_ == pg_sys::NodeTag::T_FuncExpr {
-            let func_expr = node as *mut pg_sys::FuncExpr;
-            if is_unnest_func((*func_expr).funcid) {
-                return make_placeholder_func_expr_internal(
-                    (*func_expr).funcresulttype,
-                    (*func_expr).inputcollid,
-                    (*func_expr).location,
-                    "UNNEST",
-                ) as *mut pg_sys::Node;
-            }
-        }
+    #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
+    {
+        let fnptr = aggref_mutator as usize as *const ();
+        let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
+            std::mem::transmute(fnptr);
+        pg_sys::expression_tree_mutator(node, Some(mutator), context)
+    }
 
-        // For all other nodes, use the standard mutator to walk children
-        #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
-        {
-            let fnptr = aggref_mutator as usize as *const ();
-            let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
-                std::mem::transmute(fnptr);
-            pg_sys::expression_tree_mutator(node, Some(mutator), context)
-        }
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    {
+        pg_sys::expression_tree_mutator_impl(node, Some(aggref_mutator), context)
+    }
+}
 
-        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
-        {
-            pg_sys::expression_tree_mutator_impl(node, Some(aggref_mutator), context)
-        }
+unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
+    if (*plan).targetlist.is_null() {
+        return;
     }
 
     let targetlist = PgList::<pg_sys::TargetEntry>::from_pg((*plan).targetlist);
@@ -1437,12 +1862,12 @@ unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
     }
 
     // Build a new target list with Aggrefs replaced by placeholders and UNNEST stripped
-    let mut new_targetlist: *mut pg_sys::List = std::ptr::null_mut();
+    let mut new_targetlist: *mut pg_sys::List = ptr::null_mut();
     for te in targetlist.iter_ptr() {
         let new_te = pg_sys::flatCopyTargetEntry(te);
 
         // Use the mutator to replace any Aggref or UNNEST nodes in the expression
-        let new_expr = aggref_mutator((*te).expr as *mut pg_sys::Node, std::ptr::null_mut());
+        let new_expr = aggref_mutator((*te).expr as *mut pg_sys::Node, ptr::null_mut());
         (*new_te).expr = new_expr as *mut pg_sys::Expr;
 
         new_targetlist = pg_sys::lappend(new_targetlist, new_te.cast());
@@ -1580,5 +2005,165 @@ unsafe fn get_aggregate_name(aggref: *mut pg_sys::Aggref) -> String {
         }
     } else {
         "UNKNOWN".to_string()
+    }
+}
+
+// MPP DSM lifecycle hooks (estimate / leader-init / worker-attach).
+impl ParallelQueryCapable for AggregateScan {
+    fn estimate_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+    ) -> pg_sys::Size {
+        if !mpp_is_active() {
+            return 0;
+        }
+        let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+            mpp_log!(
+                "mpp: AggregateScan::estimate_dsm_custom_scan but logical_plan_bytes \
+                 is None (plan serialization failed earlier?); returning 0"
+            );
+            return 0;
+        };
+        let shape = match state.custom_state().mpp_shape {
+            Some(s) => s,
+            None => {
+                mpp_log!("mpp: estimate_dsm but mpp_shape is None; returning 0");
+                return 0;
+            }
+        };
+        let num_meshes = cut_count_for_shape(shape);
+        if num_meshes == 0 {
+            mpp_log!("mpp: shape {:?} requires no shuffle; returning 0", shape);
+            return 0;
+        }
+        match leader_estimate_dsm(plan_bytes.len(), num_meshes) {
+            Ok(sz) => sz,
+            Err(e) => {
+                mpp_log!("mpp: leader_estimate_dsm failed: {e}; returning 0");
+                0
+            }
+        }
+    }
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        debug_assert!(state.custom_state().mpp_state.is_none());
+        if !mpp_is_active() {
+            return;
+        }
+        if coordinate.is_null() {
+            // Estimate returned 0 (plan bytes unavailable) — PG will pass
+            // NULL coordinate. Silently fall back to non-MPP path.
+            return;
+        }
+        let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+            return;
+        };
+        let plan_bytes = plan_bytes.to_vec();
+        let shape = match state.custom_state().mpp_shape {
+            Some(s) => s,
+            None => return,
+        };
+        let num_meshes = cut_count_for_shape(shape);
+        if num_meshes == 0 {
+            return;
+        }
+        let seg = unsafe { (*pcxt).seg };
+        let ctx = unsafe { leader_init_dsm(coordinate, plan_bytes, num_meshes, seg) };
+        match ctx {
+            Ok(leader_ctx) => {
+                mpp_log!(
+                    "mpp: AggregateScan leader initialized DSM for {} participants",
+                    leader_ctx.participant_config().total_participants
+                );
+                state.custom_state_mut().mpp_state = Some(leader_ctx);
+            }
+            Err(e) => {
+                // DSM init is in the hot path of parallel-query startup —
+                // a partial init leaves the region in an undefined state,
+                // so ERROR rather than silently degrade.
+                pgrx::error!("mpp: leader_init_dsm failed: {e}");
+            }
+        }
+    }
+
+    fn reinitialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+        _coordinate: *mut c_void,
+    ) {
+        // Rescan is out of scope. A rescanned MPP aggregate would need a
+        // full mesh teardown + rebuild; silently no-op'ing would let the
+        // second scan reuse the first scan's drained queues and return
+        // wrong results. Only loud-error when MPP is actually active on
+        // this scan state — non-MPP paths have no rescan restrictions.
+        if state.custom_state().mpp_state.is_some() {
+            pgrx::error!(
+                "mpp: AggregateScan rescan not supported — rerun the query \
+                 without rescan (e.g. avoid nested-loop driving this node)"
+            );
+        }
+    }
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _toc: *mut pg_sys::shm_toc,
+        coordinate: *mut c_void,
+    ) {
+        debug_assert!(state.custom_state().mpp_state.is_none());
+        if !mpp_is_active() {
+            return;
+        }
+        if coordinate.is_null() {
+            return;
+        }
+
+        // Validate magic BEFORE trusting `header.region_total` —
+        // sourcing both from the same place would make the bounds check
+        // in `MppDsmHeader::validate` tautological.
+        let region_total = unsafe {
+            let header = ptr::read_unaligned(coordinate as *const MppDsmHeader);
+            if header.magic != MPP_DSM_MAGIC {
+                pgrx::error!(
+                    "mpp: worker DSM attach found bogus header magic 0x{:08x} \
+                     (expected 0x{:08x}) — refusing to trust region_total",
+                    header.magic,
+                    MPP_DSM_MAGIC,
+                );
+            }
+            header.region_total
+        };
+        let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+        let ctx = unsafe {
+            worker_init_dsm(
+                coordinate,
+                region_total,
+                worker_number,
+                ptr::null_mut(), // seg unknown to worker init; shm_mq_attach handles NULL
+            )
+        };
+        match ctx {
+            Ok(worker_ctx) => {
+                let _ = region_total;
+                mpp_log!(
+                    "mpp: AggregateScan worker {} attached to DSM ({} participants)",
+                    worker_number,
+                    worker_ctx.participant_config().total_participants
+                );
+                state.custom_state_mut().mpp_state = Some(worker_ctx);
+            }
+            Err(e) => {
+                // Worker-side DSM attach failure is fatal for the same
+                // reason the leader side is: the worker now has no valid
+                // MPP state but the leader expects MPP partials.
+                // Aborting here lets the leader's query fail cleanly
+                // with a diagnostic rather than silently returning
+                // wrong answers.
+                pgrx::error!("mpp: worker_init_dsm failed on worker {worker_number}: {e}");
+            }
+        }
     }
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -22,9 +22,13 @@ use crate::postgres::customscan::aggregatescan::privdat::{DataFusionTopK, Filter
 use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, MultiTablePredicateInfo, RelNode,
 };
+use crate::postgres::customscan::mpp::customscan_glue::MppExecutionState;
+use crate::postgres::customscan::mpp::shape::MppPlanShape;
 use crate::postgres::customscan::solve_expr::SolvePostgresExpressions;
 use crate::postgres::customscan::CustomScanState;
 use crate::postgres::PgSearchRelation;
+
+use std::vec::IntoIter;
 
 use arrow_array::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -34,7 +38,7 @@ use pgrx::pg_sys;
 pub enum ExecutionState {
     #[default]
     NotStarted,
-    Emitting(std::vec::IntoIter<AggregationResultsRow>),
+    Emitting(IntoIter<AggregationResultsRow>),
     Completed,
 }
 
@@ -111,6 +115,23 @@ pub struct AggregateScanState {
     /// Created once during begin_custom_scan and cleared/reused for each row
     /// to avoid per-row memory allocation and leaks
     pub scan_slot: Option<*mut pg_sys::TupleTableSlot>,
+
+    /// Pre-serialized `MppPlanBroadcast` bytes — same bytes copied into
+    /// DSM (length must match `estimate_dsm_custom_scan`'s `.len()` to
+    /// avoid overrunning the `shm_toc` region). Populated on the leader
+    /// in `begin_custom_scan` when `mpp_is_active()`. `None` for non-MPP,
+    /// non-DataFusion, or serialization-failure paths.
+    pub logical_plan_bytes: Option<bytes::Bytes>,
+
+    /// Classified MPP shape; drives DSM mesh count and per-shape plan
+    /// building. Populated alongside `logical_plan_bytes`.
+    pub mpp_shape: Option<MppPlanShape>,
+
+    /// MPP lifecycle state populated by `initialize_dsm_custom_scan` /
+    /// `initialize_worker_custom_scan`. Declared LAST so it drops after
+    /// `datafusion_state`: it owns shm_mq handles into DSM and the
+    /// leader's `DrainHandle` must `join()` before DSM detach.
+    pub mpp_state: Option<MppExecutionState>,
 }
 
 impl AggregateScanState {

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -35,7 +35,10 @@ use crate::postgres::rel_get_bm25_index;
 use crate::postgres::utils::{expr_contains_any_operator, pg_search_extension_installed};
 use once_cell::sync::Lazy;
 use pgrx::{pg_guard, pg_sys, PgList, PgMemoryContexts};
+use std::any::{type_name, TypeId};
 use std::collections::{hash_map::Entry, HashMap};
+use std::mem::size_of_val;
+use std::ptr;
 
 unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
     let forced = path.flags & Flags::Force as u32 != 0;
@@ -45,19 +48,19 @@ unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
     // Clear both complete and partial candidates up front so neither a regular path nor a
     // Gather-built parallel path can outcompete us.
     if forced {
-        (*rel).pathlist = std::ptr::null_mut();
-        (*rel).partial_pathlist = std::ptr::null_mut();
+        (*rel).pathlist = ptr::null_mut();
+        (*rel).partial_pathlist = ptr::null_mut();
     }
 
-    let mut custom_path = PgMemoryContexts::CurrentMemoryContext
-        .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+    let mut custom_path =
+        PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
 
     if (*custom_path).path.parallel_aware {
         // add the partial path since the user-generated plan is parallel aware
         pg_sys::add_partial_path(rel, custom_path.cast());
 
         // remove all the existing possible paths
-        (*rel).pathlist = std::ptr::null_mut();
+        (*rel).pathlist = ptr::null_mut();
 
         // then make another copy of it, increase its costs really, really high and
         // submit it as a regular path too, immediately after clearing out all the other
@@ -65,8 +68,8 @@ unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
         //
         // We don't want postgres to choose this path, but we have to have at least one
         // non-partial path available for it to consider
-        let copy = PgMemoryContexts::CurrentMemoryContext
-            .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+        let copy =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
         (*copy).path.parallel_aware = false;
         (*copy).path.total_cost = 1000000000.0;
         (*copy).path.startup_cost = 1000000000.0;
@@ -84,7 +87,7 @@ where
     CS: CustomScan<Args = RelPathlistHookArgs> + 'static,
 {
     unsafe {
-        static mut PREV_HOOKS: Lazy<HashMap<std::any::TypeId, pg_sys::set_rel_pathlist_hook_type>> =
+        static mut PREV_HOOKS: Lazy<HashMap<TypeId, pg_sys::set_rel_pathlist_hook_type>> =
             Lazy::new(Default::default);
 
         #[pg_guard]
@@ -98,7 +101,7 @@ where
         {
             unsafe {
                 #[allow(static_mut_refs)]
-                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&std::any::TypeId::of::<CS>()) {
+                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&TypeId::of::<CS>()) {
                     (*prev_hook)(root, rel, rti, rte);
                 }
 
@@ -107,8 +110,8 @@ where
         }
 
         #[allow(static_mut_refs)]
-        match PREV_HOOKS.entry(std::any::TypeId::of::<CS>()) {
-            Entry::Occupied(_) => panic!("{} is already registered", std::any::type_name::<CS>()),
+        match PREV_HOOKS.entry(TypeId::of::<CS>()) {
+            Entry::Occupied(_) => panic!("{} is already registered", type_name::<CS>()),
             Entry::Vacant(entry) => entry.insert(pg_sys::set_rel_pathlist_hook),
         };
 
@@ -162,9 +165,8 @@ where
     CS: CustomScan<Args = JoinPathlistHookArgs> + 'static,
 {
     unsafe {
-        static mut PREV_HOOKS: Lazy<
-            HashMap<std::any::TypeId, pg_sys::set_join_pathlist_hook_type>,
-        > = Lazy::new(Default::default);
+        static mut PREV_HOOKS: Lazy<HashMap<TypeId, pg_sys::set_join_pathlist_hook_type>> =
+            Lazy::new(Default::default);
 
         #[pg_guard]
         extern "C-unwind" fn __priv_callback<CS>(
@@ -179,7 +181,7 @@ where
         {
             unsafe {
                 #[allow(static_mut_refs)]
-                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&std::any::TypeId::of::<CS>()) {
+                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&TypeId::of::<CS>()) {
                     (*prev_hook)(root, joinrel, outerrel, innerrel, jointype, extra);
                 }
 
@@ -190,8 +192,8 @@ where
         }
 
         #[allow(static_mut_refs)]
-        match PREV_HOOKS.entry(std::any::TypeId::of::<CS>()) {
-            Entry::Occupied(_) => panic!("{} is already registered", std::any::type_name::<CS>()),
+        match PREV_HOOKS.entry(TypeId::of::<CS>()) {
+            Entry::Occupied(_) => panic!("{} is already registered", type_name::<CS>()),
             Entry::Vacant(entry) => entry.insert(pg_sys::set_join_pathlist_hook),
         };
 
@@ -245,9 +247,8 @@ where
     CS: CustomScan<Args = CreateUpperPathsHookArgs> + 'static,
 {
     unsafe {
-        static mut PREV_HOOKS: Lazy<
-            HashMap<std::any::TypeId, pg_sys::create_upper_paths_hook_type>,
-        > = Lazy::new(Default::default);
+        static mut PREV_HOOKS: Lazy<HashMap<TypeId, pg_sys::create_upper_paths_hook_type>> =
+            Lazy::new(Default::default);
 
         #[pg_guard]
         extern "C-unwind" fn __priv_callback<CS>(
@@ -261,7 +262,7 @@ where
         {
             unsafe {
                 #[allow(static_mut_refs)]
-                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&std::any::TypeId::of::<CS>()) {
+                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&TypeId::of::<CS>()) {
                     (*prev_hook)(root, stage, input_rel, output_rel, extra);
                 }
 
@@ -270,8 +271,8 @@ where
         }
 
         #[allow(static_mut_refs)]
-        match PREV_HOOKS.entry(std::any::TypeId::of::<CS>()) {
-            Entry::Occupied(_) => panic!("{} is already registered", std::any::type_name::<CS>()),
+        match PREV_HOOKS.entry(TypeId::of::<CS>()) {
+            Entry::Occupied(_) => panic!("{} is already registered", type_name::<CS>()),
             Entry::Vacant(entry) => entry.insert(pg_sys::create_upper_paths_hook),
         };
 
@@ -324,9 +325,85 @@ pub extern "C-unwind" fn paradedb_upper_paths_callback<CS>(
         ));
 
         for path in paths {
-            add_path(output_rel, path);
+            add_upper_path(root, output_rel, path);
         }
     }
+}
+
+/// Upper-rel variant of [`add_path`] for `UPPERREL_GROUP_AGG`: core has
+/// already finished gather-path generation when this hook fires, so a
+/// partial path added now would be orphaned. Wraps the MPP-ready
+/// parallel-aware custom path in an explicit `GatherPath` so the
+/// grouping-path chooser sees it; non-parallel paths fall through.
+unsafe fn add_upper_path(
+    root: *mut pg_sys::PlannerInfo,
+    rel: *mut pg_sys::RelOptInfo,
+    mut path: pg_sys::CustomPath,
+) {
+    let forced = path.flags & Flags::Force as u32 != 0;
+    path.flags ^= Flags::Force as u32;
+
+    if forced {
+        (*rel).pathlist = ptr::null_mut();
+        (*rel).partial_pathlist = ptr::null_mut();
+    }
+
+    if path.path.parallel_aware {
+        // The MPP path itself is parallel-safe; PG needs to see it as a
+        // partial path so it and the Gather wrapper agree about workers.
+        let partial_copy =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+        pg_sys::add_partial_path(rel, partial_copy.cast());
+
+        // Wrap with Gather so the grouping-path chooser actually sees a
+        // runnable parallel plan in `output_rel->pathlist`. Use the rel's
+        // reltarget directly so Gather's pathtarget structurally equals
+        // `final_target` — otherwise `create_ordered_paths` adds a
+        // ProjectionPath (→ Result plan node) above the Sort, whose
+        // targetlist carries unreplaceable Aggrefs that crash setrefs
+        // with "Aggref found in non-Agg plan node".
+        //
+        // Aggrefs in Gather.tlist get rewritten to Var(OUTER_VAR, N) by
+        // setrefs so long as the subplan (CustomScan) tlist carries
+        // structurally-equal Aggrefs — see `set_customscan_references`
+        // and `fix_upper_expr` for the matching logic.
+        let gather_target = (*rel).reltarget;
+
+        let mut rows = (*partial_copy).path.rows;
+        let gather = pg_sys::create_gather_path(
+            root,
+            rel,
+            partial_copy.cast::<pg_sys::Path>(),
+            gather_target,
+            ptr::null_mut(),
+            &mut rows,
+        );
+
+        // Clear competing paths so the chooser actually considers Gather;
+        // otherwise a single-worker serial aggregate path with matching
+        // total cost may win by tie-break. We re-add a high-cost serial
+        // fallback below so PG always has something non-partial to pick.
+        (*rel).pathlist = ptr::null_mut();
+
+        pg_sys::add_path(rel, gather.cast());
+
+        // High-cost serial fallback: same as non-upper-rel `add_path`.
+        // Keeps a non-parallel path in the list for cases where the
+        // Gather wrapper can't run (e.g., max_parallel_workers == 0).
+        let fallback =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+        (*fallback).path.parallel_aware = false;
+        (*fallback).path.parallel_safe = false;
+        (*fallback).path.parallel_workers = 0;
+        (*fallback).path.total_cost = 1_000_000_000.0;
+        (*fallback).path.startup_cost = 1_000_000_000.0;
+        pg_sys::add_path(rel, fallback.cast());
+        return;
+    }
+
+    let serial =
+        PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+    pg_sys::add_path(rel, serial.cast());
 }
 
 /// Static variable to store the previous planner hook (e.g., from Citus or other extensions)

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -166,8 +166,10 @@ use self::scan_state::{
 };
 use crate::api::HashSet;
 use crate::api::OrderByFeature;
+use crate::gucs::mpp_min_join_rows;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexManifest;
+use crate::mpp_log;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags};
 use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
@@ -177,6 +179,19 @@ use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::limit_offset::LimitOffset;
+use crate::postgres::customscan::mpp::customscan_glue::{
+    leader_estimate_dsm, leader_init_dsm, mpp_is_active, mpp_worker_count as mpp_glue_worker_count,
+    worker_init_dsm,
+};
+use crate::postgres::customscan::mpp::session::{
+    derive_query_id, MppPlanBroadcast, MppSessionProfile,
+};
+use crate::postgres::customscan::mpp::shape::{
+    broadcast_side_gate, classify as classify_shape, ClassifyInputs, MppPlanShape,
+};
+use crate::postgres::customscan::mpp::walker::{cut_count_for_shape, distribute_plan};
+use crate::postgres::customscan::mpp::worker::{MppDsmHeader, MPP_DSM_MAGIC};
+use crate::postgres::customscan::mpp::MppShardConfig;
 use crate::postgres::customscan::parallel::compute_nworkers;
 use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::customscan::{CustomScan, JoinPathlistHookArgs};
@@ -184,6 +199,7 @@ use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::{deserialize_logical_plan_with_runtime, serialize_logical_plan};
+use crate::scan::info::RowEstimate;
 use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
@@ -191,6 +207,8 @@ use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
 use futures::StreamExt;
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
+use std::ptr;
+use std::sync::Arc;
 
 #[derive(Default)]
 pub struct JoinScan;
@@ -340,7 +358,7 @@ unsafe fn is_limit_pushdown_safe(
     #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
     let all_rels = (*root).all_query_rels;
 
-    let mut absorbed_bms: *mut pg_sys::Bitmapset = std::ptr::null_mut();
+    let mut absorbed_bms: *mut pg_sys::Bitmapset = ptr::null_mut();
     for rti in &absorbed_rtis {
         absorbed_bms = pg_sys::bms_add_member(absorbed_bms, *rti as i32);
     }
@@ -665,6 +683,19 @@ impl JoinScan {
             0
         };
 
+        // When MPP is active for a binary join (the JoinOnly shape), PG's
+        // worker count must match `mpp_worker_count - 1`. Otherwise PG
+        // launches workers whose `ParallelWorkerNumber` exceeds
+        // `total_participants - 1`, and `worker_init_dsm` errors with
+        // "participant_index out of range". Mirrors the AggregateScan MPP
+        // path's `maybe_flip_mpp_parallel`.
+        let nworkers = if nworkers > 0 && join_clause.plan.sources().len() == 2 && mpp_is_active() {
+            let n = mpp_glue_worker_count() as usize;
+            n.saturating_sub(1).max(1)
+        } else {
+            nworkers
+        };
+
         if nworkers > 0 {
             let processes = std::cmp::max(
                 1,
@@ -679,7 +710,7 @@ impl JoinScan {
             let processes = processes as u64;
             let partitioning_idx = join_clause.partitioning_source_index();
             for (idx, source) in join_clause.plan.sources_mut().into_iter().enumerate() {
-                if let crate::scan::info::RowEstimate::Known(n) = source.scan_info.estimate {
+                if let RowEstimate::Known(n) = source.scan_info.estimate {
                     source.scan_info.estimated_rows_per_worker = if idx == partitioning_idx {
                         Some(n / processes)
                     } else {
@@ -689,7 +720,7 @@ impl JoinScan {
             }
         } else {
             for source in join_clause.plan.sources_mut() {
-                if let crate::scan::info::RowEstimate::Known(n) = source.scan_info.estimate {
+                if let RowEstimate::Known(n) = source.scan_info.estimate {
                     source.scan_info.estimated_rows_per_worker = Some(n);
                 }
             }
@@ -721,7 +752,7 @@ impl JoinScan {
             flags: Flags::Force as u32,
             methods: JoinScan::custom_path_methods(),
             custom_private: private_data.into(),
-            custom_paths: std::ptr::null_mut(),
+            custom_paths: ptr::null_mut(),
             ..Default::default()
         };
 
@@ -745,9 +776,167 @@ impl ParallelQueryCapable for JoinScan {
         state: &mut CustomScanStateWrapper<Self>,
         _pcxt: *mut pg_sys::ParallelContext,
     ) -> pg_sys::Size {
-        // Size DSM from actual execution-time segment counts (via manifests) rather
-        // than planning-time scan_info.segment_count, which can diverge under
-        // concurrent inserts.
+        // MPP branch: when `begin_custom_scan` classified this query as
+        // JoinOnly and serialized the broadcast plan, we size DSM for the
+        // MPP mesh instead of the broadcast-join `ParallelScanState`. PG
+        // hands us one coordinate region; MPP and broadcast-join layouts
+        // are incompatible in it, so this is an OR choice.
+        if let Some(shape) = state.custom_state().mpp_shape {
+            let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+                mpp_log!(
+                    "mpp: JoinScan::estimate_dsm_custom_scan but logical_plan_bytes is None; \
+                     falling back to non-MPP sizing"
+                );
+                return Self::estimate_broadcast_dsm(state);
+            };
+            let num_meshes = cut_count_for_shape(shape);
+            if num_meshes == 0 {
+                return Self::estimate_broadcast_dsm(state);
+            }
+            return match leader_estimate_dsm(plan_bytes.len(), num_meshes) {
+                Ok(sz) => sz,
+                Err(e) => {
+                    mpp_log!(
+                        "mpp: JoinScan leader_estimate_dsm failed: {e}; falling back to non-MPP"
+                    );
+                    Self::estimate_broadcast_dsm(state)
+                }
+            };
+        }
+
+        Self::estimate_broadcast_dsm(state)
+    }
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        // MPP branch mirrors AggregateScan::initialize_dsm_custom_scan.
+        if let Some(shape) = state.custom_state().mpp_shape {
+            debug_assert!(state.custom_state().mpp_state.is_none());
+            if coordinate.is_null() {
+                // `estimate_dsm` returned 0 (plan bytes unavailable) — PG
+                // hands us NULL. Silently fall back to non-MPP.
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            }
+            let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            };
+            let plan_bytes = plan_bytes.to_vec();
+            let num_meshes = cut_count_for_shape(shape);
+            if num_meshes == 0 {
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            }
+            let seg = unsafe { (*pcxt).seg };
+            let ctx = unsafe { leader_init_dsm(coordinate, plan_bytes, num_meshes, seg) };
+            match ctx {
+                Ok(leader_ctx) => {
+                    mpp_log!(
+                        "mpp: JoinScan leader initialized DSM for {} participants (shape={:?})",
+                        leader_ctx.participant_config().total_participants,
+                        shape,
+                    );
+                    state.custom_state_mut().mpp_state = Some(leader_ctx);
+                }
+                Err(e) => {
+                    // Partial-init leaves DSM in undefined state — fail
+                    // loudly, same rationale as AggregateScan.
+                    pgrx::error!("mpp: JoinScan leader_init_dsm failed: {e}");
+                }
+            }
+            return;
+        }
+
+        Self::initialize_broadcast_dsm(state, coordinate);
+    }
+
+    fn reinitialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        // MPP rescan is out of scope; the non-MPP path resets the
+        // broadcast-join `ParallelScanState` as before.
+        if state.custom_state().mpp_shape.is_some() {
+            // No-op: a rescanned MPP join would need a full mesh teardown
+            // + rebuild, same gap AggregateScan leaves.
+            return;
+        }
+        let pscan_state = coordinate.cast::<ParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+        unsafe {
+            (*pscan_state).reset();
+        }
+    }
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _toc: *mut pg_sys::shm_toc,
+        coordinate: *mut c_void,
+    ) {
+        // Detect MPP layout via header magic — `mpp_shape` doesn't
+        // propagate through PrivateData to workers.
+        if mpp_is_active() && !coordinate.is_null() && Self::dsm_looks_like_mpp(coordinate) {
+            debug_assert!(state.custom_state().mpp_state.is_none());
+            let region_total = unsafe {
+                let header = ptr::read_unaligned(coordinate as *const MppDsmHeader);
+                header.region_total
+            };
+            let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+            let ctx = unsafe {
+                worker_init_dsm(coordinate, region_total, worker_number, ptr::null_mut())
+            };
+            match ctx {
+                Ok(worker_ctx) => {
+                    mpp_log!(
+                        "mpp: JoinScan worker {} attached to DSM ({} participants)",
+                        worker_number,
+                        worker_ctx.participant_config().total_participants
+                    );
+                    state.custom_state_mut().mpp_state = Some(worker_ctx);
+                    return;
+                }
+                Err(e) => {
+                    // Worker-side attach failure is fatal because the
+                    // leader expects an MPP participant at this index.
+                    pgrx::error!(
+                        "mpp: JoinScan worker_init_dsm failed on worker {worker_number}: {e}"
+                    );
+                }
+            }
+        }
+
+        let pscan_state = coordinate.cast::<ParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+
+        state.custom_state_mut().parallel_state = Some(pscan_state);
+
+        // Workers must wait for the leader to finish populating the segment pool.
+        unsafe {
+            (*pscan_state).wait_for_initialization();
+        }
+
+        // Read the canonical non-partitioning segment ID sets that the leader wrote to
+        // shared memory.  These are used in exec_custom_scan to ensure every worker opens
+        // each replicated source with MvccSatisfies::ParallelWorker, which pins the
+        // visible segment list to exactly what the leader snapshotted.
+        let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
+        state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
+
+        // We don't need to deserialize query from parallel state for JoinScan
+        // because the full plan (including query) is serialized in PrivateData
+        // and available to the worker via the plan.
+    }
+}
+
+impl JoinScan {
+    /// DSM sizing for the non-MPP broadcast-join path. Extracted so both the
+    /// non-MPP branch and the MPP fallback can call it.
+    fn estimate_broadcast_dsm(state: &mut CustomScanStateWrapper<Self>) -> pg_sys::Size {
         Self::ensure_source_manifests(state);
 
         let join_clause = &state.custom_state().join_clause;
@@ -762,11 +951,9 @@ impl ParallelQueryCapable for JoinScan {
         ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false)
     }
 
-    fn initialize_dsm_custom_scan(
-        state: &mut CustomScanStateWrapper<Self>,
-        _pcxt: *mut pg_sys::ParallelContext,
-        coordinate: *mut c_void,
-    ) {
+    /// DSM population for the non-MPP broadcast-join path. Extracted so both
+    /// the non-MPP branch and the MPP fallback can call it.
+    fn initialize_broadcast_dsm(state: &mut CustomScanStateWrapper<Self>, coordinate: *mut c_void) {
         let pscan_state = coordinate.cast::<ParallelScanState>();
         assert!(!pscan_state.is_null(), "coordinate is null");
 
@@ -799,47 +986,102 @@ impl ParallelQueryCapable for JoinScan {
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
     }
 
-    fn reinitialize_dsm_custom_scan(
-        _state: &mut CustomScanStateWrapper<Self>,
-        _pcxt: *mut pg_sys::ParallelContext,
-        coordinate: *mut c_void,
-    ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
-        assert!(!pscan_state.is_null(), "coordinate is null");
+    /// Quick heuristic to detect whether `coordinate` points to an
+    /// MPP-initialized DSM region (as opposed to a `ParallelScanState` the
+    /// broadcast-join path allocated). Reads the header's `magic` field;
+    /// `MppDsmHeader` places a fixed magic at the start of the region. Safe
+    /// to call speculatively because the read is aligned and bounded to the
+    /// header struct size — if the region is `ParallelScanState`-sized, the
+    /// magic won't match and we fall through to the broadcast-join branch.
+    fn dsm_looks_like_mpp(coordinate: *mut c_void) -> bool {
         unsafe {
-            (*pscan_state).reset();
+            let header = ptr::read_unaligned(coordinate as *const MppDsmHeader);
+            header.magic == MPP_DSM_MAGIC
         }
     }
 
-    fn initialize_worker_custom_scan(
-        state: &mut CustomScanStateWrapper<Self>,
-        _toc: *mut pg_sys::shm_toc,
-        coordinate: *mut c_void,
-    ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
-        assert!(!pscan_state.is_null(), "coordinate is null");
+    /// Wrap the already-serialized logical plan in `MppPlanBroadcast` and
+    /// stash the bytes + classified shape on `JoinScanState` for the MPP DSM
+    /// hooks to consume. Called from `begin_custom_scan` when `mpp_is_active()`
+    /// and the query is not EXPLAIN-only.
+    ///
+    /// Classification is derived from `join_clause.plan.sources().len()` — a
+    /// 2-source binary join maps to [`MppPlanShape::JoinOnly`]; anything else
+    /// stays `Ineligible`. Failures (serialize error, ineligible shape) leave
+    /// the MPP fields `None` and the scan silently falls back to the non-MPP
+    /// broadcast-join path — same ops-friendly behavior as AggregateScan.
+    fn maybe_stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
+        let Some(raw_plan_bytes) = state.custom_state().logical_plan.as_ref() else {
+            mpp_log!("mpp: JoinScan begin_custom_scan has no logical_plan bytes; MPP falls back");
+            return;
+        };
+        let raw_plan_bytes = raw_plan_bytes.clone();
 
-        state.custom_state_mut().parallel_state = Some(pscan_state);
-
-        // Workers must wait for the leader to finish populating the segment pool.
-        unsafe {
-            (*pscan_state).wait_for_initialization();
+        let n_join_tables = state.custom_state().join_clause.plan.sources().len();
+        let shape = classify_shape(&ClassifyInputs {
+            n_join_tables,
+            has_group_by: false,
+            all_aggregates_splittable: true,
+            has_aggregate: false,
+        });
+        if !matches!(shape, MppPlanShape::JoinOnly) {
+            mpp_log!(
+                "mpp: JoinScan shape={:?} (n_join_tables={}); staying on non-MPP path",
+                shape,
+                n_join_tables
+            );
+            return;
         }
 
-        // Read the canonical non-partitioning segment ID sets that the leader wrote to
-        // shared memory.  These are used in exec_custom_scan to ensure every worker opens
-        // each replicated source with MvccSatisfies::ParallelWorker, which pins the
-        // visible segment list to exactly what the leader snapshotted.
-        let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
-        state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
+        // Cost gate: shuffle overhead dominates when the smallest side of the
+        // binary join is small — the non-MPP broadcast-join path is cheap in
+        // that regime (replicate the small side, probe with the large).
+        // Threshold of 0 disables the gate. See
+        // [`crate::postgres::customscan::mpp::shape::broadcast_side_gate`].
+        let estimates: Vec<RowEstimate> = state
+            .custom_state()
+            .join_clause
+            .plan
+            .sources()
+            .iter()
+            .map(|s| s.scan_info.estimate)
+            .collect();
+        let min_rows = mpp_min_join_rows();
+        if let Some(gated_rows) = broadcast_side_gate(&estimates, min_rows) {
+            mpp_log!(
+                "mpp: JoinScan {:?} gated — smallest side estimated_rows={} < \
+                 mpp_min_join_rows={}; staying on non-MPP path",
+                shape,
+                gated_rows,
+                min_rows
+            );
+            return;
+        }
 
-        // We don't need to deserialize query from parallel state for JoinScan
-        // because the full plan (including query) is serialized in PrivateData
-        // and available to the worker via the plan.
+        let n = mpp_glue_worker_count();
+        let query_id = derive_query_id();
+        let broadcast = MppPlanBroadcast::new(
+            raw_plan_bytes.to_vec(),
+            n,
+            MppSessionProfile::Join,
+            query_id,
+        );
+        let broadcast_bytes = match broadcast.serialize() {
+            Ok(b) => b,
+            Err(e) => {
+                mpp_log!("mpp: JoinScan MppPlanBroadcast serialize failed, MPP falls back: {e}");
+                return;
+            }
+        };
+        mpp_log!(
+            "mpp: JoinScan stashed plan-broadcast bytes (shape={:?}, n={})",
+            shape,
+            n
+        );
+        state.custom_state_mut().logical_plan_bytes = Some(bytes::Bytes::from(broadcast_bytes));
+        state.custom_state_mut().mpp_shape = Some(shape);
     }
-}
 
-impl JoinScan {
     /// Capture lightweight segment manifests for all join sources.
     ///
     /// Uses `SearchIndexManifest::capture` instead of opening full `SearchIndexReader`s
@@ -898,8 +1140,9 @@ impl JoinScan {
         let mut ids_by_pos = vec![None; plan_sources.len()];
         let partitioning_idx = join_clause.partitioning_source_index();
         let is_worker = unsafe { pg_sys::ParallelWorkerNumber >= 0 };
+        let is_mpp = state.custom_state().mpp_state.is_some();
 
-        if is_worker {
+        if is_worker && !is_mpp {
             let non_partitioning_segs = &state.custom_state().non_partitioning_segments;
             let mut np_counter = 0usize;
             for (i, _source) in plan_sources.iter().enumerate() {
@@ -1269,7 +1512,8 @@ impl CustomScan for JoinScan {
         estate: *mut pg_sys::EState,
         eflags: i32,
     ) {
-        if eflags & (pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) == 0 {
+        let explain_only = (eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) != 0;
+        if !explain_only {
             unsafe {
                 let planstate = state.planstate();
                 // Always assign an ExprContext — heap filters, runtime
@@ -1277,6 +1521,12 @@ impl CustomScan for JoinScan {
                 pg_sys::ExecAssignExprContext(estate, planstate);
                 state.custom_state_mut().result_slot = Some(state.csstate.ss.ps.ps_ResultTupleSlot);
                 state.runtime_context = state.csstate.ss.ps.ps_ExprContext;
+            }
+
+            // Stash MPP plan-broadcast bytes + shape when MPP is active.
+            // Non-fatal on failure (logged + falls back to broadcast-join).
+            if mpp_is_active() {
+                Self::maybe_stash_mpp_plan_bytes(state);
             }
         }
     }
@@ -1326,7 +1576,39 @@ impl CustomScan for JoinScan {
                 let index_segment_ids =
                     Self::build_index_segment_ids(state, &join_clause, &plan_sources);
 
-                let ctx = create_datafusion_session_context(SessionContextProfile::Join);
+                // Pre-read the MPP shape BEFORE we take the DataFusion
+                // session/context borrow, because rewriting the physical
+                // plan below needs `mpp_state` mutably at the same time
+                // as the ctx is built.
+                let mpp_shape = if state.custom_state().mpp_state.is_some() {
+                    state.custom_state().mpp_shape
+                } else {
+                    None
+                };
+
+                // Build the session context. When this scan is an MPP
+                // participant, use `create_datafusion_session_context_mpp`
+                // so `SortMergeJoinEnforcer` is skipped (otherwise it
+                // collapses hash-partitioned streams) and inject
+                // `MppShardConfig` so `PgSearchTableProvider::scan`
+                // opens each participant's shard of segments.
+                let ctx = match state.custom_state().mpp_state.as_ref() {
+                    Some(mpp_state) if mpp_state.participant_config().total_participants > 1 => {
+                        let cfg = mpp_state.participant_config().clone();
+                        let ctx = scan_state::create_datafusion_session_context_mpp(
+                            SessionContextProfile::Join,
+                            &cfg,
+                        );
+                        ctx.state_ref().write().config_mut().set_extension(Arc::new(
+                            MppShardConfig {
+                                participant_index: cfg.participant_index,
+                                total_participants: cfg.total_participants,
+                            },
+                        ));
+                        ctx
+                    }
+                    _ => create_datafusion_session_context(SessionContextProfile::Join),
+                };
                 let logical_plan = deserialize_logical_plan_with_runtime(
                     &plan_bytes,
                     &ctx.task_ctx(),
@@ -1366,10 +1648,44 @@ impl CustomScan for JoinScan {
                     logical_plan
                 };
 
-                // Convert logical plan to physical plan
-                let plan = runtime
+                // Convert logical plan to standard physical plan.
+                let standard_plan = runtime
                     .block_on(build_physical_plan(&ctx, logical_plan))
                     .expect("Failed to create execution plan");
+
+                // If MPP was set up by the DSM hooks, rewrite the
+                // standard plan into the JoinOnly MPP shape.
+                let plan = if let Some(shape) = mpp_shape {
+                    let mpp_state = state
+                        .custom_state_mut()
+                        .mpp_state
+                        .as_mut()
+                        .expect("mpp_shape set ⇒ mpp_state must be Some");
+                    mpp_log!(
+                        "mpp: routing JoinScan exec through shape {:?} (is_leader={})",
+                        shape,
+                        mpp_state.is_leader()
+                    );
+                    let _guard = runtime.enter();
+                    let standard_fallback = Arc::clone(&standard_plan);
+                    match distribute_plan(standard_plan, mpp_state, shape) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            // Same fallback policy as AggregateScan's
+                            // dispatcher: an unsupported plan shape
+                            // (TopK, Sort + Limit, etc.) drops to the
+                            // serial DataFusion plan rather than
+                            // aborting the query.
+                            pgrx::warning!(
+                                "mpp: JoinScan distribute_plan failed ({e}); \
+                                 running serial DataFusion plan"
+                            );
+                            standard_fallback
+                        }
+                    }
+                } else {
+                    standard_plan
+                };
 
                 let task_ctx = build_task_context(
                     &ctx,
@@ -1432,7 +1748,7 @@ impl CustomScan for JoinScan {
                         state.custom_state_mut().batch_index = 0;
                     }
                     Some(Err(e)) => panic!("DataFusion execution failed: {}", e),
-                    None => return std::ptr::null_mut(),
+                    None => return ptr::null_mut(),
                 }
             }
         }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -83,6 +83,7 @@ use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::TaskContext;
 use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 
+use crate::gucs::is_columnar_sort_enabled;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::datafusion::translator::{
     apply_join_level_filter, build_join_df_with_filter, make_col, make_source_col,
@@ -92,6 +93,9 @@ use crate::postgres::customscan::datafusion::translator::{
 use crate::postgres::customscan::joinscan::privdat::{
     OutputColumnInfo, PrivateData, SCORE_COL_NAME,
 };
+use crate::postgres::customscan::mpp::customscan_glue::MppExecutionState;
+use crate::postgres::customscan::mpp::shape::MppPlanShape;
+use crate::postgres::customscan::mpp::MppParticipantConfig;
 use crate::postgres::customscan::CustomScanState;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
@@ -250,6 +254,20 @@ pub struct JoinScanState {
     /// Dropping manifests early would release the pins and allow segment recycling
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
+
+    /// Pre-serialized `MppPlanBroadcast` bytes — see
+    /// `AggregateScanState::logical_plan_bytes` for the same length-must-
+    /// match-DSM-estimate contract.
+    pub logical_plan_bytes: Option<bytes::Bytes>,
+
+    /// Classified MPP shape for this query (always `JoinOnly` or
+    /// `Ineligible`); drives DSM mesh count.
+    pub mpp_shape: Option<MppPlanShape>,
+
+    /// MPP lifecycle state. Declared LAST so it drops after
+    /// `datafusion_stream` — same DSM-handle-ordering rationale as
+    /// `AggregateScanState::mpp_state`.
+    pub mpp_state: Option<MppExecutionState>,
 }
 
 impl JoinScanState {
@@ -288,11 +306,23 @@ pub enum SessionContextProfile {
 /// Build the shared core of a DataFusion [`SessionStateBuilder`] with:
 /// - Visibility filtering (logical + physical)
 /// - Late materialization
-/// - SortMergeJoinEnforcer (when columnar sort enabled)
+/// - SortMergeJoinEnforcer (when columnar sort enabled *and* MPP is inactive)
 /// - `PgSearchQueryPlanner`
 ///
 /// Callers append their own TopK rule and FilterPushdown passes.
-pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
+///
+/// When `mpp` is `Some` with `total_participants > 1`, two bug-fix paths from
+/// the reference MPP implementation apply:
+///   1. `SortMergeJoinEnforcer` is skipped. The SPM rewrite collapses hash
+///      partitions to one, which would make our `HashRepartitionExec::execute(i)`
+///      return empty for all `i != leader`.
+///   2. Caller `create_datafusion_session_context_mpp` disables
+///      `enable_join_dynamic_filter_pushdown` so probe-side scans do not race
+///      with the exchange producer and emit zero rows.
+pub(crate) fn build_base_session_with_mpp(
+    config: SessionConfig,
+    mpp: Option<&MppParticipantConfig>,
+) -> SessionStateBuilder {
     use super::visibility_filter::VisibilityFilterOptimizerRule;
     use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
 
@@ -308,7 +338,14 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
             crate::scan::late_materialization::LateMaterializationRule,
         ));
 
-    if crate::gucs::is_columnar_sort_enabled() {
+    // Treat any non-None MppParticipantConfig as "MPP is active" — even N=1
+    // MPP (leader-only) shares the shuffle operator tree with N>1, so the
+    // SortMergeJoinEnforcer's partition-collapsing behavior is undesirable
+    // in both cases. Callers that do *not* want the bug-fix semantics pass
+    // `None`.
+    let mpp_active = mpp.is_some();
+
+    if is_columnar_sort_enabled() && !mpp_active {
         builder = builder.with_physical_optimizer_rule(Arc::new(SortMergeJoinEnforcer::new()));
     }
 
@@ -332,6 +369,27 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
 /// - [`SessionContextProfile::Aggregate`]: appends a single `FilterPushdown`
 ///   post-pass; SegmentedTopK does not apply to aggregate-on-join queries.
 pub fn create_datafusion_session_context(profile: SessionContextProfile) -> SessionContext {
+    create_datafusion_session_context_inner(profile, None)
+}
+
+/// MPP-aware variant of [`create_datafusion_session_context`]. Applies the
+/// MPP join-layer adjustments:
+///   1. Skip `SortMergeJoinEnforcer` (handled by `build_base_session_with_mpp`).
+///   2. Keep `enable_join_dynamic_filter_pushdown = true`. The filter `Arc` is
+///      preserved across the MPP HashJoin rebuild (via `builder()`) and
+///      re-applied as a `FilterExec` above the post-shuffle probe stream by
+///      the walker's `finalize_*` arms.
+pub fn create_datafusion_session_context_mpp(
+    profile: SessionContextProfile,
+    mpp: &MppParticipantConfig,
+) -> SessionContext {
+    create_datafusion_session_context_inner(profile, Some(mpp))
+}
+
+fn create_datafusion_session_context_inner(
+    profile: SessionContextProfile,
+    mpp: Option<&MppParticipantConfig>,
+) -> SessionContext {
     let mut config = SessionConfig::new().with_target_partitions(1);
 
     // Configure dynamic filter pushdown thresholds from our GUCs
@@ -353,11 +411,41 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
             .enable_topk_dynamic_filter_pushdown = true;
     }
 
-    let mut builder = build_base_session(config);
+    // Disable DataFusion's "skip partial aggregation" probe for MPP sessions.
+    //
+    // In Partial mode, DataFusion samples the first
+    // `skip_partial_aggregation_probe_rows_threshold` (default 100_000) rows
+    // and, if the distinct-group ratio exceeds
+    // `skip_partial_aggregation_probe_ratio_threshold` (default 0.8), flips
+    // the operator into pass-through mode — every subsequent input row is
+    // emitted as its own partial output row with no deduplication. The
+    // downstream `FinalPartitioned` still produces correct results because it
+    // merges duplicates, but the intermediate shuffle must carry ~distinct_
+    // groups × rows_per_group rows instead of ~distinct_groups rows.
+    //
+    // On the 25M `aggregate_join_groupby` bench this fanout was ~7× (gb_postagg
+    // rows_in = 22M across participants for 3.1M distinct groups), and 22M rows
+    // through shm_mq saturated the shuffle for > 600s. Single-process
+    // DataFusion never pays that cost because there's no shuffle; the skip
+    // probe is a pure win in single-process. For MPP it is the dominant cost.
+    //
+    // Setting the ratio threshold to 1.1 (> 1.0, which is the max achievable
+    // ratio) disables the switch unconditionally. Partial mode still benefits
+    // from in-memory hash-table dedup within each batch flush.
+    if mpp.is_some() {
+        config
+            .options_mut()
+            .execution
+            .skip_partial_aggregation_probe_ratio_threshold = 1.1;
+    }
+
+    let mut builder = build_base_session_with_mpp(config, mpp);
+
+    let mpp_active = mpp.is_some();
 
     match profile {
         SessionContextProfile::Join => {
-            if crate::gucs::is_columnar_sort_enabled() {
+            if is_columnar_sort_enabled() && !mpp_active {
                 builder = builder.with_physical_optimizer_rule(Arc::new(
                     FilterPushdown::new_post_optimization(),
                 ));

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -1,0 +1,232 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Façade for AggregateScan / JoinScan customscan hooks: one helper per DSM
+//! hook point (estimate, leader-init, worker-attach), each a thin wrapper
+//! over [`super::worker`] primitives plus plan-broadcast serialization.
+
+use std::ffi::c_void;
+
+use pgrx::pg_sys;
+
+use crate::postgres::customscan::mpp::mesh::MeshLayout;
+use crate::postgres::customscan::mpp::session::MppPlanBroadcast;
+use crate::postgres::customscan::mpp::worker::{
+    attach_dsm_as_worker, compute_dsm_layout, initialize_dsm_as_leader, LeaderMesh, WorkerMesh,
+};
+use crate::postgres::customscan::mpp::MppParticipantConfig;
+
+/// Compute the exact DSM size the MPP custom scan needs for a plan of
+/// `plan_bytes_len` bytes, N participants, `num_meshes` independent shuffle
+/// meshes, and the configured per-edge queue size.
+///
+/// Returns `Err` on any arithmetic overflow or if the resulting region would
+/// exceed [`super::worker::MPP_DSM_MAX_BYTES`].
+pub fn estimate_mpp_dsm(
+    plan_bytes_len: usize,
+    total_participants: u32,
+    num_meshes: u32,
+    queue_bytes: usize,
+) -> Result<usize, &'static str> {
+    let mesh = MeshLayout::new(total_participants, queue_bytes);
+    let dsm = compute_dsm_layout(&mesh, num_meshes, plan_bytes_len)?;
+    Ok(dsm.total)
+}
+
+/// Leader's DSM-init entry point. Serializes `plan` into a
+/// [`MppPlanBroadcast`], writes the bytes + header + shm_mq regions into the
+/// DSM region at `coordinate`, and returns the leader's mesh wiring.
+///
+/// # Safety
+/// - `coordinate` must point to the start of a DSM region of size >= the
+///   estimate returned by [`estimate_mpp_dsm`] with the same parameters.
+/// - Caller is the leader backend and holds `pcxt` / `seg`.
+/// - Caller must not have written to the region already.
+///
+/// On `Err`, the DSM region may be partially initialized; the caller should
+/// treat this as an abort condition and tear down the parallel context
+/// rather than retrying.
+pub unsafe fn init_mpp_dsm_leader(
+    coordinate: *mut c_void,
+    plan_broadcast_bytes: Vec<u8>,
+    total_participants: u32,
+    num_meshes: u32,
+    queue_bytes: usize,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<LeaderMppContext, String> {
+    // Caller must hand us the same bytes whose length they passed to
+    // `estimate_mpp_dsm`; re-wrapping here would risk overrun.
+    let mesh = MeshLayout::new(total_participants, queue_bytes);
+    let dsm = compute_dsm_layout(&mesh, num_meshes, plan_broadcast_bytes.len())
+        .map_err(|e| format!("mpp: compute_dsm_layout failed: {e}"))?;
+
+    // Peek query_id from the broadcast — threading it separately would
+    // duplicate the same truth and risk drift.
+    let query_id = MppPlanBroadcast::deserialize(&plan_broadcast_bytes)
+        .map_err(|e| format!("mpp: leader broadcast peek failed: {e}"))?
+        .query_id;
+
+    let base = coordinate as *mut u8;
+    let meshes = unsafe {
+        initialize_dsm_as_leader(base, &dsm, &mesh, &plan_broadcast_bytes, seg)
+            .map_err(|e| format!("mpp: initialize_dsm_as_leader failed: {e}"))?
+    };
+
+    Ok(LeaderMppContext {
+        meshes,
+        participant_config: MppParticipantConfig {
+            participant_index: 0,
+            total_participants,
+        },
+        query_id,
+    })
+}
+
+/// Bundle returned to the leader after [`init_mpp_dsm_leader`]. The caller
+/// owns both the mesh wiring (for the leader's own shuffle participation)
+/// and the config that the leader feeds into its DataFusion session.
+pub struct LeaderMppContext {
+    /// One [`LeaderMesh`] per shuffle mesh, in the order the shape requested.
+    pub meshes: Vec<LeaderMesh>,
+    pub participant_config: MppParticipantConfig,
+    /// Per-query identifier the leader derived at plan time. Stamped (as
+    /// the low 64 bits) on every boundary
+    /// [`Stage`](datafusion_distributed::Stage) so workers and leader
+    /// agree on the key that keys cross-participant mesh traffic.
+    pub query_id: u64,
+}
+
+/// Worker's DSM-attach entry point. Reads the header, validates, attaches as
+/// sender/receiver for this worker's participant index, and decodes the plan broadcast.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer the leader initialized.
+/// - `region_total` must match the DSM's attached size.
+/// - `worker_number` is the PG-assigned `ParallelWorkerNumber`; the worker's
+///   participant index is `worker_number + 1` (leader is participant 0).
+/// - Caller is the worker backend and holds `pcxt` / `seg`.
+pub unsafe fn attach_mpp_dsm_worker(
+    coordinate: *mut c_void,
+    region_total: u64,
+    worker_number: i32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<WorkerMppContext, String> {
+    if worker_number < 0 {
+        return Err("mpp: worker_number < 0".into());
+    }
+    let participant_index = (worker_number as u32)
+        .checked_add(1)
+        .ok_or_else(|| "mpp: worker_number + 1 overflowed u32".to_string())?;
+
+    let base = coordinate as *mut u8;
+    let attach = unsafe { attach_dsm_as_worker(base, region_total, participant_index, seg) }
+        .map_err(|e| format!("mpp: attach_dsm_as_worker failed: {e}"))?;
+
+    // The plan bytes live inside DSM. Copy them out so we don't hold a borrow
+    // across subsequent FFI. `bincode::decode_from_slice` wants `&[u8]`.
+    let plan_bytes = unsafe { attach.copy_plan_bytes() };
+    let broadcast = MppPlanBroadcast::deserialize(&plan_bytes)
+        .map_err(|e| format!("mpp: plan deserialize failed: {e}"))?;
+    let participant_config = broadcast.participant_config(participant_index);
+    let query_id = broadcast.query_id;
+
+    Ok(WorkerMppContext {
+        meshes: attach.meshes,
+        participant_config,
+        query_id,
+    })
+}
+
+/// Bundle returned to a worker after [`attach_mpp_dsm_worker`]. The caller
+/// constructs a session with `participant_config` and wires the returned
+/// meshes into `ShuffleExec` (one mesh per shuffle).
+pub struct WorkerMppContext {
+    pub meshes: Vec<WorkerMesh>,
+    pub participant_config: MppParticipantConfig,
+    /// Per-query identifier read from the leader's broadcast.
+    pub query_id: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::session::MppSessionProfile;
+
+    #[test]
+    fn estimate_matches_compute_dsm_layout() {
+        // Cross-check: estimate_mpp_dsm returns the same `total` as a direct
+        // compute_dsm_layout call for any given config.
+        for &(plan_len, n, num_meshes, q) in &[
+            (0usize, 2u32, 1u32, 8 * 1024usize),
+            (1024, 2, 1, 8 * 1024),
+            (500_000, 4, 3, 64 * 1024),
+        ] {
+            let mesh = MeshLayout::new(n, q);
+            let direct = compute_dsm_layout(&mesh, num_meshes, plan_len).unwrap();
+            let via_estimate = estimate_mpp_dsm(plan_len, n, num_meshes, q).unwrap();
+            assert_eq!(direct.total, via_estimate);
+        }
+    }
+
+    #[test]
+    fn estimate_rejects_overflow() {
+        assert!(estimate_mpp_dsm(usize::MAX, 2, 1, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_rejects_zero_participants() {
+        assert!(estimate_mpp_dsm(100, 0, 1, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_rejects_zero_meshes() {
+        assert!(estimate_mpp_dsm(100, 2, 0, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_scales_with_num_meshes() {
+        let one = estimate_mpp_dsm(0, 4, 1, 64 * 1024).unwrap();
+        let three = estimate_mpp_dsm(0, 4, 3, 64 * 1024).unwrap();
+        // Header + padding is constant; per-mesh bytes is N*(N-1)*q.
+        // Difference between 3 and 1 meshes is exactly 2 * per-mesh bytes.
+        let per_mesh = 4 * 3 * 64 * 1024;
+        assert_eq!(three - one, 2 * per_mesh);
+    }
+
+    #[test]
+    fn init_does_not_rewrap_plan_bytes() {
+        // Pins the contract: callers must pass already-serialized broadcast
+        // bytes to `init_mpp_dsm_leader`, sized to match
+        // `estimate_mpp_dsm(plan_broadcast_bytes.len(), …)`. Re-wrapping
+        // inside the function would inflate the bytes past the estimate
+        // and overrun the DSM region.
+        let raw_plan: Vec<u8> = (0..1024u32).map(|i| (i & 0xff) as u8).collect();
+        let bc = MppPlanBroadcast::new(raw_plan.clone(), 2, MppSessionProfile::Aggregate, 0);
+        let broadcast_bytes = bc.serialize().unwrap();
+        assert_ne!(
+            broadcast_bytes.len(),
+            raw_plan.len(),
+            "MppPlanBroadcast wrapping adds framing; callers must size DSM against \
+             the wrapped bytes, not raw plan bytes"
+        );
+        assert!(
+            broadcast_bytes.len() > raw_plan.len(),
+            "wrapped bytes must be strictly larger than raw (sanity)"
+        );
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Façade for AggregateScan / JoinScan customscan hooks: one helper per DSM
 //! hook point (estimate, leader-init, worker-attach), each a thin wrapper
 //! over [`super::worker`] primitives plus plan-broadcast serialization.

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Typed customscan-DSM-hook helpers. Each `ParallelQueryCapable` impl
 //! delegates to one of [`leader_estimate_dsm`] / [`leader_init_dsm`] /
 //! [`worker_init_dsm`] and stashes the returned [`MppExecutionState`] —

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Typed customscan-DSM-hook helpers. Each `ParallelQueryCapable` impl
+//! delegates to one of [`leader_estimate_dsm`] / [`leader_init_dsm`] /
+//! [`worker_init_dsm`] and stashes the returned [`MppExecutionState`] —
+//! no raw `shm_mq` FFI in customscan code.
+
+use std::ffi::c_void;
+
+use pgrx::pg_sys;
+
+use crate::gucs::{enable_mpp, mpp_worker_count as guc_mpp_worker_count};
+use crate::postgres::customscan::mpp::coordinator::{
+    attach_mpp_dsm_worker, estimate_mpp_dsm, init_mpp_dsm_leader, LeaderMppContext,
+    WorkerMppContext,
+};
+use crate::postgres::customscan::mpp::MppParticipantConfig;
+
+/// Per-query MPP state a customscan's execution state stores. Distinct
+/// variants for leader vs worker because the two have different wiring
+/// shapes — the leader pre-creates the mesh; the worker attaches to it —
+/// and forcing a common bundle would either waste fields or require a
+/// second level of Option.
+pub enum MppExecutionState {
+    Leader(LeaderMppContext),
+    Worker(WorkerMppContext),
+}
+
+impl MppExecutionState {
+    pub fn participant_config(&self) -> &MppParticipantConfig {
+        match self {
+            MppExecutionState::Leader(l) => &l.participant_config,
+            MppExecutionState::Worker(w) => &w.participant_config,
+        }
+    }
+
+    pub fn is_leader(&self) -> bool {
+        matches!(self, MppExecutionState::Leader(_))
+    }
+
+    /// Per-query identifier stamped on every boundary `Stage`. Leader
+    /// derives it once via `session::derive_query_id` and ships it to
+    /// workers inside `MppPlanBroadcast`.
+    pub fn query_id(&self) -> u64 {
+        match self {
+            MppExecutionState::Leader(l) => l.query_id,
+            MppExecutionState::Worker(w) => w.query_id,
+        }
+    }
+}
+
+/// True when the `paradedb.enable_mpp` GUC is on AND the worker count is at
+/// least 2. The customscan checks this before announcing parallel-safe
+/// paths; if false, the non-MPP serial path is used.
+pub fn mpp_is_active() -> bool {
+    enable_mpp() && guc_mpp_worker_count() >= 2
+}
+
+/// MPP worker count from GUC, clamped to >= 2.
+pub fn mpp_worker_count() -> u32 {
+    guc_mpp_worker_count().max(2) as u32
+}
+
+/// Customscan `estimate_dsm_custom_scan` implementation for an MPP-enabled
+/// plan. Given the serialized logical plan length, returns the total DSM
+/// bytes the coordinator will need.
+///
+/// Per-edge queue size is read from `paradedb.mpp_queue_size` (default
+/// 64 MiB; see the GUC's doc comment for sizing rationale and DSM cost).
+///
+/// Call from the customscan's `ParallelQueryCapable::estimate_dsm_custom_scan`
+/// when [`mpp_is_active`] is true.
+pub fn leader_estimate_dsm(plan_bytes_len: usize, num_meshes: u32) -> Result<pg_sys::Size, String> {
+    let n = mpp_worker_count();
+    estimate_mpp_dsm(plan_bytes_len, n, num_meshes, crate::gucs::mpp_queue_size())
+        .map(|sz| sz as pg_sys::Size)
+        .map_err(|e| format!("mpp: estimate DSM failed: {e}"))
+}
+
+/// Customscan `initialize_dsm_custom_scan` implementation for an MPP leader.
+/// Takes the DSM `coordinate` pointer the PG hook received, the pre-serialized
+/// `MppPlanBroadcast` bytes (same bytes whose length was reported by
+/// [`leader_estimate_dsm`]), the session profile, and the DSM segment pointer.
+/// Returns the [`MppExecutionState::Leader`] the customscan should stash in
+/// its execution state.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer PG supplied to
+///   `initialize_dsm_custom_scan`. It must remain valid for the query's
+///   lifetime.
+/// - `seg` must be valid. On the leader it comes from `pcxt->seg`.
+/// - `plan_broadcast_bytes.len()` must equal the value passed to
+///   [`leader_estimate_dsm`]; otherwise the DSM write overruns the region PG
+///   allocated and corrupts adjacent `shm_toc` allocations (including the
+///   DSA control regions used by parallel tuple queues).
+pub unsafe fn leader_init_dsm(
+    coordinate: *mut c_void,
+    plan_broadcast_bytes: Vec<u8>,
+    num_meshes: u32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<MppExecutionState, String> {
+    if coordinate.is_null() {
+        return Err("mpp: leader_init_dsm given null coordinate".into());
+    }
+
+    let n = mpp_worker_count();
+    let leader = unsafe {
+        init_mpp_dsm_leader(
+            coordinate,
+            plan_broadcast_bytes,
+            n,
+            num_meshes,
+            crate::gucs::mpp_queue_size(),
+            seg,
+        )?
+    };
+    Ok(MppExecutionState::Leader(leader))
+}
+
+/// Customscan `initialize_worker_custom_scan` implementation. Called on
+/// worker backends with the `coordinate` pointer and the worker's
+/// `ParallelWorkerNumber`.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer PG supplied.
+/// - `seg` may be NULL — `initialize_worker_custom_scan` does not surface
+///   the DSM segment pointer, so callers typically pass NULL. `shm_mq_attach`
+///   handles NULL seg by skipping its `on_dsm_detach` callback; cleanup
+///   then relies on process exit. Safe for parallel-worker lifetimes where
+///   the process dies with the query.
+/// - `region_total` must be the size of the attached DSM region. Callers
+///   without an independent source can read it from the header itself
+///   (trading the independence of the validation check for the ability
+///   to initialize without a seg pointer).
+pub unsafe fn worker_init_dsm(
+    coordinate: *mut c_void,
+    region_total: u64,
+    worker_number: i32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<MppExecutionState, String> {
+    if coordinate.is_null() {
+        return Err("mpp: worker_init_dsm given null coordinate".into());
+    }
+    let worker = unsafe { attach_mpp_dsm_worker(coordinate, region_total, worker_number, seg)? };
+    Ok(MppExecutionState::Worker(worker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::postgres::customscan::mpp::mesh::aligned_queue_bytes;
+
+    #[test]
+    fn default_queue_bytes_is_maxalign_safe() {
+        // The GUC default (64 MiB) must be a multiple of MAXIMUM_ALIGNOF so
+        // `aligned_queue_bytes` is a no-op for the default and the queue
+        // capacity reported to operators matches what `shm_mq` actually uses.
+        let default = 64 * 1024 * 1024;
+        let aligned = aligned_queue_bytes(default);
+        assert_eq!(aligned, default);
+    }
+
+    #[test]
+    fn mpp_worker_count_clamps_below_two() {
+        // GUC default is 2; the function shouldn't drop below 2 even if
+        // the GUC were set to 0 or 1 at runtime (which `mpp_is_active`
+        // filters before this is called, but defense-in-depth).
+        let n = mpp_worker_count();
+        assert!(n >= 2, "mpp_worker_count must clamp below 2; got {n}");
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! MPP queue mesh: DSM layout for the directed N×(N-1) shm_mq mesh.
 //!
 //! Every participant has `N-1` inbound and `N-1` outbound queues — one per
@@ -36,8 +37,10 @@
 //! are in this file so the full production transport stack lives next to the
 //! layout math.
 
-#![allow(dead_code)]
+use std::ptr;
+use std::thread::{self, ThreadId};
 
+use datafusion::common::DataFusionError;
 use pgrx::pg_sys;
 
 use crate::mpp_log;
@@ -47,7 +50,6 @@ use crate::parallel_worker::mqueue::{
 use crate::postgres::customscan::mpp::transport::{
     BatchChannelReceiver, BatchChannelSender, RecvOutcome,
 };
-use datafusion::common::DataFusionError;
 
 /// Compute the linear slot index for a directed edge `src -> dst` in an
 /// N-participant mesh. `src == dst` is invalid (self-partition bypasses the
@@ -134,7 +136,7 @@ impl MeshLayout {
 /// itself self-disables in release.
 pub struct ShmMqSender {
     inner: MessageQueueSender,
-    attach_thread: std::thread::ThreadId,
+    attach_thread: ThreadId,
 }
 
 // SAFETY: see struct doc. Production callers keep the sender on the main
@@ -152,7 +154,7 @@ impl ShmMqSender {
         unsafe {
             Self {
                 inner: MessageQueueSender::new(seg, mq),
-                attach_thread: std::thread::current().id(),
+                attach_thread: thread::current().id(),
             }
         }
     }
@@ -161,7 +163,7 @@ impl ShmMqSender {
 impl BatchChannelSender for ShmMqSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
         debug_assert_eq!(
-            std::thread::current().id(),
+            thread::current().id(),
             self.attach_thread,
             "ShmMqSender::send_bytes called from a thread other than the one that \
              called attach(); shm_mq_send uses WaitLatch + CHECK_FOR_INTERRUPTS which \
@@ -185,7 +187,7 @@ impl BatchChannelSender for ShmMqSender {
 
     fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
         debug_assert_eq!(
-            std::thread::current().id(),
+            thread::current().id(),
             self.attach_thread,
             "ShmMqSender::try_send_bytes called from a thread other than the one that \
              called attach(); shm_mq_send touches process-global Postgres primitives \
@@ -255,7 +257,7 @@ impl ShmMqReceiver {
     pub unsafe fn attach_existing(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
         unsafe {
             pg_sys::shm_mq_set_receiver(mq, pg_sys::MyProc);
-            let handle = pg_sys::shm_mq_attach(mq, seg, std::ptr::null_mut());
+            let handle = pg_sys::shm_mq_attach(mq, seg, ptr::null_mut());
             Self {
                 inner: MessageQueueReceiver::from_raw_handle(handle),
             }
@@ -285,6 +287,7 @@ impl BatchChannelReceiver for ShmMqReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn edge_slot_packs_without_self_edges() {
@@ -319,7 +322,7 @@ mod tests {
     fn edge_slot_is_injective() {
         // Every (src, dst) pair maps to a unique slot in [0, N*(N-1))
         for n in [2u32, 3, 4, 5, 8] {
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::new();
             for src in 0..n {
                 for dst in 0..n {
                     if src == dst {

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP queue mesh: DSM layout for the directed N×(N-1) shm_mq mesh.
 //!
 //! Every participant has `N-1` inbound and `N-1` outbound queues — one per

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod mesh;
 pub mod session;
+pub mod shape;
 pub mod shuffle;
 pub mod transport;
 pub mod worker;

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -25,11 +25,15 @@
 //! that reads all inbound queues into a spillable local buffer — this decouples
 //! consumer-side backpressure from producer-side backpressure.
 
+pub mod coordinator;
+pub mod customscan_glue;
 pub mod mesh;
+pub mod plan_build;
 pub mod session;
 pub mod shape;
 pub mod shuffle;
 pub mod transport;
+pub mod walker;
 pub mod worker;
 
 use serde::{Deserialize, Serialize};
@@ -39,7 +43,6 @@ use serde::{Deserialize, Serialize};
 /// Injected into the DataFusion `SessionConfig` via `config_options` so downstream
 /// operators (optimizer rules, hash partitioners) can discover it without an
 /// out-of-band side channel.
-#[allow(dead_code)]
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MppParticipantConfig {
     /// 0-based index of this participant. The leader is always index 0.
@@ -60,7 +63,7 @@ pub struct MppParticipantConfig {
 /// set, the provider calls `reader.search_segments(sharded_ids)` and each
 /// participant reads only its share of segments.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
+#[allow(dead_code)] // consumed by aggregatescan/joinscan in #4932/#4872
 pub struct MppShardConfig {
     pub participant_index: u32,
     pub total_participants: u32,

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -63,7 +63,6 @@ pub struct MppParticipantConfig {
 /// set, the provider calls `reader.search_segments(sharded_ids)` and each
 /// participant reads only its share of segments.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // consumed by aggregatescan/joinscan in #4932/#4872
 pub struct MppShardConfig {
     pub participant_index: u32,
     pub total_participants: u32,

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP physical-plan primitives.
 //!
 //! [`wrap_with_mpp_shuffle`] wraps a child plan in an [`MppShuffleExec`].

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -1,0 +1,245 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! MPP physical-plan primitives.
+//!
+//! [`wrap_with_mpp_shuffle`] wraps a child plan in an [`MppShuffleExec`].
+//! For a representative scalar-agg-over-join query, the per-worker plan is:
+//!
+//! ```text
+//!     AggregateExec(Partial, COUNT(*))            ← emits one partial row per worker
+//!       HashJoinExec(PartitionMode::Partitioned)
+//!         wrap_with_mpp_shuffle([Scan f → Filter], hash=[f.id])
+//!         wrap_with_mpp_shuffle([Scan p         ], hash=[p.fileId])
+//! ```
+//!
+//! Each wrap consumes one directed mesh edge — a binary hash-join needs two
+//! independent meshes (one per side). PG's `Gather` + `Finalize Aggregate`
+//! handle the cross-worker reduction.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+
+use crate::postgres::customscan::mpp::shuffle::{MppShuffleExec, ShuffleWiring};
+use crate::postgres::customscan::mpp::transport::DrainHandle;
+use datafusion_distributed::{NetworkBoundary, Stage};
+
+/// Inputs to [`wrap_with_mpp_shuffle`].
+pub struct MppShuffleInputs {
+    /// Plan whose output rows the shuffle consumes.
+    pub child: Arc<dyn ExecutionPlan>,
+    /// Outbound half of this participant's mesh edge.
+    pub wiring: ShuffleWiring,
+    /// Inbound half (peer-shipped rows).
+    pub drain_handle: Arc<DrainHandle>,
+    /// Schema both `child.schema()` and peer Arrow IPC batches resolve to.
+    pub wrapped_schema: SchemaRef,
+    /// Diagnostic label used in `mpp_log!` row-count reports.
+    pub tag: &'static str,
+    /// Stage descriptor stamped onto the emitted [`MppShuffleExec`].
+    pub stage: Option<Stage>,
+    /// `Some(keys)` → `Partitioning::Hash(keys, N)`; `None` →
+    /// `UnknownPartitioning(1)` (scalar-final gather).
+    pub hash_keys: Option<Vec<Arc<dyn PhysicalExpr>>>,
+    /// Output partition that does the producer + drain work on this
+    /// participant. Hash shuffles: `participant_index`. Fixed-target:
+    /// the target on every participant.
+    pub drive_partition: u32,
+}
+
+/// Wrap `child` in a single [`MppShuffleExec`] that consumes both mesh
+/// halves and merges the producer + drain streams on `drive_partition`.
+/// Other partitions return empty. See [`MppShuffleInputs`] for fields.
+pub fn wrap_with_mpp_shuffle(
+    inputs: MppShuffleInputs,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let MppShuffleInputs {
+        child,
+        wiring,
+        drain_handle,
+        wrapped_schema,
+        tag,
+        stage,
+        hash_keys,
+        drive_partition,
+    } = inputs;
+    let _ = wrapped_schema; // Schema is inferred from `child.schema()`.
+
+    // Coalesce multi-partition children: the shuffle producer only consumes
+    // partition 0, so without this every partition beyond the first is
+    // silently dropped — produces correct group counts but wrong per-group
+    // aggregates.
+    let child: Arc<dyn ExecutionPlan> = if child.output_partitioning().partition_count() > 1 {
+        Arc::new(CoalescePartitionsExec::new(child))
+    } else {
+        child
+    };
+
+    let shuffle_node =
+        MppShuffleExec::new(child, wiring, drain_handle, hash_keys, drive_partition, tag);
+    match stage {
+        Some(s) => NetworkBoundary::with_input_stage(&shuffle_node, s),
+        None => Ok(Arc::new(shuffle_node)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::shuffle::tests::ModuloPartitioner;
+    use crate::postgres::customscan::mpp::transport::{
+        in_proc_channel, DrainBuffer, DrainConfig, DrainItem, MppReceiver, MppSender,
+    };
+    use datafusion::arrow::array::{Int32Array, RecordBatch, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::physical_plan::ExecutionPlanProperties;
+    use datafusion::prelude::SessionContext;
+    use futures::StreamExt;
+    use std::thread;
+    use std::time::Duration;
+
+    fn sample_batch(rows: i32) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..rows);
+        let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
+    }
+
+    /// Drive a two-participant mesh in-process: our side shuffles a 10-row
+    /// input at participant 0 with `ModuloPartitioner(2)`, a simulated peer ships
+    /// synthetic batches into our inbound drain. The wrapped stream should
+    /// emit:
+    ///
+    /// - self-partition rows (even IDs: 0,2,4,6,8)
+    /// - peer-partition rows (synthetic IDs 100,200 from the peer)
+    ///
+    /// and the outbound channel should carry the odd IDs that ShuffleExec
+    /// shipped away (1,3,5,7,9).
+    #[test]
+    fn wrap_with_mpp_shuffle_splices_self_and_peer() {
+        let batch = sample_batch(10);
+        let schema = batch.schema();
+        let input = MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap();
+
+        let (out_tx, out_rx) = in_proc_channel(16);
+        let (in_tx, in_rx) = in_proc_channel(16);
+
+        let wiring = ShuffleWiring {
+            partitioner: Arc::new(ModuloPartitioner::new(2)),
+            outbound_senders: vec![None, Some(MppSender::new(Box::new(out_tx)))],
+            participant_index: 0,
+            cooperative_drain: None,
+        };
+
+        // Simulated peer: ship two synthetic batches with a small delay so
+        // the drain thread actually waits on the waker path at least once.
+        let peer_schema = schema.clone();
+        let peer_thread = thread::spawn(move || {
+            let sender = MppSender::new(Box::new(in_tx));
+            for (id, name) in [(100i32, "peer100"), (200i32, "peer200")] {
+                thread::sleep(Duration::from_millis(10));
+                let b = RecordBatch::try_new(
+                    peer_schema.clone(),
+                    vec![
+                        Arc::new(Int32Array::from_iter_values([id])),
+                        Arc::new(StringArray::from_iter_values([name.to_string()])),
+                    ],
+                )
+                .unwrap();
+                sender.send_batch(&b).unwrap();
+            }
+        });
+
+        let inbound_recv = MppReceiver::new(Box::new(in_rx));
+        let drain_buffer = DrainBuffer::new(1);
+        let drain_handle = DrainHandle::spawn(DrainConfig::new(
+            vec![inbound_recv],
+            Arc::clone(&drain_buffer),
+        ));
+
+        let wrapped = wrap_with_mpp_shuffle(MppShuffleInputs {
+            child: input,
+            wiring,
+            drain_handle: Arc::new(drain_handle),
+            wrapped_schema: schema.clone(),
+            tag: "test",
+            stage: None,
+            hash_keys: None,
+            drive_partition: 0,
+        })
+        .unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let ctx = SessionContext::new();
+
+        let mut emitted_ids = Vec::new();
+        rt.block_on(async {
+            let n = wrapped.output_partitioning().partition_count();
+            for p in 0..n {
+                let mut s = wrapped.execute(p, ctx.task_ctx()).unwrap();
+                while let Some(b) = s.next().await {
+                    let b = b.unwrap();
+                    let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+                    emitted_ids.extend(ids.values().iter().copied());
+                }
+            }
+        });
+
+        // Drain the outbound channel to verify the peer-destined rows
+        // actually got shipped.
+        let out_receiver = MppReceiver::new(Box::new(out_rx));
+        let out_buffer = DrainBuffer::new(1);
+        let out_handle = DrainHandle::spawn(DrainConfig::new(
+            vec![out_receiver],
+            Arc::clone(&out_buffer),
+        ));
+        let mut outbound_ids = Vec::new();
+        while let DrainItem::Batch(b) = out_buffer.pop_front() {
+            outbound_ids.extend(
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied(),
+            );
+        }
+        out_handle.shutdown().unwrap();
+        peer_thread.join().unwrap();
+
+        // Union output: self-partition (even IDs) + peer-simulated (100, 200).
+        emitted_ids.sort();
+        assert_eq!(emitted_ids, vec![0, 2, 4, 6, 8, 100, 200]);
+        // Outbound: ShuffleExec shipped odd IDs (rows that hashed to participant 1).
+        outbound_ids.sort();
+        assert_eq!(outbound_ids, vec![1, 3, 5, 7, 9]);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Plan broadcast codec for MPP.
 //!
 //! The leader builds a DataFusion `LogicalPlan`, serializes it via the existing

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! Plan broadcast codec for MPP.
 //!
 //! The leader builds a DataFusion `LogicalPlan`, serializes it via the existing
@@ -31,8 +32,7 @@
 //! participant index at physical-planning time. Participant identity comes
 //! from the worker's position in the mesh, not from the plan encoding.
 
-#![allow(dead_code)]
-
+use pgrx::pg_sys;
 use serde::{Deserialize, Serialize};
 
 use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
@@ -76,6 +76,24 @@ impl From<SessionContextProfile> for MppSessionProfile {
 /// tag fields, so we do our own versioning.
 pub const MPP_PLAN_BROADCAST_VERSION: u8 = 1;
 
+/// Per-query identifier for the boundary [`Stage::query_id`] (low 64 bits;
+/// see [`walker::emit_shuffle_cut`]) and every [`MppTaskKey::query_id`].
+/// Derived on the leader from
+/// `MyProcPid` and `GetCurrentStatementStartTimestamp`. `u64` is enough:
+/// the bottom 32 bits (timestamp µs, wraps every ~71 min) distinguish
+/// sequential queries in one backend; `pid ^ (ts >> 32)` in the top 32
+/// bits separates simultaneous queries across backends.
+///
+/// SAFETY: both FFI calls are valid on the backend thread, which is where
+/// the leader always runs during plan stash.
+pub fn derive_query_id() -> u64 {
+    unsafe {
+        let pid = pg_sys::MyProcPid as u32 as u64;
+        let ts = pg_sys::GetCurrentStatementStartTimestamp() as u64;
+        ts ^ (pid << 32)
+    }
+}
+
 /// Bundle the leader writes into DSM at query start; every worker reads the
 /// same bytes and reconstructs its own `MppParticipantConfig` from its
 /// participant index.
@@ -105,6 +123,15 @@ pub struct MppPlanBroadcast {
     pub logical_plan: Vec<u8>,
     pub total_participants: u32,
     pub session_profile: MppSessionProfile,
+    /// Per-query identifier stamped on every boundary [`Stage`] (as the
+    /// low 64 bits of [`Stage::query_id`]) and every [`MppTaskKey`].
+    /// Workers reuse the same value so mesh framing agrees across
+    /// participants. Leader fills via [`derive_query_id`].
+    ///
+    /// [`Stage`]: datafusion_distributed::Stage
+    /// [`Stage::query_id`]: datafusion_distributed::Stage::query_id
+    /// [`MppTaskKey`]: super::stage::MppTaskKey
+    pub query_id: u64,
 }
 
 impl MppPlanBroadcast {
@@ -112,12 +139,14 @@ impl MppPlanBroadcast {
         logical_plan: Vec<u8>,
         total_participants: u32,
         session_profile: MppSessionProfile,
+        query_id: u64,
     ) -> Self {
         Self {
             version: MPP_PLAN_BROADCAST_VERSION,
             logical_plan,
             total_participants,
             session_profile,
+            query_id,
         }
     }
 
@@ -180,17 +209,19 @@ mod tests {
             vec![0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe],
             4,
             MppSessionProfile::Aggregate,
+            0x1234_5678_9abc_def0,
         );
         let bytes = orig.serialize().expect("serialize");
         let decoded = MppPlanBroadcast::deserialize(&bytes).expect("deserialize");
         assert_eq!(decoded.logical_plan, orig.logical_plan);
         assert_eq!(decoded.total_participants, orig.total_participants);
         assert_eq!(decoded.session_profile, orig.session_profile);
+        assert_eq!(decoded.query_id, orig.query_id);
     }
 
     #[test]
     fn participant_config_differs_per_participant_index() {
-        let bc = MppPlanBroadcast::new(vec![], 3, MppSessionProfile::Join);
+        let bc = MppPlanBroadcast::new(vec![], 3, MppSessionProfile::Join, 0);
         let leader = bc.participant_config(0);
         let w1 = bc.participant_config(1);
         let w2 = bc.participant_config(2);
@@ -204,7 +235,7 @@ mod tests {
 
     #[test]
     fn deserialize_rejects_truncated_bytes() {
-        let orig = MppPlanBroadcast::new(vec![1, 2, 3, 4], 2, MppSessionProfile::Join);
+        let orig = MppPlanBroadcast::new(vec![1, 2, 3, 4], 2, MppSessionProfile::Join, 0);
         let bytes = orig.serialize().unwrap();
         // Truncate by removing the last byte — should not round-trip.
         let truncated = &bytes[..bytes.len() - 1];
@@ -213,7 +244,7 @@ mod tests {
 
     #[test]
     fn deserialize_rejects_version_mismatch() {
-        let mut orig = MppPlanBroadcast::new(vec![1, 2, 3], 2, MppSessionProfile::Join);
+        let mut orig = MppPlanBroadcast::new(vec![1, 2, 3], 2, MppSessionProfile::Join, 0);
         orig.version = MPP_PLAN_BROADCAST_VERSION.wrapping_add(1);
         let bytes = orig.serialize().unwrap();
         let err = MppPlanBroadcast::deserialize(&bytes).expect_err("version mismatch must reject");
@@ -233,7 +264,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "participant_index")]
     fn participant_config_panics_on_out_of_bounds_index() {
-        let bc = MppPlanBroadcast::new(vec![], 2, MppSessionProfile::Join);
+        let bc = MppPlanBroadcast::new(vec![], 2, MppSessionProfile::Join, 0);
         // Participant index 2 is out of bounds for total_participants=2;
         // panic at boot time beats a silently dropped partition in
         // production.
@@ -246,7 +277,7 @@ mod tests {
         let big = (0..10_000u32)
             .map(|i| (i % 251) as u8) // non-trivial pattern
             .collect::<Vec<u8>>();
-        let orig = MppPlanBroadcast::new(big.clone(), 2, MppSessionProfile::Aggregate);
+        let orig = MppPlanBroadcast::new(big.clone(), 2, MppSessionProfile::Aggregate, 0xCAFE);
         let bytes = orig.serialize().unwrap();
         let decoded = MppPlanBroadcast::deserialize(&bytes).unwrap();
         assert_eq!(decoded.logical_plan, big);

--- a/pg_search/src/postgres/customscan/mpp/shape.rs
+++ b/pg_search/src/postgres/customscan/mpp/shape.rs
@@ -1,0 +1,272 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! MPP plan-shape classifier.
+//!
+//! Classifies a logical plan into a topology shape so `aggregatescan` /
+//! `joinscan` can decide MPP eligibility and DSM mesh size. The walker
+//! ([`super::walker::distribute_plan`]) re-derives the same shape from
+//! plan structure and uses the classifier's output only as a cross-check.
+//!
+//! Shapes:
+//!
+//! * [`MppPlanShape::ScalarAggOnBinaryJoin`] — `COUNT(*) FROM f JOIN p`.
+//!   Per worker: shuffle → HashJoin → Partial. Partials gather to the
+//!   leader's `FinalPartitioned`; workers emit zero rows.
+//! * [`MppPlanShape::GroupByAggOnBinaryJoin`] — `SELECT k, COUNT(*) … GROUP BY k`.
+//!   Per worker: shuffle → HashJoin → Partial → group-key shuffle →
+//!   `FinalPartitioned`. Each worker emits its hash partition's groups.
+//! * [`MppPlanShape::GroupByAggSingleTable`] — single-table GROUP BY.
+//!   Classified but not yet plumbed through the walker.
+//! * [`MppPlanShape::JoinOnly`] — bare join, no aggregate.
+//! * [`MppPlanShape::Ineligible`] — non-MPP serial fallback.
+
+use crate::scan::info::RowEstimate;
+
+/// MPP topology shape. Note `TopKGroupByAggOnBinaryJoin` is never produced
+/// by [`classify`] — the logical plan doesn't reveal whether DataFusion's
+/// physical planner will fuse `Sort[fetch=k]` over the aggregate. The
+/// walker's dispatcher upgrades to it when the physical plan shows that
+/// fusion; the variant lives here so the rest of the chain can `match` on
+/// one enum.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum MppPlanShape {
+    ScalarAggOnBinaryJoin,
+    GroupByAggOnBinaryJoin,
+    /// `GroupByAggOnBinaryJoin` + outer `ORDER BY agg LIMIT k`. Topology is
+    /// scalar-style: post-Partial gathers every participant to participant 0
+    /// (`FixedTargetPartitioner(0)`); the leader wraps with
+    /// `FinalPartitioned + SortExec[fetch=k]` to resolve the global Top-K.
+    /// Workers emit zero rows.
+    TopKGroupByAggOnBinaryJoin,
+    GroupByAggSingleTable,
+    JoinOnly,
+    Ineligible,
+}
+
+impl MppPlanShape {
+    /// Shapes that shuffle both sides of a binary join, hence have a
+    /// "broadcast candidate" (the smaller side) where a row-estimate cost
+    /// gate makes sense — if the smaller side is small, broadcast-join
+    /// beats MPP. Single-table shapes have no candidate and skip the gate.
+    pub fn is_binary_join(&self) -> bool {
+        matches!(
+            self,
+            MppPlanShape::JoinOnly
+                | MppPlanShape::ScalarAggOnBinaryJoin
+                | MppPlanShape::GroupByAggOnBinaryJoin
+        )
+    }
+}
+
+/// Broadcast-side MPP cost gate. Returns `Some(n)` (caller skips MPP) when
+/// the smallest known-side estimate is below `min_rows`; `None` when the
+/// gate is disabled (`min_rows <= 0`), no side has a `Known` estimate
+/// (un-ANALYZE'd tables shouldn't silently bypass MPP), or the smallest
+/// known estimate meets the threshold. Only meaningful for binary joins.
+pub fn broadcast_side_gate(estimates: &[RowEstimate], min_rows: i32) -> Option<u64> {
+    if min_rows <= 0 {
+        return None;
+    }
+    let threshold = min_rows as u64;
+    let smallest_known = estimates
+        .iter()
+        .filter_map(|e| match e {
+            RowEstimate::Known(n) => Some(*n),
+            RowEstimate::Unknown => None,
+        })
+        .min()?;
+    (smallest_known < threshold).then_some(smallest_known)
+}
+
+/// Shape-classification inputs. Kept as plain fields rather than a reference
+/// to a larger state so callers can construct it from whatever they have
+/// (RelNode walk, AggregateCSClause inspection, test synthetic data).
+#[derive(Debug, Clone)]
+pub struct ClassifyInputs {
+    /// Number of tables in the join. 0 = no join, 1 = single table,
+    /// 2 = binary join, >=3 = multi-table join.
+    pub n_join_tables: usize,
+    /// True if the query has at least one GROUP BY expression the MPP
+    /// shuffle can hash-partition on. Callers must exclude group-by
+    /// expressions whose value is not stable across workers (volatile
+    /// functions, session-dependent casts) — those break the "each group
+    /// lives on exactly one worker" invariant.
+    pub has_group_by: bool,
+    /// True if every aggregate function in the targetlist is one of
+    /// COUNT/SUM/MIN/MAX/AVG/BOOL_*/STDDEV_*/VAR_* — the set with a safe
+    /// Partial/Final split. `false` for COUNT(DISTINCT), ARRAY_AGG,
+    /// STRING_AGG, ordered-set, hypothetical-set aggregates. When
+    /// `has_aggregate=false`, this field is irrelevant and callers
+    /// conventionally pass `true`.
+    pub all_aggregates_splittable: bool,
+    /// True if the query has at least one aggregate (COUNT, SUM, …). When
+    /// `false`, we're classifying a join-only shape.
+    pub has_aggregate: bool,
+}
+
+/// Classify the query into an [`MppPlanShape`].
+///
+/// Rules (all implicitly `AND`-ed):
+///   * Two tables + has_aggregate + splittable: binary-join aggregate.
+///     Split further on `has_group_by` to pick scalar vs group-by topology.
+///   * One table + has_aggregate + group_by + splittable:
+///     single-table group-by aggregate (post-Partial shuffle helps when
+///     cardinality is high).
+///   * Two tables + no_aggregate: join-only.
+///   * Otherwise: Ineligible.
+pub fn classify(inputs: &ClassifyInputs) -> MppPlanShape {
+    if !inputs.all_aggregates_splittable && inputs.has_aggregate {
+        return MppPlanShape::Ineligible;
+    }
+    match (
+        inputs.n_join_tables,
+        inputs.has_aggregate,
+        inputs.has_group_by,
+    ) {
+        (2, true, false) => MppPlanShape::ScalarAggOnBinaryJoin,
+        (2, true, true) => MppPlanShape::GroupByAggOnBinaryJoin,
+        (1, true, true) => MppPlanShape::GroupByAggSingleTable,
+        (2, false, _) => MppPlanShape::JoinOnly,
+        _ => MppPlanShape::Ineligible,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs(n: usize, agg: bool, gb: bool, splittable: bool) -> ClassifyInputs {
+        ClassifyInputs {
+            n_join_tables: n,
+            has_group_by: gb,
+            all_aggregates_splittable: splittable,
+            has_aggregate: agg,
+        }
+    }
+
+    #[test]
+    fn binary_scalar_agg() {
+        assert_eq!(
+            classify(&inputs(2, true, false, true)),
+            MppPlanShape::ScalarAggOnBinaryJoin
+        );
+    }
+
+    #[test]
+    fn binary_groupby_agg() {
+        assert_eq!(
+            classify(&inputs(2, true, true, true)),
+            MppPlanShape::GroupByAggOnBinaryJoin
+        );
+    }
+
+    #[test]
+    fn single_groupby() {
+        assert_eq!(
+            classify(&inputs(1, true, true, true)),
+            MppPlanShape::GroupByAggSingleTable
+        );
+    }
+
+    #[test]
+    fn join_only() {
+        assert_eq!(
+            classify(&inputs(2, false, false, true)),
+            MppPlanShape::JoinOnly
+        );
+    }
+
+    #[test]
+    fn non_splittable_aggregate_is_ineligible() {
+        assert_eq!(
+            classify(&inputs(2, true, false, false)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn three_table_join_is_ineligible() {
+        assert_eq!(
+            classify(&inputs(3, true, false, true)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn is_binary_join_covers_all_join_shapes() {
+        assert!(MppPlanShape::JoinOnly.is_binary_join());
+        assert!(MppPlanShape::ScalarAggOnBinaryJoin.is_binary_join());
+        assert!(MppPlanShape::GroupByAggOnBinaryJoin.is_binary_join());
+        assert!(!MppPlanShape::GroupByAggSingleTable.is_binary_join());
+        assert!(!MppPlanShape::Ineligible.is_binary_join());
+    }
+
+    mod broadcast_gate {
+        use super::super::broadcast_side_gate;
+        use crate::scan::info::RowEstimate;
+
+        #[test]
+        fn skips_mpp_when_smallest_side_below_threshold() {
+            let est = [RowEstimate::Known(500), RowEstimate::Known(1_000_000)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), Some(500));
+        }
+
+        #[test]
+        fn allows_mpp_when_all_sides_meet_threshold() {
+            let est = [RowEstimate::Known(50_000), RowEstimate::Known(1_000_000)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), None);
+        }
+
+        #[test]
+        fn allows_mpp_at_exact_threshold() {
+            let est = [RowEstimate::Known(10_000), RowEstimate::Known(1_000_000)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), None);
+        }
+
+        #[test]
+        fn disabled_when_threshold_is_zero() {
+            let est = [RowEstimate::Known(1), RowEstimate::Known(2)];
+            assert_eq!(broadcast_side_gate(&est, 0), None);
+        }
+
+        #[test]
+        fn disabled_when_threshold_is_negative() {
+            let est = [RowEstimate::Known(1)];
+            assert_eq!(broadcast_side_gate(&est, -1), None);
+        }
+
+        #[test]
+        fn allows_mpp_when_no_known_estimates() {
+            // Un-ANALYZE'd tables: don't silently gate MPP off.
+            let est = [RowEstimate::Unknown, RowEstimate::Unknown];
+            assert_eq!(broadcast_side_gate(&est, 10_000), None);
+        }
+
+        #[test]
+        fn ignores_unknown_when_some_sides_known() {
+            let est = [RowEstimate::Unknown, RowEstimate::Known(100)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), Some(100));
+        }
+
+        #[test]
+        fn empty_estimates_returns_none() {
+            assert_eq!(broadcast_side_gate(&[], 10_000), None);
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/shape.rs
+++ b/pg_search/src/postgres/customscan/mpp/shape.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP plan-shape classifier.
 //!
 //! Classifies a logical plan into a topology shape so `aggregatescan` /

--- a/pg_search/src/postgres/customscan/mpp/shuffle.rs
+++ b/pg_search/src/postgres/customscan/mpp/shuffle.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Shuffle operator primitives for MPP.
 //!
 //! [`MppShuffleExec`] declares `Partitioning::Hash(keys, N)` natively (or

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -1,0 +1,2030 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Generic cut walker (`distribute_plan`).
+//!
+//! [`distribute_plan`] is the single entry point: turns a standard DataFusion
+//! physical plan into its MPP equivalent. Cut detection derives the topology
+//! from plan structure (locate `HashJoinExec` and any `AggregateExec(Partial|Single)`
+//! above it). The caller's [`MppPlanShape`] is a cross-check, plus DSM
+//! region sizing at plan time via [`cut_count_for_shape`].
+//!
+//! # Visibility correctness (invariant enforced here)
+//!
+//! `VisibilityFilterExec` resolves per-segment DocAddresses to heap TIDs
+//! using segment-local Tantivy state and a ctid-resolver keyed by segments
+//! **local to this participant**. Every `ShuffleExec` cut must sit inside
+//! the subtree of every `VisibilityFilterExec`, never below one — otherwise
+//! a row from participant A would reach B's resolver and look up the wrong
+//! heap TID (or panic in `heap_fetch`). [`assert_visibility_invariant`]
+//! walks the finished plan and aborts with `DataFusionError::Plan` if
+//! violated. (Same constraint applies in principle to other segment-local
+//! adornments — `SegmentedTopKExec`, `TantivyLookupExec`; only
+//! `VisibilityFilterExec` is asserted today because it's the one that
+//! crashes `heap_fetch`.)
+
+// `CoalesceBatchesExec` is deprecated in favor of arrow-rs's streaming
+// `BatchCoalescer`, but DataFusion 52 still emits it; we recognise + reuse it.
+#![allow(deprecated)]
+
+#[cfg(test)]
+use datafusion_distributed::require_one_child;
+use datafusion_distributed::{
+    annotate_plan_sync, distribute_annotated_plan, register_network_boundary_extractor,
+    BoundaryKind, DistributedConfig, NetworkBoundary, PooledBoundaryFactory,
+};
+#[cfg(test)]
+use datafusion_distributed::{AnnotatedPlan, PlanOrNetworkBoundary};
+use std::mem;
+use std::sync::{Arc, OnceLock};
+use uuid::Uuid;
+
+#[cfg(test)]
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::{DataFusionError, Result as DfResult};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{Partitioning, PhysicalExpr};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+use datafusion::physical_plan::limit::GlobalLimitExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::ExecutionPlan;
+
+use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
+use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
+
+use super::customscan_glue::MppExecutionState;
+use super::plan_build::{wrap_with_mpp_shuffle, MppShuffleInputs};
+use super::shape::MppPlanShape;
+use super::shuffle::{
+    FixedTargetPartitioner, HashPartitioner, MppShuffleExec, RowPartitioner, ShuffleWiring,
+};
+use super::transport::{DrainBuffer, DrainHandle, MppReceiver, MppSender};
+use super::worker::{LeaderMesh, WorkerMesh};
+use crate::scan::execution_plan::PgSearchScanPlan;
+use datafusion_distributed::Stage;
+
+/// How many shuffle cuts the walker will insert for `shape`. Called by the
+/// DSM-estimate hooks in `aggregatescan/mod.rs` and `joinscan/mod.rs` at
+/// plan time to size the shared-memory region before the walker has a
+/// concrete plan to inspect.
+pub fn cut_count_for_shape(shape: MppPlanShape) -> u32 {
+    match shape {
+        MppPlanShape::ScalarAggOnBinaryJoin => 3,
+        MppPlanShape::GroupByAggOnBinaryJoin => 3,
+        // TopK groupby reuses scalar-style routing (FixedTargetPartitioner
+        // postagg → leader gathers all groups), so 3 cuts: left, right,
+        // postagg-to-leader.
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => 3,
+        MppPlanShape::JoinOnly => 2,
+        MppPlanShape::GroupByAggSingleTable => 1,
+        MppPlanShape::Ineligible => 0,
+    }
+}
+
+/// Walk `standard`, insert `ShuffleExec` / `DrainGatherExec` pairs at the
+/// cut points, and stamp each with an input [`Stage`]. `shape` is
+/// cross-checked against the structural derivation; mismatch aborts with
+/// `DataFusionError::Plan`. Returns after [`assert_visibility_invariant`]
+/// passes — see module doc for the invariant.
+pub fn distribute_plan(
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+    shape: MppPlanShape,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let total = mpp_state.participant_config().total_participants;
+
+    crate::mpp_log!(
+        "mpp: distribute_plan walker dispatching shape={:?} total={} cuts={}",
+        shape,
+        total,
+        cut_count_for_shape(shape)
+    );
+
+    // Derive topology from plan structure. `find_partial_agg` walks through
+    // `AggregateExec(Final*)` / `CoalescePartitionsExec` / `CoalesceBatchesExec`
+    // layers to reach a `Partial|Single` aggregate; `find_hash_join` does the
+    // same to reach a `HashJoinExec`. Combined presence of the two + whether
+    // the partial agg has group-by keys picks one of three assemblers.
+    let partial_agg_opt = find_partial_agg(standard.as_ref());
+    let hash_join_opt = find_hash_join(standard.as_ref());
+
+    // Detect TopK structure before dispatch. Cheap walk; only relevant
+    // when there's a Partial+HashJoin pair below an outer Sort/Limit.
+    let topk_spec = if partial_agg_opt.is_some() && hash_join_opt.is_some() {
+        extract_topk_spec(standard.as_ref())
+    } else {
+        None
+    };
+
+    let built = match (partial_agg_opt, hash_join_opt) {
+        // Partial agg with empty group keys on top of a HashJoin — scalar agg.
+        (Some(agg), Some(_)) if agg.group_expr().expr().is_empty() => {
+            validate_shape_matches(shape, MppPlanShape::ScalarAggOnBinaryJoin)?;
+            distribute_plan_generic(
+                MppPlanShape::ScalarAggOnBinaryJoin,
+                standard,
+                mpp_state,
+                None,
+            )?
+        }
+        // Partial agg with group-by keys on top of a HashJoin AND an
+        // outer SortExec[fetch=k] — TopK group-by agg. The classifier
+        // (which only saw the logical plan) called this
+        // GroupByAggOnBinaryJoin; the structural derivation upgrades.
+        (Some(_), Some(_)) if topk_spec.is_some() => {
+            validate_shape_matches_topk_upgrade(shape)?;
+            distribute_plan_generic(
+                MppPlanShape::TopKGroupByAggOnBinaryJoin,
+                standard,
+                mpp_state,
+                topk_spec,
+            )?
+        }
+        // Partial agg with group-by keys on top of a HashJoin — group-by agg.
+        (Some(_), Some(_)) => {
+            validate_shape_matches(shape, MppPlanShape::GroupByAggOnBinaryJoin)?;
+            distribute_plan_generic(
+                MppPlanShape::GroupByAggOnBinaryJoin,
+                standard,
+                mpp_state,
+                None,
+            )?
+        }
+        // HashJoin without a Partial agg above — bare join.
+        (None, Some(_)) => {
+            validate_shape_matches(shape, MppPlanShape::JoinOnly)?;
+            distribute_plan_generic(MppPlanShape::JoinOnly, standard, mpp_state, None)?
+        }
+        // Partial agg without HashJoin — e.g. GroupByAggSingleTable, not yet
+        // wired.
+        (Some(_), None) => {
+            return Err(DataFusionError::Plan(
+                "mpp: distribute_plan: aggregate-on-single-table shape not yet implemented \
+                 (no HashJoinExec in plan)"
+                    .into(),
+            ));
+        }
+        // Neither — the caller's classifier should have routed to serial.
+        (None, None) => {
+            return Err(DataFusionError::Plan(
+                "mpp: distribute_plan invoked on an ineligible plan — no HashJoinExec \
+                 found; caller should have routed to the non-MPP serial path"
+                    .into(),
+            ));
+        }
+    };
+
+    assert_visibility_invariant(&built)?;
+    Ok(built)
+}
+
+/// Cross-check the pre-classified shape (from the planner) against the
+/// walker's structural derivation. Disagreement means either the planner
+/// mis-classified the query or the standard physical plan diverged from
+/// what the classifier saw — either way, executing anyway would produce
+/// wrong results for the shape we actually have.
+fn validate_shape_matches(classified: MppPlanShape, derived: MppPlanShape) -> DfResult<()> {
+    if classified == derived {
+        Ok(())
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "mpp: walker shape derivation mismatch — classifier said {classified:?} \
+             but plan structure implies {derived:?}"
+        )))
+    }
+}
+
+/// Accept the classifier's `GroupByAggOnBinaryJoin` as a valid match
+/// when the structural derivation upgrades to
+/// `TopKGroupByAggOnBinaryJoin`. The classifier only sees the logical
+/// plan and can't predict whether DataFusion's physical planner will
+/// fuse `Sort[fetch=k]` over the agg; the dispatcher refines based on
+/// the physical plan it actually got.
+fn validate_shape_matches_topk_upgrade(classified: MppPlanShape) -> DfResult<()> {
+    if matches!(classified, MppPlanShape::GroupByAggOnBinaryJoin) {
+        Ok(())
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "mpp: walker shape derivation mismatch — classifier said {classified:?} \
+             but plan structure implies TopKGroupByAggOnBinaryJoin (only \
+             GroupByAggOnBinaryJoin upgrades to TopK)"
+        )))
+    }
+}
+
+// ============================================================================
+// Generic cut walker. All three live shapes (`JoinOnly`,
+// `ScalarAggOnBinaryJoin`, `GroupByAggOnBinaryJoin`) flow through
+// `distribute_plan_generic` (`prepare_for_mpp` → `insert_mpp_cuts` →
+// `annotate_plan_sync` → `distribute_annotated_plan` → `finalize_for_mpp`).
+// `Ineligible` and `GroupByAggSingleTable` error out at the dispatcher.
+//
+// `annotate_plan_sync`, `AnnotatedPlan`, `PlanOrNetworkBoundary`,
+// `BoundaryFactory`, and `distribute_annotated_plan` are imported from the
+// `datafusion-distributed` fork. We use the fork's sync annotator (no
+// `DistributedConfig`, no `TaskEstimator`, no `Broadcast` arm) because
+// ParadeDB's participant count is fixed at plan time and we never emit
+// broadcast annotations — [`emit_mpp_boundary`] errors loudly if the
+// fork's walker ever asks for one.
+// ============================================================================
+
+/// Pre-pass: synthesize the `RepartitionExec(Hash)` / `CoalescePartitionsExec`
+/// markers `annotate_plan_sync` treats as cut triggers. ParadeDB's standard
+/// plan is single-partition and emits neither — so we add them per shape.
+/// Bottom-up traversal so descendant rewrites compose with ancestor ones.
+pub(super) fn insert_mpp_cuts(
+    plan: Arc<dyn ExecutionPlan>,
+    shape: MppPlanShape,
+    total_participants: u32,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let kind = match shape {
+        MppPlanShape::ScalarAggOnBinaryJoin => CutKind::ScalarAgg,
+        MppPlanShape::GroupByAggOnBinaryJoin => CutKind::GroupByAgg,
+        // TopK uses scalar-style postagg cut: wrap Partial in
+        // `CoalescePartitionsExec` so the walker emits a
+        // `FixedTargetPartitioner(0)` shuffle that ships every
+        // participant's groups to the leader. The leader's finalize
+        // wraps with `FinalPartitioned + SortExec[fetch=k]`.
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => CutKind::TopKGroupByAgg,
+        MppPlanShape::JoinOnly => CutKind::JoinOnly,
+        MppPlanShape::GroupByAggSingleTable => {
+            return Err(DataFusionError::Plan(
+                "mpp: insert_mpp_cuts: GroupByAggSingleTable not yet supported".into(),
+            ));
+        }
+        MppPlanShape::Ineligible => {
+            return Err(DataFusionError::Plan(
+                "mpp: insert_mpp_cuts invoked on Ineligible shape — caller should have \
+                 routed to the non-MPP serial path"
+                    .into(),
+            ));
+        }
+    };
+    rewrite_with_cuts(plan, kind, total_participants)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CutKind {
+    ScalarAgg,
+    GroupByAgg,
+    /// Like `ScalarAgg` topology-wise (CoalescePartitionsExec wrapping
+    /// → `FixedTargetPartitioner(0)` postagg), but the Partial may have
+    /// group keys; the leader resolves the global Top-K after gathering.
+    TopKGroupByAgg,
+    JoinOnly,
+}
+
+fn rewrite_with_cuts(
+    plan: Arc<dyn ExecutionPlan>,
+    kind: CutKind,
+    n: u32,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    // Recurse into children first so rewrites compose bottom-up.
+    let original_children: Vec<Arc<dyn ExecutionPlan>> =
+        plan.children().iter().map(|c| Arc::clone(c)).collect();
+    let new_children: Vec<Arc<dyn ExecutionPlan>> = original_children
+        .iter()
+        .map(|c| rewrite_with_cuts(Arc::clone(c), kind, n))
+        .collect::<DfResult<Vec<_>>>()?;
+
+    let any_child_changed = original_children
+        .iter()
+        .zip(new_children.iter())
+        .any(|(a, b)| !Arc::ptr_eq(a, b));
+    let plan = if any_child_changed {
+        Arc::clone(&plan).with_new_children(new_children)?
+    } else {
+        plan
+    };
+
+    // HashJoinExec — wrap its left / right inputs with RepartitionExec(Hash)
+    // so the DF-D walker sees Shuffle triggers there. Does *not* touch the
+    // join's own node type, mode, or keys — the join itself still runs
+    // locally on each participant, operating on shuffle-gathered inputs.
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        let join_on = hj.on().to_vec();
+        let left_keys: Vec<Arc<dyn PhysicalExpr>> =
+            join_on.iter().map(|(l, _)| Arc::clone(l)).collect();
+        let right_keys: Vec<Arc<dyn PhysicalExpr>> =
+            join_on.iter().map(|(_, r)| Arc::clone(r)).collect();
+
+        let new_left: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
+            Arc::clone(hj.left()),
+            Partitioning::Hash(left_keys, n as usize),
+        )?);
+        let new_right: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
+            Arc::clone(hj.right()),
+            Partitioning::Hash(right_keys, n as usize),
+        )?);
+        return Arc::clone(&plan).with_new_children(vec![new_left, new_right]);
+    }
+
+    // AggregateExec(Partial) — per-shape wrapping. Final/FinalPartitioned
+    // don't get wrapped; they're the stage above the cut.
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial) {
+            let group_exprs = agg.group_expr().expr();
+            match (kind, group_exprs.is_empty()) {
+                (CutKind::ScalarAgg, true) => {
+                    // Scalar agg: Coalesce trigger above the Partial.
+                    return Ok(Arc::new(CoalescePartitionsExec::new(plan)));
+                }
+                (CutKind::GroupByAgg, false) => {
+                    // Group-by agg: Shuffle trigger above the Partial,
+                    // hashed on the group-by keys.
+                    let group_keys: Vec<Arc<dyn PhysicalExpr>> =
+                        group_exprs.iter().map(|(e, _)| Arc::clone(e)).collect();
+                    return Ok(Arc::new(RepartitionExec::try_new(
+                        plan,
+                        Partitioning::Hash(group_keys, n as usize),
+                    )?));
+                }
+                // TopK group-by agg: same Coalesce trigger as ScalarAgg
+                // regardless of whether the Partial carries group keys.
+                // The leader will gather every participant's groups and
+                // run the global FinalPartitioned + SortExec[fetch=k].
+                (CutKind::TopKGroupByAgg, _) => {
+                    return Ok(Arc::new(CoalescePartitionsExec::new(plan)));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(plan)
+}
+
+/// `PooledBoundaryFactory` emit body: wires a pre-allocated mesh into an
+/// `MppShuffleExec` tagged for the shape + cut index. ParadeDB's `u64`
+/// `query_id` round-trips as the low 64 bits of the fork's UUID via
+/// `Uuid::from_u128(query_id as u128)`.
+#[allow(clippy::too_many_arguments)]
+fn emit_mpp_boundary(
+    kind: BoundaryKind,
+    mesh: MeshHalves,
+    child: Arc<dyn ExecutionPlan>,
+    stage_id: usize,
+    shape: MppPlanShape,
+    participant_index: u32,
+    total_participants: u32,
+    query_id: u64,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let cut_index = stage_id as u32;
+    let tag = tag_for_cut(shape, cut_index);
+    let stage = Stage::new_unaddressed(
+        Uuid::from_u128(query_id as u128),
+        cut_index as usize,
+        total_participants as usize,
+    );
+    let drain = spawn_drain(mesh.inbound);
+    let outbound = attach_cooperative_drain(mesh.outbound, &drain);
+
+    match kind {
+        BoundaryKind::Shuffle => {
+            let (partitioner, underlying, hash_keys) =
+                shuffle_keys_from_repartition(&child, total_participants)?;
+            let wiring = ShuffleWiring {
+                partitioner,
+                outbound_senders: outbound,
+                participant_index,
+                cooperative_drain: Some(Arc::clone(&drain)),
+            };
+            let wrapped_schema = underlying.schema();
+            wrap_with_mpp_shuffle(MppShuffleInputs {
+                child: underlying,
+                wiring,
+                drain_handle: drain,
+                wrapped_schema,
+                tag,
+                stage: Some(stage),
+                hash_keys: Some(hash_keys),
+                drive_partition: participant_index,
+            })
+        }
+        BoundaryKind::Coalesce => {
+            let partitioner: Arc<dyn RowPartitioner> =
+                Arc::new(FixedTargetPartitioner::new(0, total_participants));
+            let wiring = ShuffleWiring {
+                partitioner,
+                outbound_senders: outbound,
+                participant_index,
+                cooperative_drain: Some(Arc::clone(&drain)),
+            };
+            let wrapped_schema = child.schema();
+            wrap_with_mpp_shuffle(MppShuffleInputs {
+                child,
+                wiring,
+                drain_handle: drain,
+                wrapped_schema,
+                tag,
+                stage: Some(stage),
+                hash_keys: None,
+                drive_partition: 0,
+            })
+        }
+        BoundaryKind::Broadcast => Err(DataFusionError::Internal(
+            "mpp: emit_mpp_boundary: unexpected Broadcast emit — \
+             ParadeDB does not produce broadcast annotations"
+                .into(),
+        )),
+    }
+}
+
+/// `(HashPartitioner, underlying child, hash-key exprs)` returned by
+/// [`shuffle_keys_from_repartition`]. The exprs are forwarded into
+/// `MppShuffleExec` so the wrapped output declares `Partitioning::Hash(keys, N)`
+/// natively.
+type ShuffleEmitInputs = (
+    Arc<dyn RowPartitioner>,
+    Arc<dyn ExecutionPlan>,
+    Vec<Arc<dyn PhysicalExpr>>,
+);
+
+/// Extract `Hash(keys)` from the `RepartitionExec` marker `insert_mpp_cuts`
+/// placed below the `Shuffle` boundary, build a `HashPartitioner`, and
+/// return the underlying input (the `RepartitionExec` is dropped — the
+/// `ShuffleExec` replaces it). Errors as `DataFusionError::Plan` if the
+/// child isn't `RepartitionExec(Hash)` or any key isn't a plain `Column`.
+fn shuffle_keys_from_repartition(
+    child: &Arc<dyn ExecutionPlan>,
+    total_participants: u32,
+) -> DfResult<ShuffleEmitInputs> {
+    let r_exec = child
+        .as_any()
+        .downcast_ref::<RepartitionExec>()
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "mpp: _distribute_plan: Shuffle boundary expected RepartitionExec child \
+                 synthesized by insert_mpp_cuts"
+                    .into(),
+            )
+        })?;
+    let Partitioning::Hash(exprs, _n) = r_exec.partitioning() else {
+        return Err(DataFusionError::Plan(
+            "mpp: _distribute_plan: Shuffle boundary expected Partitioning::Hash; \
+             insert_mpp_cuts only synthesizes Hash repartitions"
+                .into(),
+        ));
+    };
+    let keys: Vec<usize> = exprs.iter().map(col_index).collect::<DfResult<Vec<_>>>()?;
+    let partitioner: Arc<dyn RowPartitioner> =
+        Arc::new(HashPartitioner::new(keys, total_participants));
+    Ok((partitioner, Arc::clone(r_exec.input()), exprs.clone()))
+}
+
+/// Map `(shape, post-order cut index)` to the diagnostic tag string used by
+/// `mpp_trace` and benchmark-log grep. Mis-indexed cuts fall through to
+/// `"mpp_unknown_cut"` (a panic would mask emit-arm regressions).
+fn tag_for_cut(shape: MppPlanShape, cut_index: u32) -> &'static str {
+    match (shape, cut_index) {
+        (MppPlanShape::JoinOnly, 0) => "join_left",
+        (MppPlanShape::JoinOnly, 1) => "join_right",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 0) => "scalar_left",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 1) => "scalar_right",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 2) => "scalar_final",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 0) => "gb_left",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 1) => "gb_right",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 2) => "gb_postagg",
+        (MppPlanShape::TopKGroupByAggOnBinaryJoin, 0) => "tk_left",
+        (MppPlanShape::TopKGroupByAggOnBinaryJoin, 1) => "tk_right",
+        (MppPlanShape::TopKGroupByAggOnBinaryJoin, 2) => "tk_final",
+        _ => "mpp_unknown_cut",
+    }
+}
+
+// ============================================================================
+// Generic MPP pipeline. `distribute_plan_generic` composes the shape-agnostic
+// walker (`insert_mpp_cuts` → `annotate_plan_sync` → `distribute_annotated_plan`)
+// with shape-specific pre-passes (`prepare_for_mpp`) and post-passes
+// (`finalize_for_mpp`). ParadeDB-specific obligations (dynamic-filter strip,
+// `PartitionMode::Partitioned` rebuild, `CoalesceBatchesExec(65_536)`,
+// leader-only `FinalPartitioned`, `VisibilityCtidResolverRule` re-run) live
+// in the pre/post passes; the walker body itself is shape-agnostic.
+// ============================================================================
+
+/// Sort + Limit info captured from the standard plan when the dispatcher
+/// upgrades a `GroupByAggOnBinaryJoin` query to
+/// `TopKGroupByAggOnBinaryJoin`. Re-applied on the leader by
+/// [`finalize_topk_groupby_agg`] after the post-agg gather.
+#[derive(Clone)]
+struct TopKSpec {
+    sort_expr: datafusion::physical_expr::LexOrdering,
+    fetch: usize,
+}
+
+/// Detect the TopK shape: outer `SortExec[fetch=k]` (DataFusion's fused
+/// TopK) or `GlobalLimitExec(SortExec)` above the Final aggregate. Walks
+/// only `SortExec` / `GlobalLimitExec` / `LocalLimitExec`; anything else
+/// stops the walk so the GroupByAgg dispatch handles it.
+fn extract_topk_spec(plan: &dyn ExecutionPlan) -> Option<TopKSpec> {
+    use datafusion::physical_plan::limit::LocalLimitExec;
+    let mut node = plan;
+    let mut limit: Option<usize> = None;
+    loop {
+        if let Some(sort) = node.as_any().downcast_ref::<SortExec>() {
+            // Prefer the SortExec's own fetch; fall back to a wrapping
+            // limit if SortExec didn't fuse the limit.
+            let fetch = sort.fetch().or(limit)?;
+            return Some(TopKSpec {
+                sort_expr: sort.expr().clone(),
+                fetch,
+            });
+        }
+        if let Some(g) = node.as_any().downcast_ref::<GlobalLimitExec>() {
+            limit = limit.or_else(|| g.fetch().map(|f| f + g.skip()));
+            node = g.input().as_ref();
+            continue;
+        }
+        if let Some(l) = node.as_any().downcast_ref::<LocalLimitExec>() {
+            limit = limit.or(Some(l.fetch()));
+            node = l.input().as_ref();
+            continue;
+        }
+        return None;
+    }
+}
+
+/// Run the generic pipeline: `prepare_for_mpp` → `insert_mpp_cuts` →
+/// `annotate_plan_sync` → `distribute_annotated_plan` (driven by
+/// [`PooledBoundaryFactory`]) → `finalize_for_mpp`.
+fn distribute_plan_generic(
+    shape: MppPlanShape,
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+    topk: Option<TopKSpec>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    debug_assert!(
+        topk.is_some() == matches!(shape, MppPlanShape::TopKGroupByAggOnBinaryJoin),
+        "topk spec must be Some iff shape is TopKGroupByAggOnBinaryJoin"
+    );
+    let participant_cfg = mpp_state.participant_config();
+    let participant_index = participant_cfg.participant_index;
+    let total_participants = participant_cfg.total_participants;
+    let query_id = mpp_state.query_id();
+    let expected_cuts = cut_count_for_shape(shape) as usize;
+
+    let prepared = prepare_for_mpp(shape, standard)?;
+    let with_cuts = insert_mpp_cuts(prepared, shape, total_participants)?;
+    let annotated = annotate_plan_sync(with_cuts, total_participants as usize)?;
+
+    // The walker's `stage_id` advances bottom-up once per emitted boundary,
+    // matching the post-order indexing `tag_for_cut` and `Stage::new_unaddressed`
+    // consume.
+    let meshes: Vec<MeshHalves> = take_meshes(mpp_state, expected_cuts);
+    let factory = PooledBoundaryFactory::new(
+        meshes,
+        move |kind, mesh, child, _qid, stage_id, _tc, _itc| {
+            emit_mpp_boundary(
+                kind,
+                mesh,
+                child,
+                stage_id,
+                shape,
+                participant_index,
+                total_participants,
+                query_id,
+            )
+        },
+    );
+
+    // The walker requires `DistributedConfig` registered on `ConfigOptions`;
+    // ParadeDB doesn't tune any of its knobs so defaults are correct.
+    let mut cfg = ConfigOptions::default();
+    cfg.extensions.insert(DistributedConfig::default());
+    let walker_query_id = Uuid::nil();
+    let mut stage_id_after: usize = 0;
+    let emitted = distribute_annotated_plan(
+        annotated,
+        &cfg,
+        walker_query_id,
+        &mut stage_id_after,
+        &factory,
+    )?;
+    factory.assert_drained()?;
+    finalize_for_mpp(shape, emitted, mpp_state, topk)
+}
+
+/// Shape-specific pre-pass. Runs before [`insert_mpp_cuts`] synthesizes
+/// the `RepartitionExec(Hash)` / `CoalescePartitionsExec` cut markers.
+///
+/// All three live shapes are wired through their own pre-pass arm:
+/// [`prepare_join_only`] for `JoinOnly`, and
+/// [`prepare_agg_on_binary_join`] for both aggregate shapes (toggling
+/// `expect_group_by` on the GROUP BY case).
+fn prepare_for_mpp(
+    shape: MppPlanShape,
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    match shape {
+        MppPlanShape::JoinOnly => prepare_join_only(plan),
+        MppPlanShape::ScalarAggOnBinaryJoin => prepare_agg_on_binary_join(plan, false),
+        MppPlanShape::GroupByAggOnBinaryJoin => prepare_agg_on_binary_join(plan, true),
+        // TopK uses the same pre-pass as GroupByAgg: returns the
+        // Partial-rooted subtree. The outer SortExec[fetch=k] wrapper
+        // is dropped here and re-applied by `finalize_topk_groupby_agg`
+        // on the leader after the post-agg gather.
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => prepare_agg_on_binary_join(plan, true),
+        MppPlanShape::GroupByAggSingleTable | MppPlanShape::Ineligible => Ok(plan),
+    }
+}
+
+/// JoinOnly pre-pass. Strips DF-inserted `RepartitionExec` /
+/// `CoalesceBatchesExec` (they'd stack with `insert_mpp_cuts`'s own
+/// markers) and the probe-side dynamic filter (`FilterPushdown`'s pushdown
+/// would drop peer-bound rows before the shuffle, since the build side
+/// hasn't filled the filter on this participant yet). Outer wrappers refresh
+/// via `with_new_children`. Errors `DataFusionError::Plan` if no
+/// `HashJoinExec` is found.
+fn prepare_join_only(plan: Arc<dyn ExecutionPlan>) -> DfResult<Arc<dyn ExecutionPlan>> {
+    fn walk(node: Arc<dyn ExecutionPlan>) -> DfResult<(Arc<dyn ExecutionPlan>, bool)> {
+        if let Some(hj) = node.as_any().downcast_ref::<HashJoinExec>() {
+            let new_left = strip_repartition_layers(Arc::clone(hj.left()));
+            let new_right =
+                strip_dynamic_filters_in_subtree(strip_repartition_layers(Arc::clone(hj.right())))?;
+            return Ok((node.with_new_children(vec![new_left, new_right])?, true));
+        }
+        let children = node.children();
+        if children.is_empty() {
+            return Ok((node, false));
+        }
+        let mut rebuilt = Vec::with_capacity(children.len());
+        let mut any_changed = false;
+        for child in children {
+            let (new, changed) = walk(Arc::clone(child))?;
+            if changed {
+                any_changed = true;
+            }
+            rebuilt.push(new);
+        }
+        if any_changed {
+            Ok((node.with_new_children(rebuilt)?, true))
+        } else {
+            Ok((node, false))
+        }
+    }
+    let (new_root, found) = walk(plan)?;
+    if !found {
+        return Err(DataFusionError::Plan(
+            "mpp: prepare_join_only: no HashJoinExec found in plan".into(),
+        ));
+    }
+    Ok(new_root)
+}
+
+/// Shape-specific post-pass. Runs after [`_distribute_plan`] emits the
+/// `ShuffleExec` / `DrainGatherExec` pairs.
+///
+/// All four live shapes are wired: [`finalize_join_only`],
+/// [`finalize_scalar_agg`], [`finalize_groupby_agg`], and
+/// [`finalize_topk_groupby_agg`]. `topk` is `Some` only for the TopK
+/// shape (asserted in the caller).
+fn finalize_for_mpp(
+    shape: MppPlanShape,
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+    topk: Option<TopKSpec>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    match shape {
+        MppPlanShape::JoinOnly => finalize_join_only(plan, mpp_state),
+        MppPlanShape::ScalarAggOnBinaryJoin => finalize_scalar_agg(plan, mpp_state),
+        MppPlanShape::GroupByAggOnBinaryJoin => finalize_groupby_agg(plan, mpp_state),
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => {
+            let spec = topk.expect("TopKGroupByAgg shape ⇒ TopKSpec must be Some");
+            finalize_topk_groupby_agg(plan, mpp_state, spec)
+        }
+        MppPlanShape::GroupByAggSingleTable | MppPlanShape::Ineligible => Ok(plan),
+    }
+}
+
+/// JoinOnly post-pass. The generic walker's `Plan` arm called
+/// `with_new_children` on the `HashJoinExec` to stitch in the emitted
+/// shuffles. That preserves the original's `on` / `filter` /
+/// `projection` / `join_type`, but two MPP-specific fixups are still
+/// needed:
+///
+///  1. **Rebuild with `PartitionMode::Partitioned`.** The standard plan's
+///     HashJoin typically carries `PartitionMode::Auto` or `CollectLeft`.
+///     Under MPP the probe + build have already been partitioned by the
+///     shuffles, so the join must run per-partition against those
+///     outputs. `with_new_children` doesn't update the partition mode.
+///  2. **Re-run `VisibilityCtidResolverRule`.** `with_new_children`
+///     rebuilt any `VisibilityFilterExec` above the join via
+///     `VisibilityFilterExec::new`, which resets `ctid_resolvers` to
+///     empty. The resolver rule re-populates them against the new
+///     subtree.
+fn finalize_join_only(
+    plan: Arc<dyn ExecutionPlan>,
+    _mpp_state: &MppExecutionState,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let rebuilt = rebuild_hash_join_as_partitioned(plan)?;
+    run_visibility_ctid_resolver_rule(rebuilt)
+}
+
+/// Rebuild the first `HashJoinExec` with `PartitionMode::Partitioned` and
+/// graft it back via [`replace_first_hash_join`] so outer wrappers refresh.
+/// `dynamic_filter` is intentionally dropped: under MPP, the local filter
+/// only knows this participant's build keys, so a probe-side filter would
+/// drop rows other participants' builds would have matched. The aggregate
+/// paths re-apply it as a `FilterExec` above the shuffle (see
+/// [`build_partitioned_hj_with_probe_filter`]); JoinOnly drops it outright.
+fn rebuild_hash_join_as_partitioned(
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_join_only: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let left = Arc::clone(hj.left());
+    let right = Arc::clone(hj.right());
+    let on = hj.on().to_vec();
+    let filter = hj.filter().cloned();
+    let join_type = *hj.join_type();
+    let projection = hj.projection.as_deref().map(|s| s.to_vec());
+    let null_equality = hj.null_equality();
+    let null_aware = hj.null_aware;
+    let replacement: Arc<dyn ExecutionPlan> = Arc::new(HashJoinExec::try_new(
+        left,
+        right,
+        on,
+        filter,
+        &join_type,
+        projection,
+        PartitionMode::Partitioned,
+        null_equality,
+        null_aware,
+    )?);
+    replace_first_hash_join(plan, replacement)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_join_only: replace_first_hash_join could not find target".into(),
+        )
+    })
+}
+
+/// Re-wire `VisibilityFilterExec.ctid_resolvers` after `with_new_children`
+/// resets them.
+fn run_visibility_ctid_resolver_rule(
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let config = ConfigOptions::default();
+    VisibilityCtidResolverRule.optimize(plan, &config)
+}
+
+/// Shared pre-pass for both aggregate-on-binary-join shapes. Locates the
+/// topmost `AggregateExec(Partial|Single)` whose descendant is a HashJoin,
+/// rebuilds the HJ subtree (preserving `dynamic_filter` via the builder),
+/// normalizes the aggregate mode to `Partial`, and returns the Partial-
+/// rooted subtree (post-pass rebuilds the right `FinalPartitioned` wrap).
+/// Same dynamic-filter strip as `prepare_join_only`; the post-pass
+/// re-applies it as a `FilterExec` above the post-shuffle probe.
+///
+/// `expect_group_by` is the shape's expected group-by-ness; mismatch
+/// against the aggregate's actual `group_expr` aborts.
+fn prepare_agg_on_binary_join(
+    plan: Arc<dyn ExecutionPlan>,
+    expect_group_by: bool,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let partial = find_partial_agg(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Plan(
+            "mpp: prepare_agg_on_binary_join: could not locate AggregateExec(Partial|Single) \
+             in standard physical plan"
+                .into(),
+        )
+    })?;
+    let hash_join = find_hash_join(partial.input().as_ref()).ok_or_else(|| {
+        DataFusionError::Plan(
+            "mpp: prepare_agg_on_binary_join: AggregateExec child is not a HashJoinExec \
+             (through coalesce layers) — plan shape unexpected for binary-join aggregate"
+                .into(),
+        )
+    })?;
+
+    let has_group_by = !partial.group_expr().expr().is_empty();
+    if has_group_by != expect_group_by {
+        return Err(DataFusionError::Plan(format!(
+            "mpp: prepare_agg_on_binary_join: expected has_group_by={expect_group_by} but \
+             aggregate has {} group keys",
+            partial.group_expr().expr().len()
+        )));
+    }
+
+    // HJ subtree cleanup.
+    let new_left = strip_repartition_layers(Arc::clone(hash_join.left()));
+    let new_right =
+        strip_dynamic_filters_in_subtree(strip_repartition_layers(Arc::clone(hash_join.right())))?;
+    let new_hj: Arc<dyn ExecutionPlan> = hash_join
+        .builder()
+        .with_new_children(vec![new_left, new_right])?
+        .build_exec()?;
+
+    // Force AggregateMode::Partial — the standard plan may have `Single`
+    // (one-partition input), which `rewrite_with_cuts` doesn't match.
+    let group_by = partial.group_expr().clone();
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let join_schema = new_hj.schema();
+    let new_partial: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+        AggregateMode::Partial,
+        group_by,
+        aggr_expr,
+        filter_expr,
+        new_hj,
+        join_schema,
+    )?);
+
+    Ok(new_partial)
+}
+
+/// Find the first `HashJoinExec` in `plan` via a depth-first traversal
+/// that descends into every child — unlike [`find_hash_join`] which only
+/// walks single-child pass-through nodes. Needed in the aggregate
+/// finalize paths because the walker output wraps the HJ inside
+/// [`ChainExec`] (2 children: `ShuffleExec` + `DrainGatherExec`), which
+/// the single-child walker would stop at.
+///
+/// Plans handled here contain exactly one `HashJoinExec`, so returning
+/// the first hit is unambiguous.
+fn find_hash_join_any(plan: &dyn ExecutionPlan) -> Option<&HashJoinExec> {
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        return Some(hj);
+    }
+    for child in plan.children() {
+        if let Some(found) = find_hash_join_any(child.as_ref()) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Find the first `AggregateExec(Partial)` in `plan` via a depth-first
+/// traversal that descends into every child — the walker output wraps
+/// the Partial inside `ChainExec` (2 children), so [`find_partial_agg`]'s
+/// single-child rule doesn't reach it. Used by the aggregate finalize
+/// paths to recover `aggr_expr` / `filter_expr` / output schema without
+/// re-threading them through the pre-pass.
+fn find_partial_agg_any(plan: &dyn ExecutionPlan) -> Option<&AggregateExec> {
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial) {
+            return Some(agg);
+        }
+    }
+    for child in plan.children() {
+        if let Some(found) = find_partial_agg_any(child.as_ref()) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Build an MPP-shuffled replacement for the walker-output `HashJoinExec`,
+/// re-applying the dynamic-filter predicate above the right probe as a
+/// `FilterExec` (the original pushdown into `PgSearchScanPlan` was
+/// stripped in the pre-pass). The rebuild goes through the builder so
+/// `dynamic_filter` survives — `HashJoinExec::try_new` drops it. The
+/// partition mode stays whatever the standard plan picked (typically
+/// `Auto` / `CollectLeft`) because the walker-emitted `ChainExec` has a
+/// single output partition, which DataFusion's execute-time assertions
+/// accept under any mode.
+fn build_partitioned_hj_with_probe_filter(hj: &HashJoinExec) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj_children = hj.children();
+    if hj_children.len() != 2 {
+        return Err(DataFusionError::Internal(format!(
+            "mpp: build_partitioned_hj_with_probe_filter: HashJoinExec expected 2 children, got {}",
+            hj_children.len()
+        )));
+    }
+    let left_shuffled = Arc::clone(hj_children[0]);
+    let right_shuffled = Arc::clone(hj_children[1]);
+
+    let right_probe: Arc<dyn ExecutionPlan> = match hj.dynamic_filter_for_test().cloned() {
+        Some(df) => Arc::new(FilterExec::try_new(df, right_shuffled)?),
+        None => right_shuffled,
+    };
+
+    // Pin `PartitionMode::Partitioned` regardless of the inbound HJ's mode.
+    // [`MppShuffleExec`] stamps both children with
+    // `Partitioning::Hash(keys, N)`, so CollectLeft's `left_partitions == 1`
+    // assertion would fail; Partitioned is the matching join mode and aligns
+    // with the [`MppPlanShape::JoinOnly`] finalizer.
+    hj.builder()
+        .with_new_children(vec![left_shuffled, right_probe])?
+        .with_partition_mode(PartitionMode::Partitioned)
+        .build_exec()
+}
+
+/// Post-pass for [`MppPlanShape::ScalarAggOnBinaryJoin`]. The walker hands
+/// us the shape:
+///
+/// ```text
+/// CoalescePartitionsExec
+///   MppShuffleExec[scalar_final(FixedTargetPartitioner(0))]
+///     AggregateExec(Partial, empty group)
+///       HashJoinExec(original mode, dynamic_filter intact)
+///         MppShuffleExec[scalar_left(HashPartitioner(left_keys))]
+///         MppShuffleExec[scalar_right(HashPartitioner(right_keys))]
+/// ```
+///
+/// We rebuild the HJ with its right probe wrapped in `FilterExec(dynamic_filter)`,
+/// graft it back, then on the leader only wrap the root with
+/// `AggregateExec(FinalPartitioned, empty group)`. Workers' shuffles are
+/// `FixedTargetPartitioner(0)` (everything ships to the leader), so their
+/// own `DrainGatherExec` reads nothing and they emit zero rows — PG's
+/// Gather sees exactly one row per query.
+fn finalize_scalar_agg(
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_scalar_agg: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let partial = find_partial_agg_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_scalar_agg: AggregateExec(Partial) missing after _distribute_plan"
+                .into(),
+        )
+    })?;
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let partial_schema = partial.schema();
+    let join_on_len = hj.on().len();
+
+    crate::mpp_log!(
+        "mpp: assembling ScalarAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, join_keys={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        join_on_len
+    );
+
+    let replacement_hj = build_partitioned_hj_with_probe_filter(hj)?;
+    let grafted = replace_first_hash_join(plan, replacement_hj)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_scalar_agg: replace_first_hash_join could not find target".into(),
+        )
+    })?;
+
+    if !mpp_state.is_leader() {
+        return Ok(grafted);
+    }
+
+    let final_agg = AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        PhysicalGroupBy::new_single(vec![]),
+        aggr_expr,
+        filter_expr,
+        grafted,
+        partial_schema,
+    )?;
+    Ok(Arc::new(final_agg))
+}
+
+/// Post-pass for [`MppPlanShape::GroupByAggOnBinaryJoin`]. Walker hands us:
+///
+/// ```text
+/// MppShuffleExec[gb_postagg(HashPartitioner(group_keys))]
+///   AggregateExec(Partial, group_by)
+///     HashJoinExec(original mode, dynamic_filter intact)
+///       MppShuffleExec[gb_left(HashPartitioner(left_keys))]
+///       MppShuffleExec[gb_right(HashPartitioner(right_keys))]
+/// ```
+///
+/// We rebuild the HJ with `FilterExec(dynamic_filter)` on the right probe,
+/// insert `CoalesceBatchesExec(65_536)` between the Partial and the
+/// post-agg shuffle (collapses ~191 batches → ~24 on the 25M benchmark,
+/// keeping the shuffle payload inside the shm_mq capacity so
+/// `FinalPartitioned` runs in parallel without backpressure), wrap with
+/// `AggregateExec(FinalPartitioned, group_by)` on every participant — no
+/// leader/worker asymmetry because the group-key hash routes each group to
+/// exactly one participant — then collapse the N-partition output back to
+/// one stream via `CoalescePartitionsExec` so PG's CustomScan
+/// (`execute(0)` only) sees every group.
+fn finalize_groupby_agg(
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let partial = find_partial_agg_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: AggregateExec(Partial) missing after _distribute_plan"
+                .into(),
+        )
+    })?;
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+    let group_by = partial.group_expr().clone();
+    let num_group_keys = group_by.expr().len();
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let partial_schema = partial.schema();
+    let join_on_len = hj.on().len();
+
+    crate::mpp_log!(
+        "mpp: assembling GroupByAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, group_keys={}, join_keys={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        num_group_keys,
+        join_on_len
+    );
+
+    let replacement_hj = build_partitioned_hj_with_probe_filter(hj)?;
+    let grafted = replace_first_hash_join(plan, replacement_hj)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: replace_first_hash_join could not find target".into(),
+        )
+    })?;
+
+    let new_chain = wrap_first_shuffle_child_in_coalesce_batches(grafted)?;
+
+    let final_agg = AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        group_by,
+        aggr_expr,
+        filter_expr,
+        new_chain,
+        partial_schema,
+    )?;
+
+    Ok(Arc::new(CoalescePartitionsExec::new(Arc::new(final_agg))))
+}
+
+/// Walk down to the first `MppShuffleExec` and wrap its child in
+/// `CoalesceBatchesExec(65_536)`. Ancestor chain rebuilds via
+/// `with_new_children`; non-shuffle siblings preserved by-reference.
+fn wrap_first_shuffle_child_in_coalesce_batches(
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    if plan.as_any().is::<MppShuffleExec>() {
+        let children = plan.children();
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: finalize_groupby_agg: expected ShuffleExec with 1 child, got {}",
+                children.len()
+            )));
+        }
+        let shuffle_child = Arc::clone(children[0]);
+        let coalesced: Arc<dyn ExecutionPlan> =
+            Arc::new(CoalesceBatchesExec::new(shuffle_child, 65_536));
+        return plan.with_new_children(vec![coalesced]);
+    }
+    let mut new_children = Vec::with_capacity(plan.children().len());
+    let mut found = false;
+    for child in plan.children() {
+        if !found {
+            let rebuilt = wrap_first_shuffle_child_in_coalesce_batches(Arc::clone(child))?;
+            if !Arc::ptr_eq(&rebuilt, child) {
+                found = true;
+            }
+            new_children.push(rebuilt);
+        } else {
+            new_children.push(Arc::clone(child));
+        }
+    }
+    if !found {
+        return Err(DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: no ShuffleExec found in plan".into(),
+        ));
+    }
+    plan.with_new_children(new_children)
+}
+
+/// Post-pass for [`MppPlanShape::TopKGroupByAggOnBinaryJoin`]. Scalar-style
+/// gather (`FixedTargetPartitioner(0)`): leader runs `FinalPartitioned`
+/// over the merged groups then `SortExec[fetch=k]`; workers return the
+/// grafted plan unchanged (their shuffle pumps to leader, their drain
+/// receives nothing). `TopKSpec` carries the original `Sort` expressions
+/// and `fetch` from the standard plan.
+fn finalize_topk_groupby_agg(
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+    topk: TopKSpec,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_topk_groupby_agg: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let partial = find_partial_agg_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_topk_groupby_agg: AggregateExec(Partial) missing after \
+             _distribute_plan"
+                .into(),
+        )
+    })?;
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+    let group_by = partial.group_expr().clone();
+    let num_group_keys = group_by.expr().len();
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let partial_schema = partial.schema();
+    let join_on_len = hj.on().len();
+
+    crate::mpp_log!(
+        "mpp: assembling TopKGroupByAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, group_keys={}, join_keys={}, fetch={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        num_group_keys,
+        join_on_len,
+        topk.fetch
+    );
+
+    let replacement_hj = build_partitioned_hj_with_probe_filter(hj)?;
+    let grafted = replace_first_hash_join(plan, replacement_hj)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_topk_groupby_agg: replace_first_hash_join could not find target".into(),
+        )
+    })?;
+
+    if !mpp_state.is_leader() {
+        return Ok(grafted);
+    }
+
+    let final_agg: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        group_by,
+        aggr_expr,
+        filter_expr,
+        grafted,
+        partial_schema,
+    )?);
+    let topk_sort = SortExec::new(topk.sort_expr, final_agg).with_fetch(Some(topk.fetch));
+    Ok(Arc::new(topk_sort))
+}
+
+// ============================================================================
+// Mesh / shuffle primitives. `emit_shuffle_cut` takes one mesh slot out of
+// `MppExecutionState`, spins up a drain, and attaches the cooperative-drain
+// + frame-id stamps before handing off to `wrap_with_mpp_shuffle`. Shared
+// across every shape; fully private to this module.
+// ============================================================================
+
+/// Single directed mesh extracted from the per-scan MPP state. A
+/// participant-agnostic adapter over `LeaderMesh` / `WorkerMesh`, whose
+/// shapes are identical but whose type-level variants force otherwise-
+/// generic code to branch for no reason.
+struct MeshHalves {
+    outbound: Vec<Option<MppSender>>,
+    inbound: Vec<Option<MppReceiver>>,
+}
+
+impl From<LeaderMesh> for MeshHalves {
+    fn from(m: LeaderMesh) -> Self {
+        MeshHalves {
+            outbound: m.outbound,
+            inbound: m.inbound,
+        }
+    }
+}
+
+impl From<WorkerMesh> for MeshHalves {
+    fn from(m: WorkerMesh) -> Self {
+        MeshHalves {
+            outbound: m.outbound,
+            inbound: m.inbound,
+        }
+    }
+}
+
+/// Take the per-mesh wirings out of `mpp_state.meshes`, replacing them with
+/// empty `Vec`s so the borrow checker is satisfied. Drops the participant's
+/// side-specific variant on the floor — only the generic `MeshHalves` survive.
+///
+/// Panics (via `pgrx::error!`) if `meshes.len() != expected`. This is a
+/// leader/worker contract mismatch and must surface loudly, not silently.
+fn take_meshes(state: &mut MppExecutionState, expected: usize) -> Vec<MeshHalves> {
+    match state {
+        MppExecutionState::Leader(ctx) => {
+            let taken = mem::take(&mut ctx.meshes);
+            if taken.len() != expected {
+                let actual = taken.len();
+                // Drop `taken` before the `pgrx::error!` longjmp so the held
+                // shm_mq attachments run their `Drop` impls. Otherwise the
+                // longjmp through Rust frames would skip them and leak the
+                // attachments until backend exit.
+                drop(taken);
+                pgrx::error!(
+                    "mpp: leader meshes.len()={} but shape expected {}",
+                    actual,
+                    expected
+                );
+            }
+            taken.into_iter().map(MeshHalves::from).collect()
+        }
+        MppExecutionState::Worker(ctx) => {
+            let taken = mem::take(&mut ctx.meshes);
+            if taken.len() != expected {
+                let actual = taken.len();
+                drop(taken);
+                pgrx::error!(
+                    "mpp: worker meshes.len()={} but shape expected {}",
+                    actual,
+                    expected
+                );
+            }
+            taken.into_iter().map(MeshHalves::from).collect()
+        }
+    }
+}
+
+fn spawn_drain(inbound: Vec<Option<MppReceiver>>) -> Arc<DrainHandle> {
+    // `inbound[participant_index]` is always `None`; flatten drops it. Every
+    // other peer contributes exactly one receiver.
+    let receivers: Vec<_> = inbound.into_iter().flatten().collect();
+    let num_sources = receivers.len();
+    // `DrainBuffer::new(0)` would flip to EOF immediately; give it at least 1.
+    let buffer = DrainBuffer::new(num_sources.max(1) as u32);
+
+    // Cooperative (not thread-backed) drain: pgrx's `check_active_thread`
+    // panics any pg FFI call from non-backend threads, so spawning a
+    // `std::thread` to read from `shm_mq` would die on its first
+    // `shm_mq_receive`. The drain work runs inline from
+    // `DrainGatherStream::poll_next` on the backend thread; the returned
+    // `Arc` is also held by each same-mesh `MppSender` so `send_batch` can
+    // cooperatively poll the inbound during would-block retries, breaking
+    // the symmetric-send deadlock on a single-threaded runtime.
+    Arc::new(DrainHandle::cooperative(receivers, buffer))
+}
+
+/// Inject `drain` into each outbound sender so its `send_batch` can
+/// cooperatively poll our inbound during would-block retries — breaks
+/// the symmetric-send deadlock on a single-threaded runtime.
+fn attach_cooperative_drain(
+    senders: Vec<Option<MppSender>>,
+    drain: &Arc<DrainHandle>,
+) -> Vec<Option<MppSender>> {
+    senders
+        .into_iter()
+        .map(|opt| opt.map(|s| s.with_cooperative_drain(Arc::clone(drain))))
+        .collect()
+}
+
+// ============================================================================
+// Plan-walking primitives. Find the Partial agg / HashJoin in a standard
+// DataFusion plan, skipping the coalesce/final wrapper layers the planner
+// may have inserted.
+// ============================================================================
+
+/// Walk the plan from the root, descending only through an explicit
+/// allow-list of pass-through wrappers, to find an `AggregateExec` in
+/// `Partial` or `Single` mode.
+///
+/// Allow-list:
+///   * `AggregateExec(Final | FinalPartitioned | SinglePartitioned)` —
+///     the outer aggregate stage emitted by DataFusion's planner.
+///   * `CoalescePartitionsExec` — multi→single partition merger.
+///   * `CoalesceBatchesExec` — batch-size normaliser.
+///
+/// Anything else (a `ProjectionExec`, `FilterExec`, etc. above the
+/// Partial) returns `None` so `prepare_agg_on_binary_join`'s caller
+/// errors out and the dispatcher falls back to the serial path. This
+/// is deliberately strict: the post-pass rebuilds the outer wrapper
+/// chain from scratch as `AggregateExec(FinalPartitioned, …)` and would
+/// silently discard any non-allow-listed node above the Partial,
+/// producing wrong-shape rows. A tight allow-list turns that silent
+/// drop into a clean fallback.
+///
+/// DataFusion's planner picks `AggregateMode::Single` when the input
+/// produces exactly one partition (our usual serial build), and
+/// `Partial + FinalPartitioned` when it produces multiple partitions —
+/// both are equally valid as the "aggregate atop the join" we want to
+/// rebuild from. The assembler always emits `Partial` on top of the
+/// shuffled join, regardless of which mode the serial plan used.
+fn find_partial_agg(plan: &dyn ExecutionPlan) -> Option<&AggregateExec> {
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial | AggregateMode::Single) {
+            return Some(agg);
+        }
+        // Final / FinalPartitioned / SinglePartitioned: descend into its child.
+        return find_partial_agg(agg.input().as_ref());
+    }
+    if let Some(cp) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
+        return find_partial_agg(cp.input().as_ref());
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return find_partial_agg(cb.input().as_ref());
+    }
+    // Anything not in the allow-list above ends the walk. Returning
+    // `None` lets `prepare_agg_on_binary_join` produce a clean
+    // `DataFusionError::Plan` so the dispatcher falls back to serial,
+    // rather than silently discarding the unknown wrapper.
+    None
+}
+
+/// Find a `HashJoinExec` underneath a Partial aggregate's input (or
+/// under the `standard` root when the plan is a bare join), tolerating
+/// `CoalescePartitionsExec` / `CoalesceBatchesExec` layers the planner
+/// may insert between them.
+fn find_hash_join(plan: &dyn ExecutionPlan) -> Option<&HashJoinExec> {
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        return Some(hj);
+    }
+    if let Some(cp) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
+        return find_hash_join(cp.input().as_ref());
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return find_hash_join(cb.input().as_ref());
+    }
+    let children = plan.children();
+    if children.len() == 1 {
+        return find_hash_join(children[0].as_ref());
+    }
+    None
+}
+
+/// Runtime-installed indirection over `PgSearchScanPlan::strip_dynamic_filters_from_dyn`.
+/// A direct call plants `<PgSearchScanPlan as ExecutionPlan>`'s vtable in every
+/// caller's static reachable graph; under `cargo llvm-cov` (instrumentation
+/// disables DCE) that pulls `execute()` → pgrx FFI → `CurrentMemoryContext`
+/// as an unresolved GLOB_DAT reloc, breaking the lib-test binary's ld.so load.
+/// Same mitigation pattern as `aggregatescan/filterquery.rs::BUILD_FILTER_QUERY_FN`.
+type StripDynamicFiltersFn = fn(Arc<dyn ExecutionPlan>) -> DfResult<Arc<dyn ExecutionPlan>>;
+static STRIP_DYNAMIC_FILTERS_FN: OnceLock<StripDynamicFiltersFn> = OnceLock::new();
+
+/// Install the real implementation. Called from `_PG_init`; because `_PG_init`
+/// is unreachable from `#[test]`, the function pointer stays out of the test
+/// binary's static reachable graph.
+pub fn init_mpp_strip_dynamic_filters() {
+    STRIP_DYNAMIC_FILTERS_FN.get_or_init(|| PgSearchScanPlan::strip_dynamic_filters_from_dyn);
+}
+
+/// Register an extractor with the `datafusion-distributed` fork so its
+/// [`NetworkBoundaryExt::as_network_boundary`] downcast chain recognizes
+/// our [`MppShuffleExec`]. Without this, the fork's idempotency check
+/// (`distribute_plan_with_factory`'s `original.exists(|p| p.is_network_boundary())`)
+/// would mis-classify our plans as boundary-free and re-run distribution,
+/// and the metrics rewriter would skip our boundaries when traversing.
+///
+/// Called from `_PG_init` alongside [`init_mpp_strip_dynamic_filters`];
+/// the registration is idempotent at the consumer level (we wrap with
+/// a `OnceLock` so repeated calls are cheap), and the fork's registry
+/// itself is append-only — first-match-wins ensures no harm even if
+/// the registration somehow fires twice.
+pub fn init_mpp_network_boundary_extractor() {
+    static REGISTERED: OnceLock<()> = OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        register_network_boundary_extractor(extract_mpp_shuffle_exec);
+    });
+}
+
+fn extract_mpp_shuffle_exec(plan: &dyn ExecutionPlan) -> Option<&dyn NetworkBoundary> {
+    plan.as_any()
+        .downcast_ref::<MppShuffleExec>()
+        .map(|e| e as &dyn NetworkBoundary)
+}
+
+/// Walk a join-input subtree and replace every `PgSearchScanPlan` with a
+/// copy whose `dynamic_filters` Vec is empty. The `FilterPushdown` physical
+/// optimizer pushed the HashJoin's dynamic-filter Arc into the probe-side
+/// scan at planning time; MPP rewires so the same Arc is applied by a
+/// `FilterExec` above the post-shuffle output instead.
+fn strip_dynamic_filters_in_subtree(
+    node: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    if node.as_any().downcast_ref::<PgSearchScanPlan>().is_some() {
+        let f = STRIP_DYNAMIC_FILTERS_FN.get().ok_or_else(|| {
+            DataFusionError::Internal(
+                "mpp: init_mpp_strip_dynamic_filters() not called — should be wired from _PG_init"
+                    .into(),
+            )
+        })?;
+        return f(node);
+    }
+
+    let children = node.children();
+    if children.is_empty() {
+        return Ok(node);
+    }
+
+    let new_children = children
+        .iter()
+        .map(|c| strip_dynamic_filters_in_subtree(Arc::clone(c)))
+        .collect::<Result<Vec<_>, _>>()?;
+    node.with_new_children(new_children)
+}
+
+/// Strip `RepartitionExec` and `CoalesceBatchesExec` layers off the top of a
+/// plan, returning the underlying child. DataFusion inserts these between a
+/// `HashJoinExec(Partitioned)` and its inputs to hash-repartition; in the MPP
+/// plan we replace them with our own shuffle.
+fn strip_repartition_layers(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    if let Some(rp) = plan.as_any().downcast_ref::<RepartitionExec>() {
+        return strip_repartition_layers(Arc::clone(rp.input()));
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return strip_repartition_layers(Arc::clone(cb.input()));
+    }
+    plan
+}
+
+fn col_index(expr: &Arc<dyn PhysicalExpr>) -> DfResult<usize> {
+    expr.as_any()
+        .downcast_ref::<Column>()
+        .map(|c| c.index())
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "mpp: join key expression {expr} is not a plain Column — MPP shuffle only \
+                 supports column-ref keys in milestone 1"
+            ))
+        })
+}
+
+/// Walk `root` top-down, replacing the first `HashJoinExec` found with
+/// `replacement`. Outer wrappers are rebuilt via `with_new_children` so their
+/// identities (and per-node state) refresh, which is required for nodes like
+/// `VisibilityFilterExec` whose resolver table must be re-wired against the
+/// new subtree. Returns `Ok(None)` if no `HashJoinExec` is present.
+fn replace_first_hash_join(
+    root: Arc<dyn ExecutionPlan>,
+    replacement: Arc<dyn ExecutionPlan>,
+) -> DfResult<Option<Arc<dyn ExecutionPlan>>> {
+    if root.as_any().downcast_ref::<HashJoinExec>().is_some() {
+        return Ok(Some(replacement));
+    }
+    let children = root.children();
+    if children.is_empty() {
+        return Ok(None);
+    }
+    let mut new_children: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(children.len());
+    let mut replaced = false;
+    for child in children {
+        if !replaced {
+            if let Some(new_child) =
+                replace_first_hash_join(Arc::clone(child), Arc::clone(&replacement))?
+            {
+                new_children.push(new_child);
+                replaced = true;
+                continue;
+            }
+        }
+        new_children.push(Arc::clone(child));
+    }
+    if replaced {
+        Ok(Some(root.with_new_children(new_children)?))
+    } else {
+        Ok(None)
+    }
+}
+
+// ============================================================================
+// Post-build validation
+// ============================================================================
+
+/// Post-build validation: no `VisibilityFilterExec` may be a descendant of a
+/// `ShuffleExec` in the produced MPP plan.
+///
+/// Rationale (see module doc): `VisibilityFilterExec` resolves packed
+/// DocAddress → heap TID via a ctid-resolver table populated with segments
+/// local to this participant. If a shuffle sits above a visibility filter, the
+/// filter operates on rows originating locally only (fine), but if a
+/// visibility filter sits below a shuffle we run the filter on rows that
+/// came in over shm_mq from a peer participant, whose `seg_ord` addresses the
+/// peer's segment catalog rather than ours — `heap_fetch` then returns
+/// garbage or panics.
+///
+/// The walk is cheap (O(nodes)) and runs once per query, so there is no
+/// perf reason to gate this behind a GUC.
+pub fn assert_visibility_invariant(plan: &Arc<dyn ExecutionPlan>) -> DfResult<()> {
+    walk_checking_visibility(plan.as_ref(), /*inside_shuffle=*/ false)
+}
+
+fn walk_checking_visibility(node: &dyn ExecutionPlan, inside_shuffle: bool) -> DfResult<()> {
+    let is_shuffle = node.as_any().downcast_ref::<MppShuffleExec>().is_some();
+    let is_visibility = node
+        .as_any()
+        .downcast_ref::<VisibilityFilterExec>()
+        .is_some();
+
+    if inside_shuffle && is_visibility {
+        return Err(DataFusionError::Plan(
+            "mpp: visibility invariant violated — VisibilityFilterExec appears below a \
+             ShuffleExec. Segment-local ctid resolution cannot run on rows that crossed \
+             an shm_mq boundary from a peer participant (peer seg_ord addresses its own segment \
+             catalog, not ours). Place every shuffle cut above any VisibilityFilterExec \
+             in the standard plan."
+                .into(),
+        ));
+    }
+
+    let next_inside_shuffle = inside_shuffle || is_shuffle;
+    for child in node.children() {
+        walk_checking_visibility(child.as_ref(), next_inside_shuffle)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Literal};
+    use datafusion::scalar::ScalarValue;
+
+    #[test]
+    fn cut_count_matches_topology() {
+        assert_eq!(cut_count_for_shape(MppPlanShape::ScalarAggOnBinaryJoin), 3);
+        assert_eq!(cut_count_for_shape(MppPlanShape::GroupByAggOnBinaryJoin), 3);
+        assert_eq!(cut_count_for_shape(MppPlanShape::GroupByAggSingleTable), 1);
+        assert_eq!(cut_count_for_shape(MppPlanShape::JoinOnly), 2);
+        assert_eq!(cut_count_for_shape(MppPlanShape::Ineligible), 0);
+    }
+
+    #[test]
+    fn col_index_plain_column() {
+        let col: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 3));
+        assert_eq!(col_index(&col).unwrap(), 3);
+    }
+
+    #[test]
+    fn col_index_rejects_non_column() {
+        let left: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 0));
+        let right: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int32(Some(0))));
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(left, Operator::Plus, right));
+        let err = col_index(&expr).unwrap_err();
+        assert!(
+            format!("{err}").contains("not a plain Column"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn find_partial_agg_walks_through_coalesce_and_final() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let input = MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap();
+
+        // Build a Partial -> CoalescePartitions -> Final stack.
+        let partial = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let partial_schema = partial.schema();
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
+        let final_agg = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Final,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                coalesced,
+                partial_schema,
+            )
+            .unwrap(),
+        );
+
+        let plan: Arc<dyn ExecutionPlan> = final_agg;
+        let partial_ref = find_partial_agg(plan.as_ref()).expect("partial found");
+        assert!(matches!(partial_ref.mode(), AggregateMode::Partial));
+    }
+
+    // The visibility-invariant walker is exercised by the regression tests
+    // (mpp_join, mpp_exec) against real plans. A lightweight unit test on
+    // synthetic `ExecutionPlan`s would require wiring up enough of
+    // `VisibilityFilterExec` + `ShuffleExec` to make the downcast fire,
+    // which duplicates the fixture the bridges already exercise. Skipped.
+
+    // ========================================================================
+    // DF-D generic cut walker tests.
+    // ========================================================================
+
+    fn mem_source(schema: &SchemaRef) -> Arc<dyn ExecutionPlan> {
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap()
+    }
+
+    #[test]
+    fn annotate_plan_sync_detects_hash_repartition_as_shuffle() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let key: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 0));
+        let repart: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::Hash(vec![key], 2)).unwrap());
+
+        let annotated = annotate_plan_sync(repart, 2).unwrap();
+        // The trigger sits *above* the RepartitionExec, so the top of the
+        // annotated tree is the Shuffle boundary whose sole child is the
+        // RepartitionExec-as-Plan.
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Shuffle
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_sync_round_robin_repartition_does_not_trigger_shuffle() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let repart: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2)).unwrap());
+
+        let annotated = annotate_plan_sync(repart, 2).unwrap();
+        // Non-hash repartitioning is not a DF-D cut trigger.
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_sync_plain_plan_has_no_boundaries() {
+        fn assert_no_boundary(a: &AnnotatedPlan) {
+            assert!(
+                !a.plan_or_nb.is_network_boundary(),
+                "unexpected boundary: {:?}",
+                a.plan_or_nb
+            );
+            for c in &a.children {
+                assert_no_boundary(c);
+            }
+        }
+
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let annotated = annotate_plan_sync(partial, 2).unwrap();
+        assert_no_boundary(&annotated);
+    }
+
+    #[test]
+    fn annotate_plan_sync_coalesce_parent_triggers_coalesce_boundary() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        // Partial aggregation is non-leaf (children() non-empty) and its
+        // parent is CoalescePartitionsExec — this is the DF-D Coalesce
+        // trigger verbatim.
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
+        let annotated = annotate_plan_sync(coalesced, 2).unwrap();
+
+        // Root is the CoalescePartitionsExec itself (annotated as Plan; the
+        // trigger only wraps the child that sits *under* the coalesce).
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        // The Partial aggregate has its parent as CoalescePartitionsExec, so
+        // the walker wraps it with Coalesce.
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Coalesce
+        ));
+        // Inside the Coalesce annotation, the wrapped plan is the Partial
+        // aggregate.
+        assert_eq!(annotated.children[0].children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_sync_leaf_under_coalesce_is_not_boundaried() {
+        // A true leaf node (no children) underneath CoalescePartitionsExec
+        // must not get a Coalesce boundary — DF-D's comment: "putting a
+        // network boundary above [a leaf] is a bit wasteful".
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(input));
+        let annotated = annotate_plan_sync(coalesced, 2).unwrap();
+
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn require_one_child_accepts_single_child() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let got = require_one_child(vec![Arc::clone(&input)]).unwrap();
+        assert!(Arc::ptr_eq(&got, &input));
+    }
+
+    #[test]
+    fn require_one_child_rejects_zero_children() {
+        let empty: Vec<Arc<dyn ExecutionPlan>> = vec![];
+        let err = require_one_child(empty).unwrap_err();
+        assert!(format!("{err}").contains("Expected exactly 1"));
+    }
+
+    #[test]
+    fn require_one_child_rejects_many_children() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let err = require_one_child(vec![mem_source(&schema), mem_source(&schema)]).unwrap_err();
+        assert!(format!("{err}").contains("Expected exactly 1"));
+    }
+
+    // ========================================================================
+    // `insert_mpp_cuts` tests.
+    //
+    // These exercise the aggregate-wrapping half of the pre-pass on
+    // synthetic plans built from `MemorySourceConfig` +
+    // `AggregateExec(Partial)`. The `HashJoinExec` half is exercised by
+    // the regression suite — building a synthetic `HashJoinExec` here
+    // would duplicate the fixture the regression tests already produce
+    // from real SQL.
+    // ========================================================================
+
+    fn partial_agg_over_mem_source(group_cols: Vec<&str>) -> Arc<dyn ExecutionPlan> {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let group_by_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = group_cols
+            .into_iter()
+            .map(|c| {
+                (
+                    Arc::new(Column::new(c, 0)) as Arc<dyn PhysicalExpr>,
+                    c.to_string(),
+                )
+            })
+            .collect();
+        Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(group_by_exprs),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn insert_mpp_cuts_scalar_wraps_partial_with_coalesce() {
+        let plan = partial_agg_over_mem_source(vec![]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::ScalarAggOnBinaryJoin, 2).unwrap();
+
+        // Root should be CoalescePartitionsExec; its sole child is the
+        // original Partial aggregate.
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .is_some());
+        assert_eq!(rewritten.children().len(), 1);
+        let partial = rewritten.children()[0]
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("child is AggregateExec");
+        assert_eq!(*partial.mode(), AggregateMode::Partial);
+
+        // Cross-check: annotate_plan should see exactly one Coalesce boundary.
+        let annotated = annotate_plan_sync(Arc::clone(&rewritten), 2).unwrap();
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Coalesce
+        ));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_groupby_wraps_partial_with_hash_repartition() {
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::GroupByAggOnBinaryJoin, 4).unwrap();
+
+        // Root should be RepartitionExec(Hash(id), 4); its sole child is
+        // the original Partial aggregate.
+        let repart = rewritten
+            .as_any()
+            .downcast_ref::<RepartitionExec>()
+            .expect("root is RepartitionExec");
+        match repart.partitioning() {
+            Partitioning::Hash(keys, n) => {
+                assert_eq!(keys.len(), 1);
+                assert_eq!(*n, 4);
+            }
+            other => panic!("expected Hash partitioning, got {other:?}"),
+        }
+        assert_eq!(rewritten.children().len(), 1);
+        let partial = rewritten.children()[0]
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("child is AggregateExec");
+        assert_eq!(*partial.mode(), AggregateMode::Partial);
+
+        // Cross-check: annotate_plan should see a Shuffle boundary on the
+        // RepartitionExec.
+        let annotated = annotate_plan_sync(Arc::clone(&rewritten), 2).unwrap();
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Shuffle
+        ));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_scalar_does_not_wrap_groupby_partial() {
+        // A Partial *with* group keys under ScalarAgg shape should not be
+        // wrapped — rewrite_with_cuts matches on (kind, group_exprs.is_empty()).
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::ScalarAggOnBinaryJoin, 2).unwrap();
+
+        // Root is still the Partial — no CoalescePartitionsExec, no RepartitionExec.
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .is_none());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_groupby_does_not_wrap_scalar_partial() {
+        // A Partial *without* group keys under GroupByAgg shape should not
+        // be wrapped. The caller's classifier is responsible for picking
+        // the right shape — rewrite_with_cuts enforces the invariant by
+        // no-op-ing on the mismatched pair.
+        let plan = partial_agg_over_mem_source(vec![]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::GroupByAggOnBinaryJoin, 2).unwrap();
+
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<RepartitionExec>()
+            .is_none());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_join_only_does_not_wrap_partial() {
+        // JoinOnly shape should leave any Partial aggregate alone — the
+        // only rewrite is on HashJoinExec children (exercised in regression).
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::JoinOnly, 2).unwrap();
+
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_rejects_ineligible() {
+        let plan = partial_agg_over_mem_source(vec![]);
+        let err = insert_mpp_cuts(plan, MppPlanShape::Ineligible, 2).unwrap_err();
+        assert!(format!("{err}").contains("Ineligible"));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_rejects_single_table_groupby() {
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let err = insert_mpp_cuts(plan, MppPlanShape::GroupByAggSingleTable, 2).unwrap_err();
+        assert!(format!("{err}").contains("GroupByAggSingleTable"));
+    }
+
+    // ========================================================================
+    // `_distribute_plan` + `tag_for_cut` tests (dead-path scaffolding — Step
+    // 2c-ii). The `Plan` arm exercises `with_new_children` recursion; the
+    // `Shuffle` and `Coalesce` arms hit `wrap_with_mpp_shuffle` against a
+    // synthetic in-process mesh and verify the resulting tree embeds the
+    // expected number of `ShuffleExec` nodes with stamped input `Stage` ids.
+    // ========================================================================
+
+    #[test]
+    fn tag_for_cut_covers_every_live_shape() {
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 0), "join_left");
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 1), "join_right");
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 0),
+            "scalar_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 1),
+            "scalar_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 2),
+            "scalar_final"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 0),
+            "gb_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 1),
+            "gb_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 2),
+            "gb_postagg"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::TopKGroupByAggOnBinaryJoin, 0),
+            "tk_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::TopKGroupByAggOnBinaryJoin, 1),
+            "tk_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::TopKGroupByAggOnBinaryJoin, 2),
+            "tk_final"
+        );
+    }
+
+    #[test]
+    fn tag_for_cut_unknown_pair_falls_through_to_placeholder() {
+        // Out-of-range indices and Ineligible / SingleTable shapes fall
+        // through to the placeholder rather than panic — a panic in the
+        // dead-code scaffold would mask a real emit-arm regression.
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 7), "mpp_unknown_cut");
+        assert_eq!(tag_for_cut(MppPlanShape::Ineligible, 0), "mpp_unknown_cut");
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggSingleTable, 0),
+            "mpp_unknown_cut"
+        );
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Generic cut walker (`distribute_plan`).
 //!
 //! [`distribute_plan`] is the single entry point: turns a standard DataFusion

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP worker lifecycle and DSM coordination.
 //!
 //! The DSM region laid out by the leader during `initialize_dsm_custom_scan`

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! MPP worker lifecycle and DSM coordination.
 //!
 //! The DSM region laid out by the leader during `initialize_dsm_custom_scan`
@@ -44,12 +45,13 @@
 //! [`ShmMqReceiver`](super::mesh::ShmMqReceiver). Here we only own the
 //! sizing/offset math and the header layout.
 
-#![allow(dead_code)]
+use std::mem::size_of;
+use std::ptr;
+
+use pgrx::pg_sys;
 
 use crate::postgres::customscan::mpp::mesh::{edge_slot, MeshLayout, ShmMqReceiver, ShmMqSender};
 use crate::postgres::customscan::mpp::transport::{MppReceiver, MppSender};
-use pgrx::pg_sys;
-use std::mem::size_of;
 
 /// Magic number stamped at the head of an MPP DSM region. Distinct from any
 /// of the other Postgres DSM magic numbers in the crate; workers assert this
@@ -262,7 +264,7 @@ pub struct DsmLayout {
 /// `plan_len == usize::MAX` fails cleanly instead of wrapping.
 #[inline]
 fn align_up_maxalign_checked(n: usize) -> Option<usize> {
-    const MA: usize = pgrx::pg_sys::MAXIMUM_ALIGNOF as usize;
+    const MA: usize = pg_sys::MAXIMUM_ALIGNOF as usize;
     let rem = n % MA;
     if rem == 0 {
         return Some(n);
@@ -329,8 +331,8 @@ pub unsafe fn initialize_dsm_as_leader(
 
     let header = MppDsmHeader::from_layout(mesh, dsm);
     unsafe {
-        std::ptr::write(base as *mut MppDsmHeader, header);
-        std::ptr::copy_nonoverlapping(plan_bytes.as_ptr(), base.add(dsm.plan_offset), dsm.plan_len);
+        ptr::write(base as *mut MppDsmHeader, header);
+        ptr::copy_nonoverlapping(plan_bytes.as_ptr(), base.add(dsm.plan_offset), dsm.plan_len);
     }
 
     let n = mesh.total_participants;
@@ -389,7 +391,7 @@ pub unsafe fn attach_dsm_as_worker(
     participant_index: u32,
     seg: *mut pg_sys::dsm_segment,
 ) -> Result<WorkerAttach, &'static str> {
-    let header = unsafe { std::ptr::read_unaligned(base as *const MppDsmHeader) };
+    let header = unsafe { ptr::read_unaligned(base as *const MppDsmHeader) };
     header.validate(region_total)?;
 
     if participant_index >= header.total_participants {
@@ -463,11 +465,7 @@ impl WorkerAttach {
     pub unsafe fn copy_plan_bytes(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(self.plan_bytes_len);
         unsafe {
-            std::ptr::copy_nonoverlapping(
-                self.plan_bytes_ptr,
-                out.as_mut_ptr(),
-                self.plan_bytes_len,
-            );
+            ptr::copy_nonoverlapping(self.plan_bytes_ptr, out.as_mut_ptr(), self.plan_bytes_len);
             out.set_len(self.plan_bytes_len);
         }
         out
@@ -536,9 +534,9 @@ mod tests {
         let plan_len = 12_345;
         let dsm = compute_dsm_layout(&layout, 1, plan_len).unwrap();
         assert!(dsm.plan_offset >= size_of::<MppDsmHeader>());
-        assert_eq!(dsm.plan_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
+        assert_eq!(dsm.plan_offset % pg_sys::MAXIMUM_ALIGNOF as usize, 0);
         assert!(dsm.mesh_offset >= dsm.plan_offset + plan_len);
-        assert_eq!(dsm.mesh_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
+        assert_eq!(dsm.mesh_offset % pg_sys::MAXIMUM_ALIGNOF as usize, 0);
         assert_eq!(dsm.mesh_bytes, layout.dsm_queue_bytes_checked().unwrap());
         assert_eq!(dsm.total, dsm.mesh_offset + dsm.mesh_bytes);
         assert_eq!(dsm.plan_len, plan_len);
@@ -604,7 +602,7 @@ mod tests {
 
     #[test]
     fn align_up_maxalign_rounds_correctly() {
-        let ma = pgrx::pg_sys::MAXIMUM_ALIGNOF as usize;
+        let ma = pg_sys::MAXIMUM_ALIGNOF as usize;
         assert_eq!(align_up_maxalign_checked(0), Some(0));
         assert_eq!(align_up_maxalign_checked(1), Some(ma));
         assert_eq!(align_up_maxalign_checked(ma), Some(ma));
@@ -626,13 +624,13 @@ mod tests {
 
         let mut buf = vec![0u8; size_of::<MppDsmHeader>() * 2];
         unsafe {
-            std::ptr::copy_nonoverlapping(
+            ptr::copy_nonoverlapping(
                 &original as *const MppDsmHeader as *const u8,
                 buf.as_mut_ptr(),
                 size_of::<MppDsmHeader>(),
             );
         }
-        let read_back = unsafe { std::ptr::read_unaligned(buf.as_ptr() as *const MppDsmHeader) };
+        let read_back = unsafe { ptr::read_unaligned(buf.as_ptr() as *const MppDsmHeader) };
         read_back.validate(dsm.total as u64).unwrap();
         assert_eq!(read_back.magic, MPP_DSM_MAGIC);
         assert_eq!(read_back.total_participants, original.total_participants);

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -277,7 +277,6 @@ impl PgSearchScanPlan {
     /// is itself below a shuffle): the dynamic filter is fully populated
     /// locally there and dropping it loses a valuable optimization with no
     /// correctness benefit.
-    #[allow(dead_code)] // walker (PR #4870) is the live caller
     pub fn strip_dynamic_filters_from_dyn(
         dyn_plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -32,6 +32,7 @@ use tantivy::index::SegmentId;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, WhichFastField};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::customscan::mpp::MppShardConfig;
 use crate::postgres::customscan::parallel::{checkout_segment, list_segment_ids};
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
@@ -565,6 +566,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         query_for_display: SearchQueryInput,
         sort_order: Option<&crate::postgres::options::SortByField>,
+        mpp_shard: Option<(u32, u32)>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -575,7 +577,16 @@ impl PgSearchTableProvider {
         let segments: Vec<ScanState> = reader
             .segment_readers()
             .iter()
-            .map(|r| {
+            .enumerate()
+            // MPP sharded eager-scan: each participant opens only its own
+            // subset. Filter applies identically across all participants
+            // because `segment_readers()` has deterministic order, so
+            // every segment ends up on exactly one participant.
+            .filter(|(i, _)| match mpp_shard {
+                Some((pi, total)) => (*i as u32) % total == pi,
+                None => true,
+            })
+            .map(|(_, r)| {
                 self.create_scan_partition(
                     reader,
                     r.segment_id(),
@@ -616,6 +627,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         query_for_display: SearchQueryInput,
         planner_estimated_rows: u64,
+        mpp_shard: Option<(u32, u32)>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -623,12 +635,39 @@ impl PgSearchTableProvider {
             heap_relid: heap_relid.into(),
             batch_size_hint: None,
         };
-        let state = ScanState {
-            recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
+        let recipe = if parallel_state.is_some() {
+            crate::scan::execution_plan::ScanRecipe::Lazy {
                 parallel_state,
                 planner_estimated_rows,
                 scanner_config,
-            },
+            }
+        } else if let Some((participant_index, total_participants)) = mpp_shard {
+            // MPP sharded lazy scan: each participant reads only its share
+            // of segments (`segment_idx % total == participant_index`), so
+            // the scan work is split N ways across participants. The
+            // hash-shuffle above then redistributes rows by join key —
+            // because each input row is scanned by exactly one participant,
+            // the shuffle output matches the serial scan.
+            let sharded_ids: Vec<SegmentId> = reader
+                .segment_readers()
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| (*i as u32) % total_participants == participant_index)
+                .map(|(_, r)| r.segment_id())
+                .collect();
+            crate::scan::execution_plan::ScanRecipe::Eager {
+                segment_ids: sharded_ids,
+                scanner_config,
+            }
+        } else {
+            crate::scan::execution_plan::ScanRecipe::Lazy {
+                parallel_state,
+                planner_estimated_rows,
+                scanner_config,
+            }
+        };
+        let state = ScanState {
+            recipe,
             ffhelper: ffhelper.clone(),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader: reader.clone(),
@@ -700,11 +739,22 @@ impl TableProvider for PgSearchTableProvider {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        // MPP sharding: the exec bridge stashes a `MppShardConfig` as a
+        // session config extension before `build_join_aggregate_plan`
+        // builds the logical plan. When present AND we take the lazy
+        // (un-parallel) scan path, each participant reads only its share
+        // of segments — see `create_lazy_scan`. Absent for non-MPP
+        // queries and for the sorted/eager paths that have their own
+        // parallelization story.
+        let mpp_shard = state
+            .config()
+            .get_extension::<MppShardConfig>()
+            .map(|cfg| (cfg.participant_index, cfg.total_participants));
         // TODO: We should support limit pushdown here to allow providing a batch size hint
         // to the Scanner.
 
@@ -812,6 +862,7 @@ impl TableProvider for PgSearchTableProvider {
                     projected_schema,
                     query,
                     Some(sort_order),
+                    mpp_shard,
                 )
             }
         } else {
@@ -831,6 +882,7 @@ impl TableProvider for PgSearchTableProvider {
                 projected_schema,
                 query,
                 total_estimated_rows,
+                mpp_shard,
             )
         }
     }

--- a/pg_search/tests/pg_regress/expected/mpp_exec.out
+++ b/pg_search/tests/pg_regress/expected/mpp_exec.out
@@ -1,0 +1,342 @@
+-- =====================================================================
+-- MPP correctness: with `paradedb.enable_mpp=on`, scalar COUNT(*) on a
+-- binary join must return the same result as with MPP off.
+--
+-- This test exercises the full shape classification + plan-stash +
+-- parallel-flag flip pipeline on a medium-sized dataset (40x200 rows).
+-- PG's planner decides whether to launch actual parallel workers based
+-- on cost; at this size it typically doesn't, so the MPP *exec* path
+-- isn't exercised here — for that you need `debug_parallel_query=on`
+-- at a larger scale, which is out of scope for pg_regress (no parallel
+-- workers launched == no DSM coordination == no cross-worker shuffle).
+--
+-- What this DOES verify:
+--   * MPP-on doesn't break the serial code path
+--   * Shape classifier agrees between path-time and plan-stash-time
+--   * `maybe_stash_mpp_plan_bytes` completes without error
+--   * The plan survives logical-plan → bytes round-trip
+--
+-- A note on EXPLAIN scope: the EXPLAINs below show the PG-level plan
+-- (the Custom Scan node is opaque from the planner's perspective). The
+-- DataFusion physical plan that the walker actually rewrites and emits
+-- is not visible here. To inspect that, set `paradedb.mpp_debug = on`
+-- and run the query at a scale that triggers parallel workers; the
+-- walker's `mpp_log!` calls render the rewritten plan to stderr. For
+-- pure plan-structure assertions there are also unit tests under
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*` that
+-- build synthetic plans and assert the cut tags
+-- (`scalar_*`, `gb_*`, `tk_*`, `join_*`).
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+CREATE TABLE mpp_exec_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+CREATE TABLE mpp_exec_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+INSERT INTO mpp_exec_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+INSERT INTO mpp_exec_reviews (product_id, rating)
+SELECT (i % 40) + 1, (i % 5) + 1 FROM generate_series(1, 200) AS i;
+CREATE INDEX mpp_exec_products_idx ON mpp_exec_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+CREATE INDEX mpp_exec_reviews_idx ON mpp_exec_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT COUNT(*) AS baseline_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ baseline_count 
+----------------
+            200
+(1 row)
+
+-- =====================================================================
+-- MPP enabled: must return the same count.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 3;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny (40x200 rows) to exercise the MPP pipeline. In production the
+-- `mpp_min_join_rows` default (10_000) would opt out of MPP for this
+-- size; here we force MPP on so the pipeline gets tested.
+SET paradedb.mpp_min_join_rows TO 0;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 2
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+         Aggregates: COUNT(*)
+(8 rows)
+
+SELECT COUNT(*) AS mpp_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ mpp_count 
+-----------
+       200
+(1 row)
+
+-- With mpp_debug, the plan should log the shape dispatch + parallel
+-- flip + the "routing exec_datafusion_aggregate through shape" line
+-- that proves the MPP exec bridge actually ran (not just the serial
+-- fallback). The answer must still match the baseline.
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*) AS mpp_count_with_debug
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape ScalarAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 3 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=0, total=3, aggr_count=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 1 attached to DSM (3 participants)
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=1, total=3, aggr_count=1, join_keys=1)
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=2, total=3, aggr_count=1, join_keys=1)
+ mpp_count_with_debug 
+----------------------
+                  200
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+-- =====================================================================
+-- GROUP BY aggregate on join, with ORDER BY on the group-by column. Both
+-- the GROUP BY and the ORDER BY are driven by the same column, so PG
+-- wraps the Gather-above-CustomScan MPP path in a Sort above the Gather.
+-- The MPP path keeps Aggrefs intact in every tlist so `fix_upper_expr`
+-- matches structurally at setrefs time (if we'd replaced them with
+-- `pdb.agg_fn(...)` placeholders only on the Gather side, setrefs would
+-- trip "Aggref found in non-Agg plan node" on the Result projection PG
+-- adds above the Sort).
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | cnt | max_rating 
+-------------+-----+------------
+ Clothing    |  50 |          5
+ Electronics |  50 |          5
+ Furniture   |  50 |          5
+ Sports      |  50 |          5
+(4 rows)
+
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_debug TO on;
+-- Force PG to pick the Gather-wrapped MPP path for GROUP BY on this
+-- small fixture: without these knobs the planner's cost model rejects
+-- Gather for aggregates at this row count and we'd fall back to the
+-- serial Custom Scan (which still produces correct output via the
+-- non-MPP code path).
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape GroupByAggOnBinaryJoin
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Sort
+   Output: p.category, (count(*)), (max(r.rating))
+   Sort Key: p.category
+   ->  Gather
+         Output: p.category, (count(*)), (max(r.rating))
+         Workers Planned: 2
+         ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+               Output: p.category, (count(*)), (max(r.rating))
+               Backend: DataFusion
+               Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+               Group By: category
+               Aggregates: COUNT(*), MAX(rating)
+(12 rows)
+
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape GroupByAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 3 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: distribute_plan walker dispatching shape=GroupByAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=0, total=3, aggr_count=2, group_keys=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 1 attached to DSM (3 participants)
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=GroupByAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=GroupByAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=2, total=3, aggr_count=2, group_keys=1, join_keys=1)
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=1, total=3, aggr_count=2, group_keys=1, join_keys=1)
+  category   | cnt | max_rating 
+-------------+-----+------------
+ Clothing    |  50 |          5
+ Electronics |  50 |          5
+ Furniture   |  50 |          5
+ Sports      |  50 |          5
+(4 rows)
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+SET paradedb.mpp_debug TO off;
+-- =====================================================================
+-- GROUP BY + ORDER BY <agg-expr> + LIMIT — the SQL pattern that the
+-- walker upgrades to the `TopKGroupByAggOnBinaryJoin` shape *when*
+-- DataFusion's physical planner fuses `Sort[fetch=k]` over the
+-- aggregate. Whether that fusion happens depends on PG's planner
+-- decisions:
+--   * On bench-scale data (e.g. `aggregate_join_topk_count - alt 2`)
+--     the Sort+Limit collapses into the AggregateScan's pushed-down
+--     plan, the walker's `extract_topk_spec` matches, and the dispatch
+--     becomes `TopKGroupByAggOnBinaryJoin` (scalar-style routing:
+--     every participant ships its Partial groups to participant 0 via
+--     `FixedTargetPartitioner(0)`, leader runs `FinalPartitioned +
+--     Sort[fetch=k]`).
+--   * In this regress fixture, PG keeps `Sort` and `Limit` above the
+--     Gather, the AggregateScan only pushes the aggregate into
+--     DataFusion, and the walker dispatches as plain
+--     `GroupByAggOnBinaryJoin`. Result is still correct because the
+--     SortExec/LimitExec live above the Gather and execute serially
+--     after MPP gathers the per-participant aggregate output.
+-- The query stays as a regression-pin for the SQL pattern (correctness
+-- under either shape); for plan-shape coverage of the TopK upgrade
+-- itself, see the synthetic-plan unit tests in
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*`.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+  category   | cnt 
+-------------+-----
+ Clothing    |  50
+ Electronics |  50
+(2 rows)
+
+SET paradedb.enable_mpp TO on;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+-- Keep mpp_debug off here so the per-worker WARNING ordering doesn't
+-- interleave non-deterministically with the EXPLAIN / SELECT output
+-- (the existing scalar + groupby blocks above already cover the
+-- mpp_debug-on case).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Limit
+   Output: p.category, (count(*))
+   ->  Sort
+         Output: p.category, (count(*))
+         Sort Key: (count(*)) DESC, p.category
+         ->  Gather
+               Output: p.category, (count(*))
+               Workers Planned: 2
+               ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+                     Output: p.category, (count(*))
+                     Backend: DataFusion
+                     Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+                     Group By: category
+                     Aggregates: COUNT(*)
+(14 rows)
+
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+  category   | cnt 
+-------------+-----
+ Clothing    |  50
+ Electronics |  50
+(2 rows)
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+-- Restore defaults + clean up.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+DROP TABLE mpp_exec_reviews;
+DROP TABLE mpp_exec_products;

--- a/pg_search/tests/pg_regress/expected/mpp_fallback.out
+++ b/pg_search/tests/pg_regress/expected/mpp_fallback.out
@@ -1,0 +1,177 @@
+-- =====================================================================
+-- MPP fallback: prove that `paradedb.enable_mpp = on` is a no-op for
+-- queries whose shape isn't (yet) wired to the MPP path.
+--
+-- Phase 4b-i landed the GUC + all the primitives + the customscan_glue
+-- helpers, but did NOT yet flip AggregateScan's or JoinScan's
+-- `ParallelQueryCapable` hooks. So with `enable_mpp=on` every query
+-- should still produce the exact same answers as with `enable_mpp=off`
+-- (there just isn't an MPP path to choose). This test locks in that
+-- no-regression invariant — if Phase 4b-ii accidentally changes the
+-- off-path result under `enable_mpp=on`, this diff catches it.
+--
+-- Data setup mirrors the non-MPP aggregate fallback test so the two are
+-- easy to compare.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+CREATE TABLE mpp_fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+CREATE TABLE mpp_fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+INSERT INTO mpp_fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99),
+    ('Office chair ergonomic', 'Furniture', 249.99);
+INSERT INTO mpp_fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4), (3, 5), (4, 2);
+CREATE INDEX mpp_fb_products_idx ON mpp_fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+CREATE INDEX mpp_fb_reviews_idx ON mpp_fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- Baseline: enable_mpp = off (current default behavior)
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+-- Scalar aggregate on join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Backend: DataFusion
+   Indexes: mpp_fb_products_idx (p), mpp_fb_reviews_idx (r)
+   Aggregates: COUNT(*)
+(5 rows)
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ count 
+-------
+     6
+(1 row)
+
+-- GROUP BY aggregate on join
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count | max_rating 
+-------------+-------+------------
+ Clothing    |     2 |          5
+ Electronics |     2 |          5
+ Furniture   |     1 |          2
+ Sports      |     1 |          3
+(4 rows)
+
+-- =====================================================================
+-- MPP enabled: results must be byte-identical.
+--
+-- With MPP on but no customscan actually routes to the MPP path yet,
+-- the queries must return the same answers as with MPP off. Any
+-- divergence here means Phase 4b-ii accidentally changed existing
+-- behavior on the enable_mpp=on branch.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny to exercise the MPP pipeline's shape classification + plan-stash
+-- path. Production default (10_000) would opt out of MPP for this size.
+SET paradedb.mpp_min_join_rows TO 0;
+-- Same EXPLAIN + query as above.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 1
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_fb_products_idx (p), mpp_fb_reviews_idx (r)
+         Aggregates: COUNT(*)
+(8 rows)
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ count 
+-------
+     6
+(1 row)
+
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count | max_rating 
+-------------+-------+------------
+ Clothing    |     2 |          5
+ Electronics |     2 |          5
+ Furniture   |     1 |          2
+ Sports      |     1 |          3
+(4 rows)
+
+-- Also verify `mpp_debug = on` is a no-op for correctness (may emit
+-- diagnostic warnings, but the query results must be unchanged).
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+WARNING:  mpp: flipping AggregateScan path parallel_workers=1 for shape ScalarAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 2 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=2 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=0, total=2, aggr_count=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (2 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=2 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=1, total=2, aggr_count=1, join_keys=1)
+ count 
+-------
+     6
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+-- Restore defaults.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+DROP TABLE mpp_fb_reviews;
+DROP TABLE mpp_fb_products;

--- a/pg_search/tests/pg_regress/expected/mpp_join.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join.out
@@ -1,0 +1,171 @@
+-- =====================================================================
+-- MPP correctness for the JoinOnly shape: a bare join without an
+-- aggregate above it. Verifies that with `paradedb.enable_mpp = on` the
+-- result rows match the serial baseline.
+--
+-- Like `mpp_exec.sql`, this test exercises plan-stash + classifier +
+-- parallel-flag pipeline. PG's planner may not launch actual workers on
+-- this small dataset; what this test DOES guarantee is:
+--   * the JoinOnly plan stash completes without error
+--   * the exec path produces correct rows whether or not workers launch
+--   * `mpp_debug` logs the `mpp: routing JoinScan exec through shape` line
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+CREATE TABLE mpp_join_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+CREATE TABLE mpp_join_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER,
+    comment TEXT
+);
+INSERT INTO mpp_join_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+INSERT INTO mpp_join_reviews (product_id, rating, comment)
+SELECT
+    (i % 40) + 1,
+    (i % 5) + 1,
+    'review ' || i
+FROM generate_series(1, 200) AS i;
+CREATE INDEX mpp_join_products_idx ON mpp_join_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+CREATE INDEX mpp_join_reviews_idx ON mpp_join_reviews
+USING bm25 (id, product_id, rating, comment)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}',
+    text_fields='{"comment": {}}'
+);
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      | rating 
+----+----------------------+--------
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+(10 rows)
+
+-- =====================================================================
+-- MPP enabled: must return the same rows (set-equality, then row-order).
+-- `mpp_min_join_rows` must be 0 here: the default (10k rows) would gate
+-- out this small dataset and silently fall through to the serial path,
+-- defeating the point of the test.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+SET paradedb.mpp_min_join_rows TO 0;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.description, r.rating, r.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.description, r.rating, r.id
+         Relation Tree: r INNER p
+         Join Cond: p.id = r.product_id
+         Limit: 10
+         Order By: p.id asc, r.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, id@1 as col_4, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST, id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[r, p]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      | rating 
+----+----------------------+--------
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+(10 rows)
+
+-- Multi-predicate join with both sides filtered.
+SELECT p.id, p.description, r.comment
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop' AND r.comment @@@ 'review'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      |  comment   
+----+----------------------+------------
+  4 | Laptop computer fast | review 3
+  4 | Laptop computer fast | review 43
+  4 | Laptop computer fast | review 83
+  4 | Laptop computer fast | review 123
+  4 | Laptop computer fast | review 163
+  8 | Laptop computer fast | review 7
+  8 | Laptop computer fast | review 47
+  8 | Laptop computer fast | review 87
+  8 | Laptop computer fast | review 127
+  8 | Laptop computer fast | review 167
+(10 rows)
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE mpp_join_reviews;
+DROP TABLE mpp_join_products;

--- a/pg_search/tests/pg_regress/sql/mpp_exec.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_exec.sql
@@ -1,0 +1,249 @@
+-- =====================================================================
+-- MPP correctness: with `paradedb.enable_mpp=on`, scalar COUNT(*) on a
+-- binary join must return the same result as with MPP off.
+--
+-- This test exercises the full shape classification + plan-stash +
+-- parallel-flag flip pipeline on a medium-sized dataset (40x200 rows).
+-- PG's planner decides whether to launch actual parallel workers based
+-- on cost; at this size it typically doesn't, so the MPP *exec* path
+-- isn't exercised here — for that you need `debug_parallel_query=on`
+-- at a larger scale, which is out of scope for pg_regress (no parallel
+-- workers launched == no DSM coordination == no cross-worker shuffle).
+--
+-- What this DOES verify:
+--   * MPP-on doesn't break the serial code path
+--   * Shape classifier agrees between path-time and plan-stash-time
+--   * `maybe_stash_mpp_plan_bytes` completes without error
+--   * The plan survives logical-plan → bytes round-trip
+--
+-- A note on EXPLAIN scope: the EXPLAINs below show the PG-level plan
+-- (the Custom Scan node is opaque from the planner's perspective). The
+-- DataFusion physical plan that the walker actually rewrites and emits
+-- is not visible here. To inspect that, set `paradedb.mpp_debug = on`
+-- and run the query at a scale that triggers parallel workers; the
+-- walker's `mpp_log!` calls render the rewritten plan to stderr. For
+-- pure plan-structure assertions there are also unit tests under
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*` that
+-- build synthetic plans and assert the cut tags
+-- (`scalar_*`, `gb_*`, `tk_*`, `join_*`).
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+CREATE TABLE mpp_exec_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+
+CREATE TABLE mpp_exec_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+
+INSERT INTO mpp_exec_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+
+INSERT INTO mpp_exec_reviews (product_id, rating)
+SELECT (i % 40) + 1, (i % 5) + 1 FROM generate_series(1, 200) AS i;
+
+CREATE INDEX mpp_exec_products_idx ON mpp_exec_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+
+CREATE INDEX mpp_exec_reviews_idx ON mpp_exec_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+
+
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+SELECT COUNT(*) AS baseline_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- =====================================================================
+-- MPP enabled: must return the same count.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 3;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny (40x200 rows) to exercise the MPP pipeline. In production the
+-- `mpp_min_join_rows` default (10_000) would opt out of MPP for this
+-- size; here we force MPP on so the pipeline gets tested.
+SET paradedb.mpp_min_join_rows TO 0;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*) AS mpp_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- With mpp_debug, the plan should log the shape dispatch + parallel
+-- flip + the "routing exec_datafusion_aggregate through shape" line
+-- that proves the MPP exec bridge actually ran (not just the serial
+-- fallback). The answer must still match the baseline.
+SET paradedb.mpp_debug TO on;
+
+SELECT COUNT(*) AS mpp_count_with_debug
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SET paradedb.mpp_debug TO off;
+
+-- =====================================================================
+-- GROUP BY aggregate on join, with ORDER BY on the group-by column. Both
+-- the GROUP BY and the ORDER BY are driven by the same column, so PG
+-- wraps the Gather-above-CustomScan MPP path in a Sort above the Gather.
+-- The MPP path keeps Aggrefs intact in every tlist so `fix_upper_expr`
+-- matches structurally at setrefs time (if we'd replaced them with
+-- `pdb.agg_fn(...)` placeholders only on the Gather side, setrefs would
+-- trip "Aggref found in non-Agg plan node" on the Result projection PG
+-- adds above the Sort).
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_debug TO on;
+-- Force PG to pick the Gather-wrapped MPP path for GROUP BY on this
+-- small fixture: without these knobs the planner's cost model rejects
+-- Gather for aggregates at this row count and we'd fall back to the
+-- serial Custom Scan (which still produces correct output via the
+-- non-MPP code path).
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+
+SET paradedb.mpp_debug TO off;
+
+-- =====================================================================
+-- GROUP BY + ORDER BY <agg-expr> + LIMIT — the SQL pattern that the
+-- walker upgrades to the `TopKGroupByAggOnBinaryJoin` shape *when*
+-- DataFusion's physical planner fuses `Sort[fetch=k]` over the
+-- aggregate. Whether that fusion happens depends on PG's planner
+-- decisions:
+--   * On bench-scale data (e.g. `aggregate_join_topk_count - alt 2`)
+--     the Sort+Limit collapses into the AggregateScan's pushed-down
+--     plan, the walker's `extract_topk_spec` matches, and the dispatch
+--     becomes `TopKGroupByAggOnBinaryJoin` (scalar-style routing:
+--     every participant ships its Partial groups to participant 0 via
+--     `FixedTargetPartitioner(0)`, leader runs `FinalPartitioned +
+--     Sort[fetch=k]`).
+--   * In this regress fixture, PG keeps `Sort` and `Limit` above the
+--     Gather, the AggregateScan only pushes the aggregate into
+--     DataFusion, and the walker dispatches as plain
+--     `GroupByAggOnBinaryJoin`. Result is still correct because the
+--     SortExec/LimitExec live above the Gather and execute serially
+--     after MPP gathers the per-participant aggregate output.
+-- The query stays as a regression-pin for the SQL pattern (correctness
+-- under either shape); for plan-shape coverage of the TopK upgrade
+-- itself, see the synthetic-plan unit tests in
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*`.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+
+SET paradedb.enable_mpp TO on;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+
+-- Keep mpp_debug off here so the per-worker WARNING ordering doesn't
+-- interleave non-deterministically with the EXPLAIN / SELECT output
+-- (the existing scalar + groupby blocks above already cover the
+-- mpp_debug-on case).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+
+-- Restore defaults + clean up.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+
+DROP TABLE mpp_exec_reviews;
+DROP TABLE mpp_exec_products;

--- a/pg_search/tests/pg_regress/sql/mpp_fallback.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_fallback.sql
@@ -1,0 +1,132 @@
+-- =====================================================================
+-- MPP fallback: prove that `paradedb.enable_mpp = on` is a no-op for
+-- queries whose shape isn't (yet) wired to the MPP path.
+--
+-- Phase 4b-i landed the GUC + all the primitives + the customscan_glue
+-- helpers, but did NOT yet flip AggregateScan's or JoinScan's
+-- `ParallelQueryCapable` hooks. So with `enable_mpp=on` every query
+-- should still produce the exact same answers as with `enable_mpp=off`
+-- (there just isn't an MPP path to choose). This test locks in that
+-- no-regression invariant — if Phase 4b-ii accidentally changes the
+-- off-path result under `enable_mpp=on`, this diff catches it.
+--
+-- Data setup mirrors the non-MPP aggregate fallback test so the two are
+-- easy to compare.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+CREATE TABLE mpp_fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+
+CREATE TABLE mpp_fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+
+INSERT INTO mpp_fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99),
+    ('Office chair ergonomic', 'Furniture', 249.99);
+
+INSERT INTO mpp_fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4), (3, 5), (4, 2);
+
+CREATE INDEX mpp_fb_products_idx ON mpp_fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+
+CREATE INDEX mpp_fb_reviews_idx ON mpp_fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+
+-- =====================================================================
+-- Baseline: enable_mpp = off (current default behavior)
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+-- Scalar aggregate on join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- GROUP BY aggregate on join
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- =====================================================================
+-- MPP enabled: results must be byte-identical.
+--
+-- With MPP on but no customscan actually routes to the MPP path yet,
+-- the queries must return the same answers as with MPP off. Any
+-- divergence here means Phase 4b-ii accidentally changed existing
+-- behavior on the enable_mpp=on branch.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny to exercise the MPP pipeline's shape classification + plan-stash
+-- path. Production default (10_000) would opt out of MPP for this size.
+SET paradedb.mpp_min_join_rows TO 0;
+
+-- Same EXPLAIN + query as above.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Also verify `mpp_debug = on` is a no-op for correctness (may emit
+-- diagnostic warnings, but the query results must be unchanged).
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+SET paradedb.mpp_debug TO off;
+
+-- Restore defaults.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+
+DROP TABLE mpp_fb_reviews;
+DROP TABLE mpp_fb_products;

--- a/pg_search/tests/pg_regress/sql/mpp_join.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_join.sql
@@ -1,0 +1,122 @@
+-- =====================================================================
+-- MPP correctness for the JoinOnly shape: a bare join without an
+-- aggregate above it. Verifies that with `paradedb.enable_mpp = on` the
+-- result rows match the serial baseline.
+--
+-- Like `mpp_exec.sql`, this test exercises plan-stash + classifier +
+-- parallel-flag pipeline. PG's planner may not launch actual workers on
+-- this small dataset; what this test DOES guarantee is:
+--   * the JoinOnly plan stash completes without error
+--   * the exec path produces correct rows whether or not workers launch
+--   * `mpp_debug` logs the `mpp: routing JoinScan exec through shape` line
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+
+CREATE TABLE mpp_join_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+
+CREATE TABLE mpp_join_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER,
+    comment TEXT
+);
+
+INSERT INTO mpp_join_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+
+INSERT INTO mpp_join_reviews (product_id, rating, comment)
+SELECT
+    (i % 40) + 1,
+    (i % 5) + 1,
+    'review ' || i
+FROM generate_series(1, 200) AS i;
+
+CREATE INDEX mpp_join_products_idx ON mpp_join_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+
+CREATE INDEX mpp_join_reviews_idx ON mpp_join_reviews
+USING bm25 (id, product_id, rating, comment)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}',
+    text_fields='{"comment": {}}'
+);
+
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- =====================================================================
+-- MPP enabled: must return the same rows (set-equality, then row-order).
+-- `mpp_min_join_rows` must be 0 here: the default (10k rows) would gate
+-- out this small dataset and silently fall through to the serial path,
+-- defeating the point of the test.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+SET paradedb.mpp_min_join_rows TO 0;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- Multi-predicate join with both sides filtered.
+SELECT p.id, p.description, r.comment
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop' AND r.comment @@@ 'review'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_join_custom_scan;
+
+DROP TABLE mpp_join_reviews;
+DROP TABLE mpp_join_products;


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #4152
- Stacked on top of #4870

## What

Fifth and final PR in the 5-PR MPP chain. Wires AggregateScan and JoinScan into the assembler so queries actually run across multiple workers under MPP — hash-partitioning both join inputs and shuffling intermediate rows through the DSM `shm_mq` mesh. Off by default (`paradedb.enable_mpp = off`).

**Chain (5/5):** #4827 → #4828 → #4869 → #4870 → **this**

## Why

The user-visible payoff of the chain. The previous PRs land transport, operators, classifier, and assembler as inert primitives; this PR opts the customscan paths into them so a query like `SELECT k, COUNT(*) FROM f JOIN p GROUP BY k` actually goes parallel under MPP instead of falling back to the serial path.

## How

- Each customscan classifies the plan shape at planning time, allocates a DSM mesh through the lifecycle hooks, and at exec time hands its plan to the assembler and runs whatever comes back.
- Under MPP we turn off two DataFusion optimizer behaviours that hurt these shapes: the sort-merge-join enforcer (collapses hash-partitioned streams) and the join-side dynamic-filter pushdown (races with the shuffle producer on the probe scan).
- A small upper-path hook so core wraps the parallel custom path in a `Gather` for `UPPERREL_GROUP_AGG`. Without it, core's gather generator runs before our hook fires for upper rels and the partial path is orphaned.
- New regression fixtures (`mpp_exec`, `mpp_fallback`, `mpp_join`) and MPP alt variants on the bench SQL so CI tracks correctness and perf.
- Drops the per-module dead-code waivers earlier PRs added across the MPP subtree — every helper now has a live caller.

## Reviewer's Guide

- Start with `aggregatescan/mod.rs`: the `ParallelQueryCapable` impl, the plan-bytes stash, and the MPP branch in the exec hook are the AggregateScan story end-to-end.
- Then `joinscan/mod.rs` for the symmetric JoinScan wiring.
- The session-context differences (the two optimizer flags) and the upper-path hook are the only non-mechanical pieces.
- Functional validation runs through the regression fixtures; perf goes through the bench SQL.

## Tests

- `cargo check` / `cargo clippy` clean.
- `cargo test -p pg_search --lib mpp::` green.
- `cargo pgrx regress pg18 mpp_smoke mpp_exec mpp_fallback mpp_join` green.