### PR TITLE
Add warning when TOPK is used with ASC ordering

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -1815,6 +1815,12 @@ impl JoinSortExprKind {
                 if !output_rtis.contains(&source.scan_info.heap_rti) {
                     continue;
                 }
+                if direction.is_asc() {
+                    pgrx::warning!(
+                        "ORDER BY pdb.score(...) ASC returns the least relevant results first. \
+                         Did you mean ORDER BY pdb.score(...) DESC?"
+                    );
+                }
                 return Self::Resolved(OrderByInfo {
                     feature: OrderByFeature::Score {
                         rti: source.scan_info.heap_rti,

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -351,6 +351,23 @@ where
 
                 match sort_type {
                     SortExpressionType::Score => {
+                        // Warn if user is ordering by score ASC, which returns
+                        // the *least* relevant results first — almost certainly
+                        // not what they intended.
+                        #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
+                        let is_asc = (*pathkey).pk_strategy as u32
+                            == pg_sys::BTLessStrategyNumber;
+                        #[cfg(feature = "pg18")]
+                        let is_asc = (*pathkey).pk_cmptype
+                            == pg_sys::CompareType::COMPARE_LT;
+
+                        if is_asc {
+                            pgrx::warning!(
+                                "ORDER BY pdb.score(...) ASC returns the least relevant results first. \
+                                 Did you mean ORDER BY pdb.score(...) DESC?"
+                            );
+                        }
+
                         pathkey_styles.push(OrderByStyle::Score { pathkey, rti });
                         found_valid_member = true;
                         break;


### PR DESCRIPTION
Display the following warning when TopK score is ordered ASC on score.

```
SELECT ... FROM ... WHERE @@@ 
ORDER BY pdb.score(id) LIMIT 10

SELECT ... FROM ... WHERE @@@ 
ORDER BY pdb.score(id) ASCLIMIT 10
```

The warning looks like this:
```
WARNING:  ORDER BY pdb.score(...) ASC returns the least relevant results first. Did you mean ORDER BY pdb.score(...) DESC?
```

