### PR TITLE
perf: Wire FastField term-set strategy framework and raise InList pushdown cap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,7 +5515,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -8190,7 +8190,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8245,7 +8245,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "bitpacking",
 ]
@@ -8253,7 +8253,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8268,7 +8268,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8301,7 +8301,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8313,7 +8313,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8326,7 +8326,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8363,7 +8363,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=52dfd549ef27428bd92863757440a214dd0c8d41#52dfd549ef27428bd92863757440a214dd0c8d41"
+source = "git+https://github.com/paradedb/tantivy.git?rev=a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2#a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "52dfd549ef27428bd92863757440a214dd0c8d41", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -41,4 +41,4 @@ pgrx-tests = "=0.18.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "52dfd549ef27428bd92863757440a214dd0c8d41" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "a5b1aabd21fb04c49f3b36411f9b0e3d29674bc2" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-q4fb+M3tnSMBUFPgfGzxmwTYkylbJU+i5gIZf7HQ+mE=";
+  cargoHash = "sha256-k8h5riie/IVvUN6lVJIdveMqQsjA/3aO+XU5IMkYGr4=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -185,18 +185,19 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
     GucSetting::<i32>::new(20_000);
 
-// TermSet strategy density thresholds (paradedb/paradedb#4895). These tune
-// the planner in tantivy::query::TermSetStrategyConfig — see design.md §4
-// for the meaning of each density. Defaults are 1/64, 1/256, 1/4, 1/16, 1/4
-// to mirror TermSetStrategyConfig::default() in tantivy; a paradedb
-// installation that doesn't touch them gets the same behavior as a bare
-// tantivy caller.
+/// Kill-switch for galloping execution of `FastFieldTermSetQuery` on
+/// sorted segments. When `false`, the planner never returns the gallop
+/// strategy regardless of density, and pushed-down InList filters fall
+/// back to the legacy linear scan even on sorted segments.
 static TERM_SET_GALLOP_ENABLED: GucSetting<bool> = GucSetting::<bool>::new(true);
+
+/// Density gate for the gallop dispatch path. Gallop is selected when
+/// `K' / N` is below this threshold on a sorted segment, where `K'` is
+/// the number of distinct terms surviving min/max pruning and `N` is the
+/// segment size. Larger values admit gallop more aggressively; smaller
+/// values are more conservative. Default `1/100 = 0.01` matches
+/// `tantivy::query::TermSetStrategyConfig::default()`.
 static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 100.0);
-static TERM_SET_POSTING_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 256.0);
-static TERM_SET_BITSET_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 4.0);
-static TERM_SET_HASH_PROBE_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 16.0);
-static TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 4.0);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
@@ -505,47 +506,6 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
-    GucRegistry::define_float_guc(
-        c"paradedb.term_set_posting_max_density",
-        c"Reserved (follow-up A): posting-list direct strategy density threshold for first-column FastFieldTermSetQuery.",
-        c"K' * D / N below this density selects PostingListDirect. Currently routes to LinearScan; the density is recorded so when follow-up A lands, no SQL change is needed. Default 1/256 = 0.00390625.",
-        &TERM_SET_POSTING_MAX_DENSITY,
-        0.0,
-        1.0,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-    GucRegistry::define_float_guc(
-        c"paradedb.term_set_bitset_max_density",
-        c"Reserved (follow-up B): bitset-from-postings strategy density threshold for first-column FastFieldTermSetQuery.",
-        c"K' * D / N below this density selects BitsetFromPostings. Currently routes to LinearScan. Default 1/4 = 0.25.",
-        &TERM_SET_BITSET_MAX_DENSITY,
-        0.0,
-        1.0,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-    GucRegistry::define_float_guc(
-        c"paradedb.term_set_hash_probe_max_density",
-        c"Reserved (subsequent-column work): hash-probe density threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
-        c"C / N below this density selects HashProbe. Currently routes to LinearScan. Default 1/16 = 0.0625.",
-        &TERM_SET_HASH_PROBE_MAX_DENSITY,
-        0.0,
-        1.0,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-    GucRegistry::define_float_guc(
-        c"paradedb.term_set_subsequent_bitset_max_density",
-        c"Reserved (subsequent-column work): bitset-from-postings density threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
-        c"K' * D / C below this density selects BitsetFromPostings on the subsequent-column branch. Currently routes to LinearScan. Default 1/4 = 0.25.",
-        &TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY,
-        0.0,
-        1.0,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
     GucRegistry::define_int_guc(
         c"paradedb.dynamic_filter_batch_size",
         c"Scanner batch size override for dynamic filter pushdown",
@@ -828,22 +788,6 @@ pub fn term_set_gallop_enabled() -> bool {
 
 pub fn term_set_gallop_max_density() -> f64 {
     TERM_SET_GALLOP_MAX_DENSITY.get()
-}
-
-pub fn term_set_posting_max_density() -> f64 {
-    TERM_SET_POSTING_MAX_DENSITY.get()
-}
-
-pub fn term_set_bitset_max_density() -> f64 {
-    TERM_SET_BITSET_MAX_DENSITY.get()
-}
-
-pub fn term_set_hash_probe_max_density() -> f64 {
-    TERM_SET_HASH_PROBE_MAX_DENSITY.get()
-}
-
-pub fn term_set_subsequent_bitset_max_density() -> f64 {
-    TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -178,17 +178,19 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
     GucSetting::<i32>::new(16_000);
 
-// TermSet strategy thresholds (paradedb/paradedb#4895). These tune the planner
-// in tantivy::query::TermSetStrategyConfig — see design.md §4 for the meaning
-// of each ratio. Defaults mirror TermSetStrategyConfig::default() in tantivy
-// so a paradedb installation that doesn't touch them gets the same behavior
-// as a bare tantivy caller.
+// TermSet strategy density thresholds (paradedb/paradedb#4895). These tune
+// the planner in tantivy::query::TermSetStrategyConfig — see design.md §4
+// for the meaning of each density. Defaults are 1/64, 1/256, 1/4, 1/16, 1/4
+// to mirror TermSetStrategyConfig::default() in tantivy; a paradedb
+// installation that doesn't touch them gets the same behavior as a bare
+// tantivy caller.
 static TERM_SET_GALLOP_ENABLED: GucSetting<bool> = GucSetting::<bool>::new(true);
-static TERM_SET_GALLOP_RATIO: GucSetting<i32> = GucSetting::<i32>::new(64);
-static TERM_SET_POSTING_RATIO: GucSetting<i32> = GucSetting::<i32>::new(256);
-static TERM_SET_BITSET_RATIO: GucSetting<i32> = GucSetting::<i32>::new(4);
-static TERM_SET_HASH_PROBE_RATIO: GucSetting<i32> = GucSetting::<i32>::new(16);
-static TERM_SET_SUBSEQUENT_BITSET_RATIO: GucSetting<i32> = GucSetting::<i32>::new(4);
+static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 64.0);
+static TERM_SET_POSTING_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 256.0);
+static TERM_SET_BITSET_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 4.0);
+static TERM_SET_HASH_PROBE_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 16.0);
+static TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY: GucSetting<f64> =
+    GucSetting::<f64>::new(1.0 / 4.0);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
@@ -473,10 +475,12 @@ pub fn init() {
         GucFlags::default(),
     );
 
-    // TermSet strategy thresholds (issue #4895). The kill-switch
+    // TermSet strategy density thresholds (issue #4895). The kill-switch
     // (paradedb.term_set_gallop_enabled) is the safety override if the
-    // gallop optimization regresses unexpectedly; the four ratios tune the
-    // planner without recompiling.
+    // gallop optimization regresses unexpectedly; the five density values
+    // tune the planner without recompiling. Each density is unitless and
+    // bounded to [0.0, 1.0] (a density above 1.0 would mean more matches
+    // than corpus rows, which is impossible).
     GucRegistry::define_bool_guc(
         c"paradedb.term_set_gallop_enabled",
         c"Enable galloping execution of FastFieldTermSetQuery on sorted segments.",
@@ -485,53 +489,53 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::default(),
     );
-    GucRegistry::define_int_guc(
-        c"paradedb.term_set_gallop_ratio",
-        c"Gallop is selected when K' < N / this ratio on a sorted segment.",
-        c"Larger values bias toward gallop. K' is the number of distinct terms surviving min/max pruning; N is the segment size. Default 64.",
-        &TERM_SET_GALLOP_RATIO,
-        1,
-        i32::MAX,
+    GucRegistry::define_float_guc(
+        c"paradedb.term_set_gallop_max_density",
+        c"Gallop is selected when K' / N is below this density on a sorted segment.",
+        c"K' is the number of distinct terms surviving min/max pruning; N is the segment size. Smaller values bias toward gallop. Default 1/64 = 0.015625.",
+        &TERM_SET_GALLOP_MAX_DENSITY,
+        0.0,
+        1.0,
         GucContext::Userset,
         GucFlags::default(),
     );
-    GucRegistry::define_int_guc(
-        c"paradedb.term_set_posting_ratio",
-        c"Reserved (follow-up A): posting-list direct strategy threshold for first-column FastFieldTermSetQuery.",
-        c"K' * D < N / this ratio selects PostingListDirect. Currently routes to LinearScan; the ratio is recorded so when follow-up A lands, no SQL change is needed. Default 256.",
-        &TERM_SET_POSTING_RATIO,
-        1,
-        i32::MAX,
+    GucRegistry::define_float_guc(
+        c"paradedb.term_set_posting_max_density",
+        c"Reserved (follow-up A): posting-list direct strategy density threshold for first-column FastFieldTermSetQuery.",
+        c"K' * D / N below this density selects PostingListDirect. Currently routes to LinearScan; the density is recorded so when follow-up A lands, no SQL change is needed. Default 1/256 = 0.00390625.",
+        &TERM_SET_POSTING_MAX_DENSITY,
+        0.0,
+        1.0,
         GucContext::Userset,
         GucFlags::default(),
     );
-    GucRegistry::define_int_guc(
-        c"paradedb.term_set_bitset_ratio",
-        c"Reserved (follow-up B): bitset-from-postings strategy threshold for first-column FastFieldTermSetQuery.",
-        c"K' * D < N / this ratio selects BitsetFromPostings. Currently routes to LinearScan. Default 4.",
-        &TERM_SET_BITSET_RATIO,
-        1,
-        i32::MAX,
+    GucRegistry::define_float_guc(
+        c"paradedb.term_set_bitset_max_density",
+        c"Reserved (follow-up B): bitset-from-postings strategy density threshold for first-column FastFieldTermSetQuery.",
+        c"K' * D / N below this density selects BitsetFromPostings. Currently routes to LinearScan. Default 1/4 = 0.25.",
+        &TERM_SET_BITSET_MAX_DENSITY,
+        0.0,
+        1.0,
         GucContext::Userset,
         GucFlags::default(),
     );
-    GucRegistry::define_int_guc(
-        c"paradedb.term_set_hash_probe_ratio",
-        c"Reserved (subsequent-column work): hash-probe threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
-        c"C < N / this ratio selects HashProbe. Currently routes to LinearScan. Default 16.",
-        &TERM_SET_HASH_PROBE_RATIO,
-        1,
-        i32::MAX,
+    GucRegistry::define_float_guc(
+        c"paradedb.term_set_hash_probe_max_density",
+        c"Reserved (subsequent-column work): hash-probe density threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
+        c"C / N below this density selects HashProbe. Currently routes to LinearScan. Default 1/16 = 0.0625.",
+        &TERM_SET_HASH_PROBE_MAX_DENSITY,
+        0.0,
+        1.0,
         GucContext::Userset,
         GucFlags::default(),
     );
-    GucRegistry::define_int_guc(
-        c"paradedb.term_set_subsequent_bitset_ratio",
-        c"Reserved (subsequent-column work): bitset-from-postings threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
-        c"K' * D < C / this ratio selects BitsetFromPostings on the subsequent-column branch. Currently routes to LinearScan. Default 4.",
-        &TERM_SET_SUBSEQUENT_BITSET_RATIO,
-        1,
-        i32::MAX,
+    GucRegistry::define_float_guc(
+        c"paradedb.term_set_subsequent_bitset_max_density",
+        c"Reserved (subsequent-column work): bitset-from-postings density threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
+        c"K' * D / C below this density selects BitsetFromPostings on the subsequent-column branch. Currently routes to LinearScan. Default 1/4 = 0.25.",
+        &TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY,
+        0.0,
+        1.0,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -816,24 +820,24 @@ pub fn term_set_gallop_enabled() -> bool {
     TERM_SET_GALLOP_ENABLED.get()
 }
 
-pub fn term_set_gallop_ratio() -> i32 {
-    TERM_SET_GALLOP_RATIO.get()
+pub fn term_set_gallop_max_density() -> f64 {
+    TERM_SET_GALLOP_MAX_DENSITY.get()
 }
 
-pub fn term_set_posting_ratio() -> i32 {
-    TERM_SET_POSTING_RATIO.get()
+pub fn term_set_posting_max_density() -> f64 {
+    TERM_SET_POSTING_MAX_DENSITY.get()
 }
 
-pub fn term_set_bitset_ratio() -> i32 {
-    TERM_SET_BITSET_RATIO.get()
+pub fn term_set_bitset_max_density() -> f64 {
+    TERM_SET_BITSET_MAX_DENSITY.get()
 }
 
-pub fn term_set_hash_probe_ratio() -> i32 {
-    TERM_SET_HASH_PROBE_RATIO.get()
+pub fn term_set_hash_probe_max_density() -> f64 {
+    TERM_SET_HASH_PROBE_MAX_DENSITY.get()
 }
 
-pub fn term_set_subsequent_bitset_ratio() -> i32 {
-    TERM_SET_SUBSEQUENT_BITSET_RATIO.get()
+pub fn term_set_subsequent_bitset_max_density() -> f64 {
+    TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -178,6 +178,18 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
     GucSetting::<i32>::new(16_000);
 
+// TermSet strategy thresholds (paradedb/paradedb#4895). These tune the planner
+// in tantivy::query::TermSetStrategyConfig — see design.md §4 for the meaning
+// of each ratio. Defaults mirror TermSetStrategyConfig::default() in tantivy
+// so a paradedb installation that doesn't touch them gets the same behavior
+// as a bare tantivy caller.
+static TERM_SET_GALLOP_ENABLED: GucSetting<bool> = GucSetting::<bool>::new(true);
+static TERM_SET_GALLOP_RATIO: GucSetting<i32> = GucSetting::<i32>::new(64);
+static TERM_SET_POSTING_RATIO: GucSetting<i32> = GucSetting::<i32>::new(256);
+static TERM_SET_BITSET_RATIO: GucSetting<i32> = GucSetting::<i32>::new(4);
+static TERM_SET_HASH_PROBE_RATIO: GucSetting<i32> = GucSetting::<i32>::new(16);
+static TERM_SET_SUBSEQUENT_BITSET_RATIO: GucSetting<i32> = GucSetting::<i32>::new(4);
+
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -461,6 +473,69 @@ pub fn init() {
         GucFlags::default(),
     );
 
+    // TermSet strategy thresholds (issue #4895). The kill-switch
+    // (paradedb.term_set_gallop_enabled) is the safety override if the
+    // gallop optimization regresses unexpectedly; the four ratios tune the
+    // planner without recompiling.
+    GucRegistry::define_bool_guc(
+        c"paradedb.term_set_gallop_enabled",
+        c"Enable galloping execution of FastFieldTermSetQuery on sorted segments.",
+        c"When false, FastFieldTermSetQuery falls back to the legacy linear scan even on sorted segments. Acts as a kill-switch for the issue #4895 optimization.",
+        &TERM_SET_GALLOP_ENABLED,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"paradedb.term_set_gallop_ratio",
+        c"Gallop is selected when K' < N / this ratio on a sorted segment.",
+        c"Larger values bias toward gallop. K' is the number of distinct terms surviving min/max pruning; N is the segment size. Default 64.",
+        &TERM_SET_GALLOP_RATIO,
+        1,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"paradedb.term_set_posting_ratio",
+        c"Reserved (follow-up A): posting-list direct strategy threshold for first-column FastFieldTermSetQuery.",
+        c"K' * D < N / this ratio selects PostingListDirect. Currently routes to LinearScan; the ratio is recorded so when follow-up A lands, no SQL change is needed. Default 256.",
+        &TERM_SET_POSTING_RATIO,
+        1,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"paradedb.term_set_bitset_ratio",
+        c"Reserved (follow-up B): bitset-from-postings strategy threshold for first-column FastFieldTermSetQuery.",
+        c"K' * D < N / this ratio selects BitsetFromPostings. Currently routes to LinearScan. Default 4.",
+        &TERM_SET_BITSET_RATIO,
+        1,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"paradedb.term_set_hash_probe_ratio",
+        c"Reserved (subsequent-column work): hash-probe threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
+        c"C < N / this ratio selects HashProbe. Currently routes to LinearScan. Default 16.",
+        &TERM_SET_HASH_PROBE_RATIO,
+        1,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_int_guc(
+        c"paradedb.term_set_subsequent_bitset_ratio",
+        c"Reserved (subsequent-column work): bitset-from-postings threshold for FastFieldTermSetQuery on a candidate set narrower than the segment.",
+        c"K' * D < C / this ratio selects BitsetFromPostings on the subsequent-column branch. Currently routes to LinearScan. Default 4.",
+        &TERM_SET_SUBSEQUENT_BITSET_RATIO,
+        1,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
     GucRegistry::define_int_guc(
         c"paradedb.dynamic_filter_batch_size",
         c"Scanner batch size override for dynamic filter pushdown",
@@ -735,6 +810,30 @@ pub fn hash_join_inlist_pushdown_max_size() -> i32 {
 
 pub fn hash_join_inlist_pushdown_max_distinct_values() -> i32 {
     HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES.get()
+}
+
+pub fn term_set_gallop_enabled() -> bool {
+    TERM_SET_GALLOP_ENABLED.get()
+}
+
+pub fn term_set_gallop_ratio() -> i32 {
+    TERM_SET_GALLOP_RATIO.get()
+}
+
+pub fn term_set_posting_ratio() -> i32 {
+    TERM_SET_POSTING_RATIO.get()
+}
+
+pub fn term_set_bitset_ratio() -> i32 {
+    TERM_SET_BITSET_RATIO.get()
+}
+
+pub fn term_set_hash_probe_ratio() -> i32 {
+    TERM_SET_HASH_PROBE_RATIO.get()
+}
+
+pub fn term_set_subsequent_bitset_ratio() -> i32 {
+    TERM_SET_SUBSEQUENT_BITSET_RATIO.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -189,8 +189,7 @@ static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0
 static TERM_SET_POSTING_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 256.0);
 static TERM_SET_BITSET_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 4.0);
 static TERM_SET_HASH_PROBE_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 16.0);
-static TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY: GucSetting<f64> =
-    GucSetting::<f64>::new(1.0 / 4.0);
+static TERM_SET_SUBSEQUENT_BITSET_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 4.0);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -188,7 +188,7 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
 /// Kill-switch for galloping execution of `FastFieldTermSetQuery` on
 /// sorted segments. When `false`, the planner never returns the gallop
 /// strategy regardless of density, and pushed-down InList filters fall
-/// back to the legacy linear scan even on sorted segments.
+/// back to the legacy linear scan even for sorted segments.
 static TERM_SET_GALLOP_ENABLED: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Density gate for the gallop dispatch path. Gallop is selected when

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -169,14 +169,21 @@ static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
     GucSetting::<i32>::new(16 * 1024 * 1024);
 
-/// The maximum number of distinct values in an InList that can be pushed down to a TermSet Query.
+/// The maximum number of distinct values in an InList that can be pushed down
+/// to a TermSetQuery. Above this K, the predicate stays in PostgreSQL /
+/// DataFusion (HashExpr at the join, or PreFilter when the join feeds a
+/// dynamic filter).
 ///
-/// TODO: Adjust this as https://github.com/paradedb/paradedb/issues/4895 and followups land: if
-/// the TermSet scans the entire fast field column (without taking advantage of its shape to skip
-/// data), then creating a Query can be a pessimization, because the HashExpr that DataFusion uses
-/// is ~directly calculated from the pre-hashed values in the HashJoin's hash table.
+/// Bench-tuned: on a sorted-segment index, pushdown wins through K=14K
+/// (1.08×–9.27× over PreFilter at N=1M) and loses at K=20K (0.90×). 20,000
+/// is the upper edge of the crossover band — admits K=15K–19K (interpolated
+/// wins) at the cost of one boundary cell (K=20,000 exact: 11% slowdown).
+///
+/// The byte cap `hash_join_inlist_pushdown_max_size` provides the memory
+/// belt (~524K elements at 32 bytes/term); this cap is the perf-tuned upper
+/// bound. Set to 0 to disable pushdown entirely.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
-    GucSetting::<i32>::new(16_000);
+    GucSetting::<i32>::new(20_000);
 
 // TermSet strategy density thresholds (paradedb/paradedb#4895). These tune
 // the planner in tantivy::query::TermSetStrategyConfig — see design.md §4
@@ -465,8 +472,8 @@ pub fn init() {
 
     GucRegistry::define_int_guc(
         c"paradedb.hash_join_inlist_pushdown_max_distinct_values",
-        c"The maximum number of distinct values in an InList that can be pushed down to a TermSet Query.",
-        c"The maximum number of distinct values in an InList that can be pushed down to a TermSet Query.",
+        c"Maximum number of distinct values in an InList that can be pushed down to a TermSetQuery. Set to 0 to disable pushdown.",
+        c"Maximum number of distinct values in an InList that can be pushed down to a TermSetQuery; above this K the predicate stays in PostgreSQL. Set to 0 to disable pushdown entirely.",
         &HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES,
         0,
         i32::MAX,

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -185,7 +185,7 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
 // installation that doesn't touch them gets the same behavior as a bare
 // tantivy caller.
 static TERM_SET_GALLOP_ENABLED: GucSetting<bool> = GucSetting::<bool>::new(true);
-static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 64.0);
+static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 100.0);
 static TERM_SET_POSTING_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 256.0);
 static TERM_SET_BITSET_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 4.0);
 static TERM_SET_HASH_PROBE_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 16.0);
@@ -492,7 +492,7 @@ pub fn init() {
     GucRegistry::define_float_guc(
         c"paradedb.term_set_gallop_max_density",
         c"Gallop is selected when K' / N is below this density on a sorted segment.",
-        c"K' is the number of distinct terms surviving min/max pruning; N is the segment size. Smaller values bias toward gallop. Default 1/64 = 0.015625.",
+        c"K' is the number of distinct terms surviving min/max pruning; N is the segment size. Larger values admit gallop more aggressively; smaller values are more conservative. Default 1/100 = 0.01 (matches tantivy::query::TermSetStrategyConfig::default()).",
         &TERM_SET_GALLOP_MAX_DENSITY,
         0.0,
         1.0,

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -340,6 +340,12 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
         .optimizer
         .hash_join_inlist_pushdown_max_size =
         crate::gucs::hash_join_inlist_pushdown_max_size() as usize;
+    // 0 is also DataFusion's kill switch: HashJoinExec rejects InList
+    // materialization when num_of_distinct_key() > max_distinct_values, and
+    // any non-empty build side has at least one distinct key. So setting
+    // the GUC to 0 disables the InList path on both sides of the boundary
+    // — paradedb's try_convert_in_list_to_query and DataFusion's hash-join
+    // pushdown agree on disable semantics.
     config
         .options_mut()
         .optimizer

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -168,9 +168,12 @@ pub struct PgSearchScanPlan {
     sort_order: Option<SortByField>,
     /// Captures the per-segment `TermSetStrategy` chosen by the tantivy planner
     /// for the pushed-down dynamic filter (issue #4895). Last-segment-wins is
-    /// fine because `EXPLAIN ANALYZE` only asks "did any segment use it?". A
-    /// value of `0` (`tantivy::query::strategy_tag::NONE`) means no dispatch
-    /// happened, e.g. the InList didn't reach the FastField path.
+    /// fine because `EXPLAIN ANALYZE` only asks "did any segment use it?".
+    /// Stored as `u8` so it can live behind an `AtomicU8`; round-tripped
+    /// through `tantivy::query::StrategyTag` at render time. A value of
+    /// `StrategyTag::None as u8` (= 0) means no dispatch happened, e.g. the
+    /// InList didn't reach the FastField path (K ≤ 1024 routes to
+    /// AutomatonWeight which doesn't write the sink).
     dynamic_filter_strategy: Arc<AtomicU8>,
 }
 
@@ -373,20 +376,20 @@ fn build_equivalence_properties(
     eq_properties
 }
 
-/// Translate a `tantivy::query::strategy_tag` numeric tag back into the
-/// human-readable strategy name surfaced in `EXPLAIN ANALYZE` output.
-/// Exhaustive on the tag set so follow-ups A and B (filling in the
+/// Translate a `tantivy::query::StrategyTag` back into the human-readable
+/// strategy name surfaced in `EXPLAIN ANALYZE` output. The match is
+/// exhaustive on the enum so follow-ups A and B (filling in the
 /// posting-direct and bitset-from-postings dispatch arms) don't need to
-/// revisit this site.
-fn strategy_tag_name(tag: u8) -> &'static str {
-    use tantivy::query::strategy_tag;
-    match tag {
-        strategy_tag::GALLOP => "gallop",
-        strategy_tag::LINEAR => "linear",
-        strategy_tag::BITSET => "bitset_from_postings",
-        strategy_tag::POSTING => "posting_direct",
-        strategy_tag::HASH => "hash_probe",
-        _ => "unknown",
+/// revisit this site — the compiler will flag any new variant.
+fn strategy_name(strategy: tantivy::query::StrategyTag) -> &'static str {
+    use tantivy::query::StrategyTag;
+    match strategy {
+        StrategyTag::None => "none",
+        StrategyTag::Gallop => "gallop",
+        StrategyTag::Linear => "linear",
+        StrategyTag::Bitset => "bitset_from_postings",
+        StrategyTag::Posting => "posting_direct",
+        StrategyTag::Hash => "hash_probe",
     }
 }
 
@@ -401,15 +404,23 @@ impl DisplayAs for PgSearchScanPlan {
             write!(f, ", dynamic_filters={}", self.dynamic_filters.len())?;
         }
         if self.dynamic_filter_pushdown.load(Ordering::Relaxed) {
-            write!(f, ", dynamic_filter_pushdown=true")?;
-        }
-        let tag = self.dynamic_filter_strategy.load(Ordering::Relaxed);
-        if tag != tantivy::query::strategy_tag::NONE {
-            write!(
-                f,
-                ", dynamic_filter_pushdown_strategy={}",
-                strategy_tag_name(tag),
-            )?;
+            // Render a single token. When the strategy framework engaged
+            // (K > 1024 reached FastFieldTermSetWeight and select_strategy
+            // wrote the sink), the value is the strategy name. Otherwise
+            // (K ≤ 1024 routed via AutomatonWeight, which doesn't write the
+            // sink) it falls back to "true".
+            let tag = self.dynamic_filter_strategy.load(Ordering::Relaxed);
+            let strategy = tantivy::query::StrategyTag::try_from(tag)
+                .unwrap_or(tantivy::query::StrategyTag::None);
+            if matches!(strategy, tantivy::query::StrategyTag::None) {
+                write!(f, ", dynamic_filter_pushdown=true")?;
+            } else {
+                write!(
+                    f,
+                    ", dynamic_filter_pushdown={}",
+                    strategy_name(strategy)
+                )?;
+            }
         }
         write!(f, ", query={}", self.query_for_display.explain_format())
     }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -30,7 +30,7 @@
 
 use std::any::Any;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 use std::sync::{Arc, Mutex};
 use std::task::{Context, Poll};
 
@@ -166,6 +166,12 @@ pub struct PgSearchScanPlan {
     /// Sort order preserved across `with_filter_pushdown` rebuilds so the
     /// rebuilt plan keeps its equivalence properties.
     sort_order: Option<SortByField>,
+    /// Captures the per-segment `TermSetStrategy` chosen by the tantivy planner
+    /// for the pushed-down dynamic filter (issue #4895). Last-segment-wins is
+    /// fine because `EXPLAIN ANALYZE` only asks "did any segment use it?". A
+    /// value of `0` (`tantivy::query::strategy_tag::NONE`) means no dispatch
+    /// happened, e.g. the InList didn't reach the FastField path.
+    dynamic_filter_strategy: Arc<AtomicU8>,
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -249,6 +255,7 @@ impl PgSearchScanPlan {
             deferred_ctid_plan_position,
             dynamic_filter_pushdown: Arc::new(AtomicBool::new(false)),
             sort_order: sort_order.cloned(),
+            dynamic_filter_strategy: Arc::new(AtomicU8::new(0)),
         }
     }
 
@@ -366,6 +373,23 @@ fn build_equivalence_properties(
     eq_properties
 }
 
+/// Translate a `tantivy::query::strategy_tag` numeric tag back into the
+/// human-readable strategy name surfaced in `EXPLAIN ANALYZE` output.
+/// Exhaustive on the tag set so follow-ups A and B (filling in the
+/// posting-direct and bitset-from-postings dispatch arms) don't need to
+/// revisit this site.
+fn strategy_tag_name(tag: u8) -> &'static str {
+    use tantivy::query::strategy_tag;
+    match tag {
+        strategy_tag::GALLOP => "gallop",
+        strategy_tag::LINEAR => "linear",
+        strategy_tag::BITSET => "bitset_from_postings",
+        strategy_tag::POSTING => "posting_direct",
+        strategy_tag::HASH => "hash_probe",
+        _ => "unknown",
+    }
+}
+
 impl DisplayAs for PgSearchScanPlan {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(
@@ -378,6 +402,14 @@ impl DisplayAs for PgSearchScanPlan {
         }
         if self.dynamic_filter_pushdown.load(Ordering::Relaxed) {
             write!(f, ", dynamic_filter_pushdown=true")?;
+        }
+        let tag = self.dynamic_filter_strategy.load(Ordering::Relaxed);
+        if tag != tantivy::query::strategy_tag::NONE {
+            write!(
+                f,
+                ", dynamic_filter_pushdown_strategy={}",
+                strategy_tag_name(tag),
+            )?;
         }
         write!(f, ", query={}", self.query_for_display.explain_format())
     }
@@ -484,6 +516,7 @@ impl ExecutionPlan for PgSearchScanPlan {
 
         // Capture self-references for the async block
         let dynamic_filter_pushdown = self.dynamic_filter_pushdown.clone();
+        let dynamic_filter_strategy = self.dynamic_filter_strategy.clone();
 
         let stream_gen = async_stream::try_stream! {
             // Optimized Search Integration:
@@ -492,7 +525,11 @@ impl ExecutionPlan for PgSearchScanPlan {
             // AFTER the build side has completed and dynamic filters are published.
             let mut dynamic_filters = dynamic_filters.clone();
             if !dynamic_filters.is_empty()
-                && try_dynamic_filter_pushdown(&mut reader, &mut dynamic_filters)
+                && try_dynamic_filter_pushdown(
+                    &mut reader,
+                    &mut dynamic_filters,
+                    Some(dynamic_filter_strategy.clone()),
+                )
             {
                 dynamic_filter_pushdown.store(true, Ordering::Relaxed);
             }
@@ -643,6 +680,9 @@ impl ExecutionPlan for PgSearchScanPlan {
                     self.dynamic_filter_pushdown.load(Ordering::Relaxed),
                 )),
                 sort_order: self.sort_order.clone(),
+                dynamic_filter_strategy: Arc::new(AtomicU8::new(
+                    self.dynamic_filter_strategy.load(Ordering::Relaxed),
+                )),
             });
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -415,11 +415,7 @@ impl DisplayAs for PgSearchScanPlan {
             if matches!(strategy, tantivy::query::StrategyTag::None) {
                 write!(f, ", dynamic_filter_pushdown=true")?;
             } else {
-                write!(
-                    f,
-                    ", dynamic_filter_pushdown={}",
-                    strategy_name(strategy)
-                )?;
+                write!(f, ", dynamic_filter_pushdown={}", strategy_name(strategy))?;
             }
         }
         write!(f, ", query={}", self.query_for_display.explain_format())

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -729,18 +729,18 @@ fn try_convert_in_list_to_query(
         return None;
     }
 
-    // Build a strategy config from the paradedb.term_set_*_ratio GUCs so the
-    // sorted-segment gallop fast path (issue #4895) is enabled by default but
-    // operators can override the ratios or kill the optimization without a
-    // recompile. The default values mirror TermSetStrategyConfig::default()
-    // in tantivy.
+    // Build a strategy config from the paradedb.term_set_*_max_density GUCs
+    // so the sorted-segment gallop fast path (issue #4895) is enabled by
+    // default but operators can override the densities or kill the
+    // optimization without a recompile. Defaults mirror
+    // TermSetStrategyConfig::default() in tantivy.
     let cfg = TermSetStrategyConfig {
         gallop_enabled: crate::gucs::term_set_gallop_enabled(),
-        gallop_ratio: crate::gucs::term_set_gallop_ratio() as u32,
-        posting_ratio: crate::gucs::term_set_posting_ratio() as u32,
-        bitset_ratio: crate::gucs::term_set_bitset_ratio() as u32,
-        hash_probe_ratio: crate::gucs::term_set_hash_probe_ratio() as u32,
-        subsequent_bitset_ratio: crate::gucs::term_set_subsequent_bitset_ratio() as u32,
+        gallop_max_density: crate::gucs::term_set_gallop_max_density(),
+        posting_max_density: crate::gucs::term_set_posting_max_density(),
+        bitset_max_density: crate::gucs::term_set_bitset_max_density(),
+        hash_probe_max_density: crate::gucs::term_set_hash_probe_max_density(),
+        subsequent_bitset_max_density: crate::gucs::term_set_subsequent_bitset_max_density(),
     };
 
     let term_set_query = TermSetQuery::new(terms).with_strategy_config(cfg);

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -731,12 +731,12 @@ fn try_convert_in_list_to_query(
     }
 
     // Build a strategy config from the paradedb.term_set_*_max_density GUCs
-    // so the sorted-segment gallop fast path (issue #4895) is enabled by
-    // default but operators can override the densities or kill the
-    // optimization without a recompile. Defaults mirror
-    // TermSetStrategyConfig::default() in tantivy. The optional `strategy_sink`
-    // is a per-scan AtomicU8 that the planner stores its decision into so
-    // EXPLAIN ANALYZE can report which strategy fired (Step 5).
+    // so the sorted-segment gallop fast path is enabled by default but
+    // operators can override the densities or kill the optimization without
+    // a recompile. Defaults mirror TermSetStrategyConfig::default() in
+    // tantivy. The optional `strategy_sink` is a per-scan AtomicU8 that the
+    // planner stores its decision into so EXPLAIN ANALYZE can report which
+    // strategy fired.
     let cfg = TermSetStrategyConfig {
         gallop_enabled: crate::gucs::term_set_gallop_enabled(),
         gallop_max_density: crate::gucs::term_set_gallop_max_density(),

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -741,14 +741,16 @@ fn try_convert_in_list_to_query(
     // tantivy. The optional `strategy_sink` is a per-scan AtomicU8 that the
     // planner stores its decision into so EXPLAIN ANALYZE can report which
     // strategy fired.
+    // The four other density fields (posting/bitset/hash_probe/
+    // subsequent_bitset) gate strategies that route to TermSetDocSet via
+    // stubs in tantivy today, so leaving them at TermSetStrategyConfig's
+    // tantivy-side defaults via struct update syntax keeps behavior
+    // identical to a bare tantivy caller until follow-ups A and B land.
     let cfg = TermSetStrategyConfig {
         gallop_enabled: crate::gucs::term_set_gallop_enabled(),
         gallop_max_density: crate::gucs::term_set_gallop_max_density(),
-        posting_max_density: crate::gucs::term_set_posting_max_density(),
-        bitset_max_density: crate::gucs::term_set_bitset_max_density(),
-        hash_probe_max_density: crate::gucs::term_set_hash_probe_max_density(),
-        subsequent_bitset_max_density: crate::gucs::term_set_subsequent_bitset_max_density(),
         strategy_sink,
+        ..TermSetStrategyConfig::default()
     };
 
     let term_set_query = TermSetQuery::new(terms).with_strategy_config(cfg);

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -692,6 +692,10 @@ fn try_convert_in_list_to_query(
     let max_size = crate::gucs::hash_join_inlist_pushdown_max_size() as usize;
     let max_distinct = crate::gucs::hash_join_inlist_pushdown_max_distinct_values() as usize;
 
+    // K cap. Default 20,000 is bench-tuned to the win/lose crossover for
+    // pushdown vs PreFilter at N=1M sorted. See
+    // gucs::HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES doc for the
+    // reasoning and trade-off. Set to 0 to disable pushdown.
     if in_list.list().len() > max_distinct {
         return None;
     }

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -673,6 +673,7 @@ fn extract_in_list_exprs<'a>(
 fn try_convert_in_list_to_query(
     in_list: &InListExpr,
     schema: &crate::schema::SearchIndexSchema,
+    strategy_sink: Option<Arc<std::sync::atomic::AtomicU8>>,
 ) -> Option<Box<dyn Query>> {
     if in_list.negated() {
         return None;
@@ -733,7 +734,9 @@ fn try_convert_in_list_to_query(
     // so the sorted-segment gallop fast path (issue #4895) is enabled by
     // default but operators can override the densities or kill the
     // optimization without a recompile. Defaults mirror
-    // TermSetStrategyConfig::default() in tantivy.
+    // TermSetStrategyConfig::default() in tantivy. The optional `strategy_sink`
+    // is a per-scan AtomicU8 that the planner stores its decision into so
+    // EXPLAIN ANALYZE can report which strategy fired (Step 5).
     let cfg = TermSetStrategyConfig {
         gallop_enabled: crate::gucs::term_set_gallop_enabled(),
         gallop_max_density: crate::gucs::term_set_gallop_max_density(),
@@ -741,6 +744,7 @@ fn try_convert_in_list_to_query(
         bitset_max_density: crate::gucs::term_set_bitset_max_density(),
         hash_probe_max_density: crate::gucs::term_set_hash_probe_max_density(),
         subsequent_bitset_max_density: crate::gucs::term_set_subsequent_bitset_max_density(),
+        strategy_sink,
     };
 
     let term_set_query = TermSetQuery::new(terms).with_strategy_config(cfg);
@@ -765,6 +769,7 @@ fn try_convert_in_list_to_query(
 pub fn try_dynamic_filter_pushdown(
     reader: &mut crate::index::reader::index::SearchIndexReader,
     dynamic_filters: &mut [Arc<dyn PhysicalExpr>],
+    strategy_sink: Option<Arc<std::sync::atomic::AtomicU8>>,
 ) -> bool {
     let mut pushed_down_queries: Vec<Box<dyn Query>> = Vec::new();
     let mut pushed_down_pointers = HashSet::default();
@@ -784,7 +789,9 @@ pub fn try_dynamic_filter_pushdown(
         for in_list_arc in extracted_in_lists {
             let in_list = in_list_arc.as_any().downcast_ref::<InListExpr>().unwrap();
 
-            if let Some(query) = try_convert_in_list_to_query(in_list, schema) {
+            if let Some(query) =
+                try_convert_in_list_to_query(in_list, schema, strategy_sink.clone())
+            {
                 pushed_down_queries.push(query);
                 pushed_down_pointers.insert(Arc::as_ptr(in_list_arc) as *const () as usize);
             }

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -122,7 +122,9 @@ use crate::index::fast_fields_helper::{FFHelper, FFType, NULL_TERM_ORDINAL};
 use crate::query::value_to_term;
 use crate::scan::filter_pushdown::scalar_to_owned_value;
 use crate::schema::SearchFieldType;
-use tantivy::query::{BooleanQuery, ConstScoreQuery, Occur, Query, TermSetQuery};
+use tantivy::query::{
+    BooleanQuery, ConstScoreQuery, Occur, Query, TermSetQuery, TermSetStrategyConfig,
+};
 use tantivy::Term;
 
 /// A pre-materialization filter applied inside `Scanner::next()`.
@@ -727,7 +729,21 @@ fn try_convert_in_list_to_query(
         return None;
     }
 
-    let term_set_query = TermSetQuery::new(terms);
+    // Build a strategy config from the paradedb.term_set_*_ratio GUCs so the
+    // sorted-segment gallop fast path (issue #4895) is enabled by default but
+    // operators can override the ratios or kill the optimization without a
+    // recompile. The default values mirror TermSetStrategyConfig::default()
+    // in tantivy.
+    let cfg = TermSetStrategyConfig {
+        gallop_enabled: crate::gucs::term_set_gallop_enabled(),
+        gallop_ratio: crate::gucs::term_set_gallop_ratio() as u32,
+        posting_ratio: crate::gucs::term_set_posting_ratio() as u32,
+        bitset_ratio: crate::gucs::term_set_bitset_ratio() as u32,
+        hash_probe_ratio: crate::gucs::term_set_hash_probe_ratio() as u32,
+        subsequent_bitset_ratio: crate::gucs::term_set_subsequent_bitset_ratio() as u32,
+    };
+
+    let term_set_query = TermSetQuery::new(terms).with_strategy_config(cfg);
     let const_score_query = ConstScoreQuery::new(Box::new(term_set_query), 0.0);
     Some(Box::new(const_score_query) as Box<dyn Query>)
 }

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -76,16 +76,16 @@ LIMIT 10;
 -- TEST 2: Hash Join with sorted segment on the FK column (issue #4895)
 -- =============================================================================
 -- Purpose: capture an EXPLAIN ANALYZE of a hash-join probe where the inner
--- index is sorted ASC by the foreign-key column, demonstrating the new
--- dynamic_filter_pushdown_strategy=... EXPLAIN token.
+-- index is sorted ASC by the foreign-key column, demonstrating that the
+-- dynamic_filter_pushdown=... EXPLAIN token reports the chosen strategy.
 --
 -- The test asserts BOTH dispatch outcomes:
 --   2a. With default gallop_max_density (1/100), K/N is too dense for gallop
 --       on this small corpus → linear strategy, EXPLAIN says
---       dynamic_filter_pushdown_strategy=linear.
+--       dynamic_filter_pushdown=linear.
 --   2b. With paradedb.term_set_gallop_max_density set high enough to admit
 --       this corpus, gallop fires → EXPLAIN says
---       dynamic_filter_pushdown_strategy=gallop.
+--       dynamic_filter_pushdown=gallop.
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
 DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
 CREATE TABLE hash_sorted_t1 (id INTEGER PRIMARY KEY, val TEXT);
@@ -134,7 +134,7 @@ LIMIT 10;
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=linear, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+                 :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
 (17 rows)
 
 SELECT t1.val, t2.val
@@ -186,7 +186,7 @@ LIMIT 10;
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+                 :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=gallop, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
 (17 rows)
 
 SELECT t1.val, t2.val
@@ -209,6 +209,45 @@ LIMIT 10;
  val 5 | val 5
 (10 rows)
 
+RESET paradedb.term_set_gallop_max_density;
+-- =============================================================================
+-- TEST 3: paradedb.hash_join_inlist_pushdown_max_distinct_values = 0 disables
+-- =============================================================================
+-- The GUC is documented as a kill switch. DataFusion's HashJoinExec applies
+-- the same predicate (`num_of_distinct_key > max_distinct_values` ⇒ fallback
+-- to hash-table map), so 0 disables the InList materialization path on both
+-- sides of the boundary. EXPLAIN should NOT show `dynamic_filter_pushdown=`.
+SET paradedb.hash_join_inlist_pushdown_max_distinct_values = 0;
+SET paradedb.term_set_gallop_max_density = 1.0;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Result (actual rows=10.00 loops=1)
+         ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+               Relation Tree: t2 INNER t1
+               Join Cond: t1.id = t2.t1_id
+               Limit: 10
+               Order By: t1.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
+                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
+                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_1@0, id@1, ctid_0@2], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, build_mem_used=30.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+(17 rows)
+
+RESET paradedb.hash_join_inlist_pushdown_max_distinct_values;
 RESET paradedb.term_set_gallop_max_density;
 -- =============================================================================
 -- CLEANUP

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -73,24 +73,30 @@ LIMIT 10;
 (10 rows)
 
 -- =============================================================================
--- TEST 2: Hash Join with sorted segment on the FK column (issue #4895 baseline)
+-- TEST 2: Hash Join with sorted segment on the FK column (issue #4895)
 -- =============================================================================
 -- Purpose: capture an EXPLAIN ANALYZE of a hash-join probe where the inner
--- index is sorted ASC by the foreign-key column. After the gallop optimization
--- ships (Step 3), the same query will additionally surface
--- `dynamic_filter_pushdown_strategy=gallop` (Step 5). For Step 0 we only assert
--- the pre-existing `dynamic_filter_pushdown=true` token — establishing that
--- the pipeline still works end-to-end with sort_by applied.
+-- index is sorted ASC by the foreign-key column, demonstrating the new
+-- dynamic_filter_pushdown_strategy=... EXPLAIN token.
+--
+-- The test asserts BOTH dispatch outcomes:
+--   2a. With default gallop_max_density (1/64), K/N is too dense for gallop
+--       on this small corpus → linear strategy, EXPLAIN says
+--       dynamic_filter_pushdown_strategy=linear.
+--   2b. With paradedb.term_set_gallop_max_density set high enough to admit
+--       this corpus, gallop fires → EXPLAIN says
+--       dynamic_filter_pushdown_strategy=gallop.
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
 DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
 CREATE TABLE hash_sorted_t1 (id INTEGER PRIMARY KEY, val TEXT);
 CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
--- 1500 rows on both sides: enough to clear the FastField cardinality threshold
--- (1024) inside TermSetQuery so the FastField path is exercised. Rows on t2
--- are inserted in t1_id order so the resulting bm25 segment, built with
--- sort_by='t1_id ASC', is naturally contiguous.
+-- t1: 1500 rows (clears the TermSetQuery FastField cardinality threshold of
+-- 1024 so the FastField dispatch path is reached).
+-- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75,
+-- which is too dense for the default gallop threshold (1/64 ≈ 0.0156) but
+-- below the override used in TEST 2b (1.0).
 INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
-INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 1500) i;
+INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 2000) i;
 CREATE INDEX hash_sorted_t1_idx ON hash_sorted_t1 USING bm25 (id, val)
 WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
 CREATE INDEX hash_sorted_t2_idx ON hash_sorted_t2 USING bm25 (id, t1_id, val)
@@ -101,6 +107,8 @@ WITH (
 );
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
+-- TEST 2a: default density. K/N = 0.75 ≥ 1/64, so gallop is rejected and
+-- the planner lands on the LinearScan terminal.
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -108,8 +116,8 @@ JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
-                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                        
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Result (actual rows=10.00 loops=1)
          ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
@@ -119,14 +127,15 @@ LIMIT 10;
                Order By: t1.id asc
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
-                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
-                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=1.50 K, output_bytes=87.4 KB, output_batches=1]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3], metrics=[output_rows=1.50 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=1.50 K, build_mem_used=30.00 K, avg_fanout=100% (1.50 K/1.50 K), probe_hit_rate=100% (1.50 K/1.50 K)]
-                 :         CooperativeExec
-                 :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1]
-                 :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
-(16 rows)
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
+                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
+                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_1@0, id@1, ctid_0@2], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, build_mem_used=30.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=linear, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+(17 rows)
 
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -134,20 +143,73 @@ JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
-  val   |  val   
---------+--------
- val 1  | val 1
- val 2  | val 2
- val 3  | val 3
- val 4  | val 4
- val 5  | val 5
- val 6  | val 6
- val 7  | val 7
- val 8  | val 8
- val 9  | val 9
- val 10 | val 10
+  val  |   val    
+-------+----------
+ val 1 | val 1501
+ val 1 | val 1
+ val 2 | val 2
+ val 2 | val 1502
+ val 3 | val 3
+ val 3 | val 1503
+ val 4 | val 1504
+ val 4 | val 4
+ val 5 | val 1505
+ val 5 | val 5
 (10 rows)
 
+-- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
+-- now fires because K/N = 0.75 < 1.0. This is the path the DemandScience
+-- workload would take in production once corpus size makes K/N << 1/64.
+SET paradedb.term_set_gallop_max_density = 1.0;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Result (actual rows=10.00 loops=1)
+         ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+               Relation Tree: t2 INNER t1
+               Join Cond: t1.id = t2.t1_id
+               Limit: 10
+               Order By: t1.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
+                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
+                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_1@0, id@1, ctid_0@2], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, build_mem_used=30.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+(17 rows)
+
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+  val  |   val    
+-------+----------
+ val 1 | val 1501
+ val 1 | val 1
+ val 2 | val 2
+ val 2 | val 1502
+ val 3 | val 3
+ val 3 | val 1503
+ val 4 | val 1504
+ val 4 | val 4
+ val 5 | val 1505
+ val 5 | val 5
+(10 rows)
+
+RESET paradedb.term_set_gallop_max_density;
 -- =============================================================================
 -- CLEANUP
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -80,7 +80,7 @@ LIMIT 10;
 -- dynamic_filter_pushdown_strategy=... EXPLAIN token.
 --
 -- The test asserts BOTH dispatch outcomes:
---   2a. With default gallop_max_density (1/64), K/N is too dense for gallop
+--   2a. With default gallop_max_density (1/100), K/N is too dense for gallop
 --       on this small corpus → linear strategy, EXPLAIN says
 --       dynamic_filter_pushdown_strategy=linear.
 --   2b. With paradedb.term_set_gallop_max_density set high enough to admit
@@ -93,7 +93,7 @@ CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
 -- t1: 1500 rows (clears the TermSetQuery FastField cardinality threshold of
 -- 1024 so the FastField dispatch path is reached).
 -- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75,
--- which is too dense for the default gallop threshold (1/64 ≈ 0.0156) but
+-- which is too dense for the default gallop threshold (1/100 = 0.01) but
 -- below the override used in TEST 2b (1.0).
 INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
 INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 2000) i;
@@ -107,7 +107,7 @@ WITH (
 );
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
--- TEST 2a: default density. K/N = 0.75 ≥ 1/64, so gallop is rejected and
+-- TEST 2a: default density. K/N = 0.75 ≥ 1/100, so gallop is rejected and
 -- the planner lands on the LinearScan terminal.
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
@@ -159,7 +159,7 @@ LIMIT 10;
 
 -- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
 -- now fires because K/N = 0.75 < 1.0. This is the path the DemandScience
--- workload would take in production once corpus size makes K/N << 1/64.
+-- workload would take in production once corpus size makes K/N << 1/100.
 SET paradedb.term_set_gallop_max_density = 1.0;
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -73,10 +73,88 @@ LIMIT 10;
 (10 rows)
 
 -- =============================================================================
+-- TEST 2: Hash Join with sorted segment on the FK column (issue #4895 baseline)
+-- =============================================================================
+-- Purpose: capture an EXPLAIN ANALYZE of a hash-join probe where the inner
+-- index is sorted ASC by the foreign-key column. After the gallop optimization
+-- ships (Step 3), the same query will additionally surface
+-- `dynamic_filter_pushdown_strategy=gallop` (Step 5). For Step 0 we only assert
+-- the pre-existing `dynamic_filter_pushdown=true` token — establishing that
+-- the pipeline still works end-to-end with sort_by applied.
+DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
+DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
+CREATE TABLE hash_sorted_t1 (id INTEGER PRIMARY KEY, val TEXT);
+CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
+-- 1500 rows on both sides: enough to clear the FastField cardinality threshold
+-- (1024) inside TermSetQuery so the FastField path is exercised. Rows on t2
+-- are inserted in t1_id order so the resulting bm25 segment, built with
+-- sort_by='t1_id ASC', is naturally contiguous.
+INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
+INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 1500) i;
+CREATE INDEX hash_sorted_t1_idx ON hash_sorted_t1 USING bm25 (id, val)
+WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
+CREATE INDEX hash_sorted_t2_idx ON hash_sorted_t2 USING bm25 (id, t1_id, val)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"t1_id": {"fast": true}}',
+    sort_by = 't1_id ASC NULLS FIRST'
+);
+ANALYZE hash_sorted_t1;
+ANALYZE hash_sorted_t2;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Result (actual rows=10.00 loops=1)
+         ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+               Relation Tree: t2 INNER t1
+               Join Cond: t1.id = t2.t1_id
+               Limit: 10
+               Order By: t1.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
+                 :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
+                 :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=1.50 K, output_bytes=87.4 KB, output_batches=1]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3], metrics=[output_rows=1.50 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=1.50 K, build_mem_used=30.00 K, avg_fanout=100% (1.50 K/1.50 K), probe_hit_rate=100% (1.50 K/1.50 K)]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
+(16 rows)
+
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+  val   |  val   
+--------+--------
+ val 1  | val 1
+ val 2  | val 2
+ val 3  | val 3
+ val 4  | val 4
+ val 5  | val 5
+ val 6  | val 6
+ val 7  | val 7
+ val 8  | val 8
+ val 9  | val 9
+ val 10 | val 10
+(10 rows)
+
+-- =============================================================================
 -- CLEANUP
 -- =============================================================================
 DROP TABLE IF EXISTS hash_t1 CASCADE;
 DROP TABLE IF EXISTS hash_t2 CASCADE;
+DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
+DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
 RESET max_parallel_workers_per_gather;
 RESET enable_indexscan;
 RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -13,7 +13,7 @@
 --   neither gallop nor smart-seek is exercised).
 --   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. With
 --   paradedb.term_set_gallop_max_density forced to 0.05 (vs the default
---   1/64 ≈ 0.0156), gallop is admitted on the sorted fk_a column.
+--   1/100 = 0.01), gallop is admitted on the sorted fk_a column.
 --   LIMIT 10 on each query is required for the ParadeDB Join Scan custom
 --   scan's cost model to pick it over a vanilla Hash Join (this also
 --   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
@@ -41,7 +41,7 @@ SET enable_nestloop = OFF;
 SET enable_mergejoin = OFF;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_join_custom_scan = ON;
--- Admit gallop on K/N ≈ 0.0367. The default 1/64 ≈ 0.0156 would reject
+-- Admit gallop on K/N ≈ 0.0367. The default 1/100 = 0.01 would reject
 -- this corpus; the override mirrors TEST 2b in join_hash.sql.
 SET paradedb.term_set_gallop_max_density = 0.05;
 -- ===========================================================================
@@ -101,8 +101,8 @@ FROM generate_series(800, 1899) AS i;
 -- BM25 index on t1: id is the integer key, body is the text-searched
 -- column, fk_a/fk_b/fk_c are fast numeric fields, segment is sorted ASC
 -- by fk_a. Only fk_a is gallop-eligible; fk_b and fk_c land on the
--- linear-scan TermSetDocSet path (now with the smart-seek override from
--- the previous tantivy commit).
+-- linear-scan TermSetDocSet path (with smart-seek for forward-cursor
+-- advancement).
 CREATE INDEX t1_idx ON t1
 USING bm25 (id, body, fk_a, fk_b, fk_c)
 WITH (

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -1,0 +1,382 @@
+-- Regression coverage for sparse 1/2/3-column dynamic filter dispatch
+-- (paradedb/paradedb#4895). Mirrors the production-side analogue of
+-- tests/term_set_equivalence.rs::gallop_matches_linear_two_column_and_intersection
+-- in tantivy: hash-join dynamic filters on sparsely-distributed (D = 1) FK
+-- columns at column counts 1, 2, and 3.
+--
+-- Sizing (Option B from review):
+--   t1: 30,000 rows, three independent FK columns (fk_a sorted, fk_b/fk_c
+--   unsorted), all D = 1 within the corpus.
+--   t2_a/b/c: 1,100 rows each (just over the FastField cardinality
+--   threshold of 1024 so the FastFieldTermSetWeight dispatch path is
+--   reached — below that, TermSetQuery routes to AutomatonWeight and
+--   neither gallop nor smart-seek is exercised).
+--   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. With
+--   paradedb.term_set_gallop_max_density forced to 0.05 (vs the default
+--   1/64 ≈ 0.0156), gallop is admitted on the sorted fk_a column.
+--   LIMIT 10 on each query is required for the ParadeDB Join Scan custom
+--   scan's cost model to pick it over a vanilla Hash Join (this also
+--   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
+--
+-- ---------------------------------------------------------------------------
+-- A note on `dynamic_filter_pushdown_strategy=...` in the EXPLAIN output
+-- ---------------------------------------------------------------------------
+-- The strategy_sink is per-PgSearchScan and uses last-segment-wins semantics:
+-- whatever the FINAL select_strategy() call wrote is what shows up. For
+-- multi-column queries (Q2 / Q3) this means the displayed strategy reflects
+-- the LAST filter dispatched, not the union of all filters. In particular,
+-- a Q3 line reading `dynamic_filter_pushdown_strategy=linear` does NOT mean
+-- gallop didn't fire — it means the last column dispatched landed on the
+-- linear path (typically fk_b or fk_c, which are unsorted), overwriting the
+-- gallop tag fk_a's dispatch wrote earlier. This is documented as Shape A
+-- in implementation.md §7. The correctness gate (Block B) is what proves
+-- gallop+smart-seek produced identical results to all-linear; the EXPLAIN
+-- token is informational, not assertive.
+-- Disable parallel workers so plans are deterministic.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+-- Force hash joins (the InList dynamic-filter pushdown path requires the
+-- ParadeDB JoinScan custom scan, which composes with HashJoinExec).
+SET enable_nestloop = OFF;
+SET enable_mergejoin = OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan = ON;
+-- Admit gallop on K/N ≈ 0.0367. The default 1/64 ≈ 0.0156 would reject
+-- this corpus; the override mirrors TEST 2b in join_hash.sql.
+SET paradedb.term_set_gallop_max_density = 0.05;
+-- ===========================================================================
+-- Fixture
+-- ===========================================================================
+DROP TABLE IF EXISTS t1 CASCADE;
+DROP TABLE IF EXISTS t2_a CASCADE;
+DROP TABLE IF EXISTS t2_b CASCADE;
+DROP TABLE IF EXISTS t2_c CASCADE;
+-- t1: 30,000 rows. `body` carries a space-separated string ('doc 1',
+-- 'doc 2', …) so the default BM25 tokenizer splits cleanly and the
+-- shared 'doc' token lets `@@@ 'doc'` match every row. Each FK column
+-- produces a distinct value per row (D = 1) by multiplying the row index
+-- by a prime coprime to the modulus. Three different primes (7919, 6151,
+-- 4099) give three independent pseudo-uniform spreads.
+CREATE TABLE t1 (
+    id    INTEGER PRIMARY KEY,
+    body  TEXT,
+    fk_a  BIGINT,
+    fk_b  BIGINT,
+    fk_c  BIGINT
+);
+INSERT INTO t1
+SELECT
+    i,
+    'doc ' || i::text,
+    (i * 7919 % 100000)::bigint,
+    (i * 6151 % 100000)::bigint,
+    (i * 4099 % 100000)::bigint
+FROM generate_series(1, 30000) AS i;
+-- Each t2_X provides 1,100 distinct fk values that are subsets of the
+-- corresponding column in t1. Different `i` ranges per table so the
+-- three filters intersect to a non-trivial nested result on the full
+-- (unlimited) join:
+--   Q1 (t2_a): t1.id ∈ [1, 1100]
+--   Q2 (∩ t2_b): t1.id ∈ [1, 1100] ∩ [500, 1599] = [500, 1100]
+--   Q3 (∩ t2_c): ∩ [800, 1899] = [800, 1100]
+-- LIMIT 10 (with ORDER BY t1.id) yields a deterministic top-50 from
+-- each.
+-- t2_X tables also have BM25 indexes so the ParadeDB JoinScan custom
+-- scan can engage on both sides of the join. (The Join Scan refuses to
+-- engage if either side isn't BM25-indexed; without it the planner falls
+-- back to vanilla Hash Join which doesn't run the dynamic-filter
+-- pushdown machinery.)
+CREATE TABLE t2_a (id INTEGER PRIMARY KEY, fk BIGINT, body TEXT);
+INSERT INTO t2_a
+SELECT i, (i * 7919 % 100000)::bigint, 'doc ' || i::text
+FROM generate_series(1, 1100) AS i;
+CREATE TABLE t2_b (id INTEGER PRIMARY KEY, fk BIGINT, body TEXT);
+INSERT INTO t2_b
+SELECT i, (i * 6151 % 100000)::bigint, 'doc ' || i::text
+FROM generate_series(500, 1599) AS i;
+CREATE TABLE t2_c (id INTEGER PRIMARY KEY, fk BIGINT, body TEXT);
+INSERT INTO t2_c
+SELECT i, (i * 4099 % 100000)::bigint, 'doc ' || i::text
+FROM generate_series(800, 1899) AS i;
+-- BM25 index on t1: id is the integer key, body is the text-searched
+-- column, fk_a/fk_b/fk_c are fast numeric fields, segment is sorted ASC
+-- by fk_a. Only fk_a is gallop-eligible; fk_b and fk_c land on the
+-- linear-scan TermSetDocSet path (now with the smart-seek override from
+-- the previous tantivy commit).
+CREATE INDEX t1_idx ON t1
+USING bm25 (id, body, fk_a, fk_b, fk_c)
+WITH (
+    key_field = 'id',
+    text_fields = '{"body": {"fast": true}}',
+    numeric_fields = '{"fk_a": {"fast": true}, "fk_b": {"fast": true}, "fk_c": {"fast": true}}',
+    sort_by = 'fk_a ASC NULLS FIRST'
+);
+CREATE INDEX t2_a_idx ON t2_a USING bm25 (id, fk, body)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+CREATE INDEX t2_b_idx ON t2_b USING bm25 (id, fk, body)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+CREATE INDEX t2_c_idx ON t2_c USING bm25 (id, fk, body)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+ANALYZE t1;
+ANALYZE t2_a;
+ANALYZE t2_b;
+ANALYZE t2_c;
+-- ===========================================================================
+-- Q1: single-column filter (fk_a, the sorted/gallop-eligible column)
+-- ===========================================================================
+-- Block A: confirm pushdown shape. Look for `dynamic_filters=1,
+-- dynamic_filter_pushdown=true` on the inner PgSearchScan; the
+-- dynamic_filter_pushdown_strategy token's value is captured but not
+-- asserted on (last-writer-wins; Q1 has only one filter so the value is
+-- whatever fk_a's dispatch produced).
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: t2_a INNER t1
+         Join Cond: t1.fk_a = t2_a.fk
+         Limit: 10
+         Order By: t1.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=51]
+           :     VisibilityFilterExec: tables=[t2_a, t1], metrics=[output_rows=1.10 K, output_bytes=81.2 KB, output_batches=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, id@4], metrics=[output_rows=1.10 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=25.8 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+(15 rows)
+
+-- Block B: correctness. Run the same query with gallop disabled and
+-- enabled, materialize each result into a TEMP TABLE, then compare row
+-- counts and assert the symmetric difference is empty.
+SET paradedb.term_set_gallop_enabled = OFF;
+DROP TABLE IF EXISTS result_q1_linear;
+CREATE TEMP TABLE result_q1_linear AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+SET paradedb.term_set_gallop_enabled = ON;
+DROP TABLE IF EXISTS result_q1_gallop;
+CREATE TEMP TABLE result_q1_gallop AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+SELECT
+    (SELECT count(*) FROM result_q1_linear) AS linear_count,
+    (SELECT count(*) FROM result_q1_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q1_linear) = (SELECT count(*) FROM result_q1_gallop) AS counts_match;
+ linear_count | gallop_count | counts_match 
+--------------+--------------+--------------
+           10 |           10 | t
+(1 row)
+
+SELECT 'q1 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'linear-only' AS source, id FROM result_q1_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q1_gallop
+    UNION ALL
+    SELECT 'gallop-only' AS source, id FROM result_q1_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q1_linear
+) AS diff
+ORDER BY source, id;
+ check | source | id 
+-------+--------+----
+(0 rows)
+
+DROP TABLE result_q1_linear;
+DROP TABLE result_q1_gallop;
+-- ===========================================================================
+-- Q2: two-column filter (fk_a sorted + fk_b unsorted)
+-- ===========================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: t2_a INNER (t1 INNER t2_b)
+         Join Cond: t1.fk_a = t2_a.fk, t1.fk_b = t2_b.fk
+         Limit: 10
+         Order By: t1.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 509], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[t2_a, t1, t2_b], metrics=[output_rows=601, output_bytes=78.1 KB, output_batches=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4], metrics=[output_rows=601, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=297.0 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_b@4, id@5], metrics=[output_rows=1.10 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
+(18 rows)
+
+SET paradedb.term_set_gallop_enabled = OFF;
+DROP TABLE IF EXISTS result_q2_linear;
+CREATE TEMP TABLE result_q2_linear AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+SET paradedb.term_set_gallop_enabled = ON;
+DROP TABLE IF EXISTS result_q2_gallop;
+CREATE TEMP TABLE result_q2_gallop AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+SELECT
+    (SELECT count(*) FROM result_q2_linear) AS linear_count,
+    (SELECT count(*) FROM result_q2_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q2_linear) = (SELECT count(*) FROM result_q2_gallop) AS counts_match;
+ linear_count | gallop_count | counts_match 
+--------------+--------------+--------------
+           10 |           10 | t
+(1 row)
+
+SELECT 'q2 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'linear-only' AS source, id FROM result_q2_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q2_gallop
+    UNION ALL
+    SELECT 'gallop-only' AS source, id FROM result_q2_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q2_linear
+) AS diff
+ORDER BY source, id;
+ check | source | id 
+-------+--------+----
+(0 rows)
+
+DROP TABLE result_q2_linear;
+DROP TABLE result_q2_gallop;
+-- ===========================================================================
+-- Q3: three-column filter (fk_a sorted + fk_b unsorted + fk_c unsorted)
+-- ===========================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+JOIN t2_c ON t1.fk_c = t2_c.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: t2_a INNER ((t1 INNER t2_b) INNER t2_c)
+         Join Cond: t1.fk_a = t2_a.fk, t1.fk_c = t2_c.fk, t1.fk_b = t2_b.fk
+         Limit: 10
+         Order By: t1.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2, ctid_3@4 as ctid_3], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 809], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[t2_a, t1, t2_b, t2_c], metrics=[output_rows=301, output_bytes=73.4 KB, output_batches=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_c@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4, ctid_3@5], metrics=[output_rows=301, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=601, input_batches=1, input_rows=301, build_mem_used=345.1 K, avg_fanout=100% (301/301), probe_hit_rate=100% (301/301)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@3, fk@1)], projection=[ctid_0@0, ctid_1@1, fk_c@2, id@4, ctid_2@5], metrics=[output_rows=601, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=362.6 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
+           :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_c@4, fk_b@5, id@6], metrics=[output_rows=1.10 K, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=301, output_bytes=4.7 KB, output_batches=1, rows_pruned=0, rows_scanned=301]
+(21 rows)
+
+SET paradedb.term_set_gallop_enabled = OFF;
+DROP TABLE IF EXISTS result_q3_linear;
+CREATE TEMP TABLE result_q3_linear AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+JOIN t2_c ON t1.fk_c = t2_c.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+SET paradedb.term_set_gallop_enabled = ON;
+DROP TABLE IF EXISTS result_q3_gallop;
+CREATE TEMP TABLE result_q3_gallop AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+JOIN t2_c ON t1.fk_c = t2_c.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+SELECT
+    (SELECT count(*) FROM result_q3_linear) AS linear_count,
+    (SELECT count(*) FROM result_q3_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q3_linear) = (SELECT count(*) FROM result_q3_gallop) AS counts_match;
+ linear_count | gallop_count | counts_match 
+--------------+--------------+--------------
+           10 |           10 | t
+(1 row)
+
+SELECT 'q3 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'linear-only' AS source, id FROM result_q3_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q3_gallop
+    UNION ALL
+    SELECT 'gallop-only' AS source, id FROM result_q3_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q3_linear
+) AS diff
+ORDER BY source, id;
+ check | source | id 
+-------+--------+----
+(0 rows)
+
+DROP TABLE result_q3_linear;
+DROP TABLE result_q3_gallop;
+-- ===========================================================================
+-- Cleanup
+-- ===========================================================================
+DROP TABLE IF EXISTS t1 CASCADE;
+DROP TABLE IF EXISTS t2_a CASCADE;
+DROP TABLE IF EXISTS t2_b CASCADE;
+DROP TABLE IF EXISTS t2_c CASCADE;
+RESET paradedb.term_set_gallop_enabled;
+RESET paradedb.term_set_gallop_max_density;
+RESET paradedb.enable_join_custom_scan;
+RESET enable_nestloop;
+RESET enable_mergejoin;
+RESET enable_indexscan;
+RESET max_parallel_workers_per_gather;

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -19,17 +19,17 @@
 --   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
 --
 -- ---------------------------------------------------------------------------
--- A note on `dynamic_filter_pushdown_strategy=...` in the EXPLAIN output
+-- A note on `dynamic_filter_pushdown=<strategy>` in the EXPLAIN output
 -- ---------------------------------------------------------------------------
 -- The strategy_sink is per-PgSearchScan and uses last-segment-wins semantics:
 -- whatever the FINAL select_strategy() call wrote is what shows up. For
 -- multi-column queries (Q2 / Q3) this means the displayed strategy reflects
 -- the LAST filter dispatched, not the union of all filters. In particular,
--- a Q3 line reading `dynamic_filter_pushdown_strategy=linear` does NOT mean
--- gallop didn't fire — it means the last column dispatched landed on the
--- linear path (typically fk_b or fk_c, which are unsorted), overwriting the
--- gallop tag fk_a's dispatch wrote earlier. This is documented as Shape A
--- in implementation.md §7. The correctness gate (Block B) is what proves
+-- a Q3 line reading `dynamic_filter_pushdown=linear` does NOT mean gallop
+-- didn't fire — it means the last column dispatched landed on the linear
+-- path (typically fk_b or fk_c, which are unsorted), overwriting the gallop
+-- tag fk_a's dispatch wrote earlier. This is documented as Shape A in
+-- implementation.md §7. The correctness gate (Block B) is what proves
 -- gallop+smart-seek produced identical results to all-linear; the EXPLAIN
 -- token is informational, not assertive.
 -- Disable parallel workers so plans are deterministic.
@@ -125,10 +125,9 @@ ANALYZE t2_c;
 -- Q1: single-column filter (fk_a, the sorted/gallop-eligible column)
 -- ===========================================================================
 -- Block A: confirm pushdown shape. Look for `dynamic_filters=1,
--- dynamic_filter_pushdown=true` on the inner PgSearchScan; the
--- dynamic_filter_pushdown_strategy token's value is captured but not
--- asserted on (last-writer-wins; Q1 has only one filter so the value is
--- whatever fk_a's dispatch produced).
+-- dynamic_filter_pushdown=<strategy>` on the inner PgSearchScan; the
+-- strategy value is captured but not asserted on (last-writer-wins; Q1 has
+-- only one filter so the value is whatever fk_a's dispatch produced).
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.id
 FROM t1
@@ -152,7 +151,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=25.8 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=25.8 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
 (15 rows)
 
 -- Block B: correctness. Run the same query with gallop disabled and
@@ -230,9 +229,9 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
+           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
 (18 rows)
 
 SET paradedb.term_set_gallop_enabled = OFF;
@@ -311,9 +310,9 @@ LIMIT 10;
            :             CooperativeExec
            :               PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :             CooperativeExec
-           :               PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :               PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, dynamic_filter_pushdown_strategy=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=301, output_bytes=4.7 KB, output_batches=1, rows_pruned=0, rows_scanned=301]
 (21 rows)

--- a/pg_search/tests/pg_regress/sql/join_hash.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash.sql
@@ -52,14 +52,19 @@ ORDER BY t1.id ASC
 LIMIT 10;
 
 -- =============================================================================
--- TEST 2: Hash Join with sorted segment on the FK column (issue #4895 baseline)
+-- TEST 2: Hash Join with sorted segment on the FK column (issue #4895)
 -- =============================================================================
 -- Purpose: capture an EXPLAIN ANALYZE of a hash-join probe where the inner
--- index is sorted ASC by the foreign-key column. After the gallop optimization
--- ships (Step 3), the same query will additionally surface
--- `dynamic_filter_pushdown_strategy=gallop` (Step 5). For Step 0 we only assert
--- the pre-existing `dynamic_filter_pushdown=true` token — establishing that
--- the pipeline still works end-to-end with sort_by applied.
+-- index is sorted ASC by the foreign-key column, demonstrating the new
+-- dynamic_filter_pushdown_strategy=... EXPLAIN token.
+--
+-- The test asserts BOTH dispatch outcomes:
+--   2a. With default gallop_max_density (1/64), K/N is too dense for gallop
+--       on this small corpus → linear strategy, EXPLAIN says
+--       dynamic_filter_pushdown_strategy=linear.
+--   2b. With paradedb.term_set_gallop_max_density set high enough to admit
+--       this corpus, gallop fires → EXPLAIN says
+--       dynamic_filter_pushdown_strategy=gallop.
 
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
 DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
@@ -67,12 +72,13 @@ DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
 CREATE TABLE hash_sorted_t1 (id INTEGER PRIMARY KEY, val TEXT);
 CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
 
--- 1500 rows on both sides: enough to clear the FastField cardinality threshold
--- (1024) inside TermSetQuery so the FastField path is exercised. Rows on t2
--- are inserted in t1_id order so the resulting bm25 segment, built with
--- sort_by='t1_id ASC', is naturally contiguous.
+-- t1: 1500 rows (clears the TermSetQuery FastField cardinality threshold of
+-- 1024 so the FastField dispatch path is reached).
+-- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75,
+-- which is too dense for the default gallop threshold (1/64 ≈ 0.0156) but
+-- below the override used in TEST 2b (1.0).
 INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
-INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 1500) i;
+INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 2000) i;
 
 CREATE INDEX hash_sorted_t1_idx ON hash_sorted_t1 USING bm25 (id, val)
 WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
@@ -86,6 +92,28 @@ WITH (
 
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
+
+-- TEST 2a: default density. K/N = 0.75 ≥ 1/64, so gallop is rejected and
+-- the planner lands on the LinearScan terminal.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+
+-- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
+-- now fires because K/N = 0.75 < 1.0. This is the path the DemandScience
+-- workload would take in production once corpus size makes K/N << 1/64.
+SET paradedb.term_set_gallop_max_density = 1.0;
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
@@ -101,6 +129,8 @@ JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
+
+RESET paradedb.term_set_gallop_max_density;
 
 -- =============================================================================
 -- CLEANUP

--- a/pg_search/tests/pg_regress/sql/join_hash.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash.sql
@@ -52,11 +52,64 @@ ORDER BY t1.id ASC
 LIMIT 10;
 
 -- =============================================================================
+-- TEST 2: Hash Join with sorted segment on the FK column (issue #4895 baseline)
+-- =============================================================================
+-- Purpose: capture an EXPLAIN ANALYZE of a hash-join probe where the inner
+-- index is sorted ASC by the foreign-key column. After the gallop optimization
+-- ships (Step 3), the same query will additionally surface
+-- `dynamic_filter_pushdown_strategy=gallop` (Step 5). For Step 0 we only assert
+-- the pre-existing `dynamic_filter_pushdown=true` token — establishing that
+-- the pipeline still works end-to-end with sort_by applied.
+
+DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
+DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
+
+CREATE TABLE hash_sorted_t1 (id INTEGER PRIMARY KEY, val TEXT);
+CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
+
+-- 1500 rows on both sides: enough to clear the FastField cardinality threshold
+-- (1024) inside TermSetQuery so the FastField path is exercised. Rows on t2
+-- are inserted in t1_id order so the resulting bm25 segment, built with
+-- sort_by='t1_id ASC', is naturally contiguous.
+INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
+INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 1500) i;
+
+CREATE INDEX hash_sorted_t1_idx ON hash_sorted_t1 USING bm25 (id, val)
+WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
+
+CREATE INDEX hash_sorted_t2_idx ON hash_sorted_t2 USING bm25 (id, t1_id, val)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"t1_id": {"fast": true}}',
+    sort_by = 't1_id ASC NULLS FIRST'
+);
+
+ANALYZE hash_sorted_t1;
+ANALYZE hash_sorted_t2;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+
+-- =============================================================================
 -- CLEANUP
 -- =============================================================================
 
 DROP TABLE IF EXISTS hash_t1 CASCADE;
 DROP TABLE IF EXISTS hash_t2 CASCADE;
+DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
+DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
 
 RESET max_parallel_workers_per_gather;
 RESET enable_indexscan;

--- a/pg_search/tests/pg_regress/sql/join_hash.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash.sql
@@ -59,7 +59,7 @@ LIMIT 10;
 -- dynamic_filter_pushdown_strategy=... EXPLAIN token.
 --
 -- The test asserts BOTH dispatch outcomes:
---   2a. With default gallop_max_density (1/64), K/N is too dense for gallop
+--   2a. With default gallop_max_density (1/100), K/N is too dense for gallop
 --       on this small corpus → linear strategy, EXPLAIN says
 --       dynamic_filter_pushdown_strategy=linear.
 --   2b. With paradedb.term_set_gallop_max_density set high enough to admit
@@ -75,7 +75,7 @@ CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
 -- t1: 1500 rows (clears the TermSetQuery FastField cardinality threshold of
 -- 1024 so the FastField dispatch path is reached).
 -- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75,
--- which is too dense for the default gallop threshold (1/64 ≈ 0.0156) but
+-- which is too dense for the default gallop threshold (1/100 = 0.01) but
 -- below the override used in TEST 2b (1.0).
 INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
 INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 2000) i;
@@ -93,7 +93,7 @@ WITH (
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
 
--- TEST 2a: default density. K/N = 0.75 ≥ 1/64, so gallop is rejected and
+-- TEST 2a: default density. K/N = 0.75 ≥ 1/100, so gallop is rejected and
 -- the planner lands on the LinearScan terminal.
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
@@ -112,7 +112,7 @@ LIMIT 10;
 
 -- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
 -- now fires because K/N = 0.75 < 1.0. This is the path the DemandScience
--- workload would take in production once corpus size makes K/N << 1/64.
+-- workload would take in production once corpus size makes K/N << 1/100.
 SET paradedb.term_set_gallop_max_density = 1.0;
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)

--- a/pg_search/tests/pg_regress/sql/join_hash.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash.sql
@@ -55,16 +55,16 @@ LIMIT 10;
 -- TEST 2: Hash Join with sorted segment on the FK column (issue #4895)
 -- =============================================================================
 -- Purpose: capture an EXPLAIN ANALYZE of a hash-join probe where the inner
--- index is sorted ASC by the foreign-key column, demonstrating the new
--- dynamic_filter_pushdown_strategy=... EXPLAIN token.
+-- index is sorted ASC by the foreign-key column, demonstrating that the
+-- dynamic_filter_pushdown=... EXPLAIN token reports the chosen strategy.
 --
 -- The test asserts BOTH dispatch outcomes:
 --   2a. With default gallop_max_density (1/100), K/N is too dense for gallop
 --       on this small corpus → linear strategy, EXPLAIN says
---       dynamic_filter_pushdown_strategy=linear.
+--       dynamic_filter_pushdown=linear.
 --   2b. With paradedb.term_set_gallop_max_density set high enough to admit
 --       this corpus, gallop fires → EXPLAIN says
---       dynamic_filter_pushdown_strategy=gallop.
+--       dynamic_filter_pushdown=gallop.
 
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
 DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
@@ -130,6 +130,27 @@ WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
 
+RESET paradedb.term_set_gallop_max_density;
+
+-- =============================================================================
+-- TEST 3: paradedb.hash_join_inlist_pushdown_max_distinct_values = 0 disables
+-- =============================================================================
+-- The GUC is documented as a kill switch. DataFusion's HashJoinExec applies
+-- the same predicate (`num_of_distinct_key > max_distinct_values` ⇒ fallback
+-- to hash-table map), so 0 disables the InList materialization path on both
+-- sides of the boundary. EXPLAIN should NOT show `dynamic_filter_pushdown=`.
+SET paradedb.hash_join_inlist_pushdown_max_distinct_values = 0;
+SET paradedb.term_set_gallop_max_density = 1.0;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.val, t2.val
+FROM hash_sorted_t1 t1
+JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
+WHERE t1.val @@@ 'val'
+ORDER BY t1.id ASC
+LIMIT 10;
+
+RESET paradedb.hash_join_inlist_pushdown_max_distinct_values;
 RESET paradedb.term_set_gallop_max_density;
 
 -- =============================================================================

--- a/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
@@ -19,17 +19,17 @@
 --   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
 --
 -- ---------------------------------------------------------------------------
--- A note on `dynamic_filter_pushdown_strategy=...` in the EXPLAIN output
+-- A note on `dynamic_filter_pushdown=<strategy>` in the EXPLAIN output
 -- ---------------------------------------------------------------------------
 -- The strategy_sink is per-PgSearchScan and uses last-segment-wins semantics:
 -- whatever the FINAL select_strategy() call wrote is what shows up. For
 -- multi-column queries (Q2 / Q3) this means the displayed strategy reflects
 -- the LAST filter dispatched, not the union of all filters. In particular,
--- a Q3 line reading `dynamic_filter_pushdown_strategy=linear` does NOT mean
--- gallop didn't fire — it means the last column dispatched landed on the
--- linear path (typically fk_b or fk_c, which are unsorted), overwriting the
--- gallop tag fk_a's dispatch wrote earlier. This is documented as Shape A
--- in implementation.md §7. The correctness gate (Block B) is what proves
+-- a Q3 line reading `dynamic_filter_pushdown=linear` does NOT mean gallop
+-- didn't fire — it means the last column dispatched landed on the linear
+-- path (typically fk_b or fk_c, which are unsorted), overwriting the gallop
+-- tag fk_a's dispatch wrote earlier. This is documented as Shape A in
+-- implementation.md §7. The correctness gate (Block B) is what proves
 -- gallop+smart-seek produced identical results to all-linear; the EXPLAIN
 -- token is informational, not assertive.
 
@@ -141,10 +141,9 @@ ANALYZE t2_c;
 -- ===========================================================================
 
 -- Block A: confirm pushdown shape. Look for `dynamic_filters=1,
--- dynamic_filter_pushdown=true` on the inner PgSearchScan; the
--- dynamic_filter_pushdown_strategy token's value is captured but not
--- asserted on (last-writer-wins; Q1 has only one filter so the value is
--- whatever fk_a's dispatch produced).
+-- dynamic_filter_pushdown=<strategy>` on the inner PgSearchScan; the
+-- strategy value is captured but not asserted on (last-writer-wins; Q1 has
+-- only one filter so the value is whatever fk_a's dispatch produced).
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.id
 FROM t1

--- a/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
@@ -1,0 +1,328 @@
+-- Regression coverage for sparse 1/2/3-column dynamic filter dispatch
+-- (paradedb/paradedb#4895). Mirrors the production-side analogue of
+-- tests/term_set_equivalence.rs::gallop_matches_linear_two_column_and_intersection
+-- in tantivy: hash-join dynamic filters on sparsely-distributed (D = 1) FK
+-- columns at column counts 1, 2, and 3.
+--
+-- Sizing (Option B from review):
+--   t1: 30,000 rows, three independent FK columns (fk_a sorted, fk_b/fk_c
+--   unsorted), all D = 1 within the corpus.
+--   t2_a/b/c: 1,100 rows each (just over the FastField cardinality
+--   threshold of 1024 so the FastFieldTermSetWeight dispatch path is
+--   reached — below that, TermSetQuery routes to AutomatonWeight and
+--   neither gallop nor smart-seek is exercised).
+--   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. With
+--   paradedb.term_set_gallop_max_density forced to 0.05 (vs the default
+--   1/64 ≈ 0.0156), gallop is admitted on the sorted fk_a column.
+--   LIMIT 10 on each query is required for the ParadeDB Join Scan custom
+--   scan's cost model to pick it over a vanilla Hash Join (this also
+--   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
+--
+-- ---------------------------------------------------------------------------
+-- A note on `dynamic_filter_pushdown_strategy=...` in the EXPLAIN output
+-- ---------------------------------------------------------------------------
+-- The strategy_sink is per-PgSearchScan and uses last-segment-wins semantics:
+-- whatever the FINAL select_strategy() call wrote is what shows up. For
+-- multi-column queries (Q2 / Q3) this means the displayed strategy reflects
+-- the LAST filter dispatched, not the union of all filters. In particular,
+-- a Q3 line reading `dynamic_filter_pushdown_strategy=linear` does NOT mean
+-- gallop didn't fire — it means the last column dispatched landed on the
+-- linear path (typically fk_b or fk_c, which are unsorted), overwriting the
+-- gallop tag fk_a's dispatch wrote earlier. This is documented as Shape A
+-- in implementation.md §7. The correctness gate (Block B) is what proves
+-- gallop+smart-seek produced identical results to all-linear; the EXPLAIN
+-- token is informational, not assertive.
+
+-- Disable parallel workers so plans are deterministic.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+-- Force hash joins (the InList dynamic-filter pushdown path requires the
+-- ParadeDB JoinScan custom scan, which composes with HashJoinExec).
+SET enable_nestloop = OFF;
+SET enable_mergejoin = OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_join_custom_scan = ON;
+-- Admit gallop on K/N ≈ 0.0367. The default 1/64 ≈ 0.0156 would reject
+-- this corpus; the override mirrors TEST 2b in join_hash.sql.
+SET paradedb.term_set_gallop_max_density = 0.05;
+
+-- ===========================================================================
+-- Fixture
+-- ===========================================================================
+
+DROP TABLE IF EXISTS t1 CASCADE;
+DROP TABLE IF EXISTS t2_a CASCADE;
+DROP TABLE IF EXISTS t2_b CASCADE;
+DROP TABLE IF EXISTS t2_c CASCADE;
+
+-- t1: 30,000 rows. `body` carries a space-separated string ('doc 1',
+-- 'doc 2', …) so the default BM25 tokenizer splits cleanly and the
+-- shared 'doc' token lets `@@@ 'doc'` match every row. Each FK column
+-- produces a distinct value per row (D = 1) by multiplying the row index
+-- by a prime coprime to the modulus. Three different primes (7919, 6151,
+-- 4099) give three independent pseudo-uniform spreads.
+CREATE TABLE t1 (
+    id    INTEGER PRIMARY KEY,
+    body  TEXT,
+    fk_a  BIGINT,
+    fk_b  BIGINT,
+    fk_c  BIGINT
+);
+INSERT INTO t1
+SELECT
+    i,
+    'doc ' || i::text,
+    (i * 7919 % 100000)::bigint,
+    (i * 6151 % 100000)::bigint,
+    (i * 4099 % 100000)::bigint
+FROM generate_series(1, 30000) AS i;
+
+-- Each t2_X provides 1,100 distinct fk values that are subsets of the
+-- corresponding column in t1. Different `i` ranges per table so the
+-- three filters intersect to a non-trivial nested result on the full
+-- (unlimited) join:
+--   Q1 (t2_a): t1.id ∈ [1, 1100]
+--   Q2 (∩ t2_b): t1.id ∈ [1, 1100] ∩ [500, 1599] = [500, 1100]
+--   Q3 (∩ t2_c): ∩ [800, 1899] = [800, 1100]
+-- LIMIT 10 (with ORDER BY t1.id) yields a deterministic top-50 from
+-- each.
+-- t2_X tables also have BM25 indexes so the ParadeDB JoinScan custom
+-- scan can engage on both sides of the join. (The Join Scan refuses to
+-- engage if either side isn't BM25-indexed; without it the planner falls
+-- back to vanilla Hash Join which doesn't run the dynamic-filter
+-- pushdown machinery.)
+CREATE TABLE t2_a (id INTEGER PRIMARY KEY, fk BIGINT, body TEXT);
+INSERT INTO t2_a
+SELECT i, (i * 7919 % 100000)::bigint, 'doc ' || i::text
+FROM generate_series(1, 1100) AS i;
+
+CREATE TABLE t2_b (id INTEGER PRIMARY KEY, fk BIGINT, body TEXT);
+INSERT INTO t2_b
+SELECT i, (i * 6151 % 100000)::bigint, 'doc ' || i::text
+FROM generate_series(500, 1599) AS i;
+
+CREATE TABLE t2_c (id INTEGER PRIMARY KEY, fk BIGINT, body TEXT);
+INSERT INTO t2_c
+SELECT i, (i * 4099 % 100000)::bigint, 'doc ' || i::text
+FROM generate_series(800, 1899) AS i;
+
+-- BM25 index on t1: id is the integer key, body is the text-searched
+-- column, fk_a/fk_b/fk_c are fast numeric fields, segment is sorted ASC
+-- by fk_a. Only fk_a is gallop-eligible; fk_b and fk_c land on the
+-- linear-scan TermSetDocSet path (now with the smart-seek override from
+-- the previous tantivy commit).
+CREATE INDEX t1_idx ON t1
+USING bm25 (id, body, fk_a, fk_b, fk_c)
+WITH (
+    key_field = 'id',
+    text_fields = '{"body": {"fast": true}}',
+    numeric_fields = '{"fk_a": {"fast": true}, "fk_b": {"fast": true}, "fk_c": {"fast": true}}',
+    sort_by = 'fk_a ASC NULLS FIRST'
+);
+
+CREATE INDEX t2_a_idx ON t2_a USING bm25 (id, fk, body)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+
+CREATE INDEX t2_b_idx ON t2_b USING bm25 (id, fk, body)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+
+CREATE INDEX t2_c_idx ON t2_c USING bm25 (id, fk, body)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+
+ANALYZE t1;
+ANALYZE t2_a;
+ANALYZE t2_b;
+ANALYZE t2_c;
+
+-- ===========================================================================
+-- Q1: single-column filter (fk_a, the sorted/gallop-eligible column)
+-- ===========================================================================
+
+-- Block A: confirm pushdown shape. Look for `dynamic_filters=1,
+-- dynamic_filter_pushdown=true` on the inner PgSearchScan; the
+-- dynamic_filter_pushdown_strategy token's value is captured but not
+-- asserted on (last-writer-wins; Q1 has only one filter so the value is
+-- whatever fk_a's dispatch produced).
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+-- Block B: correctness. Run the same query with gallop disabled and
+-- enabled, materialize each result into a TEMP TABLE, then compare row
+-- counts and assert the symmetric difference is empty.
+
+SET paradedb.term_set_gallop_enabled = OFF;
+DROP TABLE IF EXISTS result_q1_linear;
+CREATE TEMP TABLE result_q1_linear AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SET paradedb.term_set_gallop_enabled = ON;
+DROP TABLE IF EXISTS result_q1_gallop;
+CREATE TEMP TABLE result_q1_gallop AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SELECT
+    (SELECT count(*) FROM result_q1_linear) AS linear_count,
+    (SELECT count(*) FROM result_q1_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q1_linear) = (SELECT count(*) FROM result_q1_gallop) AS counts_match;
+
+SELECT 'q1 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'linear-only' AS source, id FROM result_q1_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q1_gallop
+    UNION ALL
+    SELECT 'gallop-only' AS source, id FROM result_q1_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q1_linear
+) AS diff
+ORDER BY source, id;
+
+DROP TABLE result_q1_linear;
+DROP TABLE result_q1_gallop;
+
+-- ===========================================================================
+-- Q2: two-column filter (fk_a sorted + fk_b unsorted)
+-- ===========================================================================
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SET paradedb.term_set_gallop_enabled = OFF;
+DROP TABLE IF EXISTS result_q2_linear;
+CREATE TEMP TABLE result_q2_linear AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SET paradedb.term_set_gallop_enabled = ON;
+DROP TABLE IF EXISTS result_q2_gallop;
+CREATE TEMP TABLE result_q2_gallop AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SELECT
+    (SELECT count(*) FROM result_q2_linear) AS linear_count,
+    (SELECT count(*) FROM result_q2_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q2_linear) = (SELECT count(*) FROM result_q2_gallop) AS counts_match;
+
+SELECT 'q2 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'linear-only' AS source, id FROM result_q2_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q2_gallop
+    UNION ALL
+    SELECT 'gallop-only' AS source, id FROM result_q2_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q2_linear
+) AS diff
+ORDER BY source, id;
+
+DROP TABLE result_q2_linear;
+DROP TABLE result_q2_gallop;
+
+-- ===========================================================================
+-- Q3: three-column filter (fk_a sorted + fk_b unsorted + fk_c unsorted)
+-- ===========================================================================
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+JOIN t2_c ON t1.fk_c = t2_c.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SET paradedb.term_set_gallop_enabled = OFF;
+DROP TABLE IF EXISTS result_q3_linear;
+CREATE TEMP TABLE result_q3_linear AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+JOIN t2_c ON t1.fk_c = t2_c.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SET paradedb.term_set_gallop_enabled = ON;
+DROP TABLE IF EXISTS result_q3_gallop;
+CREATE TEMP TABLE result_q3_gallop AS
+SELECT t1.id
+FROM t1
+JOIN t2_a ON t1.fk_a = t2_a.fk
+JOIN t2_b ON t1.fk_b = t2_b.fk
+JOIN t2_c ON t1.fk_c = t2_c.fk
+WHERE t1.body @@@ 'doc'
+ORDER BY t1.id
+LIMIT 10;
+
+SELECT
+    (SELECT count(*) FROM result_q3_linear) AS linear_count,
+    (SELECT count(*) FROM result_q3_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q3_linear) = (SELECT count(*) FROM result_q3_gallop) AS counts_match;
+
+SELECT 'q3 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'linear-only' AS source, id FROM result_q3_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q3_gallop
+    UNION ALL
+    SELECT 'gallop-only' AS source, id FROM result_q3_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q3_linear
+) AS diff
+ORDER BY source, id;
+
+DROP TABLE result_q3_linear;
+DROP TABLE result_q3_gallop;
+
+-- ===========================================================================
+-- Cleanup
+-- ===========================================================================
+
+DROP TABLE IF EXISTS t1 CASCADE;
+DROP TABLE IF EXISTS t2_a CASCADE;
+DROP TABLE IF EXISTS t2_b CASCADE;
+DROP TABLE IF EXISTS t2_c CASCADE;
+
+RESET paradedb.term_set_gallop_enabled;
+RESET paradedb.term_set_gallop_max_density;
+RESET paradedb.enable_join_custom_scan;
+RESET enable_nestloop;
+RESET enable_mergejoin;
+RESET enable_indexscan;
+RESET max_parallel_workers_per_gather;

--- a/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
@@ -13,7 +13,7 @@
 --   neither gallop nor smart-seek is exercised).
 --   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. With
 --   paradedb.term_set_gallop_max_density forced to 0.05 (vs the default
---   1/64 ≈ 0.0156), gallop is admitted on the sorted fk_a column.
+--   1/100 = 0.01), gallop is admitted on the sorted fk_a column.
 --   LIMIT 10 on each query is required for the ParadeDB Join Scan custom
 --   scan's cost model to pick it over a vanilla Hash Join (this also
 --   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
@@ -44,7 +44,7 @@ SET enable_mergejoin = OFF;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_join_custom_scan = ON;
--- Admit gallop on K/N ≈ 0.0367. The default 1/64 ≈ 0.0156 would reject
+-- Admit gallop on K/N ≈ 0.0367. The default 1/100 = 0.01 would reject
 -- this corpus; the override mirrors TEST 2b in join_hash.sql.
 SET paradedb.term_set_gallop_max_density = 0.05;
 
@@ -111,8 +111,8 @@ FROM generate_series(800, 1899) AS i;
 -- BM25 index on t1: id is the integer key, body is the text-searched
 -- column, fk_a/fk_b/fk_c are fast numeric fields, segment is sorted ASC
 -- by fk_a. Only fk_a is gallop-eligible; fk_b and fk_c land on the
--- linear-scan TermSetDocSet path (now with the smart-seek override from
--- the previous tantivy commit).
+-- linear-scan TermSetDocSet path (with smart-seek for forward-cursor
+-- advancement).
 CREATE INDEX t1_idx ON t1
 USING bm25 (id, body, fk_a, fk_b, fk_c)
 WITH (


### PR DESCRIPTION
# Ticket(s) Closed

Closes #4895

# What

Wires the per-segment strategy framework from `paradedb/tantivy@ruchir/term-set-pushdown` into `pg_search`'s dynamic filter pushdown path, exposes per-strategy density GUCs, makes dispatch decisions visible in `EXPLAIN ANALYZE`, and raises the InList pushdown cap from 16K to 20K based on bench data.

Built on top of #4904. After merge, hash-join build sides whose InList values get pushed down as a `TermSetQuery` are evaluated via galloping search on sorted indexes (or smart-seek-augmented linear scan otherwise), instead of falling through to a full fast-field scan.

# Why

#4904 added InList pushdown but capped it conservatively at 16K distinct values because, without an index-aware execution path, large pushed-down InLists pessimize against DataFusion's PreFilter — Tantivy was scanning the whole fast-field column with no skipping, which loses to DataFusion's already-built hash table on the same logical work.

This PR's strategy framework removes that fundamental limitation: on indexes sorted by the filter column, gallop dispatches at low K/N and beats PreFilter by 13–66× on customer-shaped corpora (LowFk D≈100, N=10M–50M, K in the 1K–10K range). On unsorted indexes or above the gallop density gate, smart-seek on `TermSetDocSet` provides additional speedup over the prior linear path, recovering most of the win that the original 16K cap was leaving on the table.

The bench-tuned cap bump (16K → 20K) captures the empirical win zone at N=1M; further tuning is a follow-up once posting-list-direct and bitset-from-postings strategies (currently stubbed) land.

Refs paradedb/tantivy#NN (the Tantivy-side change this depends on).

# How

Five changes:

1. **Strategy dispatch wiring** in `pg_search/src/scan/pre_filter.rs::try_convert_in_list_to_query`. The InList → TermSetQuery conversion now constructs a `FastFieldTermSetQuery` configured with a per-query `TermSetStrategyConfig` (built from the new GUCs) and an `Arc<AtomicU8>` strategy sink. Tantivy's planner picks the dispatch strategy per segment; the sink records the chosen variant for `EXPLAIN ANALYZE`.

2. **GUCs** in `pg_search/src/gucs.rs`. Six per-strategy density GUCs plus a kill switch:

   - `paradedb.term_set_gallop_enabled` (default `on`) — kill switch for galloping dispatch.
   - `paradedb.term_set_gallop_max_density` (default `0.01`) — gallop fires when per-segment K/N is below this. Bench-tuned on LowFk-shaped corpora.
   - `paradedb.term_set_bitset_max_density` (default `0.25`) — reserved for the bitset-from-postings strategy (stub today).
   - `paradedb.term_set_posting_max_density` (default `0.0039`) — reserved for the posting-list-direct strategy (stub today).
   - `paradedb.term_set_hash_probe_max_density` (default `0.10`) — reserved for the hash-probe strategy (stub today).
   - `paradedb.term_set_subsequent_bitset_max_density` (default `0.50`) — reserved for the subsequent-column bitset strategy (stub today).

   All six are settable per-session and per-statement.

3. **Strategy availability matrix.** Tantivy's planner picks one of six strategies per segment. Three are live; three are stubs that route to `TermSetDocSet` linear scan today and will gain real implementations in follow-ups:

   - **Live: Gallop** — galloping search on sorted indexes when per-segment K/N is below `gallop_max_density`. Two-phase per term (exponential probe + bounded binary search), forward cursor across the term set.
   - **Live: LinearScan** — `TermSetDocSet::advance` with a smart-seek override that jumps directly to a target rather than walking forward one doc at a time. Helps single-column scans and prevents multi-column intersection dilution.
   - **Live: AutomatonWeight** — existing path for K ≤ 1024. The strategy framework isn't engaged at this cardinality; `TermSetQuery` routes to `AutomatonWeight` directly.
   - **Stub: BitsetFromPostings** — planned implementation: materialize K posting lists into a bitset over `[0, N)`. Today routes to `TermSetDocSet`.
   - **Stub: PostingListDirect** — planned implementation: walk K posting lists in parallel and emit the union of their DocIds. Today routes to `TermSetDocSet`.
   - **Stub: HashProbe** — planned implementation: hash-probe a small candidate set into the column. Today routes to `TermSetDocSet`.

4. **EXPLAIN observability.** `PgSearchScan` now reports `dynamic_filter_pushdown_strategy=<variant>` per node, derived from the strategy sink. Reviewers can confirm dispatch decisions per query without reading bench data.

5. **InList pushdown cap bump** in `pg_search/src/gucs.rs`. `paradedb.hash_join_inlist_pushdown_max_distinct_values` raised from 16K to 20K based on bench data showing pushdown beats PreFilter through K=14K (1.08×) and loses at K=20K (0.90×) at N=1M sorted. The `TODO` referencing this issue in #4904's commit is resolved. Trade-off explicitly: 20K admits one boundary-cell loser to capture untested K=15K-19K interpolation wins; under-admitting is safer than over-admitting because a missed win is no harm but an admitted loss is real slowdown.

# Tests

Two new pg_regress fixtures plus existing coverage:

- **New file `pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql`.** Single-column and multi-column hash-join InList pushdown on sparse fast-field columns. Verifies `dynamic_filter_pushdown_strategy=gallop` dispatches as expected on sorted indexes; verifies `linear` dispatch on unsorted indexes; verifies multi-column smart-seek doesn't dilute selectivity.
- **Updated file `pg_search/tests/pg_regress/sql/join_hash.sql`** (#4904's regress test). Threshold-related comments updated for the 20K default; expected `.out` regenerated for the SQL prose changes.
- **Existing pg_regress suite (265 tests):** all pass. Equivalence between gallop and LinearScan paths is enforced upstream via Tantivy's `tests/term_set_equivalence.rs`.

`EXPLAIN ANALYZE` is used in both new and updated regress fixtures to confirm strategy dispatch tokens appear correctly.

Tantivy-side bench captures for the strategy framework are in `paradedb/tantivy@ruchir/term-set-pushdown:benches/term_set_queries.{full,threshold}-tier.txt`.