### PR TITLE
ci: cache cargo target directory for macOS publish workflow

### DIFF
--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -126,6 +126,16 @@ jobs:
         if: steps.cache-pgrx.outputs.cache-hit != 'true'
         run: cargo install --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug
 
+      # Cache cargo registry, git deps, and target/ across runs. Cuts the cold
+      # `cargo pgrx package` step (~30 min on PG 18 / Rust 1.95) down to a fraction
+      # on cache hits. Key includes pg_version because pgrx-pg-sys regenerates
+      # bindings against PostgreSQL headers, which change per major version.
+      - name: Cache Cargo target directory
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pg_search-macos-pg${{ matrix.pg_version }}
+          cache-on-failure: true
+
       - name: Initialize pgrx environment
         working-directory: pg_search/
         run: |


### PR DESCRIPTION
## Summary

- Adds `Swatinem/rust-cache@v2` to `publish-pg_search-macos.yml` so `~/.cargo/registry`, `~/.cargo/git`, and `target/` persist across runs.
- Cold builds of `pg_search` on PG 18 / Rust 1.95 currently take ~30 min — cache hits should bring that down substantially (typical Rust workspace cache wins are 5–10× on subsequent builds).
- Cache key includes `pg_version` because `pgrx-pg-sys` regenerates bindings against PostgreSQL headers per major version, so a single shared cache across all PG matrix entries would thrash.

## Notes

- This PR only touches the macOS publish workflow. The Postgres.app publish workflow (introduced in #4913) will get the same cache step once #4913 merges, in a small follow-up commit.
- The Linux publish workflows (`publish-pg_search-{debian,ubuntu,rhel}.yml`) and `test-pg_search.yml` run on `runs-on=` self-hosted runners which have their own caching characteristics — out of scope here.

## Test plan

- [ ] Trigger the workflow via `workflow_dispatch` against the current branch and confirm the cache step succeeds (saves on a miss, restores on a hit).
- [ ] Re-run with no Cargo.lock changes and confirm the second `cargo pgrx package` step is significantly faster than the first.
- [ ] Verify the produced `.pkg` is identical in layout to a cache-miss run (sanity check that caching isn't subtly breaking the pgrx build output).