### PR TITLE
chore: Revert "feat: Tantivy lazy fieldnorm plumbing (#4845)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7761,7 +7761,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "bitpacking",
 ]
@@ -7824,12 +7824,11 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "downcast-rs",
  "fastdivide",
  "itertools 0.14.0",
- "parking_lot",
  "serde",
  "tantivy-bitpacker",
  "tantivy-common",
@@ -7840,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7873,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7885,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7898,7 +7897,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7935,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=7aa40c6d0ad660233297e8a52bc23bb6506db64d#7aa40c6d0ad660233297e8a52bc23bb6506db64d"
+source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "7aa40c6d0ad660233297e8a52bc23bb6506db64d", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84025b075a6ea71be2b9b2ba77ae30cd208ca3f5", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.18.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "7aa40c6d0ad660233297e8a52bc23bb6506db64d" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "84025b075a6ea71be2b9b2ba77ae30cd208ca3f5" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-x+7OcplvD3xMUN3/X29vuyOtyT4bguwQxhBkbCE7Vo4=";
+  cargoHash = "sha256-HIM7zpAjoF4rZAZ+WpXWBI3e3wTQ7V3GfGNltSUbbZg=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-HIM7zpAjoF4rZAZ+WpXWBI3e3wTQ7V3GfGNltSUbbZg=";
+  cargoHash = "sha256-O6UIF0w4nGhqL66GOiVQLmogiwuBSs4TyHmav23ZcJE=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/index/reader/segment_component.rs
+++ b/pg_search/src/index/reader/segment_component.rs
@@ -54,10 +54,6 @@ impl FileHandle for SegmentComponentReader {
     fn read_bytes(&self, range: Range<usize>) -> Result<OwnedBytes, Error> {
         self.read_bytes_raw(range)
     }
-
-    fn read_byte(&self, offset: usize) -> Result<u8, Error> {
-        Ok(unsafe { self.block_list.get_byte(offset) })
-    }
 }
 
 impl HasLen for SegmentComponentReader {

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -28,43 +28,17 @@ use crate::postgres::storage::blocklist;
 use crate::postgres::storage::buffer::{init_new_buffer, BufferManager, PageHeaderMethods};
 use crate::postgres::storage::fsm::FreeSpaceManager;
 
-use std::cell::UnsafeCell;
-
 use anyhow::Result;
+use parking_lot::Mutex;
 use pgrx::{check_for_interrupts, pg_sys};
 use tantivy::directory::OwnedBytes;
 
 const BLOCK_CACHE_SIZE: usize = 16;
 
-/// Unified cache entry: stores OwnedBytes which wraps an Arc'd ImmutablePage.
-/// get_byte indexes directly into the pre-resolved &[u8] slice (no vtable dispatch).
-/// get_bytes_range_block clones the Arc on cache hit.
+#[derive(Debug)]
 struct CacheEntry {
     block_ord: usize,
     block_bytes: OwnedBytes,
-}
-
-/// UnsafeCell-based cache. SAFETY: Postgres backends are single-threaded.
-struct UnsafeCache<T>(UnsafeCell<VecDeque<T>>);
-unsafe impl<T> Send for UnsafeCache<T> {}
-unsafe impl<T> Sync for UnsafeCache<T> {}
-
-impl<T> std::fmt::Debug for UnsafeCache<T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str("UnsafeCache(..)")
-    }
-}
-
-impl<T> UnsafeCache<T> {
-    fn new() -> Self {
-        Self(UnsafeCell::new(VecDeque::with_capacity(BLOCK_CACHE_SIZE)))
-    }
-
-    #[inline(always)]
-    #[allow(clippy::mut_from_ref)] // SAFETY: Postgres backends are single-threaded.
-    unsafe fn get(&self) -> &mut VecDeque<T> {
-        &mut *self.0.get()
-    }
 }
 
 // ---------------------------------------------------------------
@@ -107,7 +81,7 @@ pub struct LinkedBytesList {
     bman: BufferManager,
     pub header_blockno: pg_sys::BlockNumber,
     blocklist_reader: OnceLock<blocklist::reader::BlockList>,
-    cache: UnsafeCache<CacheEntry>,
+    read_cache: Mutex<VecDeque<CacheEntry>>,
 }
 
 pub struct LinkedBytesListWriter {
@@ -239,7 +213,7 @@ impl LinkedBytesList {
             bman: BufferManager::new(rel),
             header_blockno,
             blocklist_reader: Default::default(),
-            cache: UnsafeCache::new(),
+            read_cache: Mutex::new(VecDeque::with_capacity(BLOCK_CACHE_SIZE)),
         }
     }
 
@@ -286,7 +260,7 @@ impl LinkedBytesList {
             bman,
             header_blockno,
             blocklist_reader: Default::default(),
-            cache: UnsafeCache::new(),
+            read_cache: Mutex::new(VecDeque::with_capacity(BLOCK_CACHE_SIZE)),
         }
     }
 
@@ -369,43 +343,6 @@ impl LinkedBytesList {
         self.bman.page_is_empty(self.get_start_blockno().0)
     }
 
-    /// Reads a single byte from the block list.
-    /// Uses the unified block cache — indexes directly into OwnedBytes' pre-resolved slice.
-    pub unsafe fn get_byte(&self, offset: usize) -> u8 {
-        const ITEM_SIZE: usize = bm25_max_free_space();
-        let block_ord = offset / ITEM_SIZE;
-        let local_offset = offset % ITEM_SIZE;
-
-        // SAFETY: Postgres backends are single-threaded.
-        let cache = self.cache.get();
-        // Redundant with rposition below, but ~0.2ms faster under saturation
-        // because it avoids the closure + iterator overhead on the hot path.
-        if let Some(last) = cache.back() {
-            if last.block_ord == block_ord {
-                return last.block_bytes[local_offset];
-            }
-        }
-        if let Some(pos) = cache.iter().rposition(|e| e.block_ord == block_ord) {
-            return cache[pos].block_bytes[local_offset];
-        }
-
-        // Cache miss: read the block, cache it, return the byte.
-        let blockno = self.block_for_ord(block_ord).expect("block not found");
-        let buffer = self.bman.get_buffer(blockno);
-        let block_bytes = OwnedBytes::new(buffer.into_immutable_page());
-        let byte = block_bytes[local_offset];
-
-        if cache.len() >= BLOCK_CACHE_SIZE {
-            cache.pop_front();
-        }
-        cache.push_back(CacheEntry {
-            block_ord,
-            block_bytes,
-        });
-
-        byte
-    }
-
     pub unsafe fn get_bytes_range(&self, range: Range<usize>) -> OwnedBytes {
         if range.is_empty() {
             return OwnedBytes::empty();
@@ -454,23 +391,27 @@ impl LinkedBytesList {
     }
 
     unsafe fn get_bytes_range_block(&self, start_block_ord: usize) -> OwnedBytes {
-        // SAFETY: Postgres backends are single-threaded.
-        let cache = self.cache.get();
+        // Lookup up in the cache.
+        let mut cache = self.read_cache.lock();
         if let Some(pos) = cache.iter().rposition(|e| e.block_ord == start_block_ord) {
-            // Cache hit: move to back, Arc clone.
+            // Cache hit: move to front and return
             let entry = cache.remove(pos).unwrap();
             let block_bytes = entry.block_bytes.clone();
             cache.push_back(entry);
             return block_bytes;
         }
+        drop(cache);
 
-        // Cache miss: read the block.
+        // We missed: read the block.
         let blockno = self
             .block_for_ord(start_block_ord)
             .expect("block not found");
         let buffer = self.bman.get_buffer(blockno);
+
         let block_bytes = OwnedBytes::new(buffer.into_immutable_page());
 
+        // Then cache it.
+        let mut cache = self.read_cache.lock();
         if cache.len() >= BLOCK_CACHE_SIZE {
             cache.pop_front();
         }


### PR DESCRIPTION
This reverts commit c1db650198823a24611b408af6e3852ed4dac51d so we can do an ordered apply of Tantivy commits
