### PR TITLE
fix: adding an error for mixed proximity operators

### DIFF
--- a/pg_search/src/api/operator/proximity.rs
+++ b/pg_search/src/api/operator/proximity.rs
@@ -47,7 +47,7 @@ fn rhs_prox(left: ProximityClause, right: ProximityClause) -> ProximityClause {
                 right: Box::new(right),
             }
         }
-        _ => panic!("lhs of ## must be an unordered ProximityClause with an uninitialized rhs"),
+        _ => panic!("lhs of `##` must be a `<token-expression> ## <distance>`"),
     }
 }
 
@@ -80,6 +80,6 @@ fn rhs_prox_in_order(left: ProximityClause, right: ProximityClause) -> Proximity
                 right: Box::new(right),
             }
         }
-        _ => panic!("lhs of ##> must be an ordered ProximityClause with an uninitialized rhs"),
+        _ => panic!("lhs of `##>` must be a `<token-expression> ##> <distance>`"),
     }
 }

--- a/pg_search/src/api/operator/proximity.rs
+++ b/pg_search/src/api/operator/proximity.rs
@@ -47,7 +47,7 @@ fn rhs_prox(left: ProximityClause, right: ProximityClause) -> ProximityClause {
                 right: Box::new(right),
             }
         }
-        _ => panic!("lhs of `##` must be a `<token-expression> ## <distance>`"),
+        _ => panic!("left hand side of `##` must be a `<token-expression> ## <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity"),
     }
 }
 
@@ -80,6 +80,6 @@ fn rhs_prox_in_order(left: ProximityClause, right: ProximityClause) -> Proximity
                 right: Box::new(right),
             }
         }
-        _ => panic!("lhs of `##>` must be a `<token-expression> ##> <distance>`"),
+        _ => panic!("left hand side of `##>` must be a `<token-expression> ##> <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity"),
     }
 }

--- a/pg_search/src/api/operator/proximity.rs
+++ b/pg_search/src/api/operator/proximity.rs
@@ -38,17 +38,16 @@ fn rhs_prox(left: ProximityClause, right: ProximityClause) -> ProximityClause {
     match left {
         ProximityClause::Proximity {
             left,
-            distance,
+            distance: distance @ ProximityDistance::AnyOrder(_),
             right: original_right,
-        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => match distance {
-            ProximityDistance::AnyOrder(_) => ProximityClause::Proximity {
+        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
+            ProximityClause::Proximity {
                 left,
                 distance,
                 right: Box::new(right),
-            },
-            _ => panic!("mismatched proximity operators: cannot mix ## and ##>"),
-        },
-        _ => panic!("lhs of ## must be a ProximityClause with an uninitialized rhs"),
+            }
+        }
+        _ => panic!("lhs of ## must be an unordered ProximityClause with an uninitialized rhs"),
     }
 }
 
@@ -72,16 +71,15 @@ fn rhs_prox_in_order(left: ProximityClause, right: ProximityClause) -> Proximity
     match left {
         ProximityClause::Proximity {
             left,
-            distance,
+            distance: distance @ ProximityDistance::InOrder(_),
             right: original_right,
-        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => match distance {
-            ProximityDistance::InOrder(_) => ProximityClause::Proximity {
+        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
+            ProximityClause::Proximity {
                 left,
                 distance,
                 right: Box::new(right),
-            },
-            _ => panic!("mismatched proximity operators: cannot mix ## and ##>"),
-        },
-        _ => panic!("lhs of ##> must be a ProximityClause with an uninitialized rhs"),
+            }
+        }
+        _ => panic!("lhs of ##> must be an ordered ProximityClause with an uninitialized rhs"),
     }
 }

--- a/pg_search/src/api/operator/proximity.rs
+++ b/pg_search/src/api/operator/proximity.rs
@@ -40,13 +40,14 @@ fn rhs_prox(left: ProximityClause, right: ProximityClause) -> ProximityClause {
             left,
             distance,
             right: original_right,
-        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
-            ProximityClause::Proximity {
+        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => match distance {
+            ProximityDistance::AnyOrder(_) => ProximityClause::Proximity {
                 left,
                 distance,
                 right: Box::new(right),
-            }
-        }
+            },
+            _ => panic!("mismatched proximity operators: cannot mix ## and ##>"),
+        },
         _ => panic!("lhs of ## must be a ProximityClause with an uninitialized rhs"),
     }
 }
@@ -73,13 +74,14 @@ fn rhs_prox_in_order(left: ProximityClause, right: ProximityClause) -> Proximity
             left,
             distance,
             right: original_right,
-        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => {
-            ProximityClause::Proximity {
+        } if matches!(original_right.as_ref(), ProximityClause::Uninitialized) => match distance {
+            ProximityDistance::InOrder(_) => ProximityClause::Proximity {
                 left,
                 distance,
                 right: Box::new(right),
-            }
-        }
-        _ => panic!("lhs of ## must be a ProximityClause with an uninitialized rhs"),
+            },
+            _ => panic!("mismatched proximity operators: cannot mix ## and ##>"),
+        },
+        _ => panic!("lhs of ##> must be a ProximityClause with an uninitialized rhs"),
     }
 }

--- a/pg_search/tests/pg_regress/expected/proximity.out
+++ b/pg_search/tests/pg_regress/expected/proximity.out
@@ -164,3 +164,10 @@ SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('z' ##>24##> 'a');   -- no ma
 ---------
 (0 rows)
 
+--
+-- mismatched proximity operators should error
+--
+SELECT * FROM prox WHERE text @@@ ('a' ##>1## 'b');   -- error: left is ##>, right is ##
+ERROR:  mismatched proximity operators: cannot mix ## and ##>
+SELECT * FROM prox WHERE text @@@ ('a' ##1##> 'b');   -- error: left is ##, right is ##>
+ERROR:  mismatched proximity operators: cannot mix ## and ##>

--- a/pg_search/tests/pg_regress/expected/proximity.out
+++ b/pg_search/tests/pg_regress/expected/proximity.out
@@ -168,6 +168,6 @@ SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('z' ##>24##> 'a');   -- no ma
 -- mismatched proximity operators should error
 --
 SELECT * FROM prox WHERE text @@@ ('a' ##>1## 'b');   -- error: left is ##>, right is ##
-ERROR:  mismatched proximity operators: cannot mix ## and ##>
+ERROR:  lhs of ## must be an unordered ProximityClause with an uninitialized rhs
 SELECT * FROM prox WHERE text @@@ ('a' ##1##> 'b');   -- error: left is ##, right is ##>
-ERROR:  mismatched proximity operators: cannot mix ## and ##>
+ERROR:  lhs of ##> must be an ordered ProximityClause with an uninitialized rhs

--- a/pg_search/tests/pg_regress/expected/proximity.out
+++ b/pg_search/tests/pg_regress/expected/proximity.out
@@ -168,6 +168,6 @@ SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('z' ##>24##> 'a');   -- no ma
 -- mismatched proximity operators should error
 --
 SELECT * FROM prox WHERE text @@@ ('a' ##>1## 'b');   -- error: left is ##>, right is ##
-ERROR:  lhs of ## must be an unordered ProximityClause with an uninitialized rhs
+ERROR:  lhs of `##` must be a `<token-expression> ## <distance>`
 SELECT * FROM prox WHERE text @@@ ('a' ##1##> 'b');   -- error: left is ##, right is ##>
-ERROR:  lhs of ##> must be an ordered ProximityClause with an uninitialized rhs
+ERROR:  lhs of `##>` must be a `<token-expression> ##> <distance>`

--- a/pg_search/tests/pg_regress/expected/proximity.out
+++ b/pg_search/tests/pg_regress/expected/proximity.out
@@ -168,6 +168,6 @@ SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('z' ##>24##> 'a');   -- no ma
 -- mismatched proximity operators should error
 --
 SELECT * FROM prox WHERE text @@@ ('a' ##>1## 'b');   -- error: left is ##>, right is ##
-ERROR:  lhs of `##` must be a `<token-expression> ## <distance>`
+ERROR:  left hand side of `##` must be a `<token-expression> ## <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity
 SELECT * FROM prox WHERE text @@@ ('a' ##1##> 'b');   -- error: left is ##, right is ##>
-ERROR:  lhs of `##>` must be a `<token-expression> ##> <distance>`
+ERROR:  left hand side of `##>` must be a `<token-expression> ##> <distance>`, see https://docs.paradedb.com/documentation/full-text/proximity

--- a/pg_search/tests/pg_regress/expected/require_positions.out
+++ b/pg_search/tests/pg_regress/expected/require_positions.out
@@ -14,7 +14,7 @@ INSERT INTO require_positions (t) VALUES ('BBBAAA');
 CREATE INDEX idxrequire_positions ON require_positions USING bm25 (id, (t::pdb.ngram(3, 3))) WITH (key_field = 'id');
 SELECT * FROM require_positions WHERE t ### 'aaa';
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
-SELECT * FROM require_positions WHERE t @@@ ('aaa' ##> 1 ## 'bbb');
+SELECT * FROM require_positions WHERE t @@@ ('aaa' ##>1##> 'bbb');
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
 SELECT * FROM require_positions WHERE t @@@ pdb.phrase('aaa');
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
@@ -32,7 +32,7 @@ INSERT INTO require_positions (t) VALUES ('{"key1": "value1", "key2": 3}');
 CREATE INDEX idxrequire_positions ON require_positions USING bm25 (id, (t::pdb.ngram(3, 3))) WITH (key_field = 'id');
 SELECT * FROM require_positions WHERE t->>'key1' ### 'aaa';
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
-SELECT * FROM require_positions WHERE t->>'key1' @@@ ('aaa' ##> 1 ## 'bbb');
+SELECT * FROM require_positions WHERE t->>'key1' @@@ ('aaa' ##>1##> 'bbb');
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
 SELECT * FROM require_positions WHERE t->>'key1' @@@ pdb.phrase('aaa');
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
@@ -50,7 +50,7 @@ INSERT INTO require_positions (t) VALUES ('{"key1": "value1", "key2": 3}');
 CREATE INDEX idxrequire_positions ON require_positions USING bm25 (id, ((t->>'key1')::pdb.ngram(3, 3))) WITH (key_field = 'id');
 SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) ### 'aaa';
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
-SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ ('aaa' ##> 1 ## 'bbb');
+SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ ('aaa' ##>1##> 'bbb');
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type
 SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ pdb.phrase('aaa');
 ERROR:  field 't' was tokenized with 'Some("ngram_mingram:3_maxgram:3_prefixonly:false")' which does not support this query type

--- a/pg_search/tests/pg_regress/sql/proximity.sql
+++ b/pg_search/tests/pg_regress/sql/proximity.sql
@@ -61,3 +61,10 @@ SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('a' ##1## ARRAY['b', 'c', 'd'
 SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('z' ##24## 'a');   -- match, any order
 SELECT pdb.snippet(text) FROM prox WHERE text @@@ ('z' ##>24##> 'a');   -- no match, in order
 
+--
+-- mismatched proximity operators should error
+--
+
+SELECT * FROM prox WHERE text @@@ ('a' ##>1## 'b');   -- error: left is ##>, right is ##
+SELECT * FROM prox WHERE text @@@ ('a' ##1##> 'b');   -- error: left is ##, right is ##>
+

--- a/pg_search/tests/pg_regress/sql/require_positions.sql
+++ b/pg_search/tests/pg_regress/sql/require_positions.sql
@@ -12,7 +12,7 @@ INSERT INTO require_positions (t) VALUES ('BBBAAA');
 CREATE INDEX idxrequire_positions ON require_positions USING bm25 (id, (t::pdb.ngram(3, 3))) WITH (key_field = 'id');
 
 SELECT * FROM require_positions WHERE t ### 'aaa';
-SELECT * FROM require_positions WHERE t @@@ ('aaa' ##> 1 ## 'bbb');
+SELECT * FROM require_positions WHERE t @@@ ('aaa' ##>1##> 'bbb');
 SELECT * FROM require_positions WHERE t @@@ pdb.phrase('aaa');
 SELECT * FROM require_positions WHERE t @@@ pdb.phrase_prefix(ARRAY['aaa', 'b']);
 SELECT * FROM require_positions WHERE t @@@ pdb.regex_phrase(ARRAY['a.*', 'bbb']);
@@ -29,7 +29,7 @@ INSERT INTO require_positions (t) VALUES ('{"key1": "value1", "key2": 3}');
 CREATE INDEX idxrequire_positions ON require_positions USING bm25 (id, (t::pdb.ngram(3, 3))) WITH (key_field = 'id');
 
 SELECT * FROM require_positions WHERE t->>'key1' ### 'aaa';
-SELECT * FROM require_positions WHERE t->>'key1' @@@ ('aaa' ##> 1 ## 'bbb');
+SELECT * FROM require_positions WHERE t->>'key1' @@@ ('aaa' ##>1##> 'bbb');
 SELECT * FROM require_positions WHERE t->>'key1' @@@ pdb.phrase('aaa');
 SELECT * FROM require_positions WHERE t->>'key1' @@@ pdb.phrase_prefix(ARRAY['aaa', 'b']);
 SELECT * FROM require_positions WHERE t->>'key1' @@@ pdb.regex_phrase(ARRAY['a.*', 'bbb']);
@@ -46,7 +46,7 @@ INSERT INTO require_positions (t) VALUES ('{"key1": "value1", "key2": 3}');
 CREATE INDEX idxrequire_positions ON require_positions USING bm25 (id, ((t->>'key1')::pdb.ngram(3, 3))) WITH (key_field = 'id');
 
 SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) ### 'aaa';
-SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ ('aaa' ##> 1 ## 'bbb');
+SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ ('aaa' ##>1##> 'bbb');
 SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ pdb.phrase('aaa');
 SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ pdb.phrase_prefix(ARRAY['aaa', 'b']);
 SELECT * FROM require_positions WHERE ((t->>'key1')::pdb.ngram(3, 3)) @@@ pdb.regex_phrase(ARRAY['a.*', 'bbb']);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4398 

## What

Proximity queries are expected to use matching pairs of operators like `## 1 ##` or `##> 1 ##>`, but they still work with mismatched pairs:

```
SELECT description, rating, category
FROM mock_items
WHERE description @@@ ('history' ##> 1 ## 'book');
```

The behavior of this query is not obvious, but in this case the first operator wins and the query is ordered. If it is changed to `('history' ## 1 ##> 'book')` it becomes unordered.
A query with mismatched operators like this should report an error instead of choosing an ambiguous behavior like it does today.

## Why

Preventing mismatched proximity operators by reporting an error to the user

## How

Modified `rhs_prox` and `rhx_prox_in_order` to expect an `AnyOrder`/`InOrder` distance respectively, and otherwise panicking with an error message about mismatched proximity operators

## Tests
Added tests to `pg_search/tests/pg_regress/sql/proximity.sql` with mismatched operators