### PR TITLE
refactor(mpp): collapse local Stage/NetworkBoundary onto fork types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,6 +323,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-flight"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "302b2e036335f3f04d65dad3f74ff1f2aae6dc671d6aa04dc6b61193761e16fb"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-schema",
+ "base64",
+ "bytes",
+ "futures",
+ "prost",
+ "prost-types",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
 name = "arrow-ipc"
 version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +355,7 @@ dependencies = [
  "arrow-select",
  "flatbuffers",
  "lz4_flex 0.13.0",
+ "zstd",
 ]
 
 [[package]]
@@ -696,6 +732,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,6 +813,15 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
  "serde",
 ]
 
@@ -910,6 +998,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1846,11 +1955,13 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions",
  "datafusion-functions-aggregate",
+ "datafusion-functions-nested",
  "datafusion-functions-table",
  "datafusion-functions-window",
  "datafusion-optimizer",
@@ -1860,13 +1971,16 @@ dependencies = [
  "datafusion-physical-optimizer",
  "datafusion-physical-plan",
  "datafusion-session",
+ "datafusion-sql",
  "futures",
  "itertools 0.14.0",
  "log",
  "object_store",
  "parking_lot",
+ "parquet",
  "rand 0.9.4",
  "regex",
+ "sqlparser",
  "tempfile",
  "tokio",
  "url",
@@ -1938,7 +2052,9 @@ dependencies = [
  "libc",
  "log",
  "object_store",
+ "parquet",
  "paste",
+ "sqlparser",
  "tokio",
  "web-time",
 ]
@@ -2055,6 +2171,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-datasource-parquet"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a8e0365e0e08e8ff94d912f0ababcf9065a1a304018ba90b1fc83c855b4997"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "bytes",
+ "datafusion-common",
+ "datafusion-common-runtime",
+ "datafusion-datasource",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-functions-aggregate-common",
+ "datafusion-physical-expr",
+ "datafusion-physical-expr-adapter",
+ "datafusion-physical-expr-common",
+ "datafusion-physical-plan",
+ "datafusion-pruning",
+ "datafusion-session",
+ "futures",
+ "itertools 0.14.0",
+ "log",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "tokio",
+]
+
+[[package]]
+name = "datafusion-distributed"
+version = "1.0.0"
+source = "git+https://github.com/paradedb/datafusion-distributed?branch=paradedb%2Fboundary-factory#8f072b90ffaa324183e3e65774d04c9a569bbb0c"
+dependencies = [
+ "arrow-flight",
+ "arrow-ipc",
+ "arrow-select",
+ "async-trait",
+ "bincode 1.3.3",
+ "bytes",
+ "chrono",
+ "crossbeam-queue",
+ "dashmap",
+ "datafusion",
+ "datafusion-proto",
+ "delegate",
+ "futures",
+ "http",
+ "itertools 0.14.0",
+ "moka",
+ "object_store",
+ "pin-project",
+ "prost",
+ "rand 0.9.4",
+ "sketches-ddsketch",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic",
+ "tonic-prost",
+ "tower",
+ "url",
+ "uuid",
+]
+
+[[package]]
 name = "datafusion-doc"
 version = "53.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2102,6 +2284,7 @@ dependencies = [
  "itertools 0.14.0",
  "paste",
  "serde_json",
+ "sqlparser",
 ]
 
 [[package]]
@@ -2178,6 +2361,31 @@ dependencies = [
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
+]
+
+[[package]]
+name = "datafusion-functions-nested"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef13a858e20d50f0a9bb5e96e7ac82b4e7597f247515bccca4fdd2992df0212a"
+dependencies = [
+ "arrow",
+ "arrow-ord",
+ "datafusion-common",
+ "datafusion-doc",
+ "datafusion-execution",
+ "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-functions",
+ "datafusion-functions-aggregate",
+ "datafusion-functions-aggregate-common",
+ "datafusion-macros",
+ "datafusion-physical-expr-common",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "itoa",
+ "log",
+ "paste",
 ]
 
 [[package]]
@@ -2374,6 +2582,7 @@ dependencies = [
  "datafusion-datasource-arrow",
  "datafusion-datasource-csv",
  "datafusion-datasource-json",
+ "datafusion-datasource-parquet",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-table",
@@ -2429,6 +2638,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "datafusion-sql"
+version = "53.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0d133ddf8b9b3b872acac900157f783e7b879fe9a6bccf389abebbfac45ec1"
+dependencies = [
+ "arrow",
+ "bigdecimal",
+ "chrono",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-functions-nested",
+ "indexmap",
+ "log",
+ "regex",
+ "sqlparser",
+]
+
+[[package]]
 name = "decimal-bytes"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,6 +2663,17 @@ checksum = "269277cb6b69f2fa55423ff5f3ff61f783893488b4e019b50fd4b57e077e1d4e"
 dependencies = [
  "serde",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "delegate"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3446,6 +3684,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,6 +3878,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "human_bytes"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3651,9 +3914,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -3675,6 +3940,19 @@ dependencies = [
  "tokio-rustls",
  "tower-service",
  "webpki-roots",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -4021,6 +4299,12 @@ checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "interpolate_name"
@@ -4726,6 +5010,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "maybe-rayon"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4795,6 +5085,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4820,6 +5116,26 @@ dependencies = [
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "async-lock 3.4.2",
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "event-listener 5.4.1",
+ "futures-util",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
 ]
 
 [[package]]
@@ -5163,6 +5479,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -5234,6 +5559,42 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parquet"
+version = "58.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d3f9f2205199603564127932b89695f52b62322f541d0fc7179d57c2e1c9877"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64",
+ "brotli",
+ "bytes",
+ "chrono",
+ "flate2",
+ "futures",
+ "half 2.7.1",
+ "hashbrown 0.16.1",
+ "lz4_flex 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "object_store",
+ "paste",
+ "seq-macro",
+ "simdutf8",
+ "snap",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd",
 ]
 
 [[package]]
@@ -5357,6 +5718,7 @@ dependencies = [
 name = "pg_search"
 version = "0.23.1"
 dependencies = [
+ "ahash 0.8.12",
  "anyhow",
  "arrow-array",
  "arrow-buffer",
@@ -5364,12 +5726,13 @@ dependencies = [
  "arrow-select",
  "async-stream",
  "async-trait",
- "bincode",
+ "bincode 2.0.1",
  "bitpacking",
  "bytemuck",
  "bytes",
  "chrono",
  "datafusion",
+ "datafusion-distributed",
  "datafusion-proto",
  "decimal-bytes",
  "derive_more",
@@ -5699,6 +6062,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher 1.0.2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6137,6 +6520,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -7059,6 +7451,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7320,6 +7718,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+
+[[package]]
 name = "soa_derive"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7378,6 +7782,27 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlparser"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf5ea8d4d7c808e1af1cbabebca9a2abe603bcefc22294c5b95018d53200cb7"
+dependencies = [
+ "log",
+ "sqlparser_derive",
+]
+
+[[package]]
+name = "sqlparser_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6dd45d8fc1c79299bfbb7190e42ccbbdf6a5f52e4a6ad98d92357ea965bd289"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7759,6 +8184,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
 name = "tantivy"
 version = "0.26.0"
 source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
@@ -8063,6 +8494,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -8371,6 +8813,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2 0.6.3",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8378,11 +8860,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_count.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*)
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_groupby.sql
@@ -19,3 +19,14 @@ JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section'
 GROUP BY f.title
 ORDER BY f.title;
+
+-- MPP aggregate scan (Phase 7: N=4 — the default `paradedb.mpp_worker_count`
+-- — after the Phase 8 coalesce + hash-partition fix stabilised the 4-way
+-- mesh for GROUP BY. The earlier N=2 pin is removed; other bench queries
+-- already run at N=4.)
+SET statement_timeout TO '600s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT f.title, COUNT(*), SUM(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section'
+GROUP BY f.title
+ORDER BY f.title;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_multi.sql
@@ -15,3 +15,9 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*), MIN(p."sizeInB
 FROM files f
 JOIN pages p ON f.id = p."fileId"
 WHERE f.content ||| 'Section';
+
+-- MPP aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*), MIN(p."sizeInBytes"), MAX(p."sizeInBytes")
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE f.content ||| 'Section';

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_join_topk_count.sql
@@ -31,3 +31,17 @@ GROUP BY
 ORDER BY
     COUNT(*) DESC
 LIMIT 10;
+
+-- MPP TopK aggregate scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.title,
+    COUNT(*)
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'
+GROUP BY
+    f.title
+ORDER BY
+    COUNT(*) DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/aggregate_sort.sql
@@ -29,3 +29,18 @@ GROUP BY
 ORDER BY
     last_activity DESC            -- Single Feature Sort (Computed Aggregate)
 LIMIT 10;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    MAX(p."createdAt") as last_activity
+FROM files f
+JOIN pages p ON f.id = p."fileId"
+WHERE
+    f.content ||| 'Section'       -- Search Term
+GROUP BY
+    f.id, f.title
+ORDER BY
+    last_activity DESC            -- Single Feature Sort (Computed Aggregate)
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/foreign_filter_local_sort.sql
@@ -31,3 +31,19 @@ WHERE
 ORDER BY
     f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
 LIMIT 20;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt",
+    d.title as document_title,
+    d.parents as document_parents
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    d.parents ||| 'parent group'
+    AND f.title ||| 'collab12'
+ORDER BY
+    f."createdAt" DESC                -- Single Feature Sort (Local Fast Field)
+LIMIT 20;

--- a/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/permissioned_search.sql
@@ -27,3 +27,17 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    pdb.score(f.id) as relevance
+FROM files f
+JOIN documents d ON f."documentId" = d.id
+WHERE
+    f.title ||| 'File'              -- Driving the Sort (Single Feature)
+    AND d.parents ||| 'parent group'
+ORDER BY
+    relevance DESC
+LIMIT 10;

--- a/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
+++ b/benchmarks/datasets/docs/queries/pg_search/semi_join_filter.sql
@@ -82,3 +82,20 @@ WHERE
 ORDER BY
     f.title ASC
 LIMIT 25;
+
+-- MPP join scan
+SET statement_timeout TO '300s'; SET work_mem TO '4GB'; SET paradedb.enable_columnar_sort TO on; SET paradedb.enable_join_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT
+    f.id,
+    f.title,
+    f."createdAt"
+FROM files f
+WHERE
+    f."documentId" IN (
+        SELECT id
+        FROM documents
+        WHERE parents ||| 'PROJECT_ALPHA'
+        AND title ||| 'Document Title 1'
+    )
+ORDER BY
+    f.title ASC
+LIMIT 25;

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -29,6 +29,9 @@ arrow-array = "58.1.0"
 arrow-buffer = "58.1.0"
 arrow-schema = "58.1.0"
 arrow-select = "58.1.0"
+# Match the version datafusion 53 and arrow use for ahash::RandomState, which
+# DataFusion's `create_hashes` helper requires as input.
+ahash = "0.8"
 bitpacking = "0.9.3"
 chrono = "0.4.44"
 time = "0.3.47"
@@ -77,6 +80,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", branch = "paradedb/boundary-factory" }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -178,6 +178,12 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
     GucSetting::<i32>::new(16_000);
 
+/// Cost gate for binary-join MPP shapes (JoinOnly, ScalarAggOnBinaryJoin,
+/// GroupByAggOnBinaryJoin). If the smaller side's row estimate is below this
+/// threshold, skip MPP — the non-MPP broadcast-join path is cheaper when the
+/// small side fits in memory. Single-table shapes are unaffected.
+static MPP_MIN_JOIN_ROWS: GucSetting<i32> = GucSetting::<i32>::new(10_000);
+
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
     // They must be namespaced... we use 'paradedb.<variable>' below.
@@ -535,6 +541,22 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_min_join_rows",
+        c"Minimum smaller-side rows before binary-join MPP shapes kick in",
+        c"Cost gate for binary-join MPP shapes: JoinOnly and aggregate-on- \
+          binary-join (both scalar and group-by). If the smaller side's \
+          planner row estimate is below this threshold, skip MPP — the \
+          non-MPP broadcast-join path is cheaper when the small side fits \
+          in memory. Single-table aggregate shapes have no broadcast \
+          candidate and are not gated. Set to 0 to disable the gate.",
+        &MPP_MIN_JOIN_ROWS,
+        0,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -735,6 +757,10 @@ pub fn hash_join_inlist_pushdown_max_size() -> i32 {
 
 pub fn hash_join_inlist_pushdown_max_distinct_values() -> i32 {
     HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES.get()
+}
+
+pub fn mpp_min_join_rows() -> i32 {
+    MPP_MIN_JOIN_ROWS.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -130,6 +130,14 @@ pub unsafe extern "C-unwind" fn _PG_init() {
 
     // Initialize the filter query builder
     customscan::aggregatescan::filterquery::init_filter_query_builder();
+
+    // Install MPP walker's runtime indirection for `PgSearchScanPlan::strip_dynamic_filters_from_dyn`.
+    // See `mpp::walker::STRIP_DYNAMIC_FILTERS_FN` for why this cannot be called statically.
+    customscan::mpp::walker::init_mpp_strip_dynamic_filters();
+
+    // Register an extractor with the datafusion-distributed fork so its
+    // NetworkBoundaryExt::as_network_boundary recognizes MppShuffleExec.
+    customscan::mpp::walker::init_mpp_network_boundary_extractor();
 }
 
 #[pg_extern]

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -38,8 +38,10 @@ use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, JoinSource, RelNode, RelationAlias,
 };
 use crate::postgres::customscan::joinscan::scan_state::{
-    create_datafusion_session_context, register_source_table, SessionContextProfile,
+    create_datafusion_session_context, create_datafusion_session_context_mpp,
+    register_source_table, SessionContextProfile,
 };
+use crate::postgres::customscan::mpp::MppParticipantConfig;
 use crate::scan::info::RowEstimate;
 use crate::scan::PgSearchTableProvider;
 use datafusion::common::{DataFusionError, Result};
@@ -49,12 +51,15 @@ use datafusion::functions_aggregate::expr_fn::{
     array_agg, avg, bool_and, bool_or, count, max, min, stddev, stddev_pop, sum, var_pop,
     var_sample,
 };
-use datafusion::functions_aggregate::string_agg::string_agg_udaf;
+use datafusion::functions_aggregate::string_agg::{string_agg, string_agg_udaf};
 use datafusion::logical_expr::expr::{AggregateFunction, Sort};
-use datafusion::logical_expr::{lit, Expr};
-use datafusion::prelude::{DataFrame, SessionContext};
+use datafusion::logical_expr::{lit, BinaryExpr, Expr, LogicalPlan, Operator};
+use datafusion::prelude::{col, DataFrame, SessionContext};
 use futures::future::{FutureExt, LocalBoxFuture};
 use pgrx::pg_sys;
+use pgrx::PgList;
+
+use crate::api::{HashMap, HashSet};
 
 /// Creates a DataFusion [`SessionContext`] for aggregate-on-join workloads.
 ///
@@ -65,6 +70,15 @@ use pgrx::pg_sys;
 /// specific session setup ever appears, this is the place to put it.
 pub fn create_aggregate_session_context() -> SessionContext {
     create_datafusion_session_context(SessionContextProfile::Aggregate)
+}
+
+/// MPP-aware variant. Applies the join-layer bug fixes required when the
+/// aggregate path runs as part of an MPP pipeline: skip `SortMergeJoinEnforcer`
+/// and disable `enable_join_dynamic_filter_pushdown`. Without this, the
+/// probe-side scan races with the exchange producer and silently drops rows
+/// before the dynamic filter stabilizes.
+pub fn create_aggregate_session_context_mpp(mpp: &MppParticipantConfig) -> SessionContext {
+    create_datafusion_session_context_mpp(SessionContextProfile::Aggregate, mpp)
 }
 
 /// Build the complete DataFusion logical plan for an aggregate-on-join query:
@@ -79,7 +93,7 @@ pub async fn build_join_aggregate_plan(
     custom_scan_tlist: *mut pg_sys::List,
     having_filter: Option<&FilterExpr>,
     ctx: &SessionContext,
-) -> Result<datafusion::logical_expr::LogicalPlan> {
+) -> Result<LogicalPlan> {
     // Step 1: Build the join DataFrame from the RelNode tree
     let df = build_relnode_df(
         ctx,
@@ -146,9 +160,7 @@ pub async fn build_join_aggregate_plan(
                     let col_expr = agg_field_col(agg, plan)?;
                     let sep_lit = lit(sep.clone());
                     if agg.order_by.is_empty() {
-                        Ok(datafusion::functions_aggregate::string_agg::string_agg(
-                            col_expr, sep_lit,
-                        ))
+                        Ok(string_agg(col_expr, sep_lit))
                     } else {
                         Ok(Expr::AggregateFunction(AggregateFunction::new_udf(
                             string_agg_udaf(),
@@ -214,8 +226,8 @@ pub async fn build_join_aggregate_plan(
     // bounded TopK heap.
     if let Some(topk) = topk {
         let sort_col_name = topk.sort_target.resolve_sort_col_name(targetlist, plan);
-        let sort_expr = datafusion::prelude::col(&sort_col_name)
-            .sort(topk.direction.is_asc(), topk.direction.is_nulls_first());
+        let sort_expr =
+            col(&sort_col_name).sort(topk.direction.is_asc(), topk.direction.is_nulls_first());
         let df = df.sort(vec![sort_expr])?;
         let df = df.limit(0, Some(topk.k))?;
         return df.into_optimized_plan();
@@ -290,13 +302,13 @@ fn build_relnode_df<'a>(
                 // in the table provider schema. After aliasing, it's accessible
                 // as `<alias>.ctid`.
                 let sources = filter.input.sources();
-                let ctid_map: crate::api::HashMap<pg_sys::Index, Expr> = sources
+                let ctid_map: HashMap<pg_sys::Index, Expr> = sources
                     .iter()
                     .map(|s| (s.plan_position as pg_sys::Index, make_source_col(s, "ctid")))
                     .collect();
 
                 // No deferred positions in aggregate path (no VisibilityFilterExec)
-                let deferred_positions = crate::api::HashSet::default();
+                let deferred_positions = HashSet::default();
 
                 // Translate custom_exprs (non-@@@ cross-table predicates) using
                 // PredicateTranslator, mirroring JoinScan's scan_state.rs:562-576.
@@ -312,7 +324,7 @@ fn build_relnode_df<'a>(
                     let translator =
                         PredicateTranslator::new(&sources).with_mapper(Box::new(mapper));
                     unsafe {
-                        let expr_list = pgrx::PgList::<pg_sys::Node>::from_pg(custom_exprs);
+                        let expr_list = PgList::<pg_sys::Node>::from_pg(custom_exprs);
                         for (i, expr_node) in expr_list.iter_ptr().enumerate() {
                             let expr = translator.translate(expr_node).ok_or_else(|| {
                                 DataFusionError::Internal(format!(
@@ -357,7 +369,7 @@ impl<'a> ColumnMapper for AggregateIndexVarMapper<'a> {
             // INDEX_VAR: look up the original Var from custom_scan_tlist.
             // varattno is 1-indexed into the target list.
             unsafe {
-                let tlist = pgrx::PgList::<pg_sys::TargetEntry>::from_pg(self.custom_scan_tlist);
+                let tlist = PgList::<pg_sys::TargetEntry>::from_pg(self.custom_scan_tlist);
                 let idx = (varattno - 1) as usize;
                 let te = tlist.get_ptr(idx)?;
                 if (*(*te).expr).type_ != pg_sys::NodeTag::T_Var {
@@ -394,18 +406,16 @@ impl FilterExpr {
     ///
     /// Used for both HAVING (pass `targetlist`) and per-aggregate FILTER (pass `plan`).
     fn to_datafusion(&self, ctx: &FilterExprExecContext<'_>) -> Option<Expr> {
-        use datafusion::logical_expr::Operator;
-
         match self {
             FilterExpr::AggRef(idx) => {
                 let tl = ctx.targetlist?;
                 if *idx < tl.aggregates.len() {
-                    Some(datafusion::prelude::col(format!("agg_{}", idx)))
+                    Some(col(format!("agg_{}", idx)))
                 } else {
                     None
                 }
             }
-            FilterExpr::GroupRef(field_name) => Some(datafusion::prelude::col(field_name.as_str())),
+            FilterExpr::GroupRef(field_name) => Some(col(field_name.as_str())),
             FilterExpr::ColumnRef { rti, field_name } => {
                 let plan = ctx.plan?;
                 Some(make_rti_col(plan, *rti, field_name))
@@ -425,7 +435,7 @@ impl FilterExpr {
                     CompareOp::Gt => Operator::Gt,
                     CompareOp::GtEq => Operator::GtEq,
                 };
-                Some(Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr::new(
+                Some(Expr::BinaryExpr(BinaryExpr::new(
                     Box::new(l),
                     df_op,
                     Box::new(r),
@@ -539,7 +549,7 @@ async fn build_source_df(
 /// Thin wrapper around the shared [`make_source_col`] that walks the plan to
 /// find the source claiming `rti` first. Use this instead of resolving the
 /// source manually at every aggregate-on-join call site.
-fn make_rti_col(plan: &RelNode, rti: pgrx::pg_sys::Index, field_name: &str) -> Expr {
+fn make_rti_col(plan: &RelNode, rti: pg_sys::Index, field_name: &str) -> Expr {
     let source = plan
         .source_for_rti_in_subtree(rti)
         .unwrap_or_else(|| panic!("make_rti_col: RTI {rti} not found in plan sources"));

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -47,6 +47,7 @@ use crate::postgres::customscan::aggregatescan::datafusion_build::{
 };
 use crate::postgres::customscan::aggregatescan::datafusion_exec::{
     build_join_aggregate_plan, create_aggregate_session_context,
+    create_aggregate_session_context_mpp,
 };
 use crate::postgres::customscan::aggregatescan::datafusion_project::project_aggregate_row_to_slot;
 use crate::postgres::customscan::aggregatescan::exec::{
@@ -63,9 +64,24 @@ use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
 };
+use crate::postgres::customscan::dsm as mpp_dsm;
+use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::scan_state::{build_physical_plan, build_task_context};
 use crate::postgres::customscan::limit_offset::LimitOffset;
+use crate::postgres::customscan::mpp::customscan_glue::{
+    leader_estimate_dsm, leader_init_dsm, mpp_is_active, mpp_worker_count as mpp_glue_worker_count,
+    worker_init_dsm,
+};
+use crate::postgres::customscan::mpp::session::{
+    derive_query_id, MppPlanBroadcast, MppSessionProfile,
+};
+use crate::postgres::customscan::mpp::shape::{
+    broadcast_side_gate, classify as classify_shape, ClassifyInputs, MppPlanShape,
+};
+use crate::postgres::customscan::mpp::walker::{cut_count_for_shape, distribute_plan};
+use crate::postgres::customscan::mpp::worker::{MppDsmHeader, MPP_DSM_MAGIC};
+use crate::postgres::customscan::mpp::MppShardConfig;
 use crate::postgres::customscan::projections::{create_placeholder_targetlist, placeholder_procid};
 use crate::postgres::customscan::solve_expr::SolvePostgresExpressions;
 use crate::postgres::customscan::{range_table, CreateUpperPathsHookArgs, CustomScan};
@@ -75,8 +91,13 @@ use crate::postgres::utils::{add_vars_to_tlist, is_unnest_func, make_text_const}
 use crate::postgres::PgSearchRelation;
 use chrono::{DateTime as ChronoDateTime, Utc};
 use pgrx::{pg_sys, PgList, PgMemoryContexts, PgTupleDesc};
-use std::ffi::CStr;
+use std::ffi::{c_void, CStr};
+use std::ptr;
+use std::sync::Arc;
 use tantivy::schema::OwnedValue;
+
+use crate::scan::codec::serialize_logical_plan;
+use crate::scan::info::RowEstimate;
 
 #[derive(Default)]
 pub struct AggregateScan;
@@ -142,10 +163,13 @@ impl CustomScan for AggregateScan {
             ReScanCustomScan: Some(crate::postgres::customscan::exec::rescan_custom_scan::<Self>),
             MarkPosCustomScan: None,
             RestrPosCustomScan: None,
-            EstimateDSMCustomScan: None,
-            InitializeDSMCustomScan: None,
-            ReInitializeDSMCustomScan: None,
-            InitializeWorkerCustomScan: None,
+            // MPP DSM slots. These are only invoked when the path is flagged
+            // parallel-safe in `create_custom_path`; they wire the MPP
+            // lifecycle when `customscan_glue::mpp_is_active()`.
+            EstimateDSMCustomScan: Some(mpp_dsm::estimate_dsm_custom_scan::<Self>),
+            InitializeDSMCustomScan: Some(mpp_dsm::initialize_dsm_custom_scan::<Self>),
+            ReInitializeDSMCustomScan: Some(mpp_dsm::reinitialize_dsm_custom_scan::<Self>),
+            InitializeWorkerCustomScan: Some(mpp_dsm::initialize_worker_custom_scan::<Self>),
             ShutdownCustomScan: Some(
                 crate::postgres::customscan::exec::shutdown_custom_scan::<Self>,
             ),
@@ -231,7 +255,8 @@ impl CustomScan for AggregateScan {
             // For join aggregates, scanrelid=0 (no single base relation)
             builder.set_scanrelid(0);
 
-            // Check if the query has pathkeys (ORDER BY) before consuming builder.
+            // Check if the query has pathkeys (e.g. GROUP BY emits group_pathkeys
+            // into query_pathkeys) before consuming builder.
             let root = builder.args().root;
             let has_pathkeys = unsafe {
                 !(*root).query_pathkeys.is_null() && pg_sys::list_length((*root).query_pathkeys) > 0
@@ -280,14 +305,31 @@ impl CustomScan for AggregateScan {
                     cscan.custom_exprs = custom_exprs_list.into_pg();
                 }
 
-                if !has_pathkeys {
-                    // No ORDER BY: safe to replace Aggrefs at plan time.
+                let parallel_aware = (*best_path).path.parallel_aware;
+                if !has_pathkeys && !parallel_aware {
+                    // Non-MPP, no-pathkeys case: replace Aggrefs at plan
+                    // time with `pdb.agg_fn(...)` placeholders. The non-MPP
+                    // CustomScan executes aggregation internally (without
+                    // a Gather above), so placing FuncExprs here is fine —
+                    // they never get evaluated because our ExecCustomScan
+                    // produces finished tuples directly.
                     let plan = &mut cscan.scan.plan;
                     replace_aggrefs_in_target_list(plan);
                 }
-                // When has_pathkeys: aggrefs stay in plan.targetlist so Postgres's
-                // make_sort_from_pathkeys can find them. Replacement is deferred to
-                // create_custom_scan_state (execution time).
+                // For the MPP (parallel_aware) path we leave Aggrefs in
+                // plan.targetlist. The Gather above us has a tlist with
+                // structurally-equal Aggrefs (from `rel->reltarget`); at
+                // setrefs time `fix_upper_expr` matches them via `equal()`
+                // and rewrites to `Var(OUTER_VAR, N)`. CustomScan's own
+                // plan.targetlist Aggrefs get rewritten to
+                // `Var(INDEX_VAR, N)` against `custom_scan_tlist`. Any
+                // Result added above a Sort for ORDER BY also sees
+                // matching Aggrefs in its subplan. Replacement here would
+                // break all three of those matches under ORDER BY.
+                // When has_pathkeys AND !parallel_aware (non-MPP ORDER BY
+                // path): aggrefs stay in plan.targetlist so Postgres's
+                // `make_sort_from_pathkeys` can find them. Replacement is
+                // deferred to `create_custom_scan_state` (execution time).
                 cscan
             }
         }
@@ -450,7 +492,7 @@ impl CustomScan for AggregateScan {
     fn begin_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
         estate: *mut pg_sys::EState,
-        _eflags: i32,
+        eflags: i32,
     ) {
         if state.custom_state().is_datafusion_backend() {
             // DataFusion backend: create scan slot for result projection
@@ -461,6 +503,19 @@ impl CustomScan for AggregateScan {
                     &pg_sys::TTSOpsVirtual,
                 );
                 state.custom_state_mut().scan_slot = Some(scan_slot);
+            }
+
+            // MPP plan-bytes stash: serialize the DataFusion logical plan
+            // at BeginCustomScan time so the DSM hooks can read `.len()`
+            // and the bytes without rebuilding the plan. Skip for
+            // `EXPLAIN` without `ANALYZE` (EXEC_FLAG_EXPLAIN_ONLY set) —
+            // users running bare EXPLAIN don't want to pay plan-build +
+            // serialize cost that's purely for parallel init. Also gated
+            // on `mpp_is_active()` so non-MPP queries pay zero cost.
+            // Failures inside the helper are non-fatal (log + fall back).
+            let explain_only = (eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) != 0;
+            if !explain_only && mpp_is_active() {
+                Self::maybe_stash_mpp_plan_bytes(state);
             }
             return;
         }
@@ -611,6 +666,300 @@ pub trait CustomScanClause<CS: CustomScan> {
 }
 
 impl AggregateScan {
+    /// Build the DataFusion logical plan now, serialize it via
+    /// `PgSearchExtensionCodec`, and stash the bytes on `AggregateScanState`
+    /// for the MPP DSM hooks to consume. Called from `begin_custom_scan`
+    /// when `mpp_is_active()` is true and the DataFusion backend is active.
+    ///
+    /// Failures (plan-build, serialize) are logged via `mpp_log!` and leave
+    /// `logical_plan_bytes` as `None` — MPP then silently falls back to the
+    /// non-MPP path at `exec_datafusion_aggregate` rather than aborting the
+    /// query. This is the most ops-friendly failure mode: a misconfigured
+    /// MPP setting shouldn't take down a query that would otherwise succeed.
+    ///
+    /// Uses a throwaway single-thread tokio runtime because
+    /// `build_join_aggregate_plan` / `build_physical_plan` are async-signature
+    /// even though their bodies don't need an I/O runtime. The
+    /// `exec_datafusion_aggregate` path does the same dance — we pay the
+    /// plan-build cost twice when MPP is active (once here, once at exec
+    /// time). A future optimization is to cache the plan, but the
+    /// complexity of keeping logical + physical in sync across parallel
+    /// workers isn't worth it for milestone 1.
+    fn maybe_stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
+        let Some(df_state) = state.custom_state().datafusion_state.as_ref() else {
+            return;
+        };
+        let plan = df_state.plan.clone();
+        let targetlist = df_state.targetlist.clone();
+        let topk = df_state.topk.clone();
+        let jlp = df_state.join_level_predicates.clone();
+        let custom_exprs = df_state.custom_exprs;
+        let custom_scan_tlist = df_state.custom_scan_tlist;
+        let having = df_state.having_filter.clone();
+        // Snapshot source row estimates for the broadcast-side cost gate
+        // below. Harvested here (cheaply, from the PG-side join tree) so we
+        // don't have to walk the DataFusion logical plan to recover them
+        // after it's built.
+        let source_estimates: Vec<RowEstimate> = plan
+            .sources()
+            .iter()
+            .map(|s| s.scan_info.estimate)
+            .collect();
+
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                crate::mpp_log!("mpp: failed to build tokio runtime for plan stash: {e}");
+                return;
+            }
+        };
+
+        let ctx = create_aggregate_session_context();
+        let plan_and_shape: datafusion::common::Result<(bytes::Bytes, MppPlanShape)> =
+            rt.block_on(async {
+                let logical = build_join_aggregate_plan(
+                    &plan,
+                    &targetlist,
+                    topk.as_ref(),
+                    &jlp,
+                    custom_exprs,
+                    custom_scan_tlist,
+                    having.as_ref(),
+                    &ctx,
+                )
+                .await?;
+                let shape = Self::classify_logical_plan(&logical);
+                let bytes = serialize_logical_plan(&logical)?;
+                Ok((bytes, shape))
+            });
+
+        match plan_and_shape {
+            Ok((bytes, shape)) => {
+                // Cost gate: for binary-join shapes (Scalar / GroupBy agg on
+                // binary join), if the smallest source is small enough to
+                // broadcast-join cheaply, skip MPP's pre-join shuffle and let
+                // the non-MPP path run. Single-table shapes
+                // (GroupByAggSingleTable) have no broadcast candidate and are
+                // not gated.
+                if shape.is_binary_join() {
+                    let min_rows = gucs::mpp_min_join_rows();
+                    if let Some(gated_rows) = broadcast_side_gate(&source_estimates, min_rows) {
+                        crate::mpp_log!(
+                            "mpp: AggregateScan {:?} gated — smallest side \
+                             estimated_rows={} < mpp_min_join_rows={}; staying on \
+                             non-MPP path",
+                            shape,
+                            gated_rows,
+                            min_rows
+                        );
+                        return;
+                    }
+                }
+                // Wrap the raw logical plan in `MppPlanBroadcast` and
+                // bincode-serialize *now* so `logical_plan_bytes.len()` equals
+                // the exact bytes that will later be copied into DSM. If we
+                // instead stashed the raw logical plan bytes here and
+                // re-wrapped at DSM init time, `estimate_dsm_custom_scan`
+                // would under-report by `MppPlanBroadcast`'s framing overhead
+                // (~6 bytes: version byte + varint length prefix +
+                // total_participants + profile tag). That mismatch causes the
+                // DSM init path to overrun the PG-allocated `shm_toc` region
+                // and corrupt adjacent DSA control blocks → crash at
+                // `dsa_release_in_place` during parallel-context teardown.
+                let n = mpp_glue_worker_count();
+                let query_id = derive_query_id();
+                let broadcast = MppPlanBroadcast::new(
+                    bytes.to_vec(),
+                    n,
+                    MppSessionProfile::Aggregate,
+                    query_id,
+                );
+                let broadcast_bytes = match broadcast.serialize() {
+                    Ok(b) => b,
+                    Err(e) => {
+                        crate::mpp_log!(
+                            "mpp: MppPlanBroadcast serialize failed, MPP will fall back: {e}"
+                        );
+                        return;
+                    }
+                };
+                crate::mpp_log!(
+                    "mpp: stashed plan-broadcast bytes (shape={shape:?}) on AggregateScanState"
+                );
+                state.custom_state_mut().logical_plan_bytes =
+                    Some(bytes::Bytes::from(broadcast_bytes));
+                state.custom_state_mut().mpp_shape = Some(shape);
+            }
+            Err(e) => {
+                crate::mpp_log!(
+                    "mpp: plan build/serialize failed, MPP will fall back to serial path: {e}"
+                );
+            }
+        }
+    }
+
+    /// Walk a built `LogicalPlan` tree and derive [`MppPlanShape`] inputs.
+    /// Counts table scans, detects GROUP BY / aggregate presence, and
+    /// inspects aggregate function names for splittability. Runs once per
+    /// MPP-eligible query; keep side-effect free so it can be called during
+    /// plan-stash.
+    fn classify_logical_plan(plan: &datafusion::logical_expr::LogicalPlan) -> MppPlanShape {
+        use datafusion::common::tree_node::TreeNode;
+        use datafusion::logical_expr::LogicalPlan;
+        let mut n_table_scans: usize = 0;
+        let mut has_aggregate = false;
+        let mut has_group_by = false;
+        let mut all_aggregates_splittable = true;
+
+        plan.apply(|node| {
+            match node {
+                LogicalPlan::TableScan(_) => {
+                    n_table_scans += 1;
+                }
+                LogicalPlan::Aggregate(a) => {
+                    has_aggregate = true;
+                    if !a.group_expr.is_empty() {
+                        has_group_by = true;
+                    }
+                    for expr in &a.aggr_expr {
+                        if !Self::is_splittable_aggregate_expr(expr) {
+                            all_aggregates_splittable = false;
+                        }
+                    }
+                }
+                _ => {}
+            }
+            Ok(datafusion::common::tree_node::TreeNodeRecursion::Continue)
+        })
+        .ok();
+
+        classify_shape(&ClassifyInputs {
+            n_join_tables: n_table_scans,
+            has_group_by,
+            all_aggregates_splittable,
+            has_aggregate,
+        })
+    }
+
+    /// Early-path classification used at `create_custom_path` time, before
+    /// we have a DataFusion logical plan. Mirrors [`Self::classify_logical_plan`]
+    /// but reads from the PG-side `sources` + `JoinAggregateTargetList` that
+    /// are already available at this stage.
+    ///
+    /// Returns the cheap-but-correct shape input triple; feeds directly into
+    /// [`mpp::shape::classify`]. Conservative: any aggregate not on the
+    /// partial-safe allow-list downgrades the whole query to `Ineligible`.
+    fn classify_path_shape(
+        sources: &[crate::postgres::customscan::aggregatescan::datafusion_build::JoinAggSource],
+        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+    ) -> MppPlanShape {
+        use crate::postgres::customscan::aggregatescan::join_targetlist::AggKind;
+        let n_join_tables = sources.len();
+        let has_group_by = !targetlist.group_columns.is_empty();
+        let has_aggregate = !targetlist.aggregates.is_empty();
+        let all_aggregates_splittable = targetlist.aggregates.iter().all(|a| {
+            matches!(
+                a.agg_kind,
+                AggKind::CountStar
+                    | AggKind::Count
+                    | AggKind::Sum
+                    | AggKind::Avg
+                    | AggKind::Min
+                    | AggKind::Max
+                    | AggKind::BoolAnd
+                    | AggKind::BoolOr
+                    | AggKind::StddevSamp
+                    | AggKind::StddevPop
+                    | AggKind::VarSamp
+                    | AggKind::VarPop
+            ) && !a.distinct
+        });
+        classify_shape(&ClassifyInputs {
+            n_join_tables,
+            has_group_by,
+            all_aggregates_splittable,
+            has_aggregate,
+        })
+    }
+
+    /// If the query is MPP-eligible, flip the path's `parallel_safe` /
+    /// `parallel_aware` / `parallel_workers` on the builder so PG launches
+    /// workers for this scan. Called from `try_build_datafusion_aggregate_path`
+    /// just before `.build(...)`.
+    ///
+    /// Returns the builder unchanged when MPP is off, the worker count is
+    /// below 2, or the shape classifies as `Ineligible`.
+    fn maybe_flip_mpp_parallel(
+        builder: CustomPathBuilder<Self>,
+        sources: &[crate::postgres::customscan::aggregatescan::datafusion_build::JoinAggSource],
+        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+    ) -> CustomPathBuilder<Self> {
+        use MppPlanShape;
+        if !mpp_is_active() {
+            return builder;
+        }
+        let shape = Self::classify_path_shape(sources, targetlist);
+
+        // `GroupByAggSingleTable` and `JoinOnly` shapes' bridges haven't
+        // landed yet; they still classify correctly but fall through to
+        // the serial path here.
+        let activate = matches!(
+            shape,
+            MppPlanShape::ScalarAggOnBinaryJoin | MppPlanShape::GroupByAggOnBinaryJoin
+        );
+        if !activate {
+            return builder;
+        }
+        let n = mpp_glue_worker_count() as usize;
+        // `mpp_worker_count` clamps to >= 2, but be defensive.
+        let nworkers = n.saturating_sub(1).max(1);
+        crate::mpp_log!(
+            "mpp: flipping AggregateScan path parallel_workers={} for shape {:?}",
+            nworkers,
+            shape
+        );
+        builder.set_parallel(nworkers)
+    }
+
+    /// Conservative allow-list of aggregate function names that are safe to
+    /// split into Partial/FinalPartitioned. Anything outside this list marks
+    /// the shape Ineligible so MPP falls back to the serial path.
+    ///
+    /// The outer expression may be wrapped in `Alias` (e.g., `COUNT(*) AS cnt`)
+    /// — unwrap before checking. Any other wrapping (casts, arithmetic) is
+    /// treated as unsafe to be conservative.
+    fn is_splittable_aggregate_expr(expr: &datafusion::logical_expr::Expr) -> bool {
+        use datafusion::logical_expr::Expr;
+        let unwrapped = match expr {
+            Expr::Alias(a) => a.expr.as_ref(),
+            other => other,
+        };
+        let name = match unwrapped {
+            Expr::AggregateFunction(af) => af.func.name().to_ascii_lowercase(),
+            // Non-aggregate in the aggr_expr slot — assume unsafe.
+            _ => return false,
+        };
+        matches!(
+            name.as_str(),
+            "count"
+                | "sum"
+                | "min"
+                | "max"
+                | "avg"
+                | "bool_and"
+                | "bool_or"
+                | "stddev"
+                | "stddev_samp"
+                | "stddev_pop"
+                | "var"
+                | "var_samp"
+                | "var_pop"
+        )
+    }
+
     /// Existing single-table Tantivy aggregate path.
     fn build_tantivy_aggregate_path(
         builder: CustomPathBuilder<Self>,
@@ -771,6 +1120,17 @@ impl AggregateScan {
             }
         };
 
+        // Flip parallel-safe with the configured worker count when the
+        // shape is MPP-eligible. Uses a cheap pre-classification based on
+        // `sources` + `targetlist` — the authoritative shape is re-derived
+        // from the DataFusion logical plan in `maybe_stash_mpp_plan_bytes`,
+        // but we must commit to parallel-safe here (before `.build()`)
+        // because PG's path-builder freezes the parallel flags at this
+        // point. Downstream failure to stash the plan falls back to the
+        // serial path via the `mpp_state.is_none()` guard in
+        // `exec_datafusion_aggregate`.
+        let builder = Self::maybe_flip_mpp_parallel(builder, &sources, &targetlist);
+
         // Build the custom path with DataFusion private data
         let multi_table_clause_count = multi_table_clauses.len();
         let mut custom_path = builder.build(PrivateData::DataFusion {
@@ -807,7 +1167,7 @@ impl AggregateScan {
         state: &mut CustomScanStateWrapper<Self>,
     ) -> *mut pg_sys::TupleTableSlot {
         let Some(row) = Self::advance_tantivy_state(state) else {
-            return std::ptr::null_mut();
+            return ptr::null_mut();
         };
 
         unsafe {
@@ -969,47 +1329,165 @@ impl AggregateScan {
     fn exec_datafusion_aggregate(
         state: &mut CustomScanStateWrapper<Self>,
     ) -> *mut pg_sys::TupleTableSlot {
+        // Correctness fence: if we're a parallel worker and `mpp_state` is
+        // None even though MPP is supposed to be active, the worker DSM
+        // attach didn't run. Silently running the non-MPP path here would
+        // double-count at the final gather. Abort loudly instead.
+        // `IsParallelWorker` is a C macro (`ParallelWorkerNumber >= 0`);
+        // pgrx exposes the underlying int but not the macro, so inline it.
+        let is_parallel_worker = unsafe { pg_sys::ParallelWorkerNumber } >= 0;
+        if is_parallel_worker && mpp_is_active() && state.custom_state().mpp_state.is_none() {
+            pgrx::error!(
+                "mpp: parallel worker reached exec_datafusion_aggregate without \
+                 MppExecutionState — worker DSM attach did not run. Wrong-result \
+                 scenario averted via loud abort."
+            );
+        }
+
         // Grab the scan_slot pointer before entering the mutable borrow
         let scan_slot = state
             .custom_state()
             .scan_slot
             .expect("scan_slot must be initialized in begin_custom_scan");
 
-        let df_state = state
-            .custom_state_mut()
-            .datafusion_state
-            .as_mut()
-            .expect("DataFusion state must be initialized");
+        // Decide whether we need the MPP rewrite *before* we take the
+        // `datafusion_state` mutable borrow below — the MPP branch needs
+        // `custom_state_mut().mpp_state`, which aliases the same
+        // `custom_state_mut()` borrow. We resolve the alias here by reading
+        // the shape first (immutable read) then taking the mpp_state
+        // mutable borrow separately from the `datafusion_state` one.
+        let mpp_shape = if state.custom_state().mpp_state.is_some() {
+            Some(match state.custom_state().mpp_shape {
+                Some(s) => s,
+                None => pgrx::error!(
+                    "mpp: exec_datafusion_aggregate has mpp_state but no mpp_shape — \
+                     begin_custom_scan must populate both or neither"
+                ),
+            })
+        } else {
+            None
+        };
 
-        // First call: build and execute the DataFusion plan
-        if df_state.runtime.is_none() {
+        // First call: build and execute the DataFusion plan.
+        //
+        // We need to reach both `state.custom_state_mut().datafusion_state`
+        // and `state.custom_state_mut().mpp_state` inside this block, so
+        // we don't take the long-lived `df_state` borrow up front; instead,
+        // we build the plan + stream locally and store into the fields at
+        // the end in a short borrow.
+        let runtime_is_none = state
+            .custom_state()
+            .datafusion_state
+            .as_ref()
+            .map(|d| d.runtime.is_none())
+            .unwrap_or(false);
+        if runtime_is_none {
+            // Always current-thread. PG FFI is single-threaded — pgrx's
+            // `thread_id_check` panics with "postgres FFI may not be
+            // called from multiple threads" on any PG call from a tokio
+            // worker thread. `PgSearchTableProvider::scan` and its
+            // downstream reach into PG during the lazy scan, so a
+            // multi-thread runtime is off the table both for MPP and
+            // non-MPP paths.
+            //
+            // The MPP `shm_mq_send` stall (the reason the earlier
+            // multi-thread experiment existed) is broken instead by
+            // making the sender cooperative: on would-block, call
+            // `DrainHandle::poll_drain_pass` on the same mesh's drain
+            // to consume inbound rows — that frees peers' outbound
+            // queues and lets their send-to-us un-stall. See
+            // `MppSender::send_batch` + `mesh::ShmMqSender::try_send_bytes`.
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
                 .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e));
 
-            let ctx = create_aggregate_session_context();
+            // When MPP is active we build the session with the join-layer
+            // bug-fixes applied: skip `SortMergeJoinEnforcer` (which would
+            // collapse hash-partitioned streams to one partition) and disable
+            // `enable_join_dynamic_filter_pushdown` (which races with the
+            // exchange producer on the probe-side scan and drops rows before
+            // the dynamic filter stabilizes). Without this, MPP AggregateScan
+            // silently loses ~83% of probe-side rows at high cardinality.
+            let ctx = match state.custom_state().mpp_state.as_ref() {
+                Some(mpp_state) if mpp_state.participant_config().total_participants > 1 => {
+                    let cfg = mpp_state.participant_config();
+                    let ctx = create_aggregate_session_context_mpp(cfg);
+                    ctx.state_ref()
+                        .write()
+                        .config_mut()
+                        .set_extension(Arc::new(MppShardConfig {
+                            participant_index: cfg.participant_index,
+                            total_participants: cfg.total_participants,
+                        }));
+                    ctx
+                }
+                _ => create_aggregate_session_context(),
+            };
 
-            let custom_exprs = df_state.custom_exprs;
-            let custom_scan_tlist = df_state.custom_scan_tlist;
-            let physical_plan = runtime.block_on(async {
-                let logical = build_join_aggregate_plan(
-                    &df_state.plan,
-                    &df_state.targetlist,
-                    df_state.topk.as_ref(),
-                    &df_state.join_level_predicates,
-                    custom_exprs,
-                    custom_scan_tlist,
-                    df_state.having_filter.as_ref(),
-                    &ctx,
-                )
-                .await?;
-                build_physical_plan(&ctx, logical).await
-            });
+            // Build the logical → standard physical plan in a short
+            // immutable-ish scope that doesn't block the later
+            // `mpp_state` mutable borrow.
+            let standard_plan = {
+                let df_state = state
+                    .custom_state_mut()
+                    .datafusion_state
+                    .as_mut()
+                    .expect("DataFusion state must be initialized");
+                let custom_exprs = df_state.custom_exprs;
+                let custom_scan_tlist = df_state.custom_scan_tlist;
+                let result = runtime.block_on(async {
+                    let logical = build_join_aggregate_plan(
+                        &df_state.plan,
+                        &df_state.targetlist,
+                        df_state.topk.as_ref(),
+                        &df_state.join_level_predicates,
+                        custom_exprs,
+                        custom_scan_tlist,
+                        df_state.having_filter.as_ref(),
+                        &ctx,
+                    )
+                    .await?;
+                    build_physical_plan(&ctx, logical).await
+                });
+                match result {
+                    Ok(p) => p,
+                    Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+                }
+            };
 
-            let physical_plan = match physical_plan {
-                Ok(p) => p,
-                Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+            // If MPP state was wired up by the DSM hooks, rewrite the
+            // standard plan into a shape-specific MPP plan. The non-MPP
+            // branch stays byte-identical to the previous behavior.
+            let physical_plan = if let Some(shape) = mpp_shape {
+                let mpp_state = state
+                    .custom_state_mut()
+                    .mpp_state
+                    .as_mut()
+                    .expect("mpp_shape set ⇒ mpp_state must also be Some");
+                crate::mpp_log!(
+                    "mpp: routing exec_datafusion_aggregate through shape {:?} (is_leader={})",
+                    shape,
+                    mpp_state.is_leader()
+                );
+                let _guard = runtime.enter();
+                let standard_fallback = Arc::clone(&standard_plan);
+                match distribute_plan(standard_plan, mpp_state, shape) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        // The dispatcher couldn't handle this plan shape
+                        // (e.g. TopK / Sort + Limit above the agg). Fall
+                        // back to the un-rewritten standard plan rather
+                        // than aborting; the query still runs, just
+                        // without MPP acceleration.
+                        pgrx::warning!(
+                            "mpp: distribute_plan failed ({e}); running serial DataFusion plan"
+                        );
+                        standard_fallback
+                    }
+                }
+            } else {
+                standard_plan
             };
 
             let task_ctx = build_task_context(
@@ -1026,9 +1504,20 @@ impl AggregateScan {
                 }
             };
 
+            let df_state = state
+                .custom_state_mut()
+                .datafusion_state
+                .as_mut()
+                .expect("DataFusion state must be initialized");
             df_state.runtime = Some(runtime);
             df_state.stream = Some(stream);
         }
+
+        let df_state = state
+            .custom_state_mut()
+            .datafusion_state
+            .as_mut()
+            .expect("DataFusion state must be initialized");
 
         // Consume batches row-by-row
         loop {
@@ -1069,7 +1558,7 @@ impl AggregateScan {
                 }
                 None => {
                     // Stream exhausted — no more results
-                    return std::ptr::null_mut();
+                    return ptr::null_mut();
                 }
             }
         }
@@ -1370,56 +1859,54 @@ unsafe fn detect_join_aggregate_topk(
 /// Replace any T_Aggref expressions in the target list with T_FuncExpr placeholders
 /// This is called at execution time to avoid "Aggref found in non-Agg plan node" errors
 /// Uses expression_tree_mutator to handle nested Aggrefs (e.g., COALESCE(COUNT(*), 0))
-unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
-    use pgrx::pg_guard;
-
-    if (*plan).targetlist.is_null() {
-        return;
+/// Mutator that replaces Aggref nodes with a placeholder FuncExpr and UNNEST
+/// FuncExprs with a generic placeholder of their result type. Used to clean
+/// up Plan targetlists (see [`replace_aggrefs_in_target_list`]) on the
+/// non-parallel path — the MPP path keeps Aggrefs intact so PG's setrefs
+/// matches them structurally between Gather/Sort/Result and the CustomScan.
+#[pgrx::pg_guard]
+pub(crate) unsafe extern "C-unwind" fn aggref_mutator(
+    node: *mut pg_sys::Node,
+    context: *mut core::ffi::c_void,
+) -> *mut pg_sys::Node {
+    if node.is_null() {
+        return ptr::null_mut();
     }
 
-    // Mutator function to replace Aggref nodes with placeholder FuncExpr
-    #[pg_guard]
-    unsafe extern "C-unwind" fn aggref_mutator(
-        node: *mut pg_sys::Node,
-        context: *mut core::ffi::c_void,
-    ) -> *mut pg_sys::Node {
-        if node.is_null() {
-            return std::ptr::null_mut();
-        }
+    if (*node).type_ == pg_sys::NodeTag::T_Aggref {
+        let aggref = node as *mut pg_sys::Aggref;
+        return make_placeholder_func_expr(aggref) as *mut pg_sys::Node;
+    }
 
-        // If this is an Aggref, replace it with a placeholder FuncExpr
-        if (*node).type_ == pg_sys::NodeTag::T_Aggref {
-            let aggref = node as *mut pg_sys::Aggref;
-            return make_placeholder_func_expr(aggref) as *mut pg_sys::Node;
+    if (*node).type_ == pg_sys::NodeTag::T_FuncExpr {
+        let func_expr = node as *mut pg_sys::FuncExpr;
+        if is_unnest_func((*func_expr).funcid) {
+            return make_placeholder_func_expr_internal(
+                (*func_expr).funcresulttype,
+                (*func_expr).inputcollid,
+                (*func_expr).location,
+                "UNNEST",
+            ) as *mut pg_sys::Node;
         }
+    }
 
-        // If this is an UNNEST FuncExpr, replace it with a placeholder FuncExpr of its result type.
-        // This is safe because AggregateScan handles the unnesting via Tantivy's terms aggregation.
-        if (*node).type_ == pg_sys::NodeTag::T_FuncExpr {
-            let func_expr = node as *mut pg_sys::FuncExpr;
-            if is_unnest_func((*func_expr).funcid) {
-                return make_placeholder_func_expr_internal(
-                    (*func_expr).funcresulttype,
-                    (*func_expr).inputcollid,
-                    (*func_expr).location,
-                    "UNNEST",
-                ) as *mut pg_sys::Node;
-            }
-        }
+    #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
+    {
+        let fnptr = aggref_mutator as usize as *const ();
+        let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
+            std::mem::transmute(fnptr);
+        pg_sys::expression_tree_mutator(node, Some(mutator), context)
+    }
 
-        // For all other nodes, use the standard mutator to walk children
-        #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
-        {
-            let fnptr = aggref_mutator as usize as *const ();
-            let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
-                std::mem::transmute(fnptr);
-            pg_sys::expression_tree_mutator(node, Some(mutator), context)
-        }
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    {
+        pg_sys::expression_tree_mutator_impl(node, Some(aggref_mutator), context)
+    }
+}
 
-        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
-        {
-            pg_sys::expression_tree_mutator_impl(node, Some(aggref_mutator), context)
-        }
+unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
+    if (*plan).targetlist.is_null() {
+        return;
     }
 
     let targetlist = PgList::<pg_sys::TargetEntry>::from_pg((*plan).targetlist);
@@ -1437,12 +1924,12 @@ unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
     }
 
     // Build a new target list with Aggrefs replaced by placeholders and UNNEST stripped
-    let mut new_targetlist: *mut pg_sys::List = std::ptr::null_mut();
+    let mut new_targetlist: *mut pg_sys::List = ptr::null_mut();
     for te in targetlist.iter_ptr() {
         let new_te = pg_sys::flatCopyTargetEntry(te);
 
         // Use the mutator to replace any Aggref or UNNEST nodes in the expression
-        let new_expr = aggref_mutator((*te).expr as *mut pg_sys::Node, std::ptr::null_mut());
+        let new_expr = aggref_mutator((*te).expr as *mut pg_sys::Node, ptr::null_mut());
         (*new_te).expr = new_expr as *mut pg_sys::Expr;
 
         new_targetlist = pg_sys::lappend(new_targetlist, new_te.cast());
@@ -1580,5 +2067,190 @@ unsafe fn get_aggregate_name(aggref: *mut pg_sys::Aggref) -> String {
         }
     } else {
         "UNKNOWN".to_string()
+    }
+}
+
+// ----------------------------------------------------------------------------
+// ParallelQueryCapable for AggregateScan — delegation surface for the MPP
+// lifecycle hooks. `create_custom_path` flags the path parallel-safe via
+// `CustomPathBuilder::set_parallel(nworkers)` when `maybe_flip_mpp_parallel`
+// determines the shape is MPP-eligible; `begin_custom_scan` serializes the
+// logical plan and stashes the bytes on `AggregateScanState`;
+// `exec_datafusion_aggregate` routes through
+// `mpp::plan_build::build_mpp_aggregate_plan` when `mpp_state` is `Some`.
+// ----------------------------------------------------------------------------
+impl ParallelQueryCapable for AggregateScan {
+    fn estimate_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+    ) -> pg_sys::Size {
+        if !mpp_is_active() {
+            return 0;
+        }
+        let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+            crate::mpp_log!(
+                "mpp: AggregateScan::estimate_dsm_custom_scan but logical_plan_bytes \
+                 is None (plan serialization failed earlier?); returning 0"
+            );
+            return 0;
+        };
+        let shape = match state.custom_state().mpp_shape {
+            Some(s) => s,
+            None => {
+                crate::mpp_log!("mpp: estimate_dsm but mpp_shape is None; returning 0");
+                return 0;
+            }
+        };
+        let num_meshes = cut_count_for_shape(shape);
+        if num_meshes == 0 {
+            crate::mpp_log!("mpp: shape {:?} requires no shuffle; returning 0", shape);
+            return 0;
+        }
+        match leader_estimate_dsm(plan_bytes.len(), num_meshes) {
+            Ok(sz) => sz,
+            Err(e) => {
+                crate::mpp_log!("mpp: leader_estimate_dsm failed: {e}; returning 0");
+                0
+            }
+        }
+    }
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        debug_assert!(state.custom_state().mpp_state.is_none());
+        if !mpp_is_active() {
+            return;
+        }
+        if coordinate.is_null() {
+            // Estimate returned 0 (plan bytes unavailable) — PG will pass
+            // NULL coordinate. Silently fall back to non-MPP path.
+            return;
+        }
+        let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+            return;
+        };
+        let plan_bytes = plan_bytes.to_vec();
+        let shape = match state.custom_state().mpp_shape {
+            Some(s) => s,
+            None => return,
+        };
+        let num_meshes = cut_count_for_shape(shape);
+        if num_meshes == 0 {
+            return;
+        }
+        let seg = unsafe { (*pcxt).seg };
+        let ctx = unsafe { leader_init_dsm(coordinate, plan_bytes, num_meshes, seg) };
+        match ctx {
+            Ok(leader_ctx) => {
+                crate::mpp_log!(
+                    "mpp: AggregateScan leader initialized DSM for {} participants",
+                    leader_ctx.participant_config().total_participants
+                );
+                state.custom_state_mut().mpp_state = Some(leader_ctx);
+            }
+            Err(e) => {
+                // DSM init is in the hot path of parallel-query startup —
+                // a partial init leaves the region in an undefined state,
+                // so ERROR rather than silently degrade.
+                pgrx::error!("mpp: leader_init_dsm failed: {e}");
+            }
+        }
+    }
+
+    fn reinitialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+        _coordinate: *mut c_void,
+    ) {
+        // Rescan is out of scope. A rescanned MPP aggregate would need a
+        // full mesh teardown + rebuild; silently no-op'ing would let the
+        // second scan reuse the first scan's drained queues and return
+        // wrong results. Only loud-error when MPP is actually active on
+        // this scan state — non-MPP paths have no rescan restrictions.
+        if state.custom_state().mpp_state.is_some() {
+            pgrx::error!(
+                "mpp: AggregateScan rescan not supported — rerun the query \
+                 without rescan (e.g. avoid nested-loop driving this node)"
+            );
+        }
+    }
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _toc: *mut pg_sys::shm_toc,
+        coordinate: *mut c_void,
+    ) {
+        debug_assert!(state.custom_state().mpp_state.is_none());
+        if !mpp_is_active() {
+            return;
+        }
+        if coordinate.is_null() {
+            return;
+        }
+
+        // Worker-side attach. PG passes `shm_toc` (not a full
+        // `ParallelContext`), so we don't have access to `pcxt->seg`
+        // directly. We pass NULL for the seg to `worker_init_dsm`:
+        // `shm_mq_attach` handles NULL seg by skipping its
+        // `on_dsm_detach` callback and letting process-exit clean up
+        // the shm_mq handles. Safe for parallel-worker lifetimes where
+        // the process dies with the query.
+        //
+        // For region_total, we read the header's own `region_total`
+        // field. This loses the independence of the check but is the
+        // only source available without a seg pointer. A defense-in-
+        // depth independent check can land later via `dsm_find_mapping`
+        // + `dsm_segment_map_length`.
+        //
+        // Validate magic BEFORE trusting `region_total`: a corrupt or
+        // pre-init DSM region can hand us a bogus size, and blindly
+        // passing it to `worker_init_dsm` would subvert the region-size
+        // bounds check in `MppDsmHeader::validate` (which compares
+        // `header.region_total` against the caller-supplied size —
+        // tautological if we sourced both from the same place).
+        let region_total = unsafe {
+            let header = ptr::read_unaligned(coordinate as *const MppDsmHeader);
+            if header.magic != MPP_DSM_MAGIC {
+                pgrx::error!(
+                    "mpp: worker DSM attach found bogus header magic 0x{:08x} \
+                     (expected 0x{:08x}) — refusing to trust region_total",
+                    header.magic,
+                    MPP_DSM_MAGIC,
+                );
+            }
+            header.region_total
+        };
+        let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+        let ctx = unsafe {
+            worker_init_dsm(
+                coordinate,
+                region_total,
+                worker_number,
+                ptr::null_mut(), // seg unknown to worker init; shm_mq_attach handles NULL
+            )
+        };
+        match ctx {
+            Ok(worker_ctx) => {
+                let _ = region_total;
+                crate::mpp_log!(
+                    "mpp: AggregateScan worker {} attached to DSM ({} participants)",
+                    worker_number,
+                    worker_ctx.participant_config().total_participants
+                );
+                state.custom_state_mut().mpp_state = Some(worker_ctx);
+            }
+            Err(e) => {
+                // Worker-side DSM attach failure is fatal for the same
+                // reason the leader side is: the worker now has no valid
+                // MPP state but the leader expects MPP partials.
+                // Aborting here lets the leader's query fail cleanly
+                // with a diagnostic rather than silently returning
+                // wrong answers.
+                pgrx::error!("mpp: worker_init_dsm failed on worker {worker_number}: {e}");
+            }
+        }
     }
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -22,9 +22,13 @@ use crate::postgres::customscan::aggregatescan::privdat::{DataFusionTopK, Filter
 use crate::postgres::customscan::joinscan::build::{
     JoinLevelSearchPredicate, MultiTablePredicateInfo, RelNode,
 };
+use crate::postgres::customscan::mpp::customscan_glue::MppExecutionState;
+use crate::postgres::customscan::mpp::shape::MppPlanShape;
 use crate::postgres::customscan::solve_expr::SolvePostgresExpressions;
 use crate::postgres::customscan::CustomScanState;
 use crate::postgres::PgSearchRelation;
+
+use std::vec::IntoIter;
 
 use arrow_array::RecordBatch;
 use datafusion::physical_plan::SendableRecordBatchStream;
@@ -34,7 +38,7 @@ use pgrx::pg_sys;
 pub enum ExecutionState {
     #[default]
     NotStarted,
-    Emitting(std::vec::IntoIter<AggregationResultsRow>),
+    Emitting(IntoIter<AggregationResultsRow>),
     Completed,
 }
 
@@ -111,6 +115,51 @@ pub struct AggregateScanState {
     /// Created once during begin_custom_scan and cleared/reused for each row
     /// to avoid per-row memory allocation and leaks
     pub scan_slot: Option<*mut pg_sys::TupleTableSlot>,
+
+    /// Serialized `MppPlanBroadcast` bytes (version byte + serialized
+    /// DataFusion logical plan + total_participants + session_profile,
+    /// bincode-encoded). Populated on the leader in `begin_custom_scan`
+    /// when `mpp_is_active()` and the DataFusion backend is active. The
+    /// bytes are consumed by `estimate_dsm_custom_scan` (just `.len()`)
+    /// and `initialize_dsm_custom_scan` (copied verbatim into DSM for
+    /// workers). These are the exact bytes that land in DSM — the
+    /// broadcast wrapping is done here, not at DSM-init time, so that
+    /// `.len()` at estimate time matches the bytes actually written at
+    /// init time (otherwise the DSM write overruns PG's `shm_toc`
+    /// allocation and corrupts adjacent DSA control regions).
+    ///
+    /// `None` means either:
+    ///   - MPP is off (the common case),
+    ///   - OR the Tantivy backend is active (non-DataFusion path), OR
+    ///   - plan serialization failed (logged via `mpp_log!`; MPP will
+    ///     silently fall back to the non-MPP path).
+    pub logical_plan_bytes: Option<bytes::Bytes>,
+
+    /// Classified MPP shape for this query, populated alongside
+    /// `logical_plan_bytes`. Drives the number of shuffle meshes the
+    /// coordinator allocates in DSM and the per-shape plan builder used
+    /// at exec time. `None` whenever `logical_plan_bytes` is `None`.
+    pub mpp_shape: Option<MppPlanShape>,
+
+    /// MPP lifecycle state. Populated by `initialize_dsm_custom_scan`
+    /// (leader) or `initialize_worker_custom_scan` (worker) when
+    /// `mpp_is_active()` AND the path was flagged parallel-safe. Left
+    /// `None` for the serial (non-MPP) code path. When `Some`,
+    /// `exec_datafusion_aggregate` routes through
+    /// `mpp::plan_build::build_mpp_aggregate_plan`.
+    ///
+    /// ## Drop ordering
+    ///
+    /// Declared LAST in the struct so it's the last field dropped. This
+    /// matters because `MppExecutionState` owns shm_mq handles pointing
+    /// into PG's DSM segment. PG's `ExecEndCustomScan` tears down our
+    /// state *before* `ExecParallelCleanup` detaches the DSM segment, so
+    /// dropping `mpp_state` while DSM is still mapped is safe.
+    /// `MppExecutionState::Leader` also holds a `DrainHandle`; that
+    /// handle must `join()` its drain thread before the DSM detaches,
+    /// so don't move `mpp_state` earlier in this struct without revisiting
+    /// the Drop chain.
+    pub mpp_state: Option<MppExecutionState>,
 }
 
 impl AggregateScanState {

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -35,7 +35,10 @@ use crate::postgres::rel_get_bm25_index;
 use crate::postgres::utils::{expr_contains_any_operator, pg_search_extension_installed};
 use once_cell::sync::Lazy;
 use pgrx::{pg_guard, pg_sys, PgList, PgMemoryContexts};
+use std::any::{type_name, TypeId};
 use std::collections::{hash_map::Entry, HashMap};
+use std::mem::size_of_val;
+use std::ptr;
 
 unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
     let forced = path.flags & Flags::Force as u32 != 0;
@@ -45,19 +48,19 @@ unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
     // Clear both complete and partial candidates up front so neither a regular path nor a
     // Gather-built parallel path can outcompete us.
     if forced {
-        (*rel).pathlist = std::ptr::null_mut();
-        (*rel).partial_pathlist = std::ptr::null_mut();
+        (*rel).pathlist = ptr::null_mut();
+        (*rel).partial_pathlist = ptr::null_mut();
     }
 
-    let mut custom_path = PgMemoryContexts::CurrentMemoryContext
-        .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+    let mut custom_path =
+        PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
 
     if (*custom_path).path.parallel_aware {
         // add the partial path since the user-generated plan is parallel aware
         pg_sys::add_partial_path(rel, custom_path.cast());
 
         // remove all the existing possible paths
-        (*rel).pathlist = std::ptr::null_mut();
+        (*rel).pathlist = ptr::null_mut();
 
         // then make another copy of it, increase its costs really, really high and
         // submit it as a regular path too, immediately after clearing out all the other
@@ -65,8 +68,8 @@ unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
         //
         // We don't want postgres to choose this path, but we have to have at least one
         // non-partial path available for it to consider
-        let copy = PgMemoryContexts::CurrentMemoryContext
-            .copy_ptr_into(&mut path, std::mem::size_of_val(&path));
+        let copy =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
         (*copy).path.parallel_aware = false;
         (*copy).path.total_cost = 1000000000.0;
         (*copy).path.startup_cost = 1000000000.0;
@@ -84,7 +87,7 @@ where
     CS: CustomScan<Args = RelPathlistHookArgs> + 'static,
 {
     unsafe {
-        static mut PREV_HOOKS: Lazy<HashMap<std::any::TypeId, pg_sys::set_rel_pathlist_hook_type>> =
+        static mut PREV_HOOKS: Lazy<HashMap<TypeId, pg_sys::set_rel_pathlist_hook_type>> =
             Lazy::new(Default::default);
 
         #[pg_guard]
@@ -98,7 +101,7 @@ where
         {
             unsafe {
                 #[allow(static_mut_refs)]
-                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&std::any::TypeId::of::<CS>()) {
+                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&TypeId::of::<CS>()) {
                     (*prev_hook)(root, rel, rti, rte);
                 }
 
@@ -107,8 +110,8 @@ where
         }
 
         #[allow(static_mut_refs)]
-        match PREV_HOOKS.entry(std::any::TypeId::of::<CS>()) {
-            Entry::Occupied(_) => panic!("{} is already registered", std::any::type_name::<CS>()),
+        match PREV_HOOKS.entry(TypeId::of::<CS>()) {
+            Entry::Occupied(_) => panic!("{} is already registered", type_name::<CS>()),
             Entry::Vacant(entry) => entry.insert(pg_sys::set_rel_pathlist_hook),
         };
 
@@ -162,9 +165,8 @@ where
     CS: CustomScan<Args = JoinPathlistHookArgs> + 'static,
 {
     unsafe {
-        static mut PREV_HOOKS: Lazy<
-            HashMap<std::any::TypeId, pg_sys::set_join_pathlist_hook_type>,
-        > = Lazy::new(Default::default);
+        static mut PREV_HOOKS: Lazy<HashMap<TypeId, pg_sys::set_join_pathlist_hook_type>> =
+            Lazy::new(Default::default);
 
         #[pg_guard]
         extern "C-unwind" fn __priv_callback<CS>(
@@ -179,7 +181,7 @@ where
         {
             unsafe {
                 #[allow(static_mut_refs)]
-                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&std::any::TypeId::of::<CS>()) {
+                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&TypeId::of::<CS>()) {
                     (*prev_hook)(root, joinrel, outerrel, innerrel, jointype, extra);
                 }
 
@@ -190,8 +192,8 @@ where
         }
 
         #[allow(static_mut_refs)]
-        match PREV_HOOKS.entry(std::any::TypeId::of::<CS>()) {
-            Entry::Occupied(_) => panic!("{} is already registered", std::any::type_name::<CS>()),
+        match PREV_HOOKS.entry(TypeId::of::<CS>()) {
+            Entry::Occupied(_) => panic!("{} is already registered", type_name::<CS>()),
             Entry::Vacant(entry) => entry.insert(pg_sys::set_join_pathlist_hook),
         };
 
@@ -245,9 +247,8 @@ where
     CS: CustomScan<Args = CreateUpperPathsHookArgs> + 'static,
 {
     unsafe {
-        static mut PREV_HOOKS: Lazy<
-            HashMap<std::any::TypeId, pg_sys::create_upper_paths_hook_type>,
-        > = Lazy::new(Default::default);
+        static mut PREV_HOOKS: Lazy<HashMap<TypeId, pg_sys::create_upper_paths_hook_type>> =
+            Lazy::new(Default::default);
 
         #[pg_guard]
         extern "C-unwind" fn __priv_callback<CS>(
@@ -261,7 +262,7 @@ where
         {
             unsafe {
                 #[allow(static_mut_refs)]
-                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&std::any::TypeId::of::<CS>()) {
+                if let Some(Some(prev_hook)) = PREV_HOOKS.get(&TypeId::of::<CS>()) {
                     (*prev_hook)(root, stage, input_rel, output_rel, extra);
                 }
 
@@ -270,8 +271,8 @@ where
         }
 
         #[allow(static_mut_refs)]
-        match PREV_HOOKS.entry(std::any::TypeId::of::<CS>()) {
-            Entry::Occupied(_) => panic!("{} is already registered", std::any::type_name::<CS>()),
+        match PREV_HOOKS.entry(TypeId::of::<CS>()) {
+            Entry::Occupied(_) => panic!("{} is already registered", type_name::<CS>()),
             Entry::Vacant(entry) => entry.insert(pg_sys::create_upper_paths_hook),
         };
 
@@ -324,9 +325,93 @@ pub extern "C-unwind" fn paradedb_upper_paths_callback<CS>(
         ));
 
         for path in paths {
-            add_path(output_rel, path);
+            add_upper_path(root, output_rel, path);
         }
     }
+}
+
+/// Upper-rel variant of [`add_path`]. `add_path` handles base/join rels well
+/// because PG's path generator calls `generate_useful_gather_paths()` AFTER
+/// the `set_rel_pathlist_hook` fires — so a partial path added there still
+/// gets wrapped in a `Gather` by core. For `UPPERREL_GROUP_AGG`, the
+/// sequence is reversed: core has already finished gather-path generation
+/// before `create_upper_paths_hook` runs, and any partial path we add at
+/// this stage is orphaned.
+///
+/// This helper wraps the MPP-ready parallel-aware custom path with an
+/// explicit `GatherPath` via `pg_sys::create_gather_path` and adds that to
+/// `output_rel->pathlist`, which is the one PG's grouping-path chooser
+/// compares against the serial aggregate path. Non-parallel custom paths
+/// fall through to the same `add_path` behavior used everywhere else.
+unsafe fn add_upper_path(
+    root: *mut pg_sys::PlannerInfo,
+    rel: *mut pg_sys::RelOptInfo,
+    mut path: pg_sys::CustomPath,
+) {
+    let forced = path.flags & Flags::Force as u32 != 0;
+    path.flags ^= Flags::Force as u32;
+
+    if forced {
+        (*rel).pathlist = ptr::null_mut();
+        (*rel).partial_pathlist = ptr::null_mut();
+    }
+
+    if path.path.parallel_aware {
+        // The MPP path itself is parallel-safe; PG needs to see it as a
+        // partial path so it and the Gather wrapper agree about workers.
+        let partial_copy =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+        pg_sys::add_partial_path(rel, partial_copy.cast());
+
+        // Wrap with Gather so the grouping-path chooser actually sees a
+        // runnable parallel plan in `output_rel->pathlist`. Use the rel's
+        // reltarget directly so Gather's pathtarget structurally equals
+        // `final_target` — otherwise `create_ordered_paths` adds a
+        // ProjectionPath (→ Result plan node) above the Sort, whose
+        // targetlist carries unreplaceable Aggrefs that crash setrefs
+        // with "Aggref found in non-Agg plan node".
+        //
+        // Aggrefs in Gather.tlist get rewritten to Var(OUTER_VAR, N) by
+        // setrefs so long as the subplan (CustomScan) tlist carries
+        // structurally-equal Aggrefs — see `set_customscan_references`
+        // and `fix_upper_expr` for the matching logic.
+        let gather_target = (*rel).reltarget;
+
+        let mut rows = (*partial_copy).path.rows;
+        let gather = pg_sys::create_gather_path(
+            root,
+            rel,
+            partial_copy.cast::<pg_sys::Path>(),
+            gather_target,
+            ptr::null_mut(),
+            &mut rows,
+        );
+
+        // Clear competing paths so the chooser actually considers Gather;
+        // otherwise a single-worker serial aggregate path with matching
+        // total cost may win by tie-break. We re-add a high-cost serial
+        // fallback below so PG always has something non-partial to pick.
+        (*rel).pathlist = ptr::null_mut();
+
+        pg_sys::add_path(rel, gather.cast());
+
+        // High-cost serial fallback: same as non-upper-rel `add_path`.
+        // Keeps a non-parallel path in the list for cases where the
+        // Gather wrapper can't run (e.g., max_parallel_workers == 0).
+        let fallback =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+        (*fallback).path.parallel_aware = false;
+        (*fallback).path.parallel_safe = false;
+        (*fallback).path.parallel_workers = 0;
+        (*fallback).path.total_cost = 1_000_000_000.0;
+        (*fallback).path.startup_cost = 1_000_000_000.0;
+        pg_sys::add_path(rel, fallback.cast());
+        return;
+    }
+
+    let serial =
+        PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+    pg_sys::add_path(rel, serial.cast());
 }
 
 /// Static variable to store the previous planner hook (e.g., from Citus or other extensions)

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -166,6 +166,7 @@ use self::scan_state::{
 };
 use crate::api::HashSet;
 use crate::api::OrderByFeature;
+use crate::gucs::mpp_min_join_rows;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags};
@@ -177,6 +178,19 @@ use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::limit_offset::LimitOffset;
+use crate::postgres::customscan::mpp::customscan_glue::{
+    leader_estimate_dsm, leader_init_dsm, mpp_is_active, mpp_worker_count as mpp_glue_worker_count,
+    worker_init_dsm,
+};
+use crate::postgres::customscan::mpp::session::{
+    derive_query_id, MppPlanBroadcast, MppSessionProfile,
+};
+use crate::postgres::customscan::mpp::shape::{
+    broadcast_side_gate, classify as classify_shape, ClassifyInputs, MppPlanShape,
+};
+use crate::postgres::customscan::mpp::walker::{cut_count_for_shape, distribute_plan};
+use crate::postgres::customscan::mpp::worker::{MppDsmHeader, MPP_DSM_MAGIC};
+use crate::postgres::customscan::mpp::MppShardConfig;
 use crate::postgres::customscan::parallel::compute_nworkers;
 use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::customscan::{CustomScan, JoinPathlistHookArgs};
@@ -184,6 +198,7 @@ use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::{deserialize_logical_plan_with_runtime, serialize_logical_plan};
+use crate::scan::info::RowEstimate;
 use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
@@ -191,6 +206,8 @@ use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
 use futures::StreamExt;
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
+use std::ptr;
+use std::sync::Arc;
 
 #[derive(Default)]
 pub struct JoinScan;
@@ -340,7 +357,7 @@ unsafe fn is_limit_pushdown_safe(
     #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
     let all_rels = (*root).all_query_rels;
 
-    let mut absorbed_bms: *mut pg_sys::Bitmapset = std::ptr::null_mut();
+    let mut absorbed_bms: *mut pg_sys::Bitmapset = ptr::null_mut();
     for rti in &absorbed_rtis {
         absorbed_bms = pg_sys::bms_add_member(absorbed_bms, *rti as i32);
     }
@@ -665,6 +682,19 @@ impl JoinScan {
             0
         };
 
+        // When MPP is active for a binary join (the JoinOnly shape), PG's
+        // worker count must match `mpp_worker_count - 1`. Otherwise PG
+        // launches workers whose `ParallelWorkerNumber` exceeds
+        // `total_participants - 1`, and `worker_init_dsm` errors with
+        // "participant_index out of range". Mirrors the AggregateScan MPP
+        // path's `maybe_flip_mpp_parallel`.
+        let nworkers = if nworkers > 0 && join_clause.plan.sources().len() == 2 && mpp_is_active() {
+            let n = mpp_glue_worker_count() as usize;
+            n.saturating_sub(1).max(1)
+        } else {
+            nworkers
+        };
+
         if nworkers > 0 {
             let processes = std::cmp::max(
                 1,
@@ -679,7 +709,7 @@ impl JoinScan {
             let processes = processes as u64;
             let partitioning_idx = join_clause.partitioning_source_index();
             for (idx, source) in join_clause.plan.sources_mut().into_iter().enumerate() {
-                if let crate::scan::info::RowEstimate::Known(n) = source.scan_info.estimate {
+                if let RowEstimate::Known(n) = source.scan_info.estimate {
                     source.scan_info.estimated_rows_per_worker = if idx == partitioning_idx {
                         Some(n / processes)
                     } else {
@@ -689,7 +719,7 @@ impl JoinScan {
             }
         } else {
             for source in join_clause.plan.sources_mut() {
-                if let crate::scan::info::RowEstimate::Known(n) = source.scan_info.estimate {
+                if let RowEstimate::Known(n) = source.scan_info.estimate {
                     source.scan_info.estimated_rows_per_worker = Some(n);
                 }
             }
@@ -721,7 +751,7 @@ impl JoinScan {
             flags: Flags::Force as u32,
             methods: JoinScan::custom_path_methods(),
             custom_private: private_data.into(),
-            custom_paths: std::ptr::null_mut(),
+            custom_paths: ptr::null_mut(),
             ..Default::default()
         };
 
@@ -745,9 +775,170 @@ impl ParallelQueryCapable for JoinScan {
         state: &mut CustomScanStateWrapper<Self>,
         _pcxt: *mut pg_sys::ParallelContext,
     ) -> pg_sys::Size {
-        // Size DSM from actual execution-time segment counts (via manifests) rather
-        // than planning-time scan_info.segment_count, which can diverge under
-        // concurrent inserts.
+        // MPP branch: when `begin_custom_scan` classified this query as
+        // JoinOnly and serialized the broadcast plan, we size DSM for the
+        // MPP mesh instead of the broadcast-join `ParallelScanState`. PG
+        // hands us one coordinate region; MPP and broadcast-join layouts
+        // are incompatible in it, so this is an OR choice.
+        if let Some(shape) = state.custom_state().mpp_shape {
+            let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+                crate::mpp_log!(
+                    "mpp: JoinScan::estimate_dsm_custom_scan but logical_plan_bytes is None; \
+                     falling back to non-MPP sizing"
+                );
+                return Self::estimate_broadcast_dsm(state);
+            };
+            let num_meshes = cut_count_for_shape(shape);
+            if num_meshes == 0 {
+                return Self::estimate_broadcast_dsm(state);
+            }
+            return match leader_estimate_dsm(plan_bytes.len(), num_meshes) {
+                Ok(sz) => sz,
+                Err(e) => {
+                    crate::mpp_log!(
+                        "mpp: JoinScan leader_estimate_dsm failed: {e}; falling back to non-MPP"
+                    );
+                    Self::estimate_broadcast_dsm(state)
+                }
+            };
+        }
+
+        Self::estimate_broadcast_dsm(state)
+    }
+
+    fn initialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        // MPP branch mirrors AggregateScan::initialize_dsm_custom_scan.
+        if let Some(shape) = state.custom_state().mpp_shape {
+            debug_assert!(state.custom_state().mpp_state.is_none());
+            if coordinate.is_null() {
+                // `estimate_dsm` returned 0 (plan bytes unavailable) — PG
+                // hands us NULL. Silently fall back to non-MPP.
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            }
+            let Some(plan_bytes) = state.custom_state().logical_plan_bytes.as_ref() else {
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            };
+            let plan_bytes = plan_bytes.to_vec();
+            let num_meshes = cut_count_for_shape(shape);
+            if num_meshes == 0 {
+                Self::initialize_broadcast_dsm(state, coordinate);
+                return;
+            }
+            let seg = unsafe { (*pcxt).seg };
+            let ctx = unsafe { leader_init_dsm(coordinate, plan_bytes, num_meshes, seg) };
+            match ctx {
+                Ok(leader_ctx) => {
+                    crate::mpp_log!(
+                        "mpp: JoinScan leader initialized DSM for {} participants (shape={:?})",
+                        leader_ctx.participant_config().total_participants,
+                        shape,
+                    );
+                    state.custom_state_mut().mpp_state = Some(leader_ctx);
+                }
+                Err(e) => {
+                    // Partial-init leaves DSM in undefined state — fail
+                    // loudly, same rationale as AggregateScan.
+                    pgrx::error!("mpp: JoinScan leader_init_dsm failed: {e}");
+                }
+            }
+            return;
+        }
+
+        Self::initialize_broadcast_dsm(state, coordinate);
+    }
+
+    fn reinitialize_dsm_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _pcxt: *mut pg_sys::ParallelContext,
+        coordinate: *mut c_void,
+    ) {
+        // MPP rescan is out of scope; the non-MPP path resets the
+        // broadcast-join `ParallelScanState` as before.
+        if state.custom_state().mpp_shape.is_some() {
+            // No-op: a rescanned MPP join would need a full mesh teardown
+            // + rebuild, same gap AggregateScan leaves.
+            return;
+        }
+        let pscan_state = coordinate.cast::<ParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+        unsafe {
+            (*pscan_state).reset();
+        }
+    }
+
+    fn initialize_worker_custom_scan(
+        state: &mut CustomScanStateWrapper<Self>,
+        _toc: *mut pg_sys::shm_toc,
+        coordinate: *mut c_void,
+    ) {
+        // MPP branch: if the leader wrote MPP header magic, attach as an
+        // MPP worker. We key off the DSM header's magic via the same
+        // `MppDsmHeader` read AggregateScan uses — we don't have
+        // `mpp_shape` on the worker side (that state doesn't propagate
+        // through PrivateData), so we inspect the region itself.
+        if mpp_is_active() && !coordinate.is_null() && Self::dsm_looks_like_mpp(coordinate) {
+            debug_assert!(state.custom_state().mpp_state.is_none());
+            let region_total = unsafe {
+                let header = ptr::read_unaligned(coordinate as *const MppDsmHeader);
+                header.region_total
+            };
+            let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+            let ctx = unsafe {
+                worker_init_dsm(coordinate, region_total, worker_number, ptr::null_mut())
+            };
+            match ctx {
+                Ok(worker_ctx) => {
+                    crate::mpp_log!(
+                        "mpp: JoinScan worker {} attached to DSM ({} participants)",
+                        worker_number,
+                        worker_ctx.participant_config().total_participants
+                    );
+                    state.custom_state_mut().mpp_state = Some(worker_ctx);
+                    return;
+                }
+                Err(e) => {
+                    // Worker-side attach failure is fatal because the
+                    // leader expects an MPP participant at this index.
+                    pgrx::error!(
+                        "mpp: JoinScan worker_init_dsm failed on worker {worker_number}: {e}"
+                    );
+                }
+            }
+        }
+
+        let pscan_state = coordinate.cast::<ParallelScanState>();
+        assert!(!pscan_state.is_null(), "coordinate is null");
+
+        state.custom_state_mut().parallel_state = Some(pscan_state);
+
+        // Workers must wait for the leader to finish populating the segment pool.
+        unsafe {
+            (*pscan_state).wait_for_initialization();
+        }
+
+        // Read the canonical non-partitioning segment ID sets that the leader wrote to
+        // shared memory.  These are used in exec_custom_scan to ensure every worker opens
+        // each replicated source with MvccSatisfies::ParallelWorker, which pins the
+        // visible segment list to exactly what the leader snapshotted.
+        let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
+        state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
+
+        // We don't need to deserialize query from parallel state for JoinScan
+        // because the full plan (including query) is serialized in PrivateData
+        // and available to the worker via the plan.
+    }
+}
+
+impl JoinScan {
+    /// DSM sizing for the non-MPP broadcast-join path. Extracted so both the
+    /// non-MPP branch and the MPP fallback can call it.
+    fn estimate_broadcast_dsm(state: &mut CustomScanStateWrapper<Self>) -> pg_sys::Size {
         Self::ensure_source_manifests(state);
 
         let join_clause = &state.custom_state().join_clause;
@@ -762,11 +953,9 @@ impl ParallelQueryCapable for JoinScan {
         ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false)
     }
 
-    fn initialize_dsm_custom_scan(
-        state: &mut CustomScanStateWrapper<Self>,
-        _pcxt: *mut pg_sys::ParallelContext,
-        coordinate: *mut c_void,
-    ) {
+    /// DSM population for the non-MPP broadcast-join path. Extracted so both
+    /// the non-MPP branch and the MPP fallback can call it.
+    fn initialize_broadcast_dsm(state: &mut CustomScanStateWrapper<Self>, coordinate: *mut c_void) {
         let pscan_state = coordinate.cast::<ParallelScanState>();
         assert!(!pscan_state.is_null(), "coordinate is null");
 
@@ -799,47 +988,106 @@ impl ParallelQueryCapable for JoinScan {
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
     }
 
-    fn reinitialize_dsm_custom_scan(
-        _state: &mut CustomScanStateWrapper<Self>,
-        _pcxt: *mut pg_sys::ParallelContext,
-        coordinate: *mut c_void,
-    ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
-        assert!(!pscan_state.is_null(), "coordinate is null");
+    /// Quick heuristic to detect whether `coordinate` points to an
+    /// MPP-initialized DSM region (as opposed to a `ParallelScanState` the
+    /// broadcast-join path allocated). Reads the header's `magic` field;
+    /// `MppDsmHeader` places a fixed magic at the start of the region. Safe
+    /// to call speculatively because the read is aligned and bounded to the
+    /// header struct size — if the region is `ParallelScanState`-sized, the
+    /// magic won't match and we fall through to the broadcast-join branch.
+    fn dsm_looks_like_mpp(coordinate: *mut c_void) -> bool {
         unsafe {
-            (*pscan_state).reset();
+            let header = ptr::read_unaligned(coordinate as *const MppDsmHeader);
+            header.magic == MPP_DSM_MAGIC
         }
     }
 
-    fn initialize_worker_custom_scan(
-        state: &mut CustomScanStateWrapper<Self>,
-        _toc: *mut pg_sys::shm_toc,
-        coordinate: *mut c_void,
-    ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
-        assert!(!pscan_state.is_null(), "coordinate is null");
+    /// Wrap the already-serialized logical plan in `MppPlanBroadcast` and
+    /// stash the bytes + classified shape on `JoinScanState` for the MPP DSM
+    /// hooks to consume. Called from `begin_custom_scan` when `mpp_is_active()`
+    /// and the query is not EXPLAIN-only.
+    ///
+    /// Classification is derived from `join_clause.plan.sources().len()` — a
+    /// 2-source binary join maps to [`MppPlanShape::JoinOnly`]; anything else
+    /// stays `Ineligible`. Failures (serialize error, ineligible shape) leave
+    /// the MPP fields `None` and the scan silently falls back to the non-MPP
+    /// broadcast-join path — same ops-friendly behavior as AggregateScan.
+    fn maybe_stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
+        let Some(raw_plan_bytes) = state.custom_state().logical_plan.as_ref() else {
+            crate::mpp_log!(
+                "mpp: JoinScan begin_custom_scan has no logical_plan bytes; MPP falls back"
+            );
+            return;
+        };
+        let raw_plan_bytes = raw_plan_bytes.clone();
 
-        state.custom_state_mut().parallel_state = Some(pscan_state);
-
-        // Workers must wait for the leader to finish populating the segment pool.
-        unsafe {
-            (*pscan_state).wait_for_initialization();
+        let n_join_tables = state.custom_state().join_clause.plan.sources().len();
+        let shape = classify_shape(&ClassifyInputs {
+            n_join_tables,
+            has_group_by: false,
+            all_aggregates_splittable: true,
+            has_aggregate: false,
+        });
+        if !matches!(shape, MppPlanShape::JoinOnly) {
+            crate::mpp_log!(
+                "mpp: JoinScan shape={:?} (n_join_tables={}); staying on non-MPP path",
+                shape,
+                n_join_tables
+            );
+            return;
         }
 
-        // Read the canonical non-partitioning segment ID sets that the leader wrote to
-        // shared memory.  These are used in exec_custom_scan to ensure every worker opens
-        // each replicated source with MvccSatisfies::ParallelWorker, which pins the
-        // visible segment list to exactly what the leader snapshotted.
-        let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
-        state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
+        // Cost gate: shuffle overhead dominates when the smallest side of the
+        // binary join is small — the non-MPP broadcast-join path is cheap in
+        // that regime (replicate the small side, probe with the large).
+        // Threshold of 0 disables the gate. See
+        // [`crate::postgres::customscan::mpp::shape::broadcast_side_gate`].
+        let estimates: Vec<RowEstimate> = state
+            .custom_state()
+            .join_clause
+            .plan
+            .sources()
+            .iter()
+            .map(|s| s.scan_info.estimate)
+            .collect();
+        let min_rows = mpp_min_join_rows();
+        if let Some(gated_rows) = broadcast_side_gate(&estimates, min_rows) {
+            crate::mpp_log!(
+                "mpp: JoinScan {:?} gated — smallest side estimated_rows={} < \
+                 mpp_min_join_rows={}; staying on non-MPP path",
+                shape,
+                gated_rows,
+                min_rows
+            );
+            return;
+        }
 
-        // We don't need to deserialize query from parallel state for JoinScan
-        // because the full plan (including query) is serialized in PrivateData
-        // and available to the worker via the plan.
+        let n = mpp_glue_worker_count();
+        let query_id = derive_query_id();
+        let broadcast = MppPlanBroadcast::new(
+            raw_plan_bytes.to_vec(),
+            n,
+            MppSessionProfile::Join,
+            query_id,
+        );
+        let broadcast_bytes = match broadcast.serialize() {
+            Ok(b) => b,
+            Err(e) => {
+                crate::mpp_log!(
+                    "mpp: JoinScan MppPlanBroadcast serialize failed, MPP falls back: {e}"
+                );
+                return;
+            }
+        };
+        crate::mpp_log!(
+            "mpp: JoinScan stashed plan-broadcast bytes (shape={:?}, n={})",
+            shape,
+            n
+        );
+        state.custom_state_mut().logical_plan_bytes = Some(bytes::Bytes::from(broadcast_bytes));
+        state.custom_state_mut().mpp_shape = Some(shape);
     }
-}
 
-impl JoinScan {
     /// Capture lightweight segment manifests for all join sources.
     ///
     /// Uses `SearchIndexManifest::capture` instead of opening full `SearchIndexReader`s
@@ -898,8 +1146,9 @@ impl JoinScan {
         let mut ids_by_pos = vec![None; plan_sources.len()];
         let partitioning_idx = join_clause.partitioning_source_index();
         let is_worker = unsafe { pg_sys::ParallelWorkerNumber >= 0 };
+        let is_mpp = state.custom_state().mpp_state.is_some();
 
-        if is_worker {
+        if is_worker && !is_mpp {
             let non_partitioning_segs = &state.custom_state().non_partitioning_segments;
             let mut np_counter = 0usize;
             for (i, _source) in plan_sources.iter().enumerate() {
@@ -1269,7 +1518,8 @@ impl CustomScan for JoinScan {
         estate: *mut pg_sys::EState,
         eflags: i32,
     ) {
-        if eflags & (pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) == 0 {
+        let explain_only = (eflags & pg_sys::EXEC_FLAG_EXPLAIN_ONLY as i32) != 0;
+        if !explain_only {
             unsafe {
                 let planstate = state.planstate();
                 // Always assign an ExprContext — heap filters, runtime
@@ -1277,6 +1527,12 @@ impl CustomScan for JoinScan {
                 pg_sys::ExecAssignExprContext(estate, planstate);
                 state.custom_state_mut().result_slot = Some(state.csstate.ss.ps.ps_ResultTupleSlot);
                 state.runtime_context = state.csstate.ss.ps.ps_ExprContext;
+            }
+
+            // Stash MPP plan-broadcast bytes + shape when MPP is active.
+            // Non-fatal on failure (logged + falls back to broadcast-join).
+            if mpp_is_active() {
+                Self::maybe_stash_mpp_plan_bytes(state);
             }
         }
     }
@@ -1326,7 +1582,39 @@ impl CustomScan for JoinScan {
                 let index_segment_ids =
                     Self::build_index_segment_ids(state, &join_clause, &plan_sources);
 
-                let ctx = create_datafusion_session_context(SessionContextProfile::Join);
+                // Pre-read the MPP shape BEFORE we take the DataFusion
+                // session/context borrow, because rewriting the physical
+                // plan below needs `mpp_state` mutably at the same time
+                // as the ctx is built.
+                let mpp_shape = if state.custom_state().mpp_state.is_some() {
+                    state.custom_state().mpp_shape
+                } else {
+                    None
+                };
+
+                // Build the session context. When this scan is an MPP
+                // participant, use `create_datafusion_session_context_mpp`
+                // so `SortMergeJoinEnforcer` is skipped (otherwise it
+                // collapses hash-partitioned streams) and inject
+                // `MppShardConfig` so `PgSearchTableProvider::scan`
+                // opens each participant's shard of segments.
+                let ctx = match state.custom_state().mpp_state.as_ref() {
+                    Some(mpp_state) if mpp_state.participant_config().total_participants > 1 => {
+                        let cfg = mpp_state.participant_config().clone();
+                        let ctx = scan_state::create_datafusion_session_context_mpp(
+                            SessionContextProfile::Join,
+                            &cfg,
+                        );
+                        ctx.state_ref().write().config_mut().set_extension(Arc::new(
+                            MppShardConfig {
+                                participant_index: cfg.participant_index,
+                                total_participants: cfg.total_participants,
+                            },
+                        ));
+                        ctx
+                    }
+                    _ => create_datafusion_session_context(SessionContextProfile::Join),
+                };
                 let logical_plan = deserialize_logical_plan_with_runtime(
                     &plan_bytes,
                     &ctx.task_ctx(),
@@ -1366,10 +1654,44 @@ impl CustomScan for JoinScan {
                     logical_plan
                 };
 
-                // Convert logical plan to physical plan
-                let plan = runtime
+                // Convert logical plan to standard physical plan.
+                let standard_plan = runtime
                     .block_on(build_physical_plan(&ctx, logical_plan))
                     .expect("Failed to create execution plan");
+
+                // If MPP was set up by the DSM hooks, rewrite the
+                // standard plan into the JoinOnly MPP shape.
+                let plan = if let Some(shape) = mpp_shape {
+                    let mpp_state = state
+                        .custom_state_mut()
+                        .mpp_state
+                        .as_mut()
+                        .expect("mpp_shape set ⇒ mpp_state must be Some");
+                    crate::mpp_log!(
+                        "mpp: routing JoinScan exec through shape {:?} (is_leader={})",
+                        shape,
+                        mpp_state.is_leader()
+                    );
+                    let _guard = runtime.enter();
+                    let standard_fallback = Arc::clone(&standard_plan);
+                    match distribute_plan(standard_plan, mpp_state, shape) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            // Same fallback policy as AggregateScan's
+                            // dispatcher: an unsupported plan shape
+                            // (TopK, Sort + Limit, etc.) drops to the
+                            // serial DataFusion plan rather than
+                            // aborting the query.
+                            pgrx::warning!(
+                                "mpp: JoinScan distribute_plan failed ({e}); \
+                                 running serial DataFusion plan"
+                            );
+                            standard_fallback
+                        }
+                    }
+                } else {
+                    standard_plan
+                };
 
                 let task_ctx = build_task_context(
                     &ctx,
@@ -1432,7 +1754,7 @@ impl CustomScan for JoinScan {
                         state.custom_state_mut().batch_index = 0;
                     }
                     Some(Err(e)) => panic!("DataFusion execution failed: {}", e),
-                    None => return std::ptr::null_mut(),
+                    None => return ptr::null_mut(),
                 }
             }
         }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -83,6 +83,7 @@ use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::TaskContext;
 use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 
+use crate::gucs::is_columnar_sort_enabled;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::datafusion::translator::{
     apply_join_level_filter, build_join_df_with_filter, make_col, make_source_col,
@@ -92,6 +93,9 @@ use crate::postgres::customscan::datafusion::translator::{
 use crate::postgres::customscan::joinscan::privdat::{
     OutputColumnInfo, PrivateData, SCORE_COL_NAME,
 };
+use crate::postgres::customscan::mpp::customscan_glue::MppExecutionState;
+use crate::postgres::customscan::mpp::shape::MppPlanShape;
+use crate::postgres::customscan::mpp::MppParticipantConfig;
 use crate::postgres::customscan::CustomScanState;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
@@ -250,6 +254,32 @@ pub struct JoinScanState {
     /// Dropping manifests early would release the pins and allow segment recycling
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
+
+    /// Serialized `MppPlanBroadcast` bytes — same framing as
+    /// `AggregateScanState::logical_plan_bytes`. Wraps the raw logical-plan
+    /// bytes already in `PrivateData::logical_plan`. Populated on the leader
+    /// in `begin_custom_scan` when MPP is active and the classified shape is
+    /// eligible; consumed by the MPP DSM hooks (`estimate_dsm_custom_scan`
+    /// reads `.len()`; `initialize_dsm_custom_scan` copies verbatim into DSM).
+    /// `None` when MPP is off, the shape is ineligible, or plan serialization
+    /// failed (logged; silently falls back to the non-MPP broadcast-join).
+    pub logical_plan_bytes: Option<bytes::Bytes>,
+
+    /// Classified MPP shape for this query, populated alongside
+    /// `logical_plan_bytes`. Drives the number of shuffle meshes allocated in
+    /// DSM and the per-shape builder used by `exec_bridge`. For JoinScan this
+    /// is always `JoinOnly` (or `Ineligible`, which means `logical_plan_bytes`
+    /// stays `None`).
+    pub mpp_shape: Option<MppPlanShape>,
+
+    /// MPP lifecycle state. Populated by `initialize_dsm_custom_scan` on the
+    /// leader or `initialize_worker_custom_scan` on a worker when MPP is
+    /// active. `None` for the non-MPP broadcast-join path.
+    ///
+    /// Declared LAST so it's the last field dropped — same rationale as
+    /// `AggregateScanState::mpp_state`: it owns shm_mq handles pointing into
+    /// DSM which must stay mapped until this drops.
+    pub mpp_state: Option<MppExecutionState>,
 }
 
 impl JoinScanState {
@@ -288,11 +318,23 @@ pub enum SessionContextProfile {
 /// Build the shared core of a DataFusion [`SessionStateBuilder`] with:
 /// - Visibility filtering (logical + physical)
 /// - Late materialization
-/// - SortMergeJoinEnforcer (when columnar sort enabled)
+/// - SortMergeJoinEnforcer (when columnar sort enabled *and* MPP is inactive)
 /// - `PgSearchQueryPlanner`
 ///
 /// Callers append their own TopK rule and FilterPushdown passes.
-pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
+///
+/// When `mpp` is `Some` with `total_participants > 1`, two bug-fix paths from
+/// the reference MPP implementation apply:
+///   1. `SortMergeJoinEnforcer` is skipped. The SPM rewrite collapses hash
+///      partitions to one, which would make our `HashRepartitionExec::execute(i)`
+///      return empty for all `i != leader`.
+///   2. Caller `create_datafusion_session_context_mpp` disables
+///      `enable_join_dynamic_filter_pushdown` so probe-side scans do not race
+///      with the exchange producer and emit zero rows.
+pub(crate) fn build_base_session_with_mpp(
+    config: SessionConfig,
+    mpp: Option<&MppParticipantConfig>,
+) -> SessionStateBuilder {
     use super::visibility_filter::VisibilityFilterOptimizerRule;
     use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
 
@@ -308,7 +350,14 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
             crate::scan::late_materialization::LateMaterializationRule,
         ));
 
-    if crate::gucs::is_columnar_sort_enabled() {
+    // Treat any non-None MppParticipantConfig as "MPP is active" — even N=1
+    // MPP (leader-only) shares the shuffle operator tree with N>1, so the
+    // SortMergeJoinEnforcer's partition-collapsing behavior is undesirable
+    // in both cases. Callers that do *not* want the bug-fix semantics pass
+    // `None`.
+    let mpp_active = mpp.is_some();
+
+    if is_columnar_sort_enabled() && !mpp_active {
         builder = builder.with_physical_optimizer_rule(Arc::new(SortMergeJoinEnforcer::new()));
     }
 
@@ -332,6 +381,29 @@ pub fn build_base_session(config: SessionConfig) -> SessionStateBuilder {
 /// - [`SessionContextProfile::Aggregate`]: appends a single `FilterPushdown`
 ///   post-pass; SegmentedTopK does not apply to aggregate-on-join queries.
 pub fn create_datafusion_session_context(profile: SessionContextProfile) -> SessionContext {
+    create_datafusion_session_context_inner(profile, None)
+}
+
+/// MPP-aware variant of [`create_datafusion_session_context`]. Applies the
+/// reference implementation's join-layer adjustment when the participant
+/// config indicates more than one participant:
+///   1. Skip `SortMergeJoinEnforcer` (handled by `build_base_session_with_mpp`).
+///   2. Keep `enable_join_dynamic_filter_pushdown = true`. The filter Arc is
+///      preserved across the MPP HashJoin rebuild (via `builder()`) and
+///      re-applied as a `FilterExec` above the post-shuffle probe stream by
+///      `shape::build_*_on_binary_join`. See `exec_bridge.rs`.
+#[allow(dead_code)] // first caller is the MPP path
+pub fn create_datafusion_session_context_mpp(
+    profile: SessionContextProfile,
+    mpp: &MppParticipantConfig,
+) -> SessionContext {
+    create_datafusion_session_context_inner(profile, Some(mpp))
+}
+
+fn create_datafusion_session_context_inner(
+    profile: SessionContextProfile,
+    mpp: Option<&MppParticipantConfig>,
+) -> SessionContext {
     let mut config = SessionConfig::new().with_target_partitions(1);
 
     // Configure dynamic filter pushdown thresholds from our GUCs
@@ -353,11 +425,41 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
             .enable_topk_dynamic_filter_pushdown = true;
     }
 
-    let mut builder = build_base_session(config);
+    // Disable DataFusion's "skip partial aggregation" probe for MPP sessions.
+    //
+    // In Partial mode, DataFusion samples the first
+    // `skip_partial_aggregation_probe_rows_threshold` (default 100_000) rows
+    // and, if the distinct-group ratio exceeds
+    // `skip_partial_aggregation_probe_ratio_threshold` (default 0.8), flips
+    // the operator into pass-through mode — every subsequent input row is
+    // emitted as its own partial output row with no deduplication. The
+    // downstream `FinalPartitioned` still produces correct results because it
+    // merges duplicates, but the intermediate shuffle must carry ~distinct_
+    // groups × rows_per_group rows instead of ~distinct_groups rows.
+    //
+    // On the 25M `aggregate_join_groupby` bench this fanout was ~7× (gb_postagg
+    // rows_in = 22M across participants for 3.1M distinct groups), and 22M rows
+    // through shm_mq saturated the shuffle for > 600s. Single-process
+    // DataFusion never pays that cost because there's no shuffle; the skip
+    // probe is a pure win in single-process. For MPP it is the dominant cost.
+    //
+    // Setting the ratio threshold to 1.1 (> 1.0, which is the max achievable
+    // ratio) disables the switch unconditionally. Partial mode still benefits
+    // from in-memory hash-table dedup within each batch flush.
+    if mpp.is_some() {
+        config
+            .options_mut()
+            .execution
+            .skip_partial_aggregation_probe_ratio_threshold = 1.1;
+    }
+
+    let mut builder = build_base_session_with_mpp(config, mpp);
+
+    let mpp_active = mpp.is_some();
 
     match profile {
         SessionContextProfile::Join => {
-            if crate::gucs::is_columnar_sort_enabled() {
+            if is_columnar_sort_enabled() && !mpp_active {
                 builder = builder.with_physical_optimizer_rule(Arc::new(
                     FilterPushdown::new_post_optimization(),
                 ));

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -125,8 +125,9 @@ pub struct LeaderMppContext {
     /// One [`LeaderMesh`] per shuffle mesh, in the order the shape requested.
     pub meshes: Vec<LeaderMesh>,
     pub participant_config: MppParticipantConfig,
-    /// Per-query identifier the leader derived at plan time. Stamped on
-    /// every [`MppStage`](super::stage::MppStage) so workers and leader
+    /// Per-query identifier the leader derived at plan time. Stamped (as
+    /// the low 64 bits) on every boundary
+    /// [`Stage`](datafusion_distributed::Stage) so workers and leader
     /// agree on the key that keys cross-participant mesh traffic.
     pub query_id: u64,
 }

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -1,0 +1,264 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! One-call façade that AggregateScan / JoinScan customscan hooks call into
+//! for MPP DSM setup.
+//!
+//! Customscan code typically has three hook points where MPP needs to
+//! participate:
+//!
+//! - `estimate_dsm_custom_scan` — leader, returns the DSM region size. Call
+//!   [`estimate_mpp_dsm`] with the serialized-plan length and mesh config.
+//! - `initialize_dsm_custom_scan` — leader, initializes DSM with the leader's
+//!   mesh wiring. Call [`init_mpp_dsm_leader`] and stash the returned
+//!   [`LeaderMesh`](super::worker::LeaderMesh) in execution state.
+//! - `initialize_worker_custom_scan` — worker, attaches to DSM with this
+//!   worker's mesh wiring. Call [`attach_mpp_dsm_worker`] and stash the
+//!   returned [`WorkerMesh`](super::worker::WorkerMesh) + decoded plan.
+//!
+//! Each function is a thin wrapper over [`super::worker`] primitives plus a
+//! plan-broadcast encode/decode. Keeping them here isolates the hook-facing
+//! glue from the lower-level DSM math so future refactors on either side
+//! stay localized.
+
+use std::ffi::c_void;
+
+use pgrx::pg_sys;
+
+use crate::postgres::customscan::mpp::mesh::MeshLayout;
+use crate::postgres::customscan::mpp::session::MppPlanBroadcast;
+use crate::postgres::customscan::mpp::worker::{
+    attach_dsm_as_worker, compute_dsm_layout, initialize_dsm_as_leader, LeaderMesh, WorkerMesh,
+};
+use crate::postgres::customscan::mpp::MppParticipantConfig;
+
+/// Compute the exact DSM size the MPP custom scan needs for a plan of
+/// `plan_bytes_len` bytes, N participants, `num_meshes` independent shuffle
+/// meshes, and the configured per-edge queue size.
+///
+/// Returns `Err` on any arithmetic overflow or if the resulting region would
+/// exceed [`super::worker::MPP_DSM_MAX_BYTES`].
+pub fn estimate_mpp_dsm(
+    plan_bytes_len: usize,
+    total_participants: u32,
+    num_meshes: u32,
+    queue_bytes: usize,
+) -> Result<usize, &'static str> {
+    let mesh = MeshLayout::new(total_participants, queue_bytes);
+    let dsm = compute_dsm_layout(&mesh, num_meshes, plan_bytes_len)?;
+    Ok(dsm.total)
+}
+
+/// Leader's DSM-init entry point. Serializes `plan` into a
+/// [`MppPlanBroadcast`], writes the bytes + header + shm_mq regions into the
+/// DSM region at `coordinate`, and returns the leader's mesh wiring.
+///
+/// # Safety
+/// - `coordinate` must point to the start of a DSM region of size >= the
+///   estimate returned by [`estimate_mpp_dsm`] with the same parameters.
+/// - Caller is the leader backend and holds `pcxt` / `seg`.
+/// - Caller must not have written to the region already.
+///
+/// On `Err`, the DSM region may be partially initialized; the caller should
+/// treat this as an abort condition and tear down the parallel context
+/// rather than retrying.
+pub unsafe fn init_mpp_dsm_leader(
+    coordinate: *mut c_void,
+    plan_broadcast_bytes: Vec<u8>,
+    total_participants: u32,
+    num_meshes: u32,
+    queue_bytes: usize,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<LeaderMppContext, String> {
+    // `plan_broadcast_bytes` is the already-serialized `MppPlanBroadcast`
+    // payload — the caller is responsible for matching these exact bytes
+    // against the `estimate_mpp_dsm` size the PG planner used to allocate
+    // the DSM region. Re-wrapping here would produce a different length
+    // than estimate and overrun the DSM allocation.
+    let mesh = MeshLayout::new(total_participants, queue_bytes);
+    let dsm = compute_dsm_layout(&mesh, num_meshes, plan_broadcast_bytes.len())
+        .map_err(|e| format!("mpp: compute_dsm_layout failed: {e}"))?;
+
+    // Peek `query_id` out of the broadcast before it's consumed into DSM.
+    // Workers recover it via `MppPlanBroadcast::deserialize`; the leader
+    // has no cheaper path (we could thread the pre-serialize value
+    // separately, but that's two copies of the same truth — one in the
+    // bytes, one in a side channel — and a drift hazard).
+    let query_id = MppPlanBroadcast::deserialize(&plan_broadcast_bytes)
+        .map_err(|e| format!("mpp: leader broadcast peek failed: {e}"))?
+        .query_id;
+
+    let base = coordinate as *mut u8;
+    let meshes = unsafe {
+        initialize_dsm_as_leader(base, &dsm, &mesh, &plan_broadcast_bytes, seg)
+            .map_err(|e| format!("mpp: initialize_dsm_as_leader failed: {e}"))?
+    };
+
+    Ok(LeaderMppContext {
+        meshes,
+        participant_config: MppParticipantConfig {
+            participant_index: 0,
+            total_participants,
+        },
+        query_id,
+    })
+}
+
+/// Bundle returned to the leader after [`init_mpp_dsm_leader`]. The caller
+/// owns both the mesh wiring (for the leader's own shuffle participation)
+/// and the config that the leader feeds into its DataFusion session.
+pub struct LeaderMppContext {
+    /// One [`LeaderMesh`] per shuffle mesh, in the order the shape requested.
+    pub meshes: Vec<LeaderMesh>,
+    pub participant_config: MppParticipantConfig,
+    /// Per-query identifier the leader derived at plan time. Stamped on
+    /// every [`MppStage`](super::stage::MppStage) so workers and leader
+    /// agree on the key that keys cross-participant mesh traffic.
+    pub query_id: u64,
+}
+
+/// Worker's DSM-attach entry point. Reads the header, validates, attaches as
+/// sender/receiver for this worker's participant index, and decodes the plan broadcast.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer the leader initialized.
+/// - `region_total` must match the DSM's attached size.
+/// - `worker_number` is the PG-assigned `ParallelWorkerNumber`; the worker's
+///   participant index is `worker_number + 1` (leader is participant 0).
+/// - Caller is the worker backend and holds `pcxt` / `seg`.
+pub unsafe fn attach_mpp_dsm_worker(
+    coordinate: *mut c_void,
+    region_total: u64,
+    worker_number: i32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<WorkerMppContext, String> {
+    if worker_number < 0 {
+        return Err("mpp: worker_number < 0".into());
+    }
+    let participant_index = (worker_number as u32)
+        .checked_add(1)
+        .ok_or_else(|| "mpp: worker_number + 1 overflowed u32".to_string())?;
+
+    let base = coordinate as *mut u8;
+    let attach = unsafe { attach_dsm_as_worker(base, region_total, participant_index, seg) }
+        .map_err(|e| format!("mpp: attach_dsm_as_worker failed: {e}"))?;
+
+    // The plan bytes live inside DSM. Copy them out so we don't hold a borrow
+    // across subsequent FFI. `bincode::decode_from_slice` wants `&[u8]`.
+    let plan_bytes = unsafe { attach.copy_plan_bytes() };
+    let broadcast = MppPlanBroadcast::deserialize(&plan_bytes)
+        .map_err(|e| format!("mpp: plan deserialize failed: {e}"))?;
+    let participant_config = broadcast.participant_config(participant_index);
+    let query_id = broadcast.query_id;
+
+    Ok(WorkerMppContext {
+        meshes: attach.meshes,
+        participant_config,
+        query_id,
+    })
+}
+
+/// Bundle returned to a worker after [`attach_mpp_dsm_worker`]. The caller
+/// constructs a session with `participant_config` and wires the returned
+/// meshes into `ShuffleExec` (one mesh per shuffle).
+pub struct WorkerMppContext {
+    pub meshes: Vec<WorkerMesh>,
+    pub participant_config: MppParticipantConfig,
+    /// Per-query identifier read from the leader's broadcast.
+    pub query_id: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::session::MppSessionProfile;
+
+    #[test]
+    fn estimate_matches_compute_dsm_layout() {
+        // Cross-check: estimate_mpp_dsm returns the same `total` as a direct
+        // compute_dsm_layout call for any given config.
+        for &(plan_len, n, num_meshes, q) in &[
+            (0usize, 2u32, 1u32, 8 * 1024usize),
+            (1024, 2, 1, 8 * 1024),
+            (500_000, 4, 3, 64 * 1024),
+        ] {
+            let mesh = MeshLayout::new(n, q);
+            let direct = compute_dsm_layout(&mesh, num_meshes, plan_len).unwrap();
+            let via_estimate = estimate_mpp_dsm(plan_len, n, num_meshes, q).unwrap();
+            assert_eq!(direct.total, via_estimate);
+        }
+    }
+
+    #[test]
+    fn estimate_rejects_overflow() {
+        assert!(estimate_mpp_dsm(usize::MAX, 2, 1, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_rejects_zero_participants() {
+        assert!(estimate_mpp_dsm(100, 0, 1, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_rejects_zero_meshes() {
+        assert!(estimate_mpp_dsm(100, 2, 0, 8 * 1024).is_err());
+    }
+
+    #[test]
+    fn estimate_scales_with_num_meshes() {
+        let one = estimate_mpp_dsm(0, 4, 1, 64 * 1024).unwrap();
+        let three = estimate_mpp_dsm(0, 4, 3, 64 * 1024).unwrap();
+        // Header + padding is constant; per-mesh bytes is N*(N-1)*q.
+        // Difference between 3 and 1 meshes is exactly 2 * per-mesh bytes.
+        let per_mesh = 4 * 3 * 64 * 1024;
+        assert_eq!(three - one, 2 * per_mesh);
+    }
+
+    #[test]
+    fn init_does_not_rewrap_plan_bytes() {
+        // Regression: the caller must pass **pre-serialized** broadcast
+        // bytes to `init_mpp_dsm_leader`, whose length matches the
+        // `estimate_mpp_dsm(plan_broadcast_bytes.len(), …)` used to size
+        // the DSM region. Earlier, `init_mpp_dsm_leader` re-wrapped the
+        // raw logical plan in `MppPlanBroadcast` + bincode-serialized it
+        // inside the body, producing bytes ~6 larger than estimate — the
+        // tail of the last mesh queue then overran the DSM region and
+        // corrupted adjacent `shm_toc` allocations (crash at
+        // `dsa_release_in_place` teardown).
+        //
+        // This test pins the invariant *statically* by asserting, for a
+        // representative raw plan, that `MppPlanBroadcast::serialize().len()
+        // != raw_plan.len()`. If some future refactor ever undoes the
+        // pre-serialize step, every test that actually exercises the DSM
+        // path will crash; this one additionally documents the
+        // why-it-matters so the regression is caught at code-review time.
+        let raw_plan: Vec<u8> = (0..1024u32).map(|i| (i & 0xff) as u8).collect();
+        let bc = MppPlanBroadcast::new(raw_plan.clone(), 2, MppSessionProfile::Aggregate, 0);
+        let broadcast_bytes = bc.serialize().unwrap();
+        assert_ne!(
+            broadcast_bytes.len(),
+            raw_plan.len(),
+            "MppPlanBroadcast wrapping adds framing; callers must size DSM against \
+             the wrapped bytes, not raw plan bytes"
+        );
+        assert!(
+            broadcast_bytes.len() > raw_plan.len(),
+            "wrapped bytes must be strictly larger than raw (sanity)"
+        );
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/coordinator.rs
+++ b/pg_search/src/postgres/customscan/mpp/coordinator.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! One-call façade that AggregateScan / JoinScan customscan hooks call into
 //! for MPP DSM setup.
 //!

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Glue between PostgreSQL customscan DSM hooks and the MPP coordinator.
 //!
 //! AggregateScan / JoinScan implement `ParallelQueryCapable` with trait

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -73,10 +73,10 @@ impl MppExecutionState {
         matches!(self, MppExecutionState::Leader(_))
     }
 
-    /// Per-query identifier used to stamp every
-    /// [`MppStage`](crate::postgres::customscan::mpp::stage::MppStage) a
-    /// bridge or the generic cut walker builds. Leader derives it once at
-    /// plan time via
+    /// Per-query identifier used to stamp every boundary
+    /// [`Stage`](datafusion_distributed::Stage) (as the low 64 bits of
+    /// [`Stage::query_id`](datafusion_distributed::Stage::query_id)) the
+    /// generic cut walker builds. Leader derives it once at plan time via
     /// [`derive_query_id`](crate::postgres::customscan::mpp::session::derive_query_id)
     /// and ships it to workers inside `MppPlanBroadcast`.
     pub fn query_id(&self) -> u64 {

--- a/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/customscan_glue.rs
@@ -1,0 +1,213 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Glue between PostgreSQL customscan DSM hooks and the MPP coordinator.
+//!
+//! AggregateScan / JoinScan implement `ParallelQueryCapable` with trait
+//! methods that receive raw pg_sys pointers. This module packages those raw
+//! calls into typed helpers that each customscan can call with minimal
+//! boilerplate:
+//!
+//! - [`MppExecutionState`] is the per-query MPP state the customscan's
+//!   execution state stores in a `Option<MppExecutionState>` field. It owns
+//!   the coordinator results (leader or worker mesh), the drain handle
+//!   (created once the worker has wired the receivers), and the decoded
+//!   plan broadcast.
+//! - [`leader_estimate_dsm`] computes the DSM size for the customscan's
+//!   `estimate_dsm_custom_scan` hook given the size of the serialized
+//!   logical plan and the MPP GUC config.
+//! - [`leader_init_dsm`] handles the full leader-side setup in one call.
+//! - [`worker_init_dsm`] mirrors [`leader_init_dsm`] on the worker side:
+//!   attach, decode plan, return everything the worker needs to rebuild its
+//!   DataFusion session.
+//!
+//! Each helper is a thin wrapper over [`crate::postgres::customscan::mpp::coordinator`]
+//! plus a couple of GUC reads — the intent is that AggregateScan's
+//! `ParallelQueryCapable` impl is five lines of delegation and never touches
+//! raw shm_mq FFI directly.
+
+use std::ffi::c_void;
+
+use pgrx::pg_sys;
+
+use crate::gucs::{enable_mpp, mpp_worker_count as guc_mpp_worker_count};
+use crate::postgres::customscan::mpp::coordinator::{
+    attach_mpp_dsm_worker, estimate_mpp_dsm, init_mpp_dsm_leader, LeaderMppContext,
+    WorkerMppContext,
+};
+use crate::postgres::customscan::mpp::MppParticipantConfig;
+
+/// Per-query MPP state a customscan's execution state stores. Distinct
+/// variants for leader vs worker because the two have different wiring
+/// shapes — the leader pre-creates the mesh; the worker attaches to it —
+/// and forcing a common bundle would either waste fields or require a
+/// second level of Option.
+pub enum MppExecutionState {
+    Leader(LeaderMppContext),
+    Worker(WorkerMppContext),
+}
+
+impl MppExecutionState {
+    pub fn participant_config(&self) -> &MppParticipantConfig {
+        match self {
+            MppExecutionState::Leader(l) => &l.participant_config,
+            MppExecutionState::Worker(w) => &w.participant_config,
+        }
+    }
+
+    pub fn is_leader(&self) -> bool {
+        matches!(self, MppExecutionState::Leader(_))
+    }
+
+    /// Per-query identifier used to stamp every
+    /// [`MppStage`](crate::postgres::customscan::mpp::stage::MppStage) a
+    /// bridge or the generic cut walker builds. Leader derives it once at
+    /// plan time via
+    /// [`derive_query_id`](crate::postgres::customscan::mpp::session::derive_query_id)
+    /// and ships it to workers inside `MppPlanBroadcast`.
+    pub fn query_id(&self) -> u64 {
+        match self {
+            MppExecutionState::Leader(l) => l.query_id,
+            MppExecutionState::Worker(w) => w.query_id,
+        }
+    }
+}
+
+/// True when the `paradedb.enable_mpp` GUC is on AND the worker count is at
+/// least 2. The customscan checks this before announcing parallel-safe
+/// paths; if false, the non-MPP serial path is used.
+pub fn mpp_is_active() -> bool {
+    enable_mpp() && guc_mpp_worker_count() >= 2
+}
+
+/// Read the configured MPP worker count from GUC. Clamps below at 2 because
+/// the MPP code paths assume at least 2 participants; callers that see
+/// `< 2` here should fall back to the non-MPP path via [`mpp_is_active`].
+pub fn mpp_worker_count() -> u32 {
+    guc_mpp_worker_count().max(2) as u32
+}
+
+/// Customscan `estimate_dsm_custom_scan` implementation for an MPP-enabled
+/// plan. Given the serialized logical plan length, returns the total DSM
+/// bytes the coordinator will need.
+///
+/// Per-edge queue size is read from `paradedb.mpp_queue_size` (default
+/// 64 MiB; see the GUC's doc comment for sizing rationale and DSM cost).
+///
+/// Call from the customscan's `ParallelQueryCapable::estimate_dsm_custom_scan`
+/// when [`mpp_is_active`] is true.
+pub fn leader_estimate_dsm(plan_bytes_len: usize, num_meshes: u32) -> Result<pg_sys::Size, String> {
+    let n = mpp_worker_count();
+    estimate_mpp_dsm(plan_bytes_len, n, num_meshes, crate::gucs::mpp_queue_size())
+        .map(|sz| sz as pg_sys::Size)
+        .map_err(|e| format!("mpp: estimate DSM failed: {e}"))
+}
+
+/// Customscan `initialize_dsm_custom_scan` implementation for an MPP leader.
+/// Takes the DSM `coordinate` pointer the PG hook received, the pre-serialized
+/// `MppPlanBroadcast` bytes (same bytes whose length was reported by
+/// [`leader_estimate_dsm`]), the session profile, and the DSM segment pointer.
+/// Returns the [`MppExecutionState::Leader`] the customscan should stash in
+/// its execution state.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer PG supplied to
+///   `initialize_dsm_custom_scan`. It must remain valid for the query's
+///   lifetime.
+/// - `seg` must be valid. On the leader it comes from `pcxt->seg`.
+/// - `plan_broadcast_bytes.len()` must equal the value passed to
+///   [`leader_estimate_dsm`]; otherwise the DSM write overruns the region PG
+///   allocated and corrupts adjacent `shm_toc` allocations (including the
+///   DSA control regions used by parallel tuple queues).
+pub unsafe fn leader_init_dsm(
+    coordinate: *mut c_void,
+    plan_broadcast_bytes: Vec<u8>,
+    num_meshes: u32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<MppExecutionState, String> {
+    if coordinate.is_null() {
+        return Err("mpp: leader_init_dsm given null coordinate".into());
+    }
+
+    let n = mpp_worker_count();
+    let leader = unsafe {
+        init_mpp_dsm_leader(
+            coordinate,
+            plan_broadcast_bytes,
+            n,
+            num_meshes,
+            crate::gucs::mpp_queue_size(),
+            seg,
+        )?
+    };
+    Ok(MppExecutionState::Leader(leader))
+}
+
+/// Customscan `initialize_worker_custom_scan` implementation. Called on
+/// worker backends with the `coordinate` pointer and the worker's
+/// `ParallelWorkerNumber`.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer PG supplied.
+/// - `seg` may be NULL — `initialize_worker_custom_scan` does not surface
+///   the DSM segment pointer, so callers typically pass NULL. `shm_mq_attach`
+///   handles NULL seg by skipping its `on_dsm_detach` callback; cleanup
+///   then relies on process exit. Safe for parallel-worker lifetimes where
+///   the process dies with the query.
+/// - `region_total` must be the size of the attached DSM region. Callers
+///   without an independent source can read it from the header itself
+///   (trading the independence of the validation check for the ability
+///   to initialize without a seg pointer).
+pub unsafe fn worker_init_dsm(
+    coordinate: *mut c_void,
+    region_total: u64,
+    worker_number: i32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<MppExecutionState, String> {
+    if coordinate.is_null() {
+        return Err("mpp: worker_init_dsm given null coordinate".into());
+    }
+    let worker = unsafe { attach_mpp_dsm_worker(coordinate, region_total, worker_number, seg)? };
+    Ok(MppExecutionState::Worker(worker))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::postgres::customscan::mpp::mesh::aligned_queue_bytes;
+
+    #[test]
+    fn default_queue_bytes_is_maxalign_safe() {
+        // The GUC default (64 MiB) must be a multiple of MAXIMUM_ALIGNOF so
+        // `aligned_queue_bytes` is a no-op for the default and the queue
+        // capacity reported to operators matches what `shm_mq` actually uses.
+        let default = 64 * 1024 * 1024;
+        let aligned = aligned_queue_bytes(default);
+        assert_eq!(aligned, default);
+    }
+
+    #[test]
+    fn mpp_worker_count_clamps_below_two() {
+        // GUC default is 2; the function shouldn't drop below 2 even if
+        // the GUC were set to 0 or 1 at runtime (which `mpp_is_active`
+        // filters before this is called, but defense-in-depth).
+        let n = mpp_worker_count();
+        assert!(n >= 2, "mpp_worker_count must clamp below 2; got {n}");
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! MPP queue mesh: DSM layout for the directed N×(N-1) shm_mq mesh.
 //!
 //! Every participant has `N-1` inbound and `N-1` outbound queues — one per
@@ -36,8 +37,10 @@
 //! are in this file so the full production transport stack lives next to the
 //! layout math.
 
-#![allow(dead_code)]
+use std::ptr;
+use std::thread::{self, ThreadId};
 
+use datafusion::common::DataFusionError;
 use pgrx::pg_sys;
 
 use crate::mpp_log;
@@ -47,7 +50,6 @@ use crate::parallel_worker::mqueue::{
 use crate::postgres::customscan::mpp::transport::{
     BatchChannelReceiver, BatchChannelSender, RecvOutcome,
 };
-use datafusion::common::DataFusionError;
 
 /// Compute the linear slot index for a directed edge `src -> dst` in an
 /// N-participant mesh. `src == dst` is invalid (self-partition bypasses the
@@ -134,7 +136,7 @@ impl MeshLayout {
 /// itself self-disables in release.
 pub struct ShmMqSender {
     inner: MessageQueueSender,
-    attach_thread: std::thread::ThreadId,
+    attach_thread: ThreadId,
 }
 
 // SAFETY: see struct doc. Production callers keep the sender on the main
@@ -152,7 +154,7 @@ impl ShmMqSender {
         unsafe {
             Self {
                 inner: MessageQueueSender::new(seg, mq),
-                attach_thread: std::thread::current().id(),
+                attach_thread: thread::current().id(),
             }
         }
     }
@@ -161,7 +163,7 @@ impl ShmMqSender {
 impl BatchChannelSender for ShmMqSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
         debug_assert_eq!(
-            std::thread::current().id(),
+            thread::current().id(),
             self.attach_thread,
             "ShmMqSender::send_bytes called from a thread other than the one that \
              called attach(); shm_mq_send uses WaitLatch + CHECK_FOR_INTERRUPTS which \
@@ -185,7 +187,7 @@ impl BatchChannelSender for ShmMqSender {
 
     fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
         debug_assert_eq!(
-            std::thread::current().id(),
+            thread::current().id(),
             self.attach_thread,
             "ShmMqSender::try_send_bytes called from a thread other than the one that \
              called attach(); shm_mq_send touches process-global Postgres primitives \
@@ -255,7 +257,7 @@ impl ShmMqReceiver {
     pub unsafe fn attach_existing(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
         unsafe {
             pg_sys::shm_mq_set_receiver(mq, pg_sys::MyProc);
-            let handle = pg_sys::shm_mq_attach(mq, seg, std::ptr::null_mut());
+            let handle = pg_sys::shm_mq_attach(mq, seg, ptr::null_mut());
             Self {
                 inner: MessageQueueReceiver::from_raw_handle(handle),
             }
@@ -285,6 +287,7 @@ impl BatchChannelReceiver for ShmMqReceiver {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashSet;
 
     #[test]
     fn edge_slot_packs_without_self_edges() {
@@ -319,7 +322,7 @@ mod tests {
     fn edge_slot_is_injective() {
         // Every (src, dst) pair maps to a unique slot in [0, N*(N-1))
         for n in [2u32, 3, 4, 5, 8] {
-            let mut seen = std::collections::HashSet::new();
+            let mut seen = HashSet::new();
             for src in 0..n {
                 for dst in 0..n {
                     if src == dst {

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP queue mesh: DSM layout for the directed N×(N-1) shm_mq mesh.
 //!
 //! Every participant has `N-1` inbound and `N-1` outbound queues — one per

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -27,6 +27,8 @@
 
 pub mod mesh;
 pub mod session;
+pub mod shuffle;
+pub mod stage;
 pub mod transport;
 pub mod worker;
 

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -25,12 +25,16 @@
 //! that reads all inbound queues into a spillable local buffer — this decouples
 //! consumer-side backpressure from producer-side backpressure.
 
+pub mod coordinator;
+pub mod customscan_glue;
 pub mod mesh;
+pub mod plan_build;
 pub mod session;
 pub mod shape;
 pub mod shuffle;
 pub mod stage;
 pub mod transport;
+pub mod walker;
 pub mod worker;
 
 use serde::{Deserialize, Serialize};
@@ -61,7 +65,7 @@ pub struct MppParticipantConfig {
 /// set, the provider calls `reader.search_segments(sharded_ids)` and each
 /// participant reads only its share of segments.
 #[derive(Clone, Debug)]
-#[allow(dead_code)]
+#[allow(dead_code)] // consumed by aggregatescan/joinscan in #4932/#4872
 pub struct MppShardConfig {
     pub participant_index: u32,
     pub total_participants: u32,

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -65,7 +65,6 @@ pub struct MppParticipantConfig {
 /// set, the provider calls `reader.search_segments(sharded_ids)` and each
 /// participant reads only its share of segments.
 #[derive(Clone, Debug)]
-#[allow(dead_code)] // consumed by aggregatescan/joinscan in #4932/#4872
 pub struct MppShardConfig {
     pub participant_index: u32,
     pub total_participants: u32,

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod mesh;
 pub mod session;
+pub mod shape;
 pub mod shuffle;
 pub mod stage;
 pub mod transport;

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -81,8 +81,8 @@ use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 
 use crate::postgres::customscan::mpp::shuffle::{MppShuffleExec, ShuffleWiring};
-use crate::postgres::customscan::mpp::stage::{MppNetworkBoundary, MppStage};
 use crate::postgres::customscan::mpp::transport::DrainHandle;
+use datafusion_distributed::{NetworkBoundary, Stage};
 
 /// Inputs to [`wrap_with_mpp_shuffle`].
 ///
@@ -106,7 +106,7 @@ pub struct MppShuffleInputs {
     pub drain_handle: Arc<DrainHandle>,
     pub wrapped_schema: SchemaRef,
     pub tag: &'static str,
-    pub stage: Option<MppStage>,
+    pub stage: Option<Stage>,
     pub hash_keys: Option<Vec<Arc<dyn PhysicalExpr>>>,
     pub drive_partition: u32,
 }
@@ -161,10 +161,10 @@ pub fn wrap_with_mpp_shuffle(
     let shuffle_node =
         MppShuffleExec::new(child, wiring, drain_handle, hash_keys, drive_partition, tag);
     match stage {
-        // Stamp via the `MppNetworkBoundary` seam. The trait method consumes
-        // the wiring + drain_handle Mutex<Option<>>s and produces a fresh
-        // `Arc`; the unstamped node is dropped immediately after.
-        Some(s) => MppNetworkBoundary::with_input_stage(&shuffle_node, s),
+        // Stamp via the fork's `NetworkBoundary` trait. The trait method
+        // consumes the wiring + drain_handle Mutex<Option<>>s and produces
+        // a fresh `Arc`; the unstamped node is dropped immediately after.
+        Some(s) => NetworkBoundary::with_input_stage(&shuffle_node, s),
         None => Ok(Arc::new(shuffle_node)),
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP physical-plan primitives.
 //!
 //! # What MPP actually does, and where this module fits

--- a/pg_search/src/postgres/customscan/mpp/plan_build.rs
+++ b/pg_search/src/postgres/customscan/mpp/plan_build.rs
@@ -1,0 +1,312 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! MPP physical-plan primitives.
+//!
+//! # What MPP actually does, and where this module fits
+//!
+//! The milestone-1 benchmark is `SELECT COUNT(*) FROM f JOIN p ON f.id = p.fileId
+//! WHERE f.content ||| 'Section'` — a scalar aggregate over a join. The MPP win
+//! for that query comes from **hash-partitioning the join inputs**, not from
+//! partitioning the aggregate output. Per worker, the physical plan looks like:
+//!
+//! ```text
+//!     AggregateExec(Partial, COUNT(*))            ← emits one partial row per worker
+//!       HashJoinExec(PartitionMode::Partitioned)
+//!         wrap_with_mpp_shuffle([Scan f → Filter], hash=[f.id])
+//!         wrap_with_mpp_shuffle([Scan p         ], hash=[p.fileId])
+//! ```
+//!
+//! PG's `Gather` concatenates all participants' Partial outputs and PG's
+//! `Finalize Aggregate` sums them into the final COUNT. Our CustomScan produces
+//! partial rows; Postgres handles the finalization above us.
+//!
+//! # What this module provides
+//!
+//! [`wrap_with_mpp_shuffle`] is the single reusable primitive that wraps any
+//! `ExecutionPlan` with the MPP mesh topology:
+//!
+//! ```text
+//!     inner ──── ShuffleExec (hash, self-partition out) ─┐
+//!                                                         ├→ UnionExec
+//!                          DrainGatherExec (peer rows) ───┘
+//! ```
+//!
+//! The output stream emits exactly the rows of `inner` that hash to this
+//! participant — some from local computation, some from peers —
+//! merged into a single Arrow IPC-compatible `SendableRecordBatchStream`.
+//!
+//! Callers (AggregateScan, JoinScan MPP) compose `HashJoinExec`,
+//! `AggregateExec(Partial)`, or any other DataFusion operator on top of the
+//! wrapped child. Because each wrap consumes one directed mesh of shm_mqs
+//! (one `ShuffleWiring` + one `DrainHandle`), a binary hash-partitioned join
+//! needs **two** independent mesh wirings — one per side. The DSM hook layer
+//! allocates and distributes them; this module is ABI-agnostic about where
+//! they come from.
+//!
+//! # What was here before
+//!
+//! An earlier version of this module shipped `build_mpp_aggregate_plan` that
+//! composed `Partial → Shuffle → Union(DrainGather) → FinalPartitioned`. That
+//! topology is structurally correct for *hash-partitioned GROUP BY* aggregates
+//! where each final group lives on exactly one participant — but it is
+//! **incorrect for scalar aggregates** (our benchmark target). The final
+//! `FinalPartitioned` on a participant whose inbound side is empty emits a
+//! spurious all-NULL row; PG's Gather concatenates that into the output and
+//! breaks the scalar contract. The broken helper is replaced rather than
+//! patched: pre-join-shuffle of raw rows (this module) is the correct
+//! building block for the benchmark and cleanly composes with DataFusion's
+//! existing `HashJoinExec(Partitioned)`.
+
+use std::sync::Arc;
+
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::{DataFusionError, Result};
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+
+use crate::postgres::customscan::mpp::shuffle::{MppShuffleExec, ShuffleWiring};
+use crate::postgres::customscan::mpp::stage::{MppNetworkBoundary, MppStage};
+use crate::postgres::customscan::mpp::transport::DrainHandle;
+
+/// Inputs to [`wrap_with_mpp_shuffle`].
+///
+/// - `child`: the plan whose output rows the shuffle will consume.
+/// - `wiring`: outbound half of this participant's mesh edge.
+/// - `drain_handle`: inbound half (peer-shipped rows).
+/// - `wrapped_schema`: schema both `child.schema()` and peer-sent Arrow IPC
+///   batches resolve to. Used to coalesce a multi-partition child if needed.
+/// - `tag`: diagnostic label used in `mpp_log!` row-count reports.
+/// - `stage`: stage descriptor stamped onto the emitted [`MppShuffleExec`].
+/// - `hash_keys`: when `Some(keys)`, the shuffle declares
+///   `Partitioning::Hash(keys, N)` natively. When `None`, output is
+///   `UnknownPartitioning(1)` (the scalar-final gather case).
+/// - `drive_partition`: the output partition that performs the producer +
+///   drain work on this participant. For hash shuffles this is
+///   `participant_index`; for fixed-target gathers it is the target on every
+///   participant.
+pub struct MppShuffleInputs {
+    pub child: Arc<dyn ExecutionPlan>,
+    pub wiring: ShuffleWiring,
+    pub drain_handle: Arc<DrainHandle>,
+    pub wrapped_schema: SchemaRef,
+    pub tag: &'static str,
+    pub stage: Option<MppStage>,
+    pub hash_keys: Option<Vec<Arc<dyn PhysicalExpr>>>,
+    pub drive_partition: u32,
+}
+
+/// Wrap a child plan with the MPP hash-shuffle topology — a single
+/// [`MppShuffleExec`] that
+///
+///   * declares `Partitioning::Hash(keys, N)` natively when `hash_keys` is
+///     provided (or `UnknownPartitioning(1)` for the scalar-final gather),
+///   * consumes both halves of the mesh edge (`wiring` + `drain_handle`)
+///     internally, merging the producer-side stream (drives upstream,
+///     hash-routes, ships to peers) with the consumer-side stream (drains
+///     peer-shipped rows from `shm_mq`) on the participant's
+///     `drive_partition`,
+///   * returns an empty stream for every other partition.
+///
+/// Replaces the older
+/// `MppPartitionAdapterExec(CoalescePartitionsExec(UnionExec(ShuffleExec,
+/// DrainGatherExec)))` four-node topology — same end-to-end semantics, one
+/// operator instead of four. Shape-aligned with
+/// `datafusion-distributed::NetworkShuffleExec`.
+///
+/// Both mesh halves are consumed on this single call; a two-input join needs
+/// two independent calls — one per side — with independently-allocated
+/// meshes.
+pub fn wrap_with_mpp_shuffle(
+    inputs: MppShuffleInputs,
+) -> Result<Arc<dyn ExecutionPlan>, DataFusionError> {
+    let MppShuffleInputs {
+        child,
+        wiring,
+        drain_handle,
+        wrapped_schema,
+        tag,
+        stage,
+        hash_keys,
+        drive_partition,
+    } = inputs;
+    let _ = wrapped_schema; // Schema is inferred from `child.schema()`.
+
+    // Multi-partition children (e.g. a PgSearchTableProvider scan that emits
+    // one partition per Tantivy segment) need to be coalesced first: the
+    // shuffle's producer-side only consumes its child's partition 0, so
+    // without this every segment beyond the first would be dropped silently,
+    // producing correct group counts but wildly wrong per-group aggregates.
+    let child: Arc<dyn ExecutionPlan> = if child.output_partitioning().partition_count() > 1 {
+        Arc::new(CoalescePartitionsExec::new(child))
+    } else {
+        child
+    };
+
+    let shuffle_node =
+        MppShuffleExec::new(child, wiring, drain_handle, hash_keys, drive_partition, tag);
+    match stage {
+        // Stamp via the `MppNetworkBoundary` seam. The trait method consumes
+        // the wiring + drain_handle Mutex<Option<>>s and produces a fresh
+        // `Arc`; the unstamped node is dropped immediately after.
+        Some(s) => MppNetworkBoundary::with_input_stage(&shuffle_node, s),
+        None => Ok(Arc::new(shuffle_node)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::shuffle::tests::ModuloPartitioner;
+    use crate::postgres::customscan::mpp::transport::{
+        in_proc_channel, DrainBuffer, DrainConfig, DrainItem, MppReceiver, MppSender,
+    };
+    use datafusion::arrow::array::{Int32Array, RecordBatch, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::physical_plan::ExecutionPlanProperties;
+    use datafusion::prelude::SessionContext;
+    use futures::StreamExt;
+    use std::thread;
+    use std::time::Duration;
+
+    fn sample_batch(rows: i32) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..rows);
+        let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
+    }
+
+    /// Drive a two-participant mesh in-process: our side shuffles a 10-row
+    /// input at participant 0 with `ModuloPartitioner(2)`, a simulated peer ships
+    /// synthetic batches into our inbound drain. The wrapped stream should
+    /// emit:
+    ///
+    /// - self-partition rows (even IDs: 0,2,4,6,8)
+    /// - peer-partition rows (synthetic IDs 100,200 from the peer)
+    ///
+    /// and the outbound channel should carry the odd IDs that ShuffleExec
+    /// shipped away (1,3,5,7,9).
+    #[test]
+    fn wrap_with_mpp_shuffle_splices_self_and_peer() {
+        let batch = sample_batch(10);
+        let schema = batch.schema();
+        let input = MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap();
+
+        let (out_tx, out_rx) = in_proc_channel(16);
+        let (in_tx, in_rx) = in_proc_channel(16);
+
+        let wiring = ShuffleWiring {
+            partitioner: Arc::new(ModuloPartitioner::new(2)),
+            outbound_senders: vec![None, Some(MppSender::new(Box::new(out_tx)))],
+            participant_index: 0,
+            cooperative_drain: None,
+        };
+
+        // Simulated peer: ship two synthetic batches with a small delay so
+        // the drain thread actually waits on the waker path at least once.
+        let peer_schema = schema.clone();
+        let peer_thread = thread::spawn(move || {
+            let sender = MppSender::new(Box::new(in_tx));
+            for (id, name) in [(100i32, "peer100"), (200i32, "peer200")] {
+                thread::sleep(Duration::from_millis(10));
+                let b = RecordBatch::try_new(
+                    peer_schema.clone(),
+                    vec![
+                        Arc::new(Int32Array::from_iter_values([id])),
+                        Arc::new(StringArray::from_iter_values([name.to_string()])),
+                    ],
+                )
+                .unwrap();
+                sender.send_batch(&b).unwrap();
+            }
+        });
+
+        let inbound_recv = MppReceiver::new(Box::new(in_rx));
+        let drain_buffer = DrainBuffer::new(1);
+        let drain_handle = DrainHandle::spawn(DrainConfig::new(
+            vec![inbound_recv],
+            Arc::clone(&drain_buffer),
+        ));
+
+        let wrapped = wrap_with_mpp_shuffle(MppShuffleInputs {
+            child: input,
+            wiring,
+            drain_handle: Arc::new(drain_handle),
+            wrapped_schema: schema.clone(),
+            tag: "test",
+            stage: None,
+            hash_keys: None,
+            drive_partition: 0,
+        })
+        .unwrap();
+
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let ctx = SessionContext::new();
+
+        let mut emitted_ids = Vec::new();
+        rt.block_on(async {
+            let n = wrapped.output_partitioning().partition_count();
+            for p in 0..n {
+                let mut s = wrapped.execute(p, ctx.task_ctx()).unwrap();
+                while let Some(b) = s.next().await {
+                    let b = b.unwrap();
+                    let ids = b.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+                    emitted_ids.extend(ids.values().iter().copied());
+                }
+            }
+        });
+
+        // Drain the outbound channel to verify the peer-destined rows
+        // actually got shipped.
+        let out_receiver = MppReceiver::new(Box::new(out_rx));
+        let out_buffer = DrainBuffer::new(1);
+        let out_handle = DrainHandle::spawn(DrainConfig::new(
+            vec![out_receiver],
+            Arc::clone(&out_buffer),
+        ));
+        let mut outbound_ids = Vec::new();
+        while let DrainItem::Batch(b) = out_buffer.pop_front() {
+            outbound_ids.extend(
+                b.column(0)
+                    .as_any()
+                    .downcast_ref::<Int32Array>()
+                    .unwrap()
+                    .values()
+                    .iter()
+                    .copied(),
+            );
+        }
+        out_handle.shutdown().unwrap();
+        peer_thread.join().unwrap();
+
+        // Union output: self-partition (even IDs) + peer-simulated (100, 200).
+        emitted_ids.sort();
+        assert_eq!(emitted_ids, vec![0, 2, 4, 6, 8, 100, 200]);
+        // Outbound: ShuffleExec shipped odd IDs (rows that hashed to participant 1).
+        outbound_ids.sort();
+        assert_eq!(outbound_ids, vec![1, 3, 5, 7, 9]);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! Plan broadcast codec for MPP.
 //!
 //! The leader builds a DataFusion `LogicalPlan`, serializes it via the existing
@@ -31,8 +32,7 @@
 //! participant index at physical-planning time. Participant identity comes
 //! from the worker's position in the mesh, not from the plan encoding.
 
-#![allow(dead_code)]
-
+use pgrx::pg_sys;
 use serde::{Deserialize, Serialize};
 
 use crate::postgres::customscan::joinscan::scan_state::SessionContextProfile;
@@ -76,6 +76,22 @@ impl From<SessionContextProfile> for MppSessionProfile {
 /// tag fields, so we do our own versioning.
 pub const MPP_PLAN_BROADCAST_VERSION: u8 = 1;
 
+/// Per-query identifier for `MppStage.query_id`, derived on the leader from
+/// `MyProcPid` and `GetCurrentStatementStartTimestamp`. `u64` is enough:
+/// the bottom 32 bits (timestamp µs, wraps every ~71 min) distinguish
+/// sequential queries in one backend; `pid ^ (ts >> 32)` in the top 32
+/// bits separates simultaneous queries across backends.
+///
+/// SAFETY: both FFI calls are valid on the backend thread, which is where
+/// the leader always runs during plan stash.
+pub fn derive_query_id() -> u64 {
+    unsafe {
+        let pid = pg_sys::MyProcPid as u32 as u64;
+        let ts = pg_sys::GetCurrentStatementStartTimestamp() as u64;
+        ts ^ (pid << 32)
+    }
+}
+
 /// Bundle the leader writes into DSM at query start; every worker reads the
 /// same bytes and reconstructs its own `MppParticipantConfig` from its
 /// participant index.
@@ -105,6 +121,13 @@ pub struct MppPlanBroadcast {
     pub logical_plan: Vec<u8>,
     pub total_participants: u32,
     pub session_profile: MppSessionProfile,
+    /// Per-query identifier stamped on every [`MppStage`] / [`MppTaskKey`]
+    /// boundary descriptor. Workers reuse the same value so mesh framing
+    /// agrees across participants. Leader fills via [`derive_query_id`].
+    ///
+    /// [`MppStage`]: super::stage::MppStage
+    /// [`MppTaskKey`]: super::stage::MppTaskKey
+    pub query_id: u64,
 }
 
 impl MppPlanBroadcast {
@@ -112,12 +135,14 @@ impl MppPlanBroadcast {
         logical_plan: Vec<u8>,
         total_participants: u32,
         session_profile: MppSessionProfile,
+        query_id: u64,
     ) -> Self {
         Self {
             version: MPP_PLAN_BROADCAST_VERSION,
             logical_plan,
             total_participants,
             session_profile,
+            query_id,
         }
     }
 
@@ -180,17 +205,19 @@ mod tests {
             vec![0xde, 0xad, 0xbe, 0xef, 0xca, 0xfe],
             4,
             MppSessionProfile::Aggregate,
+            0x1234_5678_9abc_def0,
         );
         let bytes = orig.serialize().expect("serialize");
         let decoded = MppPlanBroadcast::deserialize(&bytes).expect("deserialize");
         assert_eq!(decoded.logical_plan, orig.logical_plan);
         assert_eq!(decoded.total_participants, orig.total_participants);
         assert_eq!(decoded.session_profile, orig.session_profile);
+        assert_eq!(decoded.query_id, orig.query_id);
     }
 
     #[test]
     fn participant_config_differs_per_participant_index() {
-        let bc = MppPlanBroadcast::new(vec![], 3, MppSessionProfile::Join);
+        let bc = MppPlanBroadcast::new(vec![], 3, MppSessionProfile::Join, 0);
         let leader = bc.participant_config(0);
         let w1 = bc.participant_config(1);
         let w2 = bc.participant_config(2);
@@ -204,7 +231,7 @@ mod tests {
 
     #[test]
     fn deserialize_rejects_truncated_bytes() {
-        let orig = MppPlanBroadcast::new(vec![1, 2, 3, 4], 2, MppSessionProfile::Join);
+        let orig = MppPlanBroadcast::new(vec![1, 2, 3, 4], 2, MppSessionProfile::Join, 0);
         let bytes = orig.serialize().unwrap();
         // Truncate by removing the last byte — should not round-trip.
         let truncated = &bytes[..bytes.len() - 1];
@@ -213,7 +240,7 @@ mod tests {
 
     #[test]
     fn deserialize_rejects_version_mismatch() {
-        let mut orig = MppPlanBroadcast::new(vec![1, 2, 3], 2, MppSessionProfile::Join);
+        let mut orig = MppPlanBroadcast::new(vec![1, 2, 3], 2, MppSessionProfile::Join, 0);
         orig.version = MPP_PLAN_BROADCAST_VERSION.wrapping_add(1);
         let bytes = orig.serialize().unwrap();
         let err = MppPlanBroadcast::deserialize(&bytes).expect_err("version mismatch must reject");
@@ -233,7 +260,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "participant_index")]
     fn participant_config_panics_on_out_of_bounds_index() {
-        let bc = MppPlanBroadcast::new(vec![], 2, MppSessionProfile::Join);
+        let bc = MppPlanBroadcast::new(vec![], 2, MppSessionProfile::Join, 0);
         // Participant index 2 is out of bounds for total_participants=2;
         // panic at boot time beats a silently dropped partition in
         // production.
@@ -246,7 +273,7 @@ mod tests {
         let big = (0..10_000u32)
             .map(|i| (i % 251) as u8) // non-trivial pattern
             .collect::<Vec<u8>>();
-        let orig = MppPlanBroadcast::new(big.clone(), 2, MppSessionProfile::Aggregate);
+        let orig = MppPlanBroadcast::new(big.clone(), 2, MppSessionProfile::Aggregate, 0xCAFE);
         let bytes = orig.serialize().unwrap();
         let decoded = MppPlanBroadcast::deserialize(&bytes).unwrap();
         assert_eq!(decoded.logical_plan, big);

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -75,7 +75,9 @@ impl From<SessionContextProfile> for MppSessionProfile {
 /// tag fields, so we do our own versioning.
 pub const MPP_PLAN_BROADCAST_VERSION: u8 = 1;
 
-/// Per-query identifier for `MppStage.query_id`, derived on the leader from
+/// Per-query identifier for the boundary [`Stage::query_id`] (low 64 bits;
+/// see [`walker::emit_shuffle_cut`]) and every [`MppTaskKey::query_id`].
+/// Derived on the leader from
 /// `MyProcPid` and `GetCurrentStatementStartTimestamp`. `u64` is enough:
 /// the bottom 32 bits (timestamp µs, wraps every ~71 min) distinguish
 /// sequential queries in one backend; `pid ^ (ts >> 32)` in the top 32
@@ -120,11 +122,13 @@ pub struct MppPlanBroadcast {
     pub logical_plan: Vec<u8>,
     pub total_participants: u32,
     pub session_profile: MppSessionProfile,
-    /// Per-query identifier stamped on every [`MppStage`] / [`MppTaskKey`]
-    /// boundary descriptor. Workers reuse the same value so mesh framing
-    /// agrees across participants. Leader fills via [`derive_query_id`].
+    /// Per-query identifier stamped on every boundary [`Stage`] (as the
+    /// low 64 bits of [`Stage::query_id`]) and every [`MppTaskKey`].
+    /// Workers reuse the same value so mesh framing agrees across
+    /// participants. Leader fills via [`derive_query_id`].
     ///
-    /// [`MppStage`]: super::stage::MppStage
+    /// [`Stage`]: datafusion_distributed::Stage
+    /// [`Stage::query_id`]: datafusion_distributed::Stage::query_id
     /// [`MppTaskKey`]: super::stage::MppTaskKey
     pub query_id: u64,
 }

--- a/pg_search/src/postgres/customscan/mpp/session.rs
+++ b/pg_search/src/postgres/customscan/mpp/session.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Plan broadcast codec for MPP.
 //!
 //! The leader builds a DataFusion `LogicalPlan`, serializes it via the existing

--- a/pg_search/src/postgres/customscan/mpp/shape.rs
+++ b/pg_search/src/postgres/customscan/mpp/shape.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP plan-shape classifier.
 //!
 //! Classifies a query (at planning time) into one of a handful of MPP

--- a/pg_search/src/postgres/customscan/mpp/shape.rs
+++ b/pg_search/src/postgres/customscan/mpp/shape.rs
@@ -1,0 +1,299 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! MPP plan-shape classifier.
+//!
+//! Classifies a query (at planning time) into one of a handful of MPP
+//! topology shapes so `aggregatescan` / `joinscan` can decide whether the
+//! plan is MPP-eligible and, if so, pick the right DSM mesh allocation size.
+//! The actual plan-rewriting lives in [`super::walker::distribute_plan`],
+//! which derives the same shape from plan structure and uses the
+//! classifier's output only as a sanity cross-check.
+//!
+//! # Supported shapes
+//!
+//! [`MppPlanShape::ScalarAggOnBinaryJoin`] — e.g., `SELECT COUNT(*) FROM f
+//! JOIN p WHERE ...`. Per worker: pre-join shuffle of each side → HashJoin →
+//! AggregateExec(Partial). Partial rows are shipped to participant 0 and finalized
+//! by a single `AggregateExec(FinalPartitioned)` on the leader; workers
+//! emit zero rows so PG's Gather sees exactly one row per query.
+//!
+//! [`MppPlanShape::GroupByAggOnBinaryJoin`] — e.g., `SELECT k, COUNT(*) FROM
+//! f JOIN p GROUP BY k`. Per worker: pre-join shuffle → HashJoin →
+//! AggregateExec(Partial) → post-Partial shuffle on group keys →
+//! AggregateExec(FinalPartitioned). Each worker emits final rows for its
+//! group-key hash partition; PG's Gather concatenates — no double-count
+//! because every group lives on exactly one worker.
+//!
+//! [`MppPlanShape::GroupByAggSingleTable`] — `SELECT k, COUNT(*) FROM t
+//! GROUP BY k`. No join; Partial → post-Partial shuffle → FinalPartitioned.
+//! Not yet plumbed through the walker; classifier accepts but the walker
+//! returns `DataFusionError::Plan`.
+//!
+//! [`MppPlanShape::JoinOnly`] — `SELECT ... FROM f JOIN p`. Pre-join shuffle
+//! → HashJoin → emit rows (no aggregate).
+//!
+//! [`MppPlanShape::Ineligible`] — fall back to the non-MPP serial path.
+
+use crate::scan::info::RowEstimate;
+
+/// Classify a query so the dispatcher picks the right topology.
+///
+/// `TopKGroupByAggOnBinaryJoin` is *not* produced by [`classify`] in this
+/// file. The classifier sees only the logical plan, which doesn't tell
+/// it whether DataFusion's physical planner will fuse a `Sort[fetch=k]`
+/// over the aggregate. The walker's dispatcher upgrades a
+/// classifier-said-`GroupByAggOnBinaryJoin` query to this variant when
+/// the standard physical plan exposes that fusion. The variant lives
+/// here so `tag_for_cut` / `cut_count_for_shape` / etc. can match on
+/// it as a single enum.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum MppPlanShape {
+    ScalarAggOnBinaryJoin,
+    GroupByAggOnBinaryJoin,
+    /// Same shape as `GroupByAggOnBinaryJoin` plus an outer
+    /// `ORDER BY <agg-expr> LIMIT k` (DataFusion plans this as
+    /// `SortExec[fetch=k]` over `AggregateExec(Final)`). Topology is
+    /// scalar-style: the post-Partial cut routes every participant's
+    /// output to participant 0 via `FixedTargetPartitioner(0)`, and the
+    /// leader's finalize wraps with `FinalPartitioned + SortExec[fetch=k]`
+    /// so the global Top-K resolves on the leader. Workers emit zero
+    /// rows.
+    TopKGroupByAggOnBinaryJoin,
+    GroupByAggSingleTable,
+    JoinOnly,
+    Ineligible,
+}
+
+impl MppPlanShape {
+    /// True for shapes whose MPP plan shuffles both sides of a binary join.
+    /// These shapes have a "broadcast candidate" (the smaller side), so a
+    /// cost gate on the smaller-side row estimate is meaningful: if the
+    /// smaller side is small, the non-MPP broadcast-join path wins and the
+    /// shuffle setup cost is wasted. Single-table shapes (no broadcast
+    /// candidate) return false and skip the gate.
+    pub fn is_binary_join(&self) -> bool {
+        matches!(
+            self,
+            MppPlanShape::JoinOnly
+                | MppPlanShape::ScalarAggOnBinaryJoin
+                | MppPlanShape::GroupByAggOnBinaryJoin
+        )
+    }
+}
+
+/// Pure decision helper for the broadcast-side MPP cost gate.
+///
+/// Returns `Some(n)` when the smallest known-side row estimate `n` is below
+/// `min_rows` — the caller should skip MPP. Returns `None` when the gate is
+/// disabled (`min_rows <= 0`), when no side has a `Known` estimate (treated
+/// as "not small" so un-ANALYZE'd tables don't silently bypass MPP), or when
+/// the smallest known estimate meets the threshold.
+///
+/// Intended for shapes where [`MppPlanShape::is_binary_join`] returns true.
+pub fn broadcast_side_gate(estimates: &[RowEstimate], min_rows: i32) -> Option<u64> {
+    if min_rows <= 0 {
+        return None;
+    }
+    let threshold = min_rows as u64;
+    let smallest_known = estimates
+        .iter()
+        .filter_map(|e| match e {
+            RowEstimate::Known(n) => Some(*n),
+            RowEstimate::Unknown => None,
+        })
+        .min()?;
+    (smallest_known < threshold).then_some(smallest_known)
+}
+
+/// Shape-classification inputs. Kept as plain fields rather than a reference
+/// to a larger state so callers can construct it from whatever they have
+/// (RelNode walk, AggregateCSClause inspection, test synthetic data).
+#[derive(Debug, Clone)]
+pub struct ClassifyInputs {
+    /// Number of tables in the join. 0 = no join, 1 = single table,
+    /// 2 = binary join, >=3 = multi-table join.
+    pub n_join_tables: usize,
+    /// True if the query has at least one GROUP BY expression the MPP
+    /// shuffle can hash-partition on. Callers must exclude group-by
+    /// expressions whose value is not stable across workers (volatile
+    /// functions, session-dependent casts) — those break the "each group
+    /// lives on exactly one worker" invariant.
+    pub has_group_by: bool,
+    /// True if every aggregate function in the targetlist is one of
+    /// COUNT/SUM/MIN/MAX/AVG/BOOL_*/STDDEV_*/VAR_* — the set with a safe
+    /// Partial/Final split. `false` for COUNT(DISTINCT), ARRAY_AGG,
+    /// STRING_AGG, ordered-set, hypothetical-set aggregates. When
+    /// `has_aggregate=false`, this field is irrelevant and callers
+    /// conventionally pass `true`.
+    pub all_aggregates_splittable: bool,
+    /// True if the query has at least one aggregate (COUNT, SUM, …). When
+    /// `false`, we're classifying a join-only shape.
+    pub has_aggregate: bool,
+}
+
+/// Classify the query into an [`MppPlanShape`].
+///
+/// Rules (all implicitly `AND`-ed):
+///   * Two tables + has_aggregate + splittable: binary-join aggregate.
+///     Split further on `has_group_by` to pick scalar vs group-by topology.
+///   * One table + has_aggregate + group_by + splittable:
+///     single-table group-by aggregate (post-Partial shuffle helps when
+///     cardinality is high).
+///   * Two tables + no_aggregate: join-only.
+///   * Otherwise: Ineligible.
+pub fn classify(inputs: &ClassifyInputs) -> MppPlanShape {
+    if !inputs.all_aggregates_splittable && inputs.has_aggregate {
+        return MppPlanShape::Ineligible;
+    }
+    match (
+        inputs.n_join_tables,
+        inputs.has_aggregate,
+        inputs.has_group_by,
+    ) {
+        (2, true, false) => MppPlanShape::ScalarAggOnBinaryJoin,
+        (2, true, true) => MppPlanShape::GroupByAggOnBinaryJoin,
+        (1, true, true) => MppPlanShape::GroupByAggSingleTable,
+        (2, false, _) => MppPlanShape::JoinOnly,
+        _ => MppPlanShape::Ineligible,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn inputs(n: usize, agg: bool, gb: bool, splittable: bool) -> ClassifyInputs {
+        ClassifyInputs {
+            n_join_tables: n,
+            has_group_by: gb,
+            all_aggregates_splittable: splittable,
+            has_aggregate: agg,
+        }
+    }
+
+    #[test]
+    fn binary_scalar_agg() {
+        assert_eq!(
+            classify(&inputs(2, true, false, true)),
+            MppPlanShape::ScalarAggOnBinaryJoin
+        );
+    }
+
+    #[test]
+    fn binary_groupby_agg() {
+        assert_eq!(
+            classify(&inputs(2, true, true, true)),
+            MppPlanShape::GroupByAggOnBinaryJoin
+        );
+    }
+
+    #[test]
+    fn single_groupby() {
+        assert_eq!(
+            classify(&inputs(1, true, true, true)),
+            MppPlanShape::GroupByAggSingleTable
+        );
+    }
+
+    #[test]
+    fn join_only() {
+        assert_eq!(
+            classify(&inputs(2, false, false, true)),
+            MppPlanShape::JoinOnly
+        );
+    }
+
+    #[test]
+    fn non_splittable_aggregate_is_ineligible() {
+        assert_eq!(
+            classify(&inputs(2, true, false, false)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn three_table_join_is_ineligible() {
+        assert_eq!(
+            classify(&inputs(3, true, false, true)),
+            MppPlanShape::Ineligible
+        );
+    }
+
+    #[test]
+    fn is_binary_join_covers_all_join_shapes() {
+        assert!(MppPlanShape::JoinOnly.is_binary_join());
+        assert!(MppPlanShape::ScalarAggOnBinaryJoin.is_binary_join());
+        assert!(MppPlanShape::GroupByAggOnBinaryJoin.is_binary_join());
+        assert!(!MppPlanShape::GroupByAggSingleTable.is_binary_join());
+        assert!(!MppPlanShape::Ineligible.is_binary_join());
+    }
+
+    mod broadcast_gate {
+        use super::super::broadcast_side_gate;
+        use crate::scan::info::RowEstimate;
+
+        #[test]
+        fn skips_mpp_when_smallest_side_below_threshold() {
+            let est = [RowEstimate::Known(500), RowEstimate::Known(1_000_000)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), Some(500));
+        }
+
+        #[test]
+        fn allows_mpp_when_all_sides_meet_threshold() {
+            let est = [RowEstimate::Known(50_000), RowEstimate::Known(1_000_000)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), None);
+        }
+
+        #[test]
+        fn allows_mpp_at_exact_threshold() {
+            let est = [RowEstimate::Known(10_000), RowEstimate::Known(1_000_000)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), None);
+        }
+
+        #[test]
+        fn disabled_when_threshold_is_zero() {
+            let est = [RowEstimate::Known(1), RowEstimate::Known(2)];
+            assert_eq!(broadcast_side_gate(&est, 0), None);
+        }
+
+        #[test]
+        fn disabled_when_threshold_is_negative() {
+            let est = [RowEstimate::Known(1)];
+            assert_eq!(broadcast_side_gate(&est, -1), None);
+        }
+
+        #[test]
+        fn allows_mpp_when_no_known_estimates() {
+            // Un-ANALYZE'd tables: don't silently gate MPP off.
+            let est = [RowEstimate::Unknown, RowEstimate::Unknown];
+            assert_eq!(broadcast_side_gate(&est, 10_000), None);
+        }
+
+        #[test]
+        fn ignores_unknown_when_some_sides_known() {
+            let est = [RowEstimate::Unknown, RowEstimate::Known(100)];
+            assert_eq!(broadcast_side_gate(&est, 10_000), Some(100));
+        }
+
+        #[test]
+        fn empty_estimates_returns_none() {
+            assert_eq!(broadcast_side_gate(&[], 10_000), None);
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/shuffle.rs
+++ b/pg_search/src/postgres/customscan/mpp/shuffle.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Shuffle operator primitives for MPP.
 //!
 //! Carries both the pure-function primitives and the DataFusion operators

--- a/pg_search/src/postgres/customscan/mpp/shuffle.rs
+++ b/pg_search/src/postgres/customscan/mpp/shuffle.rs
@@ -86,11 +86,10 @@ use tokio::task::yield_now;
 
 #[cfg(not(test))]
 use crate::gucs::mpp_trace;
-use crate::postgres::customscan::mpp::stage::{MppNetworkBoundary, MppStage};
 use crate::postgres::customscan::mpp::transport::{
     DrainHandle, DrainItem, MppSender, SendBatchStats,
 };
-use datafusion_distributed::{NetworkBoundary as DfdNetworkBoundary, Stage as DfdStage};
+use datafusion_distributed::{NetworkBoundary, Stage};
 use uuid::Uuid;
 
 /// GUC read wrapper that is inert under `cfg(test)`.
@@ -878,18 +877,14 @@ pub struct MppShuffleExec {
     tag: &'static str,
     participant_index: u32,
     drive_partition: u32,
-    /// Stage this boundary consumes from, in ParadeDB's local
-    /// representation. Carries the `(query_id: u64, stage_id: u32,
-    /// task_count: u32)` tuple that frame headers use directly.
-    #[allow(dead_code)]
-    input_stage: Option<MppStage>,
-    /// Same stage info, in `datafusion-distributed`'s representation,
-    /// stamped on construction whenever `input_stage` is `Some`. The
-    /// fork's [`DfdNetworkBoundary`] trait returns `&Stage`, so this
-    /// has to live as an owned field rather than be derived on demand.
+    /// Stage this boundary consumes from. Stamped by the walker via
+    /// [`NetworkBoundary::with_input_stage`]; `None` only on un-stamped
+    /// test fixtures that construct `MppShuffleExec` directly. The fork's
+    /// [`NetworkBoundary`] trait returns `&Stage`, so we keep an owned
+    /// field rather than synthesize one on demand. ParadeDB's u64
     /// `query_id` round-trips as the low 64 bits of a UUID
     /// ([`Uuid::from_u128`] of `query_id as u128`).
-    network_stage: Option<DfdStage>,
+    input_stage: Option<Stage>,
 }
 
 impl fmt::Debug for MppShuffleExec {
@@ -961,28 +956,25 @@ impl MppShuffleExec {
             participant_index,
             drive_partition,
             input_stage: None,
-            network_stage: None,
         }
     }
 }
 
-/// Convert ParadeDB's [`MppStage`] (u64 query_id, u32 stage_id, u32 task_count)
-/// to the fork's [`DfdStage`] (Uuid query_id, usize num, Vec<ExecutionTask>).
-/// The UUID encodes our `u64` in its low 64 bits via `Uuid::from_u128`.
-fn mpp_stage_to_dfd_stage(s: &MppStage) -> DfdStage {
-    DfdStage::new_unaddressed(
-        Uuid::from_u128(s.query_id as u128),
-        s.stage_id as usize,
-        s.task_count as usize,
-    )
-}
-
-impl MppNetworkBoundary for MppShuffleExec {
-    fn input_stage(&self) -> Option<&MppStage> {
-        self.input_stage.as_ref()
+impl NetworkBoundary for MppShuffleExec {
+    fn input_stage(&self) -> &Stage {
+        // The fork's walker (idempotency check, metrics rewriter,
+        // stage-extraction paths) calls this before any in-band traversal,
+        // so an un-stamped boundary returning a placeholder Stage is safe —
+        // every walker-emitted boundary has `input_stage = Some(_)` from
+        // `with_input_stage`. Test fixtures that construct an MppShuffleExec
+        // directly hit the placeholder.
+        self.input_stage.as_ref().unwrap_or_else(|| {
+            static PLACEHOLDER: std::sync::OnceLock<Stage> = std::sync::OnceLock::new();
+            PLACEHOLDER.get_or_init(|| Stage::new_unaddressed(Uuid::nil(), 0, 0))
+        })
     }
 
-    fn with_input_stage(&self, stage: MppStage) -> DFResult<Arc<dyn ExecutionPlan>> {
+    fn with_input_stage(&self, stage: Stage) -> DFResult<Arc<dyn ExecutionPlan>> {
         let wiring = self.wiring.lock().unwrap().take().ok_or_else(|| {
             DataFusionError::Internal(
                 "MppShuffleExec::with_input_stage: wiring already consumed".into(),
@@ -1005,42 +997,8 @@ impl MppNetworkBoundary for MppShuffleExec {
             self.drive_partition,
             self.tag,
         );
-        node.network_stage = Some(mpp_stage_to_dfd_stage(&stage));
         node.input_stage = Some(stage);
         Ok(Arc::new(node))
-    }
-}
-
-impl DfdNetworkBoundary for MppShuffleExec {
-    fn input_stage(&self) -> &DfdStage {
-        // The walker's idempotency check + metrics paths call this before
-        // any in-band traversal, so an unstamped boundary returning a
-        // placeholder Stage is safe — the only consumer of the inner
-        // fields runs against walker-emitted boundaries (which always
-        // have `network_stage = Some(_)` from `with_input_stage`).
-        self.network_stage.as_ref().unwrap_or_else(|| {
-            // Static placeholder for un-stamped fixtures (only test code
-            // constructs MppShuffleExec without going through the walker).
-            // Heap-allocated once, leaked into a `&'static`, so the
-            // returned reference outlives the call.
-            static PLACEHOLDER: std::sync::OnceLock<DfdStage> = std::sync::OnceLock::new();
-            PLACEHOLDER.get_or_init(|| DfdStage::new_unaddressed(Uuid::nil(), 0, 0))
-        })
-    }
-
-    fn with_input_stage(&self, _input_stage: DfdStage) -> DFResult<Arc<dyn ExecutionPlan>> {
-        // ParadeDB stamps stage info via the local `MppNetworkBoundary`
-        // trait (which carries the u64 query_id and u32 stage_id without
-        // a UUID round-trip). The fork's walker never calls this method
-        // directly on our type — `MppBoundaryFactory::shuffle/coalesce`
-        // emits a fully-stamped MppShuffleExec via `wrap_with_mpp_shuffle`.
-        // If a future caller routes through the fork's walker without our
-        // factory, surface a planner error rather than silently no-op.
-        Err(DataFusionError::Plan(
-            "mpp: MppShuffleExec::with_input_stage (DfdNetworkBoundary) not supported — \
-             ParadeDB stamps via its local MppNetworkBoundary trait through MppBoundaryFactory"
-                .into(),
-        ))
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/shuffle.rs
+++ b/pg_search/src/postgres/customscan/mpp/shuffle.rs
@@ -1,0 +1,1635 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Shuffle operator primitives for MPP.
+//!
+//! Carries both the pure-function primitives and the DataFusion operators
+//! that compose them. The operators ([`ShuffleExec`] for the producer side,
+//! [`DrainGatherExec`] for the consumer side) live in this file alongside
+//! the primitives so a reader can step from "row → destination" through
+//! "Stream poll body" without crossing files.
+//!
+//! Primitives:
+//!
+//! - [`RowPartitioner`] is the trait `ShuffleExec` calls per batch to decide
+//!   which destination participant each row belongs to.
+//! - [`HashPartitioner`] is the production impl — a hash over join key columns
+//!   modulo N participants. Uses DataFusion's `create_hashes` helper with a
+//!   seed that matches DataFusion's own `REPARTITION_RANDOM_STATE`
+//!   (`datafusion::physical_plan::repartition` uses `with_seeds(0,0,0,0)`).
+//!   Routing is therefore stable across workers — every worker that sees the
+//!   same input rows places them on the same participant. Downstream `HashJoinExec`
+//!   and `AggregateExec` intentionally use *different* seeds internally (see
+//!   their `HASH_JOIN_SEED` / `AGGREGATION_HASH_SEED` constants) — that
+//!   keeps routing distribution and internal hash-table distribution
+//!   decoupled, and has no bearing on our shuffle correctness.
+//! - `tests::ModuloPartitioner` is the test-only variant that routes row
+//!   `i` to destination `i % N`, so tests can verify routing without
+//!   committing to a specific hash output. Lives in this file's `tests`
+//!   submodule and is reused by `plan_build.rs`'s tests via the same
+//!   path.
+//! - [`split_batch_by_partition`] is the row-scatter step: given a batch and
+//!   its per-row destination vector, return one sub-batch per destination,
+//!   preserving row order within each destination. `ShuffleExec`'s producer
+//!   loop calls this once per input batch, then feeds each sub-batch to its
+//!   corresponding `MppSender` (peers) or local channel (self).
+//!
+//! TODO(arch): the "destination participant" routing here is parallel to,
+//! but distinct from, DataFusion's own `partition` concept.
+//! `datafusion-distributed` takes a different approach: it lets each
+//! `ShuffleExec` expose N output partitions (one per participant) and
+//! uses `PartitionIsolatorExec` to select which partition a worker reads.
+//! That alignment with native DF partitions has real upside (every DF
+//! optimizer rule that reasons about partitioning would Just Work). The
+//! current code prefers the row-routing model because it keeps
+//! `ShuffleExec` shaped like a single-output operator (matches
+//! ParadeDB's pre-existing custom-scan single-partition assumption) and
+//! avoids needing a `PartitionIsolatorExec` analogue everywhere we
+//! reference a participant index. Re-evaluating once the rest of the
+//! MPP stack settles is on the table; tracked separately so a future
+//! reviewer can pick it up without re-deriving the trade-off.
+
+use std::any::Any;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use datafusion::arrow::array::{RecordBatch, UInt64Array};
+use datafusion::arrow::compute::take;
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::hash_utils::create_hashes;
+use datafusion::common::{DataFusionError, Result as DFResult};
+use datafusion::execution::{SendableRecordBatchStream, TaskContext};
+use datafusion::physical_expr::EquivalenceProperties;
+use datafusion::physical_expr::PhysicalExpr;
+use datafusion::physical_plan::execution_plan::{Boundedness, EmissionType};
+use datafusion::physical_plan::stream::{EmptyRecordBatchStream, RecordBatchStreamAdapter};
+use datafusion::physical_plan::{
+    DisplayAs, DisplayFormatType, ExecutionPlan, Partitioning, PlanProperties,
+};
+use futures::Stream;
+use tokio::task::yield_now;
+
+#[cfg(not(test))]
+use crate::gucs::mpp_trace;
+use crate::postgres::customscan::mpp::stage::{MppNetworkBoundary, MppStage};
+use crate::postgres::customscan::mpp::transport::{
+    DrainHandle, DrainItem, MppSender, SendBatchStats,
+};
+use datafusion_distributed::{NetworkBoundary as DfdNetworkBoundary, Stage as DfdStage};
+use uuid::Uuid;
+
+/// GUC read wrapper that is inert under `cfg(test)`.
+///
+/// `pgrx::guc::GucSetting::get()` calls `check_active_thread`, which panics
+/// if invoked from a thread other than the one that first touched the
+/// pgrx FFI layer. `cargo test` (no `--test-threads=1`) runs each test on
+/// a fresh worker thread, so a GUC read inside a stream poller blows up
+/// across threads. The production path still reads the GUC; tests just see
+/// `false` (no trace instrumentation needed for correctness).
+#[inline]
+fn mpp_trace_flag() -> bool {
+    #[cfg(not(test))]
+    {
+        mpp_trace()
+    }
+    #[cfg(test)]
+    {
+        false
+    }
+}
+
+/// Assigns each row of a `RecordBatch` to one of N destination participants.
+///
+/// Implementations must return exactly `batch.num_rows()` values, each in
+/// `0..total_participants`. `ShuffleExec` uses this at the top of its
+/// producer loop to fan rows out across the mesh.
+pub trait RowPartitioner: Send + Sync {
+    /// Return a destination index in `0..total_participants` for every row.
+    fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError>;
+
+    /// Total destinations this partitioner will target. Used by
+    /// `ShuffleExec` to size per-destination scratch arrays.
+    fn total_participants(&self) -> u32;
+}
+
+/// Production partitioner: hashes one or more key columns and assigns each
+/// row to `hash % total_participants`.
+///
+/// Uses `datafusion::common::hash_utils::create_hashes` with
+/// `ahash::RandomState::with_seeds(0, 0, 0, 0)` — the same seed DataFusion
+/// itself uses for `REPARTITION_RANDOM_STATE`. That gives stable routing
+/// across workers and across planner reruns. Downstream HashJoin / Aggregate
+/// use different seeds internally (by design, to avoid collisions with
+/// routing); that is not a problem for our shuffle because only the routing
+/// hash needs agreement across workers, not the internal-table hash.
+///
+/// NULL keys hash to a fixed sentinel inside `create_hashes`, so every row
+/// with a NULL in any key column routes to the same destination. That is
+/// correct for join/aggregate purposes — the receiving HashJoin/Aggregate
+/// also clusters NULL-key rows together and applies SQL NULL semantics
+/// from there — but it means a heavily-NULL key column produces skewed
+/// destination distribution. Diagnose with `mpp_trace`'s per-peer
+/// `rows_sent` counters if a hot peer shows up.
+///
+/// TODO: accept `Vec<Arc<dyn PhysicalExpr>>` instead of column indices so a
+/// planner that pushes `CAST(col)` or `col + 0` into the key list stays
+/// byte-compatible with DataFusion's own routing. Today we accept only
+/// column refs, which is sufficient for the expected planner output but
+/// will silently diverge if that changes.
+pub struct HashPartitioner {
+    /// Indices into the input schema for the key columns to hash.
+    key_columns: Vec<usize>,
+    total_participants: u32,
+}
+
+impl HashPartitioner {
+    pub fn new(key_columns: Vec<usize>, total_participants: u32) -> Self {
+        assert!(
+            total_participants > 0,
+            "HashPartitioner requires total_participants >= 1"
+        );
+        Self {
+            key_columns,
+            total_participants,
+        }
+    }
+}
+
+impl RowPartitioner for HashPartitioner {
+    fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError> {
+        if self.total_participants == 1 {
+            // Single participant degenerate case — everyone is self.
+            return Ok(vec![0u32; batch.num_rows()]);
+        }
+        if self.key_columns.is_empty() {
+            return Err(DataFusionError::Internal(
+                "HashPartitioner: no key columns provided".into(),
+            ));
+        }
+        let columns: Vec<_> = self
+            .key_columns
+            .iter()
+            .map(|&idx| batch.column(idx).clone())
+            .collect();
+        let mut hashes_buf = vec![0u64; batch.num_rows()];
+        // Use a fixed, non-zero seed so hashes stay stable across calls.
+        let random_state = ahash::RandomState::with_seeds(0, 0, 0, 0);
+        create_hashes(&columns, &random_state, &mut hashes_buf)?;
+        let n = self.total_participants as u64;
+        Ok(hashes_buf.into_iter().map(|h| (h % n) as u32).collect())
+    }
+
+    fn total_participants(&self) -> u32 {
+        self.total_participants
+    }
+}
+
+/// Route every row to one fixed destination participant. Used by the MPP scalar-
+/// aggregate final-gather step: workers ship their Partial row to participant 0 so
+/// the leader can run `AggregateExec(FinalPartitioned)` on the combined
+/// stream. Leader's self-partition is the target participant, so nothing is shipped
+/// out; its drain receives N-1 partials and it emits exactly one final row.
+/// Workers' self-partition is empty (target != self), so their
+/// `FinalPartitioned` sees 0 rows and emits 0 rows — PG's Gather on top
+/// therefore concatenates exactly one row per query, not one per worker.
+pub struct FixedTargetPartitioner {
+    target: u32,
+    total_participants: u32,
+}
+
+impl FixedTargetPartitioner {
+    pub fn new(target: u32, total_participants: u32) -> Self {
+        assert!(total_participants > 0);
+        assert!(
+            target < total_participants,
+            "FixedTargetPartitioner: target {target} >= total_participants {total_participants}"
+        );
+        Self {
+            target,
+            total_participants,
+        }
+    }
+}
+
+impl RowPartitioner for FixedTargetPartitioner {
+    fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError> {
+        Ok(vec![self.target; batch.num_rows()])
+    }
+
+    fn total_participants(&self) -> u32 {
+        self.total_participants
+    }
+}
+
+/// Scatter a `RecordBatch` into one sub-batch per destination participant.
+///
+/// Returns a `Vec` of length `total_participants`. Each entry is either:
+/// - `Some(sub_batch)` if one or more rows of `batch` routed to that participant; or
+/// - `None` if no rows routed to that participant (skip a send round-trip).
+///
+/// Row order within each sub-batch matches the original batch. Uses
+/// `arrow::compute::take` so the implementation is zero-copy per-column for
+/// fixed-width arrays and slice-copy for variable-width.
+pub fn split_batch_by_partition(
+    batch: &RecordBatch,
+    destinations: &[u32],
+    total_participants: u32,
+) -> Result<Vec<Option<RecordBatch>>, DataFusionError> {
+    if destinations.len() != batch.num_rows() {
+        return Err(DataFusionError::Internal(format!(
+            "split_batch_by_partition: destinations.len()={} != batch.num_rows()={}",
+            destinations.len(),
+            batch.num_rows()
+        )));
+    }
+    if total_participants == 0 {
+        return Err(DataFusionError::Internal(
+            "split_batch_by_partition: total_participants must be > 0".into(),
+        ));
+    }
+
+    // Bucket row indices per destination. Allocate lazily so single-destination
+    // inputs don't pay for N unused Vecs.
+    let n = total_participants as usize;
+    let mut buckets: Vec<Option<Vec<u64>>> = (0..n).map(|_| None).collect();
+    for (row_idx, &dest) in destinations.iter().enumerate() {
+        if dest as usize >= n {
+            return Err(DataFusionError::Internal(format!(
+                "split_batch_by_partition: destination {dest} >= total_participants {total_participants}"
+            )));
+        }
+        buckets[dest as usize]
+            .get_or_insert_with(Vec::new)
+            .push(row_idx as u64);
+    }
+
+    let schema = batch.schema();
+    let mut out: Vec<Option<RecordBatch>> = Vec::with_capacity(n);
+    for bucket in buckets {
+        match bucket {
+            None => out.push(None),
+            Some(indices) => {
+                let idx_array = UInt64Array::from(indices);
+                let taken_cols: Result<Vec<_>, DataFusionError> = batch
+                    .columns()
+                    .iter()
+                    .map(|c| {
+                        take(c.as_ref(), &idx_array, None)
+                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+                    })
+                    .collect();
+                let taken_cols = taken_cols?;
+                let sub = RecordBatch::try_new(schema.clone(), taken_cols)
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                out.push(Some(sub));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Concatenate destination sub-batches back into one RecordBatch.
+///
+/// Wiring passed to `ShuffleExec::new` that describes how this participant
+/// connects to the mesh. Moved into the operator at construction time; the
+/// operator owns the senders for the query's lifetime and drops them at
+/// stream EOF / abort so peer receivers cleanly observe detach.
+pub struct ShuffleWiring {
+    pub partitioner: Arc<dyn RowPartitioner>,
+    /// One slot per participant, length = `partitioner.total_participants()`.
+    /// Participant `participant_index` must be `None`; all other participants must be
+    /// `Some(MppSender)`. `ShuffleExec::new` asserts this invariant.
+    pub outbound_senders: Vec<Option<MppSender>>,
+    pub participant_index: u32,
+    /// Our inbound-side drain handle for the same mesh. When set,
+    /// `build_shuffle_stream` proactively calls
+    /// `DrainHandle::poll_drain_pass` every iteration so our inbound
+    /// queues keep draining even when our outbound sends aren't
+    /// blocking. Without this, a participant whose sends succeed fast
+    /// never drains, peers can't ship to it, and the mesh deadlocks on
+    /// one-sided pressure (observed as a 120s timeout on
+    /// `aggregate_join_groupby - alternative 2` at 25M rows).
+    pub cooperative_drain: Option<Arc<DrainHandle>>,
+}
+
+/// Mutable per-stream state for [`build_shuffle_stream`]. Kept as a
+/// struct (rather than scattered locals) so [`process_batch`] can mutate
+/// row counters, push to the self-queue, and accumulate trace metrics
+/// in one place.
+///
+/// Trace fields are only consumed by [`log_shuffle_eof`], whose body
+/// is gated to `cfg(not(test))`. Under `cfg(test)` rustc sees no reader
+/// for the fields and trips `dead_code`; the `cfg_attr` silences that
+/// for the unit-test build only.
+#[cfg_attr(test, allow(dead_code))]
+struct ShuffleState {
+    /// Set on entry; taken to `None` once the child is exhausted (or
+    /// errors mid-stream) so peer senders detach and signal EOF.
+    wiring: Option<ShuffleWiring>,
+    /// Sub-batch destined for this participant, queued for the next
+    /// `yield` from the outer loop. At most one entry: each input batch
+    /// produces a single self-share (or none), drained before pulling
+    /// another child batch.
+    self_queue: Option<RecordBatch>,
+    participant_index: u32,
+    rows_in: u64,
+    rows_self: u64,
+    /// Per-destination row counts for the EOF trace. Indexed by
+    /// destination participant; entry at `participant_index` stays 0.
+    rows_sent: Vec<u64>,
+    batches_in: u64,
+    time_in_partition: Duration,
+    time_in_split: Duration,
+    time_in_encode: Duration,
+    time_in_send_wait: Duration,
+    time_in_coop_drain_in_spin: Duration,
+    send_spin_iters: u64,
+}
+
+impl ShuffleState {
+    fn new(wiring: ShuffleWiring) -> Self {
+        let total = wiring.partitioner.total_participants() as usize;
+        let participant_index = wiring.participant_index;
+        Self {
+            wiring: Some(wiring),
+            self_queue: None,
+            participant_index,
+            rows_in: 0,
+            rows_self: 0,
+            rows_sent: vec![0u64; total],
+            batches_in: 0,
+            time_in_partition: Duration::ZERO,
+            time_in_split: Duration::ZERO,
+            time_in_encode: Duration::ZERO,
+            time_in_send_wait: Duration::ZERO,
+            time_in_coop_drain_in_spin: Duration::ZERO,
+            send_spin_iters: 0,
+        }
+    }
+
+    /// Process one input batch: partition rows, queue our self-share,
+    /// ship peer-shares via `MppSender`. Mutates row/timing counters.
+    /// `async` because `MppSender::send_batch_traced` yields to the Tokio
+    /// runtime in its cooperative-spin loop — see that fn's body comment.
+    async fn process_batch(&mut self, batch: RecordBatch, trace_on: bool) -> DFResult<()> {
+        let rows = batch.num_rows() as u64;
+        if rows == 0 {
+            return Ok(());
+        }
+        self.rows_in += rows;
+        self.batches_in += 1;
+        let wiring = self.wiring.as_ref().ok_or_else(|| {
+            DataFusionError::Internal("ShuffleStream: wiring missing mid-stream".into())
+        })?;
+        let t_part = trace_on.then(Instant::now);
+        let dests = wiring.partitioner.partition_for_each_row(&batch)?;
+        if let Some(t0) = t_part {
+            self.time_in_partition += t0.elapsed();
+        }
+        let n = wiring.partitioner.total_participants();
+        let t_split = trace_on.then(Instant::now);
+        let mut subs = split_batch_by_partition(&batch, &dests, n)?;
+        if let Some(t0) = t_split {
+            self.time_in_split += t0.elapsed();
+        }
+
+        // Self first (see run_shuffle_pump docstring for rationale).
+        if let Some(self_sub) = subs[wiring.participant_index as usize].take() {
+            self.rows_self += self_sub.num_rows() as u64;
+            // Slot is always free here: process_batch only runs when the
+            // outer pump has just yielded any prior self-share, and each
+            // input batch produces at most one self-share.
+            debug_assert!(self.self_queue.is_none(), "self_queue overwrite");
+            self.self_queue = Some(self_sub);
+        }
+        let mut send_stats = SendBatchStats::default();
+        for (dest_idx, sub) in subs.into_iter().enumerate() {
+            if dest_idx as u32 == wiring.participant_index {
+                debug_assert!(sub.is_none());
+                continue;
+            }
+            let Some(sub) = sub else { continue };
+            let sender = wiring.outbound_senders[dest_idx].as_ref().ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "ShuffleStream: no outbound sender for participant {dest_idx}"
+                ))
+            })?;
+            let sub_rows = sub.num_rows() as u64;
+            sender.send_batch_traced(&sub, &mut send_stats).await?;
+            self.rows_sent[dest_idx] += sub_rows;
+        }
+        if trace_on {
+            self.time_in_encode += send_stats.encode;
+            self.time_in_send_wait += send_stats.send_wait;
+            self.time_in_coop_drain_in_spin += send_stats.coop_drain_in_spin;
+            self.send_spin_iters += send_stats.spin_iters;
+        }
+        Ok(())
+    }
+}
+
+/// Build the async stream that powers [`ShuffleExec`]. Pulls batches from
+/// `child`, partitions each by row, ships peer-shares via the `MppSender`s
+/// in `wiring`, and yields the local participant's share back up the plan.
+///
+/// The body interleaves three concerns on a single task: pulling from
+/// `child`, shipping outbound via `shm_mq_send`, and pumping the
+/// cooperative inbound drain so peer `MppSender`s can keep flushing into
+/// us. The drain is synchronous because `shm_mq` has no async readiness
+/// signal; an `async-stream` body shaped around it (rather than a
+/// `select!` over async sources) keeps the cooperative step explicit.
+fn build_shuffle_stream(
+    mut child: SendableRecordBatchStream,
+    wiring: ShuffleWiring,
+    tag: &'static str,
+) -> impl Stream<Item = DFResult<RecordBatch>> + Send {
+    use futures::StreamExt;
+
+    async_stream::stream! {
+        let trace_on = mpp_trace_flag();
+        let first_poll_at = trace_on.then(Instant::now);
+        let mut time_in_child = Duration::ZERO;
+        let mut time_in_process = Duration::ZERO;
+        let mut time_in_coop_drain = Duration::ZERO;
+        let mut state = ShuffleState::new(wiring);
+
+        let outcome: DFResult<()> = 'pump: loop {
+            // 1. Drain any queued self-partition batches first; each
+            //    yield re-enters the loop and re-runs the inbound drain
+            //    below before pulling another child batch.
+            if let Some(b) = state.self_queue.take() {
+                yield Ok(b);
+                continue 'pump;
+            }
+
+            // 2. Proactive inbound drain: while we're producing + shipping,
+            //    keep consuming peer-shipped batches into our DrainBuffer.
+            //    Without this, a participant whose outbound sends succeed
+            //    fast never drains its inbound, peers' sends to us can't
+            //    un-stall, and the mesh deadlocks on asymmetric pressure
+            //    (observed as a 120s statement timeout on
+            //    `aggregate_join_groupby - alternative 2` at 25M rows).
+            //    The DrainBuffer is consumed later by `DrainGatherStream`
+            //    — this just keeps the pipe moving in the meantime.
+            if let Some(w) = state.wiring.as_ref() {
+                if let Some(drain) = w.cooperative_drain.as_ref() {
+                    let t0 = trace_on.then(Instant::now);
+                    let _ = drain.poll_drain_pass();
+                    if let Some(t0) = t0 {
+                        time_in_coop_drain += t0.elapsed();
+                    }
+                }
+            }
+
+            // 3. Pull child batches until one produces a self-row (handled
+            //    on the next outer iteration) or the child exhausts.
+            'pull: loop {
+                let t_child = trace_on.then(Instant::now);
+                let next = child.next().await;
+                if let Some(t0) = t_child {
+                    time_in_child += t0.elapsed();
+                }
+                match next {
+                    None => break 'pump Ok(()),
+                    Some(Err(e)) => break 'pump Err(e),
+                    Some(Ok(batch)) => {
+                        let t_proc = trace_on.then(Instant::now);
+                        let result = state.process_batch(batch, trace_on).await;
+                        if let Some(t0) = t_proc {
+                            time_in_process += t0.elapsed();
+                        }
+                        if let Err(e) = result {
+                            break 'pump Err(e);
+                        }
+                        if state.self_queue.is_some() {
+                            // Hand off to the outer loop so the queued
+                            // self-batch yields and the inbound drain
+                            // re-runs before we pull again.
+                            continue 'pump;
+                        }
+                        // No self-partition in this batch — keep pulling.
+                        continue 'pull;
+                    }
+                }
+            }
+        };
+
+        // EOF / error tail: drop wiring so peer senders detach and signal
+        // EOF downstream, then emit the trace line. A self-share that
+        // happened to land in the queue right before an error is
+        // intentionally discarded — DataFusion's contract for a yielded
+        // `Err` is that no subsequent items follow, so emitting the
+        // queued batch first would mislead aggregators above us.
+        state.wiring.take();
+        log_shuffle_eof(
+            tag,
+            &state,
+            ShuffleTimings {
+                first_poll_at,
+                time_in_child,
+                time_in_process,
+                time_in_coop_drain,
+            },
+        );
+        if let Err(e) = outcome {
+            yield Err(e);
+        }
+    }
+}
+
+/// Wall-clock timings carried alongside [`ShuffleState`] in
+/// [`build_shuffle_stream`]; emitted at EOF by [`log_shuffle_eof`].
+/// `cfg_attr` rationale: same as [`ShuffleState`].
+#[cfg_attr(test, allow(dead_code))]
+struct ShuffleTimings {
+    /// Set only when `mpp_trace_flag()` was on at first poll.
+    first_poll_at: Option<Instant>,
+    time_in_child: Duration,
+    time_in_process: Duration,
+    /// Cooperative inbound-drain time at the top of each loop iteration
+    /// (excludes the in-spin drain accounted for inside `send_batch_traced`).
+    time_in_coop_drain: Duration,
+}
+
+/// Trace-line emitter for [`build_shuffle_stream`]'s EOF path. Gated out
+/// of `cargo test --lib` for the same reason as
+/// [`log_drain_gather_eof`]: the unit-test target is not a `pg_test`
+/// target and can't link the FFI symbols `pgrx::{warning,debug1}!`
+/// expand into via `ereport`. The runtime EOF path itself *is* exercised
+/// by tests.
+fn log_shuffle_eof(tag: &'static str, state: &ShuffleState, t: ShuffleTimings) {
+    #[cfg(not(test))]
+    {
+        let sent_summary = state
+            .rows_sent
+            .iter()
+            .enumerate()
+            .map(|(i, n)| format!("->{i}={n}"))
+            .collect::<Vec<_>>()
+            .join(",");
+        let wall_ms = t
+            .first_poll_at
+            .map(|s| s.elapsed().as_secs_f64() * 1000.0)
+            .unwrap_or(0.0);
+        let child_ms = t.time_in_child.as_secs_f64() * 1000.0;
+        let process_ms = t.time_in_process.as_secs_f64() * 1000.0;
+        let coop_ms = t.time_in_coop_drain.as_secs_f64() * 1000.0;
+        let part_ms = state.time_in_partition.as_secs_f64() * 1000.0;
+        let split_ms = state.time_in_split.as_secs_f64() * 1000.0;
+        let encode_ms = state.time_in_encode.as_secs_f64() * 1000.0;
+        let send_wait_ms = state.time_in_send_wait.as_secs_f64() * 1000.0;
+        let drain_in_spin_ms = state.time_in_coop_drain_in_spin.as_secs_f64() * 1000.0;
+        if mpp_trace() {
+            pgrx::warning!(
+                "mpp: ShuffleStream[{}] participant={} EOF rows_in={} batches_in={} self={} sent=[{}] wall_ms={:.1} child_ms={:.1} process_ms={:.1} coop_drain_ms={:.1} part_ms={:.1} split_ms={:.1} encode_ms={:.1} send_wait_ms={:.1} drain_in_spin_ms={:.1} spin_iters={}",
+                tag,
+                state.participant_index,
+                state.rows_in,
+                state.batches_in,
+                state.rows_self,
+                sent_summary,
+                wall_ms,
+                child_ms,
+                process_ms,
+                coop_ms,
+                part_ms,
+                split_ms,
+                encode_ms,
+                send_wait_ms,
+                drain_in_spin_ms,
+                state.send_spin_iters,
+            );
+        } else {
+            pgrx::debug1!(
+                "mpp: ShuffleStream[{}] participant={} EOF rows_in={} self={} sent=[{}]",
+                tag,
+                state.participant_index,
+                state.rows_in,
+                state.rows_self,
+                sent_summary
+            );
+        }
+    }
+    #[cfg(test)]
+    {
+        let _ = (tag, state, t);
+    }
+}
+
+/// RAII guard ensuring `handle.shutdown()` runs even when the consumer
+/// drops the stream before the natural EOF/Err tail (e.g., a parent
+/// `LIMIT` shortcut, query cancel during the loop, panic). Without this,
+/// peer `ShuffleExec`s holding `Arc<DrainHandle>` clones via their
+/// `MppSender::cooperative_drain` would keep calling `poll_drain_pass`,
+/// pushing peer batches into a buffer no one reads — an unbounded
+/// memory-growth path on cancel. Shutdown is idempotent (cancel is
+/// idempotent; receivers are taken via `Option::take`), so the natural
+/// tail can also call it without consequence.
+struct ShutdownOnDrop {
+    handle: Arc<DrainHandle>,
+}
+
+impl Drop for ShutdownOnDrop {
+    fn drop(&mut self) {
+        let _ = self.handle.shutdown();
+    }
+}
+
+/// Build the async stream that powers [`DrainGatherExec`]. Yields decoded
+/// peer batches in arrival order; cleanly returns once every inbound
+/// source has detached and the buffer is drained.
+///
+/// Cooperative drain: for pg-backed handles the drain work happens on
+/// the consumer's own task (not a background thread, which would panic
+/// on pgrx's `check_active_thread` the moment it touched any pg FFI via
+/// `shm_mq_receive`). Each loop iteration runs one drain pass and then
+/// `try_pop`s the buffer; on empty we yield to the executor so sibling
+/// tasks (peer `ShuffleExec`s shipping us rows) can make progress before
+/// the next pass.
+fn build_drain_gather_stream(
+    handle: Arc<DrainHandle>,
+    schema: SchemaRef,
+    tag: &'static str,
+    participant_index: u32,
+) -> impl Stream<Item = DFResult<RecordBatch>> + Send {
+    async_stream::stream! {
+        // Held across the whole body so any early-drop of the stream
+        // (LIMIT shortcut, cancel, panic) still cancels the buffer and
+        // releases the receivers. Peer senders observe detach on their
+        // next outbound `try_send_bytes` instead of looping forever.
+        let _shutdown_guard = ShutdownOnDrop { handle: handle.clone() };
+
+        let trace_on = mpp_trace_flag();
+        let first_poll_at = trace_on.then(Instant::now);
+        let mut time_in_drain_pass = Duration::ZERO;
+        let mut time_in_pop = Duration::ZERO;
+        let mut pending_polls: u64 = 0;
+        let mut rows_received: u64 = 0;
+        let mut batches_received: u64 = 0;
+
+        let coop = handle.is_cooperative();
+        let buffer = handle.buffer().clone();
+
+        // Outcome of the loop body. Both break paths run the same
+        // shutdown + log_eof tail below; using a local `Result` keeps the
+        // tail in one place rather than duplicating it at every exit.
+        let outcome: DFResult<()> = 'drain: loop {
+            // A peer that crashes before sending its detach leaves us
+            // pinned in the cooperative loop until statement_timeout;
+            // honor query cancel so the consumer can exit promptly.
+            // Gated out of `cargo test --lib` for the same reason as
+            // the `MppSender::send_batch_traced` spin: the macro pulls
+            // `ProcessInterrupts` / `PG_exception_stack` / `CopyErrorData`
+            // FFI symbols that aren't linked into the unit-test binary.
+            #[cfg(not(test))]
+            pgrx::check_for_interrupts!();
+
+            if coop {
+                let t0 = trace_on.then(Instant::now);
+                let res = handle.poll_drain_pass();
+                if let Some(t0) = t0 {
+                    time_in_drain_pass += t0.elapsed();
+                }
+                if let Err(e) = res {
+                    // Any batches already pushed into the buffer by an
+                    // earlier successful pass are intentionally discarded:
+                    // DataFusion's contract for a yielded `Err` is that no
+                    // subsequent items follow, so partial results would
+                    // mislead aggregators above us.
+                    break 'drain Err(e);
+                }
+            }
+
+            let t_pop = trace_on.then(Instant::now);
+            let item = if coop {
+                buffer.try_pop()
+            } else {
+                Some(buffer.recv().await)
+            };
+            if let Some(t0) = t_pop {
+                time_in_pop += t0.elapsed();
+            }
+
+            match item {
+                Some(DrainItem::Batch(b)) => {
+                    // Peer-shipped batches went through encode_batch /
+                    // decode_batch, so their schema comes from IPC metadata
+                    // rather than from what we expected locally. A peer
+                    // running a drifted schema would otherwise silently
+                    // feed garbage into the Union above us.
+                    if b.schema() != schema {
+                        break 'drain Err(DataFusionError::Internal(format!(
+                            "DrainGatherExec: peer batch schema {:?} disagrees with expected {:?}",
+                            b.schema(),
+                            schema
+                        )));
+                    }
+                    rows_received += b.num_rows() as u64;
+                    batches_received += 1;
+                    yield Ok(b);
+                }
+                Some(DrainItem::Eof) => break 'drain Ok(()),
+                None => {
+                    // Cooperative path only: buffer empty + sources still
+                    // alive. Yield so peer `ShuffleExec`s can produce, then
+                    // loop back into another drain pass.
+                    if trace_on {
+                        pending_polls += 1;
+                    }
+                    yield_now().await;
+                }
+            }
+        };
+
+        // Single shutdown + log_eof tail. Joins the drain thread
+        // deterministically so plan teardown doesn't leave a zombie
+        // holding DSM pointers; logs trailing trace metrics.
+        let shutdown_err = handle.shutdown().err();
+        log_drain_gather_eof(
+            tag,
+            participant_index,
+            DrainGatherTrace {
+                rows_received,
+                batches_received,
+                first_poll_at,
+                time_in_drain_pass,
+                time_in_pop,
+                pending_polls,
+            },
+        );
+        if let Err(e) = outcome {
+            yield Err(e);
+        } else if let Some(e) = shutdown_err {
+            yield Err(e);
+        }
+    }
+}
+
+/// Trace metrics carried through [`build_drain_gather_stream`] and
+/// emitted at EOF by [`log_drain_gather_eof`].
+/// `cfg_attr` rationale: same as [`ShuffleState`].
+#[cfg_attr(test, allow(dead_code))]
+struct DrainGatherTrace {
+    rows_received: u64,
+    batches_received: u64,
+    /// Only set when `mpp_trace_flag()` was on at first poll.
+    first_poll_at: Option<Instant>,
+    time_in_drain_pass: Duration,
+    time_in_pop: Duration,
+    /// `try_pop` returned `None`; subset of cooperative-only iterations.
+    pending_polls: u64,
+}
+
+/// Trace-line emitter for [`build_drain_gather_stream`]'s EOF path. See
+/// the matching `log_shuffle_eof` for the full reasoning behind the
+/// `cfg(not(test))` gate (cargo test --lib is not a `pg_test` target,
+/// so it can't link the FFI symbols `pgrx::{warning,debug1}!` expand
+/// into; the EOF path itself *is* exercised by tests via e.g.
+/// `drain_gather_exec_yields_all_buffered_batches`).
+fn log_drain_gather_eof(tag: &'static str, participant_index: u32, t: DrainGatherTrace) {
+    #[cfg(not(test))]
+    {
+        let wall_ms = t
+            .first_poll_at
+            .map(|s| s.elapsed().as_secs_f64() * 1000.0)
+            .unwrap_or(0.0);
+        let drain_ms = t.time_in_drain_pass.as_secs_f64() * 1000.0;
+        let pop_ms = t.time_in_pop.as_secs_f64() * 1000.0;
+        if mpp_trace() {
+            pgrx::warning!(
+                "mpp: DrainGatherStream[{}] participant={} EOF rows_received={} batches_received={} wall_ms={:.1} drain_ms={:.1} pop_ms={:.1} pending_polls={}",
+                tag,
+                participant_index,
+                t.rows_received,
+                t.batches_received,
+                wall_ms,
+                drain_ms,
+                pop_ms,
+                t.pending_polls,
+            );
+        } else {
+            pgrx::debug1!(
+                "mpp: DrainGatherStream[{}] participant={} EOF rows_received={} batches_received={}",
+                tag,
+                participant_index,
+                t.rows_received,
+                t.batches_received
+            );
+        }
+    }
+    #[cfg(test)]
+    {
+        let _ = (tag, participant_index, t);
+    }
+}
+
+/// Single-operator MPP shuffle: subsumes the role of the older
+/// `ShuffleExec + DrainGatherExec + MppPartitionAdapterExec +
+/// CoalescePartitionsExec(UnionExec(...))` topology.
+///
+/// Shape-aligned with `datafusion-distributed::NetworkShuffleExec`: declares
+/// `Partitioning::Hash(keys, N)` natively (or `UnknownPartitioning(1)` for
+/// the scalar-final gather where there is no hash key list to declare).
+/// The walker emits one `MppShuffleExec` per cut instead of building a
+/// four-node tree.
+///
+/// # Execution model
+///
+/// On each participant, exactly one output partition triggers the work —
+/// `drive_partition`. Other partitions return an empty stream immediately
+/// without consuming wiring.
+///
+/// - `HashPartitioner` boundary: `drive_partition = participant_index`. Every
+///   participant has output rows on its own partition; other partitions are
+///   semantically empty (their rows live on peer participants).
+/// - `FixedTargetPartitioner` boundary: `drive_partition = target` on every
+///   participant. The target's `execute(target)` returns the combined
+///   producer + drain stream; non-target participants' `execute(0)` still
+///   drives upstream (so their rows ship out via `shm_mq`) and yields an
+///   empty stream — same side-effect model as the old `ShuffleExec` when its
+///   self-routed sub-batch happened to be empty.
+///
+/// # Wiring lifecycle
+///
+/// `wiring` and `drain_handle` are one-shot: the first `execute(p)` call with
+/// `p == drive_partition` consumes both. Subsequent calls (after
+/// `with_new_children`, after a re-execute, etc.) error rather than silently
+/// re-running, mirroring the existing `ShuffleExec` invariant.
+pub struct MppShuffleExec {
+    input: Arc<dyn ExecutionPlan>,
+    wiring: Mutex<Option<ShuffleWiring>>,
+    drain_handle: Mutex<Option<Arc<DrainHandle>>>,
+    plan_properties: Arc<PlanProperties>,
+    tag: &'static str,
+    participant_index: u32,
+    drive_partition: u32,
+    /// Stage this boundary consumes from, in ParadeDB's local
+    /// representation. Carries the `(query_id: u64, stage_id: u32,
+    /// task_count: u32)` tuple that frame headers use directly.
+    #[allow(dead_code)]
+    input_stage: Option<MppStage>,
+    /// Same stage info, in `datafusion-distributed`'s representation,
+    /// stamped on construction whenever `input_stage` is `Some`. The
+    /// fork's [`DfdNetworkBoundary`] trait returns `&Stage`, so this
+    /// has to live as an owned field rather than be derived on demand.
+    /// `query_id` round-trips as the low 64 bits of a UUID
+    /// ([`Uuid::from_u128`] of `query_id as u128`).
+    network_stage: Option<DfdStage>,
+}
+
+impl fmt::Debug for MppShuffleExec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("MppShuffleExec")
+            .field("tag", &self.tag)
+            .field("drive_partition", &self.drive_partition)
+            .field("participant_index", &self.participant_index)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MppShuffleExec {
+    /// Construct an `MppShuffleExec`.
+    ///
+    /// - `hash_keys`: when `Some`, output partitioning is
+    ///   `Partitioning::Hash(keys, total_participants)` — the hash-shuffle
+    ///   case. When `None`, output is `UnknownPartitioning(1)` — the
+    ///   scalar-final gather case where every row routes to one target.
+    /// - `drive_partition`: the output partition that triggers the
+    ///   participant's work. For hash shuffles this is `participant_index`;
+    ///   for fixed-target gathers it is `target` on every participant.
+    pub fn new(
+        input: Arc<dyn ExecutionPlan>,
+        wiring: ShuffleWiring,
+        drain_handle: Arc<DrainHandle>,
+        hash_keys: Option<Vec<Arc<dyn PhysicalExpr>>>,
+        drive_partition: u32,
+        tag: &'static str,
+    ) -> Self {
+        let n = wiring.partitioner.total_participants();
+        let participant_index = wiring.participant_index;
+        assert_eq!(
+            wiring.outbound_senders.len(),
+            n as usize,
+            "MppShuffleExec: outbound_senders.len() != total_participants"
+        );
+        assert!(
+            participant_index < n,
+            "MppShuffleExec: participant_index >= total_participants"
+        );
+        assert!(
+            wiring.outbound_senders[participant_index as usize].is_none(),
+            "MppShuffleExec: self participant sender slot must be None"
+        );
+        assert!(
+            drive_partition < n,
+            "MppShuffleExec: drive_partition ({drive_partition}) >= total_participants ({n})"
+        );
+
+        let partitioning = match &hash_keys {
+            Some(keys) => Partitioning::Hash(keys.clone(), n as usize),
+            None => Partitioning::UnknownPartitioning(1),
+        };
+        let eq_properties = EquivalenceProperties::new(input.schema());
+        let plan_properties = Arc::new(PlanProperties::new(
+            eq_properties,
+            partitioning,
+            EmissionType::Incremental,
+            Boundedness::Bounded,
+        ));
+
+        Self {
+            input,
+            wiring: Mutex::new(Some(wiring)),
+            drain_handle: Mutex::new(Some(drain_handle)),
+            plan_properties,
+            tag,
+            participant_index,
+            drive_partition,
+            input_stage: None,
+            network_stage: None,
+        }
+    }
+}
+
+/// Convert ParadeDB's [`MppStage`] (u64 query_id, u32 stage_id, u32 task_count)
+/// to the fork's [`DfdStage`] (Uuid query_id, usize num, Vec<ExecutionTask>).
+/// The UUID encodes our `u64` in its low 64 bits via `Uuid::from_u128`.
+fn mpp_stage_to_dfd_stage(s: &MppStage) -> DfdStage {
+    DfdStage::new_unaddressed(
+        Uuid::from_u128(s.query_id as u128),
+        s.stage_id as usize,
+        s.task_count as usize,
+    )
+}
+
+impl MppNetworkBoundary for MppShuffleExec {
+    fn input_stage(&self) -> Option<&MppStage> {
+        self.input_stage.as_ref()
+    }
+
+    fn with_input_stage(&self, stage: MppStage) -> DFResult<Arc<dyn ExecutionPlan>> {
+        let wiring = self.wiring.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec::with_input_stage: wiring already consumed".into(),
+            )
+        })?;
+        let drain_handle = self.drain_handle.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec::with_input_stage: drain handle already consumed".into(),
+            )
+        })?;
+        let hash_keys = match &self.plan_properties.partitioning {
+            Partitioning::Hash(exprs, _) => Some(exprs.clone()),
+            _ => None,
+        };
+        let mut node = MppShuffleExec::new(
+            self.input.clone(),
+            wiring,
+            drain_handle,
+            hash_keys,
+            self.drive_partition,
+            self.tag,
+        );
+        node.network_stage = Some(mpp_stage_to_dfd_stage(&stage));
+        node.input_stage = Some(stage);
+        Ok(Arc::new(node))
+    }
+}
+
+impl DfdNetworkBoundary for MppShuffleExec {
+    fn input_stage(&self) -> &DfdStage {
+        // The walker's idempotency check + metrics paths call this before
+        // any in-band traversal, so an unstamped boundary returning a
+        // placeholder Stage is safe — the only consumer of the inner
+        // fields runs against walker-emitted boundaries (which always
+        // have `network_stage = Some(_)` from `with_input_stage`).
+        self.network_stage.as_ref().unwrap_or_else(|| {
+            // Static placeholder for un-stamped fixtures (only test code
+            // constructs MppShuffleExec without going through the walker).
+            // Heap-allocated once, leaked into a `&'static`, so the
+            // returned reference outlives the call.
+            static PLACEHOLDER: std::sync::OnceLock<DfdStage> = std::sync::OnceLock::new();
+            PLACEHOLDER.get_or_init(|| DfdStage::new_unaddressed(Uuid::nil(), 0, 0))
+        })
+    }
+
+    fn with_input_stage(&self, _input_stage: DfdStage) -> DFResult<Arc<dyn ExecutionPlan>> {
+        // ParadeDB stamps stage info via the local `MppNetworkBoundary`
+        // trait (which carries the u64 query_id and u32 stage_id without
+        // a UUID round-trip). The fork's walker never calls this method
+        // directly on our type — `MppBoundaryFactory::shuffle/coalesce`
+        // emits a fully-stamped MppShuffleExec via `wrap_with_mpp_shuffle`.
+        // If a future caller routes through the fork's walker without our
+        // factory, surface a planner error rather than silently no-op.
+        Err(DataFusionError::Plan(
+            "mpp: MppShuffleExec::with_input_stage (DfdNetworkBoundary) not supported — \
+             ParadeDB stamps via its local MppNetworkBoundary trait through MppBoundaryFactory"
+                .into(),
+        ))
+    }
+}
+
+impl DisplayAs for MppShuffleExec {
+    fn fmt_as(&self, _t: DisplayFormatType, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "MppShuffleExec: tag={} drive_partition={} participant={}",
+            self.tag, self.drive_partition, self.participant_index
+        )
+    }
+}
+
+impl ExecutionPlan for MppShuffleExec {
+    fn name(&self) -> &str {
+        "MppShuffleExec"
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn properties(&self) -> &Arc<PlanProperties> {
+        &self.plan_properties
+    }
+
+    fn children(&self) -> Vec<&Arc<dyn ExecutionPlan>> {
+        vec![&self.input]
+    }
+
+    fn with_new_children(
+        self: Arc<Self>,
+        children: Vec<Arc<dyn ExecutionPlan>>,
+    ) -> DFResult<Arc<dyn ExecutionPlan>> {
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "MppShuffleExec expects exactly one child, got {}",
+                children.len()
+            )));
+        }
+        let wiring = self.wiring.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec: with_new_children called after wiring consumed".into(),
+            )
+        })?;
+        let drain_handle = self.drain_handle.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec: with_new_children called after drain handle consumed".into(),
+            )
+        })?;
+        let hash_keys = match &self.plan_properties.partitioning {
+            Partitioning::Hash(exprs, _) => Some(exprs.clone()),
+            _ => None,
+        };
+        Ok(Arc::new(MppShuffleExec::new(
+            children.into_iter().next().unwrap(),
+            wiring,
+            drain_handle,
+            hash_keys,
+            self.drive_partition,
+            self.tag,
+        )))
+    }
+
+    fn execute(
+        &self,
+        partition: usize,
+        context: Arc<TaskContext>,
+    ) -> DFResult<SendableRecordBatchStream> {
+        let n = self.plan_properties.partitioning.partition_count();
+        if partition >= n {
+            return Err(DataFusionError::Internal(format!(
+                "MppShuffleExec: partition {partition} >= partition_count {n}"
+            )));
+        }
+        if partition as u32 != self.drive_partition {
+            // Other partitions: empty stream. The drive_partition's stream
+            // performs all the work (drives upstream, ships peers, drains
+            // inbound). DataFusion will iterate execute(p) for every p in
+            // the declared partition count; only the drive partition is
+            // load-bearing.
+            return Ok(Box::pin(EmptyRecordBatchStream::new(self.input.schema())));
+        }
+
+        let wiring =
+            self.wiring.lock().unwrap().take().ok_or_else(|| {
+                DataFusionError::Internal("MppShuffleExec: already executed".into())
+            })?;
+        let drain_handle = self.drain_handle.lock().unwrap().take().ok_or_else(|| {
+            DataFusionError::Internal(
+                "MppShuffleExec: drain handle already consumed before execute".into(),
+            )
+        })?;
+
+        let child_stream = self.input.execute(0, context)?;
+        let producer = build_shuffle_stream(child_stream, wiring, self.tag);
+        let consumer = build_drain_gather_stream(
+            drain_handle,
+            self.input.schema(),
+            self.tag,
+            self.participant_index,
+        );
+
+        // Merge producer-side and consumer-side. `select` polls both
+        // concurrently on the same task; whichever has a batch ready first
+        // is yielded. Equivalent to the old
+        // `CoalescePartitionsExec(UnionExec(ShuffleExec, DrainGatherExec))`
+        // shape minus the per-side tokio task spawns — a single merged
+        // stream is sufficient because both halves are non-blocking
+        // futures; they cooperate via the in-band cooperative-drain
+        // pattern that `build_shuffle_stream` already implements.
+        let merged = futures::stream::select(producer, consumer);
+        Ok(Box::pin(RecordBatchStreamAdapter::new(
+            self.input.schema(),
+            merged,
+        )))
+    }
+}
+
+// `pub` (in test builds only, since the whole module is gated `#[cfg(test)]`)
+// so `plan_build.rs::tests` can reuse `ModuloPartitioner`. Keeping the
+// shared test helpers here rather than in a separate `test_helpers` module
+// avoids introducing a second test-utility surface for one type.
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::transport::{
+        in_proc_channel, DrainBuffer, DrainConfig, DrainItem, MppReceiver, MppSender,
+    };
+    use datafusion::arrow::array::{Int32Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+
+    // ---- shared test helpers ----
+
+    /// Test-only partitioner: row `i` -> destination `i % total_participants`.
+    ///
+    /// Not suitable for production because adjacent rows land on different
+    /// participants regardless of their join key, which would break
+    /// HashJoin/Aggregate correctness. Useful in unit tests because the
+    /// routing is trivially predictable without committing to a specific
+    /// hash output.
+    pub struct ModuloPartitioner {
+        total_participants: u32,
+    }
+
+    impl ModuloPartitioner {
+        pub fn new(total_participants: u32) -> Self {
+            assert!(total_participants > 0);
+            Self { total_participants }
+        }
+    }
+
+    impl RowPartitioner for ModuloPartitioner {
+        fn partition_for_each_row(&self, batch: &RecordBatch) -> Result<Vec<u32>, DataFusionError> {
+            let n = self.total_participants;
+            Ok((0..batch.num_rows() as u32).map(|i| i % n).collect())
+        }
+
+        fn total_participants(&self) -> u32 {
+            self.total_participants
+        }
+    }
+
+    /// Used by tests to verify round-trip: `split_batch_by_partition` followed
+    /// by `concat_batches` (over the same ordering) produces a permutation of
+    /// the original batch rows grouped by destination. In production, the
+    /// consumer side doesn't need this — the DrainBuffer just yields
+    /// sub-batches directly.
+    fn concat_batches(
+        schema: &SchemaRef,
+        batches: impl IntoIterator<Item = RecordBatch>,
+    ) -> Result<RecordBatch, DataFusionError> {
+        let collected: Vec<RecordBatch> = batches.into_iter().collect();
+        if collected.is_empty() {
+            return RecordBatch::try_new(schema.clone(), vec![])
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None));
+        }
+        let refs: Vec<&RecordBatch> = collected.iter().collect();
+        datafusion::arrow::compute::concat_batches(schema, refs)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
+    }
+
+    /// Synchronous producer-side shuffle pump.
+    ///
+    /// Consumes an iterator of input batches, partitions each batch by the
+    /// supplied [`RowPartitioner`], ships the non-self sub-batches through
+    /// `outbound_senders[j]` (for `j != participant_index`), and delivers
+    /// the self-partition sub-batch via `push_self`.
+    ///
+    /// ## Ownership contract
+    ///
+    /// `outbound_senders` is passed **by value** and dropped when the pump
+    /// returns (Ok or Err). Dropping the senders is what signals clean EOF
+    /// to peer `MppReceiver`s on the other end of the channel — the peer's
+    /// drain thread observes `Detached` and marks its corresponding source
+    /// done. Taking this by `&mut` would leave senders alive in the
+    /// caller's scope and let peers block forever; moving ownership into
+    /// this function makes the end-of-stream signal automatic.
+    ///
+    /// ## Error semantics
+    ///
+    /// On any error (partition compute, scatter, `push_self`, or `send`)
+    /// the pump returns `Err(DataFusionError)` immediately, dropping all
+    /// remaining senders. Peers cannot distinguish a truncated shuffle
+    /// from a clean EOF — the shm_mq / channel protocol doesn't carry an
+    /// explicit "abort" tag. It is therefore the caller's responsibility
+    /// to propagate the error up through the DataFusion `ExecutionPlan`
+    /// so every worker aborts the whole query, not just this operator. A
+    /// silent drop would make peers' downstream aggregate nodes happily
+    /// finalize over incomplete input and return wrong answers.
+    /// `build_shuffle_stream` honors this by surfacing the error via the
+    /// stream's `Err` item.
+    ///
+    /// ## Producer order
+    ///
+    /// Inside each input batch we push the self-partition to `push_self`
+    /// *first*, then the peer sub-batches. That means a local downstream
+    /// operator (e.g., FinalAgg on our participant) can start consuming
+    /// the self-partition even while some peer sender is blocked on
+    /// back-pressure. If we pushed peers first, a full-sender stall on
+    /// participant 0 would indirectly stall our own consumer because it
+    /// never sees any self rows until the stall unblocks.
+    ///
+    /// This is the non-streaming core of `ShuffleExec`: the DataFusion
+    /// operator composes this same logic inside a `Stream::poll_next`,
+    /// but the synchronous form is unit-testable without setting up a
+    /// DataFusion runtime.
+    fn run_shuffle_pump<I>(
+        input: I,
+        partitioner: &dyn RowPartitioner,
+        outbound_senders: Vec<Option<MppSender>>,
+        participant_index: u32,
+        mut push_self: impl FnMut(RecordBatch) -> Result<(), DataFusionError>,
+    ) -> Result<(), DataFusionError>
+    where
+        I: IntoIterator<Item = Result<RecordBatch, DataFusionError>>,
+    {
+        let n = partitioner.total_participants();
+        if outbound_senders.len() != n as usize {
+            return Err(DataFusionError::Internal(format!(
+                "run_shuffle_pump: outbound_senders.len()={} != total_participants={}",
+                outbound_senders.len(),
+                n
+            )));
+        }
+        if participant_index >= n {
+            return Err(DataFusionError::Internal(format!(
+                "run_shuffle_pump: participant_index {participant_index} >= total_participants {n}"
+            )));
+        }
+
+        for batch_result in input {
+            let batch = batch_result?;
+            if batch.num_rows() == 0 {
+                continue;
+            }
+            let dests = partitioner.partition_for_each_row(&batch)?;
+            let mut subs = split_batch_by_partition(&batch, &dests, n)?;
+
+            // Push self first so a blocked peer send doesn't starve the
+            // local downstream consumer — see module docstring.
+            if let Some(self_sub) = subs[participant_index as usize].take() {
+                push_self(self_sub)?;
+            }
+
+            for (dest_idx, sub) in subs.into_iter().enumerate() {
+                if dest_idx as u32 == participant_index {
+                    // Already handled above (taken() cleared the slot).
+                    debug_assert!(sub.is_none());
+                    continue;
+                }
+                let Some(sub) = sub else { continue };
+                let sender = outbound_senders[dest_idx].as_ref().ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "run_shuffle_pump: no outbound sender for participant {dest_idx}"
+                    ))
+                })?;
+                sender.send_batch(&sub)?;
+            }
+        }
+
+        // `outbound_senders` drops here: peer MppReceivers observe
+        // `Detached` and mark their source done, producing clean EOF on
+        // the remote drain.
+        drop(outbound_senders);
+        Ok(())
+    }
+
+    // ---- tests ----
+
+    fn sample_batch(rows: i32) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..rows);
+        let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
+    }
+
+    #[test]
+    fn modulo_partitioner_round_robins() {
+        let batch = sample_batch(7);
+        let p = ModuloPartitioner::new(3);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        assert_eq!(dests, vec![0, 1, 2, 0, 1, 2, 0]);
+    }
+
+    #[test]
+    fn split_batch_by_partition_preserves_order() {
+        let batch = sample_batch(6);
+        let dests = vec![0, 1, 0, 1, 0, 1]; // N=2
+        let out = split_batch_by_partition(&batch, &dests, 2).unwrap();
+        assert_eq!(out.len(), 2);
+        let p0 = out[0].as_ref().unwrap();
+        let p1 = out[1].as_ref().unwrap();
+        assert_eq!(p0.num_rows(), 3);
+        assert_eq!(p1.num_rows(), 3);
+        // Within each destination, original order is preserved.
+        let ids_p0 = p0.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(ids_p0.values(), &[0, 2, 4]);
+        let ids_p1 = p1.column(0).as_any().downcast_ref::<Int32Array>().unwrap();
+        assert_eq!(ids_p1.values(), &[1, 3, 5]);
+    }
+
+    #[test]
+    fn split_batch_by_partition_returns_none_for_empty_destinations() {
+        let batch = sample_batch(4);
+        let dests = vec![0, 0, 0, 0]; // All to 0
+        let out = split_batch_by_partition(&batch, &dests, 3).unwrap();
+        assert!(out[0].is_some());
+        assert!(out[1].is_none());
+        assert!(out[2].is_none());
+    }
+
+    #[test]
+    fn split_batch_by_partition_rejects_length_mismatch() {
+        let batch = sample_batch(4);
+        let dests = vec![0, 1]; // Wrong length
+        assert!(split_batch_by_partition(&batch, &dests, 2).is_err());
+    }
+
+    #[test]
+    fn split_batch_by_partition_rejects_out_of_range_destination() {
+        let batch = sample_batch(3);
+        let dests = vec![0, 5, 0]; // Destination 5 > total=2
+        assert!(split_batch_by_partition(&batch, &dests, 2).is_err());
+    }
+
+    #[test]
+    fn split_roundtrips_via_concat() {
+        // Full round-trip: split then concat in destination order; the
+        // result is a permutation of the original batch by destination.
+        let batch = sample_batch(8);
+        let p = ModuloPartitioner::new(3);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        let split = split_batch_by_partition(&batch, &dests, 3).unwrap();
+        let schema = batch.schema();
+        let concatenated = concat_batches(&schema, split.into_iter().flatten()).unwrap();
+        assert_eq!(concatenated.num_rows(), batch.num_rows());
+        // IDs should appear grouped by destination (0,3,6 then 1,4,7 then 2,5).
+        let ids = concatenated
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(ids.values(), &[0, 3, 6, 1, 4, 7, 2, 5]);
+    }
+
+    #[test]
+    fn hash_partitioner_is_deterministic() {
+        let batch = sample_batch(100);
+        let p = HashPartitioner::new(vec![0], 4);
+        let dests_a = p.partition_for_each_row(&batch).unwrap();
+        let dests_b = p.partition_for_each_row(&batch).unwrap();
+        assert_eq!(dests_a, dests_b);
+        assert_eq!(dests_a.len(), 100);
+        for d in &dests_a {
+            assert!(*d < 4);
+        }
+    }
+
+    #[test]
+    fn hash_partitioner_is_deterministic_with_multi_column_keys() {
+        // Production HashJoin keys are typically composite. Verify that
+        // multi-column routing is deterministic across repeated calls
+        // and that all destinations stay within `[0, total_participants)`.
+        // (DataFusion's `create_hashes` combines per-column hashes
+        // commutatively, so swapping `vec![0, 1]` for `vec![1, 0]` does
+        // not change the destination — that's not a property worth
+        // asserting here.)
+        let batch = sample_batch(64);
+        let p = HashPartitioner::new(vec![0, 1], 4);
+        let dests_a = p.partition_for_each_row(&batch).unwrap();
+        let dests_b = p.partition_for_each_row(&batch).unwrap();
+        assert_eq!(dests_a, dests_b);
+        assert_eq!(dests_a.len(), 64);
+        for d in &dests_a {
+            assert!(*d < 4);
+        }
+        // Distribution sanity: with 64 rows over 4 destinations, every
+        // bucket should have at least one row. A multi-column key that
+        // accidentally collapsed to a single hash would drop most of
+        // these to zero.
+        let mut hits = [false; 4];
+        for d in &dests_a {
+            hits[*d as usize] = true;
+        }
+        assert!(hits.iter().all(|h| *h));
+    }
+
+    #[test]
+    fn hash_partitioner_degenerate_n1_routes_all_to_zero() {
+        let batch = sample_batch(50);
+        let p = HashPartitioner::new(vec![0], 1);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        assert!(dests.iter().all(|&d| d == 0));
+    }
+
+    #[test]
+    fn hash_partitioner_requires_key_columns() {
+        let batch = sample_batch(10);
+        let p = HashPartitioner::new(vec![], 2);
+        assert!(p.partition_for_each_row(&batch).is_err());
+    }
+
+    /// Harness: wire N=2 in-proc channels and feed `batches` through the
+    /// pump as participant 0. Returns (self_batches, peer_batches).
+    fn drive_pump_n2(
+        batches: Vec<RecordBatch>,
+        partitioner: &dyn RowPartitioner,
+    ) -> (Vec<RecordBatch>, Vec<RecordBatch>) {
+        let (tx, rx) = in_proc_channel(16);
+        let senders: Vec<Option<MppSender>> = vec![
+            None,                               // participant 0 = self, no sender
+            Some(MppSender::new(Box::new(tx))), // participant 1 = peer
+        ];
+
+        let mut self_batches = Vec::new();
+
+        let input_iter = batches.into_iter().map(Ok::<_, DataFusionError>);
+        run_shuffle_pump(input_iter, partitioner, senders, 0, |b| {
+            self_batches.push(b);
+            Ok(())
+        })
+        .unwrap();
+        // `senders` was moved into the pump and dropped on return; peer
+        // receiver now observes `Detached` on its next `try_recv`.
+
+        // Drain the peer channel into a DrainBuffer via the drain thread so
+        // we exercise the actual drain path end-to-end.
+        let receiver = MppReceiver::new(Box::new(rx));
+        let buffer = DrainBuffer::new(1);
+        let drain_handle =
+            DrainHandle::spawn(DrainConfig::new(vec![receiver], Arc::clone(&buffer)));
+
+        let mut peer_batches = Vec::new();
+        while let DrainItem::Batch(b) = buffer.pop_front() {
+            peer_batches.push(b);
+        }
+        drain_handle.shutdown().unwrap();
+
+        (self_batches, peer_batches)
+    }
+
+    #[test]
+    fn pump_routes_self_and_peer_partitions_end_to_end() {
+        // Row i -> participant (i % 2). With 6 input rows: self gets 0,2,4; peer
+        // gets 1,3,5. Verifies the full stack: partition → scatter → send
+        // over in-proc channel → drain thread → drain buffer.
+        let input = vec![sample_batch(6)];
+        let partitioner = ModuloPartitioner::new(2);
+        let (self_b, peer_b) = drive_pump_n2(input, &partitioner);
+
+        assert_eq!(self_b.len(), 1);
+        assert_eq!(peer_b.len(), 1);
+
+        let self_ids = self_b[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(self_ids.values(), &[0, 2, 4]);
+
+        let peer_ids = peer_b[0]
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int32Array>()
+            .unwrap();
+        assert_eq!(peer_ids.values(), &[1, 3, 5]);
+    }
+
+    #[test]
+    fn pump_handles_multiple_batches() {
+        let input = vec![sample_batch(4), sample_batch(4), sample_batch(4)];
+        let partitioner = ModuloPartitioner::new(2);
+        let (self_b, peer_b) = drive_pump_n2(input, &partitioner);
+        // 3 batches × 2 rows each per destination
+        let self_total: usize = self_b.iter().map(|b| b.num_rows()).sum();
+        let peer_total: usize = peer_b.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(self_total, 6);
+        assert_eq!(peer_total, 6);
+    }
+
+    #[test]
+    fn pump_skips_empty_batches() {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let empty = RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(Int32Array::from_iter_values([])),
+                Arc::new(StringArray::from_iter_values::<String, _>([])),
+            ],
+        )
+        .unwrap();
+        let input = vec![empty, sample_batch(2)];
+        let partitioner = ModuloPartitioner::new(2);
+        let (self_b, peer_b) = drive_pump_n2(input, &partitioner);
+        let self_total: usize = self_b.iter().map(|b| b.num_rows()).sum();
+        let peer_total: usize = peer_b.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(self_total, 1);
+        assert_eq!(peer_total, 1);
+    }
+
+    #[test]
+    fn pump_propagates_input_errors() {
+        let err: Result<RecordBatch, DataFusionError> =
+            Err(DataFusionError::Execution("synthetic".into()));
+        let (tx, _rx) = in_proc_channel(1);
+        let senders: Vec<Option<MppSender>> = vec![None, Some(MppSender::new(Box::new(tx)))];
+        let partitioner = ModuloPartitioner::new(2);
+
+        let result = run_shuffle_pump(vec![err], &partitioner, senders, 0, |_| Ok(()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pump_errors_when_peer_slot_is_none() {
+        // Participant 1 should route rows to a peer, but there's no MppSender.
+        // Must fail with a meaningful error rather than silently drop data.
+        let partitioner = ModuloPartitioner::new(2);
+        let senders: Vec<Option<MppSender>> = vec![None, None];
+        let result = run_shuffle_pump(
+            vec![Ok(sample_batch(2))], // row 0 -> participant 0 (self), row 1 -> participant 1 (peer)
+            &partitioner,
+            senders,
+            0,
+            |_| Ok(()),
+        );
+        assert!(result.is_err());
+        let msg = format!("{}", result.unwrap_err());
+        assert!(
+            msg.contains("no outbound sender for participant 1"),
+            "got: {msg}"
+        );
+    }
+
+    #[test]
+    fn pump_rejects_wrong_sender_count() {
+        let partitioner = ModuloPartitioner::new(2);
+        // Only 1 sender slot for N=2.
+        let senders: Vec<Option<MppSender>> = vec![None];
+        let result = run_shuffle_pump(vec![Ok(sample_batch(4))], &partitioner, senders, 0, |_| {
+            Ok(())
+        });
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn hash_partitioner_distributes_across_participants() {
+        // Over 1000 rows with 4 participants, every participant should get at least some.
+        // This is a statistical claim that should hold for any non-adversarial
+        // hash.
+        let batch = sample_batch(1000);
+        let p = HashPartitioner::new(vec![0], 4);
+        let dests = p.partition_for_each_row(&batch).unwrap();
+        let mut counts = [0usize; 4];
+        for d in &dests {
+            counts[*d as usize] += 1;
+        }
+        for (participant, count) in counts.iter().enumerate() {
+            assert!(
+                *count > 100,
+                "participant {participant} only received {count}/1000 rows — partitioner is skewed"
+            );
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/stage.rs
+++ b/pg_search/src/postgres/customscan/mpp/stage.rs
@@ -15,69 +15,27 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Stage / TaskKey descriptors and the `MppNetworkBoundary` trait.
+//! Wire-format task descriptor for the MPP transport.
 //!
-//! Ported from datafusion-contrib/datafusion-distributed's
-//! `src/distributed_planner/network_boundary.rs` and `src/stage.rs`, with the
-//! transport-specific bits (Arrow Flight / gRPC `ExecutionTask.url`) dropped.
-//! In a PG parallel-worker world a "task" is a peer participant in the mesh, so
-//! `task_count` is enough — we don't need URLs or a `WorkerResolver`.
+//! [`MppTaskKey`] mirrors `datafusion-distributed`'s `TaskKey` protobuf
+//! (`src/worker/worker.proto:51-59`). It rides every framed batch as part
+//! of [`transport::FrameId`] so one `shm_mq` between two participants can
+//! in principle carry multiple multiplexed streams (one per
+//! `(stage, task, partition)` tuple). Today's mesh allocates one `shm_mq`
+//! per `(stage, src, dst)` so the multiplex isn't strictly needed, but
+//! stamping the descriptor now lets the future channel-flatten dispatcher
+//! land without a wire-format break.
 //!
-//! Live consumers: the walker (`walker::emit_shuffle_cut` ➜
-//! `plan_build::wrap_with_mpp_shuffle`) stamps an [`MppStage`] on every
-//! [`ShuffleExec`] / [`DrainGatherExec`] it emits via the
-//! [`MppNetworkBoundary::with_input_stage`] helper. The receiver-side
-//! validation that consumes the stamp lives in P5b — until then the
-//! frame-header bytes carry the `(query_id, stage_id, task_number,
-//! partition)` tuple and decoders discard it after a length check.
-
-use std::sync::Arc;
-
-use datafusion::common::Result as DFResult;
-use datafusion::physical_plan::ExecutionPlan;
-
-/// Identifies a sub-plan rooted at a network boundary.
-///
-/// One `MppStage` per boundary: the generic cut-rule walker assigns a monotonic
-/// `stage_id` as it walks bottom-up, so the leaf stage is 0 and each boundary
-/// above it increments. `task_count` is the number of parallel tasks in the
-/// child sub-plan — for an in-process PG MPP query this equals
-/// `MppParticipantConfig.total_participants` (i.e. one task per participant), but we
-/// keep it as a separate field to mirror datafusion-distributed's shape and
-/// leave room for future task-fan-out schemes.
-///
-/// `query_id` is currently set by the leader at plan time. A `u64` suffices
-/// for single-backend uniqueness (the query never crosses processes outside of
-/// the spawned parallel workers, which all inherit it through DSM). If we
-/// later want to address queries across unrelated backends we can upgrade to
-/// `uuid::Uuid` without changing the trait surface.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub struct MppStage {
-    pub query_id: u64,
-    pub stage_id: u32,
-    pub task_count: u32,
-}
-
-impl MppStage {
-    pub fn new(query_id: u64, stage_id: u32, task_count: u32) -> Self {
-        Self {
-            query_id,
-            stage_id,
-            task_count,
-        }
-    }
-}
+//! Stage identity itself (the `(query_id, stage_id, task_count)` tuple
+//! the walker stamps on each shuffle/gather boundary) is carried through
+//! `datafusion_distributed::Stage` directly — see
+//! `walker::emit_shuffle_cut` for the construction site.
 
 /// Wire identifier for a single stream between two participants.
 ///
-/// Mirrors datafusion-distributed's `TaskKey` protobuf
-/// (`src/worker/worker.proto:51-59`). Carried on every framed batch as
-/// part of `transport::FrameId` so one `shm_mq` between two participants
-/// can in principle carry multiple multiplexed streams (one per (stage,
-/// task, partition) tuple). Today's mesh allocates one shm_mq per
-/// `(stage, src, dst)` so the multiplex isn't strictly needed, but
-/// stamping the descriptor now lets P5b's channel-flatten dispatcher
-/// land without a wire-format break.
+/// `query_id` is the low 64 bits of the corresponding
+/// `datafusion_distributed::Stage::query_id` (see
+/// `walker::emit_shuffle_cut`); `stage_id` matches `Stage::num`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct MppTaskKey {
     pub query_id: u64,
@@ -85,50 +43,9 @@ pub struct MppTaskKey {
     pub task_number: u32,
 }
 
-/// Trait implemented by every MPP `ExecutionPlan` that represents a cut
-/// between two stages — i.e. data crosses an `shm_mq` at this node.
-///
-/// Ported from datafusion-distributed
-/// (`src/distributed_planner/network_boundary.rs:8-20`). We keep the
-/// signatures identical so the upcoming generic cut-rule walker (P3) can be
-/// ported verbatim: the walker's only dependency on boundary nodes is this
-/// trait.
-///
-/// P1 is intentionally permissive: `input_stage` returns `Option<&MppStage>`
-/// because existing call sites construct `ShuffleExec` / `DrainGatherExec`
-/// without a stage. P3's walker will stamp one via [`with_input_stage`] during
-/// the `transform_up` pass. Once every boundary is walker-produced we can
-/// tighten the signature to `&MppStage` and delete the `Option`.
-pub trait MppNetworkBoundary: ExecutionPlan {
-    /// Return the stage this boundary consumes from (i.e. the sub-plan
-    /// beneath the cut). Returns `None` only on test fixtures that
-    /// construct boundaries directly without going through the walker;
-    /// every walker-emitted boundary has a stamped stage. Read-side
-    /// consumer (P5b channel-flatten dispatcher) doesn't exist yet, so
-    /// the only live caller today is `#[cfg(test)]`.
-    #[allow(dead_code)]
-    fn input_stage(&self) -> Option<&MppStage>;
-
-    /// Return a new instance with `input_stage` stamped to `stage`. The
-    /// existing state (wiring, drain handle, etc.) is moved into the new
-    /// instance — calling `with_input_stage` a second time on the original
-    /// node will fail because those one-shot resources have been consumed.
-    fn with_input_stage(&self, stage: MppStage) -> DFResult<Arc<dyn ExecutionPlan>>;
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn mpp_stage_is_constructible_and_equal() {
-        let a = MppStage::new(7, 2, 4);
-        let b = MppStage::new(7, 2, 4);
-        assert_eq!(a, b);
-        assert_eq!(a.query_id, 7);
-        assert_eq!(a.stage_id, 2);
-        assert_eq!(a.task_count, 4);
-    }
 
     #[test]
     fn mpp_task_key_is_constructible_and_equal() {

--- a/pg_search/src/postgres/customscan/mpp/stage.rs
+++ b/pg_search/src/postgres/customscan/mpp/stage.rs
@@ -1,0 +1,148 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Stage / TaskKey descriptors and the `MppNetworkBoundary` trait.
+//!
+//! Ported from datafusion-contrib/datafusion-distributed's
+//! `src/distributed_planner/network_boundary.rs` and `src/stage.rs`, with the
+//! transport-specific bits (Arrow Flight / gRPC `ExecutionTask.url`) dropped.
+//! In a PG parallel-worker world a "task" is a peer participant in the mesh, so
+//! `task_count` is enough — we don't need URLs or a `WorkerResolver`.
+//!
+//! Live consumers: the walker (`walker::emit_shuffle_cut` ➜
+//! `plan_build::wrap_with_mpp_shuffle`) stamps an [`MppStage`] on every
+//! [`ShuffleExec`] / [`DrainGatherExec`] it emits via the
+//! [`MppNetworkBoundary::with_input_stage`] helper. The receiver-side
+//! validation that consumes the stamp lives in P5b — until then the
+//! frame-header bytes carry the `(query_id, stage_id, task_number,
+//! partition)` tuple and decoders discard it after a length check.
+
+use std::sync::Arc;
+
+use datafusion::common::Result as DFResult;
+use datafusion::physical_plan::ExecutionPlan;
+
+/// Identifies a sub-plan rooted at a network boundary.
+///
+/// One `MppStage` per boundary: the generic cut-rule walker assigns a monotonic
+/// `stage_id` as it walks bottom-up, so the leaf stage is 0 and each boundary
+/// above it increments. `task_count` is the number of parallel tasks in the
+/// child sub-plan — for an in-process PG MPP query this equals
+/// `MppParticipantConfig.total_participants` (i.e. one task per participant), but we
+/// keep it as a separate field to mirror datafusion-distributed's shape and
+/// leave room for future task-fan-out schemes.
+///
+/// `query_id` is currently set by the leader at plan time. A `u64` suffices
+/// for single-backend uniqueness (the query never crosses processes outside of
+/// the spawned parallel workers, which all inherit it through DSM). If we
+/// later want to address queries across unrelated backends we can upgrade to
+/// `uuid::Uuid` without changing the trait surface.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MppStage {
+    pub query_id: u64,
+    pub stage_id: u32,
+    pub task_count: u32,
+}
+
+impl MppStage {
+    pub fn new(query_id: u64, stage_id: u32, task_count: u32) -> Self {
+        Self {
+            query_id,
+            stage_id,
+            task_count,
+        }
+    }
+}
+
+/// Wire identifier for a single stream between two participants.
+///
+/// Mirrors datafusion-distributed's `TaskKey` protobuf
+/// (`src/worker/worker.proto:51-59`). Carried on every framed batch as
+/// part of `transport::FrameId` so one `shm_mq` between two participants
+/// can in principle carry multiple multiplexed streams (one per (stage,
+/// task, partition) tuple). Today's mesh allocates one shm_mq per
+/// `(stage, src, dst)` so the multiplex isn't strictly needed, but
+/// stamping the descriptor now lets P5b's channel-flatten dispatcher
+/// land without a wire-format break.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MppTaskKey {
+    pub query_id: u64,
+    pub stage_id: u32,
+    pub task_number: u32,
+}
+
+/// Trait implemented by every MPP `ExecutionPlan` that represents a cut
+/// between two stages — i.e. data crosses an `shm_mq` at this node.
+///
+/// Ported from datafusion-distributed
+/// (`src/distributed_planner/network_boundary.rs:8-20`). We keep the
+/// signatures identical so the upcoming generic cut-rule walker (P3) can be
+/// ported verbatim: the walker's only dependency on boundary nodes is this
+/// trait.
+///
+/// P1 is intentionally permissive: `input_stage` returns `Option<&MppStage>`
+/// because existing call sites construct `ShuffleExec` / `DrainGatherExec`
+/// without a stage. P3's walker will stamp one via [`with_input_stage`] during
+/// the `transform_up` pass. Once every boundary is walker-produced we can
+/// tighten the signature to `&MppStage` and delete the `Option`.
+pub trait MppNetworkBoundary: ExecutionPlan {
+    /// Return the stage this boundary consumes from (i.e. the sub-plan
+    /// beneath the cut). Returns `None` only on test fixtures that
+    /// construct boundaries directly without going through the walker;
+    /// every walker-emitted boundary has a stamped stage. Read-side
+    /// consumer (P5b channel-flatten dispatcher) doesn't exist yet, so
+    /// the only live caller today is `#[cfg(test)]`.
+    #[allow(dead_code)]
+    fn input_stage(&self) -> Option<&MppStage>;
+
+    /// Return a new instance with `input_stage` stamped to `stage`. The
+    /// existing state (wiring, drain handle, etc.) is moved into the new
+    /// instance — calling `with_input_stage` a second time on the original
+    /// node will fail because those one-shot resources have been consumed.
+    fn with_input_stage(&self, stage: MppStage) -> DFResult<Arc<dyn ExecutionPlan>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mpp_stage_is_constructible_and_equal() {
+        let a = MppStage::new(7, 2, 4);
+        let b = MppStage::new(7, 2, 4);
+        assert_eq!(a, b);
+        assert_eq!(a.query_id, 7);
+        assert_eq!(a.stage_id, 2);
+        assert_eq!(a.task_count, 4);
+    }
+
+    #[test]
+    fn mpp_task_key_is_constructible_and_equal() {
+        let a = MppTaskKey {
+            query_id: 42,
+            stage_id: 1,
+            task_number: 3,
+        };
+        let b = MppTaskKey {
+            query_id: 42,
+            stage_id: 1,
+            task_number: 3,
+        };
+        assert_eq!(a, b);
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/stage.rs
+++ b/pg_search/src/postgres/customscan/mpp/stage.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Stage / TaskKey descriptors and the `MppNetworkBoundary` trait.
 //!
 //! Ported from datafusion-contrib/datafusion-distributed's

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! Transport layer for MPP shuffle.
 //!
 //! Layout:
@@ -29,10 +30,10 @@
 //! The shm_mq-backed sender/receiver and drain thread spawn logic build on
 //! top of these primitives.
 
-#![allow(dead_code)]
-
 use std::collections::VecDeque;
-use std::sync::{Arc, Condvar, Mutex};
+use std::future::poll_fn;
+use std::sync::{Arc, Condvar, Mutex, MutexGuard};
+use std::task::{Poll, Waker};
 use std::thread::JoinHandle;
 #[cfg(test)]
 use std::time::Duration;
@@ -42,6 +43,103 @@ use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::common::DataFusionError;
 
+use crate::postgres::customscan::mpp::stage::MppTaskKey;
+
+/// Four-byte magic prefix that marks an MPP-framed message. Receivers that
+/// find this at the start of an incoming byte buffer strip the fixed-size
+/// [`MppFrameHeader`] before handing the remainder to the Arrow IPC reader.
+///
+/// The magic exists so test paths and production paths can share
+/// [`decode_batch`]: unit tests keep sending raw Arrow IPC (no header), the
+/// walker stamps frame ids on every emitted shuffle (`walker::stamp_frame_ids`,
+/// called from `emit_shuffle_cut`), and the receiver auto-detects which
+/// flavor it has. Arrow IPC stream messages start with the continuation
+/// bytes `0xFFFFFFFF`, which can never collide with the `MPPF` magic.
+const FRAME_MAGIC: [u8; 4] = *b"MPPF";
+
+/// On-wire header that prefixes every framed batch. 24 bytes, little-endian.
+/// Mirrors the routing tuple that datafusion-distributed's `FlightAppMetadata`
+/// protobuf carries, minus the transport-specific fields (URL / worker addr)
+/// we don't need when every participant lives in the same DSM segment.
+///
+/// Fields:
+/// - `query_id` (8 B) — `MppExecutionState::query_id()` at plan time.
+/// - `stage_id` (4 B) — boundary's [`MppStage::stage_id`]; disambiguates
+///   multiple cuts in the same plan.
+/// - `task_number` (4 B) — the *sender's* participant index; tells the
+///   receiver which peer produced this batch.
+/// - `partition` (4 B) — the destination partition inside the stage's task.
+///   Today `partition == dest_participant_index` 1:1, but that decoupling is what
+///   P5b (channel flattening) needs to multiplex multiple logical streams
+///   across one shm_mq per peer.
+///
+/// Not `#[repr(C)]`: we hand-encode little-endian via `to_le_bytes` to avoid
+/// unaligned reads on architectures where `u64` needs 8-byte alignment — the
+/// header may start at any offset within the shm_mq payload buffer.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct MppFrameHeader {
+    pub query_id: u64,
+    pub stage_id: u32,
+    pub task_number: u32,
+    pub partition: u32,
+}
+
+/// Size in bytes of [`MppFrameHeader`] on the wire, magic included.
+pub const FRAME_HEADER_LEN: usize = 4 /* magic */ + 8 + 4 + 4 + 4;
+
+impl MppFrameHeader {
+    /// Append the framed header (magic + fields) to `buf`. Caller is expected
+    /// to follow this with the Arrow IPC-encoded payload bytes.
+    fn write_to(&self, buf: &mut Vec<u8>) {
+        buf.extend_from_slice(&FRAME_MAGIC);
+        buf.extend_from_slice(&self.query_id.to_le_bytes());
+        buf.extend_from_slice(&self.stage_id.to_le_bytes());
+        buf.extend_from_slice(&self.task_number.to_le_bytes());
+        buf.extend_from_slice(&self.partition.to_le_bytes());
+    }
+
+    /// Parse a framed header from the start of `bytes`. Returns `Some(hdr)`
+    /// on a valid magic match, `None` if the buffer is too short or the
+    /// magic is missing (unframed legacy payload — pass through to Arrow IPC
+    /// as-is).
+    fn read_from(bytes: &[u8]) -> Option<Self> {
+        if bytes.len() < FRAME_HEADER_LEN || bytes[..4] != FRAME_MAGIC {
+            return None;
+        }
+        let query_id = u64::from_le_bytes(bytes[4..12].try_into().ok()?);
+        let stage_id = u32::from_le_bytes(bytes[12..16].try_into().ok()?);
+        let task_number = u32::from_le_bytes(bytes[16..20].try_into().ok()?);
+        let partition = u32::from_le_bytes(bytes[20..24].try_into().ok()?);
+        Some(Self {
+            query_id,
+            stage_id,
+            task_number,
+            partition,
+        })
+    }
+}
+
+/// Routing tag stamped on every outgoing batch when a sender has opted in via
+/// [`MppSender::with_frame_id`]. `task_key` locates the logical stream
+/// `(query, stage, producing-task)`; `partition` addresses a lane within
+/// that stream.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct FrameId {
+    pub task_key: MppTaskKey,
+    pub partition: u32,
+}
+
+impl FrameId {
+    fn to_header(self) -> MppFrameHeader {
+        MppFrameHeader {
+            query_id: self.task_key.query_id,
+            stage_id: self.task_key.stage_id,
+            task_number: self.task_key.task_number,
+            partition: self.partition,
+        }
+    }
+}
+
 /// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message.
 ///
 /// Test-only allocating wrapper for [`encode_batch_into`]; production hot paths
@@ -50,7 +148,7 @@ use datafusion::common::DataFusionError;
 #[cfg(test)]
 pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
     let mut buf = Vec::with_capacity(1024);
-    encode_batch_into(batch, &mut buf)?;
+    encode_batch_into(batch, &mut buf, None)?;
     Ok(buf)
 }
 
@@ -58,8 +156,21 @@ pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
 /// already-allocated capacity is reused. Caller is expected to hold `buf`
 /// alive across many encode calls (one per sender) so the peak-sized
 /// allocation amortizes.
-pub fn encode_batch_into(batch: &RecordBatch, buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
+///
+/// When `frame` is `Some`, the 24-byte [`MppFrameHeader`] is prepended before
+/// the Arrow IPC bytes so the receiver can route without inspecting the
+/// Arrow schema. Senders that haven't been stamped with a `FrameId` (tests,
+/// in-proc smoke harnesses) pass `None` and write unframed Arrow IPC — the
+/// receiver's `decode_batch` auto-detects either flavor.
+pub fn encode_batch_into(
+    batch: &RecordBatch,
+    buf: &mut Vec<u8>,
+    frame: Option<FrameId>,
+) -> Result<(), DataFusionError> {
     buf.clear();
+    if let Some(frame) = frame {
+        frame.to_header().write_to(buf);
+    }
     let mut writer = StreamWriter::try_new(&mut *buf, batch.schema_ref())?;
     writer.write(batch)?;
     writer.finish()?;
@@ -67,12 +178,32 @@ pub fn encode_batch_into(batch: &RecordBatch, buf: &mut Vec<u8>) -> Result<(), D
 }
 
 /// Inverse of [`encode_batch`]. Expects exactly one batch per message.
+///
+/// Auto-detects the framed wire format: a leading `FRAME_MAGIC` triggers a
+/// 24-byte strip before Arrow IPC decode. Unframed legacy payloads (the
+/// in-proc test path) pass straight through. The parsed [`MppFrameHeader`]
+/// is discarded today — P5b's channel multiplexer will extend this function
+/// (or pair it with `decode_batch_with_frame`) to surface the header to the
+/// receiver-side multiplexer.
 pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusionError> {
-    let mut reader = StreamReader::try_new(bytes, None)?;
+    let (_frame, payload) = peek_frame(bytes);
+    let mut reader = StreamReader::try_new(payload, None)?;
     let batch = reader.next().ok_or_else(|| {
         DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_batch".into())
     })??;
     Ok(batch)
+}
+
+/// Split an incoming byte buffer into `(frame_header, arrow_ipc_payload)`.
+/// `None` header means the buffer is unframed legacy bytes; `payload` is then
+/// the entire input. Used internally by [`decode_batch`] and available for
+/// future per-channel multiplexers that need the routing tag.
+fn peek_frame(bytes: &[u8]) -> (Option<MppFrameHeader>, &[u8]) {
+    if let Some(hdr) = MppFrameHeader::read_from(bytes) {
+        (Some(hdr), &bytes[FRAME_HEADER_LEN..])
+    } else {
+        (None, bytes)
+    }
 }
 
 /// Local queue that sits between the drain thread and the DataFusion consumer.
@@ -103,7 +234,7 @@ struct DrainBufferInner {
     /// DataFusion `poll_next` returns `Poll::Pending` without blocking the
     /// executor thread. `Option` so we don't allocate one if the buffer is
     /// only consumed synchronously via `pop_front`.
-    waker: Option<std::task::Waker>,
+    waker: Option<Waker>,
 }
 
 /// Yielded by [`DrainBuffer::pop_front`].
@@ -208,25 +339,74 @@ impl DrainBuffer {
     /// under peer-to-peer backpressure, where a blocking wait could deadlock
     /// with this worker's own outbound pump.
     ///
-    /// Why hand-rolled instead of `tokio::sync::mpsc`: the producer side is
-    /// a real OS thread (the drain thread) that blocks inside the `shm_mq`
-    /// FFI; it cannot be a Tokio task because `shm_mq_receive` has no async
-    /// readiness signal. Swapping `DrainBuffer` for `mpsc::unbounded_channel`
-    /// and calling `rx.poll_recv(cx)` on the consumer is plausible, but the
-    /// producer stays an OS thread regardless, and the small
-    /// `Mutex<Option<Waker>>` is the entire delta — not load-bearing for
-    /// correctness. Tracked as a post-merge follow-up.
-    pub fn poll_pop_front(&self, waker: &std::task::Waker) -> Option<DrainItem> {
+    /// Producers cannot be async tasks: the drain thread is a real OS
+    /// thread that blocks inside the `shm_mq` FFI (no async readiness
+    /// signal), so it can't be replaced with a `tokio::sync::mpsc::Sender`
+    /// either. The `Mutex<Option<Waker>>` is the consumer-side bridge
+    /// between the OS-thread producer and the executor-task consumer.
+    pub fn poll_pop_front(&self, waker: &Waker) -> Option<DrainItem> {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        if let Some(item) = Self::try_pop_locked(&mut guard) {
+            return Some(item);
+        }
+        // One consumer at a time — DrainGatherStream is the only caller,
+        // and a future plan that wired two readers off the same handle
+        // would silently drop one waker on every register. The check is
+        // a debug_assert so it's free in release; if the invariant is
+        // ever lifted, switch to a `Vec<Waker>` and wake all.
+        debug_assert!(
+            guard.waker.is_none() || guard.waker.as_ref().unwrap().will_wake(waker),
+            "DrainBuffer::poll_pop_front: second consumer registered a different waker — \
+             only one consumer is supported per buffer"
+        );
+        guard.waker = Some(waker.clone());
+        None
+    }
+
+    /// Await-able wrapper over [`poll_pop_front`]. Lets `async_stream::stream!`
+    /// bodies pull from the buffer with `buffer.recv().await` instead of
+    /// hand-rolling a `Stream` impl with manual `Pin`/`Context`/`Poll`
+    /// plumbing.
+    ///
+    /// Suitable for thread-backed handles where a separate producer
+    /// thread pushes via `push_batch`. For cooperative handles the
+    /// producer is the consumer's own task — use [`try_pop`] + an
+    /// executor yield instead, otherwise the await suspends with no
+    /// other task able to wake it.
+    ///
+    /// [`try_pop`]: Self::try_pop
+    pub async fn recv(self: &Arc<Self>) -> DrainItem {
+        let buf = Arc::clone(self);
+        poll_fn(move |cx| match buf.poll_pop_front(cx.waker()) {
+            Some(item) => Poll::Ready(item),
+            None => Poll::Pending,
+        })
+        .await
+    }
+
+    /// Non-blocking, non-waker variant of [`poll_pop_front`]. Returns the
+    /// front item or `DrainItem::Eof` if all sources have detached and
+    /// the queue is drained; returns `None` only when more data may yet
+    /// arrive. Cooperative consumers loop on `poll_drain_pass` + `try_pop`,
+    /// yielding to the executor between iterations.
+    pub fn try_pop(&self) -> Option<DrainItem> {
+        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+        Self::try_pop_locked(&mut guard)
+    }
+
+    /// Shared body of [`try_pop`] and [`poll_pop_front`]. Returns
+    /// `Some(Batch)` if the queue has data, `Some(Eof)` if all sources
+    /// have detached or the buffer is cancelled, and `None` otherwise.
+    /// Lets the two public entry points stay in lockstep on the
+    /// "buffered data wins over cancellation/EOF" invariant locked in
+    /// by `drain_buffer_drains_buffered_before_eof`.
+    fn try_pop_locked(guard: &mut MutexGuard<'_, DrainBufferInner>) -> Option<DrainItem> {
         if let Some(batch) = guard.queue.pop_front() {
             return Some(DrainItem::Batch(batch));
         }
         if guard.cancelled || guard.sources_done >= guard.num_sources {
             return Some(DrainItem::Eof);
         }
-        // Register (or replace) the waker. Only one consumer at a time is
-        // expected — DrainGatherStream — so simple replacement is fine.
-        guard.waker = Some(waker.clone());
         None
     }
 }
@@ -282,6 +462,13 @@ pub trait BatchChannelSender: Send {
 pub struct MppSender {
     channel: Box<dyn BatchChannelSender>,
     cooperative_drain: Option<Arc<DrainHandle>>,
+    /// Routing header stamped on every outgoing batch. Set via
+    /// [`Self::with_frame_id`] at bridge-construction time so peers know
+    /// which `(query, stage, task, partition)` each batch belongs to once
+    /// P5b multiplexes multiple logical streams over one shm_mq. `None`
+    /// for test paths and pre-P5 callers: [`decode_batch`] auto-handles
+    /// both flavors by sniffing the magic prefix.
+    frame_id: Option<FrameId>,
     /// Scratch buffer reused across every `encode_batch_into` on this
     /// sender. Sized by the first batch; subsequent batches clear and
     /// re-fill without reallocating. Interior mutability lets the caller
@@ -290,11 +477,25 @@ pub struct MppSender {
     scratch: std::cell::RefCell<Vec<u8>>,
 }
 
+// SAFETY: `MppSender` lives inside `ShuffleWiring`, which is owned by a
+// single `ShuffleExec` running on a single backend thread. The async
+// `send_batch_traced` future captures `&self` and contains a Tokio
+// `yield_now().await`; the compiler conservatively requires the future
+// to be `Send`, which forces `&MppSender: Send` and therefore
+// `MppSender: Sync`. At runtime the future is created and consumed on
+// the same thread (DataFusion's current-thread runtime on the backend),
+// so there is no actual cross-thread aliasing of the inner `RefCell` or
+// of the `Box<dyn BatchChannelSender>`. This mirrors the same
+// single-thread-by-construction contract that justifies
+// `unsafe impl Send for ShmMqSender` over in `mesh.rs`.
+unsafe impl Sync for MppSender {}
+
 impl MppSender {
     pub fn new(channel: Box<dyn BatchChannelSender>) -> Self {
         Self {
             channel,
             cooperative_drain: None,
+            frame_id: None,
             scratch: std::cell::RefCell::new(Vec::new()),
         }
     }
@@ -306,6 +507,31 @@ impl MppSender {
     pub fn with_cooperative_drain(mut self, drain: Arc<DrainHandle>) -> Self {
         self.cooperative_drain = Some(drain);
         self
+    }
+
+    /// Stamp every outgoing batch with `task_key` + `partition`. Called by
+    /// `walker::stamp_frame_ids` (from `emit_shuffle_cut`) so the wire
+    /// format carries enough routing information to multiplex multiple
+    /// logical streams across one shm_mq (groundwork for P5b's N×(N−1)
+    /// channel flattening). Today the receiver accepts framed bytes,
+    /// discards the header, and returns the decoded batch; P5b will plug
+    /// in a per-channel dispatcher that uses `(stage_id, task_number,
+    /// partition)` to route batches to the right `DrainBuffer`.
+    pub fn with_frame_id(mut self, task_key: MppTaskKey, partition: u32) -> Self {
+        self.frame_id = Some(FrameId {
+            task_key,
+            partition,
+        });
+        self
+    }
+
+    /// Inspect the stamped routing tag. `None` until `with_frame_id` is
+    /// called; the bridges always stamp in production. Test-only in the
+    /// current tree — exposed so unit tests can assert the bridge plumbing
+    /// wired the right tag to the right sender.
+    #[cfg(test)]
+    pub fn frame_id(&self) -> Option<FrameId> {
+        self.frame_id
     }
 
     /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
@@ -359,7 +585,7 @@ impl MppSender {
         stats: &mut SendBatchStats,
     ) -> Result<(), DataFusionError> {
         let t_enc = std::time::Instant::now();
-        encode_batch_into(batch, scratch)?;
+        encode_batch_into(batch, scratch, self.frame_id)?;
         stats.encode += t_enc.elapsed();
         let Some(drain) = self.cooperative_drain.as_ref() else {
             // No drain attached (unit tests, in-proc channels): fall
@@ -822,6 +1048,73 @@ mod tests {
             let decoded = decode_batch(&bytes).expect("decode");
             assert_eq!(orig.num_rows(), decoded.num_rows());
         }
+    }
+
+    #[test]
+    fn framed_round_trip_preserves_payload_and_strips_header() {
+        // Explicit frame round-trip: encode with a stamped header, then decode
+        // through the auto-detecting `decode_batch`. The magic prefix must
+        // be recognized and stripped before the Arrow IPC reader sees the
+        // bytes — otherwise StreamReader would either error or misread
+        // whatever happened to follow the magic.
+        let orig = sample_batch(17);
+        let frame = FrameId {
+            task_key: MppTaskKey {
+                query_id: 0xdead_beef_cafe_babe,
+                stage_id: 2,
+                task_number: 1,
+            },
+            partition: 3,
+        };
+        let mut buf = Vec::new();
+        encode_batch_into(&orig, &mut buf, Some(frame)).expect("encode framed");
+
+        // Wire invariant: magic at offset 0, then 20 bytes of fields, then
+        // the arrow stream begins. If any of these break, the field layout
+        // must be bumped and peers must agree on the new shape.
+        assert_eq!(&buf[..4], b"MPPF");
+        let hdr = MppFrameHeader::read_from(&buf).expect("header readable");
+        assert_eq!(hdr.query_id, 0xdead_beef_cafe_babe);
+        assert_eq!(hdr.stage_id, 2);
+        assert_eq!(hdr.task_number, 1);
+        assert_eq!(hdr.partition, 3);
+
+        let decoded = decode_batch(&buf).expect("decode");
+        assert_eq!(orig.num_rows(), decoded.num_rows());
+        assert_eq!(orig.schema(), decoded.schema());
+    }
+
+    #[test]
+    fn frame_header_len_matches_actual_encoded_bytes() {
+        // Lock `FRAME_HEADER_LEN` to the byte count `MppFrameHeader::write_to`
+        // actually emits. A refactor that adds a field without updating the
+        // const would silently shift the IPC stream offset and corrupt every
+        // future framed batch.
+        let orig = sample_batch(1);
+        let frame = FrameId {
+            task_key: MppTaskKey {
+                query_id: 1,
+                stage_id: 2,
+                task_number: 3,
+            },
+            partition: 4,
+        };
+        let mut framed = Vec::new();
+        encode_batch_into(&orig, &mut framed, Some(frame)).unwrap();
+        let unframed = encode_batch(&orig).unwrap();
+        assert_eq!(framed.len() - unframed.len(), FRAME_HEADER_LEN);
+    }
+
+    #[test]
+    fn unframed_bytes_still_decode() {
+        // Regression-proof: raw Arrow IPC (no header) decodes via the same
+        // public entry point. Every existing #[cfg(test)] caller relies on
+        // this — they never opt into `with_frame_id`.
+        let orig = sample_batch(5);
+        let bytes = encode_batch(&orig).expect("encode unframed");
+        assert_ne!(&bytes[..4], b"MPPF");
+        let decoded = decode_batch(&bytes).expect("decode");
+        assert_eq!(orig.num_rows(), decoded.num_rows());
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Transport layer for MPP shuffle.
 //!
 //! Layout:

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -63,7 +63,8 @@ const FRAME_MAGIC: [u8; 4] = *b"MPPF";
 ///
 /// Fields:
 /// - `query_id` (8 B) — `MppExecutionState::query_id()` at plan time.
-/// - `stage_id` (4 B) — boundary's [`MppStage::stage_id`]; disambiguates
+/// - `stage_id` (4 B) — boundary's stage number (`Stage::num` on the
+///   walker's stamped [`datafusion_distributed::Stage`]); disambiguates
 ///   multiple cuts in the same plan.
 /// - `task_number` (4 B) — the *sender's* participant index; tells the
 ///   receiver which peer produced this batch.

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -23,7 +23,7 @@
 //! network boundary, and rewrites those cuts to emit
 //! [`ShuffleExec`](crate::postgres::customscan::mpp::shuffle::ShuffleExec) +
 //! [`DrainGatherExec`](crate::postgres::customscan::mpp::shuffle::DrainGatherExec)
-//! pairs whose [`MppNetworkBoundary::input_stage`] is stamped by the walker.
+//! pairs whose [`NetworkBoundary::input_stage`] is stamped by the walker.
 //!
 //! # What this module does
 //!
@@ -125,10 +125,11 @@ use super::shape::MppPlanShape;
 use super::shuffle::{
     FixedTargetPartitioner, HashPartitioner, MppShuffleExec, RowPartitioner, ShuffleWiring,
 };
-use super::stage::{MppStage, MppTaskKey};
+use super::stage::MppTaskKey;
 use super::transport::{DrainBuffer, DrainHandle, MppReceiver, MppSender};
 use super::worker::{LeaderMesh, WorkerMesh};
 use crate::scan::execution_plan::PgSearchScanPlan;
+use datafusion_distributed::Stage;
 
 /// How many shuffle cuts the walker will insert for `shape`. Called by the
 /// DSM-estimate hooks in `aggregatescan/mod.rs` and `joinscan/mod.rs` at
@@ -165,7 +166,7 @@ pub fn worst_case_cut_count() -> u32 {
 
 /// Walk `standard` and rewrite it into an MPP-partitioned plan by
 /// identifying cut points and inserting `ShuffleExec` / `DrainGatherExec`
-/// pairs stamped with an [`MppStage`].
+/// pairs stamped with an input [`Stage`].
 ///
 /// Topology is derived from plan structure — the walker locates
 /// `HashJoinExec` and any `AggregateExec(Partial|Single)` above it, and
@@ -651,11 +652,19 @@ impl MppBoundaryFactory {
                      insert_mpp_cuts / cut_count_for_shape disagree"
                 ))
             })?;
-        let stage = MppStage::new(self.query_id, cut_index, self.total_participants);
+        // ParadeDB's u64 `query_id` round-trips as the low 64 bits of the
+        // fork's UUID (`Uuid::from_u128(query_id as u128)`). The wire-format
+        // [`MppTaskKey`] is reconstructed from the local primitives below,
+        // not from the Stage, so the conversion stays at this single seam.
+        let stage = Stage::new_unaddressed(
+            Uuid::from_u128(self.query_id as u128),
+            cut_index as usize,
+            self.total_participants as usize,
+        );
         let drain = spawn_drain(mesh.inbound);
         let task_key = MppTaskKey {
-            query_id: stage.query_id,
-            stage_id: stage.stage_id,
+            query_id: self.query_id,
+            stage_id: cut_index,
             task_number: self.participant_index,
         };
         let outbound = attach_cooperative_drain(stamp_frame_ids(mesh.outbound, task_key), &drain);
@@ -942,8 +951,8 @@ fn distribute_plan_generic(
     // Drive the fork's walker through our `MppBoundaryFactory`. The fork's
     // `_distribute_plan` increments `stage_id` once per emitted boundary
     // bottom-up, which is exactly the cut index our `tag_for_cut` and
-    // `MppStage::new` consume. Starting from 0 keeps the tag mapping
-    // identical to the legacy walker.
+    // `Stage::new_unaddressed` consume. Starting from 0 keeps the tag
+    // mapping identical to the legacy walker.
     let factory = MppBoundaryFactory::from_state(mpp_state, shape, expected_cuts);
     // Fork's `_distribute_plan` calls `DistributedConfig::from_config_options`
     // which expects the extension to be registered. We don't tune any
@@ -2057,12 +2066,11 @@ mod tests {
             Some(MppSender::new(Box::new(tx3))),
         ];
 
-        let stage = MppStage::new(0xa5a5, 2, 4);
         let stamped = stamp_frame_ids(
             senders,
             MppTaskKey {
-                query_id: stage.query_id,
-                stage_id: stage.stage_id,
+                query_id: 0xa5a5,
+                stage_id: 2,
                 task_number: 0, // pretend we're participant 0
             },
         );
@@ -2481,7 +2489,7 @@ mod tests {
     // 2c-ii). The `Plan` arm exercises `with_new_children` recursion; the
     // `Shuffle` and `Coalesce` arms hit `wrap_with_mpp_shuffle` against a
     // synthetic in-process mesh and verify the resulting tree embeds the
-    // expected number of `ShuffleExec` nodes with stamped `MppStage` ids.
+    // expected number of `ShuffleExec` nodes with stamped input `Stage` ids.
     // ========================================================================
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -1,0 +1,2542 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#![allow(dead_code)]
+//! Generic cut walker (`distribute_plan`).
+//!
+//! Ported in spirit from datafusion-contrib/datafusion-distributed's
+//! `src/distributed_planner/distribute_plan.rs`. Walks a DataFusion physical
+//! plan once, identifies the cut points where the plan needs to cross a
+//! network boundary, and rewrites those cuts to emit
+//! [`ShuffleExec`](crate::postgres::customscan::mpp::shuffle::ShuffleExec) +
+//! [`DrainGatherExec`](crate::postgres::customscan::mpp::shuffle::DrainGatherExec)
+//! pairs whose [`MppNetworkBoundary::input_stage`] is stamped by the walker.
+//!
+//! # What this module does
+//!
+//! [`distribute_plan`] is the single entry point callers invoke to turn a
+//! standard DataFusion physical plan into its MPP-partitioned equivalent.
+//! Cut detection is derived from plan structure — the walker looks for a
+//! `HashJoinExec` and any `AggregateExec(Partial|Single)` above it, and
+//! picks the right topology (scalar-agg, group-by-agg, or bare-join)
+//! from that in situ rather than trusting an out-of-band shape enum.
+//! The caller's [`MppPlanShape`] is kept around as a sanity cross-check
+//! against the derivation, and its only other role is sizing the DSM
+//! region at plan time via [`cut_count_for_shape`].
+//!
+//! # Visibility correctness (invariant enforced here)
+//!
+//! `VisibilityFilterExec` resolves per-segment packed DocAddress keys to
+//! heap TIDs using segment-local Tantivy state plus a ctid-resolver table
+//! keyed by `(plan_position, seg_ord)` that lists segments **local to this
+//! participant**. Every [`ShuffleExec`] cut must therefore sit **inside** the subtree
+//! of every [`VisibilityFilterExec`] the plan contains — i.e. no
+//! `VisibilityFilterExec` may be a descendant of a `ShuffleExec`. Inverting
+//! that placement means a row from participant A would reach participant B's resolver with
+//! a `seg_ord` that addresses A's segment catalog; the lookup would return
+//! the wrong heap TID (or panic in `heap_fetch` if the slot is absent).
+//! [`assert_visibility_invariant`] walks the finished MPP plan and rejects it
+//! with `DataFusionError::Plan` if that invariant is violated.
+//!
+//! The same constraint applies to other segment-local scan adornments
+//! (`SegmentedTopKExec` pre-merge, `TantivyLookupExec`, etc.): they must
+//! remain on the scan side of every cut. Today only
+//! `VisibilityFilterExec` is asserted because it's the one that causes
+//! `heap_fetch` panics; extending the assert to the other node types is
+//! mechanical but out of scope until one of them is re-introduced as a
+//! cross-shuffle risk.
+//!
+//! # Mesh allocation timing
+//!
+//! The walker exposes [`cut_count_for_shape`] so the DSM-estimate hook can
+//! size the region at **plan time** without needing to run the full walker
+//! inside the hook. Overestimating is cheap (one unused `shm_mq` region per
+//! edge, dropped on tear-down) — the hook is free to round up via
+//! [`worst_case_cut_count`] when the shape is not yet classified.
+//!
+//! # Leader/worker mesh-index contract
+//!
+//! Every topology consumes a contiguous slice of `MppExecutionState::meshes`
+//! in a fixed order shared by every participant:
+//!
+//! - `meshes[0]` is wired into the **left** join input's shuffle.
+//! - `meshes[1]` is wired into the **right** join input's shuffle.
+//! - `meshes[2]` (when present) is the post-join mesh — either
+//!   **final-gather-to-leader** (scalar-agg, `FixedTargetPartitioner(0)`)
+//!   or **hash-partition on group keys** (group-by-agg, `HashPartitioner`).
+//!
+//! `JoinOnly` uses only meshes 0 and 1. Mesh ordering must be identical on
+//! every participant — the meshes themselves are symmetric, but a mismatch would
+//! route left rows to the right drain and break correctness.
+
+#![allow(deprecated)] // `CoalesceBatchesExec` is deprecated in favor of
+                      // arrow-rs's streaming `BatchCoalescer`, but DataFusion
+                      // 52 still emits it as a plan node and we must recognize
+                      // + reuse it.
+
+#[cfg(test)]
+use datafusion_distributed::require_one_child;
+use datafusion_distributed::{
+    distribute_annotated_plan, AnnotatedPlan, BoundaryFactory, DistributedConfig,
+    PlanOrNetworkBoundary, TaskCountAnnotation,
+};
+use std::collections::VecDeque;
+use std::mem;
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+#[cfg(test)]
+use datafusion::arrow::datatypes::SchemaRef;
+use datafusion::common::config::ConfigOptions;
+use datafusion::common::{DataFusionError, Result as DfResult};
+use datafusion::physical_expr::expressions::Column;
+use datafusion::physical_expr::{Partitioning, PhysicalExpr};
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
+use datafusion::physical_plan::aggregates::{AggregateExec, AggregateMode, PhysicalGroupBy};
+use datafusion::physical_plan::coalesce_batches::CoalesceBatchesExec;
+use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
+use datafusion::physical_plan::filter::FilterExec;
+use datafusion::physical_plan::joins::{HashJoinExec, PartitionMode};
+use datafusion::physical_plan::limit::GlobalLimitExec;
+use datafusion::physical_plan::repartition::RepartitionExec;
+use datafusion::physical_plan::sorts::sort::SortExec;
+use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMergeExec;
+use datafusion::physical_plan::ExecutionPlan;
+
+use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
+use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
+
+use super::customscan_glue::MppExecutionState;
+use super::plan_build::{wrap_with_mpp_shuffle, MppShuffleInputs};
+use super::shape::MppPlanShape;
+use super::shuffle::{
+    FixedTargetPartitioner, HashPartitioner, MppShuffleExec, RowPartitioner, ShuffleWiring,
+};
+use super::stage::{MppStage, MppTaskKey};
+use super::transport::{DrainBuffer, DrainHandle, MppReceiver, MppSender};
+use super::worker::{LeaderMesh, WorkerMesh};
+use crate::scan::execution_plan::PgSearchScanPlan;
+
+/// How many shuffle cuts the walker will insert for `shape`. Called by the
+/// DSM-estimate hooks in `aggregatescan/mod.rs` and `joinscan/mod.rs` at
+/// plan time to size the shared-memory region before the walker has a
+/// concrete plan to inspect.
+pub fn cut_count_for_shape(shape: MppPlanShape) -> u32 {
+    match shape {
+        MppPlanShape::ScalarAggOnBinaryJoin => 3,
+        MppPlanShape::GroupByAggOnBinaryJoin => 3,
+        // TopK groupby reuses scalar-style routing (FixedTargetPartitioner
+        // postagg → leader gathers all groups), so 3 cuts: left, right,
+        // postagg-to-leader.
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => 3,
+        MppPlanShape::JoinOnly => 2,
+        MppPlanShape::GroupByAggSingleTable => 1,
+        MppPlanShape::Ineligible => 0,
+    }
+}
+
+/// Upper bound on the number of cuts the walker can produce for any
+/// supported shape. Used by the DSM estimate hook when the walker hasn't
+/// been run yet (or when we don't want to risk running DataFusion physical
+/// planning from inside the hook).
+///
+/// Safe to overestimate: an unused mesh wiring costs one `shm_mq` region
+/// per edge and is dropped during `attach_cooperative_drain` / `take_meshes`.
+#[allow(dead_code)]
+pub fn worst_case_cut_count() -> u32 {
+    cut_count_for_shape(MppPlanShape::ScalarAggOnBinaryJoin)
+        .max(cut_count_for_shape(MppPlanShape::GroupByAggOnBinaryJoin))
+        .max(cut_count_for_shape(MppPlanShape::GroupByAggSingleTable))
+        .max(cut_count_for_shape(MppPlanShape::JoinOnly))
+}
+
+/// Walk `standard` and rewrite it into an MPP-partitioned plan by
+/// identifying cut points and inserting `ShuffleExec` / `DrainGatherExec`
+/// pairs stamped with an [`MppStage`].
+///
+/// Topology is derived from plan structure — the walker locates
+/// `HashJoinExec` and any `AggregateExec(Partial|Single)` above it, and
+/// picks the right assembler from there. `shape` is kept as an explicit
+/// parameter so the pre-classified shape from `aggregatescan` / `joinscan`
+/// can be cross-checked against the derivation; a disagreement aborts the
+/// query via `DataFusionError::Plan` rather than silently executing the
+/// wrong topology.
+///
+/// Before returning, the built plan is validated against the visibility
+/// invariant (see module doc). A violation aborts the query with
+/// `DataFusionError::Plan` rather than risk a `heap_fetch` panic at
+/// execution.
+pub fn distribute_plan(
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+    shape: MppPlanShape,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let total = mpp_state.participant_config().total_participants;
+
+    crate::mpp_log!(
+        "mpp: distribute_plan walker dispatching shape={:?} total={} cuts={}",
+        shape,
+        total,
+        cut_count_for_shape(shape)
+    );
+
+    // Derive topology from plan structure. `find_partial_agg` walks through
+    // `AggregateExec(Final*)` / `CoalescePartitionsExec` / `CoalesceBatchesExec`
+    // layers to reach a `Partial|Single` aggregate; `find_hash_join` does the
+    // same to reach a `HashJoinExec`. Combined presence of the two + whether
+    // the partial agg has group-by keys picks one of three assemblers.
+    let partial_agg_opt = find_partial_agg(standard.as_ref());
+    let hash_join_opt = find_hash_join(standard.as_ref());
+
+    // Detect TopK structure before dispatch. Cheap walk; only relevant
+    // when there's a Partial+HashJoin pair below an outer Sort/Limit.
+    let topk_spec = if partial_agg_opt.is_some() && hash_join_opt.is_some() {
+        extract_topk_spec(standard.as_ref())
+    } else {
+        None
+    };
+
+    let built = match (partial_agg_opt, hash_join_opt) {
+        // Partial agg with empty group keys on top of a HashJoin — scalar agg.
+        (Some(agg), Some(_)) if agg.group_expr().expr().is_empty() => {
+            validate_shape_matches(shape, MppPlanShape::ScalarAggOnBinaryJoin)?;
+            distribute_plan_generic(
+                MppPlanShape::ScalarAggOnBinaryJoin,
+                standard,
+                mpp_state,
+                None,
+            )?
+        }
+        // Partial agg with group-by keys on top of a HashJoin AND an
+        // outer SortExec[fetch=k] — TopK group-by agg. The classifier
+        // (which only saw the logical plan) called this
+        // GroupByAggOnBinaryJoin; the structural derivation upgrades.
+        (Some(_), Some(_)) if topk_spec.is_some() => {
+            validate_shape_matches_topk_upgrade(shape)?;
+            distribute_plan_generic(
+                MppPlanShape::TopKGroupByAggOnBinaryJoin,
+                standard,
+                mpp_state,
+                topk_spec,
+            )?
+        }
+        // Partial agg with group-by keys on top of a HashJoin — group-by agg.
+        (Some(_), Some(_)) => {
+            validate_shape_matches(shape, MppPlanShape::GroupByAggOnBinaryJoin)?;
+            distribute_plan_generic(
+                MppPlanShape::GroupByAggOnBinaryJoin,
+                standard,
+                mpp_state,
+                None,
+            )?
+        }
+        // HashJoin without a Partial agg above — bare join.
+        //
+        // Step 2d: all three supported shapes route through the DF-D-aligned
+        // generic pipeline (`prepare_for_mpp` → `insert_mpp_cuts` →
+        // `annotate_plan` → `_distribute_plan` → `finalize_for_mpp`). The
+        // legacy topology assemblers below are retained `#[allow(dead_code)]`
+        // until Step 2e deletes them.
+        (None, Some(_)) => {
+            validate_shape_matches(shape, MppPlanShape::JoinOnly)?;
+            distribute_plan_generic(MppPlanShape::JoinOnly, standard, mpp_state, None)?
+        }
+        // Partial agg without HashJoin — e.g. GroupByAggSingleTable, not yet
+        // wired through the assembler code.
+        (Some(_), None) => {
+            return Err(DataFusionError::Plan(
+                "mpp: distribute_plan: aggregate-on-single-table shape not yet implemented \
+                 (no HashJoinExec in plan)"
+                    .into(),
+            ));
+        }
+        // Neither — the caller's classifier should have routed to serial.
+        (None, None) => {
+            return Err(DataFusionError::Plan(
+                "mpp: distribute_plan invoked on an ineligible plan — no HashJoinExec \
+                 found; caller should have routed to the non-MPP serial path"
+                    .into(),
+            ));
+        }
+    };
+
+    assert_visibility_invariant(&built)?;
+    Ok(built)
+}
+
+/// Cross-check the pre-classified shape (from the planner) against the
+/// walker's structural derivation. Disagreement means either the planner
+/// mis-classified the query or the standard physical plan diverged from
+/// what the classifier saw — either way, executing anyway would produce
+/// wrong results for the shape we actually have.
+fn validate_shape_matches(classified: MppPlanShape, derived: MppPlanShape) -> DfResult<()> {
+    if classified == derived {
+        Ok(())
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "mpp: walker shape derivation mismatch — classifier said {classified:?} \
+             but plan structure implies {derived:?}"
+        )))
+    }
+}
+
+/// Accept the classifier's `GroupByAggOnBinaryJoin` as a valid match
+/// when the structural derivation upgrades to
+/// `TopKGroupByAggOnBinaryJoin`. The classifier only sees the logical
+/// plan and can't predict whether DataFusion's physical planner will
+/// fuse `Sort[fetch=k]` over the agg; the dispatcher refines based on
+/// the physical plan it actually got.
+fn validate_shape_matches_topk_upgrade(classified: MppPlanShape) -> DfResult<()> {
+    if matches!(classified, MppPlanShape::GroupByAggOnBinaryJoin) {
+        Ok(())
+    } else {
+        Err(DataFusionError::Plan(format!(
+            "mpp: walker shape derivation mismatch — classifier said {classified:?} \
+             but plan structure implies TopKGroupByAggOnBinaryJoin (only \
+             GroupByAggOnBinaryJoin upgrades to TopK)"
+        )))
+    }
+}
+
+// ============================================================================
+// Generic cut walker (dead-code scaffolding ported from
+// datafusion-contrib/datafusion-distributed).
+//
+// Port aims to match DF-D's `src/distributed_planner/plan_annotator.rs` and
+// `src/common/children_helpers.rs` as closely as ParadeDB allows. The three
+// deviations are all driven by ParadeDB constraints, not aesthetics:
+//
+//   * DF-D's `PlanOrNetworkBoundary::Broadcast` variant is dropped because
+//     ParadeDB doesn't do broadcast joins.
+//   * DF-D's `AnnotatedPlan::task_count` field is dropped because ParadeDB's
+//     participant count is fixed by `MppParticipantConfig::total_participants`
+//     at plan time — no task estimators, no cardinality scale factors, no
+//     propagation passes needed.
+//   * DF-D's `annotate_plan` / `_annotate_plan` are `async` to accommodate
+//     task-estimator I/O; ParadeDB's are sync because there's nothing to
+//     await.
+//
+// All three live shapes (`JoinOnly`, `ScalarAggOnBinaryJoin`,
+// `GroupByAggOnBinaryJoin`) flow through `distribute_plan_generic`
+// (`prepare_for_mpp` → `insert_mpp_cuts` → `annotate_plan` →
+// `_distribute_plan` → `finalize_for_mpp`). The legacy topology assemblers
+// are gone; this generic pipeline is the only path.
+// `Ineligible` and `GroupByAggSingleTable` error out at the dispatcher.
+// ============================================================================
+
+// `PlanOrNetworkBoundary` and `AnnotatedPlan` are now imported from the
+// `datafusion-distributed` fork (the `paradedb/boundary-factory` branch).
+// The fork's variant of `PlanOrNetworkBoundary` has a `Broadcast` arm that
+// ParadeDB never emits — `_annotate_plan` below produces only `Plan`,
+// `Shuffle`, and `Coalesce` annotations, and `MppBoundaryFactory::broadcast`
+// errors loudly if the fork's walker ever asks for one.
+
+/// Annotates recursively an [`ExecutionPlan`] and its children with
+/// information about whether a network boundary is needed below it. Ported
+/// from DF-D's `annotate_plan` minus `async`, `DistributedConfig`,
+/// `TaskEstimator`, `children_isolator_unions`, `propagate_task_count`, and
+/// the `Broadcast` cut trigger (none of which apply to ParadeDB).
+///
+/// The two cut triggers preserved verbatim are:
+///
+/// * `RepartitionExec(Hash)` → annotate with `Shuffle`.
+/// * Any non-leaf plan whose parent is `CoalescePartitionsExec` or
+///   `SortPreservingMergeExec` → annotate with `Coalesce`.
+///
+/// Running this over ParadeDB's serial standard plan (as produced by
+/// `exec_datafusion_aggregate`) yields zero network-boundary annotations
+/// because the serial plan emits neither trigger. Step 2b adds
+/// `insert_mpp_cuts`, a pre-pass that synthesizes the expected markers per
+/// [`MppPlanShape`] before this walker runs.
+pub(super) fn annotate_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    total_participants: u32,
+) -> DfResult<AnnotatedPlan> {
+    let task_count = TaskCountAnnotation::Desired(total_participants as usize);
+    _annotate_plan(plan, None, task_count)
+}
+
+fn _annotate_plan(
+    plan: Arc<dyn ExecutionPlan>,
+    parent: Option<&Arc<dyn ExecutionPlan>>,
+    task_count: TaskCountAnnotation,
+) -> DfResult<AnnotatedPlan> {
+    let annotated_children: Vec<AnnotatedPlan> = plan
+        .children()
+        .into_iter()
+        .map(|child| _annotate_plan(Arc::clone(child), Some(&plan), task_count.clone()))
+        .collect::<DfResult<Vec<_>>>()?;
+
+    // Wrap the node with a boundary node if the parent marks it.
+    let mut annotation = AnnotatedPlan {
+        plan_or_nb: PlanOrNetworkBoundary::Plan(Arc::clone(&plan)),
+        children: annotated_children,
+        task_count: task_count.clone(),
+    };
+
+    // Upon reaching a hash repartition, we need to introduce a shuffle right above it.
+    if let Some(r_exec) = plan.as_any().downcast_ref::<RepartitionExec>() {
+        if matches!(r_exec.partitioning(), Partitioning::Hash(_, _)) {
+            annotation = AnnotatedPlan {
+                plan_or_nb: PlanOrNetworkBoundary::Shuffle,
+                children: vec![annotation],
+                task_count: task_count.clone(),
+            };
+        }
+    } else if let Some(parent) = parent {
+        // DF-D expresses this as a single `else if let` + `&&` chain; Rust
+        // 2021 doesn't allow let-chains, so split into nested ifs. Comments
+        // preserved verbatim.
+        //
+        // If this node is a leaf node, putting a network boundary above is a bit wasteful, so
+        // we don't want to do it.
+        // If the parent is trying to coalesce all partitions into one, we need to introduce
+        // a network coalesce right below it (or in other words, above the current node)
+        if !plan.children().is_empty()
+            && (parent.as_any().is::<CoalescePartitionsExec>()
+                || parent.as_any().is::<SortPreservingMergeExec>())
+        {
+            annotation = AnnotatedPlan {
+                plan_or_nb: PlanOrNetworkBoundary::Coalesce,
+                children: vec![annotation],
+                task_count,
+            };
+        }
+    }
+
+    Ok(annotation)
+}
+
+/// Pre-pass: rewrite a ParadeDB "standard" physical plan so it carries the
+/// `RepartitionExec(Hash)` / `CoalescePartitionsExec` markers the DF-D
+/// generic walker treats as cut triggers.
+///
+/// ParadeDB's standard plan (as produced by `exec_datafusion_aggregate`) is
+/// single-partition and emits neither marker: the `HashJoinExec` is
+/// `CollectLeft` with serial left/right scans, there's no upstream
+/// `RepartitionExec`, and the aggregate chain has no `CoalescePartitionsExec`
+/// above the `Partial` because there's only one input partition to begin
+/// with. Running [`annotate_plan`] directly over that plan yields zero
+/// boundary annotations.
+///
+/// This function closes that gap by shape:
+///
+/// * [`MppPlanShape::JoinOnly`] — wrap `HashJoinExec.left()` and `.right()`
+///   in `RepartitionExec(Hash(key))`. Two Shuffle triggers result.
+///
+/// * [`MppPlanShape::ScalarAggOnBinaryJoin`] — the two pre-join
+///   `RepartitionExec(Hash(key))` above, plus a `CoalescePartitionsExec`
+///   wrapping the `AggregateExec(Partial)`. The two pre-join wrappers give
+///   Shuffle triggers; the coalesce wrapper gives a Coalesce trigger above
+///   the Partial whose Step-2c rewrite emits a `FixedTargetPartitioner(0)`
+///   (final-gather to leader).
+///
+/// * [`MppPlanShape::GroupByAggOnBinaryJoin`] — the two pre-join
+///   `RepartitionExec(Hash(key))` above, plus a
+///   `RepartitionExec(Hash(group_keys))` wrapping the `AggregateExec(Partial)`.
+///   Three Shuffle triggers; the post-Partial one drives the postagg shuffle
+///   with a `HashPartitioner` in Step 2c.
+///
+/// The rewrite walks bottom-up so rewrites of descendants compose cleanly
+/// with rewrites of ancestors (e.g. the scalar-agg Partial wrap must see
+/// the already-shuffled join as its grandchild).
+pub(super) fn insert_mpp_cuts(
+    plan: Arc<dyn ExecutionPlan>,
+    shape: MppPlanShape,
+    total_participants: u32,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let kind = match shape {
+        MppPlanShape::ScalarAggOnBinaryJoin => CutKind::ScalarAgg,
+        MppPlanShape::GroupByAggOnBinaryJoin => CutKind::GroupByAgg,
+        // TopK uses scalar-style postagg cut: wrap Partial in
+        // `CoalescePartitionsExec` so the walker emits a
+        // `FixedTargetPartitioner(0)` shuffle that ships every
+        // participant's groups to the leader. The leader's finalize
+        // wraps with `FinalPartitioned + SortExec[fetch=k]`.
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => CutKind::TopKGroupByAgg,
+        MppPlanShape::JoinOnly => CutKind::JoinOnly,
+        MppPlanShape::GroupByAggSingleTable => {
+            return Err(DataFusionError::Plan(
+                "mpp: insert_mpp_cuts: GroupByAggSingleTable not yet supported".into(),
+            ));
+        }
+        MppPlanShape::Ineligible => {
+            return Err(DataFusionError::Plan(
+                "mpp: insert_mpp_cuts invoked on Ineligible shape — caller should have \
+                 routed to the non-MPP serial path"
+                    .into(),
+            ));
+        }
+    };
+    rewrite_with_cuts(plan, kind, total_participants)
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CutKind {
+    ScalarAgg,
+    GroupByAgg,
+    /// Like `ScalarAgg` topology-wise (CoalescePartitionsExec wrapping
+    /// → `FixedTargetPartitioner(0)` postagg), but the Partial may have
+    /// group keys; the leader resolves the global Top-K after gathering.
+    TopKGroupByAgg,
+    JoinOnly,
+}
+
+fn rewrite_with_cuts(
+    plan: Arc<dyn ExecutionPlan>,
+    kind: CutKind,
+    n: u32,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    // Recurse into children first so rewrites compose bottom-up.
+    let original_children: Vec<Arc<dyn ExecutionPlan>> =
+        plan.children().iter().map(|c| Arc::clone(c)).collect();
+    let new_children: Vec<Arc<dyn ExecutionPlan>> = original_children
+        .iter()
+        .map(|c| rewrite_with_cuts(Arc::clone(c), kind, n))
+        .collect::<DfResult<Vec<_>>>()?;
+
+    let any_child_changed = original_children
+        .iter()
+        .zip(new_children.iter())
+        .any(|(a, b)| !Arc::ptr_eq(a, b));
+    let plan = if any_child_changed {
+        Arc::clone(&plan).with_new_children(new_children)?
+    } else {
+        plan
+    };
+
+    // HashJoinExec — wrap its left / right inputs with RepartitionExec(Hash)
+    // so the DF-D walker sees Shuffle triggers there. Does *not* touch the
+    // join's own node type, mode, or keys — the join itself still runs
+    // locally on each participant, operating on shuffle-gathered inputs.
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        let join_on = hj.on().to_vec();
+        let left_keys: Vec<Arc<dyn PhysicalExpr>> =
+            join_on.iter().map(|(l, _)| Arc::clone(l)).collect();
+        let right_keys: Vec<Arc<dyn PhysicalExpr>> =
+            join_on.iter().map(|(_, r)| Arc::clone(r)).collect();
+
+        let new_left: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
+            Arc::clone(hj.left()),
+            Partitioning::Hash(left_keys, n as usize),
+        )?);
+        let new_right: Arc<dyn ExecutionPlan> = Arc::new(RepartitionExec::try_new(
+            Arc::clone(hj.right()),
+            Partitioning::Hash(right_keys, n as usize),
+        )?);
+        return Arc::clone(&plan).with_new_children(vec![new_left, new_right]);
+    }
+
+    // AggregateExec(Partial) — per-shape wrapping. Final/FinalPartitioned
+    // don't get wrapped; they're the stage above the cut.
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial) {
+            let group_exprs = agg.group_expr().expr();
+            match (kind, group_exprs.is_empty()) {
+                (CutKind::ScalarAgg, true) => {
+                    // Scalar agg: Coalesce trigger above the Partial.
+                    return Ok(Arc::new(CoalescePartitionsExec::new(plan)));
+                }
+                (CutKind::GroupByAgg, false) => {
+                    // Group-by agg: Shuffle trigger above the Partial,
+                    // hashed on the group-by keys.
+                    let group_keys: Vec<Arc<dyn PhysicalExpr>> =
+                        group_exprs.iter().map(|(e, _)| Arc::clone(e)).collect();
+                    return Ok(Arc::new(RepartitionExec::try_new(
+                        plan,
+                        Partitioning::Hash(group_keys, n as usize),
+                    )?));
+                }
+                // TopK group-by agg: same Coalesce trigger as ScalarAgg
+                // regardless of whether the Partial carries group keys.
+                // The leader will gather every participant's groups and
+                // run the global FinalPartitioned + SortExec[fetch=k].
+                (CutKind::TopKGroupByAgg, _) => {
+                    return Ok(Arc::new(CoalescePartitionsExec::new(plan)));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(plan)
+}
+
+/// Per-query state the [`MppBoundaryFactory`] captures behind a
+/// [`Mutex`] so the fork's `_distribute_plan` walker can call our
+/// [`BoundaryFactory`] methods through a `&self` reference.
+struct MppBoundaryFactoryState {
+    /// Pool of pre-allocated meshes; each [`MppBoundaryFactory::shuffle`] /
+    /// [`MppBoundaryFactory::coalesce`] call pops one off the front.
+    meshes: VecDeque<MeshHalves>,
+}
+
+/// [`BoundaryFactory`] implementation that emits ParadeDB's `MppShuffleExec`
+/// (instead of the fork's `NetworkShuffleExec` / `NetworkCoalesceExec` /
+/// `NetworkBroadcastExec`) for each annotated boundary the walker encounters.
+///
+/// The factory wraps the per-query mesh pool, query id, participant index,
+/// and shape classification — the same scalars the legacy `CutEmitCtx`
+/// carried — so the fork's `distribute_annotated_plan` walker can run
+/// unchanged and dispatch through the trait. The Mutex<>-wrapped state is
+/// the price of `&self` in the trait signature; the walker is single-
+/// threaded and the lock is uncontended.
+struct MppBoundaryFactory {
+    shape: MppPlanShape,
+    state: Mutex<MppBoundaryFactoryState>,
+    query_id: u64,
+    participant_index: u32,
+    total_participants: u32,
+}
+
+impl MppBoundaryFactory {
+    /// Construct a factory by draining the meshes the leader / worker
+    /// allocated up front. `expected_cuts` must match
+    /// [`cut_count_for_shape`] for the shape — [`take_meshes`] panics
+    /// otherwise, surfacing the leader/worker contract mismatch loudly
+    /// rather than deferring to a walker-side error.
+    fn from_state(
+        state: &mut MppExecutionState,
+        shape: MppPlanShape,
+        expected_cuts: usize,
+    ) -> Self {
+        let cfg = state.participant_config();
+        let participant_index = cfg.participant_index;
+        let total_participants = cfg.total_participants;
+        let query_id = state.query_id();
+        let meshes: VecDeque<MeshHalves> = take_meshes(state, expected_cuts).into();
+        Self {
+            shape,
+            state: Mutex::new(MppBoundaryFactoryState { meshes }),
+            query_id,
+            participant_index,
+            total_participants,
+        }
+    }
+
+    /// Shape-aware emit body shared by the `shuffle` and `coalesce` arms.
+    /// Pops a mesh, builds the `ShuffleWiring`, and hands off to
+    /// [`wrap_with_mpp_shuffle`] which constructs the `MppShuffleExec`.
+    fn emit_one_cut(
+        &self,
+        cut_index: u32,
+        child: Arc<dyn ExecutionPlan>,
+        partitioner: Arc<dyn RowPartitioner>,
+        tag: &'static str,
+        hash_keys: Option<Vec<Arc<dyn PhysicalExpr>>>,
+        drive_partition: u32,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        let mesh = self
+            .state
+            .lock()
+            .unwrap()
+            .meshes
+            .pop_front()
+            .ok_or_else(|| {
+                DataFusionError::Plan(format!(
+                    "mpp: MppBoundaryFactory: out of mesh slots at cut {cut_index} ({tag}); \
+                     insert_mpp_cuts / cut_count_for_shape disagree"
+                ))
+            })?;
+        let stage = MppStage::new(self.query_id, cut_index, self.total_participants);
+        let drain = spawn_drain(mesh.inbound);
+        let task_key = MppTaskKey {
+            query_id: stage.query_id,
+            stage_id: stage.stage_id,
+            task_number: self.participant_index,
+        };
+        let outbound = attach_cooperative_drain(stamp_frame_ids(mesh.outbound, task_key), &drain);
+        let wiring = ShuffleWiring {
+            partitioner,
+            outbound_senders: outbound,
+            participant_index: self.participant_index,
+            cooperative_drain: Some(Arc::clone(&drain)),
+        };
+        let wrapped_schema = child.schema();
+        wrap_with_mpp_shuffle(MppShuffleInputs {
+            child,
+            wiring,
+            drain_handle: drain,
+            wrapped_schema,
+            tag,
+            stage: Some(stage),
+            hash_keys,
+            drive_partition,
+        })
+    }
+
+    /// Postcondition: every mesh popped corresponds to a real cut emitted
+    /// into the plan. The over-emit case is caught inside `emit_one_cut`
+    /// when `pop_front` returns `None`. This catches the symmetric
+    /// under-emit case where `insert_mpp_cuts` synthesized fewer cut
+    /// markers than `cut_count_for_shape` promised — meshes left
+    /// unconsumed here would otherwise be silently dropped along with
+    /// the factory.
+    fn assert_all_meshes_consumed(&self, observed_cuts: u32) -> DfResult<()> {
+        let leftover = self.state.lock().unwrap().meshes.len();
+        if leftover > 0 {
+            return Err(DataFusionError::Plan(format!(
+                "mpp: distribute_plan_generic: walker emitted {observed_cuts} cuts but \
+                 shape {:?} pre-allocated {} meshes; {leftover} meshes left unconsumed",
+                self.shape,
+                observed_cuts as usize + leftover
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl BoundaryFactory for MppBoundaryFactory {
+    fn shuffle(
+        &self,
+        child: Arc<dyn ExecutionPlan>,
+        _query_id: uuid::Uuid,
+        stage_id: usize,
+        _task_count: usize,
+        _input_task_count: usize,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        let cut_index = stage_id as u32;
+        let tag = tag_for_cut(self.shape, cut_index);
+        let (partitioner, underlying, hash_keys) =
+            shuffle_keys_from_repartition(&child, self.total_participants)?;
+        // Hash shuffle: drive_partition is this participant's index — the
+        // partition that holds this participant's local slice of rows.
+        self.emit_one_cut(
+            cut_index,
+            underlying,
+            partitioner,
+            tag,
+            Some(hash_keys),
+            self.participant_index,
+        )
+    }
+
+    fn coalesce(
+        &self,
+        child: Arc<dyn ExecutionPlan>,
+        _query_id: uuid::Uuid,
+        stage_id: usize,
+        _task_count: usize,
+        _input_task_count: usize,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        let cut_index = stage_id as u32;
+        let tag = tag_for_cut(self.shape, cut_index);
+        let partitioner: Arc<dyn RowPartitioner> =
+            Arc::new(FixedTargetPartitioner::new(0, self.total_participants));
+        // Fixed-target gather: drive_partition is the target (0) on every
+        // participant. No hash keys to declare — output partitioning is
+        // `UnknownPartitioning(1)` since only the target ever has rows.
+        self.emit_one_cut(cut_index, child, partitioner, tag, None, 0)
+    }
+
+    fn broadcast(
+        &self,
+        _child: Arc<dyn ExecutionPlan>,
+        _query_id: uuid::Uuid,
+        _stage_id: usize,
+        _task_count: usize,
+        _input_task_count: usize,
+    ) -> DfResult<Arc<dyn ExecutionPlan>> {
+        // ParadeDB never emits a Broadcast annotation in `_annotate_plan`
+        // and never inserts a `BroadcastExec` marker in `insert_mpp_cuts`,
+        // so the fork's walker should not reach this arm. If it ever does,
+        // surface a planner error rather than silently no-op.
+        Err(DataFusionError::Internal(
+            "mpp: MppBoundaryFactory: unexpected Broadcast emit — \
+             ParadeDB does not produce broadcast annotations"
+                .into(),
+        ))
+    }
+}
+
+/// Extract hash-key column indices from the `RepartitionExec(Hash)` marker
+/// that [`insert_mpp_cuts`] sits directly below a `Shuffle` boundary, then
+/// build a [`HashPartitioner`] and return the marker's underlying input.
+/// The walker wraps that input directly, dropping the `RepartitionExec` —
+/// the MPP `ShuffleExec` replaces what the `RepartitionExec` was doing.
+///
+/// Errors (all surface as `DataFusionError::Plan`) when the child is not a
+/// `RepartitionExec(Hash)` or any hash key is not a plain
+/// [`Column`](datafusion::physical_expr::expressions::Column). The second
+/// case is the same constraint the legacy topology assemblers enforce via
+/// [`extract_key_col_indices`] — milestone 1 only supports column-ref join
+/// keys.
+/// Tuple returned by [`shuffle_keys_from_repartition`]: the production
+/// `RowPartitioner` (production `HashPartitioner`), the underlying
+/// `ExecutionPlan` whose rows the shuffle consumes, and the original hash-key
+/// `PhysicalExpr` list — the latter is forwarded into
+/// [`MppPartitionAdapterExec`] so the wrapped output declares
+/// `Partitioning::Hash(keys, N)` natively.
+type ShuffleEmitInputs = (
+    Arc<dyn RowPartitioner>,
+    Arc<dyn ExecutionPlan>,
+    Vec<Arc<dyn PhysicalExpr>>,
+);
+
+fn shuffle_keys_from_repartition(
+    child: &Arc<dyn ExecutionPlan>,
+    total_participants: u32,
+) -> DfResult<ShuffleEmitInputs> {
+    let r_exec = child
+        .as_any()
+        .downcast_ref::<RepartitionExec>()
+        .ok_or_else(|| {
+            DataFusionError::Plan(
+                "mpp: _distribute_plan: Shuffle boundary expected RepartitionExec child \
+                 synthesized by insert_mpp_cuts"
+                    .into(),
+            )
+        })?;
+    let Partitioning::Hash(exprs, _n) = r_exec.partitioning() else {
+        return Err(DataFusionError::Plan(
+            "mpp: _distribute_plan: Shuffle boundary expected Partitioning::Hash; \
+             insert_mpp_cuts only synthesizes Hash repartitions"
+                .into(),
+        ));
+    };
+    let keys: Vec<usize> = exprs.iter().map(col_index).collect::<DfResult<Vec<_>>>()?;
+    let partitioner: Arc<dyn RowPartitioner> =
+        Arc::new(HashPartitioner::new(keys, total_participants));
+    Ok((partitioner, Arc::clone(r_exec.input()), exprs.clone()))
+}
+
+/// Map a (shape, bottom-up cut index) pair to the byte-exact tag string the
+/// existing topology assemblers pass to `wrap_with_mpp_shuffle`. Keeps
+/// benchmark-log grep patterns and `mpp_trace` output unchanged across the
+/// generic-walker migration.
+///
+/// The cut ordinals below follow the post-order (children-first) traversal
+/// `_distribute_plan` performs against a plan produced by [`insert_mpp_cuts`]:
+///
+/// * `JoinOnly`: `HashJoinExec` has two children — left subtree first, then
+///   right subtree. After `insert_mpp_cuts` each is wrapped in
+///   `RepartitionExec(Hash)` that `annotate_plan` lifts to a `Shuffle`.
+///   Bottom-up visit order therefore yields indices 0 = `join_left`,
+///   1 = `join_right`.
+///
+/// * `ScalarAggOnBinaryJoin`: same two join-side cuts (0, 1) plus a top
+///   `CoalescePartitionsExec` over the `AggregateExec(Partial)` that
+///   `annotate_plan` lifts to a `Coalesce`. Bottom-up the join-side cuts
+///   come first (descendants visited before parents), then the scalar-final
+///   cut at index 2.
+///
+/// * `GroupByAggOnBinaryJoin`: same two join-side cuts (0, 1) plus a top
+///   `RepartitionExec(Hash(group_keys))` that becomes a `Shuffle` at index 2.
+///
+/// Mis-indexed cuts fall through to `"mpp_unknown_cut"` rather than panic —
+/// a panic would mask a real emit-arm regression.
+fn tag_for_cut(shape: MppPlanShape, cut_index: u32) -> &'static str {
+    match (shape, cut_index) {
+        (MppPlanShape::JoinOnly, 0) => "join_left",
+        (MppPlanShape::JoinOnly, 1) => "join_right",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 0) => "scalar_left",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 1) => "scalar_right",
+        (MppPlanShape::ScalarAggOnBinaryJoin, 2) => "scalar_final",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 0) => "gb_left",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 1) => "gb_right",
+        (MppPlanShape::GroupByAggOnBinaryJoin, 2) => "gb_postagg",
+        (MppPlanShape::TopKGroupByAggOnBinaryJoin, 0) => "tk_left",
+        (MppPlanShape::TopKGroupByAggOnBinaryJoin, 1) => "tk_right",
+        (MppPlanShape::TopKGroupByAggOnBinaryJoin, 2) => "tk_final",
+        _ => "mpp_unknown_cut",
+    }
+}
+
+// ============================================================================
+// Generic MPP pipeline (Step 2d). `distribute_plan_generic` composes the
+// shape-agnostic walker (`insert_mpp_cuts` → `annotate_plan` →
+// `_distribute_plan`) with explicit shape-specific pre-passes
+// (`prepare_for_mpp`) and post-passes (`finalize_for_mpp`). ParadeDB-specific
+// obligations that don't fit DF-D's generic emit model (probe-side dynamic
+// filter strip, HashJoinExec rebuild with `PartitionMode::Partitioned`,
+// CoalesceBatchesExec(65_536), leader-only FinalPartitioned,
+// VisibilityCtidResolverRule re-run) live in the pre/post passes — the
+// walker body stays verbatim-DF-D.
+//
+// The dispatcher above (`distribute_plan`) routes per shape: JoinOnly goes
+// through this pipeline (Step 2d); the two aggregate shapes stay on the
+// legacy topology assemblers below until their pre/post passes are wired
+// (still on the critical path for Step 2d follow-up).
+// ============================================================================
+
+/// Sort + Limit info captured from the standard plan when the dispatcher
+/// upgrades a `GroupByAggOnBinaryJoin` query to
+/// `TopKGroupByAggOnBinaryJoin`. Re-applied on the leader by
+/// [`finalize_topk_groupby_agg`] after the post-agg gather.
+#[derive(Clone)]
+struct TopKSpec {
+    sort_expr: datafusion::physical_expr::LexOrdering,
+    fetch: usize,
+}
+
+/// Look at the standard plan for an outer `SortExec[fetch=k]` (DataFusion's
+/// fused TopK) or `GlobalLimitExec(SortExec)` above the
+/// `AggregateExec(Final|FinalPartitioned|SinglePartitioned)`. Returns
+/// `Some(TopKSpec)` so the dispatcher can route to the TopK shape.
+///
+/// Walks a small allow-list (`SortExec`, `GlobalLimitExec`,
+/// `LocalLimitExec`); anything else stops the walk and returns `None`,
+/// preserving the existing GroupByAgg dispatch for plans we don't
+/// recognise as TopK.
+fn extract_topk_spec(plan: &dyn ExecutionPlan) -> Option<TopKSpec> {
+    use datafusion::physical_plan::limit::LocalLimitExec;
+    let mut node = plan;
+    let mut limit: Option<usize> = None;
+    loop {
+        if let Some(sort) = node.as_any().downcast_ref::<SortExec>() {
+            // Prefer the SortExec's own fetch; fall back to a wrapping
+            // limit if SortExec didn't fuse the limit.
+            let fetch = sort.fetch().or(limit)?;
+            return Some(TopKSpec {
+                sort_expr: sort.expr().clone(),
+                fetch,
+            });
+        }
+        if let Some(g) = node.as_any().downcast_ref::<GlobalLimitExec>() {
+            limit = limit.or_else(|| g.fetch().map(|f| f + g.skip()));
+            node = g.input().as_ref();
+            continue;
+        }
+        if let Some(l) = node.as_any().downcast_ref::<LocalLimitExec>() {
+            limit = limit.or(Some(l.fetch()));
+            node = l.input().as_ref();
+            continue;
+        }
+        return None;
+    }
+}
+
+/// Glue together the generic walker (`insert_mpp_cuts` → `annotate_plan` →
+/// `_distribute_plan`) with the shape-specific pre/post passes. Called by
+/// [`distribute_plan`] for shapes whose post-passes have been ported.
+fn distribute_plan_generic(
+    shape: MppPlanShape,
+    standard: Arc<dyn ExecutionPlan>,
+    mpp_state: &mut MppExecutionState,
+    topk: Option<TopKSpec>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    debug_assert!(
+        topk.is_some() == matches!(shape, MppPlanShape::TopKGroupByAggOnBinaryJoin),
+        "topk spec must be Some iff shape is TopKGroupByAggOnBinaryJoin"
+    );
+    let n = mpp_state.participant_config().total_participants;
+    let expected_cuts = cut_count_for_shape(shape) as usize;
+
+    let prepared = prepare_for_mpp(shape, standard)?;
+    let with_cuts = insert_mpp_cuts(prepared, shape, n)?;
+    let annotated = annotate_plan(with_cuts, n)?;
+
+    // Drive the fork's walker through our `MppBoundaryFactory`. The fork's
+    // `_distribute_plan` increments `stage_id` once per emitted boundary
+    // bottom-up, which is exactly the cut index our `tag_for_cut` and
+    // `MppStage::new` consume. Starting from 0 keeps the tag mapping
+    // identical to the legacy walker.
+    let factory = MppBoundaryFactory::from_state(mpp_state, shape, expected_cuts);
+    // Fork's `_distribute_plan` calls `DistributedConfig::from_config_options`
+    // which expects the extension to be registered. We don't tune any
+    // distributed-specific knobs (broadcast_joins, partial_reduce, etc.) so
+    // the default values are correct for ParadeDB's pipeline.
+    let mut cfg = ConfigOptions::default();
+    cfg.extensions.insert(DistributedConfig::default());
+    let query_id = Uuid::nil();
+    let mut stage_id_after: usize = 0;
+    let emitted =
+        distribute_annotated_plan(annotated, &cfg, query_id, &mut stage_id_after, &factory)?;
+    factory.assert_all_meshes_consumed(stage_id_after as u32)?;
+    finalize_for_mpp(shape, emitted, mpp_state, topk)
+}
+
+/// Shape-specific pre-pass. Runs before [`insert_mpp_cuts`] synthesizes
+/// the `RepartitionExec(Hash)` / `CoalescePartitionsExec` cut markers.
+///
+/// All three live shapes are wired through their own pre-pass arm:
+/// [`prepare_join_only`] for `JoinOnly`, and
+/// [`prepare_agg_on_binary_join`] for both aggregate shapes (toggling
+/// `expect_group_by` on the GROUP BY case).
+fn prepare_for_mpp(
+    shape: MppPlanShape,
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    match shape {
+        MppPlanShape::JoinOnly => prepare_join_only(plan),
+        MppPlanShape::ScalarAggOnBinaryJoin => prepare_agg_on_binary_join(plan, false),
+        MppPlanShape::GroupByAggOnBinaryJoin => prepare_agg_on_binary_join(plan, true),
+        // TopK uses the same pre-pass as GroupByAgg: returns the
+        // Partial-rooted subtree. The outer SortExec[fetch=k] wrapper
+        // is dropped here and re-applied by `finalize_topk_groupby_agg`
+        // on the leader after the post-agg gather.
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => prepare_agg_on_binary_join(plan, true),
+        MppPlanShape::GroupByAggSingleTable | MppPlanShape::Ineligible => Ok(plan),
+    }
+}
+
+/// JoinOnly pre-pass. Rewrites the first `HashJoinExec` in `plan` so
+/// that [`insert_mpp_cuts`] sees a clean subtree below each side.
+///
+///  * `strip_repartition_layers` peels off any DataFusion-inserted
+///    `RepartitionExec` / `CoalesceBatchesExec` layers. `insert_mpp_cuts`
+///    will add its own `RepartitionExec(Hash)` marker; leaving the old
+///    layers in place would just stack redundant partitioners.
+///  * `strip_dynamic_filters_in_subtree` removes the probe-side dynamic
+///    filter the `FilterPushdown` physical optimizer pushed into the
+///    `PgSearchScanPlan`. With a dynamic filter on the probe, rows
+///    destined for peer participants get dropped before they hit the shuffle
+///    (the build side hasn't filled the filter yet on this participant), and
+///    the row count drops to ~0 across the mesh.
+///
+/// Outer wrappers (`VisibilityFilterExec`, `SegmentedTopKExec`, ...) are
+/// rebuilt by `with_new_children` so their subtree identity refreshes.
+/// Errors (via `DataFusionError::Plan`) when no `HashJoinExec` is found
+/// — the caller already validated the shape, so the absence would
+/// indicate a planner bug.
+fn prepare_join_only(plan: Arc<dyn ExecutionPlan>) -> DfResult<Arc<dyn ExecutionPlan>> {
+    fn walk(node: Arc<dyn ExecutionPlan>) -> DfResult<(Arc<dyn ExecutionPlan>, bool)> {
+        if let Some(hj) = node.as_any().downcast_ref::<HashJoinExec>() {
+            let new_left = strip_repartition_layers(Arc::clone(hj.left()));
+            let new_right =
+                strip_dynamic_filters_in_subtree(strip_repartition_layers(Arc::clone(hj.right())))?;
+            return Ok((node.with_new_children(vec![new_left, new_right])?, true));
+        }
+        let children = node.children();
+        if children.is_empty() {
+            return Ok((node, false));
+        }
+        let mut rebuilt = Vec::with_capacity(children.len());
+        let mut any_changed = false;
+        for child in children {
+            let (new, changed) = walk(Arc::clone(child))?;
+            if changed {
+                any_changed = true;
+            }
+            rebuilt.push(new);
+        }
+        if any_changed {
+            Ok((node.with_new_children(rebuilt)?, true))
+        } else {
+            Ok((node, false))
+        }
+    }
+    let (new_root, found) = walk(plan)?;
+    if !found {
+        return Err(DataFusionError::Plan(
+            "mpp: prepare_join_only: no HashJoinExec found in plan".into(),
+        ));
+    }
+    Ok(new_root)
+}
+
+/// Shape-specific post-pass. Runs after [`_distribute_plan`] emits the
+/// `ShuffleExec` / `DrainGatherExec` pairs.
+///
+/// All four live shapes are wired: [`finalize_join_only`],
+/// [`finalize_scalar_agg`], [`finalize_groupby_agg`], and
+/// [`finalize_topk_groupby_agg`]. `topk` is `Some` only for the TopK
+/// shape (asserted in the caller).
+fn finalize_for_mpp(
+    shape: MppPlanShape,
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+    topk: Option<TopKSpec>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    match shape {
+        MppPlanShape::JoinOnly => finalize_join_only(plan, mpp_state),
+        MppPlanShape::ScalarAggOnBinaryJoin => finalize_scalar_agg(plan, mpp_state),
+        MppPlanShape::GroupByAggOnBinaryJoin => finalize_groupby_agg(plan, mpp_state),
+        MppPlanShape::TopKGroupByAggOnBinaryJoin => {
+            let spec = topk.expect("TopKGroupByAgg shape ⇒ TopKSpec must be Some");
+            finalize_topk_groupby_agg(plan, mpp_state, spec)
+        }
+        MppPlanShape::GroupByAggSingleTable | MppPlanShape::Ineligible => Ok(plan),
+    }
+}
+
+/// JoinOnly post-pass. The generic walker's `Plan` arm called
+/// `with_new_children` on the `HashJoinExec` to stitch in the emitted
+/// shuffles. That preserves the original's `on` / `filter` /
+/// `projection` / `join_type`, but two MPP-specific fixups are still
+/// needed:
+///
+///  1. **Rebuild with `PartitionMode::Partitioned`.** The standard plan's
+///     HashJoin typically carries `PartitionMode::Auto` or `CollectLeft`.
+///     Under MPP the probe + build have already been partitioned by the
+///     shuffles, so the join must run per-partition against those
+///     outputs. `with_new_children` doesn't update the partition mode.
+///  2. **Re-run `VisibilityCtidResolverRule`.** `with_new_children`
+///     rebuilt any `VisibilityFilterExec` above the join via
+///     `VisibilityFilterExec::new`, which resets `ctid_resolvers` to
+///     empty. The resolver rule re-populates them against the new
+///     subtree.
+fn finalize_join_only(
+    plan: Arc<dyn ExecutionPlan>,
+    _mpp_state: &MppExecutionState,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let rebuilt = rebuild_hash_join_as_partitioned(plan)?;
+    run_visibility_ctid_resolver_rule(rebuilt)
+}
+
+/// Find the first `HashJoinExec` in `plan`, rebuild it via
+/// `HashJoinExec::try_new` with `PartitionMode::Partitioned`, and graft
+/// back into the tree via [`replace_first_hash_join`] so outer wrappers
+/// (`VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
+/// ...) refresh their subtree identity.
+///
+/// Most fields are preserved (`on`, `filter`, `join_type`, `projection`,
+/// `null_equality`, `null_aware`). One field is **intentionally
+/// dropped**: `dynamic_filter`. `prepare_join_only` already stripped the
+/// probe-side dynamic filter via `strip_dynamic_filters_in_subtree`; we
+/// don't re-apply it here because under MPP the build side is split
+/// across participants and the local `Arc<DynamicFilterPhysicalExpr>`
+/// only knows this participant's keys — a probe-side filter against
+/// that partial key set would drop rows that other participants' builds
+/// would have matched. The aggregate paths take the same approach with
+/// a small twist (`build_partitioned_hj_with_probe_filter` re-applies
+/// the filter as a `FilterExec` *above* the post-shuffle output, where
+/// only the local partition flows through anyway). For JoinOnly, the
+/// per-participant `FilterExec` would still be safe but the optimizer
+/// rebuild for visibility-ctid resolution makes the savings small;
+/// dropping is the simpler choice and is correct.
+fn rebuild_hash_join_as_partitioned(
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_join_only: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let left = Arc::clone(hj.left());
+    let right = Arc::clone(hj.right());
+    let on = hj.on().to_vec();
+    let filter = hj.filter().cloned();
+    let join_type = *hj.join_type();
+    let projection = hj.projection.as_deref().map(|s| s.to_vec());
+    let null_equality = hj.null_equality();
+    let null_aware = hj.null_aware;
+    let replacement: Arc<dyn ExecutionPlan> = Arc::new(HashJoinExec::try_new(
+        left,
+        right,
+        on,
+        filter,
+        &join_type,
+        projection,
+        PartitionMode::Partitioned,
+        null_equality,
+        null_aware,
+    )?);
+    replace_first_hash_join(plan, replacement)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_join_only: replace_first_hash_join could not find target".into(),
+        )
+    })
+}
+
+/// Re-run `VisibilityCtidResolverRule` on `plan` so any
+/// `VisibilityFilterExec` rebuilt by `with_new_children` (which resets
+/// its `ctid_resolvers` table) gets wired back to the scans in its fresh
+/// subtree.
+fn run_visibility_ctid_resolver_rule(
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let config = ConfigOptions::default();
+    VisibilityCtidResolverRule.optimize(plan, &config)
+}
+
+/// Shared pre-pass for the two aggregate-on-binary-join shapes. Locates
+/// the topmost `AggregateExec(Partial|Single)` whose transitive child is a
+/// `HashJoinExec`, rebuilds the HJ subtree so
+/// [`insert_mpp_cuts`] sees a clean cut site, normalizes the aggregate
+/// mode to `Partial` (so [`rewrite_with_cuts`]'s Partial-only match
+/// fires), and returns just that Partial-rooted subtree. Outer wrappers
+/// in the standard plan (e.g. `AggregateExec(Final)` /
+/// `AggregateExec(FinalPartitioned)` / `CoalescePartitionsExec`) are
+/// dropped — the post-pass (`finalize_scalar_agg` /
+/// `finalize_groupby_agg`) rebuilds the correct `FinalPartitioned` wrap
+/// against the MPP-shuffled plan.
+///
+///  * `strip_repartition_layers` peels off `RepartitionExec` /
+///    `CoalesceBatchesExec` layers DataFusion inserted for single-
+///    process hash partitioning — `insert_mpp_cuts` will add its own
+///    `RepartitionExec(Hash)` cut markers; leaving the old layers in
+///    place would stack redundant partitioners.
+///  * `strip_dynamic_filters_in_subtree` removes the probe-side dynamic
+///    filter the `FilterPushdown` physical optimizer pushed into the
+///    `PgSearchScanPlan`. With a dynamic filter on the probe, rows
+///    destined for peer participants get dropped before they hit the shuffle
+///    (the build side hasn't populated the filter yet on this participant), and
+///    the row count drops to ~0 across the mesh. The post-pass re-applies
+///    the same `Arc<DynamicFilterPhysicalExpr>` as a `FilterExec` above
+///    the post-shuffle probe output where it's safe.
+///  * The HJ itself is rebuilt via
+///    `HashJoinExecBuilder::with_new_children` so `dynamic_filter`
+///    survives — `HashJoinExec::try_new` drops it.
+///
+/// `expect_group_by` — `false` for `ScalarAggOnBinaryJoin`, `true` for
+/// `GroupByAggOnBinaryJoin`. Disagreement with the aggregate's actual
+/// group_expr aborts with `DataFusionError::Plan`.
+fn prepare_agg_on_binary_join(
+    plan: Arc<dyn ExecutionPlan>,
+    expect_group_by: bool,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let partial = find_partial_agg(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Plan(
+            "mpp: prepare_agg_on_binary_join: could not locate AggregateExec(Partial|Single) \
+             in standard physical plan"
+                .into(),
+        )
+    })?;
+    let hash_join = find_hash_join(partial.input().as_ref()).ok_or_else(|| {
+        DataFusionError::Plan(
+            "mpp: prepare_agg_on_binary_join: AggregateExec child is not a HashJoinExec \
+             (through coalesce layers) — plan shape unexpected for binary-join aggregate"
+                .into(),
+        )
+    })?;
+
+    let has_group_by = !partial.group_expr().expr().is_empty();
+    if has_group_by != expect_group_by {
+        return Err(DataFusionError::Plan(format!(
+            "mpp: prepare_agg_on_binary_join: expected has_group_by={expect_group_by} but \
+             aggregate has {} group keys",
+            partial.group_expr().expr().len()
+        )));
+    }
+
+    // HJ subtree cleanup.
+    let new_left = strip_repartition_layers(Arc::clone(hash_join.left()));
+    let new_right =
+        strip_dynamic_filters_in_subtree(strip_repartition_layers(Arc::clone(hash_join.right())))?;
+    let new_hj: Arc<dyn ExecutionPlan> = hash_join
+        .builder()
+        .with_new_children(vec![new_left, new_right])?
+        .build_exec()?;
+
+    // Force AggregateMode::Partial — the standard plan may have `Single`
+    // (one-partition input), which `rewrite_with_cuts` doesn't match.
+    let group_by = partial.group_expr().clone();
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let join_schema = new_hj.schema();
+    let new_partial: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+        AggregateMode::Partial,
+        group_by,
+        aggr_expr,
+        filter_expr,
+        new_hj,
+        join_schema,
+    )?);
+
+    Ok(new_partial)
+}
+
+/// Find the first `HashJoinExec` in `plan` via a depth-first traversal
+/// that descends into every child — unlike [`find_hash_join`] which only
+/// walks single-child pass-through nodes. Needed in the aggregate
+/// finalize paths because the walker output wraps the HJ inside
+/// [`ChainExec`] (2 children: `ShuffleExec` + `DrainGatherExec`), which
+/// the single-child walker would stop at.
+///
+/// Plans handled here contain exactly one `HashJoinExec`, so returning
+/// the first hit is unambiguous.
+fn find_hash_join_any(plan: &dyn ExecutionPlan) -> Option<&HashJoinExec> {
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        return Some(hj);
+    }
+    for child in plan.children() {
+        if let Some(found) = find_hash_join_any(child.as_ref()) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Find the first `AggregateExec(Partial)` in `plan` via a depth-first
+/// traversal that descends into every child — the walker output wraps
+/// the Partial inside `ChainExec` (2 children), so [`find_partial_agg`]'s
+/// single-child rule doesn't reach it. Used by the aggregate finalize
+/// paths to recover `aggr_expr` / `filter_expr` / output schema without
+/// re-threading them through the pre-pass.
+fn find_partial_agg_any(plan: &dyn ExecutionPlan) -> Option<&AggregateExec> {
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial) {
+            return Some(agg);
+        }
+    }
+    for child in plan.children() {
+        if let Some(found) = find_partial_agg_any(child.as_ref()) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Build an MPP-shuffled replacement for the walker-output `HashJoinExec`,
+/// re-applying the dynamic-filter predicate above the right probe as a
+/// `FilterExec` (the original pushdown into `PgSearchScanPlan` was
+/// stripped in the pre-pass). The rebuild goes through the builder so
+/// `dynamic_filter` survives — `HashJoinExec::try_new` drops it. The
+/// partition mode stays whatever the standard plan picked (typically
+/// `Auto` / `CollectLeft`) because the walker-emitted `ChainExec` has a
+/// single output partition, which DataFusion's execute-time assertions
+/// accept under any mode.
+fn build_partitioned_hj_with_probe_filter(hj: &HashJoinExec) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj_children = hj.children();
+    if hj_children.len() != 2 {
+        return Err(DataFusionError::Internal(format!(
+            "mpp: build_partitioned_hj_with_probe_filter: HashJoinExec expected 2 children, got {}",
+            hj_children.len()
+        )));
+    }
+    let left_shuffled = Arc::clone(hj_children[0]);
+    let right_shuffled = Arc::clone(hj_children[1]);
+
+    let right_probe: Arc<dyn ExecutionPlan> = match hj.dynamic_filter_for_test().cloned() {
+        Some(df) => Arc::new(FilterExec::try_new(df, right_shuffled)?),
+        None => right_shuffled,
+    };
+
+    // Pin `PartitionMode::Partitioned` regardless of the inbound HJ's mode.
+    // The native-partition pivot stamps both children with
+    // `Partitioning::Hash(keys, N)` via [`MppPartitionAdapterExec`], so
+    // CollectLeft's `left_partitions == 1` assertion would fail; Partitioned
+    // is the matching join mode and aligns with the upstream
+    // `MppPlanShape::JoinOnly` finalizer.
+    hj.builder()
+        .with_new_children(vec![left_shuffled, right_probe])?
+        .with_partition_mode(PartitionMode::Partitioned)
+        .build_exec()
+}
+
+/// Post-pass for [`MppPlanShape::ScalarAggOnBinaryJoin`]. The walker
+/// produced a tree shaped like
+///
+/// ```text
+/// CoalescePartitionsExec                             // preserved from
+///                                                    // insert_mpp_cuts
+///   ChainExec[scalar_final(FixedTargetPartitioner(0))]
+///     ShuffleExec
+///       AggregateExec(Partial, empty group)
+///         HashJoinExec(original mode, dynamic_filter intact)
+///           ChainExec[scalar_left(HashPartitioner(left_keys))]
+///           ChainExec[scalar_right(HashPartitioner(right_keys))]
+///     DrainGatherExec
+/// ```
+///
+/// The outer `CoalescePartitionsExec` is preserved because [`annotate_plan`]
+/// turned it into a `Plan` annotation while wrapping its child Partial in
+/// the `Coalesce` boundary that [`emit_shuffle_cut`] then rewrites — so
+/// the walker's `with_new_children` call on the CP node hands back the
+/// rebuilt CP-over-Chain tree above.
+///
+/// This pass:
+///  1. Emits the byte-exact `mpp: assembling ScalarAggOnBinaryJoin plan
+///     (participant=, total=, aggr_count=, join_keys=)` warning line so
+///     regress tests' `mpp_debug=on` output stays stable.
+///  2. Rebuilds the HJ with its right probe wrapped in a
+///     `FilterExec(dynamic_filter)` via
+///     [`build_partitioned_hj_with_probe_filter`], then grafts the
+///     replacement back through [`replace_first_hash_join`].
+///  3. Leader-only: wraps the root with `AggregateExec(FinalPartitioned,
+///     empty group)` using the Partial's `aggr_expr` / `filter_expr`.
+///     Workers return the grafted tree as-is — their output stream's
+///     `DrainGatherExec` reads nothing (every peer ships *to* the leader,
+///     not to workers), so the worker emits zero rows and PG's Gather
+///     sees exactly one row per query from the leader's final aggregate.
+fn finalize_scalar_agg(
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_scalar_agg: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let partial = find_partial_agg_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_scalar_agg: AggregateExec(Partial) missing after _distribute_plan"
+                .into(),
+        )
+    })?;
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let partial_schema = partial.schema();
+    let join_on_len = hj.on().len();
+
+    crate::mpp_log!(
+        "mpp: assembling ScalarAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, join_keys={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        join_on_len
+    );
+
+    let replacement_hj = build_partitioned_hj_with_probe_filter(hj)?;
+    let grafted = replace_first_hash_join(plan, replacement_hj)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_scalar_agg: replace_first_hash_join could not find target".into(),
+        )
+    })?;
+
+    if !mpp_state.is_leader() {
+        return Ok(grafted);
+    }
+
+    let final_agg = AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        PhysicalGroupBy::new_single(vec![]),
+        aggr_expr,
+        filter_expr,
+        grafted,
+        partial_schema,
+    )?;
+    Ok(Arc::new(final_agg))
+}
+
+/// Post-pass for [`MppPlanShape::GroupByAggOnBinaryJoin`]. The walker
+/// produced a tree shaped like
+///
+/// ```text
+/// ChainExec[gb_postagg(HashPartitioner(group_keys))]
+///   AggregateExec(Partial, group_by)
+///     HashJoinExec(original mode, dynamic_filter intact)
+///       ChainExec[gb_left(HashPartitioner(left_keys))]
+///       ChainExec[gb_right(HashPartitioner(right_keys))]
+/// ```
+///
+/// This pass:
+///  1. Emits the byte-exact `mpp: assembling GroupByAggOnBinaryJoin plan
+///     (participant=, total=, aggr_count=, group_keys=, join_keys=)`
+///     warning line.
+///  2. Rebuilds the HJ with its right probe wrapped in a
+///     `FilterExec(dynamic_filter)` and grafts the replacement back via
+///     [`replace_first_hash_join`].
+///  3. Inserts `CoalesceBatchesExec(target = 64 Ki rows)` between the
+///     Partial aggregate and the `gb_postagg` `ShuffleExec`. On the 25 M
+///     row benchmark this collapses ~191 batches per participant to ~24, keeping
+///     the post-agg shuffle payload under the 64 MiB shm_mq queue
+///     capacity so backpressure stays near zero while `FinalPartitioned`
+///     runs in parallel on every participant.
+///  4. Wraps the root with `AggregateExec(FinalPartitioned, group_by)`
+///     on every participant (no leader/worker asymmetry — each group lands on
+///     exactly one participant via the group-key hash shuffle, so every participant's
+///     Final emits a disjoint subset and PG's Gather concatenates
+///     without double-counting).
+fn finalize_groupby_agg(
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let partial = find_partial_agg_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: AggregateExec(Partial) missing after _distribute_plan"
+                .into(),
+        )
+    })?;
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+    let group_by = partial.group_expr().clone();
+    let num_group_keys = group_by.expr().len();
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let partial_schema = partial.schema();
+    let join_on_len = hj.on().len();
+
+    crate::mpp_log!(
+        "mpp: assembling GroupByAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, group_keys={}, join_keys={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        num_group_keys,
+        join_on_len
+    );
+
+    // Phase 1: rebuild HJ with FilterExec on right probe, graft back.
+    let replacement_hj = build_partitioned_hj_with_probe_filter(hj)?;
+    let grafted = replace_first_hash_join(plan, replacement_hj)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: replace_first_hash_join could not find target".into(),
+        )
+    })?;
+
+    // Phase 2: insert `CoalesceBatchesExec(65_536)` between the Partial
+    // aggregate and the `gb_postagg` ShuffleExec. Walks down to the
+    // first ShuffleExec, wraps its single child in CoalesceBatches, and
+    // rebuilds the ancestor chain via `with_new_children`. Shape-
+    // agnostic with respect to the wrapper above ShuffleExec
+    // (`wrap_with_mpp_shuffle` produces
+    // `CoalescePartitionsExec(UnionExec(repartition, drain))`).
+    let new_chain = wrap_first_shuffle_child_in_coalesce_batches(grafted)?;
+
+    // Phase 3: wrap with `FinalPartitioned` on every participant.
+    let final_agg = AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        group_by,
+        aggr_expr,
+        filter_expr,
+        new_chain,
+        partial_schema,
+    )?;
+
+    // Phase 4: collapse the FinalPartitioned's N output partitions back to a
+    // single stream so PG's CustomScan (which only drives `execute(0)`) sees
+    // the participant's complete output. The post-agg shuffle's
+    // [`MppPartitionAdapterExec`] declares `Partitioning::Hash(group_keys, N)`
+    // — without this gather, only partition 0's groups would surface to PG
+    // and the other N-1 participants' contributions would be dropped.
+    Ok(Arc::new(CoalescePartitionsExec::new(Arc::new(final_agg))))
+}
+
+/// Walk down `plan`, find the first `ShuffleExec`, and wrap its single
+/// child in `CoalesceBatchesExec(65_536)`. Used by
+/// [`finalize_groupby_agg`]'s Phase 2 to coalesce the post-Partial
+/// payload before the post-agg shuffle.
+///
+/// Shape-agnostic: works regardless of the operator that
+/// [`wrap_with_mpp_shuffle`] put above `ShuffleExec` (today
+/// `CoalescePartitionsExec(UnionExec(shuffle, drain))`). The
+/// `with_new_children` chain rebuilds the ancestor nodes; siblings of
+/// the ShuffleExec are preserved by-reference.
+fn wrap_first_shuffle_child_in_coalesce_batches(
+    plan: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    if plan.as_any().is::<MppShuffleExec>() {
+        let children = plan.children();
+        if children.len() != 1 {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: finalize_groupby_agg: expected ShuffleExec with 1 child, got {}",
+                children.len()
+            )));
+        }
+        let shuffle_child = Arc::clone(children[0]);
+        let coalesced: Arc<dyn ExecutionPlan> =
+            Arc::new(CoalesceBatchesExec::new(shuffle_child, 65_536));
+        return plan.with_new_children(vec![coalesced]);
+    }
+    let mut new_children = Vec::with_capacity(plan.children().len());
+    let mut found = false;
+    for child in plan.children() {
+        if !found {
+            let rebuilt = wrap_first_shuffle_child_in_coalesce_batches(Arc::clone(child))?;
+            if !Arc::ptr_eq(&rebuilt, child) {
+                found = true;
+            }
+            new_children.push(rebuilt);
+        } else {
+            new_children.push(Arc::clone(child));
+        }
+    }
+    if !found {
+        return Err(DataFusionError::Internal(
+            "mpp: finalize_groupby_agg: no ShuffleExec found in plan".into(),
+        ));
+    }
+    plan.with_new_children(new_children)
+}
+
+/// Post-pass for [`MppPlanShape::TopKGroupByAggOnBinaryJoin`]. Topology
+/// is scalar-style: every participant ships its `Partial(group_by)`
+/// output to participant 0 via `FixedTargetPartitioner(0)`; the leader
+/// gathers, runs `AggregateExec(FinalPartitioned, group_by)` over the
+/// merged groups, then applies `SortExec[fetch=k]` to resolve the
+/// global Top-K. Workers return the grafted plan as-is (their `Shuffle`
+/// pumps groups to leader, their `DrainGather` receives nothing because
+/// no peer ships *to* them).
+///
+/// The `TopKSpec` carries the original `Sort` expressions and `fetch`
+/// extracted from the standard plan by `extract_topk_spec`.
+fn finalize_topk_groupby_agg(
+    plan: Arc<dyn ExecutionPlan>,
+    mpp_state: &MppExecutionState,
+    topk: TopKSpec,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    let hj = find_hash_join_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_topk_groupby_agg: HashJoinExec missing after _distribute_plan".into(),
+        )
+    })?;
+    let partial = find_partial_agg_any(plan.as_ref()).ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_topk_groupby_agg: AggregateExec(Partial) missing after \
+             _distribute_plan"
+                .into(),
+        )
+    })?;
+
+    let participant_index = mpp_state.participant_config().participant_index;
+    let total_participants = mpp_state.participant_config().total_participants;
+    let group_by = partial.group_expr().clone();
+    let num_group_keys = group_by.expr().len();
+    let aggr_expr = partial.aggr_expr().to_vec();
+    let filter_expr = partial.filter_expr().to_vec();
+    let partial_schema = partial.schema();
+    let join_on_len = hj.on().len();
+
+    crate::mpp_log!(
+        "mpp: assembling TopKGroupByAggOnBinaryJoin plan (participant={}, total={}, \
+         aggr_count={}, group_keys={}, join_keys={}, fetch={})",
+        participant_index,
+        total_participants,
+        aggr_expr.len(),
+        num_group_keys,
+        join_on_len,
+        topk.fetch
+    );
+
+    // Phase 1: rebuild HJ with FilterExec on right probe, graft back.
+    // Same as the other agg shapes — the post-shuffle right probe needs
+    // its dynamic filter re-applied above the shuffle.
+    let replacement_hj = build_partitioned_hj_with_probe_filter(hj)?;
+    let grafted = replace_first_hash_join(plan, replacement_hj)?.ok_or_else(|| {
+        DataFusionError::Internal(
+            "mpp: finalize_topk_groupby_agg: replace_first_hash_join could not find target".into(),
+        )
+    })?;
+
+    // Workers ship their Partial groups to leader; they emit no rows
+    // upward. Returning the grafted tree as-is matches scalar_agg's
+    // worker path.
+    if !mpp_state.is_leader() {
+        return Ok(grafted);
+    }
+
+    // Leader: run FinalPartitioned over the gathered groups, then
+    // SortExec[fetch=k] to pick the global Top-K.
+    let final_agg: Arc<dyn ExecutionPlan> = Arc::new(AggregateExec::try_new(
+        AggregateMode::FinalPartitioned,
+        group_by,
+        aggr_expr,
+        filter_expr,
+        grafted,
+        partial_schema,
+    )?);
+    let topk_sort = SortExec::new(topk.sort_expr, final_agg).with_fetch(Some(topk.fetch));
+    Ok(Arc::new(topk_sort))
+}
+
+// ============================================================================
+// Mesh / shuffle primitives. `emit_shuffle_cut` takes one mesh slot out of
+// `MppExecutionState`, spins up a drain, and attaches the cooperative-drain
+// + frame-id stamps before handing off to `wrap_with_mpp_shuffle`. Shared
+// across every shape; fully private to this module.
+// ============================================================================
+
+/// Single directed mesh extracted from the per-scan MPP state. A
+/// participant-agnostic adapter over `LeaderMesh` / `WorkerMesh`, whose
+/// shapes are identical but whose type-level variants force otherwise-
+/// generic code to branch for no reason.
+struct MeshHalves {
+    outbound: Vec<Option<MppSender>>,
+    inbound: Vec<Option<MppReceiver>>,
+}
+
+impl From<LeaderMesh> for MeshHalves {
+    fn from(m: LeaderMesh) -> Self {
+        MeshHalves {
+            outbound: m.outbound,
+            inbound: m.inbound,
+        }
+    }
+}
+
+impl From<WorkerMesh> for MeshHalves {
+    fn from(m: WorkerMesh) -> Self {
+        MeshHalves {
+            outbound: m.outbound,
+            inbound: m.inbound,
+        }
+    }
+}
+
+/// Take the per-mesh wirings out of `mpp_state.meshes`, replacing them with
+/// empty `Vec`s so the borrow checker is satisfied. Drops the participant's
+/// side-specific variant on the floor — only the generic `MeshHalves` survive.
+///
+/// Panics (via `pgrx::error!`) if `meshes.len() != expected`. This is a
+/// leader/worker contract mismatch and must surface loudly, not silently.
+fn take_meshes(state: &mut MppExecutionState, expected: usize) -> Vec<MeshHalves> {
+    match state {
+        MppExecutionState::Leader(ctx) => {
+            let taken = mem::take(&mut ctx.meshes);
+            if taken.len() != expected {
+                let actual = taken.len();
+                // Drop `taken` before the `pgrx::error!` longjmp so the held
+                // shm_mq attachments run their `Drop` impls. Otherwise the
+                // longjmp through Rust frames would skip them and leak the
+                // attachments until backend exit.
+                drop(taken);
+                pgrx::error!(
+                    "mpp: leader meshes.len()={} but shape expected {}",
+                    actual,
+                    expected
+                );
+            }
+            taken.into_iter().map(MeshHalves::from).collect()
+        }
+        MppExecutionState::Worker(ctx) => {
+            let taken = mem::take(&mut ctx.meshes);
+            if taken.len() != expected {
+                let actual = taken.len();
+                drop(taken);
+                pgrx::error!(
+                    "mpp: worker meshes.len()={} but shape expected {}",
+                    actual,
+                    expected
+                );
+            }
+            taken.into_iter().map(MeshHalves::from).collect()
+        }
+    }
+}
+
+fn spawn_drain(inbound: Vec<Option<MppReceiver>>) -> Arc<DrainHandle> {
+    // `inbound[participant_index]` is always `None`; flatten drops it. Every
+    // other peer contributes exactly one receiver.
+    let receivers: Vec<_> = inbound.into_iter().flatten().collect();
+    let num_sources = receivers.len();
+    // `DrainBuffer::new(0)` would flip to EOF immediately; give it at least 1.
+    let buffer = DrainBuffer::new(num_sources.max(1) as u32);
+
+    // Cooperative (not thread-backed) drain: pgrx's `check_active_thread`
+    // panics any pg FFI call from non-backend threads, so spawning a
+    // `std::thread` to read from `shm_mq` would die on its first
+    // `shm_mq_receive`. The drain work runs inline from
+    // `DrainGatherStream::poll_next` on the backend thread; the returned
+    // `Arc` is also held by each same-mesh `MppSender` so `send_batch` can
+    // cooperatively poll the inbound during would-block retries, breaking
+    // the symmetric-send deadlock on a single-threaded runtime.
+    Arc::new(DrainHandle::cooperative(receivers, buffer))
+}
+
+/// Inject `drain` into each outbound sender so its `send_batch` can
+/// cooperatively poll our inbound during would-block retries — breaks
+/// the symmetric-send deadlock on a single-threaded runtime.
+fn attach_cooperative_drain(
+    senders: Vec<Option<MppSender>>,
+    drain: &Arc<DrainHandle>,
+) -> Vec<Option<MppSender>> {
+    senders
+        .into_iter()
+        .map(|opt| opt.map(|s| s.with_cooperative_drain(Arc::clone(drain))))
+        .collect()
+}
+
+/// Stamp every outbound sender in `senders` with a `FrameId` computed from
+/// the shared `task_key` (one per mesh — query_id + stage_id + our
+/// participant_index as `task_number`) plus the sender's position in the
+/// `Vec` as `partition`. Position == destination participant index today: the
+/// outbound vec is already built that way by `take_meshes`. P5b will
+/// decouple the two when multiple logical streams share one shm_mq.
+fn stamp_frame_ids(
+    senders: Vec<Option<MppSender>>,
+    task_key: MppTaskKey,
+) -> Vec<Option<MppSender>> {
+    senders
+        .into_iter()
+        .enumerate()
+        .map(|(partition, opt)| opt.map(|s| s.with_frame_id(task_key, partition as u32)))
+        .collect()
+}
+
+// ============================================================================
+// Plan-walking primitives. Find the Partial agg / HashJoin in a standard
+// DataFusion plan, skipping the coalesce/final wrapper layers the planner
+// may have inserted.
+// ============================================================================
+
+/// Walk the plan from the root, descending only through an explicit
+/// allow-list of pass-through wrappers, to find an `AggregateExec` in
+/// `Partial` or `Single` mode.
+///
+/// Allow-list:
+///   * `AggregateExec(Final | FinalPartitioned | SinglePartitioned)` —
+///     the outer aggregate stage emitted by DataFusion's planner.
+///   * `CoalescePartitionsExec` — multi→single partition merger.
+///   * `CoalesceBatchesExec` — batch-size normaliser.
+///
+/// Anything else (a `ProjectionExec`, `FilterExec`, etc. above the
+/// Partial) returns `None` so `prepare_agg_on_binary_join`'s caller
+/// errors out and the dispatcher falls back to the serial path. This
+/// is deliberately strict: the post-pass rebuilds the outer wrapper
+/// chain from scratch as `AggregateExec(FinalPartitioned, …)` and would
+/// silently discard any non-allow-listed node above the Partial,
+/// producing wrong-shape rows. A tight allow-list turns that silent
+/// drop into a clean fallback.
+///
+/// DataFusion's planner picks `AggregateMode::Single` when the input
+/// produces exactly one partition (our usual serial build), and
+/// `Partial + FinalPartitioned` when it produces multiple partitions —
+/// both are equally valid as the "aggregate atop the join" we want to
+/// rebuild from. The assembler always emits `Partial` on top of the
+/// shuffled join, regardless of which mode the serial plan used.
+fn find_partial_agg(plan: &dyn ExecutionPlan) -> Option<&AggregateExec> {
+    if let Some(agg) = plan.as_any().downcast_ref::<AggregateExec>() {
+        if matches!(agg.mode(), AggregateMode::Partial | AggregateMode::Single) {
+            return Some(agg);
+        }
+        // Final / FinalPartitioned / SinglePartitioned: descend into its child.
+        return find_partial_agg(agg.input().as_ref());
+    }
+    if let Some(cp) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
+        return find_partial_agg(cp.input().as_ref());
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return find_partial_agg(cb.input().as_ref());
+    }
+    // Anything not in the allow-list above ends the walk. Returning
+    // `None` lets `prepare_agg_on_binary_join` produce a clean
+    // `DataFusionError::Plan` so the dispatcher falls back to serial,
+    // rather than silently discarding the unknown wrapper.
+    None
+}
+
+/// Find a `HashJoinExec` underneath a Partial aggregate's input (or
+/// under the `standard` root when the plan is a bare join), tolerating
+/// `CoalescePartitionsExec` / `CoalesceBatchesExec` layers the planner
+/// may insert between them.
+fn find_hash_join(plan: &dyn ExecutionPlan) -> Option<&HashJoinExec> {
+    if let Some(hj) = plan.as_any().downcast_ref::<HashJoinExec>() {
+        return Some(hj);
+    }
+    if let Some(cp) = plan.as_any().downcast_ref::<CoalescePartitionsExec>() {
+        return find_hash_join(cp.input().as_ref());
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return find_hash_join(cb.input().as_ref());
+    }
+    let children = plan.children();
+    if children.len() == 1 {
+        return find_hash_join(children[0].as_ref());
+    }
+    None
+}
+
+/// Runtime-installed indirection over `PgSearchScanPlan::strip_dynamic_filters_from_dyn`.
+/// A direct call plants `<PgSearchScanPlan as ExecutionPlan>`'s vtable in every
+/// caller's static reachable graph; under `cargo llvm-cov` (instrumentation
+/// disables DCE) that pulls `execute()` → pgrx FFI → `CurrentMemoryContext`
+/// as an unresolved GLOB_DAT reloc, breaking the lib-test binary's ld.so load.
+/// Same mitigation pattern as `aggregatescan/filterquery.rs::BUILD_FILTER_QUERY_FN`.
+type StripDynamicFiltersFn = fn(Arc<dyn ExecutionPlan>) -> DfResult<Arc<dyn ExecutionPlan>>;
+static STRIP_DYNAMIC_FILTERS_FN: std::sync::OnceLock<StripDynamicFiltersFn> =
+    std::sync::OnceLock::new();
+
+/// Install the real implementation. Called from `_PG_init`; because `_PG_init`
+/// is unreachable from `#[test]`, the function pointer stays out of the test
+/// binary's static reachable graph.
+pub fn init_mpp_strip_dynamic_filters() {
+    STRIP_DYNAMIC_FILTERS_FN.get_or_init(|| PgSearchScanPlan::strip_dynamic_filters_from_dyn);
+}
+
+/// Register an extractor with the `datafusion-distributed` fork so its
+/// [`NetworkBoundaryExt::as_network_boundary`] downcast chain recognizes
+/// our [`MppShuffleExec`]. Without this, the fork's idempotency check
+/// (`distribute_plan_with_factory`'s `original.exists(|p| p.is_network_boundary())`)
+/// would mis-classify our plans as boundary-free and re-run distribution,
+/// and the metrics rewriter would skip our boundaries when traversing.
+///
+/// Called from `_PG_init` alongside [`init_mpp_strip_dynamic_filters`];
+/// the registration is idempotent at the consumer level (we wrap with
+/// a `OnceLock` so repeated calls are cheap), and the fork's registry
+/// itself is append-only — first-match-wins ensures no harm even if
+/// the registration somehow fires twice.
+pub fn init_mpp_network_boundary_extractor() {
+    static REGISTERED: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    REGISTERED.get_or_init(|| {
+        datafusion_distributed::register_network_boundary_extractor(extract_mpp_shuffle_exec);
+    });
+}
+
+fn extract_mpp_shuffle_exec(
+    plan: &dyn datafusion::physical_plan::ExecutionPlan,
+) -> Option<&dyn datafusion_distributed::NetworkBoundary> {
+    plan.as_any()
+        .downcast_ref::<crate::postgres::customscan::mpp::shuffle::MppShuffleExec>()
+        .map(|e| e as &dyn datafusion_distributed::NetworkBoundary)
+}
+
+/// Walk a join-input subtree and replace every `PgSearchScanPlan` with a
+/// copy whose `dynamic_filters` Vec is empty. The `FilterPushdown` physical
+/// optimizer pushed the HashJoin's dynamic-filter Arc into the probe-side
+/// scan at planning time; MPP rewires so the same Arc is applied by a
+/// `FilterExec` above the post-shuffle output instead.
+fn strip_dynamic_filters_in_subtree(
+    node: Arc<dyn ExecutionPlan>,
+) -> DfResult<Arc<dyn ExecutionPlan>> {
+    if node.as_any().downcast_ref::<PgSearchScanPlan>().is_some() {
+        let f = STRIP_DYNAMIC_FILTERS_FN.get().ok_or_else(|| {
+            DataFusionError::Internal(
+                "mpp: init_mpp_strip_dynamic_filters() not called — should be wired from _PG_init"
+                    .into(),
+            )
+        })?;
+        return f(node);
+    }
+
+    let children = node.children();
+    if children.is_empty() {
+        return Ok(node);
+    }
+
+    let new_children = children
+        .iter()
+        .map(|c| strip_dynamic_filters_in_subtree(Arc::clone(c)))
+        .collect::<Result<Vec<_>, _>>()?;
+    node.with_new_children(new_children)
+}
+
+/// Strip `RepartitionExec` and `CoalesceBatchesExec` layers off the top of a
+/// plan, returning the underlying child. DataFusion inserts these between a
+/// `HashJoinExec(Partitioned)` and its inputs to hash-repartition; in the MPP
+/// plan we replace them with our own shuffle.
+fn strip_repartition_layers(plan: Arc<dyn ExecutionPlan>) -> Arc<dyn ExecutionPlan> {
+    if let Some(rp) = plan.as_any().downcast_ref::<RepartitionExec>() {
+        return strip_repartition_layers(Arc::clone(rp.input()));
+    }
+    if let Some(cb) = plan.as_any().downcast_ref::<CoalesceBatchesExec>() {
+        return strip_repartition_layers(Arc::clone(cb.input()));
+    }
+    plan
+}
+
+fn col_index(expr: &Arc<dyn PhysicalExpr>) -> DfResult<usize> {
+    expr.as_any()
+        .downcast_ref::<Column>()
+        .map(|c| c.index())
+        .ok_or_else(|| {
+            DataFusionError::Plan(format!(
+                "mpp: join key expression {expr} is not a plain Column — MPP shuffle only \
+                 supports column-ref keys in milestone 1"
+            ))
+        })
+}
+
+/// Walk `root` top-down, replacing the first `HashJoinExec` found with
+/// `replacement`. Outer wrappers are rebuilt via `with_new_children` so their
+/// identities (and per-node state) refresh, which is required for nodes like
+/// `VisibilityFilterExec` whose resolver table must be re-wired against the
+/// new subtree. Returns `Ok(None)` if no `HashJoinExec` is present.
+fn replace_first_hash_join(
+    root: Arc<dyn ExecutionPlan>,
+    replacement: Arc<dyn ExecutionPlan>,
+) -> DfResult<Option<Arc<dyn ExecutionPlan>>> {
+    if root.as_any().downcast_ref::<HashJoinExec>().is_some() {
+        return Ok(Some(replacement));
+    }
+    let children = root.children();
+    if children.is_empty() {
+        return Ok(None);
+    }
+    let mut new_children: Vec<Arc<dyn ExecutionPlan>> = Vec::with_capacity(children.len());
+    let mut replaced = false;
+    for child in children {
+        if !replaced {
+            if let Some(new_child) =
+                replace_first_hash_join(Arc::clone(child), Arc::clone(&replacement))?
+            {
+                new_children.push(new_child);
+                replaced = true;
+                continue;
+            }
+        }
+        new_children.push(Arc::clone(child));
+    }
+    if replaced {
+        Ok(Some(root.with_new_children(new_children)?))
+    } else {
+        Ok(None)
+    }
+}
+
+// ============================================================================
+// Post-build validation
+// ============================================================================
+
+/// Post-build validation: no `VisibilityFilterExec` may be a descendant of a
+/// `ShuffleExec` in the produced MPP plan.
+///
+/// Rationale (see module doc): `VisibilityFilterExec` resolves packed
+/// DocAddress → heap TID via a ctid-resolver table populated with segments
+/// local to this participant. If a shuffle sits above a visibility filter, the
+/// filter operates on rows originating locally only (fine), but if a
+/// visibility filter sits below a shuffle we run the filter on rows that
+/// came in over shm_mq from a peer participant, whose `seg_ord` addresses the
+/// peer's segment catalog rather than ours — `heap_fetch` then returns
+/// garbage or panics.
+///
+/// The walk is cheap (O(nodes)) and runs once per query, so there is no
+/// perf reason to gate this behind a GUC.
+pub fn assert_visibility_invariant(plan: &Arc<dyn ExecutionPlan>) -> DfResult<()> {
+    walk_checking_visibility(plan.as_ref(), /*inside_shuffle=*/ false)
+}
+
+fn walk_checking_visibility(node: &dyn ExecutionPlan, inside_shuffle: bool) -> DfResult<()> {
+    let is_shuffle = node.as_any().downcast_ref::<MppShuffleExec>().is_some();
+    let is_visibility = node
+        .as_any()
+        .downcast_ref::<VisibilityFilterExec>()
+        .is_some();
+
+    if inside_shuffle && is_visibility {
+        return Err(DataFusionError::Plan(
+            "mpp: visibility invariant violated — VisibilityFilterExec appears below a \
+             ShuffleExec. Segment-local ctid resolution cannot run on rows that crossed \
+             an shm_mq boundary from a peer participant (peer seg_ord addresses its own segment \
+             catalog, not ours). Place every shuffle cut above any VisibilityFilterExec \
+             in the standard plan."
+                .into(),
+        ));
+    }
+
+    let next_inside_shuffle = inside_shuffle || is_shuffle;
+    for child in node.children() {
+        walk_checking_visibility(child.as_ref(), next_inside_shuffle)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::mpp::transport::{in_proc_channel, MppSender};
+    use datafusion::arrow::array::{Int32Array, RecordBatch};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::datasource::memory::MemorySourceConfig;
+    use datafusion::logical_expr::Operator;
+    use datafusion::physical_expr::expressions::{BinaryExpr, Literal};
+    use datafusion::scalar::ScalarValue;
+
+    #[test]
+    fn cut_count_matches_topology() {
+        assert_eq!(cut_count_for_shape(MppPlanShape::ScalarAggOnBinaryJoin), 3);
+        assert_eq!(cut_count_for_shape(MppPlanShape::GroupByAggOnBinaryJoin), 3);
+        assert_eq!(cut_count_for_shape(MppPlanShape::GroupByAggSingleTable), 1);
+        assert_eq!(cut_count_for_shape(MppPlanShape::JoinOnly), 2);
+        assert_eq!(cut_count_for_shape(MppPlanShape::Ineligible), 0);
+    }
+
+    #[test]
+    fn worst_case_cut_count_matches_widest_shape() {
+        // Scalar-agg-on-join and groupby-agg-on-join are tied at 3 cuts.
+        // If someone adds a shape with more cuts, this assertion surfaces
+        // the mismatch.
+        assert_eq!(worst_case_cut_count(), 3);
+    }
+
+    #[test]
+    fn stamp_frame_ids_assigns_destination_partition_per_slot() {
+        // The vec slot index equals the destination participant today. If
+        // `stamp_frame_ids` ever stops using the slot index as partition,
+        // the wire format's routing guarantee breaks.
+        let (tx1, _rx1) = in_proc_channel(1);
+        let (tx3, _rx3) = in_proc_channel(1);
+        let senders: Vec<Option<MppSender>> = vec![
+            None, // participant 0 (self)
+            Some(MppSender::new(Box::new(tx1))),
+            None, // gap — simulates a partially-built mesh on a larger cluster
+            Some(MppSender::new(Box::new(tx3))),
+        ];
+
+        let stage = MppStage::new(0xa5a5, 2, 4);
+        let stamped = stamp_frame_ids(
+            senders,
+            MppTaskKey {
+                query_id: stage.query_id,
+                stage_id: stage.stage_id,
+                task_number: 0, // pretend we're participant 0
+            },
+        );
+
+        assert!(stamped[0].is_none());
+        let f1 = stamped[1].as_ref().unwrap().frame_id().unwrap();
+        assert_eq!(f1.partition, 1);
+        assert_eq!(f1.task_key.stage_id, 2);
+        assert_eq!(f1.task_key.task_number, 0);
+        assert_eq!(f1.task_key.query_id, 0xa5a5);
+
+        assert!(stamped[2].is_none());
+        let f3 = stamped[3].as_ref().unwrap().frame_id().unwrap();
+        assert_eq!(f3.partition, 3);
+    }
+
+    #[test]
+    fn col_index_plain_column() {
+        let col: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 3));
+        assert_eq!(col_index(&col).unwrap(), 3);
+    }
+
+    #[test]
+    fn col_index_rejects_non_column() {
+        let left: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 0));
+        let right: Arc<dyn PhysicalExpr> = Arc::new(Literal::new(ScalarValue::Int32(Some(0))));
+        let expr: Arc<dyn PhysicalExpr> = Arc::new(BinaryExpr::new(left, Operator::Plus, right));
+        let err = col_index(&expr).unwrap_err();
+        assert!(
+            format!("{err}").contains("not a plain Column"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn find_partial_agg_walks_through_coalesce_and_final() {
+        let schema = Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        let input = MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap();
+
+        // Build a Partial -> CoalescePartitions -> Final stack.
+        let partial = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let partial_schema = partial.schema();
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
+        let final_agg = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Final,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                coalesced,
+                partial_schema,
+            )
+            .unwrap(),
+        );
+
+        let plan: Arc<dyn ExecutionPlan> = final_agg;
+        let partial_ref = find_partial_agg(plan.as_ref()).expect("partial found");
+        assert!(matches!(partial_ref.mode(), AggregateMode::Partial));
+    }
+
+    // The visibility-invariant walker is exercised by the regression tests
+    // (mpp_join, mpp_exec) against real plans. A lightweight unit test on
+    // synthetic `ExecutionPlan`s would require wiring up enough of
+    // `VisibilityFilterExec` + `ShuffleExec` to make the downcast fire,
+    // which duplicates the fixture the bridges already exercise. Skipped.
+
+    // ========================================================================
+    // DF-D generic cut walker tests (dead-path scaffolding — Step 2a).
+    // ========================================================================
+
+    fn mem_source(schema: &SchemaRef) -> Arc<dyn ExecutionPlan> {
+        let batch = RecordBatch::try_new(
+            schema.clone(),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .unwrap();
+        MemorySourceConfig::try_new_from_batches(schema.clone(), vec![batch]).unwrap()
+    }
+
+    #[test]
+    fn annotate_plan_detects_hash_repartition_as_shuffle() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let key: Arc<dyn PhysicalExpr> = Arc::new(Column::new("id", 0));
+        let repart: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::Hash(vec![key], 2)).unwrap());
+
+        let annotated = annotate_plan(repart, 2).unwrap();
+        // The trigger sits *above* the RepartitionExec, so the top of the
+        // annotated tree is the Shuffle boundary whose sole child is the
+        // RepartitionExec-as-Plan.
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Shuffle
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_round_robin_repartition_does_not_trigger_shuffle() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let repart: Arc<dyn ExecutionPlan> =
+            Arc::new(RepartitionExec::try_new(input, Partitioning::RoundRobinBatch(2)).unwrap());
+
+        let annotated = annotate_plan(repart, 2).unwrap();
+        // Non-hash repartitioning is not a DF-D cut trigger.
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_plain_plan_has_no_boundaries() {
+        fn assert_no_boundary(a: &AnnotatedPlan) {
+            assert!(
+                !a.plan_or_nb.is_network_boundary(),
+                "unexpected boundary: {:?}",
+                a.plan_or_nb
+            );
+            for c in &a.children {
+                assert_no_boundary(c);
+            }
+        }
+
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let annotated = annotate_plan(partial, 2).unwrap();
+        assert_no_boundary(&annotated);
+    }
+
+    #[test]
+    fn annotate_plan_coalesce_parent_triggers_coalesce_boundary() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        // Partial aggregation is non-leaf (children() non-empty) and its
+        // parent is CoalescePartitionsExec — this is the DF-D Coalesce
+        // trigger verbatim.
+        let partial: Arc<dyn ExecutionPlan> = Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(vec![]),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        );
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(partial));
+        let annotated = annotate_plan(coalesced, 2).unwrap();
+
+        // Root is the CoalescePartitionsExec itself (annotated as Plan; the
+        // trigger only wraps the child that sits *under* the coalesce).
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        // The Partial aggregate has its parent as CoalescePartitionsExec, so
+        // the walker wraps it with Coalesce.
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Coalesce
+        ));
+        // Inside the Coalesce annotation, the wrapped plan is the Partial
+        // aggregate.
+        assert_eq!(annotated.children[0].children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn annotate_plan_leaf_under_coalesce_is_not_boundaried() {
+        // A true leaf node (no children) underneath CoalescePartitionsExec
+        // must not get a Coalesce boundary — DF-D's comment: "putting a
+        // network boundary above [a leaf] is a bit wasteful".
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let coalesced: Arc<dyn ExecutionPlan> = Arc::new(CoalescePartitionsExec::new(input));
+        let annotated = annotate_plan(coalesced, 2).unwrap();
+
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+    }
+
+    #[test]
+    fn require_one_child_accepts_single_child() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let got = require_one_child(vec![Arc::clone(&input)]).unwrap();
+        assert!(Arc::ptr_eq(&got, &input));
+    }
+
+    #[test]
+    fn require_one_child_rejects_zero_children() {
+        let empty: Vec<Arc<dyn ExecutionPlan>> = vec![];
+        let err = require_one_child(empty).unwrap_err();
+        assert!(format!("{err}").contains("Expected exactly 1"));
+    }
+
+    #[test]
+    fn require_one_child_rejects_many_children() {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let err = require_one_child(vec![mem_source(&schema), mem_source(&schema)]).unwrap_err();
+        assert!(format!("{err}").contains("Expected exactly 1"));
+    }
+
+    // ========================================================================
+    // `insert_mpp_cuts` tests (dead-path scaffolding — Step 2b).
+    //
+    // These exercise the aggregate-wrapping half of the pre-pass on
+    // synthetic plans built from `MemorySourceConfig` +
+    // `AggregateExec(Partial)`. The `HashJoinExec` half is exercised by
+    // regression tests in Step 2d, when `insert_mpp_cuts` is wired into
+    // `distribute_plan`'s live path — building a synthetic `HashJoinExec`
+    // here would duplicate the fixture the regression tests already
+    // produce from real SQL.
+    // ========================================================================
+
+    fn partial_agg_over_mem_source(group_cols: Vec<&str>) -> Arc<dyn ExecutionPlan> {
+        let schema: SchemaRef =
+            Arc::new(Schema::new(vec![Field::new("id", DataType::Int32, false)]));
+        let input = mem_source(&schema);
+        let group_by_exprs: Vec<(Arc<dyn PhysicalExpr>, String)> = group_cols
+            .into_iter()
+            .map(|c| {
+                (
+                    Arc::new(Column::new(c, 0)) as Arc<dyn PhysicalExpr>,
+                    c.to_string(),
+                )
+            })
+            .collect();
+        Arc::new(
+            AggregateExec::try_new(
+                AggregateMode::Partial,
+                PhysicalGroupBy::new_single(group_by_exprs),
+                vec![],
+                vec![],
+                input,
+                schema.clone(),
+            )
+            .unwrap(),
+        )
+    }
+
+    #[test]
+    fn insert_mpp_cuts_scalar_wraps_partial_with_coalesce() {
+        let plan = partial_agg_over_mem_source(vec![]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::ScalarAggOnBinaryJoin, 2).unwrap();
+
+        // Root should be CoalescePartitionsExec; its sole child is the
+        // original Partial aggregate.
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .is_some());
+        assert_eq!(rewritten.children().len(), 1);
+        let partial = rewritten.children()[0]
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("child is AggregateExec");
+        assert_eq!(*partial.mode(), AggregateMode::Partial);
+
+        // Cross-check: annotate_plan should see exactly one Coalesce boundary.
+        let annotated = annotate_plan(Arc::clone(&rewritten), 2).unwrap();
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Plan(_)
+        ));
+        assert_eq!(annotated.children.len(), 1);
+        assert!(matches!(
+            annotated.children[0].plan_or_nb,
+            PlanOrNetworkBoundary::Coalesce
+        ));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_groupby_wraps_partial_with_hash_repartition() {
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::GroupByAggOnBinaryJoin, 4).unwrap();
+
+        // Root should be RepartitionExec(Hash(id), 4); its sole child is
+        // the original Partial aggregate.
+        let repart = rewritten
+            .as_any()
+            .downcast_ref::<RepartitionExec>()
+            .expect("root is RepartitionExec");
+        match repart.partitioning() {
+            Partitioning::Hash(keys, n) => {
+                assert_eq!(keys.len(), 1);
+                assert_eq!(*n, 4);
+            }
+            other => panic!("expected Hash partitioning, got {other:?}"),
+        }
+        assert_eq!(rewritten.children().len(), 1);
+        let partial = rewritten.children()[0]
+            .as_any()
+            .downcast_ref::<AggregateExec>()
+            .expect("child is AggregateExec");
+        assert_eq!(*partial.mode(), AggregateMode::Partial);
+
+        // Cross-check: annotate_plan should see a Shuffle boundary on the
+        // RepartitionExec.
+        let annotated = annotate_plan(Arc::clone(&rewritten), 2).unwrap();
+        assert!(matches!(
+            annotated.plan_or_nb,
+            PlanOrNetworkBoundary::Shuffle
+        ));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_scalar_does_not_wrap_groupby_partial() {
+        // A Partial *with* group keys under ScalarAgg shape should not be
+        // wrapped — rewrite_with_cuts matches on (kind, group_exprs.is_empty()).
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::ScalarAggOnBinaryJoin, 2).unwrap();
+
+        // Root is still the Partial — no CoalescePartitionsExec, no RepartitionExec.
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<CoalescePartitionsExec>()
+            .is_none());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_groupby_does_not_wrap_scalar_partial() {
+        // A Partial *without* group keys under GroupByAgg shape should not
+        // be wrapped. The caller's classifier is responsible for picking
+        // the right shape — rewrite_with_cuts enforces the invariant by
+        // no-op-ing on the mismatched pair.
+        let plan = partial_agg_over_mem_source(vec![]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::GroupByAggOnBinaryJoin, 2).unwrap();
+
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+        assert!(rewritten
+            .as_any()
+            .downcast_ref::<RepartitionExec>()
+            .is_none());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_join_only_does_not_wrap_partial() {
+        // JoinOnly shape should leave any Partial aggregate alone — the
+        // only rewrite is on HashJoinExec children (exercised in regression).
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let rewritten = insert_mpp_cuts(plan, MppPlanShape::JoinOnly, 2).unwrap();
+
+        assert!(rewritten.as_any().downcast_ref::<AggregateExec>().is_some());
+    }
+
+    #[test]
+    fn insert_mpp_cuts_rejects_ineligible() {
+        let plan = partial_agg_over_mem_source(vec![]);
+        let err = insert_mpp_cuts(plan, MppPlanShape::Ineligible, 2).unwrap_err();
+        assert!(format!("{err}").contains("Ineligible"));
+    }
+
+    #[test]
+    fn insert_mpp_cuts_rejects_single_table_groupby() {
+        let plan = partial_agg_over_mem_source(vec!["id"]);
+        let err = insert_mpp_cuts(plan, MppPlanShape::GroupByAggSingleTable, 2).unwrap_err();
+        assert!(format!("{err}").contains("GroupByAggSingleTable"));
+    }
+
+    // ========================================================================
+    // `_distribute_plan` + `tag_for_cut` tests (dead-path scaffolding — Step
+    // 2c-ii). The `Plan` arm exercises `with_new_children` recursion; the
+    // `Shuffle` and `Coalesce` arms hit `wrap_with_mpp_shuffle` against a
+    // synthetic in-process mesh and verify the resulting tree embeds the
+    // expected number of `ShuffleExec` nodes with stamped `MppStage` ids.
+    // ========================================================================
+
+    #[test]
+    fn tag_for_cut_covers_every_live_shape() {
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 0), "join_left");
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 1), "join_right");
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 0),
+            "scalar_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 1),
+            "scalar_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::ScalarAggOnBinaryJoin, 2),
+            "scalar_final"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 0),
+            "gb_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 1),
+            "gb_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggOnBinaryJoin, 2),
+            "gb_postagg"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::TopKGroupByAggOnBinaryJoin, 0),
+            "tk_left"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::TopKGroupByAggOnBinaryJoin, 1),
+            "tk_right"
+        );
+        assert_eq!(
+            tag_for_cut(MppPlanShape::TopKGroupByAggOnBinaryJoin, 2),
+            "tk_final"
+        );
+    }
+
+    #[test]
+    fn tag_for_cut_unknown_pair_falls_through_to_placeholder() {
+        // Out-of-range indices and Ineligible / SingleTable shapes fall
+        // through to the placeholder rather than panic — a panic in the
+        // dead-code scaffold would mask a real emit-arm regression.
+        assert_eq!(tag_for_cut(MppPlanShape::JoinOnly, 7), "mpp_unknown_cut");
+        assert_eq!(tag_for_cut(MppPlanShape::Ineligible, 0), "mpp_unknown_cut");
+        assert_eq!(
+            tag_for_cut(MppPlanShape::GroupByAggSingleTable, 0),
+            "mpp_unknown_cut"
+        );
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/walker.rs
+++ b/pg_search/src/postgres/customscan/mpp/walker.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! Generic cut walker (`distribute_plan`).
 //!
 //! Ported in spirit from datafusion-contrib/datafusion-distributed's

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
 //! MPP worker lifecycle and DSM coordination.
 //!
 //! The DSM region laid out by the leader during `initialize_dsm_custom_scan`

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code)]
 //! MPP worker lifecycle and DSM coordination.
 //!
 //! The DSM region laid out by the leader during `initialize_dsm_custom_scan`
@@ -44,12 +45,13 @@
 //! [`ShmMqReceiver`](super::mesh::ShmMqReceiver). Here we only own the
 //! sizing/offset math and the header layout.
 
-#![allow(dead_code)]
+use std::mem::size_of;
+use std::ptr;
+
+use pgrx::pg_sys;
 
 use crate::postgres::customscan::mpp::mesh::{edge_slot, MeshLayout, ShmMqReceiver, ShmMqSender};
 use crate::postgres::customscan::mpp::transport::{MppReceiver, MppSender};
-use pgrx::pg_sys;
-use std::mem::size_of;
 
 /// Magic number stamped at the head of an MPP DSM region. Distinct from any
 /// of the other Postgres DSM magic numbers in the crate; workers assert this
@@ -262,7 +264,7 @@ pub struct DsmLayout {
 /// `plan_len == usize::MAX` fails cleanly instead of wrapping.
 #[inline]
 fn align_up_maxalign_checked(n: usize) -> Option<usize> {
-    const MA: usize = pgrx::pg_sys::MAXIMUM_ALIGNOF as usize;
+    const MA: usize = pg_sys::MAXIMUM_ALIGNOF as usize;
     let rem = n % MA;
     if rem == 0 {
         return Some(n);
@@ -329,8 +331,8 @@ pub unsafe fn initialize_dsm_as_leader(
 
     let header = MppDsmHeader::from_layout(mesh, dsm);
     unsafe {
-        std::ptr::write(base as *mut MppDsmHeader, header);
-        std::ptr::copy_nonoverlapping(plan_bytes.as_ptr(), base.add(dsm.plan_offset), dsm.plan_len);
+        ptr::write(base as *mut MppDsmHeader, header);
+        ptr::copy_nonoverlapping(plan_bytes.as_ptr(), base.add(dsm.plan_offset), dsm.plan_len);
     }
 
     let n = mesh.total_participants;
@@ -389,7 +391,7 @@ pub unsafe fn attach_dsm_as_worker(
     participant_index: u32,
     seg: *mut pg_sys::dsm_segment,
 ) -> Result<WorkerAttach, &'static str> {
-    let header = unsafe { std::ptr::read_unaligned(base as *const MppDsmHeader) };
+    let header = unsafe { ptr::read_unaligned(base as *const MppDsmHeader) };
     header.validate(region_total)?;
 
     if participant_index >= header.total_participants {
@@ -463,11 +465,7 @@ impl WorkerAttach {
     pub unsafe fn copy_plan_bytes(&self) -> Vec<u8> {
         let mut out = Vec::with_capacity(self.plan_bytes_len);
         unsafe {
-            std::ptr::copy_nonoverlapping(
-                self.plan_bytes_ptr,
-                out.as_mut_ptr(),
-                self.plan_bytes_len,
-            );
+            ptr::copy_nonoverlapping(self.plan_bytes_ptr, out.as_mut_ptr(), self.plan_bytes_len);
             out.set_len(self.plan_bytes_len);
         }
         out
@@ -536,9 +534,9 @@ mod tests {
         let plan_len = 12_345;
         let dsm = compute_dsm_layout(&layout, 1, plan_len).unwrap();
         assert!(dsm.plan_offset >= size_of::<MppDsmHeader>());
-        assert_eq!(dsm.plan_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
+        assert_eq!(dsm.plan_offset % pg_sys::MAXIMUM_ALIGNOF as usize, 0);
         assert!(dsm.mesh_offset >= dsm.plan_offset + plan_len);
-        assert_eq!(dsm.mesh_offset % pgrx::pg_sys::MAXIMUM_ALIGNOF as usize, 0);
+        assert_eq!(dsm.mesh_offset % pg_sys::MAXIMUM_ALIGNOF as usize, 0);
         assert_eq!(dsm.mesh_bytes, layout.dsm_queue_bytes_checked().unwrap());
         assert_eq!(dsm.total, dsm.mesh_offset + dsm.mesh_bytes);
         assert_eq!(dsm.plan_len, plan_len);
@@ -604,7 +602,7 @@ mod tests {
 
     #[test]
     fn align_up_maxalign_rounds_correctly() {
-        let ma = pgrx::pg_sys::MAXIMUM_ALIGNOF as usize;
+        let ma = pg_sys::MAXIMUM_ALIGNOF as usize;
         assert_eq!(align_up_maxalign_checked(0), Some(0));
         assert_eq!(align_up_maxalign_checked(1), Some(ma));
         assert_eq!(align_up_maxalign_checked(ma), Some(ma));
@@ -626,13 +624,13 @@ mod tests {
 
         let mut buf = vec![0u8; size_of::<MppDsmHeader>() * 2];
         unsafe {
-            std::ptr::copy_nonoverlapping(
+            ptr::copy_nonoverlapping(
                 &original as *const MppDsmHeader as *const u8,
                 buf.as_mut_ptr(),
                 size_of::<MppDsmHeader>(),
             );
         }
-        let read_back = unsafe { std::ptr::read_unaligned(buf.as_ptr() as *const MppDsmHeader) };
+        let read_back = unsafe { ptr::read_unaligned(buf.as_ptr() as *const MppDsmHeader) };
         read_back.validate(dsm.total as u64).unwrap();
         assert_eq!(read_back.magic, MPP_DSM_MAGIC);
         assert_eq!(read_back.total_participants, original.total_participants);

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -163,6 +163,9 @@ pub struct PgSearchScanPlan {
     deferred_ctid_plan_position: Option<usize>,
     /// When true, a HashJoin InList was successfully pushed down to a TermSet query.
     dynamic_filter_pushdown: Arc<AtomicBool>,
+    /// Sort order preserved across `with_filter_pushdown` rebuilds so the
+    /// rebuilt plan keeps its equivalence properties.
+    sort_order: Option<SortByField>,
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -245,7 +248,73 @@ impl PgSearchScanPlan {
             indexrelid,
             deferred_ctid_plan_position,
             dynamic_filter_pushdown: Arc::new(AtomicBool::new(false)),
+            sort_order: sort_order.cloned(),
         }
+    }
+
+    /// Produce a plan identical to `dyn_plan` but with `dynamic_filters` emptied.
+    ///
+    /// Used by MPP: the join's dynamic-filter Arc is pushed to the probe-side
+    /// scan by `FilterPushdown`, but MPP needs to apply it *after* the probe
+    /// shuffle (so local bounds are not applied to rows destined for peer
+    /// participants). We strip it from the scan and re-apply it via a
+    /// `FilterExec` above the post-shuffle output.
+    ///
+    /// Transfers scan state out of the original plan — the original becomes
+    /// a dead stub whose `execute` returns empty streams. Returns the plan
+    /// unchanged when there are no dynamic filters to strip.
+    ///
+    /// # Caller contract
+    ///
+    /// This is a primitive: it strips unconditionally and does not validate
+    /// that re-attaching the filter elsewhere is safe. It is correct only
+    /// when the caller is rebuilding the plan such that the stripped
+    /// filter will be reapplied above a `ShuffleExec` that crosses
+    /// participant boundaries.
+    ///
+    /// In particular, do *not* call this on a scan whose enclosing
+    /// `HashJoinExec` lives entirely on one participant (e.g., a join that
+    /// is itself below a shuffle): the dynamic filter is fully populated
+    /// locally there and dropping it loses a valuable optimization with no
+    /// correctness benefit.
+    #[allow(dead_code)] // walker (PR #4870) is the live caller
+    pub fn strip_dynamic_filters_from_dyn(
+        dyn_plan: Arc<dyn ExecutionPlan>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let scan = match dyn_plan.as_any().downcast_ref::<PgSearchScanPlan>() {
+            Some(s) => s,
+            None => {
+                return Err(DataFusionError::Internal(
+                    "strip_dynamic_filters_from_dyn called on a non-PgSearchScanPlan ExecutionPlan"
+                        .into(),
+                ));
+            }
+        };
+
+        if scan.dynamic_filters.is_empty() {
+            return Ok(dyn_plan);
+        }
+
+        let taken = {
+            let mut guard = scan.states.lock().map_err(|e| {
+                DataFusionError::Internal(format!("Failed to lock PgSearchScanPlan state: {e}"))
+            })?;
+            std::mem::take(&mut *guard)
+        };
+        let states: Vec<ScanState> = taken.into_iter().flatten().map(|u| u.0).collect();
+
+        let schema = scan.properties.eq_properties.schema().clone();
+        let new_plan = PgSearchScanPlan::new(
+            states,
+            schema,
+            scan.query_for_display.clone(),
+            scan.sort_order.as_ref(),
+            scan.deferred_fields.clone(),
+            scan.ffhelper.clone(),
+            scan.indexrelid,
+            scan.deferred_ctid_plan_position,
+        );
+        Ok(Arc::new(new_plan))
     }
 
     pub fn has_deferred_fields(&self) -> bool {
@@ -573,6 +642,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                 dynamic_filter_pushdown: Arc::new(AtomicBool::new(
                     self.dynamic_filter_pushdown.load(Ordering::Relaxed),
                 )),
+                sort_order: self.sort_order.clone(),
             });
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -277,7 +277,6 @@ impl PgSearchScanPlan {
     /// is itself below a shuffle): the dynamic filter is fully populated
     /// locally there and dropping it loses a valuable optimization with no
     /// correctness benefit.
-    #[allow(dead_code)] // walker (PR #4870) is the live caller
     pub fn strip_dynamic_filters_from_dyn(
         dyn_plan: Arc<dyn ExecutionPlan>,
     ) -> Result<Arc<dyn ExecutionPlan>> {

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -32,6 +32,7 @@ use tantivy::index::SegmentId;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, WhichFastField};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::customscan::mpp::MppShardConfig;
 use crate::postgres::customscan::parallel::{checkout_segment, list_segment_ids};
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
@@ -565,6 +566,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         query_for_display: SearchQueryInput,
         sort_order: Option<&crate::postgres::options::SortByField>,
+        mpp_shard: Option<(u32, u32)>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -575,7 +577,16 @@ impl PgSearchTableProvider {
         let segments: Vec<ScanState> = reader
             .segment_readers()
             .iter()
-            .map(|r| {
+            .enumerate()
+            // MPP sharded eager-scan: each participant opens only its own
+            // subset. Filter applies identically across all participants
+            // because `segment_readers()` has deterministic order, so
+            // every segment ends up on exactly one participant.
+            .filter(|(i, _)| match mpp_shard {
+                Some((pi, total)) => (*i as u32) % total == pi,
+                None => true,
+            })
+            .map(|(_, r)| {
                 self.create_scan_partition(
                     reader,
                     r.segment_id(),
@@ -616,6 +627,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         query_for_display: SearchQueryInput,
         planner_estimated_rows: u64,
+        mpp_shard: Option<(u32, u32)>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -623,12 +635,39 @@ impl PgSearchTableProvider {
             heap_relid: heap_relid.into(),
             batch_size_hint: None,
         };
-        let state = ScanState {
-            recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
+        let recipe = if parallel_state.is_some() {
+            crate::scan::execution_plan::ScanRecipe::Lazy {
                 parallel_state,
                 planner_estimated_rows,
                 scanner_config,
-            },
+            }
+        } else if let Some((participant_index, total_participants)) = mpp_shard {
+            // MPP sharded lazy scan: each participant reads only its share
+            // of segments (`segment_idx % total == participant_index`), so
+            // the scan work is split N ways across participants. The
+            // hash-shuffle above then redistributes rows by join key —
+            // because each input row is scanned by exactly one participant,
+            // the shuffle output matches the serial scan.
+            let sharded_ids: Vec<SegmentId> = reader
+                .segment_readers()
+                .iter()
+                .enumerate()
+                .filter(|(i, _)| (*i as u32) % total_participants == participant_index)
+                .map(|(_, r)| r.segment_id())
+                .collect();
+            crate::scan::execution_plan::ScanRecipe::Eager {
+                segment_ids: sharded_ids,
+                scanner_config,
+            }
+        } else {
+            crate::scan::execution_plan::ScanRecipe::Lazy {
+                parallel_state,
+                planner_estimated_rows,
+                scanner_config,
+            }
+        };
+        let state = ScanState {
+            recipe,
             ffhelper: ffhelper.clone(),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader: reader.clone(),
@@ -700,11 +739,22 @@ impl TableProvider for PgSearchTableProvider {
 
     async fn scan(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         _limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
+        // MPP sharding: the exec bridge stashes a `MppShardConfig` as a
+        // session config extension before `build_join_aggregate_plan`
+        // builds the logical plan. When present AND we take the lazy
+        // (un-parallel) scan path, each participant reads only its share
+        // of segments — see `create_lazy_scan`. Absent for non-MPP
+        // queries and for the sorted/eager paths that have their own
+        // parallelization story.
+        let mpp_shard = state
+            .config()
+            .get_extension::<MppShardConfig>()
+            .map(|cfg| (cfg.participant_index, cfg.total_participants));
         // TODO: We should support limit pushdown here to allow providing a batch size hint
         // to the Scanner.
 
@@ -812,6 +862,7 @@ impl TableProvider for PgSearchTableProvider {
                     projected_schema,
                     query,
                     Some(sort_order),
+                    mpp_shard,
                 )
             }
         } else {
@@ -831,6 +882,7 @@ impl TableProvider for PgSearchTableProvider {
                 projected_schema,
                 query,
                 total_estimated_rows,
+                mpp_shard,
             )
         }
     }

--- a/pg_search/tests/pg_regress/expected/mpp_exec.out
+++ b/pg_search/tests/pg_regress/expected/mpp_exec.out
@@ -1,0 +1,342 @@
+-- =====================================================================
+-- MPP correctness: with `paradedb.enable_mpp=on`, scalar COUNT(*) on a
+-- binary join must return the same result as with MPP off.
+--
+-- This test exercises the full shape classification + plan-stash +
+-- parallel-flag flip pipeline on a medium-sized dataset (40x200 rows).
+-- PG's planner decides whether to launch actual parallel workers based
+-- on cost; at this size it typically doesn't, so the MPP *exec* path
+-- isn't exercised here — for that you need `debug_parallel_query=on`
+-- at a larger scale, which is out of scope for pg_regress (no parallel
+-- workers launched == no DSM coordination == no cross-worker shuffle).
+--
+-- What this DOES verify:
+--   * MPP-on doesn't break the serial code path
+--   * Shape classifier agrees between path-time and plan-stash-time
+--   * `maybe_stash_mpp_plan_bytes` completes without error
+--   * The plan survives logical-plan → bytes round-trip
+--
+-- A note on EXPLAIN scope: the EXPLAINs below show the PG-level plan
+-- (the Custom Scan node is opaque from the planner's perspective). The
+-- DataFusion physical plan that the walker actually rewrites and emits
+-- is not visible here. To inspect that, set `paradedb.mpp_debug = on`
+-- and run the query at a scale that triggers parallel workers; the
+-- walker's `mpp_log!` calls render the rewritten plan to stderr. For
+-- pure plan-structure assertions there are also unit tests under
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*` that
+-- build synthetic plans and assert the cut tags
+-- (`scalar_*`, `gb_*`, `tk_*`, `join_*`).
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+CREATE TABLE mpp_exec_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+CREATE TABLE mpp_exec_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+INSERT INTO mpp_exec_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+INSERT INTO mpp_exec_reviews (product_id, rating)
+SELECT (i % 40) + 1, (i % 5) + 1 FROM generate_series(1, 200) AS i;
+CREATE INDEX mpp_exec_products_idx ON mpp_exec_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+CREATE INDEX mpp_exec_reviews_idx ON mpp_exec_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT COUNT(*) AS baseline_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ baseline_count 
+----------------
+            200
+(1 row)
+
+-- =====================================================================
+-- MPP enabled: must return the same count.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 3;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny (40x200 rows) to exercise the MPP pipeline. In production the
+-- `mpp_min_join_rows` default (10_000) would opt out of MPP for this
+-- size; here we force MPP on so the pipeline gets tested.
+SET paradedb.mpp_min_join_rows TO 0;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                              QUERY PLAN                              
+----------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 2
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+         Aggregates: COUNT(*)
+(8 rows)
+
+SELECT COUNT(*) AS mpp_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ mpp_count 
+-----------
+       200
+(1 row)
+
+-- With mpp_debug, the plan should log the shape dispatch + parallel
+-- flip + the "routing exec_datafusion_aggregate through shape" line
+-- that proves the MPP exec bridge actually ran (not just the serial
+-- fallback). The answer must still match the baseline.
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*) AS mpp_count_with_debug
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape ScalarAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 3 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=0, total=3, aggr_count=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 1 attached to DSM (3 participants)
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=1, total=3, aggr_count=1, join_keys=1)
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=2, total=3, aggr_count=1, join_keys=1)
+ mpp_count_with_debug 
+----------------------
+                  200
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+-- =====================================================================
+-- GROUP BY aggregate on join, with ORDER BY on the group-by column. Both
+-- the GROUP BY and the ORDER BY are driven by the same column, so PG
+-- wraps the Gather-above-CustomScan MPP path in a Sort above the Gather.
+-- The MPP path keeps Aggrefs intact in every tlist so `fix_upper_expr`
+-- matches structurally at setrefs time (if we'd replaced them with
+-- `pdb.agg_fn(...)` placeholders only on the Gather side, setrefs would
+-- trip "Aggref found in non-Agg plan node" on the Result projection PG
+-- adds above the Sort).
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | cnt | max_rating 
+-------------+-----+------------
+ Clothing    |  50 |          5
+ Electronics |  50 |          5
+ Furniture   |  50 |          5
+ Sports      |  50 |          5
+(4 rows)
+
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_debug TO on;
+-- Force PG to pick the Gather-wrapped MPP path for GROUP BY on this
+-- small fixture: without these knobs the planner's cost model rejects
+-- Gather for aggregates at this row count and we'd fall back to the
+-- serial Custom Scan (which still produces correct output via the
+-- non-MPP code path).
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape GroupByAggOnBinaryJoin
+                                 QUERY PLAN                                 
+----------------------------------------------------------------------------
+ Sort
+   Output: p.category, (count(*)), (max(r.rating))
+   Sort Key: p.category
+   ->  Gather
+         Output: p.category, (count(*)), (max(r.rating))
+         Workers Planned: 2
+         ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+               Output: p.category, (count(*)), (max(r.rating))
+               Backend: DataFusion
+               Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+               Group By: category
+               Aggregates: COUNT(*), MAX(rating)
+(12 rows)
+
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+WARNING:  mpp: flipping AggregateScan path parallel_workers=2 for shape GroupByAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 3 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: distribute_plan walker dispatching shape=GroupByAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=0, total=3, aggr_count=2, group_keys=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: stashed plan-broadcast bytes (shape=GroupByAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 1 attached to DSM (3 participants)
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (3 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=GroupByAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: routing exec_datafusion_aggregate through shape GroupByAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=GroupByAggOnBinaryJoin total=3 cuts=3
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=2, total=3, aggr_count=2, group_keys=1, join_keys=1)
+WARNING:  mpp: assembling GroupByAggOnBinaryJoin plan (participant=1, total=3, aggr_count=2, group_keys=1, join_keys=1)
+  category   | cnt | max_rating 
+-------------+-----+------------
+ Clothing    |  50 |          5
+ Electronics |  50 |          5
+ Furniture   |  50 |          5
+ Sports      |  50 |          5
+(4 rows)
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+SET paradedb.mpp_debug TO off;
+-- =====================================================================
+-- GROUP BY + ORDER BY <agg-expr> + LIMIT — the SQL pattern that the
+-- walker upgrades to the `TopKGroupByAggOnBinaryJoin` shape *when*
+-- DataFusion's physical planner fuses `Sort[fetch=k]` over the
+-- aggregate. Whether that fusion happens depends on PG's planner
+-- decisions:
+--   * On bench-scale data (e.g. `aggregate_join_topk_count - alt 2`)
+--     the Sort+Limit collapses into the AggregateScan's pushed-down
+--     plan, the walker's `extract_topk_spec` matches, and the dispatch
+--     becomes `TopKGroupByAggOnBinaryJoin` (scalar-style routing:
+--     every participant ships its Partial groups to participant 0 via
+--     `FixedTargetPartitioner(0)`, leader runs `FinalPartitioned +
+--     Sort[fetch=k]`).
+--   * In this regress fixture, PG keeps `Sort` and `Limit` above the
+--     Gather, the AggregateScan only pushes the aggregate into
+--     DataFusion, and the walker dispatches as plain
+--     `GroupByAggOnBinaryJoin`. Result is still correct because the
+--     SortExec/LimitExec live above the Gather and execute serially
+--     after MPP gathers the per-participant aggregate output.
+-- The query stays as a regression-pin for the SQL pattern (correctness
+-- under either shape); for plan-shape coverage of the TopK upgrade
+-- itself, see the synthetic-plan unit tests in
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*`.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+  category   | cnt 
+-------------+-----
+ Clothing    |  50
+ Electronics |  50
+(2 rows)
+
+SET paradedb.enable_mpp TO on;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+-- Keep mpp_debug off here so the per-worker WARNING ordering doesn't
+-- interleave non-deterministically with the EXPLAIN / SELECT output
+-- (the existing scalar + groupby blocks above already cover the
+-- mpp_debug-on case).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+                                    QUERY PLAN                                    
+----------------------------------------------------------------------------------
+ Limit
+   Output: p.category, (count(*))
+   ->  Sort
+         Output: p.category, (count(*))
+         Sort Key: (count(*)) DESC, p.category
+         ->  Gather
+               Output: p.category, (count(*))
+               Workers Planned: 2
+               ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+                     Output: p.category, (count(*))
+                     Backend: DataFusion
+                     Indexes: mpp_exec_products_idx (p), mpp_exec_reviews_idx (r)
+                     Group By: category
+                     Aggregates: COUNT(*)
+(14 rows)
+
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+  category   | cnt 
+-------------+-----
+ Clothing    |  50
+ Electronics |  50
+(2 rows)
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+-- Restore defaults + clean up.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+DROP TABLE mpp_exec_reviews;
+DROP TABLE mpp_exec_products;

--- a/pg_search/tests/pg_regress/expected/mpp_fallback.out
+++ b/pg_search/tests/pg_regress/expected/mpp_fallback.out
@@ -1,0 +1,177 @@
+-- =====================================================================
+-- MPP fallback: prove that `paradedb.enable_mpp = on` is a no-op for
+-- queries whose shape isn't (yet) wired to the MPP path.
+--
+-- Phase 4b-i landed the GUC + all the primitives + the customscan_glue
+-- helpers, but did NOT yet flip AggregateScan's or JoinScan's
+-- `ParallelQueryCapable` hooks. So with `enable_mpp=on` every query
+-- should still produce the exact same answers as with `enable_mpp=off`
+-- (there just isn't an MPP path to choose). This test locks in that
+-- no-regression invariant — if Phase 4b-ii accidentally changes the
+-- off-path result under `enable_mpp=on`, this diff catches it.
+--
+-- Data setup mirrors the non-MPP aggregate fallback test so the two are
+-- easy to compare.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+CREATE TABLE mpp_fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+CREATE TABLE mpp_fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+INSERT INTO mpp_fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99),
+    ('Office chair ergonomic', 'Furniture', 249.99);
+INSERT INTO mpp_fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4), (3, 5), (4, 2);
+CREATE INDEX mpp_fb_products_idx ON mpp_fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+CREATE INDEX mpp_fb_reviews_idx ON mpp_fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+-- =====================================================================
+-- Baseline: enable_mpp = off (current default behavior)
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+-- Scalar aggregate on join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                         QUERY PLAN                         
+------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Backend: DataFusion
+   Indexes: mpp_fb_products_idx (p), mpp_fb_reviews_idx (r)
+   Aggregates: COUNT(*)
+(5 rows)
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ count 
+-------
+     6
+(1 row)
+
+-- GROUP BY aggregate on join
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count | max_rating 
+-------------+-------+------------
+ Clothing    |     2 |          5
+ Electronics |     2 |          5
+ Furniture   |     1 |          2
+ Sports      |     1 |          3
+(4 rows)
+
+-- =====================================================================
+-- MPP enabled: results must be byte-identical.
+--
+-- With MPP on but no customscan actually routes to the MPP path yet,
+-- the queries must return the same answers as with MPP off. Any
+-- divergence here means Phase 4b-ii accidentally changed existing
+-- behavior on the enable_mpp=on branch.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny to exercise the MPP pipeline's shape classification + plan-stash
+-- path. Production default (10_000) would opt out of MPP for this size.
+SET paradedb.mpp_min_join_rows TO 0;
+-- Same EXPLAIN + query as above.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+                            QUERY PLAN                            
+------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 1
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_fb_products_idx (p), mpp_fb_reviews_idx (r)
+         Aggregates: COUNT(*)
+(8 rows)
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+ count 
+-------
+     6
+(1 row)
+
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+  category   | count | max_rating 
+-------------+-------+------------
+ Clothing    |     2 |          5
+ Electronics |     2 |          5
+ Furniture   |     1 |          2
+ Sports      |     1 |          3
+(4 rows)
+
+-- Also verify `mpp_debug = on` is a no-op for correctness (may emit
+-- diagnostic warnings, but the query results must be unchanged).
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+WARNING:  mpp: flipping AggregateScan path parallel_workers=1 for shape ScalarAggOnBinaryJoin
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan leader initialized DSM for 2 participants
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=true)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=2 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=0, total=2, aggr_count=1, join_keys=1)
+WARNING:  mpp: stashed plan-broadcast bytes (shape=ScalarAggOnBinaryJoin) on AggregateScanState
+WARNING:  mpp: AggregateScan worker 0 attached to DSM (2 participants)
+WARNING:  mpp: routing exec_datafusion_aggregate through shape ScalarAggOnBinaryJoin (is_leader=false)
+WARNING:  mpp: distribute_plan walker dispatching shape=ScalarAggOnBinaryJoin total=2 cuts=3
+WARNING:  mpp: assembling ScalarAggOnBinaryJoin plan (participant=1, total=2, aggr_count=1, join_keys=1)
+ count 
+-------
+     6
+(1 row)
+
+SET paradedb.mpp_debug TO off;
+-- Restore defaults.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+DROP TABLE mpp_fb_reviews;
+DROP TABLE mpp_fb_products;

--- a/pg_search/tests/pg_regress/expected/mpp_join.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join.out
@@ -1,0 +1,171 @@
+-- =====================================================================
+-- MPP correctness for the JoinOnly shape: a bare join without an
+-- aggregate above it. Verifies that with `paradedb.enable_mpp = on` the
+-- result rows match the serial baseline.
+--
+-- Like `mpp_exec.sql`, this test exercises plan-stash + classifier +
+-- parallel-flag pipeline. PG's planner may not launch actual workers on
+-- this small dataset; what this test DOES guarantee is:
+--   * the JoinOnly plan stash completes without error
+--   * the exec path produces correct rows whether or not workers launch
+--   * `mpp_debug` logs the `mpp: routing JoinScan exec through shape` line
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+CREATE TABLE mpp_join_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+CREATE TABLE mpp_join_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER,
+    comment TEXT
+);
+INSERT INTO mpp_join_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+INSERT INTO mpp_join_reviews (product_id, rating, comment)
+SELECT
+    (i % 40) + 1,
+    (i % 5) + 1,
+    'review ' || i
+FROM generate_series(1, 200) AS i;
+CREATE INDEX mpp_join_products_idx ON mpp_join_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+CREATE INDEX mpp_join_reviews_idx ON mpp_join_reviews
+USING bm25 (id, product_id, rating, comment)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}',
+    text_fields='{"comment": {}}'
+);
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      | rating 
+----+----------------------+--------
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+(10 rows)
+
+-- =====================================================================
+-- MPP enabled: must return the same rows (set-equality, then row-order).
+-- `mpp_min_join_rows` must be 0 here: the default (10k rows) would gate
+-- out this small dataset and silently fall through to the serial path,
+-- defeating the point of the test.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+SET paradedb.mpp_min_join_rows TO 0;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.description, r.rating, r.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.description, r.rating, r.id
+         Relation Tree: r INNER p
+         Join Cond: p.id = r.product_id
+         Limit: 10
+         Order By: p.id asc, r.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, NULL as col_3, id@1 as col_4, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST, id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[r, p]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      | rating 
+----+----------------------+--------
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  4 | Laptop computer fast |      4
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+  8 | Laptop computer fast |      3
+(10 rows)
+
+-- Multi-predicate join with both sides filtered.
+SELECT p.id, p.description, r.comment
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop' AND r.comment @@@ 'review'
+ORDER BY p.id, r.id
+LIMIT 10;
+ id |     description      |  comment   
+----+----------------------+------------
+  4 | Laptop computer fast | review 3
+  4 | Laptop computer fast | review 43
+  4 | Laptop computer fast | review 83
+  4 | Laptop computer fast | review 123
+  4 | Laptop computer fast | review 163
+  8 | Laptop computer fast | review 7
+  8 | Laptop computer fast | review 47
+  8 | Laptop computer fast | review 87
+  8 | Laptop computer fast | review 127
+  8 | Laptop computer fast | review 167
+(10 rows)
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_join_custom_scan;
+DROP TABLE mpp_join_reviews;
+DROP TABLE mpp_join_products;

--- a/pg_search/tests/pg_regress/sql/mpp_exec.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_exec.sql
@@ -1,0 +1,249 @@
+-- =====================================================================
+-- MPP correctness: with `paradedb.enable_mpp=on`, scalar COUNT(*) on a
+-- binary join must return the same result as with MPP off.
+--
+-- This test exercises the full shape classification + plan-stash +
+-- parallel-flag flip pipeline on a medium-sized dataset (40x200 rows).
+-- PG's planner decides whether to launch actual parallel workers based
+-- on cost; at this size it typically doesn't, so the MPP *exec* path
+-- isn't exercised here — for that you need `debug_parallel_query=on`
+-- at a larger scale, which is out of scope for pg_regress (no parallel
+-- workers launched == no DSM coordination == no cross-worker shuffle).
+--
+-- What this DOES verify:
+--   * MPP-on doesn't break the serial code path
+--   * Shape classifier agrees between path-time and plan-stash-time
+--   * `maybe_stash_mpp_plan_bytes` completes without error
+--   * The plan survives logical-plan → bytes round-trip
+--
+-- A note on EXPLAIN scope: the EXPLAINs below show the PG-level plan
+-- (the Custom Scan node is opaque from the planner's perspective). The
+-- DataFusion physical plan that the walker actually rewrites and emits
+-- is not visible here. To inspect that, set `paradedb.mpp_debug = on`
+-- and run the query at a scale that triggers parallel workers; the
+-- walker's `mpp_log!` calls render the rewritten plan to stderr. For
+-- pure plan-structure assertions there are also unit tests under
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*` that
+-- build synthetic plans and assert the cut tags
+-- (`scalar_*`, `gb_*`, `tk_*`, `join_*`).
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+CREATE TABLE mpp_exec_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+
+CREATE TABLE mpp_exec_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+
+INSERT INTO mpp_exec_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+
+INSERT INTO mpp_exec_reviews (product_id, rating)
+SELECT (i % 40) + 1, (i % 5) + 1 FROM generate_series(1, 200) AS i;
+
+CREATE INDEX mpp_exec_products_idx ON mpp_exec_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+
+CREATE INDEX mpp_exec_reviews_idx ON mpp_exec_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+
+
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+SELECT COUNT(*) AS baseline_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- =====================================================================
+-- MPP enabled: must return the same count.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 3;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny (40x200 rows) to exercise the MPP pipeline. In production the
+-- `mpp_min_join_rows` default (10_000) would opt out of MPP for this
+-- size; here we force MPP on so the pipeline gets tested.
+SET paradedb.mpp_min_join_rows TO 0;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*) AS mpp_count
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- With mpp_debug, the plan should log the shape dispatch + parallel
+-- flip + the "routing exec_datafusion_aggregate through shape" line
+-- that proves the MPP exec bridge actually ran (not just the serial
+-- fallback). The answer must still match the baseline.
+SET paradedb.mpp_debug TO on;
+
+SELECT COUNT(*) AS mpp_count_with_debug
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SET paradedb.mpp_debug TO off;
+
+-- =====================================================================
+-- GROUP BY aggregate on join, with ORDER BY on the group-by column. Both
+-- the GROUP BY and the ORDER BY are driven by the same column, so PG
+-- wraps the Gather-above-CustomScan MPP path in a Sort above the Gather.
+-- The MPP path keeps Aggrefs intact in every tlist so `fix_upper_expr`
+-- matches structurally at setrefs time (if we'd replaced them with
+-- `pdb.agg_fn(...)` placeholders only on the Gather side, setrefs would
+-- trip "Aggref found in non-Agg plan node" on the Result projection PG
+-- adds above the Sort).
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_debug TO on;
+-- Force PG to pick the Gather-wrapped MPP path for GROUP BY on this
+-- small fixture: without these knobs the planner's cost model rejects
+-- Gather for aggregates at this row count and we'd fall back to the
+-- serial Custom Scan (which still produces correct output via the
+-- non-MPP code path).
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+SELECT p.category, COUNT(*) AS cnt, MAX(r.rating) AS max_rating
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+
+SET paradedb.mpp_debug TO off;
+
+-- =====================================================================
+-- GROUP BY + ORDER BY <agg-expr> + LIMIT — the SQL pattern that the
+-- walker upgrades to the `TopKGroupByAggOnBinaryJoin` shape *when*
+-- DataFusion's physical planner fuses `Sort[fetch=k]` over the
+-- aggregate. Whether that fusion happens depends on PG's planner
+-- decisions:
+--   * On bench-scale data (e.g. `aggregate_join_topk_count - alt 2`)
+--     the Sort+Limit collapses into the AggregateScan's pushed-down
+--     plan, the walker's `extract_topk_spec` matches, and the dispatch
+--     becomes `TopKGroupByAggOnBinaryJoin` (scalar-style routing:
+--     every participant ships its Partial groups to participant 0 via
+--     `FixedTargetPartitioner(0)`, leader runs `FinalPartitioned +
+--     Sort[fetch=k]`).
+--   * In this regress fixture, PG keeps `Sort` and `Limit` above the
+--     Gather, the AggregateScan only pushes the aggregate into
+--     DataFusion, and the walker dispatches as plain
+--     `GroupByAggOnBinaryJoin`. Result is still correct because the
+--     SortExec/LimitExec live above the Gather and execute serially
+--     after MPP gathers the per-participant aggregate output.
+-- The query stays as a regression-pin for the SQL pattern (correctness
+-- under either shape); for plan-shape coverage of the TopK upgrade
+-- itself, see the synthetic-plan unit tests in
+-- `pg_search/src/postgres/customscan/mpp/walker.rs::tests::*`.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+
+SET paradedb.enable_mpp TO on;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+SET max_parallel_workers_per_gather TO 2;
+
+-- Keep mpp_debug off here so the per-worker WARNING ordering doesn't
+-- interleave non-deterministically with the EXPLAIN / SELECT output
+-- (the existing scalar + groupby blocks above already cover the
+-- mpp_debug-on case).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+
+SELECT p.category, COUNT(*) AS cnt
+FROM mpp_exec_products p
+JOIN mpp_exec_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY cnt DESC, p.category
+LIMIT 2;
+
+RESET min_parallel_table_scan_size;
+RESET parallel_setup_cost;
+RESET parallel_tuple_cost;
+RESET max_parallel_workers_per_gather;
+
+-- Restore defaults + clean up.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+
+DROP TABLE mpp_exec_reviews;
+DROP TABLE mpp_exec_products;

--- a/pg_search/tests/pg_regress/sql/mpp_fallback.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_fallback.sql
@@ -1,0 +1,132 @@
+-- =====================================================================
+-- MPP fallback: prove that `paradedb.enable_mpp = on` is a no-op for
+-- queries whose shape isn't (yet) wired to the MPP path.
+--
+-- Phase 4b-i landed the GUC + all the primitives + the customscan_glue
+-- helpers, but did NOT yet flip AggregateScan's or JoinScan's
+-- `ParallelQueryCapable` hooks. So with `enable_mpp=on` every query
+-- should still produce the exact same answers as with `enable_mpp=off`
+-- (there just isn't an MPP path to choose). This test locks in that
+-- no-regression invariant — if Phase 4b-ii accidentally changes the
+-- off-path result under `enable_mpp=on`, this diff catches it.
+--
+-- Data setup mirrors the non-MPP aggregate fallback test so the two are
+-- easy to compare.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+CREATE TABLE mpp_fb_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT,
+    price FLOAT
+);
+
+CREATE TABLE mpp_fb_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER
+);
+
+INSERT INTO mpp_fb_products (description, category, price) VALUES
+    ('Laptop computer fast', 'Electronics', 999.99),
+    ('Running shoes light', 'Sports', 89.99),
+    ('Winter jacket warm', 'Clothing', 129.99),
+    ('Office chair ergonomic', 'Furniture', 249.99);
+
+INSERT INTO mpp_fb_reviews (product_id, rating) VALUES
+    (1, 5), (1, 4), (2, 3), (3, 4), (3, 5), (4, 2);
+
+CREATE INDEX mpp_fb_products_idx ON mpp_fb_products
+USING bm25 (id, description, category, price)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}',
+    numeric_fields='{"price": {"fast": true}}'
+);
+
+CREATE INDEX mpp_fb_reviews_idx ON mpp_fb_reviews
+USING bm25 (id, product_id, rating)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}'
+);
+
+-- =====================================================================
+-- Baseline: enable_mpp = off (current default behavior)
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+-- Scalar aggregate on join
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+-- GROUP BY aggregate on join
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- =====================================================================
+-- MPP enabled: results must be byte-identical.
+--
+-- With MPP on but no customscan actually routes to the MPP path yet,
+-- the queries must return the same answers as with MPP off. Any
+-- divergence here means Phase 4b-ii accidentally changed existing
+-- behavior on the enable_mpp=on branch.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+-- Disable the broadcast-side cost gate: these tables are intentionally
+-- tiny to exercise the MPP pipeline's shape classification + plan-stash
+-- path. Production default (10_000) would opt out of MPP for this size.
+SET paradedb.mpp_min_join_rows TO 0;
+
+-- Same EXPLAIN + query as above.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+
+SELECT p.category, COUNT(*), MAX(r.rating) AS max_rating
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair'
+GROUP BY p.category
+ORDER BY p.category;
+
+-- Also verify `mpp_debug = on` is a no-op for correctness (may emit
+-- diagnostic warnings, but the query results must be unchanged).
+SET paradedb.mpp_debug TO on;
+SELECT COUNT(*)
+FROM mpp_fb_products p
+JOIN mpp_fb_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR chair';
+SET paradedb.mpp_debug TO off;
+
+-- Restore defaults.
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_aggregate_custom_scan;
+
+DROP TABLE mpp_fb_reviews;
+DROP TABLE mpp_fb_products;

--- a/pg_search/tests/pg_regress/sql/mpp_join.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_join.sql
@@ -1,0 +1,122 @@
+-- =====================================================================
+-- MPP correctness for the JoinOnly shape: a bare join without an
+-- aggregate above it. Verifies that with `paradedb.enable_mpp = on` the
+-- result rows match the serial baseline.
+--
+-- Like `mpp_exec.sql`, this test exercises plan-stash + classifier +
+-- parallel-flag pipeline. PG's planner may not launch actual workers on
+-- this small dataset; what this test DOES guarantee is:
+--   * the JoinOnly plan stash completes without error
+--   * the exec path produces correct rows whether or not workers launch
+--   * `mpp_debug` logs the `mpp: routing JoinScan exec through shape` line
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan TO on;
+
+CREATE TABLE mpp_join_products (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    category TEXT
+);
+
+CREATE TABLE mpp_join_reviews (
+    id SERIAL PRIMARY KEY,
+    product_id INTEGER,
+    rating INTEGER,
+    comment TEXT
+);
+
+INSERT INTO mpp_join_products (description, category)
+SELECT
+    CASE (i % 4)
+        WHEN 0 THEN 'Laptop computer fast'
+        WHEN 1 THEN 'Running shoes light'
+        WHEN 2 THEN 'Winter jacket warm'
+        ELSE 'Office chair ergonomic'
+    END,
+    CASE (i % 4)
+        WHEN 0 THEN 'Electronics'
+        WHEN 1 THEN 'Sports'
+        WHEN 2 THEN 'Clothing'
+        ELSE 'Furniture'
+    END
+FROM generate_series(1, 40) AS i;
+
+INSERT INTO mpp_join_reviews (product_id, rating, comment)
+SELECT
+    (i % 40) + 1,
+    (i % 5) + 1,
+    'review ' || i
+FROM generate_series(1, 200) AS i;
+
+CREATE INDEX mpp_join_products_idx ON mpp_join_products
+USING bm25 (id, description, category)
+WITH (
+    key_field='id',
+    text_fields='{"description": {}, "category": {"fast": true}}'
+);
+
+CREATE INDEX mpp_join_reviews_idx ON mpp_join_reviews
+USING bm25 (id, product_id, rating, comment)
+WITH (
+    key_field='id',
+    numeric_fields='{"product_id": {"fast": true}, "rating": {"fast": true}}',
+    text_fields='{"comment": {}}'
+);
+
+-- =====================================================================
+-- Serial baseline
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- =====================================================================
+-- MPP enabled: must return the same rows (set-equality, then row-order).
+-- `mpp_min_join_rows` must be 0 here: the default (10k rows) would gate
+-- out this small dataset and silently fall through to the serial path,
+-- defeating the point of the test.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 2;
+SET paradedb.mpp_min_join_rows TO 0;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+SELECT p.id, p.description, r.rating
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- Multi-predicate join with both sides filtered.
+SELECT p.id, p.description, r.comment
+FROM mpp_join_products p
+JOIN mpp_join_reviews r ON p.id = r.product_id
+WHERE p.description @@@ 'laptop' AND r.comment @@@ 'review'
+ORDER BY p.id, r.id
+LIMIT 10;
+
+-- =====================================================================
+-- Clean up
+-- =====================================================================
+RESET paradedb.enable_mpp;
+RESET paradedb.mpp_worker_count;
+RESET paradedb.mpp_min_join_rows;
+RESET paradedb.enable_join_custom_scan;
+
+DROP TABLE mpp_join_reviews;
+DROP TABLE mpp_join_products;


### PR DESCRIPTION
# Ticket(s) Closed

- Part of #4152
- Stacked on top of #4932

## Summary

Follow-up cleanup to the 5-PR MPP chain. Drops the local \`MppStage\` struct and \`MppNetworkBoundary\` trait; leans on \`datafusion_distributed::Stage\` and \`NetworkBoundary\` directly. The fork's types carry the same information (query_id + stage number + task count) modulo a u64→Uuid round-trip on \`query_id\`, which now happens once at the single construction site in \`walker::emit_shuffle_cut\`.

**Net -111 LOC** with no behaviour change.

## Why

After the chain landed the fork integration (PR #4870), \`MppShuffleExec\` was carrying *two* stage representations side-by-side: a local \`Option<MppStage>\` (used by ParadeDB code) and an \`Option<Stage>\` (used by the fork's metrics/idempotency paths). The fork's \`NetworkBoundary::with_input_stage\` was a stub that returned an error; the local trait was the real stamping path. That duplication is dead weight — the fork's types are sufficient on their own.

## How

- \`MppShuffleExec\` now holds a single \`Option<Stage>\` field. The fork's \`NetworkBoundary\` impl becomes the real one (does the wiring/drain transfer that the local \`MppNetworkBoundary::with_input_stage\` used to do); the stub is gone. Un-stamped test fixtures still resolve via a process-static placeholder \`Stage\`, identical to the pattern the stub already used.
- \`walker::emit_shuffle_cut\` constructs \`Stage::new_unaddressed(Uuid::from_u128(query_id as u128), cut_index, total_participants)\` directly. The wire-format \`MppTaskKey\` is built from the local primitives in the same function — the conversion stays at one seam.
- \`plan_build.rs\` switches its \`MppShuffleInputs.stage\` from \`Option<MppStage>\` to \`Option<Stage>\` and stamps via \`NetworkBoundary::with_input_stage\`.
- \`stage.rs\` shrinks to just \`MppTaskKey\` + its tests. \`MppTaskKey\` stays — it is the wire descriptor inside the transport frame header (\`{query_id, stage_id, task_number}\`) and has no fork equivalent.
- Doc comments in \`session.rs\`, \`coordinator.rs\`, \`customscan_glue.rs\`, \`transport.rs\`, and \`walker.rs\` updated to reference \`Stage\` / \`Stage::query_id\` instead of the dropped local types.

## Reviewer's guide

- \`shuffle.rs\`: only one \`NetworkBoundary\` impl now; the previous dual-impl plus \`mpp_stage_to_dfd_stage\` helper are gone.
- \`walker.rs\`: the seam that converts \`u64 query_id\` → \`Uuid\` is the one site at \`emit_shuffle_cut\`. Everything else uses \`Stage\` accessors.
- \`stage.rs\`: down to one type and one test.

## Test plan

- [x] \`cargo check -p pg_search --features pg18\` clean
- [x] \`cargo clippy -p pg_search --features pg18 --all-targets -- -D warnings\` clean
- [x] \`cargo test -p pg_search --lib mpp:: --features pg18 -- --test-threads=1\` — 108/108 passing (one fewer than before because the dropped \`MppStage\` round-trip test went away with the type)