### PR TITLE
chore: Update Tantivy rev to include upstream Tantivy changes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7761,7 +7761,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "bitpacking",
 ]
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7872,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7897,7 +7897,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7934,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152#3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84025b075a6ea71be2b9b2ba77ae30cd208ca3f5", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.18.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "84025b075a6ea71be2b9b2ba77ae30cd208ca3f5" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-vJwh8vlroAa2gr+3c+RbLKqUr431yfhDSYqXQWtu5KI=";
+  cargoHash = "sha256-xKCoYYJaKgIfK5CCH3u13J9b21otB8Qjbz+RQXKP1qM=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-ObZHz9MFp23NoVWg7/+FVzdtEzURE6ddK5YgqA+vGFI=";
+  cargoHash = "sha256-vJwh8vlroAa2gr+3c+RbLKqUr431yfhDSYqXQWtu5KI="
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-vJwh8vlroAa2gr+3c+RbLKqUr431yfhDSYqXQWtu5KI="
+  cargoHash = "sha256-vJwh8vlroAa2gr+3c+RbLKqUr431yfhDSYqXQWtu5KI=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
- [fix: Optimize single term BooleanQuery to use BMW (](https://github.com/paradedb/tantivy/commit/32c398897b4a15b0be3fb3ad73a80133459a4b14)https://github.com/paradedb/tantivy/pull/121[)](https://github.com/paradedb/tantivy/commit/32c398897b4a15b0be3fb3ad73a80133459a4b14)
- [chore: Remove our BooleanTerm single-term fix, replace with Paul's generic upstream fix. (](https://github.com/paradedb/tantivy/commit/a1af0a189aff96fc986cd1352ecd360d5fb6c713)https://github.com/paradedb/tantivy/pull/130[)](https://github.com/paradedb/tantivy/commit/a1af0a189aff96fc986cd1352ecd360d5fb6c713)
- [Enable BMW for single-scorer boolean queries by removing early return… (](https://github.com/paradedb/tantivy/commit/3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152)https://github.com/paradedb/tantivy/pull/131[)](https://github.com/paradedb/tantivy/commit/3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152)

(and some other ones which wouldn't help perf)