### PR TITLE
feat: explicitly set columnar codec types for new indexes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7761,7 +7761,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "bitpacking",
 ]
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7872,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7897,7 +7897,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7934,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=84025b075a6ea71be2b9b2ba77ae30cd208ca3f5#84025b075a6ea71be2b9b2ba77ae30cd208ca3f5"
+source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5192,7 +5192,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7761,7 +7761,7 @@ dependencies = [
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7816,7 +7816,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "bitpacking",
 ]
@@ -7824,7 +7824,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7839,7 +7839,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7872,7 +7872,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7884,7 +7884,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7897,7 +7897,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7934,7 +7934,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=431636a778644ab7ef48e6ea9ee8260ff486e5cf#431636a778644ab7ef48e6ea9ee8260ff486e5cf"
+source = "git+https://github.com/paradedb/tantivy.git?rev=242e72b78547cfd494097bf7c0c4029e27be4cc9#242e72b78547cfd494097bf7c0c4029e27be4cc9"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "84025b075a6ea71be2b9b2ba77ae30cd208ca3f5", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "431636a778644ab7ef48e6ea9ee8260ff486e5cf", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.18.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "84025b075a6ea71be2b9b2ba77ae30cd208ca3f5" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "431636a778644ab7ef48e6ea9ee8260ff486e5cf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "431636a778644ab7ef48e6ea9ee8260ff486e5cf", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "242e72b78547cfd494097bf7c0c4029e27be4cc9", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "quickwit",                  # for sstable support
@@ -40,4 +40,4 @@ pgrx-tests = "=0.18.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "431636a778644ab7ef48e6ea9ee8260ff486e5cf" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "242e72b78547cfd494097bf7c0c4029e27be4cc9" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-WAcs+pUckvGYVvNrQ2z7mgUnwxGUVKibq419bJxcbZU=";
+  cargoHash = "sha256-Dexyng9xtPrhGGf6xk983TwXW7LA5wziz+B/I7f6yWs=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -65,7 +65,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-xKCoYYJaKgIfK5CCH3u13J9b21otB8Qjbz+RQXKP1qM=";
+  cargoHash = "sha256-WAcs+pUckvGYVvNrQ2z7mgUnwxGUVKibq419bJxcbZU=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -175,6 +175,10 @@ impl SerialIndexWriter {
             SearchIndexSchema::build_sort_by_field(&options.sort_by(), &tantivy_schema);
         let settings = IndexSettings {
             sort_by_field,
+            codec_types: vec![
+                tantivy::columnar::CodecType::Bitpacked,
+                tantivy::columnar::CodecType::BlockwiseLinear,
+            ],
             ..IndexSettings::default()
         };
         let mut index = Index::create(directory, tantivy_schema, settings)?;

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -308,6 +308,10 @@ fn create_index(index_relation: &PgSearchRelation) -> Result<()> {
     let settings = IndexSettings {
         sort_by_field,
         docstore_compress_dedicated_thread: false,
+        codec_types: vec![
+            tantivy::columnar::CodecType::Bitpacked,
+            tantivy::columnar::CodecType::BlockwiseLinear,
+        ],
         ..IndexSettings::default()
     };
     let _ = Index::create(directory, schema, settings)?;
@@ -450,5 +454,34 @@ mod tests {
         let sort_field = stored_settings.sort_by_field.as_ref().unwrap();
         assert_eq!(sort_field.field, "score");
         assert_eq!(sort_field.order, Order::Desc);
+    }
+
+    #[pg_test]
+    fn test_new_index_uses_configured_codecs() {
+        use tantivy::columnar::CodecType;
+        use tantivy::directory::RamDirectory;
+
+        let mut builder = Schema::builder();
+        builder.add_u64_field("val", FAST);
+        let schema = builder.build();
+
+        let settings = IndexSettings {
+            codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinear],
+            ..IndexSettings::default()
+        };
+
+        let directory = RamDirectory::create();
+        let index = Index::create(directory, schema, settings).unwrap();
+
+        // Verify codec_types persisted and round-tripped
+        let stored = index.settings();
+        assert_eq!(
+            stored.codec_types,
+            vec![CodecType::Bitpacked, CodecType::BlockwiseLinear]
+        );
+        assert_eq!(
+            stored.columnar_codec_types(),
+            &[CodecType::Bitpacked, CodecType::BlockwiseLinear]
+        );
     }
 }


### PR DESCRIPTION
Use tantivy's new codec selection mechanics to explicitly configure `[Bitpacked, BlockwiseLinear]` as the codec types for u64-based column serialization. These codec types are persisted in index metadata and used for initial index creation, REINDEX, subsequent segment merges, and in memory segments.

This is in preparation for the `BlockwiseLinearV2` addition.

**DO NOT MERGE UNTIL `Cargo.toml` is repointed at a main commit.**