### PR TITLE
chore: Pin ORM library versions (#4823)

### DIFF
--- a/.github/scripts/smoke_test_code_snippets.sh
+++ b/.github/scripts/smoke_test_code_snippets.sh
@@ -82,16 +82,16 @@ drop_snippet_indexes() {
 echo "Creating temporary Python environment for Python snippet verification..."
 python3 -m venv "$PYTHON_ENV_DIR"
 
-echo "Installing latest Django and SQLAlchemy ParadeDB clients from PyPI..."
+echo "Installing Django and SQLAlchemy ParadeDB clients from PyPI..."
 PIP_DISABLE_PIP_VERSION_CHECK=1 "$PYTHON_BIN" -m pip install --quiet --upgrade \
-  "django-paradedb" \
-  "sqlalchemy-paradedb" \
+  "django-paradedb==0.5.0" \
+  "sqlalchemy-paradedb==0.5.0" \
   "psycopg[binary]"
 
-echo "Installing latest rails-paradedb from RubyGems..."
+echo "Installing rails-paradedb from RubyGems..."
 GEM_HOME="$RUBY_GEM_HOME" GEM_PATH="$RUBY_GEM_HOME" \
   gem install --silent --no-document --install-dir "$RUBY_GEM_HOME" \
-  "rails-paradedb" \
+  "rails-paradedb:0.6.0" \
   "pg"
 
 "$PYTHON_BIN" "${SCRIPT_DIR}/extract_code_snippets.py" >/dev/null

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -65,7 +65,7 @@ To start you'll need a [Django](https://www.djangoproject.com/) project with [Ps
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install django psycopg django-paradedb
+pip install django psycopg django-paradedb==0.5.0
 python3 -m django startproject myproject .
 python3 manage.py startapp myapp
 ```
@@ -182,7 +182,7 @@ To get started, install [SQLAlchemy](https://www.sqlalchemy.org/), [Alembic](htt
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install sqlalchemy psycopg alembic sqlalchemy-paradedb
+pip install sqlalchemy psycopg alembic sqlalchemy-paradedb==0.5.0
 ```
 
 Initialize Alembic:
@@ -440,7 +440,7 @@ cd paradedb
 Add the [rails-paradedb](https://rubygems.org/gems/rails-paradedb) gem to your `Gemfile`:
 
 ```ruby Gemfile
-gem "rails-paradedb", require: "parade_db"
+gem "rails-paradedb", "0.6.0", require: "parade_db"
 ```
 
 Then install it:


### PR DESCRIPTION
# Ticket(s) Closed

Backport the change to pin the ORM versions in the doc snippet test script so that the workflow passes on 0.23.x.

## What

## Why

## How

## Tests
