### PR TITLE
chore: Backport numeric compatibility fix to 0.22.x

### DIFF
--- a/.github/actions/test-pg_search-upgrade/README.md
+++ b/.github/actions/test-pg_search-upgrade/README.md
@@ -1,0 +1,7 @@
+# Version Upgrade Testing
+
+New versions of ParadeDB must maintain compatibility with old versions so that users can upgrade the extension smoothly. This action tests the upgrade flow by creating an instance with the old version of the extension, arranging some data, upgrading to the latest version, and verifying that queries can still be run against the upgraded version.
+
+To add a test, add a folder containing files called `setup.sql` and `queries.sql`. `setup.sql` should create the tables, indexes, and data necessary to arrange your test case and will be run on the old version of the DB. `queries.sql` should contain the queries to run against the upgraded DB. The folder name will be used as the name of the DB so that there is isolation between test cases.
+
+We also run the integration tests after upgrading. This verifies that the extension symbols are upgraded properly but does not give any validation that the on-disk changes are correct because the tests don't use DBs created on the old version.

--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -1,0 +1,168 @@
+name: Test pg_search Upgrade
+description: Test that the pg_search extension can upgrade via ALTER EXTENSION from a given prior version
+
+inputs:
+  prior_pg_search_version:
+    description: "The prior pg_search version (git tag) to upgrade from, e.g. v0.21.0"
+    required: true
+  prior_pgrx_version:
+    description: "The pgrx version compatible with the prior pg_search version, e.g. 0.16.1"
+    required: true
+  pg_version:
+    description: "The PostgreSQL major version to test against"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Extract pgrx Version
+      id: pgrx
+      shell: bash
+      run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+
+    - name: Preserve SQL Files
+      shell: bash
+      run: |
+        SQL_DIR="$(mktemp -d)"
+        for case_dir in "${{ github.action_path }}"/*; do
+          [ -d "$case_dir" ] && cp -R "$case_dir" "$SQL_DIR/"
+        done
+        echo "UPGRADE_SQL_DIR=$SQL_DIR" >> "$GITHUB_ENV"
+
+    # This is the pgrx version compatible with ParadeDB ${{ inputs.prior_pg_search_version }}
+    - name: Install pgrx for ParadeDB ${{ inputs.prior_pg_search_version }}
+      shell: bash
+      run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ inputs.prior_pgrx_version }} --force --debug
+
+    - name: Initialize pgrx environment for ParadeDB ${{ inputs.prior_pg_search_version }}
+      shell: bash
+      run: cargo pgrx init "--pg${{ inputs.pg_version }}=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Checkout ParadeDB ${{ inputs.prior_pg_search_version }}
+      shell: bash
+      run: |
+        # cleanup any local modifications the above steps may have made
+        git checkout .
+
+        # checkout the prior version of ParadeDB
+        git checkout ${{ inputs.prior_pg_search_version }}
+
+    - name: Compile & install pg_search ${{ inputs.prior_pg_search_version }}
+      working-directory: pg_search/
+      shell: bash
+      run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Add pg_search to shared_preload_libraries
+      working-directory: /home/runner/.pgrx/data-${{ inputs.pg_version }}/
+      shell: bash
+      run: echo "shared_preload_libraries = 'pg_search'" >> postgresql.conf
+
+    - name: Start Postgres via pgrx
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        RUST_BACKTRACE=1 cargo pgrx start pg${{ inputs.pg_version }}
+        # Necessary for the ephemeral Postgres test to have proper permissions
+        sudo chown -R $(whoami) /var/run/postgresql/
+
+    - name: Create pg_search Extension
+      working-directory: pg_search/
+      shell: bash
+      run: psql -h localhost -p 288${{ inputs.pg_version }} postgres -c 'CREATE EXTENSION pg_search;'
+
+    - name: Create Upgrade Test Databases
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        set -euo pipefail
+        for case_dir in "$UPGRADE_SQL_DIR"/*; do
+          db="$(basename "$case_dir")"
+          createdb -h localhost -p 288${{ inputs.pg_version }} "$db"
+          psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} "$db" -c 'CREATE EXTENSION pg_search;'
+          psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} "$db" -f "$case_dir/setup.sql"
+        done
+
+    - name: Stop Postgres via pgrx
+      working-directory: pg_search/
+      shell: bash
+      run: RUST_BACKTRACE=1 cargo pgrx stop pg${{ inputs.pg_version }}
+
+    - name: Install the pgrx version for ParadeDB
+      shell: bash
+      run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --force --debug
+
+    - name: Initialize pgrx environment for ParadeDB
+      shell: bash
+      run: cargo pgrx init "--pg${{ inputs.pg_version }}=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Fetch and Checkout PR Head (PR) or Pushed Commit (push)
+      shell: bash
+      run: |
+        set -euo pipefail
+        git checkout .
+
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          git fetch origin +refs/pull/${{ github.event.pull_request.number }}/head:${{ github.event.pull_request.head.ref }}
+          git checkout ${{ github.event.pull_request.head.ref }}
+        else
+          # For push (and other non-PR events), use the exact commit that triggered the workflow
+          git fetch origin ${{ github.sha }}:commit-${{ github.sha }}
+          git checkout commit-${{ github.sha }}
+        fi
+
+    - name: Compile & install pg_search
+      working-directory: pg_search/
+      shell: bash
+      run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+
+    - name: Add pg_search to shared_preload_libraries
+      working-directory: /home/runner/.pgrx/data-${{ inputs.pg_version }}/
+      shell: bash
+      run: echo "shared_preload_libraries = 'pg_search'" >> postgresql.conf
+
+    - name: Start Postgres via pgrx
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        RUST_BACKTRACE=1 cargo pgrx start pg${{ inputs.pg_version }}
+        # Necessary for the ephemeral Postgres test to have proper permissions
+        sudo chown -R $(whoami) /var/run/postgresql/
+
+    - name: Alter pg_search extension to the latest version
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        set -euo pipefail
+        VERSION=$(grep "^version" ../Cargo.toml | head -1 | awk -F '"' '{print $2}')
+        psql -h localhost -p 288${{ inputs.pg_version }} postgres -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
+        for case_dir in "$UPGRADE_SQL_DIR"/*; do
+          db="$(basename "$case_dir")"
+          echo "Creating database $db"
+          psql -h localhost -p 288${{ inputs.pg_version }} "$db" -c "ALTER EXTENSION pg_search UPDATE TO '$VERSION';"
+        done
+
+    # We test each BM25 index after the upgrade to test for version compatibility.
+    - name: Test BM25 Index
+      working-directory: pg_search/
+      shell: bash
+      run: |
+        set -euo pipefail
+        for case_dir in "$UPGRADE_SQL_DIR"/*; do
+          db="$(basename "$case_dir")"
+          echo "Running queries against $db"
+          psql -v ON_ERROR_STOP=1 -h localhost -p 288${{ inputs.pg_version }} "$db" -f "$case_dir/queries.sql"
+        done
+
+    # We only run the integration tests since pgrx won't run the #[pg_test] unit tests in an existing database
+    - name: Run pg_search Integration Tests
+      working-directory: tests/
+      shell: bash
+      run: |
+        export DATABASE_URL=postgresql://localhost:288${{ inputs.pg_version }}/postgres
+        export PG_CONFIG=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config
+        RUST_BACKTRACE=1 cargo test --jobs $(nproc)
+
+    - name: Print the Postgres Logs
+      if: always()
+      shell: bash
+      run: cat ~/.pgrx/${{ inputs.pg_version }}.log

--- a/.github/actions/test-pg_search-upgrade/codecs/queries.sql
+++ b/.github/actions/test-pg_search-upgrade/codecs/queries.sql
@@ -1,0 +1,3 @@
+insert into items (id, number) values (2, 4534534);
+
+select id, number from items where id @@@ pdb.all();

--- a/.github/actions/test-pg_search-upgrade/codecs/setup.sql
+++ b/.github/actions/test-pg_search-upgrade/codecs/setup.sql
@@ -1,0 +1,9 @@
+create table items (
+    id bigserial,
+    number bigint
+);
+
+create index search_idx on items
+using bm25 (id, number) with (key_field='id');
+
+insert into items (id, number) values (1, 12345);

--- a/.github/actions/test-pg_search-upgrade/kitchen_sink/queries.sql
+++ b/.github/actions/test-pg_search-upgrade/kitchen_sink/queries.sql
@@ -1,0 +1,220 @@
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pdb.verify_index('search_idx') WHERE NOT passed) THEN
+        RAISE EXCEPTION 'search_idx failed verification';
+    END IF;
+END;
+$$;
+
+SELECT id, description, pdb.score(id), pdb.snippet(description)
+FROM mock_items
+WHERE description ||| 'running shoes'
+ORDER BY pdb.score(id) DESC
+LIMIT 5;
+
+SELECT id, description
+FROM mock_items
+WHERE description::pdb.alias('description_whitespace') ||| 'running shoes'
+ORDER BY id;
+
+SELECT id, description
+FROM mock_items
+WHERE description::pdb.alias('description_source_code') ||| 'HTTPRequest source_code'
+ORDER BY id
+LIMIT 5;
+
+SELECT id, description
+FROM mock_items
+WHERE description::pdb.alias('description_literal_normalized') === 'generic shoes'
+ORDER BY id;
+
+SELECT id, description, category
+FROM mock_items
+WHERE (description || ' ' || category) &&& 'running footwear'
+ORDER BY id;
+
+SELECT id, metadata->>'color'
+FROM mock_items
+WHERE metadata->>'color' @@@ 'whi'
+ORDER BY id
+LIMIT 5;
+
+SELECT id, category
+FROM mock_items
+WHERE category === 'Footwear'
+ORDER BY id;
+
+SELECT id, weight_range
+FROM mock_items
+WHERE weight_range @@@ pdb.range_term('(2, 11]'::int4range, 'Intersects')
+ORDER BY id
+LIMIT 5;
+
+SELECT id, active_period
+FROM mock_items
+WHERE active_period @@@ pdb.range_term('[2023-05-01,2023-05-15]'::daterange, 'Intersects')
+ORDER BY id;
+
+SELECT id, price, precise_price, score
+FROM mock_items
+WHERE id @@@ pdb.all() AND price > 50 AND precise_price > 100000000 AND score > 1
+ORDER BY price
+LIMIT 5;
+
+SELECT id, external_id, ip
+FROM mock_items
+WHERE id @@@ pdb.all()
+AND external_id IN ('00000000-0000-0000-0000-000000000003'::uuid, '00000000-0000-0000-0000-000000100001'::uuid)
+ORDER BY id
+LIMIT 5;
+
+SELECT id, tags
+FROM mock_items
+WHERE tags === 'footwear'
+ORDER BY id
+LIMIT 5;
+
+SELECT pdb.agg('{"value_count": {"field": "id"}}')
+FROM mock_items
+WHERE id @@@ pdb.all();
+
+-- Insert some data
+
+INSERT INTO mock_items (
+    description,
+    rating,
+    category,
+    in_stock,
+    metadata,
+    created_at,
+    last_updated_date,
+    latest_available_time,
+    weight_range,
+    price,
+    precise_price,
+    score,
+    external_id,
+    ip,
+    tags,
+    active_period
+)
+VALUES
+    (
+        'Waterproof running shoes',
+        5,
+        'Footwear',
+        true,
+        '{"color": "White", "location": "United States"}'::jsonb,
+        '2023-05-10 10:00:00'::timestamp,
+        '2023-05-10'::date,
+        '10:00:00'::time,
+        '[4,12]'::int4range,
+        129.99,
+        12345678901234567890.12345,
+        9.5,
+        '00000000-0000-0000-0000-000000100001'::uuid,
+        '10.1.0.1'::inet,
+        ARRAY['footwear', 'waterproof', 'running'],
+        '[2023-05-10,2023-06-01]'::daterange
+    ),
+    (
+        '',
+        NULL,
+        '',
+        NULL,
+        '{}'::jsonb,
+        NULL,
+        NULL,
+        NULL,
+        'empty'::int4range,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        NULL,
+        ARRAY[]::TEXT[],
+        'empty'::daterange
+    );
+
+
+-- Run the queries again after doing the inserts
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pdb.verify_index('search_idx') WHERE NOT passed) THEN
+        RAISE EXCEPTION 'search_idx failed verification';
+    END IF;
+END;
+$$;
+
+SELECT id, description, pdb.score(id), pdb.snippet(description)
+FROM mock_items
+WHERE description ||| 'running shoes'
+ORDER BY pdb.score(id) DESC
+LIMIT 5;
+
+SELECT id, description
+FROM mock_items
+WHERE description::pdb.alias('description_whitespace') ||| 'running shoes'
+ORDER BY id;
+
+SELECT id, description
+FROM mock_items
+WHERE description::pdb.alias('description_source_code') ||| 'HTTPRequest source_code'
+ORDER BY id
+LIMIT 5;
+
+SELECT id, description
+FROM mock_items
+WHERE description::pdb.alias('description_literal_normalized') === 'generic shoes'
+ORDER BY id;
+
+SELECT id, description, category
+FROM mock_items
+WHERE (description || ' ' || category) &&& 'running footwear'
+ORDER BY id;
+
+SELECT id, metadata->>'color'
+FROM mock_items
+WHERE metadata->>'color' @@@ 'whi'
+ORDER BY id
+LIMIT 5;
+
+SELECT id, category
+FROM mock_items
+WHERE category === 'Footwear'
+ORDER BY id;
+
+SELECT id, weight_range
+FROM mock_items
+WHERE weight_range @@@ pdb.range_term('(2, 11]'::int4range, 'Intersects')
+ORDER BY id
+LIMIT 5;
+
+SELECT id, active_period
+FROM mock_items
+WHERE active_period @@@ pdb.range_term('[2023-05-01,2023-05-15]'::daterange, 'Intersects')
+ORDER BY id;
+
+SELECT id, price, precise_price, score
+FROM mock_items
+WHERE id @@@ pdb.all() AND price > 50 AND precise_price > 100000000 AND score > 1
+ORDER BY price
+LIMIT 5;
+
+SELECT id, external_id, ip
+FROM mock_items
+WHERE id @@@ pdb.all()
+AND external_id IN ('00000000-0000-0000-0000-000000000003'::uuid, '00000000-0000-0000-0000-000000100001'::uuid)
+ORDER BY id
+LIMIT 5;
+
+SELECT id, tags
+FROM mock_items
+WHERE tags === 'footwear'
+ORDER BY id
+LIMIT 5;
+
+SELECT pdb.agg('{"value_count": {"field": "id"}}')
+FROM mock_items
+WHERE id @@@ pdb.all();
+

--- a/.github/actions/test-pg_search-upgrade/kitchen_sink/setup.sql
+++ b/.github/actions/test-pg_search-upgrade/kitchen_sink/setup.sql
@@ -1,0 +1,47 @@
+CALL paradedb.create_bm25_test_table(schema_name => 'public', table_name => 'mock_items');
+
+ALTER TABLE mock_items
+ADD COLUMN price NUMERIC(10, 2),
+ADD COLUMN precise_price NUMERIC,
+ADD COLUMN score DOUBLE PRECISION,
+ADD COLUMN external_id UUID,
+ADD COLUMN ip INET,
+ADD COLUMN tags TEXT[],
+ADD COLUMN active_period DATERANGE;
+
+UPDATE mock_items
+SET
+    price = rating * 19.99,
+    precise_price = 0.9554861284073128,
+    score = rating::DOUBLE PRECISION / 3,
+    external_id = ('00000000-0000-0000-0000-' || lpad(id::TEXT, 12, '0'))::UUID,
+    ip = ('10.0.0.' || ((id % 250) + 1))::INET,
+    tags = ARRAY[lower(category), split_part(lower(description), ' ', 1)],
+    active_period = daterange(last_updated_date, last_updated_date + rating, '[]');
+
+CREATE INDEX search_idx ON mock_items
+USING bm25 (
+    id,
+    description,
+    (category::pdb.literal),
+    rating,
+    in_stock,
+    created_at,
+    last_updated_date,
+    latest_available_time,
+    metadata,
+    weight_range,
+    price,
+    precise_price,
+    score,
+    external_id,
+    ip,
+    tags,
+    active_period,
+    ((description || ' ' || category)::pdb.simple('alias=description_category')),
+    (description::pdb.whitespace('alias=description_whitespace')),
+    (description::pdb.source_code('alias=description_source_code')),
+    (description::pdb.literal_normalized('alias=description_literal_normalized')),
+    ((metadata->>'color')::pdb.ngram(2,3, 'alias=metadata_color'))
+)
+WITH (key_field='id');

--- a/.github/actions/test-pg_search-upgrade/numeric/queries.sql
+++ b/.github/actions/test-pg_search-upgrade/numeric/queries.sql
@@ -1,0 +1,3 @@
+insert into items (id, numeric64, numeric_bytes) values (2, 0.098098098, 0.09809809809809809);
+
+select id, numeric64, numeric_bytes from items where id @@@ pdb.all();

--- a/.github/actions/test-pg_search-upgrade/numeric/setup.sql
+++ b/.github/actions/test-pg_search-upgrade/numeric/setup.sql
@@ -1,0 +1,10 @@
+create table items (
+    id bigserial,
+    numeric64 numeric(15, 9),
+    numeric_bytes numeric
+);
+
+create index search_idx on items
+using bm25 (id, numeric64, numeric_bytes) with (key_field='id');
+
+insert into items (id, numeric64, numeric_bytes) values (1, 0.098098098, 0.09809809809809809);

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -195,8 +195,15 @@ CREATE EXTENSION pg_search;
 ### Testing
 
 This section covers the **unit tests** located in the `pg_search/src` directory. For a complete overview of ParadeDB's testing infrastructure (which includes integration tests, client property tests, and pg regress tests), please see the [Testing section in `CONTRIBUTING.md`](../CONTRIBUTING.md#testing).
+For the other test categories (pg regress, integration tests, client property tests, stress tests, upgrade tests), see:
 
 Unit tests can be run using `cargo test -p pg_search -- a_specific_method_to_run`. These tests sometimes (if marked `#[pg_test]`) run inside the Postgres process, which allows them to use all of Postgres APIs via `pgrx`. There is no need to pre-install the extension for these: the `#[pg_test]` annotation on the test will re-install the extension automatically.
+
+- [`pg_search/tests/pg_regress/README.md`](tests/pg_regress/README.md) — pg_regress tests
+- [`tests/README.md`](../tests/README.md) — integration tests and client property tests
+- [`stressgres/README.md`](../stressgres/README.md) — Stressgres, the stress-testing tool used locally and in CI
+- [`CONTRIBUTING.md#testing`](../CONTRIBUTING.md#testing) — overview of all test categories and when to use which
+- [`test-pg_search-upgrade/README.md`](../.github/actions/test-pg_search-upgrade/README.md) - compatibility tests for extension version upgrades
 
 _Note: For **pg regress tests**, please refer to [pg_search/tests/pg_regress/README.md](tests/pg_regress/README.md). For **integration tests** and **client property tests**, please refer to [tests/README.md](../tests/README.md)._
 

--- a/pg_search/src/postgres/types_arrow.rs
+++ b/pg_search/src/postgres/types_arrow.rs
@@ -175,6 +175,12 @@ pub fn arrow_array_to_datum(
             match &oid {
                 PgOid::BuiltIn(PgBuiltInOids::FLOAT8OID) => val.into_datum(),
                 PgOid::BuiltIn(PgBuiltInOids::FLOAT4OID) => (val as f32).into_datum(), // Cast f64 to f32
+                // Legacy pre-v0.22.0 indexes stored NUMERIC fields as F64. Reading those
+                // fast fields back must round-trip through `AnyNumeric` to return a NUMERIC
+                // datum rather than the FLOAT8 the column-type widening would imply.
+                PgOid::BuiltIn(PgBuiltInOids::NUMERICOID) => pgrx::AnyNumeric::try_from(val)
+                    .map_err(|e| format!("Failed to convert f64 to AnyNumeric: {e:?}"))?
+                    .into_datum(),
                 _ => return Err(format!("Unsupported OID for Float64 Arrow type: {oid:?}")),
             }
         }
@@ -552,6 +558,12 @@ mod tests {
                 let oid_f32 = PgOid::from(PgBuiltInOids::FLOAT4OID.value());
                 test_conversion_roundtrip(original_val, create_float64_array, oid_f32, |v| v as f32);
             }
+
+            // Test NUMERICOID (legacy pre-v0.22.0 indexes stored NUMERIC as F64).
+            let oid_numeric = PgOid::from(PgBuiltInOids::NUMERICOID.value());
+            test_conversion_roundtrip(original_val, create_float64_array, oid_numeric, |v| {
+                pgrx::AnyNumeric::try_from(v).unwrap()
+            });
         });
     }
 


### PR DESCRIPTION
# Ticket(s) Closed

Backport numeric compatibility fix to 0.22.x

## What

## Why

## How

## Tests
