### PR TITLE
ci: relax release-with-debug profile to fit docker build memory budget

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,15 @@ codegen-units = 1
 [profile.release-with-debug]
 inherits = "release"
 debug = true
+# Override release's `lto = "fat"` + `codegen-units = 1` so the linker can
+# fit the docker `cargo pgrx package` step under the GitHub runner's memory
+# budget. Fat LTO + single codegen unit + full debug symbols pushes peak
+# linker RSS past 20 GB once we link the datafusion-distributed dep tree
+# (arrow-flight, tonic, prost, ...) and the runner OOMs. Thin LTO and
+# codegen-units = 16 trade a small amount of runtime perf for a much
+# smaller linker working set; the production `release` profile is unaffected.
+lto = "thin"
+codegen-units = 16
 
 [workspace.dependencies]
 tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "3b6bcdaee22a39f5f9a72f7d64b3527ab4b48152", features = [


### PR DESCRIPTION
## What

Override `[profile.release-with-debug]` in the workspace `Cargo.toml` to use `lto = "thin"` + `codegen-units = 16` instead of inheriting `lto = "fat"` + `codegen-units = 1` from `[profile.release]`.

## Why

The docker image build (\`cargo pgrx package --profile=release-with-debug\` in \`docker/Dockerfile\`) currently OOMs the GitHub runner during the linker step. It links a release binary with fat LTO, a single codegen unit, full debug symbols, and the entire \`datafusion-distributed\` transitive dep tree (arrow-flight, tonic, prost, ...). Peak linker RSS pushes past ~20 GB, well beyond the runner's available memory.

The production \`release\` profile is unaffected — only the docker-image-only \`release-with-debug\` profile is relaxed. Post-build \`objcopy --strip-debug\` / \`--add-gnu-debuglink\` still produces the separate \`.dbg\` artifact unchanged.

## Trade-offs

- Thin LTO over fat: a small runtime-perf hit for the debug-symbolicated docker artifact only. Production \`release\` binary unchanged.
- \`codegen-units = 16\`: slightly less optimal codegen, but the linker no longer holds the whole-program graph in memory at once.

## Tests

- [x] Locally compiled \`release-with-debug\` profile with the override; build succeeds.
- [ ] CI Docker build job passes (will verify once this lands and the MPP chain rebases on top).