### PR TITLE
feat: Remove githash from paradedb.version_info()

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -90,7 +90,6 @@ jobs:
           context: .
           build-args: |
             PG_VERSION_MAJOR=${{ matrix.pg_version }}
-            COMMIT_SHA=${{ github.sha }}
             ENABLE_ANTITHESIS_INSTRUMENTATION=true
           platforms: linux/amd64
           file: docker/Dockerfile

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -90,7 +90,6 @@ jobs:
           echo "GitHub Tag Version: $VERSION"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "tag=$TAG" >> $GITHUB_OUTPUT
-          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
       - name: Determine if Release Should be Marked as Latest
         id: release_latest
@@ -159,7 +158,6 @@ jobs:
           context: .
           build-args: |
             PG_VERSION_MAJOR=${{ matrix.pg_version }}
-            COMMIT_SHA=${{ steps.version.outputs.commit_sha }}
           platforms: linux/amd64,linux/arm64
           file: docker/Dockerfile
           push: true

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -216,7 +216,6 @@ jobs:
           fi
           echo "GitHub Tag Version: $VERSION"
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
           OS_VERSION="$(lsb_release -cs)"
           echo "OS Version: $OS_VERSION"
@@ -261,8 +260,6 @@ jobs:
 
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
-        env:
-          COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
         run: |
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx package --pg-config $PG_CONFIG_PATH

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -95,7 +95,6 @@ jobs:
           fi
           echo "GitHub Tag Version: $VERSION"
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
           OS_VERSION=$(sw_vers -productVersion)
           case $OS_VERSION in
@@ -138,8 +137,6 @@ jobs:
           PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
           export PATH="/opt/homebrew/bin:$PATH"
           cargo pgrx package --pg-config $PG_CONFIG_PATH
-        env:
-          COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
 
       - name: Create .pkg Package
         run: |

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -252,7 +252,6 @@ jobs:
           fi
           echo "GitHub Tag Version: $VERSION"
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
           OS_VERSION="el$(cat /etc/os-release | grep ^VERSION_ID= | cut -d= -f2 | tr -d '"' | cut -d. -f1)"
           echo "OS Version: $OS_VERSION"
@@ -298,8 +297,6 @@ jobs:
 
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
-        env:
-          COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
         run: |
           PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx package --pg-config $PG_CONFIG_PATH

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -195,7 +195,6 @@ jobs:
           fi
           echo "GitHub Tag Version: $VERSION"
           echo "tag_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
 
           OS_VERSION="$(lsb_release -cs)"
           echo "OS Version: $OS_VERSION"
@@ -240,8 +239,6 @@ jobs:
 
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
-        env:
-          COMMIT_SHA: ${{ steps.version.outputs.commit_sha }}
         run: |
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx package --pg-config $PG_CONFIG_PATH

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -124,7 +124,6 @@ jobs:
             --platform ${{ matrix.platform }} \
             --file docker/Dockerfile \
             --tag paradedb/paradedb:latest \
-            --build-arg COMMIT_SHA=${{ github.sha }} \
             --cache-from type=gha,scope=paradedb-docker-${{ matrix.arch }} \
             --cache-to type=gha,mode=max,scope=paradedb-docker-${{ matrix.arch }} \
             --load \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4717,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5096,13 +5096,12 @@ checksum = "269bca4c2591a28585d6bf10d9ed0332b7d76900a1b02bec41bdc3a2cdcda107"
 
 [[package]]
 name = "opencc-jieba-rs"
-version = "0.7.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1374548d1a5832b9a25a69aef815a5ec9128051f7f583ed0452cdfeafcb427d0"
+checksum = "f1fc1e7585809b7c6292ef55fbf9c4c9fcc5333d26bfbedd0b93585425472150"
 dependencies = [
  "include-flate",
  "jieba-rs 0.7.4",
- "once_cell",
  "rayon",
  "rayon-core",
  "regex",
@@ -5355,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7598,7 +7597,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -7980,7 +7979,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -8149,7 +8148,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "emoji",
@@ -9465,9 +9464,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yeslogic-fontconfig-sys"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503a066b4c037c440169d995b869046827dbc71263f6e8f3be6d77d4f3229dbd"
+checksum = "1d8b8abf912b9a29ff112e1671c97c33636903d13a69712037190e6805af4f76"
 dependencies = [
  "dlib",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.2"
+version = "0.23.3"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -426,15 +426,13 @@ async fn write_test_info_csv(args: &CommonBenchmarkArgs, rows_display: &str) -> 
         let mut conn = PgConnection::connect(&args.url)
             .await
             .with_context(|| "Failed to connect to database for version info")?;
-        let row = sqlx::query("SELECT version, githash, build_mode FROM paradedb.version_info()")
+        let row = sqlx::query("SELECT version, build_mode FROM paradedb.version_info()")
             .fetch_one(&mut conn)
             .await
             .with_context(|| "Failed to fetch paradedb.version_info()")?;
         let version: String = row.get(0);
-        let githash: String = row.get(1);
-        let build_mode: String = row.get(2);
+        let build_mode: String = row.get(1);
         writeln!(file, "pg_search Version,{version}")?;
-        writeln!(file, "pg_search Git Hash,{githash}")?;
         writeln!(file, "pg_search Build Mode,{build_mode}")?;
     }
     Ok(())
@@ -551,15 +549,13 @@ async fn write_test_info(
         let mut conn = PgConnection::connect(&args.url)
             .await
             .with_context(|| "Failed to connect to database for version info")?;
-        let row = sqlx::query("SELECT version, githash, build_mode FROM paradedb.version_info()")
+        let row = sqlx::query("SELECT version, build_mode FROM paradedb.version_info()")
             .fetch_one(&mut conn)
             .await
             .with_context(|| "Failed to fetch paradedb.version_info()")?;
         let version: String = row.get(0);
-        let githash: String = row.get(1);
-        let build_mode: String = row.get(2);
+        let build_mode: String = row.get(1);
         writeln!(file, "| pg_search Version | {version} |")?;
-        writeln!(file, "| pg_search Git Hash | {githash} |")?;
         writeln!(file, "| pg_search Build Mode | {build_mode} |")?;
     }
     Ok(())

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,12 +55,10 @@ RUN PGRX_VERSION=$(grep 'pgrx =' Cargo.toml | head -n 1 | cut -d '"' -f 2 | tr -
 # pg_search
 ######################
 
-ARG COMMIT_SHA
 ARG ENABLE_ANTITHESIS_INSTRUMENTATION
 
 # Declare compile-time environment variables
-ENV COMMIT_SHA=${COMMIT_SHA} \
-    ENABLE_ANTITHESIS_INSTRUMENTATION=${ENABLE_ANTITHESIS_INSTRUMENTATION}
+ENV ENABLE_ANTITHESIS_INSTRUMENTATION=${ENABLE_ANTITHESIS_INSTRUMENTATION}
 
 COPY Cargo.toml Cargo.lock rust-toolchain.toml /tmp/
 COPY .cargo/ /tmp/.cargo/

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -59,7 +59,6 @@ buildPgrxExtension (finalAttrs: {
   pname = "pg_search";
   version = rootCargoToml.workspace.package.version;
   src = self;
-  COMMIT_SHA = self.rev or self.dirtyRev or "unknown";
 
   # This hash needs to change any time the Rust dependencies are updated.
   # If maintainers forget to do so, Nix will throw an error message that begins

--- a/pg_search/sql/pg_search--0.23.2--0.23.3.sql
+++ b/pg_search/sql/pg_search--0.23.2--0.23.3.sql
@@ -1,0 +1,5 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.3'" to load this file. \quit
+
+DROP FUNCTION IF EXISTS version_info();
+
+CREATE OR REPLACE FUNCTION version_info() RETURNS TABLE(version text, build_mode text) AS 'MODULE_PATHNAME', 'version_info_wrapper' LANGUAGE c STRICT;

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -744,19 +744,10 @@ fn page_info(
 }
 
 #[pg_extern]
-fn version_info() -> TableIterator<
-    'static,
-    (
-        name!(version, String),
-        name!(githash, String),
-        name!(build_mode, String),
-    ),
-> {
+fn version_info() -> TableIterator<'static, (name!(version, String), name!(build_mode, String))> {
     let version = option_env!("CARGO_PKG_VERSION")
         .unwrap_or("unknown")
         .to_string();
-
-    let git_sha = option_env!("COMMIT_SHA").unwrap_or("unknown").to_string();
 
     let build_mode = if cfg!(debug_assertions) {
         "debug".to_string()
@@ -764,7 +755,7 @@ fn version_info() -> TableIterator<
         "release".to_string()
     };
 
-    TableIterator::once((version, git_sha, build_mode))
+    TableIterator::once((version, build_mode))
 }
 
 #[pg_extern(name = "force_merge")]


### PR DESCRIPTION
# Ticket(s) Closed

## What

Remove `githash` from `paradedb.version_info()`.

If you load the new shared library before updating the extension, calling version_info breaks:
```
select paradedb.version_info();
ERROR:  compressed pglz data is corrupt
```
I'm guessing this won't be an issue with the way upgrades are handled for CNPG deployments, but users could encounter it for manual updates. I haven't tried it but I believe we could expose two versions of `version_info` at once, one that returns two values and one that returns three (the three valued one would return `unknown` for the hash). Maybe there's a better way to make this more backwards compatible though. Or maybe it's fine to leave as is. Thoughts? 
 
## Why

Right now the build process requires `COMMIT_SHA` to be set to thread it through to `githash`. This causes problems for Docker Official Images which doesn't support passing in arguments. Since the version number is already included, having the hash also is not stricly necessary and would only be useful in very uncommon scenarios.

## How

## Tests
