### PR TITLE
ci: Increase disk size for Test pg_search (Docker) runner

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -45,6 +45,7 @@ jobs:
       - family=${{ matrix.runner_family }}
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
+      - disk=large
       - image=${{ matrix.runner_image }}
       - extras=s3-cache
     strategy:

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -46,7 +46,7 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
-      - disk=large # 80GB (default is 40GB)
+      - volume=80gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -46,7 +46,7 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
-      - disk=large
+      - disk=large # 80GB (default is 40GB)
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -45,8 +45,8 @@ jobs:
       - family=${{ matrix.runner_family }}
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
-      - disk=large
       - image=${{ matrix.runner_image }}
+      - disk=large
       - extras=s3-cache
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Adds `disk=large` to the runs-on runner labels for the `Test pg_search (Docker)` workflow.
- The amd64 job in [run 25208046702](https://github.com/paradedb/paradedb/actions/runs/25208046702) failed with "self-hosted runner lost communication with the server", which is a common symptom of disk pressure during a `docker buildx build` with cache import/export.

## Test plan
- [x] CI green on this PR's `Test pg_search (Docker)` jobs (amd64 + arm64).