### PR TITLE
fix: Fix JSON projections for aggregates-on-joins

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -1029,14 +1029,6 @@ pub unsafe fn populate_required_fields(
         for agg in &targetlist.aggregates {
             for (rti, attno, field_name) in &agg.field_refs {
                 if source.contains_rti(*rti) {
-                    // Try by name first if it's a dotted name (JSON sub-field)
-                    if field_name.contains('.') {
-                        if let Some(field) = resolve_fast_field_by_name(field_name, indexrel) {
-                            source.scan_info.add_field_by_name(*attno, field);
-                            continue;
-                        }
-                    }
-
                     require_fast_field(source, &tupdesc, indexrel, *attno, || {
                         format!("aggregate argument '{}' (attno={attno})", field_name)
                     })?;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -993,11 +993,29 @@ pub unsafe fn populate_required_fields(
             if !source.contains_rti(gc.rti) {
                 continue;
             }
-            if let Some(field) = resolve_fast_field(gc.attno as i32, &tupdesc, indexrel) {
-                source.scan_info.add_field(gc.attno, field);
-            } else if let Some(field) = resolve_fast_field_by_name(&gc.field_name, indexrel) {
-                source.scan_info.add_field_by_name(gc.attno, field);
-            } else {
+
+            let mut resolved_field = None;
+            // For dotted names (JSON sub-fields), try resolving by name first.
+            // This is more specific than attno-based resolution which might
+            // find the parent JSON column if it's also indexed as text.
+            if gc.field_name.contains('.') {
+                if let Some(field) = resolve_fast_field_by_name(&gc.field_name, indexrel) {
+                    source.scan_info.add_field_by_name(gc.attno, field.clone());
+                    resolved_field = Some(field);
+                }
+            }
+
+            if resolved_field.is_none() {
+                if let Some(field) = resolve_fast_field(gc.attno as i32, &tupdesc, indexrel) {
+                    source.scan_info.add_field(gc.attno, field.clone());
+                    resolved_field = Some(field);
+                } else if let Some(field) = resolve_fast_field_by_name(&gc.field_name, indexrel) {
+                    source.scan_info.add_field_by_name(gc.attno, field.clone());
+                    resolved_field = Some(field);
+                }
+            }
+
+            if resolved_field.is_none() {
                 return Err(format!(
                     "GROUP BY column '{}' (attno={}) is not a fast field on table {}",
                     gc.field_name,
@@ -1009,10 +1027,18 @@ pub unsafe fn populate_required_fields(
 
         // Aggregate arguments.
         for agg in &targetlist.aggregates {
-            for (rti, attno, _) in &agg.field_refs {
+            for (rti, attno, field_name) in &agg.field_refs {
                 if source.contains_rti(*rti) {
+                    // Try by name first if it's a dotted name (JSON sub-field)
+                    if field_name.contains('.') {
+                        if let Some(field) = resolve_fast_field_by_name(field_name, indexrel) {
+                            source.scan_info.add_field_by_name(*attno, field);
+                            continue;
+                        }
+                    }
+
                     require_fast_field(source, &tupdesc, indexrel, *attno, || {
-                        format!("aggregate argument (attno={attno})")
+                        format!("aggregate argument '{}' (attno={attno})", field_name)
                     })?;
                 }
             }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -79,7 +79,7 @@ pub async fn build_join_aggregate_plan(
     custom_scan_tlist: *mut pg_sys::List,
     having_filter: Option<&FilterExpr>,
     ctx: &SessionContext,
-) -> Result<datafusion::logical_expr::LogicalPlan> {
+) -> Result<(datafusion::logical_expr::LogicalPlan, Vec<usize>)> {
     // Step 1: Build the join DataFrame from the RelNode tree
     let df = build_relnode_df(
         ctx,
@@ -91,11 +91,26 @@ pub async fn build_join_aggregate_plan(
     .await?;
 
     // Step 2: Build GROUP BY expressions
-    let group_exprs: Vec<Expr> = targetlist
-        .group_columns
-        .iter()
-        .map(|gc| make_rti_col(plan, gc.rti, &gc.field_name))
-        .collect();
+    // DataFusion deduplicates grouping expressions that resolve to the same
+    // column name (e.g. metadata.brand). We must track which DataFusion output
+    // column index corresponds to each of our original targetlist.group_columns.
+    let mut group_exprs = Vec::new();
+    let mut field_to_df_idx = crate::api::HashMap::default();
+    let mut group_df_indices = Vec::with_capacity(targetlist.group_columns.len());
+
+    for gc in &targetlist.group_columns {
+        let entry = field_to_df_idx.entry((gc.rti, gc.field_name.clone()));
+        let df_idx = match entry {
+            std::collections::hash_map::Entry::Vacant(v) => {
+                let df_idx = group_exprs.len();
+                v.insert(df_idx);
+                group_exprs.push(make_rti_col(plan, gc.rti, &gc.field_name));
+                df_idx
+            }
+            std::collections::hash_map::Entry::Occupied(o) => *o.get(),
+        };
+        group_df_indices.push(df_idx);
+    }
 
     // Step 3: Build aggregate expressions
     let agg_exprs: Vec<Expr> = targetlist
@@ -218,10 +233,10 @@ pub async fn build_join_aggregate_plan(
             .sort(topk.direction.is_asc(), topk.direction.is_nulls_first());
         let df = df.sort(vec![sort_expr])?;
         let df = df.limit(0, Some(topk.k))?;
-        return df.into_optimized_plan();
+        return Ok((df.into_optimized_plan()?, group_df_indices));
     }
 
-    df.into_optimized_plan()
+    Ok((df.into_optimized_plan()?, group_df_indices))
 }
 
 /// Recursively lower a [`RelNode`] tree into a DataFusion [`DataFrame`].

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -169,9 +169,48 @@ fn arrow_value_to_datum(
         }
         DataType::Float64 => float64_to_datum(downcast_value!(Float64Array), typoid),
         DataType::Float32 => float64_to_datum(downcast_value!(Float32Array) as f64, typoid),
-        DataType::Utf8 => downcast_value!(StringArray).to_string().into_datum(),
-        DataType::Utf8View => downcast_value!(StringViewArray).to_string().into_datum(),
-        DataType::LargeUtf8 => downcast_value!(LargeStringArray).to_string().into_datum(),
+        DataType::Utf8 => {
+            let s = downcast_value!(StringArray);
+            if typoid == pg_sys::JSONOID || typoid == pg_sys::JSONBOID {
+                let json = serde_json::from_str(s)
+                    .unwrap_or_else(|_| serde_json::Value::String(s.to_string()));
+                if typoid == pg_sys::JSONOID {
+                    pgrx::Json(json).into_datum()
+                } else {
+                    pgrx::datum::JsonB(json).into_datum()
+                }
+            } else {
+                s.to_string().into_datum()
+            }
+        }
+        DataType::Utf8View => {
+            let s = downcast_value!(StringViewArray);
+            if typoid == pg_sys::JSONOID || typoid == pg_sys::JSONBOID {
+                let json = serde_json::from_str(s)
+                    .unwrap_or_else(|_| serde_json::Value::String(s.to_string()));
+                if typoid == pg_sys::JSONOID {
+                    pgrx::Json(json).into_datum()
+                } else {
+                    pgrx::datum::JsonB(json).into_datum()
+                }
+            } else {
+                s.to_string().into_datum()
+            }
+        }
+        DataType::LargeUtf8 => {
+            let s = downcast_value!(LargeStringArray);
+            if typoid == pg_sys::JSONOID || typoid == pg_sys::JSONBOID {
+                let json = serde_json::from_str(s)
+                    .unwrap_or_else(|_| serde_json::Value::String(s.to_string()));
+                if typoid == pg_sys::JSONOID {
+                    pgrx::Json(json).into_datum()
+                } else {
+                    pgrx::datum::JsonB(json).into_datum()
+                }
+            } else {
+                s.to_string().into_datum()
+            }
+        }
         DataType::Boolean => downcast_value!(BooleanArray).into_datum(),
         DataType::Timestamp(unit, _tz_opt) => {
             let nanos = match unit {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -140,6 +140,9 @@ pub unsafe fn project_aggregate_row_to_slot(
 
 /// Convert a single value from an Arrow array to a Postgres `Datum`.
 ///
+/// TODO: Duplicated with `arrow_array_to_datum` in `types_arrow.rs`.
+/// See https://github.com/paradedb/paradedb/issues/4959
+///
 /// Dispatches on the Arrow data type and converts to the target Postgres type OID.
 /// Returns `None` for unsupported type combinations.
 fn arrow_value_to_datum(

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_project.rs
@@ -43,23 +43,22 @@ pub unsafe fn project_aggregate_row_to_slot(
     batch: &RecordBatch,
     row_idx: usize,
     targetlist: &JoinAggregateTargetList,
+    group_df_indices: &[usize],
 ) -> *mut pg_sys::TupleTableSlot {
     let tupdesc = (*slot).tts_tupleDescriptor;
     let natts = (*tupdesc).natts as usize;
     let datums = std::slice::from_raw_parts_mut((*slot).tts_values, natts);
     let isnull = std::slice::from_raw_parts_mut((*slot).tts_isnull, natts);
 
-    // DataFusion output column index: group columns come first, then aggregates
-    let mut df_col_idx = 0;
-
     // Fill GROUP BY columns
-    for gc in &targetlist.group_columns {
+    for (i, gc) in targetlist.group_columns.iter().enumerate() {
         let pg_idx = gc.output_index;
         if pg_idx >= natts {
-            df_col_idx += 1;
             continue;
         }
 
+        // Use the pre-calculated DataFusion column index for this GROUP BY column
+        let df_col_idx = group_df_indices[i];
         let col = batch.column(df_col_idx);
         let expected_type = {
             #[cfg(any(feature = "pg15", feature = "pg16", feature = "pg17"))]
@@ -87,10 +86,15 @@ pub unsafe fn project_aggregate_row_to_slot(
                 }
             }
         }
-        df_col_idx += 1;
     }
 
     // Fill aggregate columns
+    // Aggregate columns always follow ALL deduplicated GROUP BY columns in the
+    // RecordBatch. The number of deduplicated group columns is the number of
+    // unique indices in group_df_indices.
+    let num_unique_group_cols = group_df_indices.iter().max().map(|&m| m + 1).unwrap_or(0);
+    let mut df_col_idx = num_unique_group_cols;
+
     for agg in &targetlist.aggregates {
         let pg_idx = agg.output_index;
         if pg_idx >= natts {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -379,12 +379,17 @@ impl CustomScan for AggregateScan {
 
                 // Show GROUP BY columns
                 if !df_state.targetlist.group_columns.is_empty() {
-                    let groups: Vec<String> = df_state
+                    // TODO: When grouping on expressions with the same underlying input columns,
+                    // it's possible to get dupes here. We should consider rendering the expression
+                    // instead, but for now we dedupe.
+                    let mut groups: Vec<String> = df_state
                         .targetlist
                         .group_columns
                         .iter()
                         .map(|gc| gc.field_name.clone())
                         .collect();
+                    groups.sort();
+                    groups.dedup();
                     explainer.add_text("Group By", groups.join(", "));
                 }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -344,6 +344,7 @@ impl CustomScan for AggregateScan {
                     stream: None,
                     current_batch: None,
                     batch_row_idx: 0,
+                    group_df_indices: Vec::new(),
                 });
                 builder.build()
             }
@@ -993,7 +994,7 @@ impl AggregateScan {
             let custom_exprs = df_state.custom_exprs;
             let custom_scan_tlist = df_state.custom_scan_tlist;
             let physical_plan = runtime.block_on(async {
-                let logical = build_join_aggregate_plan(
+                let (logical, group_df_indices) = build_join_aggregate_plan(
                     &df_state.plan,
                     &df_state.targetlist,
                     df_state.topk.as_ref(),
@@ -1004,6 +1005,7 @@ impl AggregateScan {
                     &ctx,
                 )
                 .await?;
+                df_state.group_df_indices = group_df_indices;
                 build_physical_plan(&ctx, logical).await
             });
 
@@ -1040,8 +1042,15 @@ impl AggregateScan {
                     }
                     let row_idx = df_state.batch_row_idx;
                     let targetlist = &df_state.targetlist;
+                    let group_df_indices = &df_state.group_df_indices;
                     let result = unsafe {
-                        project_aggregate_row_to_slot(scan_slot, batch, row_idx, targetlist)
+                        project_aggregate_row_to_slot(
+                            scan_slot,
+                            batch,
+                            row_idx,
+                            targetlist,
+                            group_df_indices,
+                        )
                     };
                     df_state.batch_row_idx += 1;
                     return result;

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -68,6 +68,10 @@ pub struct DataFusionAggState {
     pub current_batch: Option<RecordBatch>,
     /// Row index within current_batch.
     pub batch_row_idx: usize,
+    /// Mapping from group_columns[i] to its 0-based column index in DataFusion's
+    /// output RecordBatch. Needed because DataFusion deduplicates grouping
+    /// expressions (e.g. metadata.brand).
+    pub group_df_indices: Vec<usize>,
 }
 
 /// State for projecting wrapped aggregate expressions through Postgres' own

--- a/pg_search/src/postgres/types_arrow.rs
+++ b/pg_search/src/postgres/types_arrow.rs
@@ -27,6 +27,9 @@ use pgrx::{datum, IntoDatum, PgBuiltInOids, PgOid};
 
 /// Get a value of the given type from the given index/row of the given array.
 ///
+/// TODO: Duplicated with `arrow_value_to_datum` in `datafusion_project.rs`.
+/// See https://github.com/paradedb/paradedb/issues/4959
+///
 /// This effectively inlines `TantivyValue::try_into_datum` in order to avoid creating both
 /// `OwnedValue` and `TantivyValue` wrappers around primitives (but particularly around strings).
 ///

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -417,6 +417,53 @@ ORDER BY 1;
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================
+-- Test 6: Complex 3-table join (FULL + LEFT) with JSONB aggregation
+-- Adapted from user query: FULL JOIN, LEFT JOIN, and JSONB GROUP BY
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json
+FROM ec_products p
+FULL JOIN ec_reviews r ON p.id = r.id
+LEFT JOIN ec_suppliers s ON r.category = s.category
+WHERE p.description @@@ 'laptop'
+GROUP BY p.metadata->>'brand', p.metadata->'brand'
+ORDER BY brand_text;
+                                    QUERY PLAN                                     
+-----------------------------------------------------------------------------------
+ Sort
+   Output: ((p.metadata ->> 'brand'::text)), ((p.metadata -> 'brand'::text))
+   Sort Key: ((p.metadata ->> 'brand'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Output: ((p.metadata ->> 'brand'::text)), ((p.metadata -> 'brand'::text))
+         Backend: DataFusion
+         Indexes: ec_products_idx (p), ec_reviews_idx (r), ec_suppliers_idx (s)
+         Group By: metadata.brand, metadata.brand
+(8 rows)
+
+SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json
+FROM ec_products p
+FULL JOIN ec_reviews r ON p.id = r.id
+LEFT JOIN ec_suppliers s ON r.category = s.category
+WHERE p.description @@@ 'laptop'
+GROUP BY p.metadata->>'brand', p.metadata->'brand'
+ORDER BY brand_text;
+ERROR:  index out of bounds: the len is 1 but the index is 1
+-- Parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json
+FROM ec_products p
+FULL JOIN ec_reviews r ON p.id = r.id
+LEFT JOIN ec_suppliers s ON r.category = s.category
+WHERE p.description @@@ 'laptop'
+GROUP BY p.metadata->>'brand', p.metadata->'brand'
+ORDER BY brand_text;
+ brand_text | brand_json 
+------------+------------
+ TechCorp   | "TechCorp"
+(1 row)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE ec_suppliers;

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -11,7 +11,8 @@ CREATE TABLE ec_products (
     id SERIAL PRIMARY KEY,
     description TEXT,
     category TEXT,
-    price FLOAT
+    price FLOAT,
+    metadata JSONB
 );
 CREATE TABLE ec_reviews (
     id SERIAL PRIMARY KEY,
@@ -24,12 +25,12 @@ CREATE TABLE ec_suppliers (
     category TEXT,
     supplier_name TEXT
 );
-INSERT INTO ec_products (description, category, price) VALUES
-    ('Laptop computer', 'Electronics', 999.99),
-    ('Desktop monitor', 'Electronics', 499.99),
-    ('Running shoes', 'Sports', 89.99),
-    ('Tennis racket', 'Sports', 149.99),
-    ('Winter jacket', 'Clothing', 129.99);
+INSERT INTO ec_products (description, category, price, metadata) VALUES
+    ('Laptop computer', 'Electronics', 999.99, '{"brand": "TechCorp"}'),
+    ('Desktop monitor', 'Electronics', 499.99, '{"brand": "ViewSonic"}'),
+    ('Running shoes', 'Sports', 89.99, '{"brand": "Speedy"}'),
+    ('Tennis racket', 'Sports', 149.99, '{"brand": "Smash"}'),
+    ('Winter jacket', 'Clothing', 129.99, '{"brand": "Warmth"}');
 INSERT INTO ec_reviews (category, rating, reviewer) VALUES
     ('Electronics', 5, 'alice'),
     ('Electronics', 4, 'bob'),
@@ -45,7 +46,7 @@ INSERT INTO ec_suppliers (category, supplier_name) VALUES
     ('Clothing', 'FashionInc'),
     ('Clothing', 'StyleHouse');
 CREATE INDEX ec_products_idx ON ec_products
-USING bm25 (id, description, category, price)
+USING bm25 (id, description, category, price, (metadata::pdb.literal_normalized))
 WITH (
     key_field='id',
     text_fields='{"description": {}, "category": {"fast": true}}',
@@ -162,8 +163,8 @@ ORDER BY p.category;
 
 -- Test 1e: LEFT JOIN with non-unique key — all products, even unmatched
 -- If we add a product with category 'Books' (no reviews), LEFT JOIN should include it
-INSERT INTO ec_products (description, category, price) VALUES
-    ('Science fiction novel', 'Books', 19.99);
+INSERT INTO ec_products (description, category, price, metadata) VALUES
+    ('Science fiction novel', 'Books', 19.99, '{"brand": "PublisherX"}');
 -- Re-index is automatic on INSERT
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT p.category, COUNT(*), COUNT(r.rating)
@@ -358,6 +359,53 @@ ORDER BY p.category;
  Electronics |     6 |     6
  Sports      |     4 |     4
 (4 rows)
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- =====================================================================
+-- Test 5: Join with JSONB field and GROUP BY
+-- =====================================================================
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.metadata -> 'brand'
+FROM ec_products p
+JOIN ec_reviews r ON p.category = r.category
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
+GROUP BY 1
+ORDER BY 1;
+                        QUERY PLAN                        
+----------------------------------------------------------
+ Sort
+   Output: ((p.metadata -> 'brand'::text))
+   Sort Key: ((p.metadata -> 'brand'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Output: ((p.metadata -> 'brand'::text))
+         Backend: DataFusion
+         Indexes: ec_products_idx (p), ec_reviews_idx (r)
+         Group By: metadata.brand
+(8 rows)
+
+SELECT p.metadata -> 'brand'
+FROM ec_products p
+JOIN ec_reviews r ON p.category = r.category
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
+GROUP BY 1
+ORDER BY 1;
+ERROR:  Failed to build DataFusion aggregate plan: Schema error: No field named p_0."metadata.brand". Valid fields are p_0.id, p_0.category, p_0.price, p_0.metadata, p_0.ctid, r_1.id, r_1.category, r_1.rating, r_1.reviewer, r_1.ctid.
+-- Parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.metadata -> 'brand'
+FROM ec_products p
+JOIN ec_reviews r ON p.category = r.category
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
+GROUP BY 1
+ORDER BY 1;
+  ?column?   
+-------------
+ "Smash"
+ "Speedy"
+ "TechCorp"
+ "ViewSonic"
+ "Warmth"
+(5 rows)
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -447,7 +447,11 @@ LEFT JOIN ec_suppliers s ON r.category = s.category
 WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
-ERROR:  index out of bounds: the len is 1 but the index is 1
+ brand_text | brand_json 
+------------+------------
+ TechCorp   | "TechCorp"
+(1 row)
+
 -- Parity
 SET paradedb.enable_aggregate_custom_scan TO off;
 SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -437,7 +437,7 @@ ORDER BY brand_text;
          Output: ((p.metadata ->> 'brand'::text)), ((p.metadata -> 'brand'::text))
          Backend: DataFusion
          Indexes: ec_products_idx (p), ec_reviews_idx (r), ec_suppliers_idx (s)
-         Group By: metadata.brand, metadata.brand
+         Group By: metadata.brand
 (8 rows)
 
 SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -389,7 +389,15 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY 1
 ORDER BY 1;
-ERROR:  Failed to build DataFusion aggregate plan: Schema error: No field named p_0."metadata.brand". Valid fields are p_0.id, p_0.category, p_0.price, p_0.metadata, p_0.ctid, r_1.id, r_1.category, r_1.rating, r_1.reviewer, r_1.ctid.
+  ?column?   
+-------------
+ "Smash"
+ "Speedy"
+ "TechCorp"
+ "ViewSonic"
+ "Warmth"
+(5 rows)
+
 -- Parity
 SET paradedb.enable_aggregate_custom_scan TO off;
 SELECT p.metadata -> 'brand'

--- a/pg_search/tests/pg_regress/expected/issue_3298.out
+++ b/pg_search/tests/pg_regress/expected/issue_3298.out
@@ -10,6 +10,7 @@ CALL paradedb.create_bm25_test_table(
   table_name => 'mock_items'
 );
 CREATE INDEX search_idx ON mock_items USING bm25 (id, description, rating, (category::pdb.literal), metadata) WITH (key_field='id');
+DROP TABLE IF EXISTS allowed_categories;
 CREATE TABLE allowed_categories (
     category TEXT PRIMARY KEY
 );

--- a/pg_search/tests/pg_regress/expected/mutable-toast.out
+++ b/pg_search/tests/pg_regress/expected/mutable-toast.out
@@ -4,6 +4,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan to OFF;
 SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS data_docstore;
 CREATE TABLE data_docstore (
     id SERIAL PRIMARY KEY,
     doc_text VARCHAR
@@ -44,3 +45,4 @@ BEGIN
     UPDATE data_docstore SET doc_text = repeat('BigData_ ', 200000) WHERE id = 1;
   END LOOP;
 END$$;
+DROP TABLE data_docstore;

--- a/pg_search/tests/pg_regress/expected/setup.out
+++ b/pg_search/tests/pg_regress/expected/setup.out
@@ -1,4 +1,5 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS mock_items_issue_2528;
 CALL paradedb.create_bm25_test_table(
   schema_name => 'public',
   table_name => 'mock_items_issue_2528'

--- a/pg_search/tests/pg_regress/expected/slop.out
+++ b/pg_search/tests/pg_regress/expected/slop.out
@@ -89,7 +89,8 @@ ERROR:  operator is not unique: text === pdb.slop at character 97
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WHERE description @@@ pdb.term('running shoes')::pdb.slop(2);
 ERROR:  query type is not compatible with slop
 -- test for JIEBA tokenizer
-CREATE TABLE IF NOT EXISTS content_segment_text (
+DROP TABLE IF EXISTS content_segment_text;
+CREATE TABLE content_segment_text (
 id VARCHAR, -- 唯一标识（fileid_chunkid）
 routing_id VARCHAR NOT NULL, -- 对应 ES 的 routing
 chunk_id INT NOT NULL, -- 文档内容块的 ID

--- a/pg_search/tests/pg_regress/sql/aggregate_join_edge_cases.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join_edge_cases.sql
@@ -279,6 +279,39 @@ ORDER BY 1;
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================
+-- Test 6: Complex 3-table join (FULL + LEFT) with JSONB aggregation
+-- Adapted from user query: FULL JOIN, LEFT JOIN, and JSONB GROUP BY
+-- =====================================================================
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json
+FROM ec_products p
+FULL JOIN ec_reviews r ON p.id = r.id
+LEFT JOIN ec_suppliers s ON r.category = s.category
+WHERE p.description @@@ 'laptop'
+GROUP BY p.metadata->>'brand', p.metadata->'brand'
+ORDER BY brand_text;
+
+SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json
+FROM ec_products p
+FULL JOIN ec_reviews r ON p.id = r.id
+LEFT JOIN ec_suppliers s ON r.category = s.category
+WHERE p.description @@@ 'laptop'
+GROUP BY p.metadata->>'brand', p.metadata->'brand'
+ORDER BY brand_text;
+
+-- Parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.metadata->>'brand' AS brand_text, p.metadata->'brand' AS brand_json
+FROM ec_products p
+FULL JOIN ec_reviews r ON p.id = r.id
+LEFT JOIN ec_suppliers s ON r.category = s.category
+WHERE p.description @@@ 'laptop'
+GROUP BY p.metadata->>'brand', p.metadata->'brand'
+ORDER BY brand_text;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE ec_suppliers;

--- a/pg_search/tests/pg_regress/sql/aggregate_join_edge_cases.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join_edge_cases.sql
@@ -13,7 +13,8 @@ CREATE TABLE ec_products (
     id SERIAL PRIMARY KEY,
     description TEXT,
     category TEXT,
-    price FLOAT
+    price FLOAT,
+    metadata JSONB
 );
 
 CREATE TABLE ec_reviews (
@@ -29,12 +30,12 @@ CREATE TABLE ec_suppliers (
     supplier_name TEXT
 );
 
-INSERT INTO ec_products (description, category, price) VALUES
-    ('Laptop computer', 'Electronics', 999.99),
-    ('Desktop monitor', 'Electronics', 499.99),
-    ('Running shoes', 'Sports', 89.99),
-    ('Tennis racket', 'Sports', 149.99),
-    ('Winter jacket', 'Clothing', 129.99);
+INSERT INTO ec_products (description, category, price, metadata) VALUES
+    ('Laptop computer', 'Electronics', 999.99, '{"brand": "TechCorp"}'),
+    ('Desktop monitor', 'Electronics', 499.99, '{"brand": "ViewSonic"}'),
+    ('Running shoes', 'Sports', 89.99, '{"brand": "Speedy"}'),
+    ('Tennis racket', 'Sports', 149.99, '{"brand": "Smash"}'),
+    ('Winter jacket', 'Clothing', 129.99, '{"brand": "Warmth"}');
 
 INSERT INTO ec_reviews (category, rating, reviewer) VALUES
     ('Electronics', 5, 'alice'),
@@ -53,7 +54,7 @@ INSERT INTO ec_suppliers (category, supplier_name) VALUES
     ('Clothing', 'StyleHouse');
 
 CREATE INDEX ec_products_idx ON ec_products
-USING bm25 (id, description, category, price)
+USING bm25 (id, description, category, price, (metadata::pdb.literal_normalized))
 WITH (
     key_field='id',
     text_fields='{"description": {}, "category": {"fast": true}}',
@@ -132,8 +133,8 @@ ORDER BY p.category;
 
 -- Test 1e: LEFT JOIN with non-unique key — all products, even unmatched
 -- If we add a product with category 'Books' (no reviews), LEFT JOIN should include it
-INSERT INTO ec_products (description, category, price) VALUES
-    ('Science fiction novel', 'Books', 19.99);
+INSERT INTO ec_products (description, category, price, metadata) VALUES
+    ('Science fiction novel', 'Books', 19.99, '{"brand": "PublisherX"}');
 -- Re-index is automatic on INSERT
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
@@ -246,6 +247,35 @@ FULL JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- =====================================================================
+-- Test 5: Join with JSONB field and GROUP BY
+-- =====================================================================
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT p.metadata -> 'brand'
+FROM ec_products p
+JOIN ec_reviews r ON p.category = r.category
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
+GROUP BY 1
+ORDER BY 1;
+
+SELECT p.metadata -> 'brand'
+FROM ec_products p
+JOIN ec_reviews r ON p.category = r.category
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
+GROUP BY 1
+ORDER BY 1;
+
+-- Parity
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT p.metadata -> 'brand'
+FROM ec_products p
+JOIN ec_reviews r ON p.category = r.category
+WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
+GROUP BY 1
+ORDER BY 1;
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/sql/issue_3298.sql
+++ b/pg_search/tests/pg_regress/sql/issue_3298.sql
@@ -9,6 +9,7 @@ CALL paradedb.create_bm25_test_table(
 
 CREATE INDEX search_idx ON mock_items USING bm25 (id, description, rating, (category::pdb.literal), metadata) WITH (key_field='id');
 
+DROP TABLE IF EXISTS allowed_categories;
 CREATE TABLE allowed_categories (
     category TEXT PRIMARY KEY
 );

--- a/pg_search/tests/pg_regress/sql/mutable-toast.sql
+++ b/pg_search/tests/pg_regress/sql/mutable-toast.sql
@@ -1,5 +1,6 @@
 \i common/common_setup.sql
 
+DROP TABLE IF EXISTS data_docstore;
 CREATE TABLE data_docstore (
     id SERIAL PRIMARY KEY,
     doc_text VARCHAR
@@ -31,3 +32,5 @@ BEGIN
     UPDATE data_docstore SET doc_text = repeat('BigData_ ', 200000) WHERE id = 1;
   END LOOP;
 END$$;
+
+DROP TABLE data_docstore;

--- a/pg_search/tests/pg_regress/sql/setup.sql
+++ b/pg_search/tests/pg_regress/sql/setup.sql
@@ -1,5 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
+DROP TABLE IF EXISTS mock_items_issue_2528;
 CALL paradedb.create_bm25_test_table(
   schema_name => 'public',
   table_name => 'mock_items_issue_2528'

--- a/pg_search/tests/pg_regress/sql/slop.sql
+++ b/pg_search/tests/pg_regress/sql/slop.sql
@@ -34,7 +34,8 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT * FROM regress.mock_items WH
 
 
 -- test for JIEBA tokenizer
-CREATE TABLE IF NOT EXISTS content_segment_text (
+DROP TABLE IF EXISTS content_segment_text;
+CREATE TABLE content_segment_text (
 id VARCHAR, -- 唯一标识（fileid_chunkid）
 routing_id VARCHAR NOT NULL, -- 对应 ES 的 routing
 chunk_id INT NOT NULL, -- 文档内容块的 ID

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -116,6 +116,14 @@ impl Column {
         self
     }
 
+    pub const fn bm25_json_field(mut self, config_json: &'static str) -> Self {
+        self.bm25_options = Some(BM25Options {
+            field_type: "json_fields",
+            config_json,
+        });
+        self
+    }
+
     /// Note: should use only the `random()` function to generate random data.
     pub const fn random_generator_sql(mut self, random_generator_sql: &'static str) -> Self {
         self.random_generator_sql = random_generator_sql;
@@ -196,6 +204,15 @@ pub fn generated_queries_setup(
         .collect::<Vec<_>>()
         .join(",\n");
 
+    let json_fields = columns_def
+        .iter()
+        .filter(|c| c.is_indexed && c.index_expression.is_none())
+        .filter_map(|c| c.bm25_options.as_ref())
+        .filter(|o| o.field_type == "json_fields")
+        .map(|o| o.config_json)
+        .collect::<Vec<_>>()
+        .join(",\n");
+
     // Find the first indexed numeric/date fast field for sort_by (Tantivy doesn't support Str).
     let sortable_types = [
         "INT",
@@ -261,7 +278,8 @@ CREATE TABLE {tname} (
 CREATE INDEX idx{tname} ON {tname} USING bm25 ({bm25_columns}) WITH (
     key_field = '{key_field}',
     text_fields = '{{ {text_fields} }}',
-    numeric_fields = '{{ {numeric_fields} }}'{sort_by_clause}
+    numeric_fields = '{{ {numeric_fields} }}',
+    json_fields = '{{ {json_fields} }}'{sort_by_clause}
 );
 
 INSERT into {tname} ({insert_columns}) VALUES ({sample_values});

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -131,6 +131,16 @@ const COLUMNS: &[Column] = &[
         .random_generator_sql(
             "(ARRAY ['Hello World', 'HELLO WORLD', 'hello world', 'HeLLo WoRLD', 'GOODBYE WORLD', 'goodbye world']::text[])[(floor(random() * 6) + 1)::int]"
         ),
+    Column::new("metadata", "JSONB", "'{\"brand\": \"apple\", \"rating\": 4}'")
+        .whereable(false)
+        .groupable(false)
+        .bm25_json_field(r#""metadata": { "fast": true }"#)
+        .random_generator_sql(
+            "jsonb_build_object(
+                'brand', (ARRAY ['apple', 'samsung', 'sony', 'lg']::text[])[(floor(random() * 4) + 1)::int],
+                'rating', (floor(random() * 5) + 1)::int
+            )"
+        ),
 ];
 
 fn columns_named(names: Vec<&'static str>) -> Vec<Column> {
@@ -834,11 +844,19 @@ async fn generated_aggregate_join(database: Db) {
     // Columns for join keys
     let join_key_columns = vec!["id", "age"];
     // Columns for GROUP BY (must be fast fields)
-    let grouping_columns: Vec<&str> = COLUMNS
+    let mut grouping_columns: Vec<String> = COLUMNS
         .iter()
         .filter(|col| col.is_groupable && col.is_whereable)
-        .map(|col| col.name)
+        .map(|col| format!("{}.{}", all_tables[0], col.name))
         .collect();
+
+    grouping_columns.extend(vec![
+        // Group by text representation
+        // TODO: Fails: fix in followup.
+        //format!("{}->>'brand'", format!("{}.metadata", all_tables[0])),
+        // Group by JSONB representation
+        format!("{}->'brand'", format!("{}.metadata", all_tables[0])),
+    ]);
 
     proptest!(|(
         num_tables in 2..=3usize,
@@ -846,13 +864,18 @@ async fn generated_aggregate_join(database: Db) {
         outer_bm25 in arb_wheres(vec![all_tables[0]], &text_columns),
         // GROUP BY + aggregates
         group_by_expr in arb_group_by(
-            grouping_columns.iter().map(|c| format!("{}.{}", all_tables[0], c)).collect::<Vec<_>>(),
+            grouping_columns.clone(),
             vec![
                 "COUNT(*)",
                 "SUM(users.age)",
                 "AVG(users.age)",
                 "MIN(users.rating)",
                 "MAX(users.rating)",
+                // JSON aggregates
+                "SUM((users.metadata->'rating')::int)",
+                "SUM((users.metadata->>'rating')::int)",
+                "MIN((users.metadata->>'rating')::int)",
+                "MAX((users.metadata->>'rating')::int)",
             ],
         ),
     )| {

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -852,9 +852,9 @@ async fn generated_aggregate_join(database: Db) {
 
     grouping_columns.extend(vec![
         // Group by text representation
-        format!("{}->>'brand'", format!("{}.metadata", all_tables[0])),
+        format!("{}.metadata->>'brand'", all_tables[0]),
         // Group by JSONB representation
-        format!("{}->'brand'", format!("{}.metadata", all_tables[0])),
+        format!("{}.metadata->'brand'", all_tables[0]),
     ]);
 
     proptest!(|(
@@ -870,11 +870,6 @@ async fn generated_aggregate_join(database: Db) {
                 "AVG(users.age)",
                 "MIN(users.rating)",
                 "MAX(users.rating)",
-                // JSON aggregates
-                "SUM((users.metadata->'rating')::int)",
-                "SUM((users.metadata->>'rating')::int)",
-                "MIN((users.metadata->>'rating')::int)",
-                "MAX((users.metadata->>'rating')::int)",
             ],
         ),
     )| {

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -852,8 +852,7 @@ async fn generated_aggregate_join(database: Db) {
 
     grouping_columns.extend(vec![
         // Group by text representation
-        // TODO: Fails: fix in followup.
-        //format!("{}->>'brand'", format!("{}.metadata", all_tables[0])),
+        format!("{}->>'brand'", format!("{}.metadata", all_tables[0])),
         // Group by JSONB representation
         format!("{}->'brand'", format!("{}.metadata", all_tables[0])),
     ]);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4928

## What

* Adds JSON aggregates to property testing
* Fixes DataFusion aggregates on JSON(B) projections
* Fixes group-by on duplicated input columns

## Why

To further expand the coverage of aggregates-on-joins.

## Tests

New property and regress tests.