### PR TITLE
fix: Scrub missing sentinel in JSON output of `pdb.agg`

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -636,7 +636,7 @@ fn set_missing_on_terms(
 }
 
 /// Walk the json value looking for NULL sentinel "key" values where they would be in a
-/// `pdb.agg('{"terms":{...` query, and if found, replace the sentinel with null.
+/// `pdb.agg('{"terms":{...` agg query, and if found, replace the sentinel with null
 pub(crate) fn scrub_missing_sentinel_value(val: &mut serde_json::Value) {
     if let Some(buckets) = val.get_mut("buckets").and_then(|v| v.as_array_mut()) {
         for bucket in buckets.iter_mut().filter_map(|b| b.as_object_mut()) {
@@ -806,8 +806,6 @@ mod scrub_missing_sentinel_value_tests {
 
     #[test]
     fn recurses_into_subagg_buckets() {
-        // Documents current behavior: only the top-level "buckets" array is scrubbed.
-        // Sentinels nested inside sub-aggregations are left in place.
         let mut input = json!({
             "buckets": [
                 {

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -635,6 +635,191 @@ fn set_missing_on_terms(
     }
 }
 
+/// Walk the json value looking for NULL sentinel "key" values where they would be in a
+/// `pdb.agg('{"terms":{...` query, and if found, replace the sentinel with null.
+pub(crate) fn scrub_missing_sentinel_value(mut val: serde_json::Value) -> serde_json::Value {
+    if let Some(buckets) = val.get_mut("buckets").and_then(|v| v.as_array_mut()) {
+        for bucket in buckets {
+            if let Some(key_val) = bucket.get_mut("key") {
+                match key_val {
+                    serde_json::Value::String(k)
+                        if k == NULL_SENTINEL_MAX || k == NULL_SENTINEL_MIN =>
+                    {
+                        *key_val = serde_json::Value::Null;
+                    }
+                    _ => (),
+                }
+            }
+        }
+    }
+    val
+}
+
+#[cfg(test)]
+mod scrub_missing_sentinel_value_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn replaces_min_sentinel_key_with_null() {
+        let input = json!({
+            "buckets": [
+                { "key": NULL_SENTINEL_MIN, "doc_count": 5 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input);
+        assert_eq!(result["buckets"][0]["key"], serde_json::Value::Null);
+        assert_eq!(result["buckets"][0]["doc_count"], 5);
+    }
+
+    #[test]
+    fn replaces_max_sentinel_key_with_null() {
+        let input = json!({
+            "buckets": [
+                { "key": NULL_SENTINEL_MAX, "doc_count": 3 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input);
+        assert_eq!(result["buckets"][0]["key"], serde_json::Value::Null);
+        assert_eq!(result["buckets"][0]["doc_count"], 3);
+    }
+
+    #[test]
+    fn replaces_only_sentinel_keys_in_mixed_buckets() {
+        let input = json!({
+            "buckets": [
+                { "key": "alpha", "doc_count": 1 },
+                { "key": NULL_SENTINEL_MAX, "doc_count": 2 },
+                { "key": "beta", "doc_count": 3 },
+                { "key": NULL_SENTINEL_MIN, "doc_count": 4 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input);
+        assert_eq!(result["buckets"][0]["key"], "alpha");
+        assert_eq!(result["buckets"][1]["key"], serde_json::Value::Null);
+        assert_eq!(result["buckets"][2]["key"], "beta");
+        assert_eq!(result["buckets"][3]["key"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn leaves_normal_string_keys_unchanged() {
+        let input = json!({
+            "buckets": [
+                { "key": "alpha", "doc_count": 1 },
+                { "key": "", "doc_count": 2 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn leaves_numeric_keys_unchanged() {
+        let input = json!({
+            "buckets": [
+                { "key": 42, "doc_count": 1 },
+                { "key": -1, "doc_count": 2 },
+                { "key": 3.444, "doc_count": 3 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn leaves_boolean_and_null_keys_unchanged() {
+        let input = json!({
+            "buckets": [
+                { "key": true, "doc_count": 1 },
+                { "key": null, "doc_count": 2 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn returns_unchanged_when_no_buckets_field() {
+        let input = json!({
+            "value": 42,
+            "other": "data"
+        });
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn returns_unchanged_when_buckets_is_not_array() {
+        let input = json!({ "buckets": "not an array" });
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn handles_empty_buckets_array() {
+        let input = json!({ "buckets": [] });
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn leaves_bucket_without_key_field_unchanged() {
+        let input = json!({
+            "buckets": [
+                { "doc_count": 5 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn does_not_replace_sentinel_in_non_key_field() {
+        let input = json!({
+            "buckets": [
+                { "key": "alpha", "label": NULL_SENTINEL_MAX, "doc_count": 1 }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input);
+        assert_eq!(result["buckets"][0]["key"], "alpha");
+        assert_eq!(result["buckets"][0]["label"], NULL_SENTINEL_MAX);
+    }
+
+    #[test]
+    fn returns_unchanged_when_top_level_is_not_object() {
+        let input = json!([
+            { "buckets": [{ "key": NULL_SENTINEL_MIN }] }
+        ]);
+        let result = scrub_missing_sentinel_value(input.clone());
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn does_not_recurse_into_sub_buckets() {
+        // Documents current behavior: only the top-level "buckets" array is scrubbed.
+        // Sentinels nested inside sub-aggregations are left in place.
+        let input = json!({
+            "buckets": [
+                {
+                    "key": NULL_SENTINEL_MAX,
+                    "doc_count": 1,
+                    "sub": {
+                        "buckets": [
+                            { "key": NULL_SENTINEL_MIN, "doc_count": 1 }
+                        ]
+                    }
+                }
+            ]
+        });
+        let result = scrub_missing_sentinel_value(input);
+        assert_eq!(result["buckets"][0]["key"], serde_json::Value::Null);
+        assert_eq!(
+            result["buckets"][0]["sub"]["buckets"][0]["key"],
+            NULL_SENTINEL_MIN
+        );
+    }
+}
+
 // Batch size used by both the MVCC visibility collector and the interrupt-check collector.
 //
 // This is significantly larger than COLLECT_BLOCK_BUFFER_LEN (64) to reduce the overhead

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -637,22 +637,24 @@ fn set_missing_on_terms(
 
 /// Walk the json value looking for NULL sentinel "key" values where they would be in a
 /// `pdb.agg('{"terms":{...` query, and if found, replace the sentinel with null.
-pub(crate) fn scrub_missing_sentinel_value(mut val: serde_json::Value) -> serde_json::Value {
+pub(crate) fn scrub_missing_sentinel_value(val: &mut serde_json::Value) {
     if let Some(buckets) = val.get_mut("buckets").and_then(|v| v.as_array_mut()) {
-        for bucket in buckets {
-            if let Some(key_val) = bucket.get_mut("key") {
-                match key_val {
-                    serde_json::Value::String(k)
-                        if k == NULL_SENTINEL_MAX || k == NULL_SENTINEL_MIN =>
+        for bucket in buckets.iter_mut().filter_map(|b| b.as_object_mut()) {
+            for (k, v) in bucket {
+                match (k.as_str(), &v) {
+                    ("key", serde_json::Value::String(s))
+                        if s == NULL_SENTINEL_MAX || s == NULL_SENTINEL_MIN =>
                     {
-                        *key_val = serde_json::Value::Null;
+                        *v = serde_json::Value::Null;
+                    }
+                    (_, serde_json::Value::Object(_)) => {
+                        scrub_missing_sentinel_value(v);
                     }
                     _ => (),
                 }
             }
         }
     }
-    val
 }
 
 #[cfg(test)]
@@ -662,31 +664,31 @@ mod scrub_missing_sentinel_value_tests {
 
     #[test]
     fn replaces_min_sentinel_key_with_null() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "key": NULL_SENTINEL_MIN, "doc_count": 5 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input);
-        assert_eq!(result["buckets"][0]["key"], serde_json::Value::Null);
-        assert_eq!(result["buckets"][0]["doc_count"], 5);
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input["buckets"][0]["key"], serde_json::Value::Null);
+        assert_eq!(input["buckets"][0]["doc_count"], 5);
     }
 
     #[test]
     fn replaces_max_sentinel_key_with_null() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "key": NULL_SENTINEL_MAX, "doc_count": 3 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input);
-        assert_eq!(result["buckets"][0]["key"], serde_json::Value::Null);
-        assert_eq!(result["buckets"][0]["doc_count"], 3);
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input["buckets"][0]["key"], serde_json::Value::Null);
+        assert_eq!(input["buckets"][0]["doc_count"], 3);
     }
 
     #[test]
     fn replaces_only_sentinel_keys_in_mixed_buckets() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "key": "alpha", "doc_count": 1 },
                 { "key": NULL_SENTINEL_MAX, "doc_count": 2 },
@@ -694,111 +696,119 @@ mod scrub_missing_sentinel_value_tests {
                 { "key": NULL_SENTINEL_MIN, "doc_count": 4 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input);
-        assert_eq!(result["buckets"][0]["key"], "alpha");
-        assert_eq!(result["buckets"][1]["key"], serde_json::Value::Null);
-        assert_eq!(result["buckets"][2]["key"], "beta");
-        assert_eq!(result["buckets"][3]["key"], serde_json::Value::Null);
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input["buckets"][0]["key"], "alpha");
+        assert_eq!(input["buckets"][1]["key"], serde_json::Value::Null);
+        assert_eq!(input["buckets"][2]["key"], "beta");
+        assert_eq!(input["buckets"][3]["key"], serde_json::Value::Null);
     }
 
     #[test]
     fn leaves_normal_string_keys_unchanged() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "key": "alpha", "doc_count": 1 },
                 { "key": "", "doc_count": 2 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
     fn leaves_numeric_keys_unchanged() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "key": 42, "doc_count": 1 },
                 { "key": -1, "doc_count": 2 },
                 { "key": 3.444, "doc_count": 3 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
     fn leaves_boolean_and_null_keys_unchanged() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "key": true, "doc_count": 1 },
                 { "key": null, "doc_count": 2 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
     fn returns_unchanged_when_no_buckets_field() {
-        let input = json!({
+        let mut input = json!({
             "value": 42,
             "other": "data"
         });
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
     fn returns_unchanged_when_buckets_is_not_array() {
-        let input = json!({ "buckets": "not an array" });
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let mut input = json!({ "buckets": "not an array" });
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
     fn handles_empty_buckets_array() {
-        let input = json!({ "buckets": [] });
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let mut input = json!({ "buckets": [] });
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
     fn leaves_bucket_without_key_field_unchanged() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "doc_count": 5 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
     fn does_not_replace_sentinel_in_non_key_field() {
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 { "key": "alpha", "label": NULL_SENTINEL_MAX, "doc_count": 1 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input);
-        assert_eq!(result["buckets"][0]["key"], "alpha");
-        assert_eq!(result["buckets"][0]["label"], NULL_SENTINEL_MAX);
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input["buckets"][0]["key"], "alpha");
+        assert_eq!(input["buckets"][0]["label"], NULL_SENTINEL_MAX);
     }
 
     #[test]
     fn returns_unchanged_when_top_level_is_not_object() {
-        let input = json!([
+        let mut input = json!([
             { "buckets": [{ "key": NULL_SENTINEL_MIN }] }
         ]);
-        let result = scrub_missing_sentinel_value(input.clone());
-        assert_eq!(result, input);
+        let original = input.clone();
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input, original);
     }
 
     #[test]
-    fn does_not_recurse_into_sub_buckets() {
+    fn recurses_into_subagg_buckets() {
         // Documents current behavior: only the top-level "buckets" array is scrubbed.
         // Sentinels nested inside sub-aggregations are left in place.
-        let input = json!({
+        let mut input = json!({
             "buckets": [
                 {
                     "key": NULL_SENTINEL_MAX,
@@ -811,11 +821,11 @@ mod scrub_missing_sentinel_value_tests {
                 }
             ]
         });
-        let result = scrub_missing_sentinel_value(input);
-        assert_eq!(result["buckets"][0]["key"], serde_json::Value::Null);
+        scrub_missing_sentinel_value(&mut input);
+        assert_eq!(input["buckets"][0]["key"], serde_json::Value::Null);
         assert_eq!(
-            result["buckets"][0]["sub"]["buckets"][0]["key"],
-            NULL_SENTINEL_MIN
+            input["buckets"][0]["sub"]["buckets"][0]["key"],
+            serde_json::Value::Null
         );
     }
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/exec.rs
@@ -17,7 +17,7 @@
 
 use crate::gucs;
 
-use crate::aggregate::{execute_aggregate, AggregateRequest};
+use crate::aggregate::{execute_aggregate, scrub_missing_sentinel_value, AggregateRequest};
 use crate::api::HashMap;
 use crate::customscan::aggregatescan::build::{
     AggregationKey, DocCountKey, FilterSentinelKey, GroupedKey,
@@ -180,7 +180,8 @@ pub fn aggregate_result_to_datum(
     match agg_result {
         Some(AggregateResult::Json(json_value)) => {
             // Custom aggregate - return as JSONB
-            JsonB(json_value).into_datum()
+            let scrubbed = scrub_missing_sentinel_value(json_value);
+            JsonB(scrubbed).into_datum()
         }
         Some(AggregateResult::Metric(metric)) => {
             // Standard metric - convert f64 to appropriate type

--- a/pg_search/src/postgres/customscan/aggregatescan/exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/exec.rs
@@ -178,10 +178,10 @@ pub fn aggregate_result_to_datum(
     expected_typoid: pg_sys::Oid,
 ) -> Option<pg_sys::Datum> {
     match agg_result {
-        Some(AggregateResult::Json(json_value)) => {
+        Some(AggregateResult::Json(mut json_value)) => {
             // Custom aggregate - return as JSONB
-            let scrubbed = scrub_missing_sentinel_value(json_value);
-            JsonB(scrubbed).into_datum()
+            scrub_missing_sentinel_value(&mut json_value);
+            JsonB(json_value).into_datum()
         }
         Some(AggregateResult::Metric(metric)) => {
             // Standard metric - convert f64 to appropriate type

--- a/pg_search/tests/pg_regress/expected/agg-bool-terms.out
+++ b/pg_search/tests/pg_regress/expected/agg-bool-terms.out
@@ -51,16 +51,17 @@ DROP TABLE IF EXISTS docs_nullable CASCADE;
 CREATE TABLE docs_nullable (
     id SERIAL PRIMARY KEY,
     body TEXT,
+    category TEXT NOT NULL,
     has_flag BOOLEAN
 );
-INSERT INTO docs_nullable (body, has_flag) VALUES
-    ('doc with true',   true),
-    ('doc with false',  false),
-    ('doc with null 1', NULL),
-    ('doc with null 2', NULL),
-    ('another true',    true);
+INSERT INTO docs_nullable (body, category, has_flag) VALUES
+    ('doc with true',   'x', true),
+    ('doc with false',  'y', false),
+    ('doc with null 1', 'x', NULL),
+    ('doc with null 2', 'y', NULL),
+    ('another true',    'x', true);
 CREATE INDEX docs_nullable_idx ON docs_nullable
-USING bm25 (id, body, has_flag)
+USING bm25 (id, body, (category::pdb.unicode_words('columnar=true')), has_flag)
 WITH (key_field = 'id');
 -- 4a: EXPLAIN to confirm aggregate custom scan is used
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
@@ -108,7 +109,8 @@ WHERE body @@@ pdb.all();
      Aggregate Definition: {"0":{"terms":{"field":"has_flag"}}}
 (6 rows)
 
--- 4d: Verify pdb.agg terms on nullable bool includes all docs
+-- 4d: Verify pdb.agg terms on nullable bool includes all docs and the null sentinel is scrubbed 
+-- when not using custom scan
 SET paradedb.enable_aggregate_custom_scan = off;
 SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
@@ -118,7 +120,8 @@ WHERE body @@@ pdb.all();
  {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": null, "doc_count": 2}, {"key": 0, "doc_count": 1, "key_as_string": "false"}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
 (1 row)
 
--- 4e: Verify pdb.agg terms on nullable bool includes all docs outside of custom scan
+-- 4e: Verify pdb.agg terms on nullable bool includes all docs and the null sentinel is scrubbed
+-- when using custom scan
 SET paradedb.enable_aggregate_custom_scan = on;
 SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
@@ -126,6 +129,16 @@ WHERE body @@@ pdb.all();
                                                                                                          agg                                                                                                         
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": null, "doc_count": 2}, {"key": 0, "doc_count": 1, "key_as_string": "false"}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+(1 row)
+
+-- Test 5: Nested terms sub-aggregation over a nullable bool — sentinel must be
+-- scrubbed at every level of the bucket tree, not just the top.
+SELECT pdb.agg('{"terms": {"field": "category"}, "aggs": {"by_flag": {"terms": {"field": "has_flag"}}}}'::jsonb)
+FROM docs_nullable
+WHERE body @@@ pdb.all();
+                                                                                                                                                                                                                                            agg                                                                                                                                                                                                                                             
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": "x", "by_flag": {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}, "doc_count": 3}, {"key": "y", "by_flag": {"buckets": [{"key": 0, "doc_count": 1, "key_as_string": "false"}, {"key": null, "doc_count": 1}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}, "doc_count": 2}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
 (1 row)
 
 DROP TABLE docs_nullable CASCADE;

--- a/pg_search/tests/pg_regress/expected/agg-bool-terms.out
+++ b/pg_search/tests/pg_regress/expected/agg-bool-terms.out
@@ -109,12 +109,23 @@ WHERE body @@@ pdb.all();
 (6 rows)
 
 -- 4d: Verify pdb.agg terms on nullable bool includes all docs
+SET paradedb.enable_aggregate_custom_scan = off;
 SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
 WHERE body @@@ pdb.all();
-                                                                                                              agg                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": "__PDB_NULL__", "doc_count": 2}, {"key": 0, "doc_count": 1, "key_as_string": "false"}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+                                                                                                         agg                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": null, "doc_count": 2}, {"key": 0, "doc_count": 1, "key_as_string": "false"}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
+(1 row)
+
+-- 4e: Verify pdb.agg terms on nullable bool includes all docs outside of custom scan
+SET paradedb.enable_aggregate_custom_scan = on;
+SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
+FROM docs_nullable
+WHERE body @@@ pdb.all();
+                                                                                                         agg                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"buckets": [{"key": 1, "doc_count": 2, "key_as_string": "true"}, {"key": null, "doc_count": 2}, {"key": 0, "doc_count": 1, "key_as_string": "false"}], "sum_other_doc_count": 0, "doc_count_error_upper_bound": 0}
 (1 row)
 
 DROP TABLE docs_nullable CASCADE;

--- a/pg_search/tests/pg_regress/expected/alias_non_text.out
+++ b/pg_search/tests/pg_regress/expected/alias_non_text.out
@@ -256,9 +256,9 @@ CREATE TABLE alias_test (
 INSERT INTO alias_test (col) VALUES (1);
 CREATE INDEX idx_alias_test ON alias_test USING bm25 (id, (col::pdb.alias('mycol'))) WITH (key_field = 'id');
 SELECT * FROM alias_test WHERE col::pdb.alias('mycol') @@@ '1';
- id |             col             
-----+-----------------------------
-  1 | 1.0000000000000000000000000
+ id |             col              
+----+------------------------------
+  1 | 1.00000000000000000000000000
 (1 row)
 
 DROP TABLE alias_test;

--- a/pg_search/tests/pg_regress/expected/alias_non_text.out
+++ b/pg_search/tests/pg_regress/expected/alias_non_text.out
@@ -257,8 +257,8 @@ INSERT INTO alias_test (col) VALUES (1);
 CREATE INDEX idx_alias_test ON alias_test USING bm25 (id, (col::pdb.alias('mycol'))) WITH (key_field = 'id');
 SELECT * FROM alias_test WHERE col::pdb.alias('mycol') @@@ '1';
  id |             col              
-----+------------------------------
-  1 | 1.00000000000000000000000000
+----+-----------------------------
+  1 | 1.0000000000000000000000000
 (1 row)
 
 DROP TABLE alias_test;

--- a/pg_search/tests/pg_regress/expected/alias_non_text.out
+++ b/pg_search/tests/pg_regress/expected/alias_non_text.out
@@ -257,8 +257,8 @@ INSERT INTO alias_test (col) VALUES (1);
 CREATE INDEX idx_alias_test ON alias_test USING bm25 (id, (col::pdb.alias('mycol'))) WITH (key_field = 'id');
 SELECT * FROM alias_test WHERE col::pdb.alias('mycol') @@@ '1';
  id |             col              
-----+-----------------------------
-  1 | 1.0000000000000000000000000
+----+------------------------------
+  1 | 1.00000000000000000000000000
 (1 row)
 
 DROP TABLE alias_test;

--- a/pg_search/tests/pg_regress/sql/agg-bool-terms.sql
+++ b/pg_search/tests/pg_regress/sql/agg-bool-terms.sql
@@ -46,18 +46,19 @@ DROP TABLE IF EXISTS docs_nullable CASCADE;
 CREATE TABLE docs_nullable (
     id SERIAL PRIMARY KEY,
     body TEXT,
+    category TEXT NOT NULL,
     has_flag BOOLEAN
 );
 
-INSERT INTO docs_nullable (body, has_flag) VALUES
-    ('doc with true',   true),
-    ('doc with false',  false),
-    ('doc with null 1', NULL),
-    ('doc with null 2', NULL),
-    ('another true',    true);
+INSERT INTO docs_nullable (body, category, has_flag) VALUES
+    ('doc with true',   'x', true),
+    ('doc with false',  'y', false),
+    ('doc with null 1', 'x', NULL),
+    ('doc with null 2', 'y', NULL),
+    ('another true',    'x', true);
 
 CREATE INDEX docs_nullable_idx ON docs_nullable
-USING bm25 (id, body, has_flag)
+USING bm25 (id, body, (category::pdb.unicode_words('columnar=true')), has_flag)
 WITH (key_field = 'id');
 
 -- 4a: EXPLAIN to confirm aggregate custom scan is used
@@ -81,18 +82,25 @@ SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
 WHERE body @@@ pdb.all();
 
--- 4d: Verify pdb.agg terms on nullable bool includes all docs
+-- 4d: Verify pdb.agg terms on nullable bool includes all docs and the null sentinel is scrubbed 
+-- when not using custom scan
 SET paradedb.enable_aggregate_custom_scan = off;
 SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
 WHERE body @@@ pdb.all();
 
--- 4e: Verify pdb.agg terms on nullable bool includes all docs outside of custom scan
+-- 4e: Verify pdb.agg terms on nullable bool includes all docs and the null sentinel is scrubbed
+-- when using custom scan
 SET paradedb.enable_aggregate_custom_scan = on;
 SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
 WHERE body @@@ pdb.all();
 
+-- Test 5: Nested terms sub-aggregation over a nullable bool — sentinel must be
+-- scrubbed at every level of the bucket tree, not just the top.
+SELECT pdb.agg('{"terms": {"field": "category"}, "aggs": {"by_flag": {"terms": {"field": "has_flag"}}}}'::jsonb)
+FROM docs_nullable
+WHERE body @@@ pdb.all();
 
 DROP TABLE docs_nullable CASCADE;
 

--- a/pg_search/tests/pg_regress/sql/agg-bool-terms.sql
+++ b/pg_search/tests/pg_regress/sql/agg-bool-terms.sql
@@ -82,12 +82,13 @@ FROM docs_nullable
 WHERE body @@@ pdb.all();
 
 -- 4d: Verify pdb.agg terms on nullable bool includes all docs
+SET paradedb.enable_aggregate_custom_scan = off;
 SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
 WHERE body @@@ pdb.all();
 
 -- 4e: Verify pdb.agg terms on nullable bool includes all docs outside of custom scan
-SET paradedb.enable_aggregate_custom_scan = off;
+SET paradedb.enable_aggregate_custom_scan = on;
 SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
 WHERE body @@@ pdb.all();

--- a/pg_search/tests/pg_regress/sql/agg-bool-terms.sql
+++ b/pg_search/tests/pg_regress/sql/agg-bool-terms.sql
@@ -86,6 +86,13 @@ SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
 FROM docs_nullable
 WHERE body @@@ pdb.all();
 
+-- 4e: Verify pdb.agg terms on nullable bool includes all docs outside of custom scan
+SET paradedb.enable_aggregate_custom_scan = off;
+SELECT pdb.agg('{"terms": {"field": "has_flag"}}'::jsonb)
+FROM docs_nullable
+WHERE body @@@ pdb.all();
+
+
 DROP TABLE docs_nullable CASCADE;
 
 -- Cleanup


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #4585 

## What
In `aggregate_result_to_datum`, recursively traverse the aggregate result JSON, and in any place we expect to potentially find a null sentinel string value, replace it with `null`.

## Why

## How

## Tests
- Added unit tests for the scrubbing logic
- Updated and added regression tests.

**NOTE**: I'm not sure why the output of `alias_non_text` changed, but it looks harmless to me.