### PR TITLE
ci: fix SchemaBot for fork-based PRs

### DIFF
--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           cargo pgrx init "--pg${{ matrix.pg_version }}=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           # Save the pgrx version for comparison later
-          echo "FIRST_PGRX_VERSION=${PGRX_VERSION}" >> $GITHUB_ENV
+          echo "FIRST_PGRX_VERSION=${{ steps.pgrx.outputs.version }}" >> $GITHUB_ENV
 
       - name: Generate Schema from this git rev
         run: cargo pgrx schema -p pg_search pg${{ matrix.pg_version }} > ~/this.sql
@@ -102,7 +102,17 @@ jobs:
         run: |
           # Switch to the base git rev
           git checkout .
-          git checkout ${{ github.event.pull_request.base.ref }}
+
+          # Fetch the base ref from the upstream repository (the repo the PR
+          # targets), not from the PR head's repo. For fork-based PRs the head
+          # repo's `main` branch is often stale, which would otherwise produce
+          # a misleading schema diff (and pull in a stale pgrx version below).
+          BASE_REPO="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
+          BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
+          git remote remove upstream 2>/dev/null || true
+          git remote add upstream "https://github.com/${BASE_REPO}.git"
+          git fetch --depth=1 upstream "${BASE_REF}"
+          git checkout FETCH_HEAD
 
           # See if we need a different cargo-pgrx and install it if so
           THIS_PGRX_VERSION=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)


### PR DESCRIPTION
## Summary

- SchemaBot was failing with phantom "missing migration" errors on PRs from forks (e.g. #4924). The workflow checks out the PR head's repo and then runs `git checkout ${{ pull_request.base.ref }}` for the "old" schema — which on a fork PR resolves to the fork's own (often stale) `main`. The diff then surfaces every entity added to upstream `main` since the fork was last synced, and additionally downgrades cargo-pgrx if the fork still pins an older version. Fetch the base ref from the PR's base repo and check that out instead, so the diff is always against the real upstream main.
- Adjacent fix: `FIRST_PGRX_VERSION` was being set from `${PGRX_VERSION}`, an undefined env var, so it was always empty and the version-mismatch reinstall path in the base-checkout step always fired. Source the value from `steps.pgrx.outputs.version` (already extracted at the top of the job) instead. Without this the "did pgrx change between base and head?" guard never short-circuits.

## Test plan

- [x] Re-run SchemaBot on #4924 (fork PR) and confirm it now passes without the contributor needing to rebase.
- [x] Confirm SchemaBot still passes on an in-org PR (sanity check that the `upstream` remote dance doesn't break the same-repo case).
- [x] Confirm the cargo-pgrx reinstall step is now skipped when base and head pin the same pgrx version (look for absence of "Replaced package cargo-pgrx" in the log).