### PR TITLE
fix: fix template injection in schemabot-generate-diff workflow

### DIFF
--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -99,6 +99,9 @@ jobs:
         run: cargo pgrx schema -p pg_search pg${{ matrix.pg_version }} > ~/this.sql
 
       - name: Switch to Base git rev and Generate Schema Again
+        env:
+          BASE_REPO: ${{ github.event.pull_request.base.repo.full_name || github.repository }}
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.ref_name }}
         run: |
           # Switch to the base git rev
           git checkout .
@@ -107,8 +110,6 @@ jobs:
           # targets), not from the PR head's repo. For fork-based PRs the head
           # repo's `main` branch is often stale, which would otherwise produce
           # a misleading schema diff (and pull in a stale pgrx version below).
-          BASE_REPO="${{ github.event.pull_request.base.repo.full_name || github.repository }}"
-          BASE_REF="${{ github.event.pull_request.base.ref || github.ref_name }}"
           git remote remove upstream 2>/dev/null || true
           git remote add upstream "https://github.com/${BASE_REPO}.git"
           git fetch --depth=1 upstream "${BASE_REF}"
@@ -152,9 +153,11 @@ jobs:
           perl -i -pe 'chomp if eof' ~/diff.sql
 
       - name: Switch Back to PR Branch
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref }}
         run: |
           # Switch back to the PR branch to check the migration file
-          git checkout ${{ github.event.pull_request.head.ref || github.ref }}
+          git checkout "$HEAD_REF"
 
       - name: Check Schema Diff and Validate Migration
         id: check_schema_diff


### PR DESCRIPTION
## Summary
- Fixes a GitHub Actions template injection (CWE-78) in `.github/workflows/schemabot-generate-diff.yml`.
- The `Switch Back to PR Branch` step expanded `${{ github.event.pull_request.head.ref || github.ref }}` directly into a `git checkout` shell argument. A fork PR with a branch name containing shell metacharacters (e.g. `main;id`) executed arbitrary commands on the runner.
- Moved attacker-controlled values into `env:` blocks and quoted them in `run:` blocks.
- Applied the same pattern to `base.ref` / `base.repo.full_name` for defense in depth (lower risk — these are constrained to the upstream repo, but worth fixing).

## Impact assessment
- Trigger is `pull_request` (not `pull_request_target`), so `GITHUB_TOKEN` is read-only and repo secrets are not injected for fork PRs. Blast radius is limited to RCE on the ephemeral `runs-on.com` runner with outbound network.
- Verified no other workflows use this unsafe pattern: all other `github.head_ref` / `github.ref` references are in `concurrency.group` or `actions/checkout` `ref:` inputs (both safe contexts).

Reported by Fabian Kammel.

## Test plan
- [x] SchemaBot workflow runs cleanly on this PR (no schema changes expected, but step ordering is exercised)
- [x] Existing SchemaBot behavior on PRs that touch `pg_search/**` continues to detect schema drift