### PR TITLE
ci: run SchemaBot with pg18

### DIFF
--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -40,7 +40,7 @@ jobs:
         shell: bash -eo pipefail {0}
     strategy:
       matrix:
-        pg_version: [15] # pg_search's minimum supported Postgres version
+        pg_version: [18]
 
     steps:
       - name: Checkout Git Repository


### PR DESCRIPTION
## Summary
- Bump the SchemaBot Generate Diff workflow matrix from pg15 to pg18.

## Test plan
- [x] CI passes on this PR.