### PR TITLE
fix: Bump working mem in failing aggregate queries.

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/pg_search/aggregate_join_groupby.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/aggregate_join_groupby.sql
@@ -15,8 +15,8 @@ WHERE p.body ||| 'code'
 GROUP BY p.title
 ORDER BY p.title;
 
--- DataFusion aggregate scan
-SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT p.title, COUNT(*), SUM(c.score)
+-- DataFusion aggregate scan (temporarily increased from 4GB to 8GB)
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT p.title, COUNT(*), SUM(c.score)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code'

--- a/benchmarks/datasets/stackoverflow/queries/pg_search/distinct_parent_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/pg_search/distinct_parent_sort.sql
@@ -21,7 +21,7 @@ ORDER BY
     u.display_name ASC              -- Single Feature Sort (Parent Field)
 LIMIT 50;
 
-SET work_mem TO '64MB'; SET paradedb.enable_join_custom_scan TO on; SELECT DISTINCT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT DISTINCT
     u.id,
     u.display_name,
     u.about_me


### PR DESCRIPTION
## What
`distinct_parent_sort`:Runs out of memory on the 20m StackOverflow dataset. Bumping the working memory to fix it. The value of 4GB is chosen to mirror the other stack overflow queries that have an increased amount of working memory.
`aggregate_join_groupby` temporarily increased to 8GB to get it working.

