### PR TITLE
chore: Prepare `0.23.3`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -28,7 +28,7 @@ Releases must always be triggered **from the branch being released** (e.g., `mai
 
 ## Release Preparation
 
-Before triggering the workflow, create a **Release Preparation PR** against the branch you're releasing from (`main`, or a stable branch like `0.16.x`):
+Before triggering the workflow, create a **Release Preparation PR** against `main`. This is true even when releasing a patch from a stable branch like `0.23.x`: the prep PR always targets `main`, and the PR description should reference the stable branch the release is being cut from. The actual release is then triggered against the stable branch via the workflow.
 
 - Update the `Cargo.toml` version:
   - `a.b.c-rc.d` for **beta** releases

--- a/docs/changelog/0.23.3.mdx
+++ b/docs/changelog/0.23.3.mdx
@@ -1,0 +1,16 @@
+---
+title: 0.23.3
+noindex: true
+---
+
+## Performance Improvements 🚀
+
+- Optimize deferred visibility for preserved join sides.
+
+## Stability Improvements 💪
+
+- Fix JSON projections for aggregates-on-joins.
+- Scrub missing sentinel in JSON output of `pdb.agg`.
+- Additional backwards compatibility fixes for pre-`0.22.x` indexes containing NUMERIC columns.
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.23.3).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -39,7 +39,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.23.2-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.23.3-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -36,7 +36,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.23.2` with the `pg_search` version you wish to install and
+  You can replace `0.23.3` with the `pg_search` version you wish to install and
   `18` with the version of Postgres you are using.
 </Note>
 
@@ -44,49 +44,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/postgresql-18-pg-search_0.23.2-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/postgresql-18-pg-search_0.23.3-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/postgresql-18-pg-search_0.23.2-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/postgresql-18-pg-search_0.23.3-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/postgresql-18-pg-search_0.23.2-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/postgresql-18-pg-search_0.23.3-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/postgresql-18-pg-search_0.23.2-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/postgresql-18-pg-search_0.23.3-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/pg_search_18-0.23.2-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/pg_search_18-0.23.3-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/pg_search_18-0.23.2-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/pg_search_18-0.23.3-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/pg_search@18--0.23.2.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/pg_search@18--0.23.3.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.2/pg_search@18--0.23.2.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.3/pg_search@18--0.23.3.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -37,7 +37,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.23.2`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.23.3`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -79,10 +79,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.23.2
+docker pull paradedb/paradedb:0.23.3
 ```
 
-The latest version of the Docker image should be `0.23.2`.
+The latest version of the Docker image should be `0.23.3`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -99,7 +99,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.23.2';
+ALTER EXTENSION pg_search UPDATE TO '0.23.3';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.23.2",
+        "version": "v0.23.3",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -345,6 +345,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.23.3",
                   "changelog/0.23.2",
                   "changelog/0.23.1",
                   "changelog/0.23.0",


### PR DESCRIPTION
Release preparation for 0.23.3, cut from the [`0.23.x`](https://github.com/paradedb/paradedb/tree/0.23.x) stable branch.