### PR TITLE
chore: Bump Cargo.toml to 0.23.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -709,7 +709,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4763,7 +4763,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5411,7 +5411,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7646,7 +7646,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "approx",
@@ -8211,7 +8211,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.23.2"
+version = "0.23.3"
 dependencies = [
  "anyhow",
  "emoji",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.2"
+version = "0.23.3"
 edition = "2021"
 license = "AGPL-3.0"
 


### PR DESCRIPTION
Follow-up to #4984. The release prep PR against `main` (#4983) didn't bump `Cargo.toml` because main was already at `0.23.3` from the post-0.23.2 dev bump, so the cherry-pick onto `0.23.x` missed it.