### PR TITLE
chore: Add 0.23.2 -> 0.23.3 SQL upgrade script

### DIFF
--- a/pg_search/sql/pg_search--0.23.2--0.23.3.sql
+++ b/pg_search/sql/pg_search--0.23.2--0.23.3.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.3'" to load this file. \quit


### PR DESCRIPTION
Stub upgrade script required by the release workflow. The script on `main` (added in #4956) contains a `version_info` signature change that does not apply to `0.23.x`, so this is a plain stub.