### PR TITLE
ci: Use GitHub app instead of bot

### DIFF
--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -12,8 +12,11 @@ inputs:
   ref:
     description: "Git ref or short SHA to report in benchmarks"
     required: true
-  github_token:
-    description: "GitHub token to authenticate with"
+  github_app_id:
+    description: "GitHub App ID to authenticate with"
+    required: true
+  github_app_private_key:
+    description: "GitHub App private key to authenticate with"
     required: true
   slack_oauth_token:
     description: "Slack OAuth token to authenticate with"
@@ -97,6 +100,13 @@ runs:
         with open(f"pg_search_tps.json", "w")  as o: json.dump(tps, o)
         with open(f"pg_search_other.json", "w") as o: json.dump(other, o)
 
+    - name: Generate GitHub App Token
+      id: app-token
+      uses: actions/create-github-app-token@v2
+      with:
+        app-id: ${{ inputs.github_app_id }}
+        private-key: ${{ inputs.github_app_private_key }}
+
     # Necessary to avoid "destination path is not empty" error
     - name: Cleanup Previous Benchmark Publish Working Directory
       shell: bash
@@ -115,7 +125,7 @@ runs:
         ref: ${{ inputs.ref }}
         tool: customBiggerIsBetter
         output-file-path: pg_search_tps.json
-        github-token: ${{ inputs.github_token }}
+        github-token: ${{ steps.app-token.outputs.token }}
         gh-repository: github.com/${{ github.repository }}
         gh-pages-branch: gh-pages
         auto-push: ${{ github.event_name != 'pull_request' }}
@@ -143,7 +153,7 @@ runs:
         ref: ${{ inputs.ref }}
         tool: customSmallerIsBetter
         output-file-path: pg_search_other.json
-        github-token: ${{ inputs.github_token }}
+        github-token: ${{ steps.app-token.outputs.token }}
         gh-repository: github.com/${{ github.repository }}
         gh-pages-branch: gh-pages
         auto-push: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ inputs.reset_data }}
         run: |
           git config user.name "Benchmark Backfill Job"
-          git config user.email "282009505+paradedb-app[bot]@users.noreply.github.com"
+          git config user.email "282009505+paradedb-github-app[bot]@users.noreply.github.com"
           files=$(git ls-files stressgres/data.js benchmarks/data.js)
           if [ -n "$files" ]; then
             echo "$files" | xargs git rm

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -43,7 +43,7 @@ jobs:
         if: ${{ inputs.reset_data }}
         run: |
           git config user.name "Benchmark Backfill Job"
-          git config user.email "developers@paradedb.com"
+          git config user.email "282009505+paradedb-app[bot]@users.noreply.github.com"
           files=$(git ls-files stressgres/data.js benchmarks/data.js)
           if [ -n "$files" ]; then
             echo "$files" | xargs git rm

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -222,7 +222,8 @@ jobs:
         with:
           test_file: single-server.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
@@ -232,7 +233,8 @@ jobs:
         with:
           test_file: bulk-updates.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
@@ -242,7 +244,8 @@ jobs:
         with:
           test_file: wide-table.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
@@ -252,7 +255,8 @@ jobs:
         with:
           test_file: background-merge.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
@@ -262,7 +266,8 @@ jobs:
         with:
           test_file: logical-replication.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -18,18 +18,25 @@ jobs:
       contains(join(github.event.pull_request.labels.*.name, ','), 'cherry-pick/')
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout Git Repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Backport based on cherry-pick/<branch> labels
         uses: korthout/backport-action@v4
         with:
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
-          git_committer_name: paradedb[bot]
-          git_committer_email: developers@paradedb.com
+          github_token: ${{ steps.app-token.outputs.token }}
+          git_committer_name: paradedb-app[bot]
+          git_committer_email: 282009505+paradedb-app[bot]@users.noreply.github.com
           add_author_as_assignee: true
           add_author_as_reviewer: true
           add_labels: automated-cherry-pick

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -35,8 +35,8 @@ jobs:
         uses: korthout/backport-action@v4
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          git_committer_name: paradedb-app[bot]
-          git_committer_email: 282009505+paradedb-app[bot]@users.noreply.github.com
+          git_committer_name: paradedb-github-app[bot]
+          git_committer_email: 282009505+paradedb-github-app[bot]@users.noreply.github.com
           add_author_as_assignee: true
           add_author_as_reviewer: true
           add_labels: automated-cherry-pick

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
 
       - name: Publish Docs to Mintlify
         run: |

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -47,13 +47,13 @@ jobs:
 
       - name: Checkout Git Repository
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
 
       # We confirm that if the release type is beta, the version in Cargo.toml matches with "-rc.X", and that the
       # version provided matches the version in Cargo.toml. If the user forgot to increment the version, they will
       # need to do it in a PR, which will trigger the workflow test_pg_search-upgrade.yml, ensuring that the upgrade is tested.
       - name: Validate Cargo.toml Version Matches Release Type
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "Checking for existing release..."
           if gh release view v${{ github.event.inputs.version }} > /dev/null 2>&1; then
@@ -125,7 +125,7 @@ jobs:
       - name: Determine if Release Should be Marked as Latest
         id: release_latest
         env:
-          GITHUB_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           current_tag_version="${{ github.event.inputs.version }}"
           latest_tag_version=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
@@ -176,7 +176,7 @@ jobs:
           make_latest: ${{ steps.release_latest.outputs.is_latest }}
           generate_release_notes: true
         env:
-          GITHUB_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Slack on Failure
         if: failure()

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -146,17 +146,24 @@ jobs:
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
-      # Create the tag ref ourselves, using the PARADEDB_BOT_GITHUB_TOKEN PAT, BEFORE
+      # Create the tag ref ourselves, using the GitHub App token, BEFORE
       # calling softprops/action-gh-release. Since v2.5.0, that action publishes releases
       # via a draft-first flow where the tag ref is created as a side effect of the
       # publish API call, which does not emit a cascading `push` event — so our downstream
       # `publish-*` workflows (triggered on `push: tags: v*`) never fire. Pushing the tag
-      # ref directly with the PAT here ensures the push event is attributed to the PAT and
+      # ref directly with the app token here ensures the push event is attributed to the app and
       # cascades to the downstream workflows. The subsequent release-creation step then
       # attaches the release to the already-existing tag.
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Create Tag
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           sha=$(git rev-parse HEAD)
           echo "Creating tag v${{ github.event.inputs.version }} pointing at $sha"

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -67,8 +67,6 @@ jobs:
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
 
       - name: Retrieve GitHub Release Version
         id: version
@@ -94,7 +92,7 @@ jobs:
       - name: Determine if Release Should be Marked as Latest
         id: release_latest
         env:
-          GITHUB_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           current_tag_version="${{ steps.version.outputs.version }}"
           latest_tag_version=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -195,9 +195,21 @@ jobs:
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: |
+            django-paradedb
+            rails-paradedb
+            sqlalchemy-paradedb
+
       - name: Notify ORM Repos of New Release
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           while IFS= read -r repo; do
             repo=$(echo "$repo" | xargs)

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -309,7 +309,7 @@ jobs:
         id: upload_url
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
@@ -323,7 +323,7 @@ jobs:
       - name: Upload pg_search .deb to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1
         with:
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -201,7 +201,7 @@ jobs:
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
@@ -215,7 +215,7 @@ jobs:
       - name: Upload pg_search .pkg to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1
         with:
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
           asset_name: pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -23,8 +23,6 @@ jobs:
     steps:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
-        with:
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
 
       - name: Bundle the Release
         run: make dist

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -359,7 +359,7 @@ jobs:
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
@@ -373,7 +373,7 @@ jobs:
       - name: Upload pg_search .rpm to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1
         with:
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
           asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -90,7 +90,7 @@ jobs:
 
       - name: Upload Schema to GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload v${{ steps.version.outputs.version }} pg_search.schema.sql --clobber
 
       - name: Notify Slack on Failure

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -285,7 +285,7 @@ jobs:
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
         env:
-          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
@@ -299,7 +299,7 @@ jobs:
       - name: Upload pg_search .deb to GitHub Release
         uses: shogo82148/actions-upload-release-asset@v1
         with:
-          github_token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -1,7 +1,7 @@
 # workflows/schemabot-generate-diff.yml
 #
 # SchemaBot Generate Diff
-# Determine if a commit introduces an extension schema change for pg_search and post a comment to the PR.
+# Determine if a commit introduces an extension schema change for pg_search
 
 name: SchemaBot Generate Diff
 

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -70,14 +70,24 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
 
+      - name: Generate GitHub App Token
+        id: app-token
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
       # This step is used to check if the PR author is a member of the org, since
       # access to GitHub Actions secrets is limited to org members.
       - name: Check if PR author is member of org
         id: org-check
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           echo "Checking if ${{ github.actor }} is a member of the org..."
           result=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Authorization: token ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}" \
+            -H "Authorization: Bearer $GH_TOKEN" \
             "https://api.github.com/orgs/paradedb/members/${{ github.actor }}") || result="000"
           if [ "$result" -eq 204 ]; then
             echo "is_member=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -37,11 +37,19 @@ jobs:
       PG_MAJOR_VERSION: "18"
 
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Checkout Git Repository
         uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@main
@@ -53,7 +61,7 @@ jobs:
       # Build only cargo deps to surface cargoHash mismatches quickly, without
       # compiling pg_search for every Postgres variant. If the hash is stale,
       # compute the correct one and push a fix commit to the PR branch.
-      # The push uses PARADEDB_BOT_GITHUB_TOKEN (a PAT) so that GitHub fires a
+      # The push uses a GitHub App token so that GitHub fires a
       # synchronize event, which re-triggers all CI workflows on the new HEAD.
       # Pushes made with the default GITHUB_TOKEN do not fire events.
       - name: Verify Nix Cargo Hash
@@ -76,8 +84,8 @@ jobs:
               exit 1
             fi
 
-            git config user.name "paradedb-bot"
-            git config user.email "developers@paradedb.com"
+            git config user.name "paradedb-app[bot]"
+            git config user.email "282009505+paradedb-app[bot]@users.noreply.github.com"
             git add nix/pg_search.nix
             git commit -m "fix: update nix cargoHash for changed Cargo.lock"
             git push

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -84,8 +84,8 @@ jobs:
               exit 1
             fi
 
-            git config user.name "paradedb-app[bot]"
-            git config user.email "282009505+paradedb-app[bot]@users.noreply.github.com"
+            git config user.name "paradedb-github-app[bot]"
+            git config user.email "282009505+paradedb-github-app[bot]@users.noreply.github.com"
             git add nix/pg_search.nix
             git commit -m "fix: update nix cargoHash for changed Cargo.lock"
             git push


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

- Use GITHUB_TOKEN instead of PARADEDB_BOT_GITHUB_TOKEN where possible
- Use the newly created GitHub app instead of paradedb-bot

## Why

A GitHub app is a more robust solution to this problem and gives us more control. We expect to implement more automations over time, so changing is a good idea.

## How

## Tests

- CI passes
- confirmed that the commit to update the cargoHash worked properly
