### PR TITLE
fix: pick highest-OID bm25 index consistently when multiple exist

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -44,7 +44,8 @@ use crate::postgres::customscan::opexpr::{
 };
 use crate::postgres::deparse::deparse_expr;
 use crate::postgres::rel::PgSearchRelation;
-use crate::postgres::utils::{locate_bm25_index_from_heaprel, ToPalloc};
+use crate::postgres::rel_get_bm25_index;
+use crate::postgres::utils::ToPalloc;
 #[cfg(feature = "pg18")]
 use crate::postgres::var::resolve_rte_group_var;
 use crate::postgres::var::{
@@ -373,9 +374,12 @@ pub unsafe fn tantivy_field_name_from_node(
     if heaprelid == pg_sys::Oid::INVALID {
         return None;
     }
-    let heaprel = PgSearchRelation::open(heaprelid);
-    let indexrel = locate_bm25_index_from_heaprel(&heaprel)
-        .unwrap_or_else(|| panic!("`{}` does not contain a `USING bm25` index", heaprel.name()));
+    let (heaprel, indexrel) = rel_get_bm25_index(heaprelid).unwrap_or_else(|| {
+        panic!(
+            "`{}` does not contain a `USING bm25` index",
+            PgSearchRelation::open(heaprelid).name()
+        )
+    });
 
     let field_name =
         field_name_from_node(VarContext::from_planner(root), &heaprel, &indexrel, node)?;

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -22,8 +22,8 @@ use crate::index::fast_fields_helper::FFHelper;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::rel::PgSearchRelation;
+use crate::postgres::rel_get_bm25_index;
 use crate::postgres::types::TantivyValue;
-use crate::postgres::utils::locate_bm25_index;
 use crate::query::SearchQueryInput;
 use crate::{nodecast, PARAMETERIZED_SELECTIVITY, UNKNOWN_SELECTIVITY};
 use pgrx::callconv::{Arg, ArgAbi};
@@ -282,7 +282,7 @@ pub fn query_input_restrict(
                 pg_sys::NodeTag::T_Const => {
                     let const_ = rhs.cast::<pg_sys::Const>();
                     let (heaprelid, _, _) = find_var_relation(var, info);
-                    let indexrel = locate_bm25_index(heaprelid)?;
+                    let indexrel = rel_get_bm25_index(heaprelid)?.1;
                     let search_query_input =
                         SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
                     estimate_selectivity(&indexrel, search_query_input)

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -132,6 +132,13 @@ fn bm25_handler(_fcinfo: pg_sys::FunctionCallInfo) -> PgBox<pg_sys::IndexAmRouti
     amroutine.into_pg_boxed()
 }
 
+/// Finds and returns the `USING bm25` index on the specified relation with the highest OID,
+/// along with the heap relation. Returns [`None`] if there isn't one.
+///
+/// Filters out indexes that aren't yet `indisvalid` (e.g. mid-`CREATE INDEX CONCURRENTLY`
+/// or a failed `REINDEX`). When more than one valid bm25 index exists on the relation
+/// (only possible via `CREATE INDEX CONCURRENTLY`, which bypasses the single-bm25-index
+/// check), the highest-OID one is chosen so that the index added most recently wins.
 pub fn rel_get_bm25_index(
     relid: pg_sys::Oid,
 ) -> Option<(rel::PgSearchRelation, rel::PgSearchRelation)> {
@@ -140,9 +147,12 @@ pub fn rel_get_bm25_index(
     }
 
     let rel = PgSearchRelation::with_lock(relid, pg_sys::AccessShareLock as _);
-    rel.indices(pg_sys::AccessShareLock as _)
-        .find(is_bm25_index)
-        .map(|index| (rel, index))
+    let index = unsafe {
+        rel.indices(pg_sys::AccessShareLock as _)
+            .filter(|index| pg_sys::get_index_isvalid(index.oid()) && is_bm25_index(index))
+            .max_by_key(|i| i.oid().to_u32())?
+    };
+    Some((rel, index))
 }
 
 // 16 bytes for segment UUID

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -23,7 +23,6 @@ use crate::api::tokenizers::{
 use crate::api::{FieldName, HashMap};
 use crate::index::writer::index::IndexError;
 use crate::nodecast;
-use crate::postgres::build::is_bm25_index;
 use crate::postgres::composite::{
     get_composite_fields_for_index, is_composite_type, CompositeSlotValues,
 };
@@ -213,26 +212,6 @@ mod tests {
             let pg = unsafe { pg_sys::TransactionIdPrecedesOrEquals(pg_sys::TransactionId::from(xid1), pg_sys::TransactionId::from(xid2)) };
             prop_assert_eq!(us, pg);
         });
-    }
-}
-
-/// Finds and returns the `USING bm25` index on the specified relation with the
-/// highest OID, or [`None`] if there aren't any.
-pub fn locate_bm25_index(heaprelid: pg_sys::Oid) -> Option<PgSearchRelation> {
-    locate_bm25_index_from_heaprel(&PgSearchRelation::open(heaprelid))
-}
-
-/// Finds and returns the `USING bm25` index on the specified relation with the
-/// highest OID, or [`None`] if there aren't any.
-pub fn locate_bm25_index_from_heaprel(heaprel: &PgSearchRelation) -> Option<PgSearchRelation> {
-    unsafe {
-        let indices = heaprel.indices(pg_sys::AccessShareLock as _);
-
-        // Find all bm25 indexes and keep the one with highest OID
-        indices
-            .into_iter()
-            .filter(|index| pg_sys::get_index_isvalid(index.oid()) && is_bm25_index(index))
-            .max_by_key(|index| index.oid().to_u32())
     }
 }
 

--- a/pg_search/tests/pg_regress/expected/multi_bm25_index.out
+++ b/pg_search/tests/pg_regress/expected/multi_bm25_index.out
@@ -1,0 +1,47 @@
+-- A relation may only have a single `USING bm25` index, but the check is
+-- bypassed when CREATE INDEX CONCURRENTLY is used (for the build-new/swap/drop-old
+-- workflow). When two bm25 indexes coexist `rel_get_bm25_index` should pick the
+-- highest-OID bm25 index, so a query referencing a field that only exists in the
+-- newer index still resolves correctly.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS multi_bm25 CASCADE;
+CREATE TABLE multi_bm25 (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    custom_identifiers JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+INSERT INTO multi_bm25 (description, custom_identifiers) VALUES
+    ('alpha', '{"invoice_number": "abc-001"}'),
+    ('beta',  '{"invoice_number": "def-002"}');
+-- Older index lacks `custom_identifiers` -- represents a previous schema.
+CREATE INDEX CONCURRENTLY multi_bm25_old ON multi_bm25
+USING bm25 (id, description) WITH (key_field = 'id');
+-- Newer index adds `custom_identifiers`. CONCURRENTLY bypasses the
+-- single-bm25-index restriction.
+CREATE INDEX CONCURRENTLY multi_bm25_new ON multi_bm25
+USING bm25 (id, description, (custom_identifiers::pdb.literal_normalized))
+WITH (key_field = 'id');
+-- A query against the field that only `multi_bm25_new` knows about should
+-- succeed because we pick the highest-OID bm25 index, which is `multi_bm25_new`.
+-- Without the fix this would error with `field 'custom_identifiers.invoice_number'
+-- is not part of the pg_search index`.
+SELECT id FROM multi_bm25
+ WHERE custom_identifiers->>'invoice_number' &&& 'abc-001'
+ ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+-- Drop the older index. From here only `multi_bm25_new` remains and the query
+-- continues to work.
+DROP INDEX multi_bm25_old;
+SELECT id FROM multi_bm25
+ WHERE custom_identifiers->>'invoice_number' &&& 'abc-001'
+ ORDER BY id;
+ id 
+----
+  1
+(1 row)
+
+DROP TABLE multi_bm25 CASCADE;

--- a/pg_search/tests/pg_regress/sql/multi_bm25_index.sql
+++ b/pg_search/tests/pg_regress/sql/multi_bm25_index.sql
@@ -1,0 +1,46 @@
+-- A relation may only have a single `USING bm25` index, but the check is
+-- bypassed when CREATE INDEX CONCURRENTLY is used (for the build-new/swap/drop-old
+-- workflow). When two bm25 indexes coexist `rel_get_bm25_index` should pick the
+-- highest-OID bm25 index, so a query referencing a field that only exists in the
+-- newer index still resolves correctly.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS multi_bm25 CASCADE;
+CREATE TABLE multi_bm25 (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    custom_identifiers JSONB NOT NULL DEFAULT '{}'::jsonb
+);
+
+INSERT INTO multi_bm25 (description, custom_identifiers) VALUES
+    ('alpha', '{"invoice_number": "abc-001"}'),
+    ('beta',  '{"invoice_number": "def-002"}');
+
+-- Older index lacks `custom_identifiers` -- represents a previous schema.
+CREATE INDEX CONCURRENTLY multi_bm25_old ON multi_bm25
+USING bm25 (id, description) WITH (key_field = 'id');
+
+-- Newer index adds `custom_identifiers`. CONCURRENTLY bypasses the
+-- single-bm25-index restriction.
+CREATE INDEX CONCURRENTLY multi_bm25_new ON multi_bm25
+USING bm25 (id, description, (custom_identifiers::pdb.literal_normalized))
+WITH (key_field = 'id');
+
+-- A query against the field that only `multi_bm25_new` knows about should
+-- succeed because we pick the highest-OID bm25 index, which is `multi_bm25_new`.
+-- Without the fix this would error with `field 'custom_identifiers.invoice_number'
+-- is not part of the pg_search index`.
+SELECT id FROM multi_bm25
+ WHERE custom_identifiers->>'invoice_number' &&& 'abc-001'
+ ORDER BY id;
+
+-- Drop the older index. From here only `multi_bm25_new` remains and the query
+-- continues to work.
+DROP INDEX multi_bm25_old;
+
+SELECT id FROM multi_bm25
+ WHERE custom_identifiers->>'invoice_number' &&& 'abc-001'
+ ORDER BY id;
+
+DROP TABLE multi_bm25 CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

When a table ends up with two `USING bm25` indexes (only possible via `CREATE INDEX CONCURRENTLY`, which bypasses the single-bm25-index check), queries that reference a field present in only one of them can fail with:

```
ERROR:  field 'X.Y' is not part of the pg_search index
```

This PR makes the bm25 index lookup consistent across the codebase, so the index added most recently (highest OID) wins everywhere.

## Why

Two helpers were doing almost the same thing with different selection rules:

- `rel_get_bm25_index` (basescan path-building) returned the **first** match in `RelationGetIndexList` order via `find(is_bm25_index)`, which is the lowest-OID bm25 index.
- `locate_bm25_index_from_heaprel` (operator simplification, where `expr &&& 'x'` is rewritten) returned the **highest-OID** bm25 index via `max_by_key`.

When the two diverged, simplification resolved a field name against the highest-OID index but the basescan tried to compile the resulting query against the lowest-OID index's schema. If the field only existed in the higher-OID index (e.g. a JSON column added in a newer index revision), the schema lookup at `pdb_query.rs::match_query` failed.

## How

## Tests

Added regression test