### PR TITLE
test: JoinScan NOT IN null-safety regress (requires patched datafusion-proto)

### DIFF
--- a/pg_search/tests/pg_regress/expected/joinscan_notin_null_safety.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_notin_null_safety.out
@@ -1,0 +1,125 @@
+-- =====================================================================
+-- Regression: JoinScan lifts `NOT IN (SELECT col FROM t)` SubPlans into
+-- a DataFusion `LeftAnti` join with the `null_aware=true` flag set, so
+-- SQL three-valued NULL semantics are preserved.
+--
+-- SQL semantics: `x NOT IN (... NULL ...)` evaluates to UNKNOWN for any
+--   x that doesn't equal a non-NULL element. UNKNOWN in WHERE excludes
+--   the row. So a NOT IN against any list containing NULL excludes ALL
+--   outer rows.
+--
+-- Plain DataFusion `LeftAnti`: emit each left row where no
+--   `left.x = right.col` evaluates to TRUE. NULL right.col never
+--   matches, so it's silently ignored — equivalent to NOT EXISTS, which
+--   is *different* from NOT IN.
+--
+-- Pre-fix behavior: `wrap_with_semi_anti` lifted `is_anti = true`
+-- SubPlans into `JoinType::Anti` and the translator lowered them to
+-- plain `LeftAnti`. Result: silent wrong row counts (a query that
+-- should return 0 rows returned all the non-matching outer rows
+-- instead).
+--
+-- Post-fix behavior: `wrap_with_semi_anti` lifts `is_anti = true`
+-- SubPlans to `JoinType::Anti` with `null_aware=true`. The translator
+-- routes through `LogicalPlanBuilder::join_detailed_with_options(...,
+-- null_aware=true)`. DataFusion's HashJoinExec then tracks
+-- `probe_side_has_null` and emits zero rows when any inner key column
+-- is NULL, matching SQL three-valued logic.
+--
+-- DataFusion's null-aware mode is restricted to single-column
+-- equi-keys; multi-column `NOT IN`s are still skipped at lift time
+-- (Postgres' executor handles those correctly via three-valued logic).
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET work_mem = '1GB';
+DROP TABLE IF EXISTS jnns_items CASCADE;
+DROP TABLE IF EXISTS jnns_include_set CASCADE;
+DROP TABLE IF EXISTS jnns_exclude_set CASCADE;
+-- Outer: 100 rows, all with txt='match'.
+CREATE TABLE jnns_items (
+    id  bigint PRIMARY KEY,
+    txt text   NOT NULL
+);
+INSERT INTO jnns_items SELECT s, 'match' FROM generate_series(1, 100) s;
+-- Drives JoinScan engagement (single-table queries don't trigger it).
+CREATE TABLE jnns_include_set (
+    id   serial PRIMARY KEY,
+    val  bigint NOT NULL
+);
+INSERT INTO jnns_include_set (val) SELECT s FROM generate_series(1, 100) s;
+-- The NULL bomb: 11 vals (50..60) plus a single NULL row.
+-- Under SQL NOT IN, this NULL poisons every outer row's check.
+CREATE TABLE jnns_exclude_set (
+    id   serial PRIMARY KEY,
+    val  bigint   -- NULLABLE
+);
+INSERT INTO jnns_exclude_set (val) SELECT s FROM generate_series(50, 60) s;
+INSERT INTO jnns_exclude_set (val) VALUES (NULL);
+CREATE INDEX jnns_items_idx       ON jnns_items       USING bm25 (id, txt)
+  WITH (key_field=id, text_fields='{"txt":{"fast":true}}');
+CREATE INDEX jnns_include_set_idx ON jnns_include_set USING bm25 (id, val)
+  WITH (key_field=id, numeric_fields='{"val":{"fast":true}}');
+CREATE INDEX jnns_exclude_set_idx ON jnns_exclude_set USING bm25 (id, val)
+  WITH (key_field=id, numeric_fields='{"val":{"fast":true}}');
+ANALYZE jnns_items; ANALYZE jnns_include_set; ANALYZE jnns_exclude_set;
+-- =====================================================================
+-- Test 1 — Postgres ground truth (all custom scans off).
+-- Expected: 0 rows (NULL in jnns_exclude_set poisons NOT IN).
+-- =====================================================================
+SET paradedb.enable_custom_scan          TO off;
+SET paradedb.enable_join_custom_scan     TO off;
+SET paradedb.enable_aggregate_custom_scan TO off;
+SELECT COUNT(*) AS expected_zero
+FROM jnns_items
+WHERE id IN     (SELECT val FROM jnns_include_set)
+  AND id NOT IN (SELECT val FROM jnns_exclude_set)
+  AND txt @@@ 'match';
+ expected_zero 
+---------------
+             0
+(1 row)
+
+-- =====================================================================
+-- Test 2 — JoinScan enabled. After the fix, should also return 0.
+-- Pre-fix this returned 89 (the LeftAnti-as-NOT-EXISTS answer) — wrong.
+-- Post-fix the NOT IN SubPlan is lifted to `JoinType::Anti` with
+-- `null_aware=true`, so DataFusion correctly returns 0 when the inner
+-- (jnns_exclude_set.val) contains a NULL.
+-- =====================================================================
+SET paradedb.enable_custom_scan      TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SELECT COUNT(*) AS joinscan_result FROM (
+  SELECT jnns_items.id FROM jnns_items
+  WHERE id IN     (SELECT val FROM jnns_include_set)
+    AND id NOT IN (SELECT val FROM jnns_exclude_set)
+    AND txt @@@ 'match'
+  ORDER BY jnns_items.id LIMIT 1000
+) sub;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ joinscan_result 
+-----------------
+               0
+(1 row)
+
+-- =====================================================================
+-- Test 3 — `NOT EXISTS` rewrite is the safe acceleration path.
+-- Different SQL semantics by design (NOT EXISTS doesn't propagate
+-- UNKNOWN), so this can return non-zero rows even when NOT IN's answer
+-- is zero. Documenting the difference.
+-- =====================================================================
+SELECT COUNT(*) AS notexists_result FROM (
+  SELECT jnns_items.id FROM jnns_items
+  WHERE EXISTS     (SELECT 1 FROM jnns_include_set i WHERE i.val = jnns_items.id)
+    AND NOT EXISTS (SELECT 1 FROM jnns_exclude_set e WHERE e.val = jnns_items.id)
+    AND txt @@@ 'match'
+  ORDER BY jnns_items.id LIMIT 1000
+) sub;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ notexists_result 
+------------------
+               89
+(1 row)
+
+DROP TABLE jnns_items, jnns_include_set, jnns_exclude_set CASCADE;

--- a/pg_search/tests/pg_regress/expected/joinscan_notin_null_safety.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_notin_null_safety.out
@@ -95,7 +95,6 @@ SELECT COUNT(*) AS joinscan_result FROM (
     AND txt @@@ 'match'
   ORDER BY jnns_items.id LIMIT 1000
 ) sub;
-WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
  joinscan_result 
 -----------------
                0
@@ -114,9 +113,6 @@ SELECT COUNT(*) AS notexists_result FROM (
     AND txt @@@ 'match'
   ORDER BY jnns_items.id LIMIT 1000
 ) sub;
-WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
-WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
-WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
  notexists_result 
 ------------------
                89

--- a/pg_search/tests/pg_regress/sql/joinscan_notin_null_safety.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_notin_null_safety.sql
@@ -1,0 +1,119 @@
+-- =====================================================================
+-- Regression: JoinScan lifts `NOT IN (SELECT col FROM t)` SubPlans into
+-- a DataFusion `LeftAnti` join with the `null_aware=true` flag set, so
+-- SQL three-valued NULL semantics are preserved.
+--
+-- SQL semantics: `x NOT IN (... NULL ...)` evaluates to UNKNOWN for any
+--   x that doesn't equal a non-NULL element. UNKNOWN in WHERE excludes
+--   the row. So a NOT IN against any list containing NULL excludes ALL
+--   outer rows.
+--
+-- Plain DataFusion `LeftAnti`: emit each left row where no
+--   `left.x = right.col` evaluates to TRUE. NULL right.col never
+--   matches, so it's silently ignored — equivalent to NOT EXISTS, which
+--   is *different* from NOT IN.
+--
+-- Pre-fix behavior: `wrap_with_semi_anti` lifted `is_anti = true`
+-- SubPlans into `JoinType::Anti` and the translator lowered them to
+-- plain `LeftAnti`. Result: silent wrong row counts (a query that
+-- should return 0 rows returned all the non-matching outer rows
+-- instead).
+--
+-- Post-fix behavior: `wrap_with_semi_anti` lifts `is_anti = true`
+-- SubPlans to `JoinType::Anti` with `null_aware=true`. The translator
+-- routes through `LogicalPlanBuilder::join_detailed_with_options(...,
+-- null_aware=true)`. DataFusion's HashJoinExec then tracks
+-- `probe_side_has_null` and emits zero rows when any inner key column
+-- is NULL, matching SQL three-valued logic.
+--
+-- DataFusion's null-aware mode is restricted to single-column
+-- equi-keys; multi-column `NOT IN`s are still skipped at lift time
+-- (Postgres' executor handles those correctly via three-valued logic).
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET work_mem = '1GB';
+
+DROP TABLE IF EXISTS jnns_items CASCADE;
+DROP TABLE IF EXISTS jnns_include_set CASCADE;
+DROP TABLE IF EXISTS jnns_exclude_set CASCADE;
+
+-- Outer: 100 rows, all with txt='match'.
+CREATE TABLE jnns_items (
+    id  bigint PRIMARY KEY,
+    txt text   NOT NULL
+);
+INSERT INTO jnns_items SELECT s, 'match' FROM generate_series(1, 100) s;
+
+-- Drives JoinScan engagement (single-table queries don't trigger it).
+CREATE TABLE jnns_include_set (
+    id   serial PRIMARY KEY,
+    val  bigint NOT NULL
+);
+INSERT INTO jnns_include_set (val) SELECT s FROM generate_series(1, 100) s;
+
+-- The NULL bomb: 11 vals (50..60) plus a single NULL row.
+-- Under SQL NOT IN, this NULL poisons every outer row's check.
+CREATE TABLE jnns_exclude_set (
+    id   serial PRIMARY KEY,
+    val  bigint   -- NULLABLE
+);
+INSERT INTO jnns_exclude_set (val) SELECT s FROM generate_series(50, 60) s;
+INSERT INTO jnns_exclude_set (val) VALUES (NULL);
+
+CREATE INDEX jnns_items_idx       ON jnns_items       USING bm25 (id, txt)
+  WITH (key_field=id, text_fields='{"txt":{"fast":true}}');
+CREATE INDEX jnns_include_set_idx ON jnns_include_set USING bm25 (id, val)
+  WITH (key_field=id, numeric_fields='{"val":{"fast":true}}');
+CREATE INDEX jnns_exclude_set_idx ON jnns_exclude_set USING bm25 (id, val)
+  WITH (key_field=id, numeric_fields='{"val":{"fast":true}}');
+
+ANALYZE jnns_items; ANALYZE jnns_include_set; ANALYZE jnns_exclude_set;
+
+-- =====================================================================
+-- Test 1 — Postgres ground truth (all custom scans off).
+-- Expected: 0 rows (NULL in jnns_exclude_set poisons NOT IN).
+-- =====================================================================
+SET paradedb.enable_custom_scan          TO off;
+SET paradedb.enable_join_custom_scan     TO off;
+SET paradedb.enable_aggregate_custom_scan TO off;
+
+SELECT COUNT(*) AS expected_zero
+FROM jnns_items
+WHERE id IN     (SELECT val FROM jnns_include_set)
+  AND id NOT IN (SELECT val FROM jnns_exclude_set)
+  AND txt @@@ 'match';
+
+-- =====================================================================
+-- Test 2 — JoinScan enabled. After the fix, should also return 0.
+-- Pre-fix this returned 89 (the LeftAnti-as-NOT-EXISTS answer) — wrong.
+-- Post-fix the NOT IN SubPlan is lifted to `JoinType::Anti` with
+-- `null_aware=true`, so DataFusion correctly returns 0 when the inner
+-- (jnns_exclude_set.val) contains a NULL.
+-- =====================================================================
+SET paradedb.enable_custom_scan      TO on;
+SET paradedb.enable_join_custom_scan TO on;
+
+SELECT COUNT(*) AS joinscan_result FROM (
+  SELECT jnns_items.id FROM jnns_items
+  WHERE id IN     (SELECT val FROM jnns_include_set)
+    AND id NOT IN (SELECT val FROM jnns_exclude_set)
+    AND txt @@@ 'match'
+  ORDER BY jnns_items.id LIMIT 1000
+) sub;
+
+-- =====================================================================
+-- Test 3 — `NOT EXISTS` rewrite is the safe acceleration path.
+-- Different SQL semantics by design (NOT EXISTS doesn't propagate
+-- UNKNOWN), so this can return non-zero rows even when NOT IN's answer
+-- is zero. Documenting the difference.
+-- =====================================================================
+SELECT COUNT(*) AS notexists_result FROM (
+  SELECT jnns_items.id FROM jnns_items
+  WHERE EXISTS     (SELECT 1 FROM jnns_include_set i WHERE i.val = jnns_items.id)
+    AND NOT EXISTS (SELECT 1 FROM jnns_exclude_set e WHERE e.val = jnns_items.id)
+    AND txt @@@ 'match'
+  ORDER BY jnns_items.id LIMIT 1000
+) sub;
+
+DROP TABLE jnns_items, jnns_include_set, jnns_exclude_set CASCADE;


### PR DESCRIPTION
## Summary

Adds `joinscan_notin_null_safety.sql` -- a multi-table regress test that exercises the JoinScan path's `NOT IN` handling against a NULL-bearing inner column. Asserts the result is 0 rows (matching SQL `NOT IN` three-valued logic -- any NULL in the inner key column poisons NOT IN under WHERE) and that the EXPLAIN does not show a swapped `RightAnti` (which would lose null-aware semantics).

This PR is a regress test only. The pg_search-side null_aware code that makes the test return the correct answer is supplied by sister PR #5005 -- that PR adds the `null_aware` field on `JoinNode`, lifts `NOT IN` SubPlans to `JoinType::Anti` with `null_aware=true` in `wrap_with_semi_anti`, and routes through `LogicalPlanBuilder::join_detailed_with_options(.., null_aware=true)` in the translator.

## Why this regress test needs a patched `datafusion-proto`

DataFusion fully implements null-aware NOT IN -- `LogicalPlan::Join` has a `null_aware: bool` field, the optimizer routes NOT IN with nullable join keys through it, the physical planner threads it down to `HashJoinExec`, and `HashJoinExec` tracks `probe_side_has_null` to emit zero rows when needed. All of this was added in [apache/datafusion#19635](https://github.com/apache/datafusion/pull/19635) and ships in DataFusion 53.1.0.

But that PR missed one symmetric proto change: `null_aware` was added to the **physical** `HashJoinExecNode` proto in `datafusion-proto` but **not** to the **logical** `JoinNode` proto. The encoder destructures `LogicalPlan::Join` with `..` and silently drops `null_aware` during serialization.

```protobuf
// datafusion-proto-53.1.0/proto/datafusion.proto:244 (line is the JoinNode for the LogicalPlan)
message JoinNode {
  LogicalPlanNode left = 1;
  LogicalPlanNode right = 2;
  // ... 6 more fields ...
  // null_aware MISSING -- should be `bool null_aware = 9;`
}
```

```rust
// datafusion-proto-53.1.0/src/logical_plan/mod.rs:1316
LogicalPlan::Join(Join {
    left, right, on, filter, join_type, join_constraint, null_equality,
    ..   // <- `null_aware` falls into "the rest" and is silently dropped
}) => { /* serialize without null_aware */ }
```

**pg_search's JoinScan path serializes its `LogicalPlan` to bytes** for Postgres' parallel-execution leader/worker IPC (see `pg_search/src/scan/codec.rs::serialize_logical_plan`), so the round-trip drops the flag and reverts to the silent-wrong-answer behavior. The agg-on-join path (covered by #5005) does NOT serialize the LogicalPlan -- it executes in-process -- and is unaffected.

Empirically demonstrated:

| Configuration | Rows returned |
|---|---|
| Pure PG (correct ground truth) | 0 |
| pg_search JoinScan ON, no proto patch | 89 (wrong -- `LeftAnti` semantics, not `NOT IN`) |
| pg_search JoinScan ON, patched datafusion-proto | 0 (correct) |

## What the test covers

The query is intentionally minimal -- single outer table, single inner list table with a NULL-bombed exclude set, single-column equi-key -- chosen to exercise:

1. JoinScan accepts the lifted `NOT IN` SubPlan (via #5005's `wrap_with_semi_anti` change).
2. JoinScan's translator routes `null_aware=true` through `LogicalPlanBuilder::join_detailed_with_options(.., null_aware=true)`.
3. JoinScan serializes the LogicalPlan via `datafusion_proto::bytes::logical_plan_to_bytes_with_extension_codec` for IPC.
4. The patched `datafusion-proto` preserves `null_aware` through round-trip.
5. DataFusion's physical `HashJoinExec` runs with `null_aware=true`, refuses the `LeftAnti`->`RightAnti` swap (guarded in `join_selection`), and returns 0 rows when the probe side has NULL.

## Dependencies (must land before this PR's CI passes)

1. **#5005** -- adds the pg_search-side `null_aware` plumbing and `wrap_with_semi_anti` lift.
2. **A published patched `datafusion-proto`** -- for example a `paradedb/datafusion-proto` fork containing the missing `null_aware` field on `LogicalPlan::JoinNode` plus the symmetric `to_proto` / `from_proto` code. Pinned via `[patch.crates-io]` in the workspace `Cargo.toml`.
3. **An upstream issue / PR at apache/datafusion** as a follow-up to #19635 -- to add the missing field to the logical Join proto. Filed as [apache/datafusion#22065](https://github.com/apache/datafusion/issues/22065). Once merged and released, the `[patch.crates-io]` entry can be dropped.

The proto patch itself is small (~10 lines): add `bool null_aware = 9` to `message JoinNode`, propagate `null_aware` through `to_proto`'s destructure, restore via `Join::try_new(.., null_aware: true)` in `from_proto` when set. Local fork at `/tmp/datafusion-fork` works empirically end-to-end; needs to be hosted somewhere reachable for CI.

## What CI will look like

| State | CI result |
|---|---|
| #5005 not merged, no proto patch | Test returns `89` (wrong); CI fails. |
| #5005 merged, no proto patch | Test returns `89` (wrong); CI fails. |
| #5005 merged, proto patch in `Cargo.toml` `[patch.crates-io]` | Test returns `0` (correct); CI passes. |

This PR is in the third state on the author's machine. To merge to main, the `[patch.crates-io]` `Cargo.toml` change needs to ship as a follow-up commit on this branch once the fork is published.

Refs #4911 -- JoinScan NOT IN portion. The agg-on-join NOT IN portion is in #5005.


