### PR TITLE
ci: skip pg_search Docker test on manifests changes

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -25,6 +25,7 @@ on:
     paths:
       - ".github/workflows/test-pg_search-docker.yml"
       - "docker/**"
+      - "!docker/manifests/**"
       - "!docker/Dockerfile.stressgres"
       - "pg_search/**"
       - "!pg_search/README.md"


### PR DESCRIPTION
## Summary
- Exclude `docker/manifests/**` from the `test-pg_search-docker` workflow path filter so changes to CNPG/Antithesis manifest YAMLs don't trigger a full Docker image build + smoke test.

## Test plan
- [x] Verify the workflow does not run on a PR that only touches files under `docker/manifests/`.
- [x] Verify the workflow still runs on PRs that touch other `docker/**` files.