### PR TITLE
fix: Backfill 0.23.4 artifacts to Cloudsmith

### DIFF
--- a/.github/workflows/backfill-pg_search-cloudsmith-deb.yml
+++ b/.github/workflows/backfill-pg_search-cloudsmith-deb.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: backfill-pg_search-cloudsmith-deb-0.23.2
+  group: backfill-pg_search-cloudsmith-deb-0.23.4
   cancel-in-progress: false
 
 permissions:
@@ -36,7 +36,7 @@ jobs:
           GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          version="0.23.2"
+          version="0.23.4"
 
           mkdir artifacts
           for codename in bookworm trixie; do
@@ -51,7 +51,7 @@ jobs:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         run: |
           set -euo pipefail
-          version="0.23.2"
+          version="0.23.4"
 
           for codename in bookworm trixie; do
             for pg_version in 15 16 17 18; do

--- a/.github/workflows/backfill-pg_search-cloudsmith-deb.yml
+++ b/.github/workflows/backfill-pg_search-cloudsmith-deb.yml
@@ -1,0 +1,69 @@
+# workflows/backfill-pg_search-cloudsmith-deb.yml
+#
+# Backfill existing Debian pg_search .deb assets from a GitHub Release to Cloudsmith.
+
+name: Backfill Debian pg_search .deb to Cloudsmith
+
+on:
+  push:
+    paths:
+      - ".github/workflows/backfill-pg_search-cloudsmith-deb.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: backfill-pg_search-cloudsmith-deb-0.23.2
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  backfill-pg_search-cloudsmith-deb:
+    name: Backfill Debian pg_search .deb to Cloudsmith
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Cloudsmith CLI
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y python3-pip python3-venv
+          python3 -m venv /tmp/cloudsmith-venv
+          /tmp/cloudsmith-venv/bin/pip install --quiet cloudsmith-cli
+
+      - name: Download .deb Assets from GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.PARADEDB_BOT_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="0.23.2"
+
+          mkdir artifacts
+          for codename in bookworm trixie; do
+            gh release download "v${version}" \
+              --repo paradedb/paradedb \
+              --pattern "postgresql-*-pg-search_${version}-1PARADEDB-${codename}_*.deb" \
+              --dir artifacts
+          done
+
+      - name: Push Debian .deb Assets to Cloudsmith
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        run: |
+          set -euo pipefail
+          version="0.23.2"
+
+          for codename in bookworm trixie; do
+            for pg_version in 15 16 17 18; do
+              for arch in amd64 arm64; do
+                release_asset="artifacts/postgresql-${pg_version}-pg-search_${version}-1PARADEDB-${codename}_${arch}.deb"
+                cloudsmith_asset="artifacts/pg_search-${version}-${codename}-${arch}-pg${pg_version}.deb"
+                mv "$release_asset" "$cloudsmith_asset"
+
+                /tmp/cloudsmith-venv/bin/cloudsmith push deb \
+                  "paradedb/paradedb/debian/${codename}" \
+                  "$cloudsmith_asset" \
+                  --republish
+              done
+            done
+          done


### PR DESCRIPTION
# Ticket(s) Closed

The 0.23.4 artifacts need to be in Cloudsmith so I can update the new Dockerfiles to point to them. They should have been published by the 0.23.4 release workflow, but I didn't port the changes to the CI workflow to 0.23.x so they were not. This PR adds a workflow to fetch to 0.23.4 .debs from GH releases and then uploads them to Cloudsmith.

This should not be merged. Once the workflow runs I'll close the PR.

## What

## Why

## How

## Tests
