### PR TITLE
fix: Fix rows label in benchmarking action

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -47,7 +47,7 @@ runs:
           --output json \
           --fail-on-error ${{ inputs.fail_on_error }}
 
-        ROWS_LABEL="${{ inputs.size }}"
+        echo "ROWS_LABEL=${{ inputs.size }}" >> $GITHUB_ENV
 
     - name: Print the Postgres Logs
       if: failure()


### PR DESCRIPTION
In #5011, I missed this line. Without it benchmark results don't get labeled correctly.