### PR TITLE
docs: Move ai-agents page under Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ParadeDB integrates with the tools you already use, with more on the way.
 ### AI Agents
 
 - [Agent Skills](https://github.com/paradedb/agent-skills)
-- [MCP Integration](https://docs.paradedb.com/welcome/ai-agents)
+- [MCP Integration](https://docs.paradedb.com/documentation/getting-started/ai-agents)
 
 ### PaaS & Cloud Platforms
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -37,7 +37,7 @@
                   {
                     "group": "Getting Started",
                     "pages": [
-                      "welcome/ai-agents",
+                      "documentation/getting-started/ai-agents",
                       "documentation/getting-started/install",
                       "documentation/getting-started/environment",
                       "documentation/getting-started/queries",

--- a/docs/documentation/getting-started/ai-agents.mdx
+++ b/docs/documentation/getting-started/ai-agents.mdx
@@ -1,7 +1,7 @@
 ---
 title: Integrate with AI
 description: Teach your coding assistant to use ParadeDB
-canonical: https://docs.paradedb.com/welcome/ai-agents
+canonical: https://docs.paradedb.com/documentation/getting-started/ai-agents
 ---
 
 Before getting started, let's give your coding agent full context of ParadeDB by adding the ParadeDB agent skill.


### PR DESCRIPTION
## Summary
- Move `docs/welcome/ai-agents.mdx` to `docs/documentation/getting-started/ai-agents.mdx` so the URL matches its nav location (it was nested under `welcome/` but appears in the Getting Started nav group).
- Update `docs.json` nav entry, the page's canonical URL, and the MCP Integration link in `README.md`.

## Test plan
- [ ] `docs.paradedb.com/documentation/getting-started/ai-agents` renders
- [ ] Sidebar still shows "Integrate with AI" under Getting Started