### PR TITLE
chore: Turn off `paradedb.enable_columnar_sort` by default.

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -52,9 +52,9 @@ static ENABLE_FAST_FIELD_EXEC: GucSetting<bool> = GucSetting::<bool>::new(true);
 /// Allows the user to enable or disable the ColumnarExecState executor. Default is `true`.
 static ENABLE_COLUMNAR_EXEC: GucSetting<bool> = GucSetting::<bool>::new(true);
 
-/// Allows the user to enable or disable sorted execution for ColumnarExecState.
-/// When disabled, sorted paths will not be created even if the index has sort_by.
-static ENABLE_COLUMNAR_SORT: GucSetting<bool> = GucSetting::<bool>::new(true);
+/// When enabled, columnar scans use the index sort order if the query's ORDER BY matches the index's sort_by configuration.
+/// Defaults to false due to stability issues (see https://github.com/paradedb/paradedb/issues/4293).
+static ENABLE_COLUMNAR_SORT: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 /// In a Top K query, the limit is multiplied by this factor to determine the chunk size.
 static LIMIT_FETCH_MULTIPLIER: GucSetting<f64> = GucSetting::<f64>::new(1.0);
@@ -279,12 +279,12 @@ pub fn init() {
 
     GucRegistry::define_bool_guc(
         c"paradedb.enable_columnar_sort",
-        c"Enable sorted execution for ColumnarExecState",
-        c"Enable sorted execution for ColumnarExecState when the index has sort_by and the query ORDER BY matches the prefix. Disabling this forces unsorted execution.",
-                &ENABLE_COLUMNAR_SORT,
-                GucContext::Userset,
-                GucFlags::default(),
-            );
+        c"Enable sorted execution for columnar scans",
+        c"When enabled, columnar scans use the index sort order if the query's ORDER BY or join keys match the index's sort_by configuration. This also enables SortMergeJoin for joins on sorted index fields. Default is false.",
+        &ENABLE_COLUMNAR_SORT,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 
     GucRegistry::define_int_guc(
                 COLUMNAR_EXEC_COLUMN_THRESHOLD_NAME,        c"Threshold of fetched columns below which ColumnarExecState will be used.",

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -90,7 +90,7 @@ Execution-layer files under [`pg_search/src/scan/`](../../scan/):
 | ---------------------------------- | ------- | ----------------------------- |
 | `paradedb.enable_join_custom_scan` | `on`    | Master switch                 |
 | `paradedb.enable_segmented_topk`   | `true`  | `SegmentedTopKExec` injection |
-| `paradedb.enable_columnar_sort`    | `true`  | Enables SortMergeJoin path    |
+| `paradedb.enable_columnar_sort`    | `false` | Enables SortMergeJoin path    |
 
 [activation]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/mod.rs#L317
 [relnode]: https://github.com/paradedb/paradedb/blob/53b9d11/pg_search/src/postgres/customscan/joinscan/build.rs#L575

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -36,7 +36,7 @@
 //! resides in fast fields, and that the result set size is small enough (via LIMIT)
 //! that the random heap access cost doesn't outweigh the join benefit.
 //!
-//! 1. **GUC enabled**: `paradedb.enable_join_custom_scan = on` (default: on)
+//! 1. **GUC enabled**: `paradedb.enable_join_custom_scan = on` (default: off)
 //!
 //! 2. **Join type**: INNER, SEMI, and ANTI joins are supported
 //!    - LEFT, RIGHT, and FULL joins are planned for future work

--- a/pg_search/tests/pg_regress/expected/composite_advanced.out
+++ b/pg_search/tests/pg_regress/expected/composite_advanced.out
@@ -1103,6 +1103,7 @@ ORDER BY score DESC, id LIMIT 1;
 ------------------------------------------------------------
 \echo '=== TEST: ColumnarExecState with Composite Fields ==='
 === TEST: ColumnarExecState with Composite Fields ===
+SET paradedb.enable_columnar_sort = on;
 DROP TYPE IF EXISTS columnar_comp CASCADE;
 CREATE TYPE columnar_comp AS (priority INTEGER, created_at DATE);
 DROP TABLE IF EXISTS columnar_comp_test CASCADE;

--- a/pg_search/tests/pg_regress/expected/join_sort_merge.out
+++ b/pg_search/tests/pg_regress/expected/join_sort_merge.out
@@ -7,6 +7,7 @@ SET enable_indexscan to OFF;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 -- Make sure the GUC is enabled
 SET paradedb.enable_join_custom_scan = on;
+SET paradedb.enable_columnar_sort = on;
 -- =============================================================================
 -- TEST 1: Join on sorted keys (Both sides sorted on join key)
 -- =============================================================================

--- a/pg_search/tests/pg_regress/sql/composite_advanced.sql
+++ b/pg_search/tests/pg_regress/sql/composite_advanced.sql
@@ -527,6 +527,8 @@ ORDER BY score DESC, id LIMIT 1;
 ------------------------------------------------------------
 \echo '=== TEST: ColumnarExecState with Composite Fields ==='
 
+SET paradedb.enable_columnar_sort = on;
+
 DROP TYPE IF EXISTS columnar_comp CASCADE;
 CREATE TYPE columnar_comp AS (priority INTEGER, created_at DATE);
 

--- a/pg_search/tests/pg_regress/sql/join_sort_merge.sql
+++ b/pg_search/tests/pg_regress/sql/join_sort_merge.sql
@@ -10,8 +10,7 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 
 -- Make sure the GUC is enabled
 SET paradedb.enable_join_custom_scan = on;
-
-
+SET paradedb.enable_columnar_sort = on;
 
 -- =============================================================================
 -- TEST 1: Join on sorted keys (Both sides sorted on join key)

--- a/tests/tests/columnar.rs
+++ b/tests/tests/columnar.rs
@@ -391,6 +391,7 @@ fn columnar_sorted_scan(
     }
 
     "SET paradedb.enable_columnar_exec TO true;".execute(&mut conn);
+    "SET paradedb.enable_columnar_sort TO true;".execute(&mut conn);
     "SET paradedb.columnar_exec_column_threshold = 10;".execute(&mut conn);
 
     let sort_by = format!(


### PR DESCRIPTION
Until #4293 and its associated upstream issues are resolved, `SortMergeJoin` is not going to be faster than a `HashJoin` in any case. Although it is unlikely to accidentally get a `SortMergeJoin` (because you need to have declared the index sorted), we _are_ beginning to experiment with that configuration in production due to #4939 and #4904.