### PR TITLE
chore: Increase memory limits to allow for HashJoins.

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/aggregate_join_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/aggregate_join_count.sql
@@ -14,7 +14,7 @@ JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';
 
 -- DataFusion aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*)
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';

--- a/benchmarks/datasets/stackoverflow/queries/aggregate_join_multi.sql
+++ b/benchmarks/datasets/stackoverflow/queries/aggregate_join_multi.sql
@@ -14,7 +14,7 @@ JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';
 
 -- DataFusion aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*), MIN(c.score), MAX(c.score)
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*), MIN(c.score), MAX(c.score)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';

--- a/benchmarks/datasets/stackoverflow/queries/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/cardinality.sql
@@ -14,7 +14,7 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(post_type_id) FROM
 SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- high-cardinality aggregate scan
-SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET work_mem TO '4GB'; SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg
 SET paradedb.enable_aggregate_custom_scan TO on; SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;

--- a/benchmarks/datasets/stackoverflow/queries/distinct_parent_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/distinct_parent_sort.sql
@@ -21,7 +21,7 @@ ORDER BY
     u.display_name ASC              -- Single Feature Sort (Parent Field)
 LIMIT 50;
 
-SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT DISTINCT
+SET work_mem TO '8GB'; SET paradedb.enable_join_custom_scan TO on; SELECT DISTINCT
     u.id,
     u.display_name,
     u.about_me


### PR DESCRIPTION
Cleanup post #5017 to increase memory limits now that more queries are using HashJoins.