### PR TITLE
fix: Fix ORDER BY score with alternate join shapes

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/join_permissioned_search.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_permissioned_search.sql
@@ -20,17 +20,16 @@ ORDER BY
     relevance DESC
 LIMIT 10;
 
--- TODO: Skipped! See https://github.com/paradedb/paradedb/issues/5003
--- SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT
---     p.id,
---     p.title,
---     pdb.score(p.id) as relevance
--- FROM stackoverflow_posts p
--- JOIN users u ON p.owner_user_id = u.id
--- WHERE
---     p.title ||| 'how using get create'  -- Driving the Sort (Single Feature)
---     AND u.id @@@ pdb.all()
---     AND u.reputation > 100
--- ORDER BY
---     relevance DESC
--- LIMIT 10;
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO on; SELECT
+    p.id,
+    p.title,
+    pdb.score(p.id) as relevance
+FROM stackoverflow_posts p
+JOIN users u ON p.owner_user_id = u.id
+WHERE
+    p.title ||| 'how using get create'  -- Driving the Sort (Single Feature)
+    AND u.id @@@ pdb.all()
+    AND u.reputation > 100
+ORDER BY
+    relevance DESC
+LIMIT 10;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1109,11 +1109,30 @@ impl CustomScan for JoinScan {
         let mut node = builder.build();
 
         unsafe {
-            // For joins, we need to set custom_scan_tlist to describe the output columns.
-            // Create a fresh copy of the target list to avoid corrupting the original.
-            let original_tlist = node.scan.plan.targetlist;
-            let copied_tlist = pg_sys::copyObjectImpl(original_tlist.cast()).cast::<pg_sys::List>();
-            let tlist = PgList::<pg_sys::TargetEntry>::from_pg(copied_tlist);
+            // For joins, we need to set both custom_scan_tlist and scan.plan.targetlist
+            // to describe the output columns. We create a fresh copy of the target list
+            // to avoid corrupting the original.
+            let mut tlist = PgList::<pg_sys::TargetEntry>::from_pg(
+                pg_sys::copyObjectImpl(node.scan.plan.targetlist.cast()).cast(),
+            );
+
+            // If the parent plan (`processed_tlist` or `pathkeys`) needs `pdb.score(...)` but the
+            // planner didn't push it down into the target list, we must add it. Otherwise,
+            // the parent node will attempt to evaluate `pdb.score(...)` natively, which fails.
+            crate::postgres::utils::add_missing_search_operators_to_tlist(
+                root,
+                best_path as *mut pg_sys::Path,
+                &mut tlist,
+                crate::postgres::customscan::score_funcoids(),
+            );
+
+            // Update node.scan.plan.targetlist so parent nodes can reference the outputs.
+            // We also set custom_scan_tlist, which is what setrefs.c uses to translate
+            // Vars in custom_exprs into INDEX_VAR references. We must provide a separate
+            // copy to custom_scan_tlist because setrefs.c may modify it in-place.
+            let tlist_ptr = tlist.into_pg();
+            node.scan.plan.targetlist = tlist_ptr;
+            node.custom_scan_tlist = pg_sys::copyObjectImpl(tlist_ptr.cast()).cast();
 
             // For join custom scans, PostgreSQL doesn't pass clauses via the usual parameter.
             // We stored the restrictlist in custom_private during create_custom_path.
@@ -1124,17 +1143,17 @@ impl CustomScan for JoinScan {
             // join condition evaluation manually during execution using the original Var
             // references.
 
-            // Extract the column mappings from the ORIGINAL targetlist (before we add restrictlist
-            // Vars). The original_tlist has the SELECT's output columns, which is what
-            // ps_ResultTupleSlot is based on. We store this mapping in PrivateData so
-            // build_result_tuple can use it during execution.
+            // Extract the column mappings from the UPDATED targetlist (before we add restrictlist
+            // Vars). The updated targetlist has the SELECT's output columns plus any missing
+            // search operators, which is what ps_ResultTupleSlot is based on. We store this
+            // mapping in PrivateData so build_result_tuple can use it during execution.
             let mut private_data = PrivateData::from(node.custom_private);
-            let original_entries = PgList::<pg_sys::TargetEntry>::from_pg(original_tlist);
 
             private_data.output_columns =
-                compute_output_columns(&private_data.join_clause, original_tlist, root);
+                compute_output_columns(&private_data.join_clause, tlist_ptr, root);
 
-            build_output_projection(&mut private_data, &original_entries, root);
+            let updated_entries = PgList::<pg_sys::TargetEntry>::from_pg(tlist_ptr);
+            build_output_projection(&mut private_data, &updated_entries, root);
 
             // Add heap condition clauses to custom_exprs so they get transformed by
             // set_customscan_references. The Vars in these expressions will be converted to
@@ -1153,9 +1172,6 @@ impl CustomScan for JoinScan {
             // Convert PrivateData back to a list and preserve the restrictlist.
             let private_list = PrivateData::into(private_data);
             node.custom_private = splice_path_private_into_list(private_list, best_path);
-
-            // Set custom_scan_tlist with all needed columns
-            node.custom_scan_tlist = tlist.into_pg();
         }
         node
     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1123,7 +1123,7 @@ impl CustomScan for JoinScan {
                 root,
                 best_path as *mut pg_sys::Path,
                 &mut tlist,
-                crate::postgres::customscan::score_funcoids(),
+                &crate::postgres::customscan::score_funcoids(),
             );
 
             // Update node.scan.plan.targetlist so parent nodes can reference the outputs.
@@ -1675,7 +1675,7 @@ unsafe fn compute_output_columns(
     let original_entries = PgList::<pg_sys::TargetEntry>::from_pg(original_tlist);
 
     for te in original_entries.iter_ptr() {
-        let check_expr = planning::strip_wrappers((*te).expr.cast());
+        let check_expr = crate::postgres::utils::strip_wrappers((*te).expr.cast());
         if (*check_expr).type_ == pg_sys::NodeTag::T_Var {
             let var = check_expr as *mut pg_sys::Var;
             let rti = (*var).varno as pg_sys::Index;

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -46,7 +46,7 @@ use crate::postgres::customscan::score_funcoids;
 use crate::postgres::customscan::CustomScan;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::rel_get_bm25_index;
-use crate::postgres::utils::{expr_collect_vars, expr_contains_any_operator};
+use crate::postgres::utils::{expr_collect_vars, expr_contains_any_operator, strip_wrappers};
 use crate::postgres::var::{fieldname_from_var, strip_identity_wrappers};
 use crate::query::SearchQueryInput;
 
@@ -1894,25 +1894,6 @@ pub(super) unsafe fn pathkey_uses_scores_from_source(
     }
 
     false
-}
-
-/// Recursively peels `RelabelType` and `PlaceHolderVar` wrappers to get the underlying node.
-pub(super) unsafe fn strip_wrappers(mut node: *mut pg_sys::Node) -> *mut pg_sys::Node {
-    loop {
-        if node.is_null() {
-            return node;
-        }
-        match (*node).type_ {
-            pg_sys::NodeTag::T_RelabelType => {
-                node = (*(node as *mut pg_sys::RelabelType)).arg.cast();
-            }
-            pg_sys::NodeTag::T_PlaceHolderVar => {
-                node = (*(node as *mut pg_sys::PlaceHolderVar)).phexpr.cast();
-            }
-            _ => break,
-        }
-    }
-    node
 }
 
 /// Extracts the RTI of the variable passed to a `paradedb.score(var)` function call.

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -1156,11 +1156,23 @@ unsafe fn opexpr(
             attempt_pushdown,
         ),
 
-        pg_sys::NodeTag::T_FuncExpr => {
-            // direct support for pdb.score() in the WHERE clause
-            let funcexpr = nodecast!(FuncExpr, T_FuncExpr, lhs)?;
-            if !score_funcoids().contains(&(*funcexpr).funcid) {
-                return node_opexpr(
+        pg_sys::NodeTag::T_FuncExpr | pg_sys::NodeTag::T_PlaceHolderVar => {
+            if crate::postgres::utils::unwrap_search_operator(lhs, &score_funcoids()).is_some() {
+                state.uses_our_operator = true;
+
+                if is_complex(rhs) {
+                    return None;
+                }
+
+                return Some(Qual::ScoreExpr {
+                    opoid: opexpr.opno(),
+                    value: rhs,
+                });
+            }
+
+            // Not a score function - fall through to node_opexpr for FuncExpr or pushdown
+            if (*lhs).type_ == pg_sys::NodeTag::T_FuncExpr {
+                node_opexpr(
                     context,
                     rti,
                     ri_type,
@@ -1171,51 +1183,20 @@ unsafe fn opexpr(
                     rhs,
                     convert_external_to_special_qual,
                     attempt_pushdown,
-                );
-            }
-
-            state.uses_our_operator = true;
-
-            if is_complex(rhs) {
-                return None;
-            }
-
-            Some(Qual::ScoreExpr {
-                opoid: opexpr.opno(),
-                value: rhs,
-            })
-        }
-        pg_sys::NodeTag::T_PlaceHolderVar => {
-            // PlaceHolderVar may wrap a score function when the query has joins or aggregates.
-            // We need to unwrap it to check if it's a score expression.
-            let phv = nodecast!(PlaceHolderVar, T_PlaceHolderVar, lhs)?;
-            let phexpr = (*phv).phexpr;
-            if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, phexpr) {
-                if score_funcoids().contains(&(*funcexpr).funcid) {
-                    state.uses_our_operator = true;
-
-                    if is_complex(rhs) {
-                        return None;
-                    }
-
-                    return Some(Qual::ScoreExpr {
-                        opoid: opexpr.opno(),
-                        value: rhs,
-                    });
-                }
-            }
-            // Not a score function - fall through to pushdown
-            if attempt_pushdown {
-                try_pushdown(
-                    context,
-                    rti,
-                    opexpr,
-                    indexrel,
-                    state,
-                    convert_external_to_special_qual,
                 )
             } else {
-                None
+                if attempt_pushdown {
+                    try_pushdown(
+                        context,
+                        rti,
+                        opexpr,
+                        indexrel,
+                        state,
+                        convert_external_to_special_qual,
+                    )
+                } else {
+                    None
+                }
             }
         }
         pg_sys::NodeTag::T_OpExpr => node_opexpr(

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -1156,8 +1156,8 @@ unsafe fn opexpr(
             attempt_pushdown,
         ),
 
-        pg_sys::NodeTag::T_FuncExpr | pg_sys::NodeTag::T_PlaceHolderVar => {
-            if crate::postgres::utils::unwrap_search_operator(lhs, &score_funcoids()).is_some() {
+        pg_sys::NodeTag::T_FuncExpr => {
+            if crate::postgres::utils::is_search_operator(lhs, &score_funcoids()) {
                 state.uses_our_operator = true;
 
                 if is_complex(rhs) {
@@ -1170,33 +1170,45 @@ unsafe fn opexpr(
                 });
             }
 
-            // Not a score function - fall through to node_opexpr for FuncExpr or pushdown
-            if (*lhs).type_ == pg_sys::NodeTag::T_FuncExpr {
-                node_opexpr(
+            node_opexpr(
+                context,
+                rti,
+                ri_type,
+                indexrel,
+                state,
+                opexpr,
+                lhs,
+                rhs,
+                convert_external_to_special_qual,
+                attempt_pushdown,
+            )
+        }
+
+        pg_sys::NodeTag::T_PlaceHolderVar => {
+            if crate::postgres::utils::is_search_operator(lhs, &score_funcoids()) {
+                state.uses_our_operator = true;
+
+                if is_complex(rhs) {
+                    return None;
+                }
+
+                return Some(Qual::ScoreExpr {
+                    opoid: opexpr.opno(),
+                    value: rhs,
+                });
+            }
+
+            if attempt_pushdown {
+                try_pushdown(
                     context,
                     rti,
-                    ri_type,
+                    opexpr,
                     indexrel,
                     state,
-                    opexpr,
-                    lhs,
-                    rhs,
                     convert_external_to_special_qual,
-                    attempt_pushdown,
                 )
             } else {
-                if attempt_pushdown {
-                    try_pushdown(
-                        context,
-                        rti,
-                        opexpr,
-                        indexrel,
-                        state,
-                        convert_external_to_special_qual,
-                    )
-                } else {
-                    None
-                }
+                None
             }
         }
         pg_sys::NodeTag::T_OpExpr => node_opexpr(

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -1362,3 +1362,85 @@ pub unsafe fn add_vars_to_tlist(expr: *mut pg_sys::Node, tlist: &mut PgList<pg_s
         }
     }
 }
+
+/// Unwraps `PlaceHolderVar` nodes (if any) and checks if the underlying node is a `FuncExpr`
+/// whose OID is present in `funcoids`. Returns the `FuncExpr` if it matches.
+pub unsafe fn unwrap_search_operator(
+    node: *mut pg_sys::Node,
+    funcoids: &[pg_sys::Oid],
+) -> Option<*mut pg_sys::FuncExpr> {
+    if node.is_null() {
+        return None;
+    }
+
+    let mut check_node = node;
+    if (*check_node).type_ == pg_sys::NodeTag::T_PlaceHolderVar {
+        let phv = check_node as *mut pg_sys::PlaceHolderVar;
+        check_node = (*phv).phexpr as *mut pg_sys::Node;
+    }
+
+    if (*check_node).type_ == pg_sys::NodeTag::T_FuncExpr {
+        let funcexpr = check_node as *mut pg_sys::FuncExpr;
+        if funcoids.contains(&(*funcexpr).funcid) {
+            return Some(funcexpr);
+        }
+    }
+    None
+}
+
+/// Helper function to inspect the parent plan's requirements (`processed_tlist`
+/// and `pathkeys`) and add any missing search operator function calls (like `pdb.score(...)`)
+/// into the CustomScan's targetlist.
+///
+/// This ensures that if the CustomScan is expected to output a score (or similar),
+/// it is actually present in its `targetlist` so the `Result` node can simply
+/// project it, rather than Postgres natively trying to execute the dummy function.
+pub unsafe fn add_missing_search_operators_to_tlist(
+    root: *mut pg_sys::PlannerInfo,
+    best_path: *mut pg_sys::Path,
+    tlist: &mut PgList<pg_sys::TargetEntry>,
+    search_operator_funcoids: [pg_sys::Oid; 2],
+) {
+    let mut add_missing_func = |expr: *mut pg_sys::Node| {
+        if unwrap_search_operator(expr, &search_operator_funcoids).is_none() {
+            return;
+        }
+
+        let already_present = tlist
+            .iter_ptr()
+            .any(|te| pg_sys::equal((*te).expr.cast(), expr.cast()));
+
+        if !already_present {
+            let resno = tlist.len() as pg_sys::AttrNumber + 1;
+            let te = pg_sys::makeTargetEntry(
+                pg_sys::copyObjectImpl(expr.cast()).cast(),
+                resno,
+                std::ptr::null_mut(),
+                true, // resjunk
+            );
+            tlist.push(te);
+        }
+    };
+
+    // Look in processed_tlist
+    if !(*root).processed_tlist.is_null() {
+        let p_tlist = PgList::<pg_sys::TargetEntry>::from_pg((*root).processed_tlist);
+        for te in p_tlist.iter_ptr() {
+            add_missing_func((*te).expr.cast());
+        }
+    }
+
+    // Look in pathkeys
+    if !best_path.is_null() && !(*best_path).pathkeys.is_null() {
+        let pathkeys = PgList::<pg_sys::PathKey>::from_pg((*best_path).pathkeys);
+        for pk in pathkeys.iter_ptr() {
+            let eclass = (*pk).pk_eclass;
+            if !eclass.is_null() {
+                let members = PgList::<pg_sys::EquivalenceMember>::from_pg((*eclass).ec_members);
+                for em in members.iter_ptr() {
+                    add_missing_func((*em).em_expr.cast());
+                }
+            }
+        }
+    }
+}

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -1363,29 +1363,41 @@ pub unsafe fn add_vars_to_tlist(expr: *mut pg_sys::Node, tlist: &mut PgList<pg_s
     }
 }
 
+/// Recursively peels `RelabelType` and `PlaceHolderVar` wrappers to get the underlying node.
+pub unsafe fn strip_wrappers(mut node: *mut pg_sys::Node) -> *mut pg_sys::Node {
+    loop {
+        if node.is_null() {
+            return node;
+        }
+        match (*node).type_ {
+            pg_sys::NodeTag::T_RelabelType => {
+                node = (*(node as *mut pg_sys::RelabelType)).arg.cast();
+            }
+            pg_sys::NodeTag::T_PlaceHolderVar => {
+                node = (*(node as *mut pg_sys::PlaceHolderVar)).phexpr.cast();
+            }
+            _ => break,
+        }
+    }
+    node
+}
+
 /// Unwraps `PlaceHolderVar` nodes (if any) and checks if the underlying node is a `FuncExpr`
-/// whose OID is present in `funcoids`. Returns the `FuncExpr` if it matches.
-pub unsafe fn unwrap_search_operator(
-    node: *mut pg_sys::Node,
-    funcoids: &[pg_sys::Oid],
-) -> Option<*mut pg_sys::FuncExpr> {
+/// whose OID is present in `funcoids`. Returns true if it matches.
+pub unsafe fn is_search_operator(node: *mut pg_sys::Node, funcoids: &[pg_sys::Oid]) -> bool {
     if node.is_null() {
-        return None;
+        return false;
     }
 
-    let mut check_node = node;
-    if (*check_node).type_ == pg_sys::NodeTag::T_PlaceHolderVar {
-        let phv = check_node as *mut pg_sys::PlaceHolderVar;
-        check_node = (*phv).phexpr as *mut pg_sys::Node;
-    }
+    let check_node = strip_wrappers(node);
 
     if (*check_node).type_ == pg_sys::NodeTag::T_FuncExpr {
         let funcexpr = check_node as *mut pg_sys::FuncExpr;
         if funcoids.contains(&(*funcexpr).funcid) {
-            return Some(funcexpr);
+            return true;
         }
     }
-    None
+    false
 }
 
 /// Helper function to inspect the parent plan's requirements (`processed_tlist`
@@ -1399,16 +1411,20 @@ pub unsafe fn add_missing_search_operators_to_tlist(
     root: *mut pg_sys::PlannerInfo,
     best_path: *mut pg_sys::Path,
     tlist: &mut PgList<pg_sys::TargetEntry>,
-    search_operator_funcoids: [pg_sys::Oid; 2],
+    search_operator_funcoids: &[pg_sys::Oid],
 ) {
     let mut add_missing_func = |expr: *mut pg_sys::Node| {
-        if unwrap_search_operator(expr, &search_operator_funcoids).is_none() {
+        if !is_search_operator(expr, search_operator_funcoids) {
             return;
         }
 
-        let already_present = tlist
-            .iter_ptr()
-            .any(|te| pg_sys::equal((*te).expr.cast(), expr.cast()));
+        let unwrapped_expr = strip_wrappers(expr.cast());
+        let already_present = tlist.iter_ptr().any(|te| {
+            pg_sys::equal(
+                strip_wrappers((*te).expr.cast()).cast(),
+                unwrapped_expr.cast(),
+            )
+        });
 
         if !already_present {
             let resno = tlist.len() as pg_sys::AttrNumber + 1;

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -20,7 +20,7 @@ use crate::index::fast_fields_helper::{
 };
 use crate::index::reader::index::MultiSegmentSearchResults;
 use crate::postgres::heap::VisibilityChecker;
-use arrow_array::builder::BooleanBuilder;
+use arrow_array::builder::{BooleanBuilder, UInt64Builder};
 use arrow_array::{Array, ArrayRef, BooleanArray, Float32Array, RecordBatch, UInt64Array};
 use arrow_schema::SchemaRef;
 use datafusion::arrow::compute;
@@ -39,7 +39,7 @@ const MAX_BATCH_SIZE: usize = 128_000;
 /// batch size, since we are not fetching string dictionaries during the scan phase.
 const DEFERRED_BATCH_SIZE: usize = 8_192;
 
-/// Compact `ids` and `scores` in-place based on a boolean mask.
+/// Compact `ids` and `memoized_columns` in-place based on a boolean mask.
 fn compact_with_mask(
     ids: &mut Vec<DocId>,
     memoized_columns: &mut [Option<ArrayRef>],
@@ -329,10 +329,10 @@ impl Scanner {
         // Batch lookup the ctids and visibility check them.
         // When defer_visibility is true, we skip visibility checking entirely —
         // VisibilityFilterExec will handle it in batch after the join.
-        // The `ctids` Vec here is used only for:
+        // The `ctids_builder` here is used only for:
         //   1. Visibility masking (compacting invisible rows out of `ids` and `memoized_columns`).
         //   2. The `WhichFastField::Ctid` Arrow output column.
-        let ctids: Vec<u64> = if self.defer_visibility {
+        let ctids_array: Option<ArrayRef> = if self.defer_visibility {
             // defer_visibility=true always uses DeferredCtid, never WhichFastField::Ctid.
             // A physical Ctid column in this path indicates a planning bug.
             debug_assert!(
@@ -342,8 +342,8 @@ impl Scanner {
                     .any(|f| matches!(f, WhichFastField::Ctid)),
                 "defer_visibility=true but WhichFastField::Ctid is present — planning bug"
             );
-            // No real ctid lookup needed — an empty vec is correct here.
-            vec![]
+            // No real ctid lookup needed.
+            None
         } else {
             self.maybe_ctids.resize(ids.len(), None);
             ffhelper
@@ -354,12 +354,12 @@ impl Scanner {
             self.visibility_results.resize(ids.len(), None);
             visibility.check_batch(&self.maybe_ctids, &mut self.visibility_results);
 
-            let mut ctids = Vec::with_capacity(ids.len());
+            let mut ctids_builder = UInt64Builder::with_capacity(ids.len());
             let mut visibility_mask_builder = BooleanBuilder::with_capacity(ids.len());
             for maybe_visible_ctid in self.visibility_results.drain(..) {
                 if let Some(visible_ctid) = maybe_visible_ctid {
                     visibility_mask_builder.append_value(true);
-                    ctids.push(visible_ctid);
+                    ctids_builder.append_value(visible_ctid);
                 } else {
                     visibility_mask_builder.append_value(false);
                 }
@@ -370,7 +370,7 @@ impl Scanner {
                 &mut memoized_columns,
                 &visibility_mask_builder.finish(),
             );
-            ctids
+            Some(Arc::new(ctids_builder.finish()) as ArrayRef)
         };
 
         // Pre-fetch any Named columns that weren't already fetched by pre-filters.
@@ -394,9 +394,7 @@ impl Scanner {
             .iter()
             .enumerate()
             .map(|(ff_index, which_ff)| match which_ff {
-                WhichFastField::Ctid => {
-                    Some(Arc::new(UInt64Array::from(ctids.clone())) as ArrayRef)
-                }
+                WhichFastField::Ctid => Some(ctids_array.clone().unwrap()),
                 WhichFastField::Score => Some(memoized_columns[ff_index].clone().unwrap()),
                 WhichFastField::TableOid => {
                     let mut builder = arrow_array::builder::UInt32Builder::with_capacity(ids.len());

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -280,16 +280,13 @@ impl Scanner {
         // to keep them aligned with `ids`.
         let mut memoized_columns: Vec<Option<ArrayRef>> = vec![None; self.which_fast_fields.len()];
 
-        if self
-            .which_fast_fields
-            .iter()
-            .any(|f| matches!(f, WhichFastField::Score))
-        {
-            let score_array = Arc::new(Float32Array::from(scores)) as ArrayRef;
-            for (idx, ff) in self.which_fast_fields.iter().enumerate() {
-                if matches!(ff, WhichFastField::Score) {
-                    memoized_columns[idx] = Some(score_array.clone());
-                }
+        let mut lazy_score_array: Option<ArrayRef> = None;
+        for (idx, ff) in self.which_fast_fields.iter().enumerate() {
+            if matches!(ff, WhichFastField::Score) {
+                let score_array = lazy_score_array.get_or_insert_with(|| {
+                    Arc::new(Float32Array::from(scores.clone())) as ArrayRef
+                });
+                memoized_columns[idx] = Some(score_array.clone());
             }
         }
 

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -18,14 +18,14 @@
 use crate::index::fast_fields_helper::{
     ords_to_bytes_array, ords_to_string_array, FFHelper, FFType, WhichFastField,
 };
-use crate::index::reader::index::{MultiSegmentSearchResults, SearchIndexScore};
+use crate::index::reader::index::MultiSegmentSearchResults;
 use crate::postgres::heap::VisibilityChecker;
 use arrow_array::builder::BooleanBuilder;
 use arrow_array::{Array, ArrayRef, BooleanArray, Float32Array, RecordBatch, UInt64Array};
 use arrow_schema::SchemaRef;
 use datafusion::arrow::compute;
 use std::sync::Arc;
-use tantivy::{DocAddress, DocId, Score, SegmentOrdinal};
+use tantivy::{DocId, Score, SegmentOrdinal};
 
 /// The maximum number of rows to batch materialize in memory while iterating over a result set.
 ///
@@ -42,27 +42,24 @@ const DEFERRED_BATCH_SIZE: usize = 8_192;
 /// Compact `ids` and `scores` in-place based on a boolean mask.
 fn compact_with_mask(
     ids: &mut Vec<DocId>,
-    scores: &mut Vec<Score>,
-    memoized_columns: &mut Vec<Option<ArrayRef>>,
+    memoized_columns: &mut [Option<ArrayRef>],
     mask: &BooleanArray,
 ) {
     if mask.false_count() == 0 && mask.null_count() == 0 {
         return;
     }
 
-    // Compact ids and scores.
+    // Compact ids.
     let mut write_idx = 0;
     for (read_idx, valid) in mask.iter().enumerate() {
         if valid == Some(true) {
             if read_idx != write_idx {
                 ids[write_idx] = ids[read_idx];
-                scores[write_idx] = scores[read_idx];
             }
             write_idx += 1;
         }
     }
     ids.truncate(write_idx);
-    scores.truncate(write_idx);
 
     // Compact memoized columns
     for opt_col in memoized_columns {
@@ -79,7 +76,6 @@ fn ensure_column_fetched(
     segment_ord: SegmentOrdinal,
     ff_index: usize,
     ids: &[DocId],
-    scores: &[Score],
 ) {
     if memoized_columns[ff_index].is_some() {
         return;
@@ -93,11 +89,10 @@ fn ensure_column_fetched(
                     .fetch_values_or_ords_to_arrow(ids, *search_field_type),
             );
         }
-        WhichFastField::Score => {
-            memoized_columns[ff_index] =
-                Some(Arc::new(arrow_array::Float32Array::from(scores.to_vec())) as ArrayRef);
-        }
-        WhichFastField::Ctid | WhichFastField::TableOid | WhichFastField::Junk(_) => {}
+        WhichFastField::Score
+        | WhichFastField::Ctid
+        | WhichFastField::TableOid
+        | WhichFastField::Junk(_) => {}
         WhichFastField::DeferredCtid(alias) => {
             panic!(
                 "pre-filter referenced DeferredCtid column '{alias}' at index {ff_index} \
@@ -110,9 +105,8 @@ fn ensure_column_fetched(
 /// A batch of visible tuples and their fast field values.
 #[derive(Default)]
 pub struct Batch {
-    /// An iterator of ids which have been consumed from the underlying `SearchResults`
-    /// iterator as a batch.
-    pub ids: Vec<(SearchIndexScore, DocAddress)>,
+    /// The number of rows in this batch.
+    pub num_rows: usize,
 
     /// The current batch of fast field values, indexed by FFIndex, then by row.
     /// This uses Arrow arrays for efficient columnar storage.
@@ -129,7 +123,7 @@ impl Batch {
             .map(|(i, field)| {
                 field.clone().unwrap_or_else(|| {
                     let data_type = schema.field(i).data_type();
-                    arrow_array::new_null_array(data_type, self.ids.len())
+                    arrow_array::new_null_array(data_type, self.num_rows)
                 })
             })
             .collect();
@@ -275,7 +269,7 @@ impl Scanner {
             return Some(batch);
         }
         pgrx::check_for_interrupts!();
-        let (segment_ord, mut scores, mut ids) = self.try_get_batch_ids()?;
+        let (segment_ord, scores, mut ids) = self.try_get_batch_ids()?;
 
         // Memoize fetched columns to avoid redundant fetches.
         // - Numeric columns: stores the values directly.
@@ -285,6 +279,19 @@ impl Scanner {
         // We must compact these arrays whenever we filter rows (pre-filtering or visibility)
         // to keep them aligned with `ids`.
         let mut memoized_columns: Vec<Option<ArrayRef>> = vec![None; self.which_fast_fields.len()];
+
+        if self
+            .which_fast_fields
+            .iter()
+            .any(|f| matches!(f, WhichFastField::Score))
+        {
+            let score_array = Arc::new(Float32Array::from(scores)) as ArrayRef;
+            for (idx, ff) in self.which_fast_fields.iter().enumerate() {
+                if matches!(ff, WhichFastField::Score) {
+                    memoized_columns[idx] = Some(score_array.clone());
+                }
+            }
+        }
 
         // Apply pre-materialization filters before visibility checks (which require the ctid), and
         // before dictionary lookups.
@@ -302,7 +309,6 @@ impl Scanner {
                         segment_ord,
                         ff_index,
                         &ids,
-                        &scores,
                     );
                 }
                 let mask = pre_filter
@@ -314,7 +320,7 @@ impl Scanner {
                         ids.len(),
                     )
                     .unwrap_or_else(|e| panic!("Pre-filter failed: {e}"));
-                compact_with_mask(&mut ids, &mut scores, &mut memoized_columns, &mask);
+                compact_with_mask(&mut ids, &mut memoized_columns, &mask);
             }
             self.pre_filter_rows_scanned += before;
             self.pre_filter_rows_pruned += before - ids.len();
@@ -324,9 +330,8 @@ impl Scanner {
         // When defer_visibility is true, we skip visibility checking entirely —
         // VisibilityFilterExec will handle it in batch after the join.
         // The `ctids` Vec here is used only for:
-        //   1. Visibility masking (compacting invisible rows out of `ids`/`scores`).
+        //   1. Visibility masking (compacting invisible rows out of `ids` and `memoized_columns`).
         //   2. The `WhichFastField::Ctid` Arrow output column.
-        // It is NOT placed in SearchIndexScore — the score carries only `bm25`.
         let ctids: Vec<u64> = if self.defer_visibility {
             // defer_visibility=true always uses DeferredCtid, never WhichFastField::Ctid.
             // A physical Ctid column in this path indicates a planning bug.
@@ -362,7 +367,6 @@ impl Scanner {
             // Then filter the remaining columns using the mask.
             compact_with_mask(
                 &mut ids,
-                &mut scores,
                 &mut memoized_columns,
                 &visibility_mask_builder.finish(),
             );
@@ -379,7 +383,6 @@ impl Scanner {
                     segment_ord,
                     ff_index,
                     &ids,
-                    &scores,
                 );
             }
         }
@@ -394,9 +397,7 @@ impl Scanner {
                 WhichFastField::Ctid => {
                     Some(Arc::new(UInt64Array::from(ctids.clone())) as ArrayRef)
                 }
-                WhichFastField::Score => {
-                    Some(Arc::new(Float32Array::from(scores.clone())) as ArrayRef)
-                }
+                WhichFastField::Score => Some(memoized_columns[ff_index].clone().unwrap()),
                 WhichFastField::TableOid => {
                     let mut builder = arrow_array::builder::UInt32Builder::with_capacity(ids.len());
                     for _ in 0..ids.len() {
@@ -471,16 +472,7 @@ impl Scanner {
             .collect();
 
         Some(Batch {
-            ids: ids
-                .into_iter()
-                .zip(scores)
-                .map(|(id, score)| {
-                    (
-                        SearchIndexScore { bm25: score },
-                        DocAddress::new(segment_ord, id),
-                    )
-                })
-                .collect(),
+            num_rows: ids.len(),
             fields,
         })
     }

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -79,6 +79,7 @@ fn ensure_column_fetched(
     segment_ord: SegmentOrdinal,
     ff_index: usize,
     ids: &[DocId],
+    scores: &[Score],
 ) {
     if memoized_columns[ff_index].is_some() {
         return;
@@ -92,10 +93,11 @@ fn ensure_column_fetched(
                     .fetch_values_or_ords_to_arrow(ids, *search_field_type),
             );
         }
-        WhichFastField::Ctid
-        | WhichFastField::Score
-        | WhichFastField::TableOid
-        | WhichFastField::Junk(_) => {}
+        WhichFastField::Score => {
+            memoized_columns[ff_index] =
+                Some(Arc::new(arrow_array::Float32Array::from(scores.to_vec())) as ArrayRef);
+        }
+        WhichFastField::Ctid | WhichFastField::TableOid | WhichFastField::Junk(_) => {}
         WhichFastField::DeferredCtid(alias) => {
             panic!(
                 "pre-filter referenced DeferredCtid column '{alias}' at index {ff_index} \
@@ -300,6 +302,7 @@ impl Scanner {
                         segment_ord,
                         ff_index,
                         &ids,
+                        &scores,
                     );
                 }
                 let mask = pre_filter
@@ -376,6 +379,7 @@ impl Scanner {
                     segment_ord,
                     ff_index,
                     &ids,
+                    &scores,
                 );
             }
         }

--- a/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
+++ b/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
@@ -69,7 +69,20 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
-ERROR:  Pre-filter failed: Column 0 not fetched
+  id   |        title         |   relevance   
+-------+----------------------+---------------
+  2000 | how using get create | 0.00019978978
+  3000 | how using get create | 0.00019978978
+  4000 | how using get create | 0.00019978978
+  5000 | how using get create | 0.00019978978
+  6000 | how using get create | 0.00019978978
+  7000 | how using get create | 0.00019978978
+  8000 | how using get create | 0.00019978978
+  9000 | how using get create | 0.00019978978
+ 10000 | how using get create | 0.00019978978
+  1000 | how using get create | 0.00019978978
+(10 rows)
+
 -- Teardown
 DROP TABLE issue_join_pre_filter_users CASCADE;
 DROP TABLE issue_join_pre_filter_posts CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
+++ b/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
@@ -19,7 +19,11 @@ ANALYZE issue_join_pre_filter_posts;
 SET max_parallel_workers_per_gather = 2;
 SET paradedb.enable_join_custom_scan TO on;
 SET work_mem TO '4GB';
-EXPLAIN SELECT
+-- Note: This test reliably reproduces the pre-filter "Column 0 not fetched" panic.
+-- It may or may not exercise the second fix (ensuring pdb.score is projected
+-- when a parent Result node needs it) depending on whether the planner
+-- chooses a plan shape with a Result node above the Custom Scan.
+EXPLAIN (COSTS OFF, TIMING OFF) SELECT
     p.id,
     p.title,
     pdb.score(p.id) as relevance
@@ -32,12 +36,12 @@ WHERE
 ORDER BY
     relevance DESC
 LIMIT 10;
-                                                                                                                                  QUERY PLAN                                                                                                                                  
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Limit  (cost=1010.01..1011.14 rows=10 width=29)
-   ->  Gather Merge  (cost=1010.01..2136.01 rows=10000 width=29)
+                                                                                                                                 QUERY PLAN                                                                                                                                 
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Gather Merge
          Workers Planned: 1
-         ->  Parallel Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=5 width=29)
+         ->  Parallel Custom Scan (ParadeDB Join Scan)
                Relation Tree: u INNER p
                Join Cond: p.owner_user_id = u.id
                Limit: 10
@@ -46,14 +50,13 @@ LIMIT 10;
                  : ProjectionExec: expr=[NULL as col_1, NULL as col_2, score@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
                  :   SortExec: TopK(fetch=10), expr=[score@1 DESC], preserve_partitioning=[false]
                  :     VisibilityFilterExec: tables=[u, p]
-                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, score@0 as score, ctid_1@1 as ctid_1]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(owner_user_id@2, id@1)], projection=[score@0, ctid_1@1, ctid_0@3]
-                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, owner_user_id@2 as owner_user_id]
-                 :             CooperativeExec
-                 :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"match":{"field":"title","value":"how using get create","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(owner_user_id@2, id@1)], projection=[ctid_0@3, score@0, ctid_1@1]
+                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, owner_user_id@2 as owner_user_id]
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"range":{"field":"reputation","lower_bound":{"excluded":100},"upper_bound":null,"is_datetime":false}}]}}
-(19 rows)
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"match":{"field":"title","value":"how using get create","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"range":{"field":"reputation","lower_bound":{"excluded":100},"upper_bound":null}}]}}
+(18 rows)
 
 -- Reproduce the bug
 SELECT

--- a/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
+++ b/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
@@ -1,0 +1,75 @@
+-- Setup
+DROP TABLE IF EXISTS issue_join_pre_filter_users CASCADE;
+DROP TABLE IF EXISTS issue_join_pre_filter_posts CASCADE;
+CREATE TABLE issue_join_pre_filter_users (
+    id integer PRIMARY KEY,
+    reputation integer
+);
+CREATE INDEX ON issue_join_pre_filter_users USING bm25 (id, reputation) WITH (key_field=id, sort_by='id ASC NULLS FIRST');
+CREATE TABLE issue_join_pre_filter_posts (
+    id integer PRIMARY KEY,
+    title text,
+    owner_user_id integer
+);
+CREATE INDEX ON issue_join_pre_filter_posts USING bm25 (id, (title::pdb.unicode_words('columnar=true')), owner_user_id) WITH (key_field=id, sort_by='owner_user_id ASC NULLS FIRST');
+INSERT INTO issue_join_pre_filter_users SELECT i, 200 FROM generate_series(1, 10000) i;
+INSERT INTO issue_join_pre_filter_posts SELECT i, 'how using get create', i % 1000 + 1 FROM generate_series(1, 10000) i;
+ANALYZE issue_join_pre_filter_users;
+ANALYZE issue_join_pre_filter_posts;
+SET max_parallel_workers_per_gather = 2;
+SET paradedb.enable_join_custom_scan TO on;
+SET work_mem TO '4GB';
+EXPLAIN SELECT
+    p.id,
+    p.title,
+    pdb.score(p.id) as relevance
+FROM issue_join_pre_filter_posts p
+JOIN issue_join_pre_filter_users u ON p.owner_user_id = u.id
+WHERE
+    p.title ||| 'how using get create'
+    AND u.id @@@ pdb.all()
+    AND u.reputation > 100
+ORDER BY
+    relevance DESC
+LIMIT 10;
+                                                                                                                                  QUERY PLAN                                                                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit  (cost=1010.01..1011.14 rows=10 width=29)
+   ->  Gather Merge  (cost=1010.01..2136.01 rows=10000 width=29)
+         Workers Planned: 1
+         ->  Parallel Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=5 width=29)
+               Relation Tree: u INNER p
+               Join Cond: p.owner_user_id = u.id
+               Limit: 10
+               Order By: pdb.score() desc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[NULL as col_1, NULL as col_2, score@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[score@1 DESC], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[u, p]
+                 :       ProjectionExec: expr=[ctid_0@2 as ctid_0, score@0 as score, ctid_1@1 as ctid_1]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(owner_user_id@2, id@1)], projection=[score@0, ctid_1@1, ctid_0@3]
+                 :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, owner_user_id@2 as owner_user_id]
+                 :             CooperativeExec
+                 :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"match":{"field":"title","value":"how using get create","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"range":{"field":"reputation","lower_bound":{"excluded":100},"upper_bound":null,"is_datetime":false}}]}}
+(19 rows)
+
+-- Reproduce the bug
+SELECT
+    p.id,
+    p.title,
+    pdb.score(p.id) as relevance
+FROM issue_join_pre_filter_posts p
+JOIN issue_join_pre_filter_users u ON p.owner_user_id = u.id
+WHERE
+    p.title ||| 'how using get create'
+    AND u.id @@@ pdb.all()
+    AND u.reputation > 100
+ORDER BY
+    relevance DESC
+LIMIT 10;
+ERROR:  Pre-filter failed: Column 0 not fetched
+-- Teardown
+DROP TABLE issue_join_pre_filter_users CASCADE;
+DROP TABLE issue_join_pre_filter_posts CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_join_pre_filter.sql
+++ b/pg_search/tests/pg_regress/sql/issue_join_pre_filter.sql
@@ -25,7 +25,11 @@ SET max_parallel_workers_per_gather = 2;
 SET paradedb.enable_join_custom_scan TO on;
 SET work_mem TO '4GB';
 
-EXPLAIN SELECT
+-- Note: This test reliably reproduces the pre-filter "Column 0 not fetched" panic.
+-- It may or may not exercise the second fix (ensuring pdb.score is projected
+-- when a parent Result node needs it) depending on whether the planner
+-- chooses a plan shape with a Result node above the Custom Scan.
+EXPLAIN (COSTS OFF, TIMING OFF) SELECT
     p.id,
     p.title,
     pdb.score(p.id) as relevance

--- a/pg_search/tests/pg_regress/sql/issue_join_pre_filter.sql
+++ b/pg_search/tests/pg_regress/sql/issue_join_pre_filter.sql
@@ -1,0 +1,59 @@
+-- Setup
+DROP TABLE IF EXISTS issue_join_pre_filter_users CASCADE;
+DROP TABLE IF EXISTS issue_join_pre_filter_posts CASCADE;
+
+CREATE TABLE issue_join_pre_filter_users (
+    id integer PRIMARY KEY,
+    reputation integer
+);
+CREATE INDEX ON issue_join_pre_filter_users USING bm25 (id, reputation) WITH (key_field=id, sort_by='id ASC NULLS FIRST');
+
+CREATE TABLE issue_join_pre_filter_posts (
+    id integer PRIMARY KEY,
+    title text,
+    owner_user_id integer
+);
+CREATE INDEX ON issue_join_pre_filter_posts USING bm25 (id, (title::pdb.unicode_words('columnar=true')), owner_user_id) WITH (key_field=id, sort_by='owner_user_id ASC NULLS FIRST');
+
+INSERT INTO issue_join_pre_filter_users SELECT i, 200 FROM generate_series(1, 10000) i;
+INSERT INTO issue_join_pre_filter_posts SELECT i, 'how using get create', i % 1000 + 1 FROM generate_series(1, 10000) i;
+
+ANALYZE issue_join_pre_filter_users;
+ANALYZE issue_join_pre_filter_posts;
+
+SET max_parallel_workers_per_gather = 2;
+SET paradedb.enable_join_custom_scan TO on;
+SET work_mem TO '4GB';
+
+EXPLAIN SELECT
+    p.id,
+    p.title,
+    pdb.score(p.id) as relevance
+FROM issue_join_pre_filter_posts p
+JOIN issue_join_pre_filter_users u ON p.owner_user_id = u.id
+WHERE
+    p.title ||| 'how using get create'
+    AND u.id @@@ pdb.all()
+    AND u.reputation > 100
+ORDER BY
+    relevance DESC
+LIMIT 10;
+
+-- Reproduce the bug
+SELECT
+    p.id,
+    p.title,
+    pdb.score(p.id) as relevance
+FROM issue_join_pre_filter_posts p
+JOIN issue_join_pre_filter_users u ON p.owner_user_id = u.id
+WHERE
+    p.title ||| 'how using get create'
+    AND u.id @@@ pdb.all()
+    AND u.reputation > 100
+ORDER BY
+    relevance DESC
+LIMIT 10;
+
+-- Teardown
+DROP TABLE issue_join_pre_filter_users CASCADE;
+DROP TABLE issue_join_pre_filter_posts CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5003

## What

The `permissioned_search` benchmark query began failing recently at larger dataset sizes (due to simultaneous changes to the benchmarks and code, it's hard to determine where).

This change fixes two issues:
* When a dynamic filter was pushed down on `pdb.score`, there was no way to apply it via our prefiltering infrastructure, which lead to the initial error on #5003.
* Hidden behind that error, in some plan shapes, Postgres would not actually place the `pdb.score` call in the join scan's target list for projection, which meant that a wrapping `Result` node tried to compute it instead: since this function must _always_ be executed via our infrastructure, this failed with an "unsupported query shape" error. 

## How

Cleaned up the `Scanner`'s approach to rendering scores, and removed vestigial use of the `SearchIndexScore` type. Additionally, adjusted custom path creation to ensure that we include `pdb.score` in our target list when a parent node might otherwise compute it.

## Tests

New regress test, and re-enabling of the failing benchmark query.