### PR TITLE
test(qgen): vary parallel_leader_participation

### DIFF
--- a/tests/antithesis/singleton_driver_property-tests.sh
+++ b/tests/antithesis/singleton_driver_property-tests.sh
@@ -15,7 +15,7 @@ set -Eeuo pipefail
 export DATABASE_URL="postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"
 export PARADEDB_FORCE_PARALLEL=1
 export PARADEDB_QGEN_STATEMENT_TIMEOUT_MS="${PARADEDB_QGEN_STATEMENT_TIMEOUT_MS:-60000}"
-export PROPTEST_CASES="${PROPTEST_CASES:-128}"
+export PROPTEST_CASES="${PROPTEST_CASES:-2048}"
 # Disable proptest's source-relative regression file persistence: the qgen
 # binary runs air-gapped from /home/app and can't resolve lib.rs/main.rs, which
 # otherwise spams a warning on every iteration.

--- a/tests/antithesis/singleton_driver_property-tests.sh
+++ b/tests/antithesis/singleton_driver_property-tests.sh
@@ -15,7 +15,7 @@ set -Eeuo pipefail
 export DATABASE_URL="postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"
 export PARADEDB_FORCE_PARALLEL=1
 export PARADEDB_QGEN_STATEMENT_TIMEOUT_MS="${PARADEDB_QGEN_STATEMENT_TIMEOUT_MS:-60000}"
-export PROPTEST_CASES="${PROPTEST_CASES:-2048}"
+export PROPTEST_CASES="${PROPTEST_CASES:-128}"
 # Disable proptest's source-relative regression file persistence: the qgen
 # binary runs air-gapped from /home/app and can't resolve lib.rs/main.rs, which
 # otherwise spams a warning on every iteration.

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -360,6 +360,10 @@ pub struct PgGucs {
     pub seqscan: bool,
     pub indexscan: bool,
     pub parallel_workers: bool,
+    /// Toggles Postgres' `parallel_leader_participation` GUC. When `false`,
+    /// only background workers emit tuples — useful for shaking out parallel
+    /// scans whose leader/worker partitioning is incorrect (e.g. issue #5024).
+    pub parallel_leader_participation: bool,
     /// Enable columnar execution (ColumnarExecState).
     /// When enabled with a sorted index, uses SortPreservingMergeExec for sorted output.
     pub columnar_exec: bool,
@@ -398,7 +402,7 @@ impl Arbitrary for PgGucs {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any::<[bool; 10]>()
+        any::<[bool; 11]>()
             .prop_map(|b| {
                 let mut g = PgGucs {
                     aggregate_custom_scan: b[0],
@@ -411,6 +415,7 @@ impl Arbitrary for PgGucs {
                     parallel_workers: b[7],
                     columnar_exec: b[8],
                     columnar_sort: b[9],
+                    parallel_leader_participation: b[10],
                 };
                 if force_parallel() {
                     g.parallel_workers = true;
@@ -432,6 +437,7 @@ impl Default for PgGucs {
             seqscan: true,
             indexscan: true,
             parallel_workers: true,
+            parallel_leader_participation: true,
             columnar_exec: false,
             columnar_sort: true,
         }
@@ -449,6 +455,7 @@ impl PgGucs {
             seqscan,
             indexscan,
             parallel_workers,
+            parallel_leader_participation,
             columnar_exec,
             columnar_sort,
         } = self;
@@ -480,6 +487,11 @@ impl PgGucs {
         writeln!(gucs, "SET enable_seqscan TO {seqscan};").unwrap();
         writeln!(gucs, "SET enable_indexscan TO {indexscan};").unwrap();
         writeln!(gucs, "SET max_parallel_workers TO {max_parallel_workers};").unwrap();
+        writeln!(
+            gucs,
+            "SET parallel_leader_participation TO {parallel_leader_participation};"
+        )
+        .unwrap();
         writeln!(gucs, "SET paradedb.add_doc_count_to_aggs TO true;").unwrap();
         writeln!(
             gucs,


### PR DESCRIPTION
## Summary

Adds Postgres' `parallel_leader_participation` GUC to the qgen proptest matrix in `PgGucs`. Flipping this knob shakes out parallel-scan coordination bugs where the leader and workers emit overlapping rows.

## Why now

Antithesis just caught one such parallel-coordination bug (#5024) — a `Parallel Custom Scan (ParadeDB Base Scan)` with `ColumnarExecState` + `Full Index Scan: true` returns each row twice when both the leader and a worker emit. Setting `parallel_leader_participation=false` in the proptest matrix forces a workers-only execution, which is the cleanest way to differentially detect this class of bug.

## Changes

- `tests/tests/fixtures/querygen/mod.rs`: add `parallel_leader_participation: bool` to `PgGucs` (struct, `Arbitrary` impl bumps `[bool; 10]` → `[bool; 11]`, `Default`, and `set()` emits `SET parallel_leader_participation TO {bool};`).

## Test plan

- [x] `cargo check -p tests` passes locally
- [x] Trigger an Antithesis proptests run via the `antithesis-proptests` label and confirm the new GUC shows up in the GUC dump on a failure (or a successful run with no result-mismatch errors)