### PR TITLE
feat(mpp): multi-peer-mesh AggregateScan + thread-tracking infra

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/aggregate_join_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/aggregate_join_count.sql
@@ -24,3 +24,9 @@ SET statement_timeout TO '600s'; SET work_mem TO '4GB'; SET paradedb.enable_aggr
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';
+
+-- MPP aggregate scan (ScalarAggOnBinaryJoin shape; default mpp_worker_count=4)
+SET statement_timeout TO '600s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE p.body ||| 'code';

--- a/benchmarks/datasets/stackoverflow/queries/aggregate_join_multi.sql
+++ b/benchmarks/datasets/stackoverflow/queries/aggregate_join_multi.sql
@@ -25,3 +25,10 @@ SET statement_timeout TO '600s'; SET work_mem TO '4GB'; SET paradedb.enable_aggr
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';
+
+-- MPP aggregate scan (ScalarAggOnBinaryJoin shape with multiple aggregates;
+-- default mpp_worker_count=4)
+SET statement_timeout TO '600s'; SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_mpp TO on; SELECT COUNT(*), MIN(c.score), MAX(c.score)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE p.body ||| 'code';

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-dt0rqcwNrV101vCXoOCsc4M+qiJVK/iWCG9/bttcvqY=";
+  cargoHash = "sha256-BCyJKiLiTEKX8w1QXm9BXgtNsTOsbzb8wTwdG6vYGvg=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-BCyJKiLiTEKX8w1QXm9BXgtNsTOsbzb8wTwdG6vYGvg=";
+  cargoHash = "sha256-dt0rqcwNrV101vCXoOCsc4M+qiJVK/iWCG9/bttcvqY=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -165,14 +165,22 @@ static MPP_WORKER_COUNT: GucSetting<i32> = GucSetting::<i32>::new(4);
 /// likely a per-query DSM cap than a raw per-edge byte count.
 static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024);
 
-/// Per-source-per-worker build-side cache slot size (bytes). The build-side
-/// all-gather reserves N slots of this size in DSM; total cache reservation
-/// is `n_cache_sources × n_workers × mpp_cache_per_slot`. Sized so a 1.25M-row
-/// build side encoded in Arrow IPC (~400 MB total at our 25M bench, accounting
-/// for Utf8View widening + schema overhead) fits split across N workers with
-/// headroom for the worst single-worker slice. A future heuristic should
-/// derive this from index stats per query.
-static MPP_CACHE_PER_SLOT: GucSetting<i32> = GucSetting::<i32>::new(256 * 1024 * 1024);
+/// Per-edge shm_mq queue size for the peer mesh (Track B). Sized smaller than
+/// `mpp_queue_size` because peer-mesh traffic per edge is the *partial-agg*
+/// output for one consumer's hash bucket — typically 1–10 MiB at the 25M
+/// bench, well below the 64 MiB worst-case post-agg burst on the leader-bound
+/// mesh. Total peer-mesh DSM is `n_workers² × mpp_peer_queue_bytes`: at N=8
+/// with 16 MiB that is 1 GiB per query.
+static MPP_PEER_QUEUE_BYTES: GucSetting<i32> = GucSetting::<i32>::new(16 * 1024 * 1024);
+
+/// Gate the post-aggregate peer-mesh shuffle (Track A + Track B). When off,
+/// the planner and runtime keep the single-boundary worker→leader gather and
+/// run `AggregateExec(FinalPartitioned)` single-threaded on the leader. When
+/// on, the planner emits a two-boundary plan: workers exchange partial-agg
+/// rows over the peer mesh, run `FinalPartitioned` in parallel, and the
+/// outer Coalesce becomes a pure gather. Default off; flip on once the
+/// peer-mesh transport is verified end-to-end.
+static ENABLE_MPP_POSTAGG_SHUFFLE: GucSetting<bool> = GucSetting::<bool>::new(false);
 
 /// The maximum size of an InList that can be pushed down to a TermSet Query.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
@@ -591,18 +599,31 @@ pub fn init() {
     );
 
     GucRegistry::define_int_guc(
-        c"paradedb.mpp_cache_per_slot",
-        c"Per-source-per-worker build-side cache slot size",
-        c"Sets the per-source-per-worker build-side all-gather cache slot size, in \
-          bytes. Total cache reservation per query is \
-          `n_cache_sources × n_workers × mpp_cache_per_slot`. The default 256 MiB is \
-          sized for a 1.25M-row build side encoded in Arrow IPC (~400 MB total at the \
-          25M bench scale) split across N workers; raise it for larger build sides.",
-        &MPP_CACHE_PER_SLOT,
-        1024 * 1024,
-        i32::MAX,
+        c"paradedb.mpp_peer_queue_bytes",
+        c"Per-edge shm_mq queue size for the MPP peer mesh (Track B)",
+        c"When `enable_mpp_postagg_shuffle = on`, each MPP query allocates an \
+          n_workers × n_workers peer mesh on top of the leader-bound queues. \
+          This GUC sizes one peer-mesh edge. Total peer-mesh DSM is \
+          `n_workers² × mpp_peer_queue_bytes`; at N=8 with the 16MB default \
+          that is 1GB. Lower it on memory-constrained boxes.",
+        &MPP_PEER_QUEUE_BYTES,
+        64 * 1024,
+        1024 * 1024 * 1024,
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
+    );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.enable_mpp_postagg_shuffle",
+        c"Enable the MPP post-aggregate peer-mesh shuffle (Track A + Track B)",
+        c"When on, the planner emits a two-boundary plan for aggregate-on-join \
+          MPP queries: workers exchange partial-agg rows over the peer mesh, \
+          run AggregateExec(FinalPartitioned) in parallel, and the leader's \
+          Coalesce is a pure gather. When off, the leader runs FinalPartitioned \
+          single-threaded — the current 1.47× plateau. Default off.",
+        &ENABLE_MPP_POSTAGG_SHUFFLE,
+        GucContext::Userset,
+        GucFlags::default(),
     );
 }
 
@@ -798,8 +819,12 @@ pub fn mpp_queue_size() -> usize {
     MPP_QUEUE_SIZE.get() as usize
 }
 
-pub fn mpp_cache_per_slot() -> usize {
-    MPP_CACHE_PER_SLOT.get() as usize
+pub fn mpp_peer_queue_bytes() -> usize {
+    MPP_PEER_QUEUE_BYTES.get() as usize
+}
+
+pub fn enable_mpp_postagg_shuffle() -> bool {
+    ENABLE_MPP_POSTAGG_SHUFFLE.get()
 }
 
 pub fn hash_join_inlist_pushdown_max_size() -> i32 {

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -173,6 +173,15 @@ static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024
 /// with 16 MiB that is 1 GiB per query.
 static MPP_PEER_QUEUE_BYTES: GucSetting<i32> = GucSetting::<i32>::new(16 * 1024 * 1024);
 
+/// Per-source-per-worker build-side cache slot size (bytes). The build-side
+/// all-gather reserves N slots of this size in DSM; total cache reservation
+/// is `n_cache_sources × n_workers × mpp_cache_per_slot`. Sized so a 1.25M-row
+/// build side encoded in Arrow IPC (~400 MB total at our 25M bench, accounting
+/// for Utf8View widening + schema overhead) fits split across N workers with
+/// headroom for the worst single-worker slice. A future heuristic should
+/// derive this from index stats per query.
+static MPP_CACHE_PER_SLOT: GucSetting<i32> = GucSetting::<i32>::new(256 * 1024 * 1024);
+
 /// Gate the post-aggregate peer-mesh shuffle (Track A + Track B). When off,
 /// the planner and runtime keep the single-boundary worker→leader gather and
 /// run `AggregateExec(FinalPartitioned)` single-threaded on the leader. When
@@ -613,6 +622,21 @@ pub fn init() {
         GucFlags::UNIT_BYTE,
     );
 
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_cache_per_slot",
+        c"Per-source-per-worker build-side cache slot size",
+        c"Sets the per-source-per-worker build-side all-gather cache slot size, in \
+          bytes. Total cache reservation per query is \
+          `n_cache_sources × n_workers × mpp_cache_per_slot`. The default 256 MiB is \
+          sized for a 1.25M-row build side encoded in Arrow IPC (~400 MB total at the \
+          25M bench scale) split across N workers; raise it for larger build sides.",
+        &MPP_CACHE_PER_SLOT,
+        1024 * 1024,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::UNIT_BYTE,
+    );
+
     GucRegistry::define_bool_guc(
         c"paradedb.enable_mpp_postagg_shuffle",
         c"Enable the MPP post-aggregate peer-mesh shuffle (Track A + Track B)",
@@ -821,6 +845,10 @@ pub fn mpp_queue_size() -> usize {
 
 pub fn mpp_peer_queue_bytes() -> usize {
     MPP_PEER_QUEUE_BYTES.get() as usize
+}
+
+pub fn mpp_cache_per_slot() -> usize {
+    MPP_CACHE_PER_SLOT.get() as usize
 }
 
 pub fn enable_mpp_postagg_shuffle() -> bool {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1089,7 +1089,9 @@ impl AggregateScan {
             .with_distributed_task_estimator(n_workers)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
-            .with_distributed_user_codec(PgSearchPhysicalCodecStub)
+            .with_distributed_in_process_peer_shuffle(crate::gucs::enable_mpp_postagg_shuffle())
+            .expect("with_distributed_in_process_peer_shuffle")
+            .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
             .with_distributed_planner();
         datafusion::prelude::SessionContext::new_with_state(state_builder.build())
     }
@@ -1143,9 +1145,16 @@ impl AggregateScan {
         // its hash to mpp_n_partitions × mpp_n_partitions = 81 partitions.
         let n_workers = worker.participant_config.total_participants;
         let worker_idx_for_cache = worker.participant_config.participant_index;
-        let outbound_senders: Vec<MppSender> = match df_state.mpp.as_mut() {
-            Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
-            _ => unreachable!(),
+        let outbound_senders: Vec<crate::postgres::customscan::mpp::transport::MppSender> =
+            match df_state.mpp.as_mut() {
+                Some(scan_state::MppExecState::Worker(w)) => {
+                    std::mem::take(&mut w.outbound_senders)
+                }
+                _ => unreachable!(),
+            };
+        let peer_mesh = match df_state.mpp.as_ref() {
+            Some(scan_state::MppExecState::Worker(w)) => w.peer_mesh.as_ref().map(Arc::clone),
+            _ => None,
         };
 
         let runtime = match tokio::runtime::Builder::new_current_thread()
@@ -1207,28 +1216,55 @@ impl AggregateScan {
         // `build_mpp_leader_session_context`); otherwise the worker re-plans
         // a different shape and `find_worker_fragment` returns None.
         let n_workers_us = n_workers as usize;
+        // Stamp DistributedTaskContext { task_index, task_count } so the fork's
+        // NetworkShuffleExec.execute computes per-task partition slices correctly.
+        // Without this, every worker reads off=0 and produces all N global
+        // partitions itself, so workers send duplicate data to the leader.
+        let task_ctx_ext = std::sync::Arc::new(datafusion_distributed::DistributedTaskContext {
+            task_index: worker_idx_for_cache as usize,
+            task_count: n_workers_us,
+        });
         let cfg = ctx
             .copied_config()
-            .with_target_partitions(n_workers_us.max(2));
+            .with_target_partitions(n_workers_us.max(2))
+            .with_extension(task_ctx_ext);
+        use datafusion::execution::SessionStateBuilder;
+        use datafusion_distributed::SessionStateBuilderExt;
         let state_builder = SessionStateBuilder::new()
             .with_default_features()
             .with_config(cfg)
-            .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers_us))
-            // Workers may encounter nested network boundaries inside the
-            // producer fragment (e.g. a `NetworkBroadcastExec` on the build
-            // side of a `HashJoin`). Without a transport registered, the
-            // default `FlightWorkerTransport` would try to dial the empty
-            // URL and error out. The `LocalExecWorkerTransport` re-executes
-            // the boundary's input subtree locally — duplicates the build
-            // scan across workers, but for small index scans that's cheap
-            // and keeps the in-process design self-contained.
-            .with_distributed_worker_transport(LocalExecWorkerTransport)
+            .with_distributed_worker_resolver(
+                crate::postgres::customscan::mpp::runtime::MppWorkerResolver::new(n_workers_us),
+            )
+            // Workers may encounter two kinds of nested network boundaries
+            // inside the producer fragment:
+            //   1. `NetworkBroadcastExec` on the build side of a HashJoin —
+            //      input_stage.tasks.len() == 1, no peer mesh needed; the
+            //      composite routes to `LocalExecWorkerTransport` which
+            //      re-executes the build subtree locally.
+            //   2. `NetworkShuffleExec` for the post-agg peer mesh (Track B,
+            //      gated by `enable_mpp_postagg_shuffle`) — input_stage.tasks
+            //      .len() == n_workers > 1; the composite routes to
+            //      `ShmMqPeerWorkerTransport` which streams from the peer
+            //      mesh column for this worker.
+            // When the GUC is off, no peer mesh was reserved at DSM init
+            // time and `peer_mesh` is `None`; `tasks.len() > 1` paths then
+            // surface an internal error (currently unreachable because the
+            // fork only emits the inner peer-mesh boundary when the flag
+            // is on, and the build-side broadcast keeps tasks.len() == 1).
+            .with_distributed_worker_transport(
+                crate::postgres::customscan::mpp::runtime::CompositeWorkerTransport::new(
+                    peer_mesh.clone(),
+                ),
+            )
             .with_distributed_in_process_mode(true)
             .expect("with_distributed_in_process_mode")
             .with_distributed_task_estimator(n_workers_us)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
-            .with_distributed_user_codec(PgSearchPhysicalCodecStub)
+            .with_distributed_in_process_peer_shuffle(crate::gucs::enable_mpp_postagg_shuffle())
+            .expect("with_distributed_in_process_peer_shuffle")
+            .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
             .with_distributed_planner();
         let session_state = state_builder.build();
         let session = datafusion::prelude::SessionContext::new_with_state(session_state);
@@ -1268,10 +1304,74 @@ impl AggregateScan {
             unsafe { pg_sys::work_mem as usize * 1024 },
             unsafe { pg_sys::hash_mem_multiplier },
         );
-        let result = runtime
-            .block_on(async { run_producer_fragment(fragment, outbound_senders, task_ctx).await });
+
+        // Two-boundary mode (Track A + Track B): spawn the inner peer-mesh
+        // producer fragment alongside the outer worker→leader fragment.
+        // The inner fragment pushes hash-partitioned partial-agg rows into
+        // peer_outbound (tagged by partition_id); the outer fragment runs
+        // FinalPartitioned by pulling from the peer mesh and pushes the
+        // final-aggregated rows into the leader-bound mesh.
+        //
+        // Detection: a two-boundary plan has 2+ NetworkShuffleExec nodes
+        // (the OUTER gather + the INNER peer-mesh) AND a registered peer
+        // mesh on the worker side. Single-boundary plans have exactly one
+        // NetworkShuffleExec and no peer mesh.
+        let inner_fragment =
+            if peer_mesh.is_some() && Self::count_network_shuffles(&physical_plan) >= 2 {
+                Self::find_inner_producer_fragment(&physical_plan)
+            } else {
+                None
+            };
+
+        let result = runtime.block_on(async {
+            match (inner_fragment, peer_mesh.as_ref()) {
+                (Some(inner), Some(mesh)) => {
+                    let peer_outbound = mesh.take_outbound().ok_or_else(|| {
+                        datafusion::common::DataFusionError::Internal(
+                            "mpp worker: peer mesh outbound senders already taken".into(),
+                        )
+                    })?;
+                    let n_consumers = mesh.n_workers as usize;
+                    let inner_task_ctx = build_task_context(
+                        &session,
+                        &inner,
+                        unsafe { pg_sys::work_mem as usize * 1024 },
+                        unsafe { pg_sys::hash_mem_multiplier },
+                    );
+                    // Run both fragments concurrently on the worker's
+                    // current_thread Tokio runtime. The cooperative drains
+                    // interleave correctly: when the outer fragment awaits
+                    // peer-mesh data, the runtime polls the inner fragment
+                    // which pushes a batch, which then unblocks the outer
+                    // fragment's pull.
+                    let inner_fut =
+                        crate::postgres::customscan::mpp::exec::run_inner_producer_fragment(
+                            inner,
+                            peer_outbound,
+                            n_consumers,
+                            inner_task_ctx,
+                        );
+                    let outer_fut = crate::postgres::customscan::mpp::exec::run_producer_fragment(
+                        fragment,
+                        outbound_senders,
+                        task_ctx,
+                    );
+                    let (inner_res, outer_res) = futures::join!(inner_fut, outer_fut);
+                    inner_res?;
+                    outer_res
+                }
+                _ => {
+                    crate::postgres::customscan::mpp::exec::run_producer_fragment(
+                        fragment,
+                        outbound_senders,
+                        task_ctx,
+                    )
+                    .await
+                }
+            }
+        });
         if let Err(e) = result {
-            pgrx::error!("mpp worker: run_producer_fragment failed: {e}");
+            pgrx::error!("mpp worker: producer fragment(s) failed: {e}");
         }
         std::ptr::null_mut()
     }
@@ -1282,12 +1382,9 @@ impl AggregateScan {
     ///
     /// Pre-order traversal returns on the first match, which is the
     /// outermost shuffle — the one that straddles the worker→leader split.
-    /// Nested `NetworkShuffleExec`s inside the worker fragment (e.g. the
-    /// shuffles `HashJoinExec(Partitioned)` inserts on each side once the
-    /// build side crosses `hash_join_single_partition_threshold`) are
-    /// re-executed locally by `LocalExecWorkerTransport` at execute time,
-    /// so the worker only needs to find the outermost one.
-    fn find_worker_fragment(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
+    fn find_worker_fragment(
+        plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    ) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
         if plan.name() == "NetworkShuffleExec" {
             return plan.children().first().map(|c| Arc::clone(c));
         }
@@ -1297,6 +1394,46 @@ impl AggregateScan {
             }
         }
         None
+    }
+
+    /// Walk a DistributedExec-rooted plan and return the input subtree of
+    /// the **bottommost** `NetworkShuffleExec` (the inner peer-mesh
+    /// producer fragment for two-boundary plans).
+    ///
+    /// In single-boundary mode (one shuffle) this returns the same subtree
+    /// as `find_worker_fragment`. In two-boundary mode (Track A's gather +
+    /// peer-mesh shuffle) this returns the input of the inner shuffle —
+    /// `RepartitionExec(Hash, N²) → AggregateExec(Partial) → ...` — which
+    /// is the data each worker pushes to the peer mesh.
+    fn find_inner_producer_fragment(
+        plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    ) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+        // Recurse first so the deepest `NetworkShuffleExec` wins (post-order).
+        for child in plan.children() {
+            if let Some(found) = Self::find_inner_producer_fragment(child) {
+                return Some(found);
+            }
+        }
+        if plan.name() == "NetworkShuffleExec" {
+            return plan.children().first().map(|c| Arc::clone(c));
+        }
+        None
+    }
+
+    /// Identifier for the boundary kinds currently emitted by the fork's
+    /// `_distribute_plan`. Used to disambiguate single-boundary vs
+    /// two-boundary plans when deciding whether to spawn the inner
+    /// peer-mesh producer fragment.
+    fn count_network_shuffles(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> usize {
+        let mut count = if plan.name() == "NetworkShuffleExec" {
+            1
+        } else {
+            0
+        };
+        for child in plan.children() {
+            count += Self::count_network_shuffles(child);
+        }
+        count
     }
 
     /// Existing single-table Tantivy aggregate path.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1172,14 +1172,11 @@ impl AggregateScan {
                 }
                 _ => unreachable!(),
             };
-        // For now (with the fork's `!has_shuffle_ancestor` guard) the planner
-        // emits at most one nested cross-worker shuffle, so peer_meshes is
-        // either empty or has length 1. Take the first as the active peer
-        // mesh; G2 will swap this scalar for a stage-id-keyed map.
-        let peer_mesh = match df_state.mpp.as_ref() {
-            Some(scan_state::MppExecState::Worker(w)) => w.peer_meshes.first().map(Arc::clone),
-            _ => None,
-        };
+        let peer_meshes: Vec<Arc<crate::postgres::customscan::mpp::mesh::MppPeerMesh>> =
+            match df_state.mpp.as_ref() {
+                Some(scan_state::MppExecState::Worker(w)) => w.peer_meshes.clone(),
+                _ => Vec::new(),
+            };
 
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -1252,6 +1249,10 @@ impl AggregateScan {
             .copied_config()
             .with_target_partitions(n_workers_us.max(2))
             .with_extension(task_ctx_ext);
+        // Shared stage→peer-mesh routing map for the worker's
+        // `CompositeWorkerTransport`. Empty until populated below.
+        let shared_routes =
+            crate::postgres::customscan::mpp::runtime::CompositeWorkerTransport::empty_routes();
         use datafusion::execution::SessionStateBuilder;
         use datafusion_distributed::SessionStateBuilderExt;
         let state_builder = SessionStateBuilder::new()
@@ -1271,14 +1272,15 @@ impl AggregateScan {
             //      .len() == n_workers > 1; the composite routes to
             //      `ShmMqPeerWorkerTransport` which streams from the peer
             //      mesh column for this worker.
-            // When the GUC is off, no peer mesh was reserved at DSM init
-            // time and `peer_mesh` is `None`; `tasks.len() > 1` paths then
-            // surface an internal error (currently unreachable because the
-            // fork only emits the inner peer-mesh boundary when the flag
-            // is on, and the build-side broadcast keeps tasks.len() == 1).
+            // When the GUC is off (or the planner emits no nested
+            // cross-worker shuffles) the shared map stays empty and every
+            // `NetworkShuffleExec` falls through to `LocalExecWorkerTransport`.
+            // The map is populated below, AFTER the physical plan is built,
+            // by walking the worker fragment for nested `NetworkShuffleExec`
+            // stage IDs and zipping with the worker's `peer_meshes` Vec.
             .with_distributed_worker_transport(
                 crate::postgres::customscan::mpp::runtime::CompositeWorkerTransport::new(
-                    peer_mesh.clone(),
+                    Arc::clone(&shared_routes),
                 ),
             )
             .with_distributed_in_process_mode(true)
@@ -1322,6 +1324,26 @@ impl AggregateScan {
                 return std::ptr::null_mut();
             }
         };
+
+        // Populate the shared stage→peer-mesh routing map now that the
+        // physical plan is in hand. Walk the worker fragment for nested
+        // `NetworkShuffleExec` stage IDs (deterministic across leader and
+        // worker), zip with the leader's allocated `peer_meshes` Vec.
+        // Mismatch is a hard error since it indicates the leader and
+        // worker disagree on plan shape.
+        let inner_stage_ids =
+            crate::postgres::customscan::mpp::runtime::collect_inner_shuffle_stage_ids(&fragment);
+        match crate::postgres::customscan::mpp::runtime::build_stage_to_mesh_map(
+            &inner_stage_ids,
+            &peer_meshes,
+        ) {
+            Ok(map) => {
+                *shared_routes.write() = map;
+            }
+            Err(e) => {
+                pgrx::error!("mpp worker: failed to build stage→mesh routing: {e}");
+            }
+        }
         let task_ctx = build_task_context(
             &session,
             &fragment,
@@ -1336,19 +1358,18 @@ impl AggregateScan {
         // FinalPartitioned by pulling from the peer mesh and pushes the
         // final-aggregated rows into the leader-bound mesh.
         //
-        // Detection: a two-boundary plan has 2+ NetworkShuffleExec nodes
-        // (the OUTER gather + the INNER peer-mesh) AND a registered peer
-        // mesh on the worker side. Single-boundary plans have exactly one
-        // NetworkShuffleExec and no peer mesh.
+        // For now (with the fork's `!has_shuffle_ancestor` guard) at most
+        // one peer-mesh shuffle is in play. G3 will replace this with K
+        // concurrent inner-fragment runners.
         let inner_fragment =
-            if peer_mesh.is_some() && Self::count_network_shuffles(&physical_plan) >= 2 {
+            if !peer_meshes.is_empty() && Self::count_network_shuffles(&physical_plan) >= 2 {
                 Self::find_inner_producer_fragment(&physical_plan)
             } else {
                 None
             };
 
         let result = runtime.block_on(async {
-            match (inner_fragment, peer_mesh.as_ref()) {
+            match (inner_fragment, peer_meshes.first()) {
                 (Some(inner), Some(mesh)) => {
                     let peer_outbound = mesh.take_outbound().ok_or_else(|| {
                         datafusion::common::DataFusionError::Internal(

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -753,11 +753,18 @@ impl ParallelQueryCapable for AggregateScan {
         let mpp_offset = mpp_align(mpp_agg_pscan_offset() + pscan_size);
 
         // Number of non-partitioning sources gets a build-cache slot per worker.
-        let n_cache_sources = state
-            .custom_state()
-            .source_manifests
-            .len()
-            .saturating_sub(1) as u32;
+        // Skipped in peer-shuffle mode: the non-partitioning source is sliced
+        // per worker via `slice_segment_ids_round_robin`, so the all-gather
+        // is unused.
+        let n_cache_sources = if crate::gucs::enable_mpp_postagg_shuffle() {
+            0
+        } else {
+            state
+                .custom_state()
+                .source_manifests
+                .len()
+                .saturating_sub(1) as u32
+        };
         // K peer meshes: counted in `stash_mpp_plan_bytes` by walking a stub
         // physical plan. Equals (total NetworkShuffleExecs - 1) since the
         // OUTER (gather) uses the leader-bound mesh. 0 when the post-agg
@@ -855,6 +862,12 @@ impl ParallelQueryCapable for AggregateScan {
             .source_manifests
             .len()
             .saturating_sub(1) as u32;
+        // Match the gating in `estimate_dsm_custom_scan`.
+        let n_cache_sources = if crate::gucs::enable_mpp_postagg_shuffle() {
+            0
+        } else {
+            n_cache_sources
+        };
         let n_peer_meshes: u32 = state
             .custom_state()
             .datafusion_state
@@ -1286,8 +1299,28 @@ impl AggregateScan {
         // (workers will then claim individual segments via `checkout_segment`
         // inside their `PgSearchTableProvider`). For non-partitioning sources,
         // use the segment IDs the leader snapshotted into shared memory.
-        let mut index_segment_ids: Vec<HashSet<tantivy::index::SegmentId>> =
-            vec![HashSet::default(); plan_sources_count];
+        // In peer-shuffle mode, the build-cache all-gather (which replicates
+        // the non-partitioning source data to every worker) becomes a hard
+        // correctness bug: every worker independently runs
+        // `RepartitionExec(Hash([id]))` on its full copy of the build, so
+        // every producer emits the SAME data into the peer mesh and consumers
+        // see N copies of every row. Slice the non-partitioning segment IDs
+        // round-robin per worker so each scans only its 1/N slice — same
+        // model the partitioning source already uses.
+        let peer_shuffle_on = crate::gucs::enable_mpp_postagg_shuffle();
+        let non_partitioning_segments: Vec<crate::api::HashSet<tantivy::index::SegmentId>> =
+            if peer_shuffle_on {
+                non_partitioning_segments
+                    .iter()
+                    .map(|ids| {
+                        Self::slice_segment_ids_round_robin(ids, worker_idx_for_cache, n_workers)
+                    })
+                    .collect()
+            } else {
+                non_partitioning_segments
+            };
+        let mut index_segment_ids: Vec<crate::api::HashSet<tantivy::index::SegmentId>> =
+            vec![crate::api::HashSet::default(); plan_sources_count];
         if let Some(ps) = parallel_state {
             let mut np_counter = 0usize;
             for (i, slot) in index_segment_ids.iter_mut().enumerate() {
@@ -1300,9 +1333,16 @@ impl AggregateScan {
             }
         }
 
-        let mpp_build_cache = match df_state.mpp.as_ref() {
-            Some(scan_state::MppExecState::Worker(w)) => w.build_cache.as_ref().map(Arc::clone),
-            _ => None,
+        // Skip the build-cache in peer-shuffle mode (each worker has its own
+        // 1/N slice of the non-partitioning source thanks to the slicing
+        // above; there's nothing to all-gather).
+        let mpp_build_cache = if peer_shuffle_on {
+            None
+        } else {
+            match df_state.mpp.as_ref() {
+                Some(scan_state::MppExecState::Worker(w)) => w.build_cache.as_ref().map(Arc::clone),
+                _ => None,
+            }
         };
         let logical = match deserialize_logical_plan_with_runtime(
             &plan_bytes,
@@ -1535,6 +1575,37 @@ impl AggregateScan {
             }
         }
         None
+    }
+
+    /// Slice a non-partitioning source's canonical segment IDs round-robin
+    /// across workers. `worker_idx` keeps every Nth segment (sorted by uuid
+    /// for determinism) starting at `worker_idx`. Used in peer-shuffle mode
+    /// so each worker scans only its 1/N slice of an otherwise-replicated
+    /// source — the build-cache all-gather is bypassed.
+    ///
+    /// Falls back to the full set when `n_segments < n_workers`: at that
+    /// scale, slicing would leave most workers with zero segments and any
+    /// `HashJoinExec(CollectLeft)` consumer that locally re-executes its
+    /// build subtree (via `LocalExecWorkerTransport`) would observe an
+    /// empty build → empty join → empty result. Replicating the full set
+    /// at small scale is correct (and N× is negligible when the source is
+    /// tiny anyway).
+    fn slice_segment_ids_round_robin(
+        ids: &crate::api::HashSet<tantivy::index::SegmentId>,
+        worker_idx: u32,
+        n_workers: u32,
+    ) -> crate::api::HashSet<tantivy::index::SegmentId> {
+        if n_workers <= 1 || (ids.len() as u32) < n_workers {
+            return ids.clone();
+        }
+        let mut sorted: Vec<tantivy::index::SegmentId> = ids.iter().copied().collect();
+        sorted.sort_by_key(|id| id.uuid_string());
+        sorted
+            .into_iter()
+            .enumerate()
+            .filter(|(i, _)| (*i as u32) % n_workers == worker_idx)
+            .map(|(_, id)| id)
+            .collect()
     }
 
     /// Existing single-table Tantivy aggregate path.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -393,6 +393,7 @@ impl CustomScan for AggregateScan {
                     mpp: None,
                     mpp_plan_bytes: None,
                     mpp_n_partitions: 1,
+                    mpp_n_peer_meshes: 0,
                 });
                 builder.build()
             }
@@ -638,6 +639,79 @@ fn mpp_align(n: usize) -> usize {
     n.next_multiple_of(a)
 }
 
+/// Build a stub physical plan from `logical` using the same fork knobs the
+/// real leader uses, then count nested cross-worker `NetworkShuffleExec`
+/// stages — i.e., total `NetworkShuffleExec` minus the OUTER (gather).
+/// Returns 0 on any planning failure so the MPP path falls back gracefully.
+///
+/// Used by `stash_mpp_plan_bytes` to size the DSM peer-mesh array (K) before
+/// the leader allocates DSM. The plan is built once per query and discarded;
+/// the leader rebuilds it for execution after `leader_setup` completes.
+fn count_peer_mesh_shuffles(
+    runtime: &tokio::runtime::Runtime,
+    logical: &datafusion::logical_expr::LogicalPlan,
+    n_workers: u32,
+) -> u32 {
+    use datafusion::execution::SessionStateBuilder;
+    use datafusion_distributed::SessionStateBuilderExt;
+    let n_workers_us = n_workers as usize;
+    let serial = create_aggregate_session_context();
+    let cfg = serial
+        .copied_config()
+        .with_target_partitions(n_workers_us.max(2));
+    let state_builder = SessionStateBuilder::new()
+        .with_default_features()
+        .with_config(cfg)
+        .with_distributed_worker_resolver(
+            crate::postgres::customscan::mpp::runtime::MppWorkerResolver::new(n_workers_us),
+        )
+        // The fork's `is_in_process()` predicate gates peer-shuffle emission
+        // on a registered `WorkerTransport`. Use the bare LocalExec stub —
+        // the plan is built and discarded for counting only, never executed,
+        // so `LocalExecWorkerTransport.open()` is never invoked.
+        .with_distributed_worker_transport(
+            crate::postgres::customscan::mpp::runtime::LocalExecWorkerTransport,
+        )
+        .with_distributed_task_estimator(n_workers_us)
+        .with_distributed_broadcast_joins(true)
+        .ok();
+    let Some(state_builder) = state_builder else {
+        return 0;
+    };
+    let state_builder = match state_builder.with_distributed_in_process_peer_shuffle(true) {
+        Ok(b) => b,
+        Err(_) => return 0,
+    };
+    let state_builder = state_builder
+        .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
+        .with_distributed_planner();
+    let state = state_builder.build();
+    let session = datafusion::prelude::SessionContext::new_with_state(state);
+
+    let physical =
+        match runtime.block_on(async { session.state().create_physical_plan(logical).await }) {
+            Ok(p) => p,
+            Err(_) => return 0,
+        };
+    let total = count_network_shuffles_in(&physical);
+    // Subtract 1 for the OUTER (gather) shuffle, which uses the leader-bound
+    // mesh, not a peer mesh. If the planner didn't emit any (K=0), the
+    // saturating_sub keeps us safe.
+    total.saturating_sub(1)
+}
+
+fn count_network_shuffles_in(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> u32 {
+    let mut count = if plan.name() == "NetworkShuffleExec" {
+        1
+    } else {
+        0
+    };
+    for child in plan.children() {
+        count += count_network_shuffles_in(child);
+    }
+    count
+}
+
 fn mpp_agg_pscan_offset() -> usize {
     mpp_align(MPP_AGG_DSM_HEADER_SIZE)
 }
@@ -684,15 +758,16 @@ impl ParallelQueryCapable for AggregateScan {
             .source_manifests
             .len()
             .saturating_sub(1) as u32;
-        // K peer meshes: 1 when post-agg shuffle is on (the post-aggregate
-        // peer mesh), 0 otherwise. The runtime substrate is K-aware (Vec<MppPeerMesh>);
-        // the planner side currently emits at most 1 nested cross-worker shuffle
-        // (the `!has_shuffle_ancestor` guard in fork's `_distribute_plan`).
-        let n_peer_meshes: u32 = if crate::gucs::enable_mpp_postagg_shuffle() {
-            1
-        } else {
-            0
-        };
+        // K peer meshes: counted in `stash_mpp_plan_bytes` by walking a stub
+        // physical plan. Equals (total NetworkShuffleExecs - 1) since the
+        // OUTER (gather) uses the leader-bound mesh. 0 when the post-agg
+        // shuffle GUC is off.
+        let n_peer_meshes: u32 = state
+            .custom_state()
+            .datafusion_state
+            .as_ref()
+            .map(|d| d.mpp_n_peer_meshes)
+            .unwrap_or(0);
         let mpp_size = match crate::postgres::customscan::mpp::glue::estimate_dsm_size(
             plan_bytes_len,
             n_partitions,
@@ -780,11 +855,12 @@ impl ParallelQueryCapable for AggregateScan {
             .source_manifests
             .len()
             .saturating_sub(1) as u32;
-        let n_peer_meshes: u32 = if crate::gucs::enable_mpp_postagg_shuffle() {
-            1
-        } else {
-            0
-        };
+        let n_peer_meshes: u32 = state
+            .custom_state()
+            .datafusion_state
+            .as_ref()
+            .map(|d| d.mpp_n_peer_meshes)
+            .unwrap_or(0);
         let leader = match unsafe {
             leader_setup(
                 mpp_coordinate,
@@ -1070,6 +1146,19 @@ impl AggregateScan {
         // n_workers (matching `build_mpp_leader_session_context`).
         let n_workers = producer_worker_count();
         df_state.mpp_n_partitions = n_workers.max(1);
+
+        // K-aware peer-mesh sizing: if the post-agg peer-shuffle GUC is on,
+        // build a stub physical plan to count how many cross-worker
+        // `NetworkShuffleExec` stages the planner emits. The OUTER (gather)
+        // is always present and uses the leader-bound mesh; every other
+        // `NetworkShuffleExec` becomes a peer-mesh stage. Once the fork's
+        // `!has_shuffle_ancestor` guard is dropped, this count climbs
+        // beyond 1 for plans like aggregate-on-(HashJoinExec(Partitioned)).
+        df_state.mpp_n_peer_meshes = if crate::gucs::enable_mpp_postagg_shuffle() {
+            count_peer_mesh_shuffles(&runtime, &logical, n_workers)
+        } else {
+            0
+        };
     }
 
     /// MPP leader exec helper: build a `SessionContext` that mirrors

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -642,7 +642,7 @@ fn mpp_align(n: usize) -> usize {
     n.next_multiple_of(a)
 }
 
-/// Build a stub physical plan from `logical` using the same fork knobs the
+/// Build a stub physical plan from `logical` using the same DF-D fork knobs the
 /// real leader uses, then count nested cross-worker `NetworkShuffleExec`
 /// stages — i.e., total `NetworkShuffleExec` minus the OUTER (gather).
 /// Returns 0 on any planning failure so the MPP path falls back gracefully.
@@ -1160,7 +1160,7 @@ impl AggregateScan {
         // build a stub physical plan to count how many cross-worker
         // `NetworkShuffleExec` stages the planner emits. The OUTER (gather)
         // is always present and uses the leader-bound mesh; every other
-        // `NetworkShuffleExec` becomes a peer-mesh stage. Once the fork's
+        // `NetworkShuffleExec` becomes a peer-mesh stage. Once the DF-D fork's
         // `!has_shuffle_ancestor` guard is dropped, this count climbs
         // beyond 1 for plans like aggregate-on-(HashJoinExec(Partitioned)).
         df_state.mpp_n_peer_meshes = if gucs::enable_mpp_postagg_shuffle() {
@@ -1370,7 +1370,7 @@ impl AggregateScan {
         // `build_mpp_leader_session_context`); otherwise the worker re-plans
         // a different shape and `find_worker_fragment` returns None.
         let n_workers_us = n_workers as usize;
-        // Stamp DistributedTaskContext { task_index, task_count } so the fork's
+        // Stamp DistributedTaskContext { task_index, task_count } so the DF-D fork's
         // NetworkShuffleExec.execute computes per-task partition slices correctly.
         // Without this, every worker reads off=0 and produces all N global
         // partitions itself, so workers send duplicate data to the leader.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1239,6 +1239,12 @@ impl AggregateScan {
             Ok(p) => p,
             Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
         };
+        if crate::gucs::mpp_debug() && worker_idx_for_cache == 0 {
+            let dumped = datafusion::physical_plan::displayable(physical_plan.as_ref())
+                .indent(true)
+                .to_string();
+            pgrx::warning!("mpp worker[0] physical plan:\n{dumped}");
+        }
         // Find the bottom NetworkShuffleExec; its input_stage.plan (==
         // children()[0]) is the worker fragment. If the DF-D fork's planner
         // didn't insert one (some plan shapes don't benefit from a network

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -40,18 +40,21 @@ use std::sync::Arc;
 
 use datafusion::execution::SessionStateBuilder;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::{DistributedExt, SessionStateBuilderExt};
+use datafusion_distributed::{DistributedExt, DistributedTaskContext, SessionStateBuilderExt};
 
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
-use crate::postgres::customscan::mpp::exec::run_producer_fragment;
+use crate::postgres::customscan::mpp::exec::run_inner_producer_fragment;
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_is_active, mpp_worker_count, producer_worker_count,
     worker_setup,
 };
+use crate::postgres::customscan::mpp::mesh::MppPeerMesh;
 use crate::postgres::customscan::mpp::runtime::{
-    LocalExecWorkerTransport, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
+    build_stage_to_mesh_map, collect_inner_producer_fragments, collect_inner_shuffle_stage_ids,
+    CompositeWorkerTransport, LocalExecWorkerTransport, MppMesh, MppWorkerResolver,
+    ShmMqWorkerTransport,
 };
-use crate::postgres::customscan::mpp::transport::MppSender;
+use crate::postgres::customscan::mpp::transport::{mark_backend_thread, MppSender};
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
@@ -652,8 +655,6 @@ fn count_peer_mesh_shuffles(
     logical: &datafusion::logical_expr::LogicalPlan,
     n_workers: u32,
 ) -> u32 {
-    use datafusion::execution::SessionStateBuilder;
-    use datafusion_distributed::SessionStateBuilderExt;
     let n_workers_us = n_workers as usize;
     let serial = create_aggregate_session_context();
     let cfg = serial
@@ -662,16 +663,12 @@ fn count_peer_mesh_shuffles(
     let state_builder = SessionStateBuilder::new()
         .with_default_features()
         .with_config(cfg)
-        .with_distributed_worker_resolver(
-            crate::postgres::customscan::mpp::runtime::MppWorkerResolver::new(n_workers_us),
-        )
+        .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers_us))
         // Peer-shuffle emission requires in-process mode. The bare LocalExec
         // stub is registered so the planner has a transport to dispatch
         // through, but the plan here is built and discarded for counting
         // only, never executed.
-        .with_distributed_worker_transport(
-            crate::postgres::customscan::mpp::runtime::LocalExecWorkerTransport,
-        );
+        .with_distributed_worker_transport(LocalExecWorkerTransport);
     let state_builder = match state_builder.with_distributed_in_process_mode(true) {
         Ok(b) => b,
         Err(_) => return 0,
@@ -703,7 +700,7 @@ fn count_peer_mesh_shuffles(
     total.saturating_sub(1)
 }
 
-fn count_network_shuffles_in(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> u32 {
+fn count_network_shuffles_in(plan: &Arc<dyn ExecutionPlan>) -> u32 {
     let mut count = if plan.name() == "NetworkShuffleExec" {
         1
     } else {
@@ -778,18 +775,14 @@ impl ParallelQueryCapable for AggregateScan {
             .as_ref()
             .map(|d| d.mpp_n_peer_meshes)
             .unwrap_or(0);
-        let mpp_size = match crate::postgres::customscan::mpp::glue::estimate_dsm_size(
-            plan_bytes_len,
-            n_partitions,
-            n_cache_sources,
-            n_peer_meshes,
-        ) {
-            Ok(sz) => sz,
-            Err(e) => {
-                pgrx::warning!("mpp: estimate_dsm failed: {e}; falling back to serial");
-                return 0;
-            }
-        };
+        let mpp_size =
+            match estimate_dsm_size(plan_bytes_len, n_partitions, n_cache_sources, n_peer_meshes) {
+                Ok(sz) => sz,
+                Err(e) => {
+                    pgrx::warning!("mpp: estimate_dsm failed: {e}; falling back to serial");
+                    return 0;
+                }
+            };
 
         (mpp_offset + mpp_size) as pg_sys::Size
     }
@@ -1233,7 +1226,7 @@ impl AggregateScan {
         // drain spin's `pgrx::check_for_interrupts!()` is gated to it
         // (compute futures running on the multi-thread Tokio runtime skip
         // the check).
-        crate::postgres::customscan::mpp::transport::mark_backend_thread();
+        mark_backend_thread();
         // Pull worker-thread inputs from the outer state before we borrow
         // df_state mutably. parallel_state and non_partitioning_segments
         // are required to pin each worker's PgSearchTableProvider to the
@@ -1275,18 +1268,14 @@ impl AggregateScan {
         // its hash to mpp_n_partitions × mpp_n_partitions = 81 partitions.
         let n_workers = worker.participant_config.total_participants;
         let worker_idx_for_cache = worker.participant_config.participant_index;
-        let outbound_senders: Vec<crate::postgres::customscan::mpp::transport::MppSender> =
-            match df_state.mpp.as_mut() {
-                Some(scan_state::MppExecState::Worker(w)) => {
-                    std::mem::take(&mut w.outbound_senders)
-                }
-                _ => unreachable!(),
-            };
-        let peer_meshes: Vec<Arc<crate::postgres::customscan::mpp::mesh::MppPeerMesh>> =
-            match df_state.mpp.as_ref() {
-                Some(scan_state::MppExecState::Worker(w)) => w.peer_meshes.clone(),
-                _ => Vec::new(),
-            };
+        let outbound_senders: Vec<MppSender> = match df_state.mpp.as_mut() {
+            Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
+            _ => unreachable!(),
+        };
+        let peer_meshes: Vec<Arc<MppPeerMesh>> = match df_state.mpp.as_ref() {
+            Some(scan_state::MppExecState::Worker(w)) => w.peer_meshes.clone(),
+            _ => Vec::new(),
+        };
 
         // Single-threaded Tokio runtime is the current safe default —
         // pgrx 0.18 auto-wraps every `pg_sys::*` FFI call with
@@ -1385,7 +1374,7 @@ impl AggregateScan {
         // NetworkShuffleExec.execute computes per-task partition slices correctly.
         // Without this, every worker reads off=0 and produces all N global
         // partitions itself, so workers send duplicate data to the leader.
-        let task_ctx_ext = std::sync::Arc::new(datafusion_distributed::DistributedTaskContext {
+        let task_ctx_ext = std::sync::Arc::new(DistributedTaskContext {
             task_index: worker_idx_for_cache as usize,
             task_count: n_workers_us,
         });
@@ -1395,16 +1384,11 @@ impl AggregateScan {
             .with_extension(task_ctx_ext);
         // Shared stage→peer-mesh routing map for the worker's
         // `CompositeWorkerTransport`. Empty until populated below.
-        let shared_routes =
-            crate::postgres::customscan::mpp::runtime::CompositeWorkerTransport::empty_routes();
-        use datafusion::execution::SessionStateBuilder;
-        use datafusion_distributed::SessionStateBuilderExt;
+        let shared_routes = CompositeWorkerTransport::empty_routes();
         let state_builder = SessionStateBuilder::new()
             .with_default_features()
             .with_config(cfg)
-            .with_distributed_worker_resolver(
-                crate::postgres::customscan::mpp::runtime::MppWorkerResolver::new(n_workers_us),
-            )
+            .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers_us))
             // Workers may encounter two kinds of nested network boundaries
             // inside the producer fragment:
             //   1. `NetworkBroadcastExec` on the build side of a HashJoin —
@@ -1422,11 +1406,9 @@ impl AggregateScan {
             // The map is populated below, AFTER the physical plan is built,
             // by walking the worker fragment for nested `NetworkShuffleExec`
             // stage IDs and zipping with the worker's `peer_meshes` Vec.
-            .with_distributed_worker_transport(
-                crate::postgres::customscan::mpp::runtime::CompositeWorkerTransport::new(
-                    Arc::clone(&shared_routes),
-                ),
-            )
+            .with_distributed_worker_transport(CompositeWorkerTransport::new(Arc::clone(
+                &shared_routes,
+            )))
             .with_distributed_in_process_mode(true)
             .expect("with_distributed_in_process_mode")
             .with_distributed_task_estimator(n_workers_us)
@@ -1475,12 +1457,8 @@ impl AggregateScan {
         // worker), zip with the leader's allocated `peer_meshes` Vec.
         // Mismatch is a hard error since it indicates the leader and
         // worker disagree on plan shape.
-        let inner_stage_ids =
-            crate::postgres::customscan::mpp::runtime::collect_inner_shuffle_stage_ids(&fragment);
-        match crate::postgres::customscan::mpp::runtime::build_stage_to_mesh_map(
-            &inner_stage_ids,
-            &peer_meshes,
-        ) {
+        let inner_stage_ids = collect_inner_shuffle_stage_ids(&fragment);
+        match build_stage_to_mesh_map(&inner_stage_ids, &peer_meshes) {
             Ok(map) => {
                 *shared_routes.write() = map;
             }
@@ -1511,8 +1489,7 @@ impl AggregateScan {
         // same pre-order DFS that `collect_inner_shuffle_stage_ids` uses
         // to build the routing map; the lengths must match (already
         // validated by `build_stage_to_mesh_map`).
-        let inner_fragments =
-            crate::postgres::customscan::mpp::runtime::collect_inner_producer_fragments(&fragment);
+        let inner_fragments = collect_inner_producer_fragments(&fragment);
         if inner_fragments.len() != peer_meshes.len() {
             pgrx::error!(
                 "mpp worker: inner-fragment count ({}) != peer-mesh count ({})",
@@ -1548,14 +1525,12 @@ impl AggregateScan {
                     unsafe { pg_sys::work_mem as usize * 1024 },
                     unsafe { pg_sys::hash_mem_multiplier },
                 );
-                futures_vec.push(Box::pin(
-                    crate::postgres::customscan::mpp::exec::run_inner_producer_fragment(
-                        inner,
-                        peer_outbound,
-                        n_consumers,
-                        inner_task_ctx,
-                    ),
-                ));
+                futures_vec.push(Box::pin(run_inner_producer_fragment(
+                    inner,
+                    peer_outbound,
+                    n_consumers,
+                    inner_task_ctx,
+                )));
             }
             futures_vec.push(Box::pin(
                 crate::postgres::customscan::mpp::exec::run_producer_fragment(
@@ -1578,9 +1553,7 @@ impl AggregateScan {
     ///
     /// Pre-order traversal returns on the first match, which is the
     /// outermost shuffle — the one that straddles the worker→leader split.
-    fn find_worker_fragment(
-        plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    ) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+    fn find_worker_fragment(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
         if plan.name() == "NetworkShuffleExec" {
             return plan.children().first().map(|c| Arc::clone(c));
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -684,7 +684,21 @@ impl ParallelQueryCapable for AggregateScan {
             .source_manifests
             .len()
             .saturating_sub(1) as u32;
-        let mpp_size = match estimate_dsm_size(plan_bytes_len, n_partitions, n_cache_sources) {
+        // K peer meshes: 1 when post-agg shuffle is on (the post-aggregate
+        // peer mesh), 0 otherwise. The runtime substrate is K-aware (Vec<MppPeerMesh>);
+        // the planner side currently emits at most 1 nested cross-worker shuffle
+        // (the `!has_shuffle_ancestor` guard in fork's `_distribute_plan`).
+        let n_peer_meshes: u32 = if crate::gucs::enable_mpp_postagg_shuffle() {
+            1
+        } else {
+            0
+        };
+        let mpp_size = match crate::postgres::customscan::mpp::glue::estimate_dsm_size(
+            plan_bytes_len,
+            n_partitions,
+            n_cache_sources,
+            n_peer_meshes,
+        ) {
             Ok(sz) => sz,
             Err(e) => {
                 pgrx::warning!("mpp: estimate_dsm failed: {e}; falling back to serial");
@@ -766,6 +780,11 @@ impl ParallelQueryCapable for AggregateScan {
             .source_manifests
             .len()
             .saturating_sub(1) as u32;
+        let n_peer_meshes: u32 = if crate::gucs::enable_mpp_postagg_shuffle() {
+            1
+        } else {
+            0
+        };
         let leader = match unsafe {
             leader_setup(
                 mpp_coordinate,
@@ -773,6 +792,7 @@ impl ParallelQueryCapable for AggregateScan {
                 n_partitions,
                 plan_bytes,
                 n_cache_sources,
+                n_peer_meshes,
             )
         } {
             Ok(l) => l,
@@ -1152,8 +1172,12 @@ impl AggregateScan {
                 }
                 _ => unreachable!(),
             };
+        // For now (with the fork's `!has_shuffle_ancestor` guard) the planner
+        // emits at most one nested cross-worker shuffle, so peer_meshes is
+        // either empty or has length 1. Take the first as the active peer
+        // mesh; G2 will swap this scalar for a stage-id-keyed map.
         let peer_mesh = match df_state.mpp.as_ref() {
-            Some(scan_state::MppExecState::Worker(w)) => w.peer_mesh.as_ref().map(Arc::clone),
+            Some(scan_state::MppExecState::Worker(w)) => w.peer_meshes.first().map(Arc::clone),
             _ => None,
         };
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -665,20 +665,23 @@ fn count_peer_mesh_shuffles(
         .with_distributed_worker_resolver(
             crate::postgres::customscan::mpp::runtime::MppWorkerResolver::new(n_workers_us),
         )
-        // The fork's `is_in_process()` predicate gates peer-shuffle emission
-        // on a registered `WorkerTransport`. Use the bare LocalExec stub —
-        // the plan is built and discarded for counting only, never executed,
-        // so `LocalExecWorkerTransport.open()` is never invoked.
+        // Peer-shuffle emission requires in-process mode. The bare LocalExec
+        // stub is registered so the planner has a transport to dispatch
+        // through, but the plan here is built and discarded for counting
+        // only, never executed.
         .with_distributed_worker_transport(
             crate::postgres::customscan::mpp::runtime::LocalExecWorkerTransport,
-        )
-        .with_distributed_task_estimator(n_workers_us)
-        .with_distributed_broadcast_joins(true)
-        .ok();
-    let Some(state_builder) = state_builder else {
-        return 0;
+        );
+    let state_builder = match state_builder.with_distributed_in_process_mode(true) {
+        Ok(b) => b,
+        Err(_) => return 0,
     };
-    let state_builder = match state_builder.with_distributed_in_process_peer_shuffle(true) {
+    let state_builder = state_builder.with_distributed_task_estimator(n_workers_us);
+    let state_builder = match state_builder.with_distributed_broadcast_joins(true) {
+        Ok(b) => b,
+        Err(_) => return 0,
+    };
+    let state_builder = match state_builder.with_distributed_emit_peer_shuffles(true) {
         Ok(b) => b,
         Err(_) => return 0,
     };
@@ -1211,8 +1214,8 @@ impl AggregateScan {
             .with_distributed_task_estimator(n_workers)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
-            .with_distributed_in_process_peer_shuffle(crate::gucs::enable_mpp_postagg_shuffle())
-            .expect("with_distributed_in_process_peer_shuffle")
+            .with_distributed_emit_peer_shuffles(crate::gucs::enable_mpp_postagg_shuffle())
+            .expect("with_distributed_emit_peer_shuffles")
             .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
             .with_distributed_planner();
         datafusion::prelude::SessionContext::new_with_state(state_builder.build())
@@ -1429,8 +1432,8 @@ impl AggregateScan {
             .with_distributed_task_estimator(n_workers_us)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
-            .with_distributed_in_process_peer_shuffle(crate::gucs::enable_mpp_postagg_shuffle())
-            .expect("with_distributed_in_process_peer_shuffle")
+            .with_distributed_emit_peer_shuffles(crate::gucs::enable_mpp_postagg_shuffle())
+            .expect("with_distributed_emit_peer_shuffles")
             .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
             .with_distributed_planner();
         let session_state = state_builder.build();

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1351,69 +1351,76 @@ impl AggregateScan {
             unsafe { pg_sys::hash_mem_multiplier },
         );
 
-        // Two-boundary mode (Track A + Track B): spawn the inner peer-mesh
-        // producer fragment alongside the outer worker→leader fragment.
-        // The inner fragment pushes hash-partitioned partial-agg rows into
-        // peer_outbound (tagged by partition_id); the outer fragment runs
-        // FinalPartitioned by pulling from the peer mesh and pushes the
-        // final-aggregated rows into the leader-bound mesh.
+        // Multi-boundary mode (Track A + Track B): spawn one inner
+        // peer-mesh producer fragment per nested cross-worker shuffle,
+        // alongside the outer worker→leader fragment. Each inner fragment
+        // pushes its own hash-partitioned rows into its peer mesh's
+        // outbound (tagged by partition_id); the outer fragment runs
+        // FinalPartitioned by pulling from the post-agg peer mesh and
+        // pushes the final-aggregated rows into the leader-bound mesh.
+        // The K+1 fragments run concurrently on the worker's
+        // current_thread Tokio runtime; cooperative drains interleave
+        // pushes and pulls so the consumer side never starves the
+        // producer side.
         //
-        // For now (with the fork's `!has_shuffle_ancestor` guard) at most
-        // one peer-mesh shuffle is in play. G3 will replace this with K
-        // concurrent inner-fragment runners.
-        let inner_fragment =
-            if !peer_meshes.is_empty() && Self::count_network_shuffles(&physical_plan) >= 2 {
-                Self::find_inner_producer_fragment(&physical_plan)
-            } else {
-                None
-            };
+        // The inner fragments and their peer meshes are paired by the
+        // same pre-order DFS that `collect_inner_shuffle_stage_ids` uses
+        // to build the routing map; the lengths must match (already
+        // validated by `build_stage_to_mesh_map`).
+        let inner_fragments =
+            crate::postgres::customscan::mpp::runtime::collect_inner_producer_fragments(&fragment);
+        if inner_fragments.len() != peer_meshes.len() {
+            pgrx::error!(
+                "mpp worker: inner-fragment count ({}) != peer-mesh count ({})",
+                inner_fragments.len(),
+                peer_meshes.len()
+            );
+        }
 
         let result = runtime.block_on(async {
-            match (inner_fragment, peer_meshes.first()) {
-                (Some(inner), Some(mesh)) => {
-                    let peer_outbound = mesh.take_outbound().ok_or_else(|| {
-                        datafusion::common::DataFusionError::Internal(
+            // Build K inner runner futures + 1 outer.
+            type FragmentFuture = std::pin::Pin<
+                Box<
+                    dyn std::future::Future<
+                            Output = std::result::Result<(), datafusion::common::DataFusionError>,
+                        > + Send,
+                >,
+            >;
+            let mut futures_vec: Vec<FragmentFuture> =
+                Vec::with_capacity(inner_fragments.len() + 1);
+            for (inner, mesh) in inner_fragments.into_iter().zip(peer_meshes.iter()) {
+                let peer_outbound = match mesh.take_outbound() {
+                    Some(senders) => senders,
+                    None => {
+                        return Err(datafusion::common::DataFusionError::Internal(
                             "mpp worker: peer mesh outbound senders already taken".into(),
-                        )
-                    })?;
-                    let n_consumers = mesh.n_workers as usize;
-                    let inner_task_ctx = build_task_context(
-                        &session,
-                        &inner,
-                        unsafe { pg_sys::work_mem as usize * 1024 },
-                        unsafe { pg_sys::hash_mem_multiplier },
-                    );
-                    // Run both fragments concurrently on the worker's
-                    // current_thread Tokio runtime. The cooperative drains
-                    // interleave correctly: when the outer fragment awaits
-                    // peer-mesh data, the runtime polls the inner fragment
-                    // which pushes a batch, which then unblocks the outer
-                    // fragment's pull.
-                    let inner_fut =
-                        crate::postgres::customscan::mpp::exec::run_inner_producer_fragment(
-                            inner,
-                            peer_outbound,
-                            n_consumers,
-                            inner_task_ctx,
-                        );
-                    let outer_fut = crate::postgres::customscan::mpp::exec::run_producer_fragment(
-                        fragment,
-                        outbound_senders,
-                        task_ctx,
-                    );
-                    let (inner_res, outer_res) = futures::join!(inner_fut, outer_fut);
-                    inner_res?;
-                    outer_res
-                }
-                _ => {
-                    crate::postgres::customscan::mpp::exec::run_producer_fragment(
-                        fragment,
-                        outbound_senders,
-                        task_ctx,
-                    )
-                    .await
-                }
+                        ));
+                    }
+                };
+                let n_consumers = mesh.n_workers as usize;
+                let inner_task_ctx = build_task_context(
+                    &session,
+                    &inner,
+                    unsafe { pg_sys::work_mem as usize * 1024 },
+                    unsafe { pg_sys::hash_mem_multiplier },
+                );
+                futures_vec.push(Box::pin(
+                    crate::postgres::customscan::mpp::exec::run_inner_producer_fragment(
+                        inner,
+                        peer_outbound,
+                        n_consumers,
+                        inner_task_ctx,
+                    ),
+                ));
             }
+            futures_vec.push(Box::pin(
+                crate::postgres::customscan::mpp::exec::run_producer_fragment(
+                    fragment,
+                    outbound_senders,
+                    task_ctx,
+                ),
+            ));
+            futures::future::try_join_all(futures_vec).await.map(|_| ())
         });
         if let Err(e) = result {
             pgrx::error!("mpp worker: producer fragment(s) failed: {e}");
@@ -1439,46 +1446,6 @@ impl AggregateScan {
             }
         }
         None
-    }
-
-    /// Walk a DistributedExec-rooted plan and return the input subtree of
-    /// the **bottommost** `NetworkShuffleExec` (the inner peer-mesh
-    /// producer fragment for two-boundary plans).
-    ///
-    /// In single-boundary mode (one shuffle) this returns the same subtree
-    /// as `find_worker_fragment`. In two-boundary mode (Track A's gather +
-    /// peer-mesh shuffle) this returns the input of the inner shuffle —
-    /// `RepartitionExec(Hash, N²) → AggregateExec(Partial) → ...` — which
-    /// is the data each worker pushes to the peer mesh.
-    fn find_inner_producer_fragment(
-        plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-    ) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
-        // Recurse first so the deepest `NetworkShuffleExec` wins (post-order).
-        for child in plan.children() {
-            if let Some(found) = Self::find_inner_producer_fragment(child) {
-                return Some(found);
-            }
-        }
-        if plan.name() == "NetworkShuffleExec" {
-            return plan.children().first().map(|c| Arc::clone(c));
-        }
-        None
-    }
-
-    /// Identifier for the boundary kinds currently emitted by the fork's
-    /// `_distribute_plan`. Used to disambiguate single-boundary vs
-    /// two-boundary plans when deciding whether to spawn the inner
-    /// peer-mesh producer fragment.
-    fn count_network_shuffles(plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>) -> usize {
-        let mut count = if plan.name() == "NetworkShuffleExec" {
-            1
-        } else {
-            0
-        };
-        for child in plan.children() {
-            count += Self::count_network_shuffles(child);
-        }
-        count
     }
 
     /// Existing single-table Tantivy aggregate path.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -43,7 +43,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{DistributedExt, DistributedTaskContext, SessionStateBuilderExt};
 
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
-use crate::postgres::customscan::mpp::exec::run_inner_producer_fragment;
+use crate::postgres::customscan::mpp::exec::{run_inner_producer_fragment, run_producer_fragment};
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_is_active, mpp_worker_count, producer_worker_count,
     worker_setup,
@@ -683,7 +683,7 @@ fn count_peer_mesh_shuffles(
         Err(_) => return 0,
     };
     let state_builder = state_builder
-        .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
+        .with_distributed_user_codec(PgSearchPhysicalCodecStub)
         .with_distributed_planner();
     let state = state_builder.build();
     let session = datafusion::prelude::SessionContext::new_with_state(state);
@@ -756,7 +756,7 @@ impl ParallelQueryCapable for AggregateScan {
         // Skipped in peer-shuffle mode: the non-partitioning source is sliced
         // per worker via `slice_segment_ids_round_robin`, so the all-gather
         // is unused.
-        let n_cache_sources = if crate::gucs::enable_mpp_postagg_shuffle() {
+        let n_cache_sources = if gucs::enable_mpp_postagg_shuffle() {
             0
         } else {
             state
@@ -859,7 +859,7 @@ impl ParallelQueryCapable for AggregateScan {
             .len()
             .saturating_sub(1) as u32;
         // Match the gating in `estimate_dsm_custom_scan`.
-        let n_cache_sources = if crate::gucs::enable_mpp_postagg_shuffle() {
+        let n_cache_sources = if gucs::enable_mpp_postagg_shuffle() {
             0
         } else {
             n_cache_sources
@@ -1163,7 +1163,7 @@ impl AggregateScan {
         // `NetworkShuffleExec` becomes a peer-mesh stage. Once the fork's
         // `!has_shuffle_ancestor` guard is dropped, this count climbs
         // beyond 1 for plans like aggregate-on-(HashJoinExec(Partitioned)).
-        df_state.mpp_n_peer_meshes = if crate::gucs::enable_mpp_postagg_shuffle() {
+        df_state.mpp_n_peer_meshes = if gucs::enable_mpp_postagg_shuffle() {
             count_peer_mesh_shuffles(&runtime, &logical, n_workers)
         } else {
             0
@@ -1207,9 +1207,9 @@ impl AggregateScan {
             .with_distributed_task_estimator(n_workers)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
-            .with_distributed_emit_peer_shuffles(crate::gucs::enable_mpp_postagg_shuffle())
+            .with_distributed_emit_peer_shuffles(gucs::enable_mpp_postagg_shuffle())
             .expect("with_distributed_emit_peer_shuffles")
-            .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
+            .with_distributed_user_codec(PgSearchPhysicalCodecStub)
             .with_distributed_planner();
         datafusion::prelude::SessionContext::new_with_state(state_builder.build())
     }
@@ -1311,20 +1311,20 @@ impl AggregateScan {
         // see N copies of every row. Slice the non-partitioning segment IDs
         // round-robin per worker so each scans only its 1/N slice — same
         // model the partitioning source already uses.
-        let peer_shuffle_on = crate::gucs::enable_mpp_postagg_shuffle();
-        let non_partitioning_segments: Vec<crate::api::HashSet<tantivy::index::SegmentId>> =
-            if peer_shuffle_on {
-                non_partitioning_segments
-                    .iter()
-                    .map(|ids| {
-                        Self::slice_segment_ids_round_robin(ids, worker_idx_for_cache, n_workers)
-                    })
-                    .collect()
-            } else {
-                non_partitioning_segments
-            };
-        let mut index_segment_ids: Vec<crate::api::HashSet<tantivy::index::SegmentId>> =
-            vec![crate::api::HashSet::default(); plan_sources_count];
+        let peer_shuffle_on = gucs::enable_mpp_postagg_shuffle();
+        let non_partitioning_segments: Vec<HashSet<tantivy::index::SegmentId>> = if peer_shuffle_on
+        {
+            non_partitioning_segments
+                .iter()
+                .map(|ids| {
+                    Self::slice_segment_ids_round_robin(ids, worker_idx_for_cache, n_workers)
+                })
+                .collect()
+        } else {
+            non_partitioning_segments
+        };
+        let mut index_segment_ids: Vec<HashSet<tantivy::index::SegmentId>> =
+            vec![HashSet::default(); plan_sources_count];
         if let Some(ps) = parallel_state {
             let mut np_counter = 0usize;
             for (i, slot) in index_segment_ids.iter_mut().enumerate() {
@@ -1414,9 +1414,9 @@ impl AggregateScan {
             .with_distributed_task_estimator(n_workers_us)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
-            .with_distributed_emit_peer_shuffles(crate::gucs::enable_mpp_postagg_shuffle())
+            .with_distributed_emit_peer_shuffles(gucs::enable_mpp_postagg_shuffle())
             .expect("with_distributed_emit_peer_shuffles")
-            .with_distributed_user_codec(crate::scan::codec::PgSearchPhysicalCodecStub)
+            .with_distributed_user_codec(PgSearchPhysicalCodecStub)
             .with_distributed_planner();
         let session_state = state_builder.build();
         let session = datafusion::prelude::SessionContext::new_with_state(session_state);
@@ -1427,7 +1427,7 @@ impl AggregateScan {
             Ok(p) => p,
             Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
         };
-        if crate::gucs::mpp_debug() && worker_idx_for_cache == 0 {
+        if gucs::mpp_debug() && worker_idx_for_cache == 0 {
             let dumped = datafusion::physical_plan::displayable(physical_plan.as_ref())
                 .indent(true)
                 .to_string();
@@ -1532,13 +1532,11 @@ impl AggregateScan {
                     inner_task_ctx,
                 )));
             }
-            futures_vec.push(Box::pin(
-                crate::postgres::customscan::mpp::exec::run_producer_fragment(
-                    fragment,
-                    outbound_senders,
-                    task_ctx,
-                ),
-            ));
+            futures_vec.push(Box::pin(run_producer_fragment(
+                fragment,
+                outbound_senders,
+                task_ctx,
+            )));
             futures::future::try_join_all(futures_vec).await.map(|_| ())
         });
         if let Err(e) = result {
@@ -1579,10 +1577,10 @@ impl AggregateScan {
     /// at small scale is correct (and N× is negligible when the source is
     /// tiny anyway).
     fn slice_segment_ids_round_robin(
-        ids: &crate::api::HashSet<tantivy::index::SegmentId>,
+        ids: &HashSet<tantivy::index::SegmentId>,
         worker_idx: u32,
         n_workers: u32,
-    ) -> crate::api::HashSet<tantivy::index::SegmentId> {
+    ) -> HashSet<tantivy::index::SegmentId> {
         if n_workers <= 1 || (ids.len() as u32) < n_workers {
             return ids.clone();
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1226,6 +1226,11 @@ impl AggregateScan {
     /// to the leader's shm_mq queues. Workers emit zero rows back to PG;
     /// returning `null_mut()` signals end-of-stream.
     fn exec_mpp_worker(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
+        // Mark this OS thread as the PG backend thread so the cooperative
+        // drain spin's `pgrx::check_for_interrupts!()` is gated to it
+        // (compute futures running on the multi-thread Tokio runtime skip
+        // the check).
+        crate::postgres::customscan::mpp::transport::mark_backend_thread();
         // Pull worker-thread inputs from the outer state before we borrow
         // df_state mutably. parallel_state and non_partitioning_segments
         // are required to pin each worker's PgSearchTableProvider to the
@@ -1280,6 +1285,13 @@ impl AggregateScan {
                 _ => Vec::new(),
             };
 
+        // Single-threaded Tokio runtime is the current safe default —
+        // pgrx 0.18 auto-wraps every `pg_sys::*` FFI call with
+        // `check_active_thread` and panics if FFI is called from any
+        // thread other than the original backend thread. Switching to a
+        // multi-thread runtime requires either (a) raw `extern "C"`
+        // bindings to bypass `pg_guard` for the shm_mq fast path, or
+        // (b) a backend-thread FFI relay. Both are tracked under G7-MT.
         let runtime = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -89,6 +89,12 @@ pub struct DataFusionAggState {
     /// `mpp_plan_bytes`; used to size the DSM mesh.
     #[allow(dead_code)]
     pub mpp_n_partitions: u32,
+    /// Number of nested cross-worker `NetworkShuffleExec` stages in the
+    /// physical plan, computed in `stash_mpp_plan_bytes`. Determines how
+    /// many peer meshes to allocate in DSM at `estimate_dsm_size` time.
+    /// 0 when `enable_mpp_postagg_shuffle` is off.
+    #[allow(dead_code)]
+    pub mpp_n_peer_meshes: u32,
 }
 
 /// Per-query MPP state. Distinct variants for leader vs worker because the

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -54,10 +54,11 @@ use crate::postgres::customscan::mpp::mesh::{
 };
 
 pub const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
-/// Bumped 2 → 3 with the peer-mesh extension (Track B). Old workers attach
-/// to a v2 region by `MPP_DSM_HEADER_VERSION` mismatch and bail before
-/// reading the new fields.
-pub const MPP_DSM_HEADER_VERSION: u32 = 3;
+/// Bumped 3 → 4: peer-mesh region is now an array of K independent meshes
+/// (one per nested cross-worker shuffle stage), each sized N×N×peer_queue_bytes.
+/// Old workers attach to a v3 region by `MPP_DSM_HEADER_VERSION` mismatch and
+/// bail before reading the new `n_peer_meshes` field.
+pub const MPP_DSM_HEADER_VERSION: u32 = 4;
 
 /// Hard cap on per-source-per-worker cache slot size. Sized for our 25 M
 /// bench: a 1.25 M-row build side encoded in Arrow IPC is ~400 MB total
@@ -74,8 +75,9 @@ pub const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 /// C-repr header at offset 0 of the DSM region.
 ///
 /// Layout sections (bottom to top): plan bytes → leader-bound queues
-/// (n_workers × n_partitions slots) → build-side cache → peer mesh
-/// (n_workers × n_workers slots). Each section is MAXALIGN-padded.
+/// (n_workers × n_partitions slots) → build-side cache → peer-mesh array
+/// (n_peer_meshes × n_workers × n_workers slots). Each section is
+/// MAXALIGN-padded.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct MppDsmHeader {
@@ -84,7 +86,9 @@ pub struct MppDsmHeader {
     pub n_workers: u32,
     pub n_partitions: u32,
     pub n_cache_sources: u32,
-    pub _pad0: u32,
+    /// Number of peer meshes reserved. 0 means no peer-mesh region was
+    /// allocated. Each mesh is `n_workers × n_workers × peer_queue_bytes`.
+    pub n_peer_meshes: u32,
     pub queue_bytes: u64,
     pub plan_offset: u64,
     pub plan_len: u64,
@@ -95,9 +99,9 @@ pub struct MppDsmHeader {
     pub cache_data_offset: u64,
     /// Per-edge byte size for peer-mesh slots. 0 means no peer mesh.
     pub peer_queue_bytes: u64,
-    /// Byte offset (relative to DSM base) of the peer-mesh queue grid.
-    /// `peer_slot(producer, consumer) = peer_mesh_offset + (producer*n_workers + consumer) * peer_queue_bytes`.
-    /// Valid only when `peer_queue_bytes > 0`.
+    /// Byte offset (relative to DSM base) of the peer-mesh array. Each
+    /// mesh occupies `n_workers² × peer_queue_bytes` bytes; mesh `m` starts
+    /// at `peer_mesh_offset + m × n_workers² × peer_queue_bytes`.
     pub peer_mesh_offset: u64,
     pub region_total: u64,
 }
@@ -110,7 +114,7 @@ impl MppDsmHeader {
             n_workers: layout.n_workers,
             n_partitions: layout.n_partitions,
             n_cache_sources: layout.n_cache_sources,
-            _pad0: 0,
+            n_peer_meshes: layout.n_peer_meshes,
             queue_bytes: layout.queue_bytes as u64,
             plan_offset: layout.plan_offset as u64,
             plan_len: layout.plan_len as u64,
@@ -168,15 +172,20 @@ impl MppDsmHeader {
         self.cache_data_offset + slot * self.cache_per_slot
     }
 
-    /// Byte offset of the peer-mesh queue slot at `(producer, consumer)`.
-    /// Valid only when `peer_queue_bytes > 0`. Both indices are 0-based
-    /// worker indices (the leader is not part of the peer mesh).
-    pub fn peer_slot_offset(&self, producer: u32, consumer: u32) -> u64 {
+    /// Byte offset of the peer-mesh queue slot at `(mesh, producer, consumer)`.
+    /// Valid only when `peer_queue_bytes > 0`. `mesh` indexes into the array
+    /// of K peer meshes (one per nested cross-worker shuffle); `producer`
+    /// and `consumer` are 0-based worker indices.
+    pub fn peer_slot_offset(&self, mesh: u32, producer: u32, consumer: u32) -> u64 {
         debug_assert!(self.peer_queue_bytes > 0);
+        debug_assert!(mesh < self.n_peer_meshes);
         debug_assert!(producer < self.n_workers);
         debug_assert!(consumer < self.n_workers);
-        let slot = (producer as u64) * (self.n_workers as u64) + (consumer as u64);
-        self.peer_mesh_offset + slot * self.peer_queue_bytes
+        let n = self.n_workers as u64;
+        let mesh_size_bytes = n * n * self.peer_queue_bytes;
+        let mesh_base = self.peer_mesh_offset + (mesh as u64) * mesh_size_bytes;
+        let slot = (producer as u64) * n + (consumer as u64);
+        mesh_base + slot * self.peer_queue_bytes
     }
 }
 
@@ -186,6 +195,7 @@ pub struct DsmLayout {
     pub n_workers: u32,
     pub n_partitions: u32,
     pub n_cache_sources: u32,
+    pub n_peer_meshes: u32,
     pub queue_bytes: usize,
     pub cache_per_slot: usize,
     pub peer_queue_bytes: usize,
@@ -206,10 +216,15 @@ pub struct DsmLayout {
 /// each (source, worker) pair (worst-case per-worker IPC payload). Pass 0
 /// for both if no cache is needed.
 ///
-/// `peer_queue_bytes` reserves a peer-mesh queue grid sized
-/// `n_workers × n_workers × peer_queue_bytes` after the cache. Pass 0 to
-/// skip; only callers that need cross-worker shuffles (Track B post-agg
-/// peer mesh) request this.
+/// `peer_queue_bytes` and `n_peer_meshes` reserve a peer-mesh array sized
+/// `n_peer_meshes × n_workers × n_workers × peer_queue_bytes` after the
+/// cache. Pass 0 for either to skip; callers that need cross-worker
+/// shuffles request `n_peer_meshes >= 1` with `n_peer_meshes` set to the
+/// number of nested cross-worker `NetworkShuffleExec` stages in the plan.
+// Exempt from too_many_arguments: each arg is an independent dimension
+// of the layout and bundling them into a struct just adds a layer of
+// indirection across every caller.
+#[allow(clippy::too_many_arguments)]
 pub fn compute_dsm_layout(
     n_workers: u32,
     n_partitions: u32,
@@ -218,6 +233,7 @@ pub fn compute_dsm_layout(
     n_cache_sources: u32,
     cache_per_slot: usize,
     peer_queue_bytes: usize,
+    n_peer_meshes: u32,
 ) -> Result<DsmLayout, &'static str> {
     if n_workers == 0 {
         return Err("mpp: n_workers must be > 0");
@@ -280,10 +296,10 @@ pub fn compute_dsm_layout(
         .checked_add(cache_data_size)
         .ok_or("mpp: cache data end overflow")?;
 
-    // Peer-mesh queue grid: n_workers × n_workers × peer_queue_bytes.
-    // Sits after the build-side cache. Skipped (offset=cache_data_end,
-    // size=0) when peer_queue_bytes == 0.
-    let peer_queue_bytes_aligned = if peer_queue_bytes == 0 {
+    // Peer-mesh array: n_peer_meshes × n_workers × n_workers × peer_queue_bytes.
+    // Sits after the build-side cache. Skipped (size=0) when n_peer_meshes == 0
+    // or peer_queue_bytes == 0.
+    let peer_queue_bytes_aligned = if peer_queue_bytes == 0 || n_peer_meshes == 0 {
         0
     } else {
         let aligned = aligned_queue_bytes(peer_queue_bytes);
@@ -292,13 +308,19 @@ pub fn compute_dsm_layout(
         }
         aligned
     };
-    let peer_mesh_offset =
-        align_up_maxalign_checked(cache_data_end).ok_or("mpp: peer mesh alignment overflow")?;
-    let peer_mesh_size = if peer_queue_bytes_aligned == 0 {
+    let effective_n_meshes = if peer_queue_bytes_aligned == 0 {
         0
     } else {
-        (n_workers as usize)
+        n_peer_meshes
+    };
+    let peer_mesh_offset =
+        align_up_maxalign_checked(cache_data_end).ok_or("mpp: peer mesh alignment overflow")?;
+    let peer_mesh_size = if effective_n_meshes == 0 {
+        0
+    } else {
+        (effective_n_meshes as usize)
             .checked_mul(n_workers as usize)
+            .and_then(|x| x.checked_mul(n_workers as usize))
             .and_then(|x| x.checked_mul(peer_queue_bytes_aligned))
             .ok_or("mpp: peer mesh size overflow")?
     };
@@ -312,6 +334,7 @@ pub fn compute_dsm_layout(
         n_workers,
         n_partitions,
         n_cache_sources,
+        n_peer_meshes: effective_n_meshes,
         queue_bytes,
         cache_per_slot,
         peer_queue_bytes: peer_queue_bytes_aligned,
@@ -542,16 +565,20 @@ pub unsafe fn leader_init(
     }
 
     // Peer-mesh queues. The leader is not a peer (not part of the N×N
-    // grid); it just `shm_mq_create`s every slot so workers can attach as
-    // producer (their row) and consumer (their column). Skipped when no
-    // peer mesh was reserved.
-    if layout.peer_queue_bytes > 0 {
-        for prod in 0..layout.n_workers {
-            for cons in 0..layout.n_workers {
-                let slot = (prod as usize) * (layout.n_workers as usize) + (cons as usize);
-                let mq_addr =
-                    unsafe { base.add(layout.peer_mesh_offset + slot * layout.peer_queue_bytes) };
-                unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.peer_queue_bytes) };
+    // grids); it just `shm_mq_create`s every slot so workers can attach as
+    // producer (their row) and consumer (their column) for each of the K
+    // peer meshes. Skipped when no peer-mesh array was reserved.
+    if layout.peer_queue_bytes > 0 && layout.n_peer_meshes > 0 {
+        let n = layout.n_workers as usize;
+        let mesh_size_bytes = n * n * layout.peer_queue_bytes;
+        for mesh_idx in 0..layout.n_peer_meshes as usize {
+            let mesh_base = layout.peer_mesh_offset + mesh_idx * mesh_size_bytes;
+            for prod in 0..n {
+                for cons in 0..n {
+                    let slot = prod * n + cons;
+                    let mq_addr = unsafe { base.add(mesh_base + slot * layout.peer_queue_bytes) };
+                    unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.peer_queue_bytes) };
+                }
             }
         }
     }
@@ -617,9 +644,10 @@ pub unsafe fn worker_attach(
     Ok((header, plan_bytes, WorkerAttach { outbound_senders }))
 }
 
-/// Attach this worker to the peer-mesh queue grid as both producer
-/// (its row) and consumer (its column). Skipped (returns `Ok(None)`)
-/// when the region has no peer mesh reserved.
+/// Attach this worker to every peer-mesh queue grid as both producer
+/// (its row) and consumer (its column). Returns one `WorkerPeerAttach`
+/// per reserved peer mesh; an empty Vec means no peer-mesh array was
+/// reserved.
 ///
 /// # Safety
 /// - `coordinate` must be the DSM region pointer the leader initialized.
@@ -631,9 +659,9 @@ pub unsafe fn worker_peer_attach(
     header: &MppDsmHeader,
     worker_index: u32,
     seg: *mut pg_sys::dsm_segment,
-) -> Result<Option<WorkerPeerAttach>, String> {
-    if header.peer_queue_bytes == 0 {
-        return Ok(None);
+) -> Result<Vec<WorkerPeerAttach>, String> {
+    if header.peer_queue_bytes == 0 || header.n_peer_meshes == 0 {
+        return Ok(Vec::new());
     }
     if coordinate.is_null() {
         return Err("mpp: worker_peer_attach given null coordinate".into());
@@ -647,28 +675,32 @@ pub unsafe fn worker_peer_attach(
     let base = coordinate as *mut u8;
     let n = header.n_workers;
 
-    // Attach as PRODUCER (this row): one sender per consumer column.
-    let mut peer_outbound = Vec::with_capacity(n as usize);
-    for c in 0..n {
-        let off = header.peer_slot_offset(worker_index, c) as usize;
-        let mq_addr = unsafe { base.add(off) };
-        let mq = mq_addr.cast::<pg_sys::shm_mq>();
-        peer_outbound.push(unsafe { ShmMqSender::attach(seg, mq) });
-    }
+    let mut attaches = Vec::with_capacity(header.n_peer_meshes as usize);
+    for mesh_idx in 0..header.n_peer_meshes {
+        // Attach as PRODUCER (this row): one sender per consumer column.
+        let mut peer_outbound = Vec::with_capacity(n as usize);
+        for c in 0..n {
+            let off = header.peer_slot_offset(mesh_idx, worker_index, c) as usize;
+            let mq_addr = unsafe { base.add(off) };
+            let mq = mq_addr.cast::<pg_sys::shm_mq>();
+            peer_outbound.push(unsafe { ShmMqSender::attach(seg, mq) });
+        }
 
-    // Attach as CONSUMER (this column): one receiver per producer row.
-    let mut peer_inbound = Vec::with_capacity(n as usize);
-    for p in 0..n {
-        let off = header.peer_slot_offset(p, worker_index) as usize;
-        let mq_addr = unsafe { base.add(off) };
-        let mq = mq_addr.cast::<pg_sys::shm_mq>();
-        peer_inbound.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
-    }
+        // Attach as CONSUMER (this column): one receiver per producer row.
+        let mut peer_inbound = Vec::with_capacity(n as usize);
+        for p in 0..n {
+            let off = header.peer_slot_offset(mesh_idx, p, worker_index) as usize;
+            let mq_addr = unsafe { base.add(off) };
+            let mq = mq_addr.cast::<pg_sys::shm_mq>();
+            peer_inbound.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
+        }
 
-    Ok(Some(WorkerPeerAttach {
-        peer_outbound,
-        peer_inbound,
-    }))
+        attaches.push(WorkerPeerAttach {
+            peer_outbound,
+            peer_inbound,
+        });
+    }
+    Ok(attaches)
 }
 
 #[cfg(test)]
@@ -677,7 +709,7 @@ mod tests {
 
     #[test]
     fn compute_dsm_layout_works() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0, 0, 0).unwrap();
         assert_eq!(l.n_workers, 4);
         assert_eq!(l.n_partitions, 1);
         // No cache reserved → cache regions all sit at queues_end (after MAXALIGN).
@@ -690,7 +722,7 @@ mod tests {
 
     #[test]
     fn compute_dsm_layout_with_cache() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 2, 1024 * 1024, 0).unwrap();
+        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 2, 1024 * 1024, 0, 0).unwrap();
         let cache_data_size = 2 * 4 * 1024 * 1024; // 2 sources × 4 workers × 1 MiB
                                                    // peer_mesh_offset == cache_data_end after MAXALIGN; with peer=0 region_total == peer_mesh_offset.
         assert_eq!(l.region_total, l.peer_mesh_offset);
@@ -699,7 +731,7 @@ mod tests {
 
     #[test]
     fn compute_dsm_layout_with_peer_mesh() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0, 1024 * 1024).unwrap();
+        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0, 1024 * 1024, 1).unwrap();
         let aligned_peer = aligned_queue_bytes(1024 * 1024);
         let peer_mesh_size = 4 * 4 * aligned_peer;
         assert_eq!(l.peer_queue_bytes, aligned_peer);
@@ -708,22 +740,22 @@ mod tests {
 
     #[test]
     fn compute_dsm_layout_rejects_zero_workers() {
-        assert!(compute_dsm_layout(0, 1, 64 * 1024, 0, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(0, 1, 64 * 1024, 0, 0, 0, 0, 0).is_err());
     }
 
     #[test]
     fn compute_dsm_layout_rejects_zero_partitions() {
-        assert!(compute_dsm_layout(2, 0, 64 * 1024, 0, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(2, 0, 64 * 1024, 0, 0, 0, 0, 0).is_err());
     }
 
     #[test]
     fn compute_dsm_layout_rejects_oversize() {
-        assert!(compute_dsm_layout(u32::MAX, u32::MAX, 64 * 1024, 0, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(u32::MAX, u32::MAX, 64 * 1024, 0, 0, 0, 0, 0).is_err());
     }
 
     #[test]
     fn header_slot_offset_is_row_major() {
-        let l = compute_dsm_layout(3, 4, 64 * 1024, 0, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(3, 4, 64 * 1024, 0, 0, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         let aligned = h.queue_bytes;
         assert_eq!(h.slot_offset(0, 0), h.queues_offset);
@@ -734,7 +766,7 @@ mod tests {
 
     #[test]
     fn header_cache_offsets() {
-        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 2, 1024, 0).unwrap();
+        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 2, 1024, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         // (source=0, worker=0) is the first slot.
         assert_eq!(h.cache_data_slot_offset(0, 0), h.cache_data_offset);
@@ -749,34 +781,65 @@ mod tests {
 
     #[test]
     fn header_peer_slot_offset_is_row_major() {
-        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 0, 0, 64 * 1024).unwrap();
+        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 0, 0, 64 * 1024, 1).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         let aligned = h.peer_queue_bytes;
-        assert_eq!(h.peer_slot_offset(0, 0), h.peer_mesh_offset);
-        assert_eq!(h.peer_slot_offset(0, 1), h.peer_mesh_offset + aligned);
-        // (1, 0): row 1, col 0 — n_workers slots in.
-        assert_eq!(h.peer_slot_offset(1, 0), h.peer_mesh_offset + 3 * aligned);
-        // (2, 2): last slot.
-        assert_eq!(h.peer_slot_offset(2, 2), h.peer_mesh_offset + 8 * aligned);
+        assert_eq!(h.peer_slot_offset(0, 0, 0), h.peer_mesh_offset);
+        assert_eq!(h.peer_slot_offset(0, 0, 1), h.peer_mesh_offset + aligned);
+        // (mesh=0, prod=1, cons=0): row 1, col 0 — n_workers slots in.
+        assert_eq!(
+            h.peer_slot_offset(0, 1, 0),
+            h.peer_mesh_offset + 3 * aligned
+        );
+        // (mesh=0, prod=2, cons=2): last slot.
+        assert_eq!(
+            h.peer_slot_offset(0, 2, 2),
+            h.peer_mesh_offset + 8 * aligned
+        );
+    }
+
+    #[test]
+    fn header_peer_slot_offset_across_multiple_meshes() {
+        // K=3 meshes, each n_workers=2 → mesh size = 4 slots.
+        let l = compute_dsm_layout(2, 1, 64 * 1024, 0, 0, 0, 64 * 1024, 3).unwrap();
+        let h = MppDsmHeader::from_layout(&l);
+        let aligned = h.peer_queue_bytes;
+        let mesh_size = 4 * aligned;
+        // Mesh 0 starts at peer_mesh_offset.
+        assert_eq!(h.peer_slot_offset(0, 0, 0), h.peer_mesh_offset);
+        // Mesh 1 starts mesh_size bytes later.
+        assert_eq!(h.peer_slot_offset(1, 0, 0), h.peer_mesh_offset + mesh_size);
+        // Mesh 2 starts 2*mesh_size bytes later.
+        assert_eq!(
+            h.peer_slot_offset(2, 0, 0),
+            h.peer_mesh_offset + 2 * mesh_size
+        );
+        // Within mesh 1, slot (1, 1) is the last slot of that mesh.
+        assert_eq!(
+            h.peer_slot_offset(1, 1, 1),
+            h.peer_mesh_offset + mesh_size + 3 * aligned
+        );
+        // region_total covers all 3 meshes.
+        assert_eq!(h.region_total, h.peer_mesh_offset + 3 * mesh_size);
     }
 
     #[test]
     fn header_validate_accepts_self() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64).is_ok());
     }
 
     #[test]
     fn header_validate_rejects_size_mismatch() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64 + 1).is_err());
     }
 
     #[test]
     fn header_validate_accepts_with_peer_mesh() {
-        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 0, 0, 64 * 1024).unwrap();
+        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 0, 0, 64 * 1024, 1).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64).is_ok());
     }

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -54,18 +54,10 @@ use crate::postgres::customscan::mpp::mesh::{
 };
 
 pub const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
-/// Bumped 3 → 4: peer-mesh region is now an array of K independent meshes
-/// (one per nested cross-worker shuffle stage), each sized N×N×peer_queue_bytes.
-/// Old workers attach to a v3 region by `MPP_DSM_HEADER_VERSION` mismatch and
-/// bail before reading the new `n_peer_meshes` field.
-pub const MPP_DSM_HEADER_VERSION: u32 = 4;
-
-/// Hard cap on per-source-per-worker cache slot size. Sized for our 25 M
-/// bench: a 1.25 M-row build side encoded in Arrow IPC is ~400 MB total
-/// (Utf8View widening, schema overhead) — split across N workers, each
-/// slot needs ~400/N MB. 256 MiB caps at the worst single-worker slice.
-/// A future heuristic should derive this from index stats per query.
-pub const MPP_CACHE_PER_SLOT: usize = 256 * 1024 * 1024;
+/// Bumped 1 → 2: header gains an `n_peer_meshes` field and a peer-mesh
+/// region (array of K independent meshes, one per nested cross-worker
+/// shuffle stage, each sized N×N×peer_queue_bytes).
+pub const MPP_DSM_HEADER_VERSION: u32 = 2;
 
 /// Absolute cap on DSM region size. 16 GiB is two orders of magnitude beyond
 /// any realistic workload; the cap fails early on a pathologically oversized

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -54,7 +54,17 @@ use crate::postgres::customscan::mpp::mesh::{
 };
 
 pub const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
-pub const MPP_DSM_HEADER_VERSION: u32 = 1;
+/// Bumped 2 → 3 with the peer-mesh extension (Track B). Old workers attach
+/// to a v2 region by `MPP_DSM_HEADER_VERSION` mismatch and bail before
+/// reading the new fields.
+pub const MPP_DSM_HEADER_VERSION: u32 = 3;
+
+/// Hard cap on per-source-per-worker cache slot size. Sized for our 25 M
+/// bench: a 1.25 M-row build side encoded in Arrow IPC is ~400 MB total
+/// (Utf8View widening, schema overhead) — split across N workers, each
+/// slot needs ~400/N MB. 256 MiB caps at the worst single-worker slice.
+/// A future heuristic should derive this from index stats per query.
+pub const MPP_CACHE_PER_SLOT: usize = 256 * 1024 * 1024;
 
 /// Absolute cap on DSM region size. 16 GiB is two orders of magnitude beyond
 /// any realistic workload; the cap fails early on a pathologically oversized
@@ -63,8 +73,9 @@ pub const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 
 /// C-repr header at offset 0 of the DSM region.
 ///
-/// Field ordering: four `u32`s (16 bytes), four `u64`s (32 bytes). 48 bytes
-/// total with no internal padding on every supported target.
+/// Layout sections (bottom to top): plan bytes → leader-bound queues
+/// (n_workers × n_partitions slots) → build-side cache → peer mesh
+/// (n_workers × n_workers slots). Each section is MAXALIGN-padded.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct MppDsmHeader {
@@ -82,6 +93,12 @@ pub struct MppDsmHeader {
     pub cache_completion_offset: u64,
     pub cache_lengths_offset: u64,
     pub cache_data_offset: u64,
+    /// Per-edge byte size for peer-mesh slots. 0 means no peer mesh.
+    pub peer_queue_bytes: u64,
+    /// Byte offset (relative to DSM base) of the peer-mesh queue grid.
+    /// `peer_slot(producer, consumer) = peer_mesh_offset + (producer*n_workers + consumer) * peer_queue_bytes`.
+    /// Valid only when `peer_queue_bytes > 0`.
+    pub peer_mesh_offset: u64,
     pub region_total: u64,
 }
 
@@ -102,6 +119,8 @@ impl MppDsmHeader {
             cache_completion_offset: layout.cache_completion_offset as u64,
             cache_lengths_offset: layout.cache_lengths_offset as u64,
             cache_data_offset: layout.cache_data_offset as u64,
+            peer_queue_bytes: layout.peer_queue_bytes as u64,
+            peer_mesh_offset: layout.peer_mesh_offset as u64,
             region_total: layout.region_total as u64,
         }
     }
@@ -148,6 +167,17 @@ impl MppDsmHeader {
         let slot = (source as u64) * (self.n_workers as u64) + (worker as u64);
         self.cache_data_offset + slot * self.cache_per_slot
     }
+
+    /// Byte offset of the peer-mesh queue slot at `(producer, consumer)`.
+    /// Valid only when `peer_queue_bytes > 0`. Both indices are 0-based
+    /// worker indices (the leader is not part of the peer mesh).
+    pub fn peer_slot_offset(&self, producer: u32, consumer: u32) -> u64 {
+        debug_assert!(self.peer_queue_bytes > 0);
+        debug_assert!(producer < self.n_workers);
+        debug_assert!(consumer < self.n_workers);
+        let slot = (producer as u64) * (self.n_workers as u64) + (consumer as u64);
+        self.peer_mesh_offset + slot * self.peer_queue_bytes
+    }
 }
 
 /// Pure-math layout for [`compute_dsm_layout`].
@@ -158,12 +188,14 @@ pub struct DsmLayout {
     pub n_cache_sources: u32,
     pub queue_bytes: usize,
     pub cache_per_slot: usize,
+    pub peer_queue_bytes: usize,
     pub plan_offset: usize,
     pub plan_len: usize,
     pub queues_offset: usize,
     pub cache_completion_offset: usize,
     pub cache_lengths_offset: usize,
     pub cache_data_offset: usize,
+    pub peer_mesh_offset: usize,
     pub region_total: usize,
 }
 
@@ -173,6 +205,11 @@ pub struct DsmLayout {
 /// build-side cache slots for. `cache_per_slot` is the bytes reserved for
 /// each (source, worker) pair (worst-case per-worker IPC payload). Pass 0
 /// for both if no cache is needed.
+///
+/// `peer_queue_bytes` reserves a peer-mesh queue grid sized
+/// `n_workers × n_workers × peer_queue_bytes` after the cache. Pass 0 to
+/// skip; only callers that need cross-worker shuffles (Track B post-agg
+/// peer mesh) request this.
 pub fn compute_dsm_layout(
     n_workers: u32,
     n_partitions: u32,
@@ -180,6 +217,7 @@ pub fn compute_dsm_layout(
     plan_len: usize,
     n_cache_sources: u32,
     cache_per_slot: usize,
+    peer_queue_bytes: usize,
 ) -> Result<DsmLayout, &'static str> {
     if n_workers == 0 {
         return Err("mpp: n_workers must be > 0");
@@ -238,8 +276,34 @@ pub fn compute_dsm_layout(
         .checked_mul(n_workers as usize)
         .and_then(|x| x.checked_mul(cache_per_slot))
         .ok_or("mpp: cache data size overflow")?;
-    let region_total = cache_data_offset
+    let cache_data_end = cache_data_offset
         .checked_add(cache_data_size)
+        .ok_or("mpp: cache data end overflow")?;
+
+    // Peer-mesh queue grid: n_workers × n_workers × peer_queue_bytes.
+    // Sits after the build-side cache. Skipped (offset=cache_data_end,
+    // size=0) when peer_queue_bytes == 0.
+    let peer_queue_bytes_aligned = if peer_queue_bytes == 0 {
+        0
+    } else {
+        let aligned = aligned_queue_bytes(peer_queue_bytes);
+        if aligned == 0 {
+            return Err("mpp: peer_queue_bytes too small after alignment");
+        }
+        aligned
+    };
+    let peer_mesh_offset =
+        align_up_maxalign_checked(cache_data_end).ok_or("mpp: peer mesh alignment overflow")?;
+    let peer_mesh_size = if peer_queue_bytes_aligned == 0 {
+        0
+    } else {
+        (n_workers as usize)
+            .checked_mul(n_workers as usize)
+            .and_then(|x| x.checked_mul(peer_queue_bytes_aligned))
+            .ok_or("mpp: peer mesh size overflow")?
+    };
+    let region_total = peer_mesh_offset
+        .checked_add(peer_mesh_size)
         .ok_or("mpp: region total overflow")?;
     if region_total > MPP_DSM_MAX_BYTES {
         return Err("mpp: DSM region exceeds MPP_DSM_MAX_BYTES");
@@ -250,12 +314,14 @@ pub fn compute_dsm_layout(
         n_cache_sources,
         queue_bytes,
         cache_per_slot,
+        peer_queue_bytes: peer_queue_bytes_aligned,
         plan_offset,
         plan_len,
         queues_offset,
         cache_completion_offset,
         cache_lengths_offset,
         cache_data_offset,
+        peer_mesh_offset,
         region_total,
     })
 }
@@ -396,11 +462,23 @@ pub struct LeaderAttach {
     pub inbound_receivers: Vec<ShmMqReceiver>,
 }
 
-/// Worker-side return: just the senders. Workers don't consume; everything
-/// flows toward the leader.
+/// Worker-side return for the leader-bound queue mesh.
 pub struct WorkerAttach {
     /// `outbound_senders[p]` writes to `slot(this_worker, p)`.
     pub outbound_senders: Vec<ShmMqSender>,
+}
+
+/// Worker-side return for the peer-mesh queue grid (Track B).
+///
+/// Each worker is both a producer (its row of the grid) and a consumer
+/// (its column of the grid). Senders are indexed by `consumer_idx`, receivers
+/// by `producer_idx`. Self-edges (producer == consumer == this_worker) are
+/// included so the topology is symmetric.
+pub struct WorkerPeerAttach {
+    /// `peer_outbound[c]` writes to `peer_slot(this_worker, c)`.
+    pub peer_outbound: Vec<ShmMqSender>,
+    /// `peer_inbound[p]` reads from `peer_slot(p, this_worker)`.
+    pub peer_inbound: Vec<ShmMqReceiver>,
 }
 
 /// Initialize the DSM region as the leader. Writes the header, copies plan
@@ -460,6 +538,21 @@ pub unsafe fn leader_init(
             let mq_addr = unsafe { base.add(layout.queues_offset + off * layout.queue_bytes) };
             let mq = unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.queue_bytes) };
             inbound_receivers.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
+        }
+    }
+
+    // Peer-mesh queues. The leader is not a peer (not part of the N×N
+    // grid); it just `shm_mq_create`s every slot so workers can attach as
+    // producer (their row) and consumer (their column). Skipped when no
+    // peer mesh was reserved.
+    if layout.peer_queue_bytes > 0 {
+        for prod in 0..layout.n_workers {
+            for cons in 0..layout.n_workers {
+                let slot = (prod as usize) * (layout.n_workers as usize) + (cons as usize);
+                let mq_addr =
+                    unsafe { base.add(layout.peer_mesh_offset + slot * layout.peer_queue_bytes) };
+                unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.peer_queue_bytes) };
+            }
         }
     }
 
@@ -524,46 +617,113 @@ pub unsafe fn worker_attach(
     Ok((header, plan_bytes, WorkerAttach { outbound_senders }))
 }
 
+/// Attach this worker to the peer-mesh queue grid as both producer
+/// (its row) and consumer (its column). Skipped (returns `Ok(None)`)
+/// when the region has no peer mesh reserved.
+///
+/// # Safety
+/// - `coordinate` must be the DSM region pointer the leader initialized.
+/// - `header` must be the validated header read from that region.
+/// - `seg` may be NULL — `shm_mq_attach` handles NULL by skipping its
+///   on-detach callback (cleanup falls back to process exit).
+pub unsafe fn worker_peer_attach(
+    coordinate: *mut c_void,
+    header: &MppDsmHeader,
+    worker_index: u32,
+    seg: *mut pg_sys::dsm_segment,
+) -> Result<Option<WorkerPeerAttach>, String> {
+    if header.peer_queue_bytes == 0 {
+        return Ok(None);
+    }
+    if coordinate.is_null() {
+        return Err("mpp: worker_peer_attach given null coordinate".into());
+    }
+    if worker_index >= header.n_workers {
+        return Err(format!(
+            "mpp: worker_peer_attach: worker_index={worker_index} >= n_workers={}",
+            header.n_workers
+        ));
+    }
+    let base = coordinate as *mut u8;
+    let n = header.n_workers;
+
+    // Attach as PRODUCER (this row): one sender per consumer column.
+    let mut peer_outbound = Vec::with_capacity(n as usize);
+    for c in 0..n {
+        let off = header.peer_slot_offset(worker_index, c) as usize;
+        let mq_addr = unsafe { base.add(off) };
+        let mq = mq_addr.cast::<pg_sys::shm_mq>();
+        peer_outbound.push(unsafe { ShmMqSender::attach(seg, mq) });
+    }
+
+    // Attach as CONSUMER (this column): one receiver per producer row.
+    let mut peer_inbound = Vec::with_capacity(n as usize);
+    for p in 0..n {
+        let off = header.peer_slot_offset(p, worker_index) as usize;
+        let mq_addr = unsafe { base.add(off) };
+        let mq = mq_addr.cast::<pg_sys::shm_mq>();
+        peer_inbound.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
+    }
+
+    Ok(Some(WorkerPeerAttach {
+        peer_outbound,
+        peer_inbound,
+    }))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn compute_dsm_layout_works() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0).unwrap();
+        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0, 0).unwrap();
         assert_eq!(l.n_workers, 4);
         assert_eq!(l.n_partitions, 1);
         // No cache reserved → cache regions all sit at queues_end (after MAXALIGN).
         let aligned = aligned_queue_bytes(64 * 1024);
         let queues_size = 4 * aligned;
         assert!(l.region_total >= l.queues_offset + queues_size);
+        // No peer mesh reserved.
+        assert_eq!(l.peer_queue_bytes, 0);
     }
 
     #[test]
     fn compute_dsm_layout_with_cache() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 2, 1024 * 1024).unwrap();
+        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 2, 1024 * 1024, 0).unwrap();
         let cache_data_size = 2 * 4 * 1024 * 1024; // 2 sources × 4 workers × 1 MiB
-        assert_eq!(l.region_total, l.cache_data_offset + cache_data_size);
+                                                   // peer_mesh_offset == cache_data_end after MAXALIGN; with peer=0 region_total == peer_mesh_offset.
+        assert_eq!(l.region_total, l.peer_mesh_offset);
+        assert!(l.peer_mesh_offset >= l.cache_data_offset + cache_data_size);
+    }
+
+    #[test]
+    fn compute_dsm_layout_with_peer_mesh() {
+        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0, 1024 * 1024).unwrap();
+        let aligned_peer = aligned_queue_bytes(1024 * 1024);
+        let peer_mesh_size = 4 * 4 * aligned_peer;
+        assert_eq!(l.peer_queue_bytes, aligned_peer);
+        assert_eq!(l.region_total, l.peer_mesh_offset + peer_mesh_size);
     }
 
     #[test]
     fn compute_dsm_layout_rejects_zero_workers() {
-        assert!(compute_dsm_layout(0, 1, 64 * 1024, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(0, 1, 64 * 1024, 0, 0, 0, 0).is_err());
     }
 
     #[test]
     fn compute_dsm_layout_rejects_zero_partitions() {
-        assert!(compute_dsm_layout(2, 0, 64 * 1024, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(2, 0, 64 * 1024, 0, 0, 0, 0).is_err());
     }
 
     #[test]
     fn compute_dsm_layout_rejects_oversize() {
-        assert!(compute_dsm_layout(u32::MAX, u32::MAX, 64 * 1024, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(u32::MAX, u32::MAX, 64 * 1024, 0, 0, 0, 0).is_err());
     }
 
     #[test]
     fn header_slot_offset_is_row_major() {
-        let l = compute_dsm_layout(3, 4, 64 * 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(3, 4, 64 * 1024, 0, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         let aligned = h.queue_bytes;
         assert_eq!(h.slot_offset(0, 0), h.queues_offset);
@@ -574,7 +734,7 @@ mod tests {
 
     #[test]
     fn header_cache_offsets() {
-        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 2, 1024).unwrap();
+        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 2, 1024, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         // (source=0, worker=0) is the first slot.
         assert_eq!(h.cache_data_slot_offset(0, 0), h.cache_data_offset);
@@ -588,16 +748,36 @@ mod tests {
     }
 
     #[test]
+    fn header_peer_slot_offset_is_row_major() {
+        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 0, 0, 64 * 1024).unwrap();
+        let h = MppDsmHeader::from_layout(&l);
+        let aligned = h.peer_queue_bytes;
+        assert_eq!(h.peer_slot_offset(0, 0), h.peer_mesh_offset);
+        assert_eq!(h.peer_slot_offset(0, 1), h.peer_mesh_offset + aligned);
+        // (1, 0): row 1, col 0 — n_workers slots in.
+        assert_eq!(h.peer_slot_offset(1, 0), h.peer_mesh_offset + 3 * aligned);
+        // (2, 2): last slot.
+        assert_eq!(h.peer_slot_offset(2, 2), h.peer_mesh_offset + 8 * aligned);
+    }
+
+    #[test]
     fn header_validate_accepts_self() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64).is_ok());
     }
 
     #[test]
     fn header_validate_rejects_size_mismatch() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64 + 1).is_err());
+    }
+
+    #[test]
+    fn header_validate_accepts_with_peer_mesh() {
+        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 0, 0, 64 * 1024).unwrap();
+        let h = MppDsmHeader::from_layout(&l);
+        assert!(h.validate(l.region_total as u64).is_ok());
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/exec.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec.rs
@@ -94,9 +94,9 @@ pub async fn run_producer_fragment(
 /// Run the inner producer fragment for the peer-mesh post-aggregate shuffle.
 ///
 /// The plan's `output_partitioning` is the *scaled* hash count (`n_consumers²`
-/// after the fork's `RepartitionExec` rewrite). Each output partition `j` is
+/// after the DF-D fork's `RepartitionExec` rewrite). Each output partition `j` is
 /// destined for consumer task `j / partitions_per_consumer`, which equals
-/// `j / n_consumers` (since the fork scales by `consumer_tc = n_consumers`).
+/// `j / n_consumers` (since the DF-D fork scales by `consumer_tc = n_consumers`).
 /// The batch is sent through `peer_outbound[consumer]` with the framed tag
 /// `j` so the consumer side's `DemuxDrainHandle` routes it to the right
 /// partition's sub-buffer.

--- a/pg_search/src/postgres/customscan/mpp/exec.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec.rs
@@ -24,6 +24,13 @@
 //!   The leader is consumer-only in this iteration (see
 //!   [`crate::postgres::customscan::mpp::glue::producer_worker_count`]);
 //!   leader-as-worker-0 is a deferred follow-up.
+//! - [`run_inner_producer_fragment`] — peer-mesh push loop for the post-
+//!   aggregate two-boundary plan (Track A/B). Runs every output partition
+//!   of `plan` concurrently and routes each batch with a partition-tagged
+//!   frame to the right peer-mesh outbound sender. Used in tandem with
+//!   `run_producer_fragment` running the OUTER (worker→leader) fragment;
+//!   both share the worker's current_thread Tokio runtime and interleave
+//!   on the cooperative drain.
 
 use std::sync::Arc;
 
@@ -80,6 +87,77 @@ pub async fn run_producer_fragment(
     }
     futures::future::try_join_all(futures).await?;
     // Drop senders so peers observe Detached on their next try_recv.
+    drop(senders);
+    Ok(())
+}
+
+/// Run the inner producer fragment for the peer-mesh post-aggregate shuffle.
+///
+/// The plan's `output_partitioning` is the *scaled* hash count (`n_consumers²`
+/// after the fork's `RepartitionExec` rewrite). Each output partition `j` is
+/// destined for consumer task `j / partitions_per_consumer`, which equals
+/// `j / n_consumers` (since the fork scales by `consumer_tc = n_consumers`).
+/// The batch is sent through `peer_outbound[consumer]` with the framed tag
+/// `j` so the consumer side's `DemuxDrainHandle` routes it to the right
+/// partition's sub-buffer.
+///
+/// `peer_outbound.len()` must equal `n_consumers`. The plan's output
+/// partition count must be `n_consumers² / 1` (= scaled), which we verify
+/// at entry.
+pub async fn run_inner_producer_fragment(
+    plan: Arc<dyn ExecutionPlan>,
+    peer_outbound: Vec<MppSender>,
+    n_consumers: usize,
+    ctx: Arc<TaskContext>,
+) -> Result<()> {
+    let n_partitions = plan.output_partitioning().partition_count();
+    if peer_outbound.len() != n_consumers {
+        return Err(DataFusionError::Internal(format!(
+            "run_inner_producer_fragment: expected {n_consumers} peer-outbound senders, got {}",
+            peer_outbound.len()
+        )));
+    }
+    if n_consumers == 0 || !n_partitions.is_multiple_of(n_consumers) {
+        return Err(DataFusionError::Internal(format!(
+            "run_inner_producer_fragment: plan has {n_partitions} output partitions, \
+             not divisible by {n_consumers} consumers"
+        )));
+    }
+    let partitions_per_consumer = n_partitions / n_consumers;
+
+    // Each consumer column of the peer mesh is one MppSender; multiple
+    // futures push through it concurrently, demuxing on the consumer side
+    // by the per-batch partition tag. Senders are `Arc<MppSender>` so each
+    // future holds a shared reference; concurrent calls to
+    // `send_batch_traced_framed` are scratch-buffer-safe (the inner
+    // `RefCell::replace` rotates buffers atomically) on a single-threaded
+    // Tokio runtime.
+    let senders: Vec<Arc<MppSender>> = peer_outbound.into_iter().map(Arc::new).collect();
+
+    let mut futures = Vec::with_capacity(n_partitions);
+    for partition in 0..n_partitions {
+        let consumer = partition / partitions_per_consumer;
+        let sender = Arc::clone(&senders[consumer]);
+        let plan = Arc::clone(&plan);
+        let ctx = Arc::clone(&ctx);
+        let tag = partition as u32;
+        futures.push(async move {
+            let mut stream = plan.execute(partition, ctx)?;
+            let mut stats = SendBatchStats::default();
+            while let Some(batch) = stream.next().await {
+                let batch = batch?;
+                if batch.num_rows() == 0 {
+                    continue;
+                }
+                sender
+                    .as_ref()
+                    .send_batch_traced_framed(tag, &batch, &mut stats)
+                    .await?;
+            }
+            Ok::<(), DataFusionError>(())
+        });
+    }
+    futures::future::try_join_all(futures).await?;
     drop(senders);
     Ok(())
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -101,6 +101,7 @@ pub fn estimate_dsm_size(
     plan_bytes_len: usize,
     n_partitions: u32,
     n_cache_sources: u32,
+    n_peer_meshes: u32,
 ) -> Result<usize, String> {
     let layout = compute_dsm_layout(
         producer_worker_count(),
@@ -110,6 +111,7 @@ pub fn estimate_dsm_size(
         n_cache_sources,
         MPP_CACHE_PER_SLOT,
         mpp_peer_queue_bytes(),
+        n_peer_meshes,
     )
     .map_err(|e| format!("mpp: estimate_dsm_size: {e}"))?;
     Ok(layout.region_total)
@@ -151,6 +153,7 @@ pub unsafe fn leader_setup(
     n_partitions: u32,
     plan_bytes: Vec<u8>,
     n_cache_sources: u32,
+    n_peer_meshes: u32,
 ) -> Result<MppLeaderState, String> {
     let n_workers = producer_worker_count();
     let layout = compute_dsm_layout(
@@ -161,6 +164,7 @@ pub unsafe fn leader_setup(
         n_cache_sources,
         MPP_CACHE_PER_SLOT,
         mpp_peer_queue_bytes(),
+        n_peer_meshes,
     )
     .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
 
@@ -211,9 +215,11 @@ pub struct MppWorkerState {
     /// Build-side all-gather cache. The worker writes its 1/N slice for each
     /// non-partitioning source, then reads back peer slices after the barrier.
     pub build_cache: Option<Arc<MppBuildCache>>,
-    /// Peer-mesh handle for the inner cross-worker shuffle (Track B). `None`
-    /// when `enable_mpp_postagg_shuffle = off` and no peer mesh was reserved.
-    pub peer_mesh: Option<Arc<MppPeerMesh>>,
+    /// Peer-mesh handles, one per nested cross-worker shuffle stage (Track B).
+    /// Empty when `enable_mpp_postagg_shuffle = off` or the planner emitted
+    /// no nested cross-worker shuffles. Indexed in the same order as the
+    /// peer meshes in DSM (see [`crate::postgres::customscan::mpp::dsm`]).
+    pub peer_meshes: Vec<Arc<MppPeerMesh>>,
 }
 
 /// Body of `initialize_worker_custom_scan`. Reads the header, attaches as
@@ -254,21 +260,24 @@ pub unsafe fn worker_setup(
         None
     };
 
-    // Peer-mesh demux tag space = global partition count of the inner
+    // Peer-mesh demux tag space = global partition count of each inner
     // shuffle. Fork's `_distribute_plan` scales the inner `RepartitionExec`
-    // by `consumer_tc = n_workers`, so the producer emits `n_workers²`
+    // by `consumer_tc = n_workers`, so each producer emits `n_workers²`
     // distinct partition_ids and each `(producer, consumer)` peer-mesh
     // edge multiplexes `n_workers` of them.
     let peer_partitions = header.n_workers.saturating_mul(header.n_workers);
-    let peer_mesh =
-        unsafe { worker_peer_attach(coordinate, &header, worker_index, seg) }?.map(|attach| {
+    let peer_attaches = unsafe { worker_peer_attach(coordinate, &header, worker_index, seg) }?;
+    let peer_meshes: Vec<Arc<MppPeerMesh>> = peer_attaches
+        .into_iter()
+        .map(|attach| {
             Arc::new(MppPeerMesh::from_worker_attach(
                 worker_index,
                 header.n_workers,
                 peer_partitions,
                 attach,
             ))
-        });
+        })
+        .collect();
 
     Ok(MppWorkerState {
         outbound_senders,
@@ -278,6 +287,6 @@ pub unsafe fn worker_setup(
             total_participants: header.n_workers,
         },
         build_cache,
-        peer_mesh,
+        peer_meshes,
     })
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -37,7 +37,8 @@ use std::sync::Arc;
 use pgrx::pg_sys;
 
 use crate::gucs::{
-    enable_mpp, mpp_cache_per_slot, mpp_queue_size as gucs_mpp_queue_size,
+    enable_mpp, enable_mpp_postagg_shuffle as gucs_enable_mpp_postagg_shuffle,
+    mpp_peer_queue_bytes as gucs_mpp_peer_queue_bytes, mpp_queue_size as gucs_mpp_queue_size,
     mpp_worker_count as gucs_mpp_worker_count,
 };
 use crate::postgres::customscan::mpp::dsm::{
@@ -83,8 +84,8 @@ pub fn mpp_queue_size() -> usize {
 /// Per-edge peer-mesh queue size, or 0 when `enable_mpp_postagg_shuffle = off`
 /// (peer mesh skipped entirely, no DSM reserved for it).
 pub fn mpp_peer_queue_bytes() -> usize {
-    if crate::gucs::enable_mpp_postagg_shuffle() {
-        crate::gucs::mpp_peer_queue_bytes()
+    if gucs_enable_mpp_postagg_shuffle() {
+        gucs_mpp_peer_queue_bytes()
     } else {
         0
     }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -41,8 +41,10 @@ use crate::gucs::{
     mpp_worker_count as gucs_mpp_worker_count,
 };
 use crate::postgres::customscan::mpp::dsm::{
-    compute_dsm_layout, leader_init, worker_attach, MppBuildCache,
+    compute_dsm_layout, leader_init, worker_attach, worker_peer_attach, MppBuildCache,
+    MPP_CACHE_PER_SLOT,
 };
+use crate::postgres::customscan::mpp::mesh::MppPeerMesh;
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
     DrainBuffer, DrainHandle, MppReceiver, MppSender,
@@ -78,6 +80,16 @@ pub fn mpp_queue_size() -> usize {
     gucs_mpp_queue_size()
 }
 
+/// Per-edge peer-mesh queue size, or 0 when `enable_mpp_postagg_shuffle = off`
+/// (peer mesh skipped entirely, no DSM reserved for it).
+pub fn mpp_peer_queue_bytes() -> usize {
+    if crate::gucs::enable_mpp_postagg_shuffle() {
+        crate::gucs::mpp_peer_queue_bytes()
+    } else {
+        0
+    }
+}
+
 /// Body of `estimate_dsm_custom_scan`. Returns total DSM bytes the leader
 /// will need for plan + N×K queue mesh + build-side cache. `N` is the *worker*
 /// count (`mpp_worker_count - 1`); the leader is a consumer-only participant
@@ -96,7 +108,8 @@ pub fn estimate_dsm_size(
         mpp_queue_size(),
         plan_bytes_len,
         n_cache_sources,
-        mpp_cache_per_slot(),
+        MPP_CACHE_PER_SLOT,
+        mpp_peer_queue_bytes(),
     )
     .map_err(|e| format!("mpp: estimate_dsm_size: {e}"))?;
     Ok(layout.region_total)
@@ -146,7 +159,8 @@ pub unsafe fn leader_setup(
         mpp_queue_size(),
         plan_bytes.len(),
         n_cache_sources,
-        mpp_cache_per_slot(),
+        MPP_CACHE_PER_SLOT,
+        mpp_peer_queue_bytes(),
     )
     .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
 
@@ -197,6 +211,9 @@ pub struct MppWorkerState {
     /// Build-side all-gather cache. The worker writes its 1/N slice for each
     /// non-partitioning source, then reads back peer slices after the barrier.
     pub build_cache: Option<Arc<MppBuildCache>>,
+    /// Peer-mesh handle for the inner cross-worker shuffle (Track B). `None`
+    /// when `enable_mpp_postagg_shuffle = off` and no peer mesh was reserved.
+    pub peer_mesh: Option<Arc<MppPeerMesh>>,
 }
 
 /// Body of `initialize_worker_custom_scan`. Reads the header, attaches as
@@ -237,6 +254,22 @@ pub unsafe fn worker_setup(
         None
     };
 
+    // Peer-mesh demux tag space = global partition count of the inner
+    // shuffle. Fork's `_distribute_plan` scales the inner `RepartitionExec`
+    // by `consumer_tc = n_workers`, so the producer emits `n_workers²`
+    // distinct partition_ids and each `(producer, consumer)` peer-mesh
+    // edge multiplexes `n_workers` of them.
+    let peer_partitions = header.n_workers.saturating_mul(header.n_workers);
+    let peer_mesh =
+        unsafe { worker_peer_attach(coordinate, &header, worker_index, seg) }?.map(|attach| {
+            Arc::new(MppPeerMesh::from_worker_attach(
+                worker_index,
+                header.n_workers,
+                peer_partitions,
+                attach,
+            ))
+        });
+
     Ok(MppWorkerState {
         outbound_senders,
         plan_bytes,
@@ -245,5 +278,6 @@ pub unsafe fn worker_setup(
             total_participants: header.n_workers,
         },
         build_cache,
+        peer_mesh,
     })
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -42,7 +42,7 @@ use crate::gucs::{
     mpp_worker_count as gucs_mpp_worker_count,
 };
 use crate::postgres::customscan::mpp::dsm::{
-    compute_dsm_layout, leader_init, worker_attach, worker_peer_attach, MppBuildCache, MppDsmHeader,
+    compute_dsm_layout, leader_init, worker_attach, worker_peer_attach, MppBuildCache,
 };
 use crate::postgres::customscan::mpp::mesh::MppPeerMesh;
 use crate::postgres::customscan::mpp::runtime::MppMesh;

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -42,7 +42,7 @@ use crate::gucs::{
 };
 use crate::postgres::customscan::mpp::dsm::{
     compute_dsm_layout, leader_init, worker_attach, worker_peer_attach, MppBuildCache,
-    MPP_CACHE_PER_SLOT,
+    MppDsmHeader, MPP_CACHE_PER_SLOT,
 };
 use crate::postgres::customscan::mpp::mesh::MppPeerMesh;
 use crate::postgres::customscan::mpp::runtime::MppMesh;

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -37,13 +37,12 @@ use std::sync::Arc;
 use pgrx::pg_sys;
 
 use crate::gucs::{
-    enable_mpp, enable_mpp_postagg_shuffle as gucs_enable_mpp_postagg_shuffle,
+    enable_mpp, enable_mpp_postagg_shuffle as gucs_enable_mpp_postagg_shuffle, mpp_cache_per_slot,
     mpp_peer_queue_bytes as gucs_mpp_peer_queue_bytes, mpp_queue_size as gucs_mpp_queue_size,
     mpp_worker_count as gucs_mpp_worker_count,
 };
 use crate::postgres::customscan::mpp::dsm::{
-    compute_dsm_layout, leader_init, worker_attach, worker_peer_attach, MppBuildCache,
-    MppDsmHeader, MPP_CACHE_PER_SLOT,
+    compute_dsm_layout, leader_init, worker_attach, worker_peer_attach, MppBuildCache, MppDsmHeader,
 };
 use crate::postgres::customscan::mpp::mesh::MppPeerMesh;
 use crate::postgres::customscan::mpp::runtime::MppMesh;
@@ -110,7 +109,7 @@ pub fn estimate_dsm_size(
         mpp_queue_size(),
         plan_bytes_len,
         n_cache_sources,
-        MPP_CACHE_PER_SLOT,
+        mpp_cache_per_slot(),
         mpp_peer_queue_bytes(),
         n_peer_meshes,
     )
@@ -163,7 +162,7 @@ pub unsafe fn leader_setup(
         mpp_queue_size(),
         plan_bytes.len(),
         n_cache_sources,
-        MPP_CACHE_PER_SLOT,
+        mpp_cache_per_slot(),
         mpp_peer_queue_bytes(),
         n_peer_meshes,
     )

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -22,14 +22,18 @@
 //! [`super::dsm`](crate::postgres::customscan::mpp::dsm); this module owns
 //! only the per-slot FFI wrappers.
 
+use std::sync::Arc;
+
+use parking_lot::Mutex;
 use pgrx::pg_sys;
 
 use crate::mpp_log;
 use crate::parallel_worker::mqueue::{
     MessageQueueReceiver, MessageQueueRecvError, MessageQueueSendError, MessageQueueSender,
 };
+use crate::postgres::customscan::mpp::dsm::WorkerPeerAttach;
 use crate::postgres::customscan::mpp::transport::{
-    BatchChannelReceiver, BatchChannelSender, RecvOutcome,
+    BatchChannelReceiver, BatchChannelSender, DemuxDrainHandle, MppReceiver, MppSender, RecvOutcome,
 };
 use datafusion::common::DataFusionError;
 
@@ -171,6 +175,99 @@ impl BatchChannelReceiver for ShmMqReceiver {
                 RecvOutcome::Detached
             }
         }
+    }
+}
+
+/// Per-worker handle to the peer mesh (Track B).
+///
+/// Each worker is both a producer (its row of the N×N grid) and a consumer
+/// (its column). The leader is not part of the peer mesh.
+///
+/// Inbound demux drains: one [`DemuxDrainHandle`] per producer worker.
+/// Each drain reads tagged framed messages from the `(producer, this_worker)`
+/// shm_mq queue and routes by `tag = partition_id` into per-partition
+/// sub-buffers. `n_partitions` is the number of distinct partitions a
+/// producer can address — for the post-aggregate peer-mesh shuffle this
+/// is the *global* partition count (`n_workers²` after the fork's
+/// `RepartitionExec` scaling) so every consumer task K can demux its
+/// partitions `N*K..(K+1)*N - 1`.
+///
+/// The `outbound` senders are held inside a `Mutex<Option<...>>` so the
+/// inner producer fragment can take ownership exactly once via
+/// [`Self::take_outbound`] before it begins pushing.
+pub struct MppPeerMesh {
+    pub n_workers: u32,
+    pub self_idx: u32,
+    pub n_partitions: u32,
+    outbound: Mutex<Option<Vec<MppSender>>>,
+    /// Inbound demux drain handles, one per producer worker. Cloned out at
+    /// transport `open()` time so a peer-mesh shuffle can stream from
+    /// each peer independently and demux by partition tag.
+    inbound_drains: Vec<Arc<DemuxDrainHandle>>,
+}
+
+impl std::fmt::Debug for MppPeerMesh {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MppPeerMesh")
+            .field("n_workers", &self.n_workers)
+            .field("self_idx", &self.self_idx)
+            .field("n_partitions", &self.n_partitions)
+            .field("outbound_taken", &self.outbound.lock().is_none())
+            .field("inbound_drains", &self.inbound_drains.len())
+            .finish()
+    }
+}
+
+impl MppPeerMesh {
+    /// Build from `worker_peer_attach`'s output. Wraps each shm_mq receiver
+    /// in a cooperative [`DemuxDrainHandle`] sized to `n_partitions` tag
+    /// buckets — the producer side will frame each batch with `tag =
+    /// partition_id` and the consumer demuxes accordingly.
+    pub fn from_worker_attach(
+        self_idx: u32,
+        n_workers: u32,
+        n_partitions: u32,
+        attach: WorkerPeerAttach,
+    ) -> Self {
+        let outbound: Vec<MppSender> = attach
+            .peer_outbound
+            .into_iter()
+            .map(|s| MppSender::new(Box::new(s)))
+            .collect();
+        let inbound_drains: Vec<Arc<DemuxDrainHandle>> = attach
+            .peer_inbound
+            .into_iter()
+            .map(|r| {
+                let mpp_recv = MppReceiver::new(Box::new(r));
+                Arc::new(DemuxDrainHandle::cooperative(vec![mpp_recv], n_partitions))
+            })
+            .collect();
+        debug_assert_eq!(outbound.len(), n_workers as usize);
+        debug_assert_eq!(inbound_drains.len(), n_workers as usize);
+        Self {
+            n_workers,
+            self_idx,
+            n_partitions,
+            outbound: Mutex::new(Some(outbound)),
+            inbound_drains,
+        }
+    }
+
+    /// Take ownership of the outbound senders. Returns `None` if already
+    /// taken. The inner producer fragment calls this exactly once before it
+    /// begins pushing.
+    pub fn take_outbound(&self) -> Option<Vec<MppSender>> {
+        self.outbound.lock().take()
+    }
+
+    /// Demux drain handle for the queue from `producer` to this worker.
+    /// Indexed by producer worker idx; each handle exposes per-tag
+    /// sub-buffers via [`DemuxDrainHandle::buffer`].
+    pub fn drain_for_producer(&self, producer: u32) -> Option<&Arc<DemuxDrainHandle>> {
+        if producer >= self.n_workers {
+            return None;
+        }
+        self.inbound_drains.get(producer as usize)
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -88,13 +88,25 @@ impl ShmMqSender {
     }
 }
 
+impl ShmMqSender {
+    /// True iff the caller is on the thread that originally attached this
+    /// sender. Reserved for the future multi-thread Tokio path (G7-MT)
+    /// where compute threads dispatch FFI ops back to the attach thread
+    /// via channel.
+    #[allow(dead_code)]
+    pub fn on_attach_thread(&self) -> bool {
+        std::thread::current().id() == self.attach_thread
+    }
+}
+
 impl BatchChannelSender for ShmMqSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
-        debug_assert_eq!(
-            std::thread::current().id(),
-            self.attach_thread,
-            "ShmMqSender::send_bytes called off the attach thread"
-        );
+        // Non-blocking shm_mq send under the hood is thread-safe within
+        // the same process (the underlying `shm_mq_send(nowait=true)` only
+        // touches DSM-resident atomics + `SetLatch`, which is documented
+        // as safe from any thread / signal handlers). The blocking variant
+        // would call `WaitLatch` which is backend-only — but we use the
+        // cooperative-drain spin instead of the blocking path.
         self.inner.send(bytes).map_err(|e| match e {
             MessageQueueSendError::Detached => {
                 DataFusionError::Execution("mpp: shm_mq sender detached".into())
@@ -110,11 +122,6 @@ impl BatchChannelSender for ShmMqSender {
     }
 
     fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
-        debug_assert_eq!(
-            std::thread::current().id(),
-            self.attach_thread,
-            "ShmMqSender::try_send_bytes called off the attach thread"
-        );
         match self.inner.try_send(bytes) {
             Ok(Some(())) => Ok(true),
             Ok(None) => Ok(false),

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -195,7 +195,7 @@ impl BatchChannelReceiver for ShmMqReceiver {
 /// shm_mq queue and routes by `tag = partition_id` into per-partition
 /// sub-buffers. `n_partitions` is the number of distinct partitions a
 /// producer can address — for the post-aggregate peer-mesh shuffle this
-/// is the *global* partition count (`n_workers²` after the fork's
+/// is the *global* partition count (`n_workers²` after the DF-D fork's
 /// `RepartitionExec` scaling) so every consumer task K can demux its
 /// partitions `N*K..(K+1)*N - 1`.
 ///

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -51,11 +51,16 @@ pub struct MppParticipantConfig {
 /// Emit a runtime trace when `paradedb.mpp_debug` is on.
 ///
 /// Routed through `pgrx::warning!` so the line appears in the Postgres server log
-/// (and in CI benchmark logs). No-op when the GUC is off.
+/// (and in CI benchmark logs). No-op when the GUC is off OR when called from
+/// a non-backend thread (a future multi-thread Tokio runtime — see G7-MT plan
+/// in report.md). The `is_on_backend_thread()` gate is a no-op today but
+/// prepares the macro for safe use from compute threads.
 #[macro_export]
 macro_rules! mpp_log {
     ($($arg:tt)*) => {
-        if $crate::gucs::mpp_debug() {
+        if $crate::postgres::customscan::mpp::transport::is_on_backend_thread()
+            && $crate::gucs::mpp_debug()
+        {
             pgrx::warning!($($arg)*);
         }
     };

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -45,7 +45,8 @@ use datafusion_distributed::{
 };
 use url::Url;
 
-use crate::postgres::customscan::mpp::transport::{DrainHandle, DrainItem};
+use crate::postgres::customscan::mpp::mesh::MppPeerMesh;
+use crate::postgres::customscan::mpp::transport::{DemuxDrainHandle, DrainHandle, DrainItem};
 
 /// Runtime handle the customscan populates at DSM-init time.
 pub struct MppMesh {
@@ -231,5 +232,154 @@ impl WorkerConnection for LocalExecWorkerConnection {
         // the WorkerPartitionStream alias drops the schema bound, so the
         // existing pinned box satisfies it directly.
         Ok(stream)
+    }
+}
+
+/// Worker-side [`WorkerTransport`] that resolves a peer-mesh
+/// `NetworkShuffleExec(consumer_tc=N, input_tc=N)` boundary.
+///
+/// `open(input_stage, target_partitions, target_task=producer_idx, ...)`
+/// returns a [`ShmMqPeerWorkerConnection`] that streams from the peer-mesh
+/// queue at column = this worker's idx, row = `target_task`. The data IN
+/// that queue must be pushed by `target_task` running its inner producer
+/// fragment concurrently — see `exec_mpp_worker`.
+///
+/// Each `(producer, consumer)` peer-mesh edge carries N partitions
+/// multiplexed (one frame per partition tagged with `partition_id`). The
+/// connection's `stream_partition(p)` returns the demuxed sub-buffer for
+/// partition `p`, so DataFusion's scheduler calling
+/// `stream_partition(off..off+pcount)` per consumer task gets one stream
+/// per global partition.
+pub struct ShmMqPeerWorkerTransport {
+    peer_mesh: Arc<MppPeerMesh>,
+}
+
+impl ShmMqPeerWorkerTransport {
+    pub fn new(peer_mesh: Arc<MppPeerMesh>) -> Self {
+        Self { peer_mesh }
+    }
+}
+
+impl WorkerTransport for ShmMqPeerWorkerTransport {
+    fn open(
+        &self,
+        _input_stage: &Stage,
+        _target_partitions: Range<usize>,
+        target_task: usize,
+        _ctx: &Arc<TaskContext>,
+        _metrics: &ExecutionPlanMetricsSet,
+    ) -> Result<Box<dyn WorkerConnection>> {
+        let producer = u32::try_from(target_task).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "ShmMqPeerWorkerTransport: target_task={target_task} > u32::MAX"
+            ))
+        })?;
+        let drain = self
+            .peer_mesh
+            .drain_for_producer(producer)
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "ShmMqPeerWorkerTransport: no drain for producer={producer} \
+                     (n_workers={})",
+                    self.peer_mesh.n_workers
+                ))
+            })?
+            .clone();
+        Ok(Box::new(ShmMqPeerWorkerConnection { drain }))
+    }
+}
+
+struct ShmMqPeerWorkerConnection {
+    drain: Arc<DemuxDrainHandle>,
+}
+
+impl WorkerConnection for ShmMqPeerWorkerConnection {
+    fn stream_partition(&self, partition: usize) -> Result<WorkerPartitionStream> {
+        let tag = u32::try_from(partition).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "ShmMqPeerWorkerConnection: partition={partition} > u32::MAX"
+            ))
+        })?;
+        let drain = Arc::clone(&self.drain);
+        // Each call to stream_partition(p) returns the per-tag sub-buffer's
+        // stream. DataFusion's NetworkShuffleExec calls this once per
+        // consumer-side partition, so each partition gets a fresh stream
+        // backed by its own demux buffer.
+        let buffer = drain
+            .buffer(tag)
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "ShmMqPeerWorkerConnection: no demux sub-buffer for tag={tag}"
+                ))
+            })?
+            .clone();
+        let stream = async_stream::stream! {
+            loop {
+                // Drain pass populates *all* sub-buffers for this producer
+                // — we share the cooperative drain across every partition
+                // stream, so any one stream's poll moves the others
+                // forward.
+                if let Err(e) = drain.poll_drain_pass() {
+                    yield Err(e);
+                    return;
+                }
+                match buffer.try_pop() {
+                    Some(DrainItem::Batch(batch)) => yield Ok(batch),
+                    Some(DrainItem::Eof) => break,
+                    None => tokio::task::yield_now().await,
+                }
+            }
+        };
+        Ok(Box::pin(stream))
+    }
+}
+
+/// Composite worker-side [`WorkerTransport`] that routes by the input
+/// stage's producer-task count:
+///
+/// - `tasks.len() > 1` → peer-mesh shuffle (Track B), routed to
+///   [`ShmMqPeerWorkerTransport`] when a peer mesh is registered, else falls
+///   back to [`LocalExecWorkerTransport`] (the latter would crash for
+///   N>1 — see commit 5f89185 of the fork — so this fallback is only safe
+///   when no two-boundary plan is in flight).
+/// - `tasks.len() == 1` → broadcast (build-side `NetworkBroadcastExec`),
+///   routed to [`LocalExecWorkerTransport`] which re-executes the input
+///   subplan locally.
+///
+/// Track A's planner change always emits `tasks.len() = N` for the inner
+/// peer-mesh shuffle, so the heuristic discriminates cleanly between the
+/// two boundary kinds we surface in workers.
+pub struct CompositeWorkerTransport {
+    peer: Option<ShmMqPeerWorkerTransport>,
+}
+
+impl CompositeWorkerTransport {
+    pub fn new(peer_mesh: Option<Arc<MppPeerMesh>>) -> Self {
+        Self {
+            peer: peer_mesh.map(ShmMqPeerWorkerTransport::new),
+        }
+    }
+}
+
+impl WorkerTransport for CompositeWorkerTransport {
+    fn open(
+        &self,
+        input_stage: &Stage,
+        target_partitions: Range<usize>,
+        target_task: usize,
+        ctx: &Arc<TaskContext>,
+        metrics: &ExecutionPlanMetricsSet,
+    ) -> Result<Box<dyn WorkerConnection>> {
+        if input_stage.tasks.len() > 1 {
+            if let Some(peer) = &self.peer {
+                return peer.open(input_stage, target_partitions, target_task, ctx, metrics);
+            }
+            return Err(DataFusionError::Internal(format!(
+                "CompositeWorkerTransport: input_stage tasks.len()={} requires a peer mesh, \
+                 but enable_mpp_postagg_shuffle is off",
+                input_stage.tasks.len()
+            )));
+        }
+        LocalExecWorkerTransport.open(input_stage, target_partitions, target_task, ctx, metrics)
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -43,8 +43,8 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{
-    NetworkBoundary, NetworkShuffleExec, Stage, WorkerConnection, WorkerPartitionStream,
-    WorkerResolver, WorkerTransport,
+    NetworkBoundary, NetworkShuffleExec, OnMetadataCallback, Stage, WorkerConnection,
+    WorkerPartitionStream, WorkerResolver, WorkerTransport,
 };
 use url::Url;
 
@@ -299,7 +299,7 @@ impl WorkerConnection for ShmMqPeerWorkerConnection {
     fn stream_partition(
         &self,
         partition: usize,
-        _on_metadata: datafusion_distributed::OnMetadataCallback,
+        _on_metadata: OnMetadataCallback,
     ) -> Result<WorkerPartitionStream> {
         let tag = u32::try_from(partition).map_err(|_| {
             DataFusionError::Internal(format!(

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -32,16 +32,19 @@
 //!   capacity; we don't have URLs (everything is in-process), so any
 //!   address satisfies the API.
 
+use std::collections::HashMap;
 use std::ops::Range;
 use std::sync::Arc;
+
+use parking_lot::RwLock;
 
 use async_trait::async_trait;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{
-    OnMetadataCallback, Stage, WorkerConnection, WorkerPartitionStream, WorkerResolver,
-    WorkerTransport,
+    NetworkBoundary, NetworkShuffleExec, Stage, WorkerConnection, WorkerPartitionStream,
+    WorkerResolver, WorkerTransport,
 };
 use url::Url;
 
@@ -267,7 +270,6 @@ impl WorkerTransport for ShmMqPeerWorkerTransport {
         _target_partitions: Range<usize>,
         target_task: usize,
         _ctx: &Arc<TaskContext>,
-        _metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Box<dyn WorkerConnection>> {
         let producer = u32::try_from(target_task).map_err(|_| {
             DataFusionError::Internal(format!(
@@ -334,30 +336,44 @@ impl WorkerConnection for ShmMqPeerWorkerConnection {
     }
 }
 
+/// Shared, mutable routing map from `Stage` ID to peer mesh. The leader
+/// builds the physical plan first (which assigns stage IDs) and only then
+/// can it know which `stage.num()` corresponds to which DSM-allocated peer
+/// mesh — so the map is populated *after* the worker session is built but
+/// before plan execution. `CompositeWorkerTransport` holds an `Arc` over
+/// this map; `exec_mpp_worker` holds a second `Arc` for the post-planning
+/// write.
+pub type SharedStageMeshMap = Arc<RwLock<HashMap<usize, Arc<MppPeerMesh>>>>;
+
 /// Composite worker-side [`WorkerTransport`] that routes by the input
-/// stage's producer-task count:
+/// stage's `num` (its `Stage` ID). Each cross-worker shuffle stage is
+/// associated with one peer mesh (allocated in DSM); broadcast stages
+/// (or any stage without a registered mesh) fall through to
+/// [`LocalExecWorkerTransport`] which re-executes the input subplan
+/// locally.
 ///
-/// - `tasks.len() > 1` → peer-mesh shuffle (Track B), routed to
-///   [`ShmMqPeerWorkerTransport`] when a peer mesh is registered, else falls
-///   back to [`LocalExecWorkerTransport`] (the latter would crash for
-///   N>1 — see commit 5f89185 of the fork — so this fallback is only safe
-///   when no two-boundary plan is in flight).
-/// - `tasks.len() == 1` → broadcast (build-side `NetworkBroadcastExec`),
-///   routed to [`LocalExecWorkerTransport`] which re-executes the input
-///   subplan locally.
-///
-/// Track A's planner change always emits `tasks.len() = N` for the inner
-/// peer-mesh shuffle, so the heuristic discriminates cleanly between the
-/// two boundary kinds we surface in workers.
+/// The routing map is built at worker start by walking the worker fragment
+/// (the input subtree of the OUTER `NetworkShuffleExec`) and zipping each
+/// nested `NetworkShuffleExec`'s `stage.num()` with the corresponding
+/// `MppPeerMesh` from `MppWorkerState::peer_meshes`. Both leader and worker
+/// re-plan from the same logical plan deterministically, so the stage-num
+/// ordering matches what the leader allocated in DSM.
 pub struct CompositeWorkerTransport {
-    peer: Option<ShmMqPeerWorkerTransport>,
+    routes: SharedStageMeshMap,
 }
 
 impl CompositeWorkerTransport {
-    pub fn new(peer_mesh: Option<Arc<MppPeerMesh>>) -> Self {
-        Self {
-            peer: peer_mesh.map(ShmMqPeerWorkerTransport::new),
-        }
+    /// Build the composite transport over a shared routing map. The map
+    /// can be empty at construction time and populated later via the
+    /// `Arc<RwLock<...>>` held by the caller — `open()` reads under a
+    /// shared lock per call.
+    pub fn new(routes: SharedStageMeshMap) -> Self {
+        Self { routes }
+    }
+
+    /// Convenience: an empty shared routing map.
+    pub fn empty_routes() -> SharedStageMeshMap {
+        Arc::new(RwLock::new(HashMap::new()))
     }
 }
 
@@ -368,18 +384,62 @@ impl WorkerTransport for CompositeWorkerTransport {
         target_partitions: Range<usize>,
         target_task: usize,
         ctx: &Arc<TaskContext>,
-        metrics: &ExecutionPlanMetricsSet,
     ) -> Result<Box<dyn WorkerConnection>> {
-        if input_stage.tasks.len() > 1 {
-            if let Some(peer) = &self.peer {
-                return peer.open(input_stage, target_partitions, target_task, ctx, metrics);
-            }
-            return Err(DataFusionError::Internal(format!(
-                "CompositeWorkerTransport: input_stage tasks.len()={} requires a peer mesh, \
-                 but enable_mpp_postagg_shuffle is off",
-                input_stage.tasks.len()
-            )));
+        let routes = self.routes.read();
+        if let Some(mesh) = routes.get(&input_stage.num()) {
+            let peer = ShmMqPeerWorkerTransport::new(Arc::clone(mesh));
+            // Drop the read guard before doing async work below.
+            drop(routes);
+            return peer.open(input_stage, target_partitions, target_task, ctx);
         }
-        LocalExecWorkerTransport.open(input_stage, target_partitions, target_task, ctx, metrics)
+        drop(routes);
+        // No peer mesh registered for this stage: must be a broadcast or a
+        // deeper-nested shuffle that's still elided by the planner. Fall
+        // through to LocalExec which re-executes the input subplan locally.
+        LocalExecWorkerTransport.open(input_stage, target_partitions, target_task, ctx)
     }
+}
+
+/// Walk a worker fragment plan (the input subtree of the OUTER
+/// `NetworkShuffleExec`) and collect the `stage.num()` of every nested
+/// `NetworkShuffleExec`, in pre-order DFS. The order is deterministic
+/// across leader and worker because both re-plan from the same logical
+/// plan — used to zip stage numbers with the leader's allocated peer
+/// meshes.
+pub fn collect_inner_shuffle_stage_ids(plan: &Arc<dyn ExecutionPlan>) -> Vec<usize> {
+    let mut out = Vec::new();
+    collect_inner_shuffle_stage_ids_inner(plan, &mut out);
+    out
+}
+
+fn collect_inner_shuffle_stage_ids_inner(plan: &Arc<dyn ExecutionPlan>, out: &mut Vec<usize>) {
+    if let Some(nse) = plan.as_any().downcast_ref::<NetworkShuffleExec>() {
+        out.push(nse.input_stage().num());
+    }
+    for child in plan.children() {
+        collect_inner_shuffle_stage_ids_inner(child, out);
+    }
+}
+
+/// Build a `HashMap<stage_num, MppPeerMesh>` by zipping the stage IDs
+/// produced by [`collect_inner_shuffle_stage_ids`] with the worker's
+/// `peer_meshes` Vec (in the order the leader allocated them in DSM).
+/// If the lengths disagree this returns an error, since a mismatch
+/// indicates the leader and worker disagreed on plan shape.
+pub fn build_stage_to_mesh_map(
+    stage_ids: &[usize],
+    peer_meshes: &[Arc<MppPeerMesh>],
+) -> Result<HashMap<usize, Arc<MppPeerMesh>>, DataFusionError> {
+    if stage_ids.len() != peer_meshes.len() {
+        return Err(DataFusionError::Internal(format!(
+            "mpp: leader allocated {} peer meshes but worker plan has {} cross-worker shuffles",
+            peer_meshes.len(),
+            stage_ids.len()
+        )));
+    }
+    Ok(stage_ids
+        .iter()
+        .zip(peer_meshes.iter())
+        .map(|(stage, mesh)| (*stage, Arc::clone(mesh)))
+        .collect())
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -296,7 +296,11 @@ struct ShmMqPeerWorkerConnection {
 }
 
 impl WorkerConnection for ShmMqPeerWorkerConnection {
-    fn stream_partition(&self, partition: usize) -> Result<WorkerPartitionStream> {
+    fn stream_partition(
+        &self,
+        partition: usize,
+        _on_metadata: datafusion_distributed::OnMetadataCallback,
+    ) -> Result<WorkerPartitionStream> {
         let tag = u32::try_from(partition).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqPeerWorkerConnection: partition={partition} > u32::MAX"

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -421,6 +421,34 @@ fn collect_inner_shuffle_stage_ids_inner(plan: &Arc<dyn ExecutionPlan>, out: &mu
     }
 }
 
+/// Sibling of [`collect_inner_shuffle_stage_ids`]. Walks the plan in the
+/// same pre-order DFS and returns each nested `NetworkShuffleExec`'s
+/// `children()[0]` — the producer subtree the worker must run to feed
+/// that peer-mesh stage. The returned Vec is in the same order as
+/// [`collect_inner_shuffle_stage_ids`] and `peer_meshes`, so both can be
+/// zipped to spawn K concurrent inner-fragment runners.
+pub fn collect_inner_producer_fragments(
+    plan: &Arc<dyn ExecutionPlan>,
+) -> Vec<Arc<dyn ExecutionPlan>> {
+    let mut out = Vec::new();
+    collect_inner_producer_fragments_inner(plan, &mut out);
+    out
+}
+
+fn collect_inner_producer_fragments_inner(
+    plan: &Arc<dyn ExecutionPlan>,
+    out: &mut Vec<Arc<dyn ExecutionPlan>>,
+) {
+    if plan.as_any().downcast_ref::<NetworkShuffleExec>().is_some() {
+        if let Some(child) = plan.children().first() {
+            out.push(Arc::clone(child));
+        }
+    }
+    for child in plan.children() {
+        collect_inner_producer_fragments_inner(child, out);
+    }
+}
+
 /// Build a `HashMap<stage_num, MppPeerMesh>` by zipping the stage IDs
 /// produced by [`collect_inner_shuffle_stage_ids`] with the worker's
 /// `peer_meshes` Vec (in the order the leader allocated them in DSM).

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -37,6 +37,26 @@ use std::thread;
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+thread_local! {
+    /// True iff this thread is the PG backend thread — set explicitly by
+    /// `mark_backend_thread()` on entry to the customscan path. Compute
+    /// futures spawned onto a multi-thread Tokio runtime see `false` and
+    /// skip pgrx FFI that touches process-global state (e.g.
+    /// `CHECK_FOR_INTERRUPTS`).
+    static IS_BACKEND_THREAD: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
+/// Mark the current thread as the PG backend thread. Call once on entry
+/// to the customscan path before spawning Tokio compute futures.
+pub fn mark_backend_thread() {
+    IS_BACKEND_THREAD.with(|c| c.set(true));
+}
+
+/// True iff `mark_backend_thread()` was called on the current thread.
+pub fn is_on_backend_thread() -> bool {
+    IS_BACKEND_THREAD.with(|c| c.get())
+}
+
 use datafusion::arrow::array::RecordBatch;
 use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::ipc::writer::StreamWriter;
@@ -512,16 +532,19 @@ impl MppSender {
         // making forward progress during this yield instead of
         // starving.
         loop {
-            // `pgrx::check_for_interrupts!()` pulls in PG symbols
-            // (`ProcessInterrupts`, `PG_exception_stack`,
-            // `CopyErrorData`, …) that aren't linked into the crate's
-            // `--tests` / llvm-cov build. This fn is reached from
-            // `#[cfg(test)]` code in this file and `shuffle.rs`, so
-            // gate the check out of test builds; `InProc` channels
-            // used in tests never block, so the send side of the loop
-            // returns on the first iteration anyway.
+            // `pgrx::check_for_interrupts!()` reads process-global
+            // `InterruptPending` / `PG_exception_stack` etc. and is only
+            // safe on the backend thread. Today the runtime is single-
+            // threaded so this branch is always hit; the gate prepares
+            // the macro for safe use from compute threads once G7-MT
+            // (multi-thread Tokio + FFI relay) lands.
+            //
+            // (Test builds also skip it because pgrx symbols aren't linked
+            // into `--tests` / llvm-cov.)
             #[cfg(not(test))]
-            pgrx::check_for_interrupts!();
+            if is_on_backend_thread() {
+                pgrx::check_for_interrupts!();
+            }
             if self.channel.try_send_bytes(scratch)? {
                 if !first_try {
                     stats.send_wait += t_wait_start.elapsed();

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -75,6 +75,70 @@ pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusionError> {
     Ok(batch)
 }
 
+/// Wire-format primitive: a single tagged framed batch on a `BatchChannel`.
+///
+/// Layout (little-endian):
+///
+/// ```text
+///   +--------- 12 bytes ---------+
+///   | u32 magic = MPP_FRAME_MAGIC |
+///   | u32 tag                     |
+///   | u32 ipc_len                 |
+///   +------- ipc_len bytes ------+
+///   | Arrow IPC stream           |
+///   +-----------------------------+
+/// ```
+///
+/// The `tag` is an arbitrary routing key the consumer demuxes against.
+/// First user is the peer-mesh post-aggregate shuffle, where `tag = partition_id`
+/// so each `NetworkShuffleExec.execute(p)` call gets the right partition's
+/// batches. Future users can carry any other u32 routing key (stage_id,
+/// query_id, …) over the same primitive without changing the wire format.
+pub const MPP_FRAME_MAGIC: u32 = 0x4D50_4646; // "MPPF"
+pub const FRAME_HEADER_BYTES: usize = 12;
+
+/// Frame `ipc_bytes` with `tag` into `buf`, ready for [`BatchChannelSender::send_bytes`].
+/// Buf is cleared first so the caller's already-allocated capacity is reused.
+///
+/// Public utility for callers that want framing without going through
+/// [`MppSender::send_batch_traced_framed`] (e.g. tests pushing raw bytes
+/// through an in-proc channel).
+#[allow(dead_code)] // exposed as a primitive; tests + external callers use it.
+pub fn frame_into(tag: u32, ipc_bytes: &[u8], buf: &mut Vec<u8>) {
+    buf.clear();
+    buf.reserve(ipc_bytes.len() + FRAME_HEADER_BYTES);
+    buf.extend_from_slice(&MPP_FRAME_MAGIC.to_le_bytes());
+    buf.extend_from_slice(&tag.to_le_bytes());
+    buf.extend_from_slice(&(ipc_bytes.len() as u32).to_le_bytes());
+    buf.extend_from_slice(ipc_bytes);
+}
+
+/// Parse a framed message produced by [`frame_into`]. Returns `(tag, ipc_bytes)`.
+pub fn parse_frame(bytes: &[u8]) -> Result<(u32, &[u8]), DataFusionError> {
+    if bytes.len() < FRAME_HEADER_BYTES {
+        return Err(DataFusionError::Execution(format!(
+            "mpp: framed message too short: {} bytes, expected at least {}",
+            bytes.len(),
+            FRAME_HEADER_BYTES
+        )));
+    }
+    let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+    if magic != MPP_FRAME_MAGIC {
+        return Err(DataFusionError::Execution(format!(
+            "mpp: framed message magic mismatch: got 0x{magic:08x}, expected 0x{MPP_FRAME_MAGIC:08x}"
+        )));
+    }
+    let tag = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+    let ipc_len = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+    if bytes.len() != FRAME_HEADER_BYTES + ipc_len {
+        return Err(DataFusionError::Execution(format!(
+            "mpp: framed message length mismatch: ipc_len={ipc_len}, body_len={}",
+            bytes.len() - FRAME_HEADER_BYTES
+        )));
+    }
+    Ok((tag, &bytes[FRAME_HEADER_BYTES..]))
+}
+
 /// Local queue that sits between the drain thread and the DataFusion consumer.
 ///
 /// Push side: the drain thread appends fully-deserialized batches as they arrive
@@ -350,6 +414,56 @@ impl MppSender {
         result
     }
 
+    /// Tagged-frame variant of [`Self::send_batch_traced`]. Frames the
+    /// encoded batch with `[MAGIC][tag][ipc_len][ipc_bytes]` and pushes the
+    /// framed bytes through the underlying channel. The receiving end uses
+    /// [`MppReceiver::try_recv_framed`] + [`DemuxDrainHandle`] to route
+    /// batches to per-tag sub-buffers.
+    ///
+    /// First caller is the peer-mesh post-aggregate shuffle (tag =
+    /// partition_id), but the framing is generic over any u32 routing key.
+    pub async fn send_batch_traced_framed(
+        &self,
+        tag: u32,
+        batch: &RecordBatch,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
+        let mut scratch = self.scratch.replace(Vec::new());
+        let result = self
+            .send_framed_with_scratch(tag, batch, &mut scratch, stats)
+            .await;
+        self.scratch.replace(scratch);
+        result
+    }
+
+    async fn send_framed_with_scratch(
+        &self,
+        tag: u32,
+        batch: &RecordBatch,
+        scratch: &mut Vec<u8>,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
+        let t_enc = Instant::now();
+        // Reserve the 12-byte frame header at the start of `scratch` and
+        // write the IPC stream directly after, so we frame in one pass with
+        // no extra allocation. `ipc_len` is patched in afterwards now that
+        // the IPC encoder has finished.
+        scratch.clear();
+        scratch.extend_from_slice(&MPP_FRAME_MAGIC.to_le_bytes());
+        scratch.extend_from_slice(&tag.to_le_bytes());
+        scratch.extend_from_slice(&[0u8; 4]); // placeholder for ipc_len
+        let ipc_start = scratch.len();
+        {
+            let mut writer = StreamWriter::try_new(&mut *scratch, batch.schema_ref())?;
+            writer.write(batch)?;
+            writer.finish()?;
+        }
+        let ipc_len = (scratch.len() - ipc_start) as u32;
+        scratch[8..12].copy_from_slice(&ipc_len.to_le_bytes());
+        stats.encode += t_enc.elapsed();
+        self.send_scratch_via_channel(scratch, stats).await
+    }
+
     async fn send_with_scratch(
         &self,
         batch: &RecordBatch,
@@ -359,6 +473,17 @@ impl MppSender {
         let t_enc = Instant::now();
         encode_batch_into(batch, scratch)?;
         stats.encode += t_enc.elapsed();
+        self.send_scratch_via_channel(scratch, stats).await
+    }
+
+    /// Push the already-prepared `scratch` through the channel, with the
+    /// cooperative-drain spin reused by both the plain and the framed send
+    /// paths.
+    async fn send_scratch_via_channel(
+        &self,
+        scratch: &[u8],
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
         let Some(drain) = self.cooperative_drain.as_ref() else {
             // No drain attached (unit tests, in-proc channels): fall
             // back to the blocking send path.
@@ -458,6 +583,33 @@ impl MppReceiver {
             RecvOutcome::Detached => RecvBatchOutcome::Detached,
         }
     }
+
+    /// Receive one tagged framed message produced by
+    /// [`MppSender::send_batch_traced_framed`]. Returns `(tag, batch)` when
+    /// a frame is available; `Empty` when nothing is queued; `Detached`
+    /// when the peer is gone; `Error` on a malformed frame.
+    pub fn try_recv_framed(&self) -> RecvFramedOutcome {
+        match self.channel.try_recv() {
+            RecvOutcome::Bytes(bytes) => match parse_frame(&bytes) {
+                Ok((tag, ipc_bytes)) => match decode_batch(ipc_bytes) {
+                    Ok(batch) => RecvFramedOutcome::Frame(tag, batch),
+                    Err(e) => RecvFramedOutcome::Error(e),
+                },
+                Err(e) => RecvFramedOutcome::Error(e),
+            },
+            RecvOutcome::Empty => RecvFramedOutcome::Empty,
+            RecvOutcome::Detached => RecvFramedOutcome::Detached,
+        }
+    }
+}
+
+/// Decoded result of an [`MppReceiver::try_recv_framed`].
+#[derive(Debug)]
+pub enum RecvFramedOutcome {
+    Frame(u32, RecordBatch),
+    Empty,
+    Detached,
+    Error(DataFusionError),
 }
 
 /// Decoded result of an [`MppReceiver::try_recv_batch`].
@@ -666,6 +818,88 @@ impl Drop for DrainHandle {
     }
 }
 
+/// Cooperative drain handle that demuxes tagged framed messages into
+/// per-tag sub-buffers.
+///
+/// Parallel to [`DrainHandle::cooperative`] but for channels carrying
+/// [`MppSender::send_batch_traced_framed`] frames. Each `poll_drain_pass`
+/// pulls one frame from each receiver, parses the [`parse_frame`] tag, and
+/// pushes the decoded `RecordBatch` into `buffers[tag as usize]`. When a
+/// receiver detaches, every sub-buffer's source-done counter is incremented
+/// (each receiver is a single source for *all* tags), so once every receiver
+/// has detached, every sub-buffer signals EOF.
+///
+/// First user is the peer-mesh post-aggregate shuffle in
+/// [`crate::postgres::customscan::mpp::runtime::ShmMqPeerWorkerTransport`].
+pub struct DemuxDrainHandle {
+    buffers: Vec<Arc<DrainBuffer>>,
+    coop_receivers: Mutex<Option<Vec<Option<MppReceiver>>>>,
+}
+
+impl DemuxDrainHandle {
+    /// Build a cooperative demux handle. Each sub-buffer is sized to expect
+    /// `receivers.len()` source detachments before signalling EOF (every
+    /// receiver may push frames for any tag).
+    pub fn cooperative(receivers: Vec<MppReceiver>, n_tags: u32) -> Self {
+        let n_sources = receivers.len() as u32;
+        let buffers: Vec<Arc<DrainBuffer>> =
+            (0..n_tags).map(|_| DrainBuffer::new(n_sources)).collect();
+        let wrapped = receivers.into_iter().map(Some).collect();
+        Self {
+            buffers,
+            coop_receivers: Mutex::new(Some(wrapped)),
+        }
+    }
+
+    /// Sub-buffer for tag `t`. Consumers (e.g.,
+    /// `ShmMqPeerWorkerConnection::stream_partition`) pop from this buffer
+    /// to receive only the frames addressed to the given tag.
+    pub fn buffer(&self, tag: u32) -> Option<&Arc<DrainBuffer>> {
+        self.buffers.get(tag as usize)
+    }
+
+    /// One pass of the cooperative drain. Pulls up to one frame per
+    /// receiver, parses the tag, and routes the batch to the corresponding
+    /// sub-buffer.
+    pub fn poll_drain_pass(&self) -> Result<(), DataFusionError> {
+        let mut guard = self.coop_receivers.lock().unwrap();
+        let Some(receivers) = guard.as_mut() else {
+            return Ok(());
+        };
+        for slot in receivers.iter_mut() {
+            let Some(recv) = slot.as_ref() else { continue };
+            match recv.try_recv_framed() {
+                RecvFramedOutcome::Frame(tag, batch) => {
+                    let Some(buf) = self.buffers.get(tag as usize) else {
+                        return Err(DataFusionError::Execution(format!(
+                            "mpp: framed message tag={tag} >= n_tags={}",
+                            self.buffers.len()
+                        )));
+                    };
+                    buf.push_batch(batch);
+                }
+                RecvFramedOutcome::Empty => {}
+                RecvFramedOutcome::Detached => {
+                    for buf in &self.buffers {
+                        buf.notify_source_done();
+                    }
+                    *slot = None;
+                }
+                RecvFramedOutcome::Error(e) => return Err(e),
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for DemuxDrainHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DemuxDrainHandle")
+            .field("n_tags", &self.buffers.len())
+            .finish()
+    }
+}
+
 #[cfg(test)]
 fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
     let DrainConfig {
@@ -793,6 +1027,96 @@ mod tests {
         // Equality across the whole batch
         for col in 0..orig.num_columns() {
             assert_eq!(orig.column(col).as_ref(), decoded.column(col).as_ref());
+        }
+    }
+
+    #[test]
+    fn frame_round_trips_tag_and_payload() {
+        let ipc = encode_batch(&sample_batch(11)).expect("encode");
+        let mut framed = Vec::new();
+        frame_into(7, &ipc, &mut framed);
+        let (tag, body) = parse_frame(&framed).expect("parse");
+        assert_eq!(tag, 7);
+        assert_eq!(body, ipc.as_slice());
+        let decoded = decode_batch(body).expect("decode");
+        assert_eq!(decoded.num_rows(), 11);
+    }
+
+    #[test]
+    fn parse_frame_rejects_wrong_magic() {
+        let mut bytes = vec![0u8; FRAME_HEADER_BYTES];
+        bytes[0..4].copy_from_slice(&0xDEAD_BEEFu32.to_le_bytes());
+        assert!(parse_frame(&bytes).is_err());
+    }
+
+    #[test]
+    fn parse_frame_rejects_short_body() {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(&MPP_FRAME_MAGIC.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes()); // tag
+        bytes.extend_from_slice(&100u32.to_le_bytes()); // claims 100 bytes
+        bytes.extend_from_slice(&[0u8; 10]); // but only 10
+        assert!(parse_frame(&bytes).is_err());
+    }
+
+    #[test]
+    fn demux_drain_handle_routes_by_tag() {
+        // Two senders push frames with different tags; drain handle
+        // demuxes into per-tag buffers.
+        let (s0, r0) = in_proc_channel(64);
+        let (s1, r1) = in_proc_channel(64);
+        let receivers = vec![
+            MppReceiver::new(Box::new(r0)),
+            MppReceiver::new(Box::new(r1)),
+        ];
+        let demux = DemuxDrainHandle::cooperative(receivers, 4);
+
+        // Build framed messages directly through the underlying channel.
+        let ipc_a = encode_batch(&sample_batch(2)).unwrap();
+        let ipc_b = encode_batch(&sample_batch(3)).unwrap();
+        let mut buf = Vec::new();
+        frame_into(0, &ipc_a, &mut buf);
+        s0.send_bytes(&buf).unwrap();
+        frame_into(2, &ipc_b, &mut buf);
+        s1.send_bytes(&buf).unwrap();
+
+        // Drain twice (one frame per receiver per pass).
+        demux.poll_drain_pass().unwrap();
+
+        match demux.buffer(0).unwrap().try_pop() {
+            Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 2),
+            other => panic!("tag 0: expected Batch, got {other:?}"),
+        }
+        match demux.buffer(2).unwrap().try_pop() {
+            Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 3),
+            other => panic!("tag 2: expected Batch, got {other:?}"),
+        }
+        // Untagged buffers stay empty.
+        assert!(demux.buffer(1).unwrap().try_pop().is_none());
+        assert!(demux.buffer(3).unwrap().try_pop().is_none());
+    }
+
+    #[test]
+    fn demux_drain_handle_signals_eof_after_all_detach() {
+        let (s0, r0) = in_proc_channel(8);
+        let (s1, r1) = in_proc_channel(8);
+        let receivers = vec![
+            MppReceiver::new(Box::new(r0)),
+            MppReceiver::new(Box::new(r1)),
+        ];
+        let demux = DemuxDrainHandle::cooperative(receivers, 2);
+
+        drop(s0);
+        drop(s1);
+        // Drain twice so each receiver's detach is observed.
+        demux.poll_drain_pass().unwrap();
+        demux.poll_drain_pass().unwrap();
+
+        for tag in 0..2 {
+            match demux.buffer(tag).unwrap().try_pop() {
+                Some(DrainItem::Eof) => {}
+                other => panic!("tag {tag}: expected Eof, got {other:?}"),
+            }
         }
     }
 

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -1,0 +1,98 @@
+-- =====================================================================
+-- End-to-end MPP exercise on AggregateScan with the post-aggregate peer
+-- mesh shuffle (Track A + Track B) flipped on.
+--
+-- Runs the same aggregate-on-join group-by query under both
+-- `paradedb.enable_mpp_postagg_shuffle = off` (legacy single-boundary
+-- gather) and `= on` (two-boundary peer-mesh + gather), then computes
+-- aggregate totals over each result. The totals must match byte-exact;
+-- if they don't, the post-agg path has a routing/correctness bug.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+CREATE TABLE mpp_pa_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_pa_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+INSERT INTO mpp_pa_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+INSERT INTO mpp_pa_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+CREATE INDEX mpp_pa_files_idx ON mpp_pa_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+CREATE INDEX mpp_pa_pages_idx ON mpp_pa_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+ANALYZE mpp_pa_files;
+ANALYZE mpp_pa_pages;
+SET paradedb.enable_mpp TO on;
+-- =====================================================================
+-- Pass 1: legacy single-boundary path (postagg shuffle = off).
+-- Establishes the correctness baseline.
+-- =====================================================================
+SET paradedb.enable_mpp_postagg_shuffle TO off;
+SELECT
+    COUNT(*)            AS num_groups,
+    SUM(c)              AS total_count,
+    SUM(s)              AS total_sum
+FROM (
+    SELECT f.title, COUNT(*) AS c, SUM(p.size_bytes) AS s
+    FROM mpp_pa_files f JOIN mpp_pa_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY f.title
+) t;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ num_groups | total_count | total_sum 
+------------+-------------+-----------
+        200 |        1000 |   1979476
+(1 row)
+
+-- =====================================================================
+-- Pass 2: post-aggregate peer-mesh shuffle path. Same query, byte-exact
+-- expected output.
+-- =====================================================================
+SET paradedb.enable_mpp_postagg_shuffle TO on;
+SELECT
+    COUNT(*)            AS num_groups,
+    SUM(c)              AS total_count,
+    SUM(s)              AS total_sum
+FROM (
+    SELECT f.title, COUNT(*) AS c, SUM(p.size_bytes) AS s
+    FROM mpp_pa_files f JOIN mpp_pa_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY f.title
+) t;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ num_groups | total_count | total_sum 
+------------+-------------+-----------
+        200 |        1000 |   1979476
+(1 row)
+
+DROP TABLE mpp_pa_pages;
+DROP TABLE mpp_pa_files;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
@@ -1,0 +1,103 @@
+-- =====================================================================
+-- End-to-end MPP exercise on AggregateScan with the post-aggregate peer
+-- mesh shuffle (Track A + Track B) flipped on.
+--
+-- Runs the same aggregate-on-join group-by query under both
+-- `paradedb.enable_mpp_postagg_shuffle = off` (legacy single-boundary
+-- gather) and `= on` (two-boundary peer-mesh + gather), then computes
+-- aggregate totals over each result. The totals must match byte-exact;
+-- if they don't, the post-agg path has a routing/correctness bug.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+CREATE TABLE mpp_pa_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_pa_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+
+INSERT INTO mpp_pa_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+INSERT INTO mpp_pa_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+
+CREATE INDEX mpp_pa_files_idx ON mpp_pa_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+
+CREATE INDEX mpp_pa_pages_idx ON mpp_pa_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+
+ANALYZE mpp_pa_files;
+ANALYZE mpp_pa_pages;
+
+SET paradedb.enable_mpp TO on;
+
+-- =====================================================================
+-- Pass 1: legacy single-boundary path (postagg shuffle = off).
+-- Establishes the correctness baseline.
+-- =====================================================================
+
+SET paradedb.enable_mpp_postagg_shuffle TO off;
+
+SELECT
+    COUNT(*)            AS num_groups,
+    SUM(c)              AS total_count,
+    SUM(s)              AS total_sum
+FROM (
+    SELECT f.title, COUNT(*) AS c, SUM(p.size_bytes) AS s
+    FROM mpp_pa_files f JOIN mpp_pa_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY f.title
+) t;
+
+-- =====================================================================
+-- Pass 2: post-aggregate peer-mesh shuffle path. Same query, byte-exact
+-- expected output.
+-- =====================================================================
+
+SET paradedb.enable_mpp_postagg_shuffle TO on;
+
+SELECT
+    COUNT(*)            AS num_groups,
+    SUM(c)              AS total_count,
+    SUM(s)              AS total_sum
+FROM (
+    SELECT f.title, COUNT(*) AS c, SUM(p.size_bytes) AS s
+    FROM mpp_pa_files f JOIN mpp_pa_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY f.title
+) t;
+
+DROP TABLE mpp_pa_pages;
+DROP TABLE mpp_pa_files;


### PR DESCRIPTION
# Ticket(s) Closed

- Refs #4152

## What

Generalizes the AggregateScan MPP path from one peer-mesh per query to K peer-meshes per query, gated behind `paradedb.enable_mpp_postagg_shuffle` (default off). Adds the K-aware DSM layout, stage-id-keyed transport routing, K-fragment runner, segment-slicing for non-partitioning sources in peer-shuffle mode, and thread-tracking primitives that the future multi-thread compute runtime will gate on.

## Why

The path that landed in #4988 ships a single boundary at the worker → leader edge, which caps the win at the post-aggregate stage. A second boundary at the post-aggregate hash-redistribution opens up linear scaling on aggregate-on-join queries — the `aggregate_join_groupby` bench wins 2.7× at N=2 once the GUC is flipped on.

The substrate is correct at every K and N tested but regresses on wall-clock at higher N because pgrx 0.18 enforces single-threaded Postgres FFI per process — every fragment future and every demux drain handle ends up on one OS thread per worker today. Landing the substrate behind a default-off GUC unblocks the multi-thread compute follow-up without committing to a perf claim we can't deliver yet.

## How

- DSM layout grows from one N×(N−1) outbound mesh to K peer-meshes, one per `NetworkShuffleExec` boundary the planner emits. Each mesh is sized by the full per-stage participant arithmetic (`consumer_tc × producer_tc`).
- Worker transport routes inbound frames by stage id; the runtime resolves `(stage_id) → MppPeerMesh` per query via a `CompositeWorkerTransport` map.
- Each worker spawns one fragment future per inner producer fragment plus one for the consumer side, joined via `try_join_all`. Demux handles per peer-mesh decode framed inbound batches into per-tag sub-buffers.
- Non-partitioning sources are segment-sliced round-robin across workers in peer-shuffle mode (falls back to full-replicate when `n_segments < n_workers`); without this the build-cache replicates source data and inflates row counts.
- New GUCs: `paradedb.enable_mpp_postagg_shuffle` (master toggle for the K>1 path), `paradedb.mpp_peer_queue_bytes` (per-edge `shm_mq` cap).
- `is_on_backend_thread()` thread-local + gated `mpp_log!` + gated `check_for_interrupts!()` are in place but no-op today. Every gate is wired correctly for the multi-thread runtime so that work can land as a focused follow-up without touching this PR's surface again.

## Reviewer's Guide

Suggested reading order. This PR builds on #4988; the new code is concentrated in four files:

1. `mpp/dsm.rs` — K-aware layout: the header gains `n_peer_meshes` and per-mesh sizing fields; `compute_dsm_layout(... n_peer_meshes)` is parameterized over K. The `peer_slot_offset(mesh, producer, consumer)` accessor is the math for routing into the correct N×N region.
2. `mpp/runtime.rs` — `MppPeerMesh` (per-mesh runtime handle), `ShmMqPeerWorkerTransport` (peer-mesh `WorkerTransport` impl with `consumer_tc=N, input_tc=N`), `CompositeWorkerTransport` (the `(stage_id) → mesh` router on the worker side). Plus the `collect_inner_shuffle_stage_ids` walker that drives the runtime allocation.
3. `mpp/transport.rs` — `MppFrameHeader` framing (12-byte magic + tag + length, per-batch), `DemuxDrainHandle` (per-tag sub-buffer demux), and the `is_on_backend_thread()` thread-local. The thread-local is no-op today but every callsite that would need it under multi-thread Tokio is already gated.
4. `aggregatescan/mod.rs` — `count_peer_mesh_shuffles` (builds a stub plan with `LocalExecWorkerTransport` to count emitted shuffles before DSM allocation), `exec_mpp_worker` (the K-fragment runner with `try_join_all`), `slice_segment_ids_round_robin` (the segment-slice fix). Both planner-prep call sites now toggle `with_distributed_in_process_mode(true)` and `with_distributed_emit_peer_shuffles(crate::gucs::enable_mpp_postagg_shuffle())`.

The pure-refactor commits (`generalize DSM to K peer meshes`, `stage-id-keyed transport routing on workers`, `generalize worker fragment runner to K inner fragments`) are mechanical extensions of the K=1 path; only `K-aware peer-mesh allocation` and `G5 segment-slice non-partitioning sources` introduce new behavior.

## Tests

- pgrx regression suite — new `mpp_aggregate_postagg.sql` covers correctness with the postagg shuffle GUC on; existing suites pass with the GUC off (no behaviour change at default).
- 25M `aggregate_join_groupby` bench at N=2: 2.65× over the foundation PR's path. Bench numbers at higher N are tracked as the follow-up perf workstream.
- Build-side all-gather + segment-slicing path verified byte-exact at N=2/4/8/10 with the GUC on.
