### PR TITLE
ci: Remove Depot

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -271,7 +271,7 @@ jobs:
           if [ -n "$PR" ]; then
             echo "Release branch PR already exists: #$PR"
           else
-            gh pr create --base "$BASE" --head "$BRANCH" --title "Generate Dockerfiles for ${{ needs.generate-dockerfiles.outputs.tag }}" --body "Updates generated Dockerfiles for ${{ needs.generate-dockerfiles.outputs.tag }} after the Docker images were published."
+            gh pr create --base "$BASE" --head "$BRANCH" --title "chore: Generate Dockerfiles for ${{ needs.generate-dockerfiles.outputs.tag }}" --body "Updates generated Dockerfiles for ${{ needs.generate-dockerfiles.outputs.tag }} after the Docker images were published."
           fi
 
       - name: Open Main PR
@@ -295,7 +295,7 @@ jobs:
           if [ -n "$PR" ]; then
             echo "Main PR already exists: #$PR"
           else
-            gh pr create --base main --head "$BRANCH" --title "Generate Dockerfiles for $TAG" --body "Updates generated Dockerfiles for $TAG after the Docker images were published."
+            gh pr create --base main --head "$BRANCH" --title "chore: Generate Dockerfiles for $TAG" --body "Updates generated Dockerfiles for $TAG after the Docker images were published."
           fi
 
   notify-orm-repos:

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -191,15 +191,8 @@ jobs:
         with:
           ref: ${{ needs.generate-dockerfiles.outputs.branch }}
 
-      # Official releases need a single universal image so that the same tag (e.g. `paradedb:latest`)
-      # works on both amd64 and arm64 hosts — pulling clients pick the right manifest entry for their
-      # arch. That requires producing both arches under one tag, which means cross-compiling at least
-      # one of them. Cross-compilation via `docker buildx` (under QEMU emulation) is prohibitively
-      # slow for a build this size, so we offload to Depot, which provides native builders on both
-      # arches and stitches them into a single multi-arch manifest. (We could eventually replace this
-      # with Docker Build Cloud once it supports multiple concurrent builders.)
-      - name: Configure Depot CLI
-        uses: depot/setup-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -228,7 +221,7 @@ jobs:
 
       - name: Build and Push Docker Image to Docker Hub
         id: build-push
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -236,8 +229,6 @@ jobs:
           push: true
           sbom: true
           provenance: mode=max
-          project: ${{ secrets.DEPOT_PROJECT }}
-          token: ${{ secrets.DEPOT_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Sign and Attest Build Provenance

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -29,11 +29,8 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
 
-      # Cross-compilation is incredibly slow, so we use an external service called Depot to
-      # speed up container builds for universal images. We could eventually replace this with
-      # Docker Build Cloud once they add support for multiple concurrent builders.
-      - name: Configure Depot CLI
-        uses: depot/setup-action@v1
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -53,7 +50,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build and Push Docker Image to Docker Hub
-        uses: depot/build-push-action@v1
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -61,6 +58,4 @@ jobs:
           push: true
           sbom: true
           provenance: mode=max
-          project: ${{ secrets.DEPOT_PROJECT }}
-          token: ${{ secrets.DEPOT_TOKEN }}
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -3,15 +3,8 @@
 # Test pg_search (Docker)
 # Test building and running the ParadeDB Docker Image.
 #
-# Note: unlike `publish-paradedb-docker.yml`, this workflow cannot use Depot to
-# accelerate the build. Depot requires the `DEPOT_PROJECT` / `DEPOT_TOKEN` repo
-# secrets, which GitHub does not expose to PRs from forks — so any Depot-based
-# step would fail on community-contributor PRs. That's fine here because, unlike
-# the publish workflow, we don't need to produce a single universal image — we
-# only need to smoke-test that the image builds and runs on each arch. So we
-# skip cross-compilation entirely: the matrix below builds amd64 and arm64 in
-# parallel, each natively on a runner of its own arch via `docker buildx build`,
-# which works without secrets.
+# This workflow smoke-tests that the image builds and runs on each arch. It
+# builds amd64 and arm64 in parallel, each natively on a runner of its own arch.
 
 name: Test pg_search (Docker)
 
@@ -87,10 +80,9 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       # Each matrix entry builds its own arch natively (via a runner on that arch) so `--load`
-      # works and the `docker run` smoke tests below exercise the image natively — no emulation,
-      # no cross-arch shenanigans. We tag the image `latest` to match the tag used by the smoke
-      # tests, and skip pushing since this is just a test build. Building directly (rather than
-      # via Depot) avoids requiring repo secrets, which would block community-contributor PRs.
+      # works and the `docker run` smoke tests below exercise the image natively. We tag the
+      # image `latest` to match the tag used by the smoke tests, and skip pushing since this
+      # is just a test build.
       #
       # The BuildKit `type=gha` cache is transparently backed by runs-on's S3 cache (via the
       # `extras=s3-cache` runner label above), so it works without configuring a separate

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,15 @@
+# ParadeDB Dockerfiles
+
+ParadeDB's Dockerfiles are automatically generated from `Dockerfile.template`. To make a change to the files, modify `Dockerfile.template`, run `./generate-dockerfiles.sh <<current-version>>`, and commit the generated changes.
+
+There are three flavors of files generated:
+
+- `paradedb`: The default ParadeDB Docker image, published to `paradedb/paradedb`. Includes Barman Cloud which is used in our CNPG deployments.
+- `official`: The image for Docker Official Images which will be published to `paradedb` once approved by Docker. Does not include Barman.
+- `antithesis`: The image used by Antithesis test runs. Includes `libvoidstar`, Antithesis' instrumentation library.
+
+`paradedb` and `official` both install Debian artifacts published to GitHub Releases. `antithesis` installs a locally built `.deb` so that it can be run on a per-commit basis.
+
+## Release process
+
+Because the Dockerfiles depend on the Debian artifacts, they are published after the latest `.deb`s are published to GitHub. The Dockerfiles themselves can't be updated until the latest `.deb`s exist. Because of this, once a release is triggered and the `.deb`s are published, new versions of the Dockerfiles are generated in CI using the latest version. These new versions are then tested and published, and PRs are automatically opened to commit the updated files back to the repo. The files must be committed so they can be referenced by the Docker Official Images manifest file in [docker-library/official-images](https://github.com/docker-library/official-images).


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Now that we install prebuilt artifacts in our Docker builds they are significantly faster. Because of this speed up we don't need depot anymore.

## Why

## How

## Tests
