### PR TITLE
fix: Separate stregress dispatch so that both actions can get the correct inputs

### DIFF
--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -61,7 +61,7 @@ jobs:
         sha: ${{ fromJSON(github.event.inputs.commits) }} # → ["…","…"]
 
     steps:
-      - name: Fire Benchmark & Stressgres for ${{ matrix.sha }}
+      - name: Fire Benchmark for ${{ matrix.sha }}
         uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -69,20 +69,38 @@ jobs:
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
             const sha   = '${{ matrix.sha }}';
+            const wf = 'benchmark-pg_search-benchmarks.yml';
 
-            // Workflows to queue
-            const targets = ['benchmark-pg_search-benchmarks.yml', 'benchmark-pg_search-stressgres.yml'];
+            /*  createWorkflowDispatch must point at a branch or tag, not a
+                bare SHA, so we send `ref:"main"` and hand the commit SHA
+                through an input named `commit`  */
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: wf,
+              ref: 'main',
+              inputs: { commit: sha, fail_on_error: 'false' }
+            });
+            core.info(`queued ${wf} for ${sha}`);
 
-            for (const wf of targets) {
-              /*  createWorkflowDispatch must point at a branch or tag, not a
-                  bare SHA, so we send `ref:"main"` and hand the commit SHA
-                  through an input named `commit`  */
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: wf,
-                ref: 'main',
-                inputs: { commit: sha, fail_on_error: 'false' }
-              });
-              core.info(`queued ${wf} for ${sha}`);
-            }
+      - name: Fire Stressgres for ${{ matrix.sha }}
+        uses: actions/github-script@v9
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo  = context.repo.repo;
+            const sha   = '${{ matrix.sha }}';
+            const wf = 'benchmark-pg_search-stressgres.yml';
+
+            /*  createWorkflowDispatch must point at a branch or tag, not a
+                bare SHA, so we send `ref:"main"` and hand the commit SHA
+                through an input named `commit`  */
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: wf,
+              ref: 'main',
+              inputs: { commit: sha }
+            });
+            core.info(`queued ${wf} for ${sha}`);


### PR DESCRIPTION
## What
Separate the benchmark and stresgress dispatch steps in the benchmark-backfill workflow, so that we can remove the 'fail_on_error' input from the stressgress dispatch.

## Why
This action currently fails with `Unhandled error: HttpError: Unexpected inputs provided: ["fail_on_error"]` because the stresgress workflow does not expect a 'fail_on_error' input. 

