### PR TITLE
ci: Narrow the Docker build context to the `docker` directory

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -223,7 +223,7 @@ jobs:
         id: build-push
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: docker
           platforms: linux/amd64,linux/arm64
           file: docker/paradedb/${{ matrix.pg_version }}/Dockerfile
           push: true

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -96,7 +96,7 @@ jobs:
             --cache-from type=gha,scope=paradedb-docker-${{ matrix.flavor }}-${{ matrix.arch }} \
             --cache-to type=gha,mode=max,scope=paradedb-docker-${{ matrix.flavor }}-${{ matrix.arch }} \
             --load \
-            .
+            docker
 
       - name: Verify PGDG apt packages are available
         run: docker run --rm paradedb/paradedb:latest bash -c 'apt-get update && apt-get install -y --no-install-recommends postgresql-${{ env.PG_VERSION }}-partman'

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -83,7 +83,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/antithesis/18/Dockerfile
+++ b/docker/antithesis/18/Dockerfile
@@ -63,7 +63,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/official/15/Dockerfile
+++ b/docker/official/15/Dockerfile
@@ -56,7 +56,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/official/16/Dockerfile
+++ b/docker/official/16/Dockerfile
@@ -56,7 +56,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/official/17/Dockerfile
+++ b/docker/official/17/Dockerfile
@@ -56,7 +56,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/official/18/Dockerfile
+++ b/docker/official/18/Dockerfile
@@ -56,7 +56,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/paradedb/15/Dockerfile
+++ b/docker/paradedb/15/Dockerfile
@@ -70,7 +70,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/paradedb/16/Dockerfile
+++ b/docker/paradedb/16/Dockerfile
@@ -70,7 +70,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/paradedb/17/Dockerfile
+++ b/docker/paradedb/17/Dockerfile
@@ -70,7 +70,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod

--- a/docker/paradedb/18/Dockerfile
+++ b/docker/paradedb/18/Dockerfile
@@ -70,7 +70,7 @@ RUN sed -i "s/^#shared_preload_libraries = ''/shared_preload_libraries = 'pg_sea
 WORKDIR /
 
 # Copy ParadeDB bootstrap script to install extensions and configure postgresql.conf
-COPY ./docker/bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
+COPY ./bootstrap.sh /docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh
 
 # The upstream `postgres` Docker image comes with its own `entrypoint.sh` script which
 # starts as `root` and then switches to the `postgres` user after running chown and chmod


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Now that the Dockerfiles don't depend on the source code we no longer need to pass in the whole repo to the build. Narrowing it to `docker` is better in general and likely something the DOI maintainers would flag.

## Why

## How

## Tests
