### PR TITLE
fix: Default to fetching actions from main unless overridden

### DIFF
--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -79,7 +79,7 @@ jobs:
               repo,
               workflow_id: wf,
               ref: 'main',
-              inputs: { commit: sha, fail_on_error: 'false', force_use_of_from_main: 'true'}
+              inputs: { commit: sha, fail_on_error: 'false', force_use_of_benchmarks_from_main: 'true'}
             });
             core.info(`queued ${wf} for ${sha}`);
 

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -79,7 +79,7 @@ jobs:
               repo,
               workflow_id: wf,
               ref: 'main',
-              inputs: { commit: sha, fail_on_error: 'false' }
+              inputs: { commit: sha, fail_on_error: 'false', force_use_of_from_main: 'true'}
             });
             core.info(`queued ${wf} for ${sha}`);
 

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -79,7 +79,7 @@ jobs:
               repo,
               workflow_id: wf,
               ref: 'main',
-              inputs: { commit: sha, fail_on_error: 'false', force_use_of_benchmarks_from_main: 'true'}
+              inputs: { commit: sha, fail_on_error: 'false' }
             });
             core.info(`queued ${wf} for ${sha}`);
 

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -27,8 +27,8 @@ on:
         required: false
         type: boolean
         default: true
-      force_use_of_actions_from_main:
-        description: "Whether to use actions from main. By default, the actions from the specified commit will be used unless this is ran as part of merging to main. This should be set to true during backfills."
+      force_use_of_benchmarks_from_main:
+        description: "Whether to use actions and benchmark code from main. By default, the stuff from the specified commit will be used unless this is ran as part of merging to main. This should be set to true during backfills."
         required: false
         type: boolean
         default: false
@@ -113,10 +113,40 @@ jobs:
           echo "short_commit=$short_commit" >> $GITHUB_OUTPUT
           echo "Deriving short commit: $short_commit"
 
+      - name: Fetch the Latest Composite Actions
+        if: >-
+          inputs.force_use_of_benchmarks_on_main || (
+            github.event_name != 'workflow_dispatch' &&
+            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
+          )
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.repository }}
+          path: actions-temp
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 1
+          ref: main
+
+      - name: Copy latest actions into place
+        if: >-
+          inputs.force_use_of_benchmarks_on_main || (
+            github.event_name != 'workflow_dispatch' &&
+            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
+          )
+        run: cp -rv actions-temp/.github/actions .github/
+
+      - name: Cleanup temporary checkout
+        if: >-
+          inputs.force_use_of_benchmarks_on_main || (
+            github.event_name != 'workflow_dispatch' &&
+            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
+          )
+        run: rm -rf actions-temp
+
       # only fetch the latest from main when, essentially, we're merging to main.  otherwise, use whatever we checked out in the ref we're benchmarking
       - name: Fetch latest benchmark code, suites
         if: >-
-          inputs.force_use_of_actions_from_main || (
+          inputs.force_use_of_benchmarks_from_main || (
             github.event_name != 'workflow_dispatch' &&
             !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
           )

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: true
+      force_use_of_actions_from_main:
+        description: "Whether to use actions from main. By default, the actions from the specified commit will be used unless this is ran as part of merging to main. This should be set to true during backfills."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   actions: write
@@ -108,35 +113,13 @@ jobs:
           echo "short_commit=$short_commit" >> $GITHUB_OUTPUT
           echo "Deriving short commit: $short_commit"
 
-      - name: Fetch the Latest Composite Actions
-        if: >-
-          github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-        uses: actions/checkout@v6
-        with:
-          repository: ${{ github.repository }}
-          path: actions-temp
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 1
-          ref: main
-
-      - name: Copy latest actions into place
-        if: >-
-          github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-        run: cp -rv actions-temp/.github/actions .github/
-
-      - name: Cleanup temporary checkout
-        if: >-
-          github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-        run: rm -rf actions-temp
-
       # only fetch the latest from main when, essentially, we're merging to main.  otherwise, use whatever we checked out in the ref we're benchmarking
       - name: Fetch latest benchmark code, suites
         if: >-
-          github.event_name != 'workflow_dispatch' &&
-          !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
+          inputs.force_use_of_actions_from_main || (
+            github.event_name != 'workflow_dispatch' &&
+            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
+          )
         uses: ./.github/actions/benchmarks-from-main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -27,8 +27,8 @@ on:
         required: false
         type: boolean
         default: true
-      force_use_of_benchmarks_from_main:
-        description: "Whether to use actions and benchmark code from main. By default, the stuff from the specified commit will be used unless this is ran as part of merging to main. This should be set to true during backfills."
+      use_benchmarks_from_ref:
+        description: "Whether to use actions and benchmark code from the specified commit. By default, the stuff from main will be used."
         required: false
         type: boolean
         default: false
@@ -113,12 +113,10 @@ jobs:
           echo "short_commit=$short_commit" >> $GITHUB_OUTPUT
           echo "Deriving short commit: $short_commit"
 
+      # always fetch the actions from main, unless we've explicitly overridden that, or triggered this via label (like you would on a PR)
       - name: Fetch the Latest Composite Actions
         if: >-
-          inputs.force_use_of_benchmarks_from_main || (
-            github.event_name != 'workflow_dispatch' &&
-            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-          )
+          !inputs.use_benchmarks_from_ref || contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
         uses: actions/checkout@v6
         with:
           repository: ${{ github.repository }}
@@ -129,27 +127,18 @@ jobs:
 
       - name: Copy latest actions into place
         if: >-
-          inputs.force_use_of_benchmarks_from_main || (
-            github.event_name != 'workflow_dispatch' &&
-            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-          )
+          !inputs.use_benchmarks_from_ref || contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
         run: cp -rv actions-temp/.github/actions .github/
 
       - name: Cleanup temporary checkout
         if: >-
-          inputs.force_use_of_benchmarks_from_main || (
-            github.event_name != 'workflow_dispatch' &&
-            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-          )
+          !inputs.use_benchmarks_from_ref || contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
         run: rm -rf actions-temp
 
-      # only fetch the latest from main when, essentially, we're merging to main.  otherwise, use whatever we checked out in the ref we're benchmarking
+      # always fetch the code from main, unless we've explicitly overridden that, or triggered this via label (like you would on a PR)
       - name: Fetch latest benchmark code, suites
         if: >-
-          inputs.force_use_of_benchmarks_from_main || (
-            github.event_name != 'workflow_dispatch' &&
-            !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-          )
+          !inputs.use_benchmarks_from_ref || contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
         uses: ./.github/actions/benchmarks-from-main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Fetch the Latest Composite Actions
         if: >-
-          inputs.force_use_of_benchmarks_on_main || (
+          inputs.force_use_of_benchmarks_from_main || (
             github.event_name != 'workflow_dispatch' &&
             !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
           )
@@ -129,7 +129,7 @@ jobs:
 
       - name: Copy latest actions into place
         if: >-
-          inputs.force_use_of_benchmarks_on_main || (
+          inputs.force_use_of_benchmarks_from_main || (
             github.event_name != 'workflow_dispatch' &&
             !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
           )
@@ -137,7 +137,7 @@ jobs:
 
       - name: Cleanup temporary checkout
         if: >-
-          inputs.force_use_of_benchmarks_on_main || (
+          inputs.force_use_of_benchmarks_from_main || (
             github.event_name != 'workflow_dispatch' &&
             !contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
           )


### PR DESCRIPTION
## What
Changes the logic so that we default to using benchmarks from `main` unless we explicitly override it, or this run is triggered via assigning a label (like we would on a PR).

## Why
Backfills fail because they are trying to run the benchmarking cli with flags and arguments that have since been removed, indicating they are use the actions from the commit branch, rather than those from `main`. For consistent results, we need to use the ones from `main`.
