### PR TITLE
ci: Add pgX Docker tags

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -198,7 +198,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       # The pg_version-tag Docker tag syntax is necessary for our CloudNativePG Helm chart. We only deploy
-      # the `latest` and `latest-pg` tags on production releases, not for beta releases.
+      # the `latest`, `latest-pg`, and `pg` tags on production releases, not for beta releases.
       - name: Setup Docker Image tags
         id: meta
         uses: docker/metadata-action@v6
@@ -211,6 +211,7 @@ jobs:
             type=raw,value=${{ needs.generate-dockerfiles.outputs.tag }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=${{ needs.generate-dockerfiles.outputs.version }},enable=${{ matrix.pg_version == env.default_pg_version }}
             type=raw,value=latest-pg${{ matrix.pg_version }},enable=${{ needs.generate-dockerfiles.outputs.is_latest == 'true' && !contains(needs.generate-dockerfiles.outputs.tag, '-rc.') }}
+            type=raw,value=pg${{ matrix.pg_version }},enable=${{ needs.generate-dockerfiles.outputs.is_latest == 'true' && !contains(needs.generate-dockerfiles.outputs.tag, '-rc.') }}
             type=raw,value=latest,enable=${{ matrix.pg_version == env.default_pg_version && needs.generate-dockerfiles.outputs.is_latest == 'true' && !contains(needs.generate-dockerfiles.outputs.tag, '-rc.') }}
 
       - name: Login to Docker Hub


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Adds Docker tags for the most up to date release for each Postgres version: pg18, pg17, pg16, pg15. We are going to add these for DOI so this will keep things in sync.

## Why

## How

## Tests
