### PR TITLE
ci: Migrate create-github-app-token to client-id

### DIFF
--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -104,7 +104,7 @@ runs:
       id: app-token
       uses: actions/create-github-app-token@v3
       with:
-        app-id: ${{ inputs.github_app_id }}
+        client-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}
 
     # Necessary to avoid "destination path is not empty" error

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -222,7 +222,7 @@ jobs:
         with:
           test_file: single-server.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -233,7 +233,7 @@ jobs:
         with:
           test_file: bulk-updates.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -244,7 +244,7 @@ jobs:
         with:
           test_file: wide-table.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -255,7 +255,7 @@ jobs:
         with:
           test_file: background-merge.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
@@ -266,7 +266,7 @@ jobs:
         with:
           test_file: logical-replication.toml
           ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -22,7 +22,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -22,7 +22,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -158,7 +158,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Create Tag

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -158,7 +158,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Create Tag

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -76,7 +76,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
@@ -251,7 +251,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
@@ -329,7 +329,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -76,7 +76,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
@@ -251,7 +251,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
@@ -329,7 +329,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -42,7 +42,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-sgfJtbDFGjbVaZi1rdRaD2n9UYy2jd/fyy/fwJsqQts=";
+  cargoHash = "sha256-PMeQ/44jXoGglL9RaZkwqsvT1oG1pQYs2eZ3CSzEtp0=";
 
   inherit cargo-pgrx postgresql;
 


### PR DESCRIPTION
## Summary
- The `actions/create-github-app-token` action deprecated `app-id` in favor of `client-id` (warning: `Input 'app-id' has been deprecated with message: Use 'client-id' instead.`)
- Replaces `app-id:` with `client-id:` across all workflows and the `benchmark-stressgres` composite action
- Switches from `vars.PARADEDB_GITHUB_APP_ID` (numeric App ID) to `vars.PARADEDB_GITHUB_APP_CLIENT_ID` (the App's Client ID, e.g. `Iv23li...`)

## Notes
- Client ID is a public identifier, so `vars.*` is appropriate; the Private Key remains in `secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY`
- `vars.PARADEDB_GITHUB_APP_CLIENT_ID` has been added to repo variables
- The old `vars.PARADEDB_GITHUB_APP_ID` is no longer referenced and can be deleted after merge

## Test plan
- [ ] Verify cherry-pick, publish-github-release, publish-paradedb-docker, test-pg_search-nix, and benchmark-pg_search-stressgres workflows successfully mint a token on next run