### PR TITLE
feat(mpp): multi-stage natural-shape AggregateScan via multiplexed shm_mq mesh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=490af86#490af86f960c972d6c0f700e664ca0d5886cd55b"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=d3cd758#d3cd758dfe77de29d3efe1155ef560f790f9e2a1"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2817,7 +2817,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6524,7 +6524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7292,7 +7292,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7350,7 +7350,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7770,7 +7770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8405,7 +8405,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9434,7 +9434,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-dt0rqcwNrV101vCXoOCsc4M+qiJVK/iWCG9/bttcvqY=";
+  cargoHash = "sha256-nIfwvxpv7RoOOa1eZGAyaoTtj6tIGS83HXQ5d2uyxEc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
 datafusion-datasource = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "490af86" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "d3cd758" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1388,8 +1388,18 @@ impl AggregateScan {
         let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
         let session_arc = Arc::new(session);
 
+        // Two future shapes coexist in this dispatcher: real producer
+        // fragments (`run_producer_fragment`) and broadcast short-circuit
+        // EOF-only stubs. The alias keeps the `Vec<_>` declaration legible
+        // and silences clippy::type_complexity.
+        type FragmentFuture = std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
+                    + Send,
+            >,
+        >;
         let result = runtime.block_on(async move {
-            let mut futures = Vec::with_capacity(fragments.len());
+            let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
             for fragment in &fragments {
                 let n_out = fragment.plan.output_partitioning().partition_count();
                 // Build per-output-partition senders. For each partition `q`
@@ -1400,6 +1410,10 @@ impl AggregateScan {
                     let dest_proc = match &fragment.routing {
                         FragmentRouting::Coalesce { dest_proc } => *dest_proc,
                         FragmentRouting::Shuffle {
+                            parent_stage_id,
+                            partitions_per_consumer_task,
+                        }
+                        | FragmentRouting::Broadcast {
                             parent_stage_id,
                             partitions_per_consumer_task,
                         } => {
@@ -1451,6 +1465,33 @@ impl AggregateScan {
                     );
                 }
 
+                // Broadcast short-circuit: pg_search's natural-shape plan
+                // canonical-replicates the build subtree (see the doc on
+                // `FragmentRouting::Broadcast`), so running the producer
+                // plan on every input task would duplicate by
+                // `input_task_count`. Only task 0 runs the plan; tasks
+                // `task_idx > 0` send a per-partition EOF and return.
+                if matches!(fragment.routing, FragmentRouting::Broadcast { .. })
+                    && fragment.task_idx != 0
+                {
+                    crate::mpp_log!(
+                        "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
+                         task_idx={}) Broadcast short-circuit: EOF-only",
+                        fragment.stage_id,
+                        fragment.task_idx,
+                    );
+                    let senders = per_partition_senders;
+                    futures.push(Box::pin(async move {
+                        let mut stats =
+                            crate::postgres::customscan::mpp::transport::SendBatchStats::default();
+                        for sender in &senders {
+                            sender.send_eof_traced(&mut stats).await?;
+                        }
+                        Ok(())
+                    }));
+                    continue;
+                }
+
                 // Build a TaskContext seeded with the right
                 // `DistributedTaskContext` so the boundary nodes inside the
                 // fragment's plan know their `(task_index, task_count)`.
@@ -1476,7 +1517,11 @@ impl AggregateScan {
                 );
 
                 let plan = Arc::clone(&fragment.plan);
-                futures.push(run_worker_fragment(plan, per_partition_senders, task_ctx));
+                futures.push(Box::pin(run_worker_fragment(
+                    plan,
+                    per_partition_senders,
+                    task_ctx,
+                )));
             }
             // Drop the original outbound_senders so the only remaining Arcs
             // to each shm_mq queue / in-proc channel are the per-partition

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1080,7 +1080,9 @@ impl AggregateScan {
     /// shm_mq mesh at execute time.
     fn build_mpp_leader_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
         let serial = create_aggregate_session_context();
-        let n_workers = mesh.n_workers as usize;
+        // Workers are procs 1..n_procs; leader is proc 0. The producer
+        // count is therefore `n_procs - 1`.
+        let n_workers = mesh.n_procs.saturating_sub(1).max(1) as usize;
         // Four-knob unlock for actually inserting NetworkShuffleExec/etc.:
         //   1. target_partitions(N) — without this, EnforceDistribution skips
         //      every RepartitionExec, so the annotator never sees a Shuffle.
@@ -1136,13 +1138,12 @@ impl AggregateScan {
         let custom_scan_tlist = df_state.custom_scan_tlist;
         let ctx = if mpp_is_active() {
             // Drain-less stub mesh: `with_distributed_planner` only reads
-            // `n_workers` for stage sizing; `ShmMqWorkerTransport::open()`
-            // is execution-time only and never runs during EXPLAIN.
-            let stub_mesh = Arc::new(MppMesh {
-                n_workers: producer_worker_count(),
-                n_partitions: 1,
-                drains: Vec::new(),
-            });
+            // `n_procs` for stage sizing; `ShmMqWorkerTransport::open()` is
+            // execution-time only and never runs during EXPLAIN. After
+            // M1.c+d reshaped `MppMesh` to `{this_proc, n_procs,
+            // inbound_drains}`, the constructor is the only safe way to
+            // build one outside `glue::leader_setup`.
+            let stub_mesh = Arc::new(MppMesh::new(0, mpp_worker_count(), Vec::new()));
             Self::build_mpp_leader_session_context(stub_mesh)
         } else {
             create_aggregate_session_context()

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1482,7 +1482,7 @@ impl AggregateScan {
                     );
                 }
 
-                // Broadcast invariant + defensive short-circuit:
+                // Broadcast invariant — fail-loud cap check:
                 // pg_search's natural-shape AggregateScan plan canonical-
                 // replicates the build subtree via the `mpp build all-
                 // gather` step, so every producer task would scan the
@@ -1491,13 +1491,19 @@ impl AggregateScan {
                 // level [`BroadcastBuildSideOneTaskEstimator`] caps the
                 // build subtree at task_count=1, so a correct plan
                 // produces exactly one Broadcast fragment with
-                // task_idx == 0. The `debug_assert!` catches a future
-                // planner change that loses the cap, and the release-
-                // build short-circuit keeps results correct by EOF-only-
-                // ing any unexpected `task_idx > 0` fragment.
+                // task_idx == 0.
                 //
-                // See the doc on `FragmentRouting::Broadcast` and on
-                // `mpp::task_estimator::BroadcastBuildSideOneTaskEstimator`.
+                // A non-zero `task_idx` here means the cap silently
+                // failed — either the estimator wasn't installed, the
+                // chain order is wrong, or a future planner pass
+                // re-expanded the build subtree. We surface this as a
+                // hard error rather than silently EOF-only-ing the
+                // fragment: the EOF-only fallback is only correct under
+                // the canonical-replica INVARIANT documented on
+                // `FragmentRouting::Broadcast`, and we'd rather fail
+                // loudly than emit a stealth correctness regression.
+                // Matches the top-level NetworkBroadcastExec treatment
+                // in `worker_fragments::collect`.
                 if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
                     debug_assert!(
                         fragment.task_idx == 0,
@@ -1506,26 +1512,19 @@ impl AggregateScan {
                          input_task_count at 1; plan-walk drift?",
                         fragment.task_idx,
                     );
-                }
-                if matches!(fragment.routing, FragmentRouting::Broadcast { .. })
-                    && fragment.task_idx != 0
-                {
-                    crate::mpp_log!(
-                        "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
-                         task_idx={}) Broadcast short-circuit: EOF-only (cap drift)",
-                        fragment.stage_id,
-                        fragment.task_idx,
-                    );
-                    let senders = per_partition_senders;
-                    futures.push(Box::pin(async move {
-                        let mut stats =
-                            crate::postgres::customscan::mpp::transport::SendBatchStats::default();
-                        for sender in &senders {
-                            sender.send_eof_traced(&mut stats).await?;
-                        }
-                        Ok(())
-                    }));
-                    continue;
+                    if fragment.task_idx != 0 {
+                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                            "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
+                             (stage_id={}, task_idx={}) with task_idx > 0 — the planner-level \
+                             BroadcastBuildSideOneTaskEstimator should cap input_task_count at \
+                             1. A non-zero task_idx here indicates plan-walk drift or a missing \
+                             estimator chain on this session; running the producer plan would \
+                             duplicate the canonical replica, EOF-only-ing it would drop a \
+                             real shard if the cap loss was due to a sharded build subtree. \
+                             Surface as error so the divergence is visible.",
+                            fragment.stage_id, fragment.task_idx,
+                        )));
+                    }
                 }
 
                 // Build a TaskContext seeded with the right

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1246,7 +1246,7 @@ impl AggregateScan {
         // its hash to mpp_n_partitions × mpp_n_partitions = 81 partitions.
         let n_workers = worker.participant_config.total_workers;
         let worker_idx_for_cache = worker.participant_config.participant_index;
-        let outbound_senders: Vec<MppSender> = match df_state.mpp.as_mut() {
+        let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
             Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
             _ => unreachable!(),
         };
@@ -1365,16 +1365,19 @@ impl AggregateScan {
             unsafe { pg_sys::work_mem as usize * 1024 },
             unsafe { pg_sys::hash_mem_multiplier },
         );
-        // M2.a: expand the single leader-bound sender into N senders matching
+        // M2.a / M2.d.1: expand the leader-bound sender into N senders matching
         // the fragment's output_partitioning. Each clone shares the same
         // shm_mq queue but stamps a different `partition` on its frames, so
         // the leader's drain can demux. `stage_id` stays at 0 — the natural-
-        // shape gather is a single logical stage.
+        // shape gather is a single logical stage, and M2.d.3 will replace
+        // this loop with the plan-walking dispatcher that uses the worker's
+        // full per-proc-indexed sender table.
         let n_out_partitions = fragment.output_partitioning().partition_count();
-        let base_sender = outbound_senders
-            .into_iter()
-            .next()
-            .expect("worker_setup must hand back at least one MppSender");
+        let mut outbound_iter = outbound_senders.into_iter();
+        // Leader is proc 0; its slot in the per-proc-indexed vec is at index 0.
+        let leader_slot = outbound_iter.next().flatten();
+        let base_sender =
+            leader_slot.expect("worker_setup must populate outbound_senders[0] (leader)");
         let mut expanded: Vec<MppSender> = Vec::with_capacity(n_out_partitions);
         for partition in 0..n_out_partitions {
             let partition_u32 = u32::try_from(partition).unwrap_or(u32::MAX);
@@ -1386,6 +1389,9 @@ impl AggregateScan {
             ));
         }
         drop(base_sender);
+        // Remaining peer-bound senders are unused in single-fragment mode and
+        // get dropped here; M2.d.3 wires them in for peer-mesh fragments.
+        drop(outbound_iter);
 
         let result =
             runtime.block_on(async { run_worker_fragment(fragment, expanded, task_ctx).await });

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -55,10 +55,10 @@ use crate::postgres::customscan::mpp::glue::{
 use crate::postgres::customscan::mpp::runtime::{MppMesh, MppWorkerResolver, ShmMqWorkerTransport};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
+use crate::postgres::customscan::mpp::worker::run_worker_fragment;
 use crate::postgres::customscan::mpp::worker_fragments::{
     find_worker_assignments, FragmentRouting,
 };
-use crate::postgres::customscan::mpp::worker::run_worker_fragment;
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -39,7 +39,7 @@ pub use targetlist::TargetListEntry;
 use std::sync::Arc;
 
 use datafusion::execution::SessionStateBuilder;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_distributed::{
     display_plan_ascii, DistributedExec, DistributedExt, SessionStateBuilderExt,
 };
@@ -1364,8 +1364,30 @@ impl AggregateScan {
             unsafe { pg_sys::work_mem as usize * 1024 },
             unsafe { pg_sys::hash_mem_multiplier },
         );
-        let result = runtime
-            .block_on(async { run_worker_fragment(fragment, outbound_senders, task_ctx).await });
+        // M2.a: expand the single leader-bound sender into N senders matching
+        // the fragment's output_partitioning. Each clone shares the same
+        // shm_mq queue but stamps a different `partition` on its frames, so
+        // the leader's drain can demux. `stage_id` stays at 0 — the natural-
+        // shape gather is a single logical stage.
+        let n_out_partitions = fragment.output_partitioning().partition_count();
+        let base_sender = outbound_senders
+            .into_iter()
+            .next()
+            .expect("worker_setup must hand back at least one MppSender");
+        let mut expanded: Vec<MppSender> = Vec::with_capacity(n_out_partitions);
+        for partition in 0..n_out_partitions {
+            let partition_u32 = u32::try_from(partition).unwrap_or(u32::MAX);
+            expanded.push(base_sender.clone_with_header(
+                crate::postgres::customscan::mpp::transport::MppFrameHeader::batch(
+                    0,
+                    partition_u32,
+                ),
+            ));
+        }
+        drop(base_sender);
+
+        let result =
+            runtime.block_on(async { run_worker_fragment(fragment, expanded, task_ctx).await });
         if let Err(e) = result {
             pgrx::error!("mpp worker: run_worker_fragment failed: {e}");
         }
@@ -1373,18 +1395,25 @@ impl AggregateScan {
     }
 
     /// Walk a DistributedExec-rooted plan and return the input subtree of
-    /// the **topmost** `NetworkShuffleExec` (the worker producer fragment).
-    /// Returns `None` if no `NetworkShuffleExec` is reachable from the root.
+    /// the **topmost** worker→leader network boundary (the worker producer
+    /// fragment). Returns `None` if no qualifying boundary is reachable.
+    ///
+    /// In the band-aided fork the topmost boundary was always
+    /// `NetworkShuffleExec(consumer_tc=1, input_tc=N)`; in the natural-shape
+    /// plan that's now `NetworkCoalesceExec(consumer_tc=1, input_tc=N)`.
+    /// We accept either, since the worker subtree below is the same shape
+    /// in both cases.
     ///
     /// Pre-order traversal returns on the first match, which is the
-    /// outermost shuffle — the one that straddles the worker→leader split.
-    /// Nested `NetworkShuffleExec`s inside the worker fragment (e.g. the
-    /// shuffles `HashJoinExec(Partitioned)` inserts on each side once the
-    /// build side crosses `hash_join_single_partition_threshold`) are
-    /// re-executed locally by `LocalExecWorkerTransport` at execute time,
-    /// so the worker only needs to find the outermost one.
+    /// outermost boundary — the one that straddles the worker→leader split.
+    /// Nested boundaries inside the worker fragment (e.g. the shuffles
+    /// `HashJoinExec(Partitioned)` inserts on each side once the build side
+    /// crosses `hash_join_single_partition_threshold`) are re-executed
+    /// locally by `LocalExecWorkerTransport` at execute time, so the worker
+    /// only needs to find the outermost one.
     fn find_worker_fragment(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
-        if plan.name() == "NetworkShuffleExec" {
+        let name = plan.name();
+        if name == "NetworkShuffleExec" || name == "NetworkCoalesceExec" {
             return plan.children().first().map(|c| Arc::clone(c));
         }
         for child in plan.children() {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1364,6 +1364,10 @@ impl AggregateScan {
         // mesh. `ShmMqWorkerTransport::open` consults it to route nested
         // boundaries (e.g. the `NetworkShuffleExec` inside a `FinalPartitioned`
         // fragment) to the right peer proc.
+        crate::mpp_log!(
+            "mpp worker (proc={this_proc}): physical plan built; installing assignment table \
+             (total_procs={total_procs})"
+        );
         let assignment = TaskAssignment::from_plan(&physical_plan, total_procs);
         worker_mesh.install_assignment(Arc::clone(&assignment));
 
@@ -1429,6 +1433,12 @@ impl AggregateScan {
                         }
                     };
                     let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
+                    crate::mpp_log!(
+                        "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
+                         task_idx={}) partition={q} → dest_proc={dest_proc}",
+                        fragment.stage_id,
+                        fragment.task_idx,
+                    );
                     // Attach the worker mesh as the cooperative drain so a
                     // full outbound shm_mq queue doesn't block the backend
                     // thread — the spin pulls every inbound drain while
@@ -1475,7 +1485,34 @@ impl AggregateScan {
             // would never observe `Detached`, and `stream_partition`'s pull
             // loop would spin forever.
             drop(outbound_senders);
-            futures::future::try_join_all(futures).await.map(|_| ())
+            crate::mpp_log!(
+                "mpp worker dispatch this_proc={this_proc} starting try_join_all on {} fragments",
+                fragments.len()
+            );
+            // Deadlock detector: under `paradedb.mpp_debug`, if no fragment
+            // completes within 30s we treat it as a hang and surface as an
+            // error rather than letting the backend spin indefinitely.
+            // Per-drain state is logged via the inbound drains' own traces
+            // (M2.b/M2.d logging in transport.rs / runtime.rs).
+            let join_fut = futures::future::try_join_all(futures);
+            let outcome = if crate::gucs::mpp_debug() {
+                match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
+                    Ok(r) => r.map(|_| ()),
+                    Err(_) => {
+                        crate::mpp_log!(
+                            "mpp worker dispatch this_proc={this_proc} \
+                             HANG: try_join_all exceeded 30s"
+                        );
+                        Err(datafusion::common::DataFusionError::Internal(format!(
+                            "mpp worker dispatch (proc={this_proc}): try_join_all exceeded 30s — \
+                             deadlock detector triggered"
+                        )))
+                    }
+                }
+            } else {
+                join_fut.await.map(|_| ())
+            };
+            outcome
         });
         if let Err(e) = result {
             pgrx::error!("mpp worker: fragment dispatch failed: {e}");
@@ -1946,6 +1983,10 @@ impl AggregateScan {
             // execute; without it, routing falls back to the M1 single-stage
             // heuristic.
             if let Some(scan_state::MppExecState::Leader(leader)) = df_state.mpp.as_ref() {
+                crate::mpp_log!(
+                    "mpp leader: physical plan built; installing assignment table (n_procs={})",
+                    leader.mesh.n_procs
+                );
                 let assignment = TaskAssignment::from_plan(&physical_plan, leader.mesh.n_procs);
                 leader.mesh.install_assignment(assignment);
             }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -53,6 +53,7 @@ use crate::postgres::customscan::mpp::glue::{
     worker_setup,
 };
 use crate::postgres::customscan::mpp::runtime::{MppMesh, MppWorkerResolver, ShmMqWorkerTransport};
+use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
 use crate::postgres::customscan::mpp::worker_fragments::{
     find_worker_assignments, FragmentRouting,
@@ -1111,6 +1112,15 @@ impl AggregateScan {
             .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
             .with_distributed_in_process_mode(true)
             .expect("with_distributed_in_process_mode")
+            // Estimator chain — order matters. The DF-D fork tries each
+            // estimator in registration order until one returns Some.
+            // The build-side one-task estimator must come first; otherwise
+            // the default `Desired(n_workers)` leaf estimator wins and the
+            // all-gather memory leaf gets task_count = n_workers, which
+            // makes `_distribute_plan` build NetworkBroadcastExec with
+            // input_task_count = n_workers and the consumer's select_all
+            // over-counts by n_workers. See task_estimator.rs.
+            .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
             .with_distributed_task_estimator(n_workers)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
@@ -1346,6 +1356,13 @@ impl AggregateScan {
             .with_distributed_worker_transport(ShmMqWorkerTransport::new(Arc::clone(&worker_mesh)))
             .with_distributed_in_process_mode(true)
             .expect("with_distributed_in_process_mode")
+            // Same estimator chain as the leader (see
+            // `build_mpp_leader_session_context`). The build-side
+            // one-task estimator must precede the default leaf
+            // estimator so that worker physical plans match the
+            // leader's — TaskAssignment depends on byte-identical
+            // stage numbering across procs.
+            .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
             .with_distributed_task_estimator(n_workers_us)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
@@ -1465,29 +1482,37 @@ impl AggregateScan {
                     );
                 }
 
-                // Broadcast short-circuit (load-bearing for correctness):
+                // Broadcast invariant + defensive short-circuit:
                 // pg_search's natural-shape AggregateScan plan canonical-
-                // replicates the build subtree across producer procs via
-                // the `mpp build all-gather` step that pre-stages the
-                // canonical source on every worker. Each producer task's
-                // BroadcastExec would therefore scan the full canonical
-                // data — running every task and `select_all`ing their
-                // outputs in the consumer would over-count by
-                // `input_task_count`. The wire-level short-circuit forces
-                // input_task_count=1: only task 0 runs, the rest emit EOF.
+                // replicates the build subtree via the `mpp build all-
+                // gather` step, so every producer task would scan the
+                // full canonical data and the consumer's `select_all`
+                // would over-count by `input_task_count`. The planner-
+                // level [`BroadcastBuildSideOneTaskEstimator`] caps the
+                // build subtree at task_count=1, so a correct plan
+                // produces exactly one Broadcast fragment with
+                // task_idx == 0. The `debug_assert!` catches a future
+                // planner change that loses the cap, and the release-
+                // build short-circuit keeps results correct by EOF-only-
+                // ing any unexpected `task_idx > 0` fragment.
                 //
-                // INVARIANT: every `FragmentRouting::Broadcast` fragment
-                // is over a canonical-replicated child. Today this is
-                // enforced by the AggregateScan path's all-gather step.
-                // See the doc on `FragmentRouting::Broadcast` for what
-                // breaks if a future planner emits broadcast over sharded
-                // input.
+                // See the doc on `FragmentRouting::Broadcast` and on
+                // `mpp::task_estimator::BroadcastBuildSideOneTaskEstimator`.
+                if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
+                    debug_assert!(
+                        fragment.task_idx == 0,
+                        "mpp dispatcher: Broadcast fragment with task_idx={} but \
+                         BroadcastBuildSideOneTaskEstimator should have capped \
+                         input_task_count at 1; plan-walk drift?",
+                        fragment.task_idx,
+                    );
+                }
                 if matches!(fragment.routing, FragmentRouting::Broadcast { .. })
                     && fragment.task_idx != 0
                 {
                     crate::mpp_log!(
                         "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
-                         task_idx={}) Broadcast short-circuit: EOF-only",
+                         task_idx={}) Broadcast short-circuit: EOF-only (cap drift)",
                         fragment.stage_id,
                         fragment.task_idx,
                     );

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -44,6 +44,7 @@ use datafusion_distributed::{
     display_plan_ascii, DistributedExec, DistributedExt, SessionStateBuilderExt,
 };
 
+use crate::postgres::customscan::mpp::assignment::TaskAssignment;
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_is_active, mpp_worker_count, producer_worker_count,
@@ -1880,6 +1881,16 @@ impl AggregateScan {
                 Ok(p) => p,
                 Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
             };
+
+            // M2.c: install the plan-driven `(stage_id, task_idx) → proc_idx`
+            // table on the mesh now that the physical plan is in hand. The
+            // transport's `open()` reads through this on every NetworkBoundary
+            // execute; without it, routing falls back to the M1 single-stage
+            // heuristic.
+            if let Some(scan_state::MppExecState::Leader(leader)) = df_state.mpp.as_ref() {
+                let assignment = TaskAssignment::from_plan(&physical_plan, leader.mesh.n_procs);
+                leader.mesh.install_assignment(assignment);
+            }
 
             let task_ctx = build_task_context(
                 &ctx,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -681,7 +681,6 @@ impl ParallelQueryCapable for AggregateScan {
         let Some(plan_bytes) = df_state.mpp_plan_bytes.as_ref() else {
             return 0;
         };
-        let n_partitions = df_state.mpp_n_partitions;
         let plan_bytes_len = plan_bytes.len();
 
         // Capture source manifests so we can size the ParallelScanState block.
@@ -702,7 +701,7 @@ impl ParallelQueryCapable for AggregateScan {
             .source_manifests
             .len()
             .saturating_sub(1) as u32;
-        let mpp_size = match estimate_dsm_size(plan_bytes_len, n_partitions, n_cache_sources) {
+        let mpp_size = match estimate_dsm_size(plan_bytes_len, n_cache_sources) {
             Ok(sz) => sz,
             Err(e) => {
                 pgrx::warning!("mpp: estimate_dsm failed: {e}; falling back to serial");
@@ -1244,7 +1243,7 @@ impl AggregateScan {
         // producer (= mpp_n_partitions), not the worker count — using it as
         // n_workers misconfigured the planner so NetworkShuffleExec scaled
         // its hash to mpp_n_partitions × mpp_n_partitions = 81 partitions.
-        let n_workers = worker.participant_config.total_participants;
+        let n_workers = worker.participant_config.total_workers;
         let worker_idx_for_cache = worker.participant_config.participant_index;
         let outbound_senders: Vec<MppSender> = match df_state.mpp.as_mut() {
             Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -38,10 +38,12 @@ pub use targetlist::TargetListEntry;
 
 use std::sync::Arc;
 
-use datafusion::execution::SessionStateBuilder;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::execution::{SessionStateBuilder, TaskContext};
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_distributed::{
-    display_plan_ascii, DistributedExec, DistributedExt, SessionStateBuilderExt,
+    display_plan_ascii, DistributedExec, DistributedExt, DistributedTaskContext,
+    SessionStateBuilderExt,
 };
 
 use crate::postgres::customscan::mpp::assignment::TaskAssignment;
@@ -50,10 +52,11 @@ use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_is_active, mpp_worker_count, producer_worker_count,
     worker_setup,
 };
-use crate::postgres::customscan::mpp::runtime::{
-    LocalExecWorkerTransport, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
+use crate::postgres::customscan::mpp::runtime::{MppMesh, MppWorkerResolver, ShmMqWorkerTransport};
+use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
+use crate::postgres::customscan::mpp::worker_fragments::{
+    find_worker_assignments, FragmentRouting,
 };
-use crate::postgres::customscan::mpp::transport::MppSender;
 use crate::postgres::customscan::mpp::worker::run_worker_fragment;
 
 use crate::api::agg_funcoid;
@@ -86,6 +89,7 @@ use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
 };
+use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::dsm::{
     estimate_dsm_custom_scan, initialize_dsm_custom_scan, initialize_worker_custom_scan,
     reinitialize_dsm_custom_scan, ParallelQueryCapable,
@@ -1246,6 +1250,14 @@ impl AggregateScan {
         // its hash to mpp_n_partitions × mpp_n_partitions = 81 partitions.
         let n_workers = worker.participant_config.total_workers;
         let worker_idx_for_cache = worker.participant_config.participant_index;
+        // M2.d.3: capture the worker's mesh + total proc count for the
+        // dispatcher. The mesh's inbound drains were attached in
+        // `worker_setup`; here we wire its `ShmMqWorkerTransport` into the
+        // session and install the plan-driven assignment table once the
+        // physical plan is built.
+        let worker_mesh = Arc::clone(&worker.mesh);
+        let this_proc = worker.mesh.this_proc;
+        let total_procs = worker.mesh.n_procs;
         let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
             Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
             _ => unreachable!(),
@@ -1317,15 +1329,21 @@ impl AggregateScan {
             .with_default_features()
             .with_config(cfg)
             .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers_us))
-            // Workers may encounter nested network boundaries inside the
-            // producer fragment (e.g. a `NetworkBroadcastExec` on the build
-            // side of a `HashJoin`). Without a transport registered, the
-            // default `FlightWorkerTransport` would try to dial the empty
-            // URL and error out. The `LocalExecWorkerTransport` re-executes
-            // the boundary's input subtree locally — duplicates the build
-            // scan across workers, but for small index scans that's cheap
-            // and keeps the in-process design self-contained.
-            .with_distributed_worker_transport(LocalExecWorkerTransport)
+            // M2.d.3: route nested boundaries through the worker's
+            // `MppMesh` via `ShmMqWorkerTransport`. Workers running a
+            // consumer-side fragment (e.g. `FinalPartitioned` above a
+            // `NetworkShuffleExec` peer-mesh) call `WorkerTransport::open`
+            // here; the returned `ShmMqWorkerConnection` pulls from the
+            // worker's inbound drain for the producer's proc, demuxing on
+            // `(stage_id, partition)` via the M2.b sub-buffer registry.
+            //
+            // The earlier `LocalExecWorkerTransport` "re-execute the
+            // boundary's input subtree locally" path is gone: with the
+            // assignment table from M2.c the producer task is hosted on a
+            // specific peer proc, and re-executing locally would duplicate
+            // work and break correctness for hash-partitioned shuffles
+            // (each worker would see all rows instead of its hash slice).
+            .with_distributed_worker_transport(ShmMqWorkerTransport::new(Arc::clone(&worker_mesh)))
             .with_distributed_in_process_mode(true)
             .expect("with_distributed_in_process_mode")
             .with_distributed_task_estimator(n_workers_us)
@@ -1342,93 +1360,127 @@ impl AggregateScan {
             Ok(p) => p,
             Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
         };
-        // Find the bottom NetworkShuffleExec; its input_stage.plan (==
-        // children()[0]) is the worker fragment. If the DF-D fork's planner
-        // didn't insert one (some plan shapes don't benefit from a network
-        // shuffle, or PartialReduce isn't enabled), the worker has no
-        // fragment to run — emit zero rows and let the leader produce
-        // results via its own copy. Logging at WARNING so production
-        // monitors can spot the falls-back-to-no-op case.
-        let fragment = match Self::find_worker_fragment(&physical_plan) {
-            Some(f) => f,
-            None => {
-                pgrx::warning!(
-                    "mpp worker: no NetworkShuffleExec found in distributed plan; \
-                     skipping producer-fragment run (worker emits zero rows)"
-                );
-                return std::ptr::null_mut();
-            }
-        };
-        let task_ctx = build_task_context(
-            &session,
-            &fragment,
-            unsafe { pg_sys::work_mem as usize * 1024 },
-            unsafe { pg_sys::hash_mem_multiplier },
-        );
-        // M2.a / M2.d.1: expand the leader-bound sender into N senders matching
-        // the fragment's output_partitioning. Each clone shares the same
-        // shm_mq queue but stamps a different `partition` on its frames, so
-        // the leader's drain can demux. `stage_id` stays at 0 — the natural-
-        // shape gather is a single logical stage, and M2.d.3 will replace
-        // this loop with the plan-walking dispatcher that uses the worker's
-        // full per-proc-indexed sender table.
-        let n_out_partitions = fragment.output_partitioning().partition_count();
-        let mut outbound_iter = outbound_senders.into_iter();
-        // Leader is proc 0; its slot in the per-proc-indexed vec is at index 0.
-        let leader_slot = outbound_iter.next().flatten();
-        let base_sender =
-            leader_slot.expect("worker_setup must populate outbound_senders[0] (leader)");
-        let mut expanded: Vec<MppSender> = Vec::with_capacity(n_out_partitions);
-        for partition in 0..n_out_partitions {
-            let partition_u32 = u32::try_from(partition).unwrap_or(u32::MAX);
-            expanded.push(base_sender.clone_with_header(
-                crate::postgres::customscan::mpp::transport::MppFrameHeader::batch(
-                    0,
-                    partition_u32,
-                ),
-            ));
-        }
-        drop(base_sender);
-        // Remaining peer-bound senders are unused in single-fragment mode and
-        // get dropped here; M2.d.3 wires them in for peer-mesh fragments.
-        drop(outbound_iter);
+        // M2.d.3: install the plan-driven assignment table on the worker's
+        // mesh. `ShmMqWorkerTransport::open` consults it to route nested
+        // boundaries (e.g. the `NetworkShuffleExec` inside a `FinalPartitioned`
+        // fragment) to the right peer proc.
+        let assignment = TaskAssignment::from_plan(&physical_plan, total_procs);
+        worker_mesh.install_assignment(Arc::clone(&assignment));
 
-        let result =
-            runtime.block_on(async { run_worker_fragment(fragment, expanded, task_ctx).await });
+        // Walk the plan and collect every `(stage_id, task_idx)` slot the
+        // assignment table puts on this proc. The dispatcher spawns one
+        // async task per fragment; together they form the worker's complete
+        // contribution to the distributed plan.
+        let fragments = find_worker_assignments(&physical_plan, this_proc, &assignment);
+        if fragments.is_empty() {
+            pgrx::warning!(
+                "mpp worker (proc={this_proc}): no fragments assigned by TaskAssignment; \
+                 skipping (worker emits zero rows)"
+            );
+            return std::ptr::null_mut();
+        }
+
+        let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
+        let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
+        let session_arc = Arc::new(session);
+
+        let result = runtime.block_on(async move {
+            let mut futures = Vec::with_capacity(fragments.len());
+            for fragment in &fragments {
+                let n_out = fragment.plan.output_partitioning().partition_count();
+                // Build per-output-partition senders. For each partition `q`
+                // emitted by this fragment, look up the destination proc via
+                // `fragment.routing` and clone the right outbound sender.
+                let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
+                for q in 0..n_out {
+                    let dest_proc = match &fragment.routing {
+                        FragmentRouting::Coalesce { dest_proc } => *dest_proc,
+                        FragmentRouting::Shuffle {
+                            parent_stage_id,
+                            partitions_per_consumer_task,
+                        } => {
+                            let t_c = (q / partitions_per_consumer_task) as u32;
+                            match assignment.proc_for(*parent_stage_id, t_c) {
+                                Some(p) => p,
+                                None => {
+                                    return Err(datafusion::common::DataFusionError::Internal(
+                                        format!(
+                                            "mpp worker dispatch: no proc for \
+                                             (parent_stage_id={parent_stage_id}, task={t_c}); \
+                                             fragment stage_id={} task_idx={}",
+                                            fragment.stage_id, fragment.task_idx,
+                                        ),
+                                    ));
+                                }
+                            }
+                        }
+                    };
+                    let base = match outbound_senders
+                        .get(dest_proc as usize)
+                        .and_then(|s| s.as_ref())
+                    {
+                        Some(s) => s,
+                        None => {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
+                                 (self-loop or unattached); fragment stage_id={} task_idx={}",
+                                fragment.stage_id, fragment.task_idx,
+                            )));
+                        }
+                    };
+                    let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
+                    // Attach the worker mesh as the cooperative drain so a
+                    // full outbound shm_mq queue doesn't block the backend
+                    // thread — the spin pulls every inbound drain while
+                    // retrying the send, breaking N×N symmetric stalls.
+                    per_partition_senders.push(
+                        base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
+                            .with_cooperative_drain(
+                                Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
+                            ),
+                    );
+                }
+
+                // Build a TaskContext seeded with the right
+                // `DistributedTaskContext` so the boundary nodes inside the
+                // fragment's plan know their `(task_index, task_count)`.
+                let cfg = session_arc
+                    .state()
+                    .config()
+                    .clone()
+                    .with_extension(Arc::new(DistributedTaskContext {
+                        task_index: fragment.task_idx,
+                        task_count: fragment.task_count,
+                    }));
+                let memory_pool =
+                    create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
+                let task_ctx = Arc::new(
+                    TaskContext::default()
+                        .with_session_config(cfg)
+                        .with_runtime(Arc::new(
+                            RuntimeEnvBuilder::new()
+                                .with_memory_pool(memory_pool)
+                                .build()
+                                .expect("Failed to create RuntimeEnv"),
+                        )),
+                );
+
+                let plan = Arc::clone(&fragment.plan);
+                futures.push(run_worker_fragment(plan, per_partition_senders, task_ctx));
+            }
+            // Drop the original outbound_senders so the only remaining Arcs
+            // to each shm_mq queue / in-proc channel are the per-partition
+            // clones owned by the spawned fragments. Without this, the
+            // originals would outlive the futures, the consumer-side drains
+            // would never observe `Detached`, and `stream_partition`'s pull
+            // loop would spin forever.
+            drop(outbound_senders);
+            futures::future::try_join_all(futures).await.map(|_| ())
+        });
         if let Err(e) = result {
-            pgrx::error!("mpp worker: run_worker_fragment failed: {e}");
+            pgrx::error!("mpp worker: fragment dispatch failed: {e}");
         }
         std::ptr::null_mut()
-    }
-
-    /// Walk a DistributedExec-rooted plan and return the input subtree of
-    /// the **topmost** worker→leader network boundary (the worker producer
-    /// fragment). Returns `None` if no qualifying boundary is reachable.
-    ///
-    /// In the band-aided fork the topmost boundary was always
-    /// `NetworkShuffleExec(consumer_tc=1, input_tc=N)`; in the natural-shape
-    /// plan that's now `NetworkCoalesceExec(consumer_tc=1, input_tc=N)`.
-    /// We accept either, since the worker subtree below is the same shape
-    /// in both cases.
-    ///
-    /// Pre-order traversal returns on the first match, which is the
-    /// outermost boundary — the one that straddles the worker→leader split.
-    /// Nested boundaries inside the worker fragment (e.g. the shuffles
-    /// `HashJoinExec(Partitioned)` inserts on each side once the build side
-    /// crosses `hash_join_single_partition_threshold`) are re-executed
-    /// locally by `LocalExecWorkerTransport` at execute time, so the worker
-    /// only needs to find the outermost one.
-    fn find_worker_fragment(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
-        let name = plan.name();
-        if name == "NetworkShuffleExec" || name == "NetworkCoalesceExec" {
-            return plan.children().first().map(|c| Arc::clone(c));
-        }
-        for child in plan.children() {
-            if let Some(found) = Self::find_worker_fragment(child) {
-                return Some(found);
-            }
-        }
-        None
     }
 
     /// Existing single-table Tantivy aggregate path.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1956,6 +1956,27 @@ impl AggregateScan {
                 unsafe { pg_sys::work_mem as usize * 1024 },
                 unsafe { pg_sys::hash_mem_multiplier },
             );
+            // M2.d review-fix: explicitly install `DistributedTaskContext` on
+            // the leader's task_ctx. The fork's `from_ctx` defaults to
+            // `{task_index: 0, task_count: 1}` which arithmetically matches
+            // our current single-leader natural-shape gather, but the
+            // implicit fallback silently masks any planner shape that emits
+            // a different `consumer_tc` at the top boundary. Installing it
+            // up-front makes the contract explicit and aligns with the
+            // worker dispatcher's `DistributedTaskContext` setup.
+            let task_ctx = {
+                let cfg = task_ctx.session_config().clone().with_extension(Arc::new(
+                    DistributedTaskContext {
+                        task_index: 0,
+                        task_count: 1,
+                    },
+                ));
+                Arc::new(
+                    TaskContext::default()
+                        .with_session_config(cfg)
+                        .with_runtime(task_ctx.runtime_env().clone()),
+                )
+            };
             let stream = {
                 let _guard = runtime.enter();
                 match physical_plan.execute(0, task_ctx) {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1465,12 +1465,23 @@ impl AggregateScan {
                     );
                 }
 
-                // Broadcast short-circuit: pg_search's natural-shape plan
-                // canonical-replicates the build subtree (see the doc on
-                // `FragmentRouting::Broadcast`), so running the producer
-                // plan on every input task would duplicate by
-                // `input_task_count`. Only task 0 runs the plan; tasks
-                // `task_idx > 0` send a per-partition EOF and return.
+                // Broadcast short-circuit (load-bearing for correctness):
+                // pg_search's natural-shape AggregateScan plan canonical-
+                // replicates the build subtree across producer procs via
+                // the `mpp build all-gather` step that pre-stages the
+                // canonical source on every worker. Each producer task's
+                // BroadcastExec would therefore scan the full canonical
+                // data — running every task and `select_all`ing their
+                // outputs in the consumer would over-count by
+                // `input_task_count`. The wire-level short-circuit forces
+                // input_task_count=1: only task 0 runs, the rest emit EOF.
+                //
+                // INVARIANT: every `FragmentRouting::Broadcast` fragment
+                // is over a canonical-replicated child. Today this is
+                // enforced by the AggregateScan path's all-gather step.
+                // See the doc on `FragmentRouting::Broadcast` for what
+                // breaks if a future planner emits broadcast over sharded
+                // input.
                 if matches!(fragment.routing, FragmentRouting::Broadcast { .. })
                     && fragment.task_idx != 0
                 {

--- a/pg_search/src/postgres/customscan/mpp/assignment.rs
+++ b/pg_search/src/postgres/customscan/mpp/assignment.rs
@@ -111,7 +111,25 @@ impl TaskAssignment {
         let n_workers = n_procs.saturating_sub(1).max(1);
         let mut map = HashMap::new();
         collect_into(plan, &mut map, n_workers);
-        Arc::new(Self { map, n_procs })
+        let table = Arc::new(Self { map, n_procs });
+        #[cfg(not(test))]
+        {
+            // Diagnostic dump: every (stage_id, task_idx) → proc_idx the walker
+            // recorded. Lets us compare leader vs worker on the same logical
+            // plan and confirm `Stage.num` parity.
+            crate::mpp_log!(
+                "mpp assignment::from_plan n_procs={} entries={}",
+                n_procs,
+                table.map.len()
+            );
+            let mut entries: Vec<(u32, u32, u32)> =
+                table.map.iter().map(|(&(s, t), &p)| (s, t, p)).collect();
+            entries.sort_unstable();
+            for (s, t, p) in entries {
+                crate::mpp_log!("mpp assignment::from_plan stage_id={s} task_idx={t} proc_idx={p}");
+            }
+        }
+        table
     }
 
     /// Look up the proc that hosts `(stage_id, task_idx)`. Returns `None` if

--- a/pg_search/src/postgres/customscan/mpp/assignment.rs
+++ b/pg_search/src/postgres/customscan/mpp/assignment.rs
@@ -1,0 +1,247 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Plan-driven `(stage_id, task_idx) → proc_idx` assignment table for
+//! [`crate::postgres::customscan::mpp::runtime::ShmMqWorkerTransport`].
+//!
+//! M1 used a single-stage heuristic (`sender_proc_for_task = task + 1`).
+//! That accidentally produces the right answer when there is exactly one
+//! producer stage with `task_count == n_workers` (the natural-shape gather)
+//! and the wrong answer for any peer-mesh shuffle where Stage 2's tasks
+//! get the same indices as Stage 1's tasks but should host different work.
+//!
+//! M2.c builds an explicit table by walking the physical plan: for every
+//! [`datafusion_distributed::NetworkBoundary`] node, the table records
+//! `(input_stage.num, task_idx) → proc_idx` for each task. The current
+//! policy is round-robin over the worker procs:
+//!
+//! ```text
+//! proc_idx = 1 + (task_idx % n_workers)
+//! ```
+//!
+//! ...which means tasks 0..n_workers map 1:1 onto workers 1..n_procs and any
+//! tasks past that wrap. With the planner's `target_partitions = n_workers`
+//! and `distributed_task_estimator = n_workers` knobs (set in the
+//! AggregateScan leader session context), the natural-shape plans never
+//! exceed `n_workers` tasks per stage, so wrap-around is dormant today.
+//! Encoding it now means later milestones can grow stages independently
+//! without revisiting this rule.
+//!
+//! The table is shared via [`MppMesh::install_assignment`]; the transport
+//! reads it through `MppMesh::task_assignment()`. M2.d will introduce
+//! per-worker meshes that share the same table so worker→worker peer-mesh
+//! routing is consistent across procs.
+//!
+//! [`MppMesh`]: crate::postgres::customscan::mpp::runtime::MppMesh
+//! [`MppMesh::install_assignment`]: crate::postgres::customscan::mpp::runtime::MppMesh::install_assignment
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_distributed::NetworkBoundaryExt;
+
+/// Plan-derived mapping from `(stage_id, task_idx)` to the `proc_idx` that
+/// hosts that task. Leader is `proc_idx = 0`; workers are `1..n_procs`.
+///
+/// Construction goes through [`Self::from_plan`] so the table reflects the
+/// concrete physical plan we're about to execute — particularly the
+/// `stage.tasks.len()` per [`Stage`], which is what the DF-D planner picked
+/// for each [`NetworkBoundary`].
+///
+/// [`Stage`]: datafusion_distributed::Stage
+/// [`NetworkBoundary`]: datafusion_distributed::NetworkBoundary
+#[derive(Debug, Clone)]
+pub struct TaskAssignment {
+    map: HashMap<(u32, u32), u32>,
+    /// Total participant count (leader + workers). Held for diagnostics and
+    /// for the wrap-around math; the table itself is the authoritative
+    /// lookup.
+    #[allow(dead_code)]
+    n_procs: u32,
+}
+
+impl TaskAssignment {
+    /// Build an empty table. Useful for tests; production goes through
+    /// [`Self::from_plan`].
+    #[allow(dead_code)]
+    pub fn empty(n_procs: u32) -> Arc<Self> {
+        Arc::new(Self {
+            map: HashMap::new(),
+            n_procs,
+        })
+    }
+
+    /// Walk `plan`, collect every [`NetworkBoundary`] node's input stage, and
+    /// assign each task to a proc via round-robin over the worker procs
+    /// (`1..n_procs`).
+    ///
+    /// The walk descends through `Stage.plan()` for each network boundary so
+    /// nested stages (peer-mesh shuffles below a top-level gather) are
+    /// visible. Each `Stage.num` appears at most once in the resulting map.
+    ///
+    /// [`NetworkBoundary`]: datafusion_distributed::NetworkBoundary
+    pub fn from_plan(plan: &Arc<dyn ExecutionPlan>, n_procs: u32) -> Arc<Self> {
+        let n_workers = n_procs.saturating_sub(1).max(1);
+        let mut map = HashMap::new();
+        collect_into(plan, &mut map, n_workers);
+        Arc::new(Self { map, n_procs })
+    }
+
+    /// Look up the proc that hosts `(stage_id, task_idx)`. Returns `None` if
+    /// the pair isn't in the table — caller decides whether to fall back to
+    /// a heuristic or surface an error.
+    pub fn proc_for(&self, stage_id: u32, task_idx: u32) -> Option<u32> {
+        self.map.get(&(stage_id, task_idx)).copied()
+    }
+
+    /// Inverse lookup: every `(stage_id, task_idx)` slot hosted by
+    /// `proc_idx`. The worker side consumes this in M2.d to know which
+    /// fragments it must run; today this is exercised in tests only.
+    #[allow(dead_code)]
+    pub fn slots_for_proc(&self, proc_idx: u32) -> Vec<(u32, u32)> {
+        let mut out: Vec<(u32, u32)> = self
+            .map
+            .iter()
+            .filter_map(|(&k, &p)| if p == proc_idx { Some(k) } else { None })
+            .collect();
+        // Stable order so M2.d's worker-side iteration is deterministic
+        // (sorted by (stage_id, task_idx)).
+        out.sort();
+        out
+    }
+
+    /// Iterate `(stage_id, task_idx, proc_idx)` tuples. Exposed for
+    /// debugging and tests.
+    #[allow(dead_code)]
+    pub fn iter(&self) -> impl Iterator<Item = (u32, u32, u32)> + '_ {
+        self.map.iter().map(|(&(s, t), &p)| (s, t, p))
+    }
+
+    /// Number of entries in the table.
+    #[allow(dead_code)]
+    pub fn len(&self) -> usize {
+        self.map.len()
+    }
+}
+
+/// Recursive plan walker. On every [`NetworkBoundary`], records the input
+/// stage's per-task assignments and recurses into `stage.plan()` so nested
+/// stages contribute too.
+///
+/// [`NetworkBoundary`]: datafusion_distributed::NetworkBoundary
+fn collect_into(plan: &Arc<dyn ExecutionPlan>, map: &mut HashMap<(u32, u32), u32>, n_workers: u32) {
+    if let Some(nb) = plan.as_ref().as_network_boundary() {
+        let stage = nb.input_stage();
+        let stage_num = stage.num() as u32;
+        for task_idx in 0..stage.tasks.len() {
+            let task_idx_u32 = task_idx as u32;
+            let proc_idx = 1 + (task_idx_u32 % n_workers);
+            map.insert((stage_num, task_idx_u32), proc_idx);
+        }
+        if let Some(inner) = stage.plan() {
+            collect_into(inner, map, n_workers);
+        }
+    } else {
+        for child in plan.children() {
+            collect_into(child, map, n_workers);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_returns_none_for_any_key() {
+        let a = TaskAssignment::empty(4);
+        assert_eq!(a.proc_for(0, 0), None);
+        assert_eq!(a.proc_for(5, 3), None);
+        assert_eq!(a.len(), 0);
+    }
+
+    #[test]
+    fn round_robin_assigns_workers_starting_from_proc_1() {
+        // Synthetic table that mirrors what `from_plan` would compute for
+        // a single stage of T tasks with n_workers = 3.
+        let n_procs = 4u32; // 1 leader + 3 workers
+        let n_workers = n_procs - 1;
+        let mut map = HashMap::new();
+        for task_idx in 0..5u32 {
+            map.insert((0, task_idx), 1 + (task_idx % n_workers));
+        }
+        let a = Arc::new(TaskAssignment { map, n_procs });
+        assert_eq!(a.proc_for(0, 0), Some(1));
+        assert_eq!(a.proc_for(0, 1), Some(2));
+        assert_eq!(a.proc_for(0, 2), Some(3));
+        // Wrap.
+        assert_eq!(a.proc_for(0, 3), Some(1));
+        assert_eq!(a.proc_for(0, 4), Some(2));
+    }
+
+    #[test]
+    fn slots_for_proc_is_inverse_of_proc_for() {
+        let n_procs = 5u32; // 4 workers
+        let n_workers = n_procs - 1;
+        let mut map = HashMap::new();
+        // Two stages, S0 with 4 tasks, S1 with 2 tasks.
+        for task_idx in 0..4u32 {
+            map.insert((0, task_idx), 1 + (task_idx % n_workers));
+        }
+        for task_idx in 0..2u32 {
+            map.insert((1, task_idx), 1 + (task_idx % n_workers));
+        }
+        let a = Arc::new(TaskAssignment { map, n_procs });
+
+        // proc 1 hosts (0, 0) and (1, 0).
+        assert_eq!(a.slots_for_proc(1), vec![(0, 0), (1, 0)]);
+        // proc 2 hosts (0, 1) and (1, 1).
+        assert_eq!(a.slots_for_proc(2), vec![(0, 1), (1, 1)]);
+        // proc 3 hosts only (0, 2).
+        assert_eq!(a.slots_for_proc(3), vec![(0, 2)]);
+        // proc 4 hosts only (0, 3).
+        assert_eq!(a.slots_for_proc(4), vec![(0, 3)]);
+        // Leader hosts nothing in the producer-side table.
+        assert_eq!(a.slots_for_proc(0), Vec::<(u32, u32)>::new());
+    }
+
+    #[test]
+    fn from_plan_collects_nested_stages() {
+        // Synthetic ExecutionPlan that nests two NetworkBoundary nodes:
+        // outer NetworkCoalesceExec with 2 tasks, inner NetworkShuffleExec
+        // with 4 tasks. Verifies `collect_into` descends into `Stage.plan()`.
+        //
+        // We build real DF-D nodes here because the trait's downcast checks
+        // exact types. The test harness mimics what `_distribute_plan`
+        // produces but skips the full planner setup.
+        //
+        // NOTE: this is light-touch — the constructors involved aren't
+        // exposed at the top-level crate API, so this test focuses on the
+        // empty-plan and round-robin math. Coverage of the full plan walk
+        // lives in the AggregateScan regression once M2.d makes the wiring
+        // observable end-to-end.
+        let n_procs = 4u32;
+        let a = TaskAssignment::empty(n_procs);
+        assert_eq!(a.len(), 0);
+        // Sanity-check from_plan with a trivial non-network plan (no boundaries).
+        // We can't easily construct one inline here without dragging in a
+        // pile of DF imports; the function is exercised in production by
+        // the leader's `build_mpp_leader_session_context` flow + the
+        // mpp_aggregate regression. Leaving this stub as a marker.
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/assignment.rs
+++ b/pg_search/src/postgres/customscan/mpp/assignment.rs
@@ -92,10 +92,22 @@ impl TaskAssignment {
     ///
     /// The walk descends through `Stage.plan()` for each network boundary so
     /// nested stages (peer-mesh shuffles below a top-level gather) are
-    /// visible. Each `Stage.num` appears at most once in the resulting map.
+    /// visible. Duplicate visits to the same `(stage_num, task_idx)` overwrite
+    /// with the same value — harmless given the deterministic round-robin
+    /// policy.
+    ///
+    /// Precondition: `n_procs >= 2` (one leader + at least one worker). The
+    /// production gate at `glue::mpp_is_active` already enforces
+    /// `mpp_worker_count >= 3`, so callers downstream of the customscan
+    /// activation always satisfy this. The `debug_assert` exists to catch
+    /// future direct callers that miss the gate.
     ///
     /// [`NetworkBoundary`]: datafusion_distributed::NetworkBoundary
     pub fn from_plan(plan: &Arc<dyn ExecutionPlan>, n_procs: u32) -> Arc<Self> {
+        debug_assert!(
+            n_procs >= 2,
+            "TaskAssignment::from_plan requires n_procs >= 2 (1 leader + N workers), got {n_procs}"
+        );
         let n_workers = n_procs.saturating_sub(1).max(1);
         let mut map = HashMap::new();
         collect_into(plan, &mut map, n_workers);
@@ -112,6 +124,9 @@ impl TaskAssignment {
     /// Inverse lookup: every `(stage_id, task_idx)` slot hosted by
     /// `proc_idx`. The worker side consumes this in M2.d to know which
     /// fragments it must run; today this is exercised in tests only.
+    ///
+    /// Keys are unique by construction, so `sort_unstable` is sufficient
+    /// for a deterministic order.
     #[allow(dead_code)]
     pub fn slots_for_proc(&self, proc_idx: u32) -> Vec<(u32, u32)> {
         let mut out: Vec<(u32, u32)> = self
@@ -119,9 +134,7 @@ impl TaskAssignment {
             .iter()
             .filter_map(|(&k, &p)| if p == proc_idx { Some(k) } else { None })
             .collect();
-        // Stable order so M2.d's worker-side iteration is deterministic
-        // (sorted by (stage_id, task_idx)).
-        out.sort();
+        out.sort_unstable();
         out
     }
 
@@ -140,8 +153,13 @@ impl TaskAssignment {
 }
 
 /// Recursive plan walker. On every [`NetworkBoundary`], records the input
-/// stage's per-task assignments and recurses into `stage.plan()` so nested
-/// stages contribute too.
+/// stage's per-task assignments, recurses into `stage.plan()` so nested
+/// stages contribute too, and ALSO recurses into `plan.children()` for
+/// defensiveness — the DF-D fork's `find_input_stages` (private) uses the
+/// children path, and the two would diverge only if DF-D ever exposes a
+/// boundary node with children other than its input subplan. Duplicate
+/// visits hit `HashMap::insert` with the same value (deterministic policy),
+/// so the defensive recursion is idempotent.
 ///
 /// [`NetworkBoundary`]: datafusion_distributed::NetworkBoundary
 fn collect_into(plan: &Arc<dyn ExecutionPlan>, map: &mut HashMap<(u32, u32), u32>, n_workers: u32) {
@@ -156,10 +174,11 @@ fn collect_into(plan: &Arc<dyn ExecutionPlan>, map: &mut HashMap<(u32, u32), u32
         if let Some(inner) = stage.plan() {
             collect_into(inner, map, n_workers);
         }
-    } else {
-        for child in plan.children() {
-            collect_into(child, map, n_workers);
-        }
+    }
+    // Non-boundary nodes always recurse; boundary nodes recurse defensively
+    // in case `children()` carries something `stage.plan()` doesn't.
+    for child in plan.children() {
+        collect_into(child, map, n_workers);
     }
 }
 
@@ -221,27 +240,20 @@ mod tests {
     }
 
     #[test]
-    fn from_plan_collects_nested_stages() {
-        // Synthetic ExecutionPlan that nests two NetworkBoundary nodes:
-        // outer NetworkCoalesceExec with 2 tasks, inner NetworkShuffleExec
-        // with 4 tasks. Verifies `collect_into` descends into `Stage.plan()`.
-        //
-        // We build real DF-D nodes here because the trait's downcast checks
-        // exact types. The test harness mimics what `_distribute_plan`
-        // produces but skips the full planner setup.
-        //
-        // NOTE: this is light-touch — the constructors involved aren't
-        // exposed at the top-level crate API, so this test focuses on the
-        // empty-plan and round-robin math. Coverage of the full plan walk
-        // lives in the AggregateScan regression once M2.d makes the wiring
-        // observable end-to-end.
-        let n_procs = 4u32;
-        let a = TaskAssignment::empty(n_procs);
+    fn from_plan_on_boundary_free_plan_is_empty() {
+        // A plan with no NetworkBoundary nodes (just a leaf `EmptyExec`) must
+        // yield an empty assignment. Exercises the early-return path of
+        // `collect_into` end-to-end through `from_plan`.
+        use datafusion::arrow::datatypes::{Field, Schema};
+        use datafusion::physical_plan::empty::EmptyExec;
+        let schema = Arc::new(Schema::new(vec![Field::new(
+            "x",
+            datafusion::arrow::datatypes::DataType::Int32,
+            false,
+        )]));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let a = TaskAssignment::from_plan(&plan, 4);
         assert_eq!(a.len(), 0);
-        // Sanity-check from_plan with a trivial non-network plan (no boundaries).
-        // We can't easily construct one inline here without dragging in a
-        // pile of DF imports; the function is exercised in production by
-        // the leader's `build_mpp_leader_session_context` flow + the
-        // mpp_aggregate regression. Leaving this stub as a marker.
+        assert_eq!(a.proc_for(0, 0), None);
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -43,10 +43,11 @@
 //!   carries frames for any number of logical `(stage_id, partition)`
 //!   channels, demultiplexed on the receive side via the [`MppFrameHeader`]
 //!   prefix introduced in M1.a.
-//! - Self-loops (`slot(k, k)`) are included on purpose. They are rarely the
-//!   hot path (an embedded query usually keeps single-process traffic
-//!   off-mesh), but keeping the topology symmetric simplifies the attach
-//!   protocol and the routing math in [`super::runtime::ShmMqWorkerTransport`].
+//! - Self-loop slots (`slot(k, k)`) are reserved in the layout and
+//!   `shm_mq_create`'d by the leader so the slot-offset math stays a simple
+//!   row-major index, but no process attaches as sender or receiver to its
+//!   own self-loop. In-process traffic stays off the mesh; M2 may decide
+//!   to put it on a bypass channel rather than wake the self-loop slots.
 
 use std::ffi::c_void;
 use std::mem::size_of;
@@ -151,10 +152,13 @@ impl MppDsmHeader {
     /// Byte offset of the build-side cache slot at `(source, worker)`. The
     /// build-cache region is sized as `n_cache_sources × (n_procs - 1)` to
     /// match the worker-only producer count (leader does not write the cache).
+    /// `compute_dsm_layout` requires `n_procs >= 2`, so `n_procs - 1` is
+    /// always a valid worker count.
     #[cfg(test)]
     pub fn cache_data_slot_offset(&self, source: u32, worker: u32) -> u64 {
         debug_assert!(source < self.n_cache_sources);
-        let worker_slots = self.n_procs.saturating_sub(1);
+        debug_assert!(self.n_procs >= 2);
+        let worker_slots = self.n_procs - 1;
         debug_assert!(worker < worker_slots);
         let slot = (source as u64) * (worker_slots as u64) + (worker as u64);
         self.cache_data_offset + slot * self.cache_per_slot
@@ -196,8 +200,14 @@ pub fn compute_dsm_layout(
     n_cache_sources: u32,
     cache_per_slot: usize,
 ) -> Result<DsmLayout, &'static str> {
-    if n_procs == 0 {
-        return Err("mpp: n_procs must be > 0");
+    // Require at least one leader + one worker. `mpp_is_active` enforces a
+    // stricter `n_procs >= 3` (leader + ≥2 workers for meaningful
+    // parallelism); the looser bound here keeps DSM layout math valid for
+    // any plausible runtime configuration without burning a special case
+    // into `cache_data_slot_offset` / `MppBuildCache` for the n_procs=1
+    // edge.
+    if n_procs < 2 {
+        return Err("mpp: n_procs must be >= 2 (leader + at least one worker)");
     }
     let queue_bytes = aligned_queue_bytes(queue_bytes);
     if queue_bytes == 0 {
@@ -227,8 +237,9 @@ pub fn compute_dsm_layout(
     //   data:       n_cache_sources × worker_slots × cache_per_slot
     //
     // `worker_slots = n_procs - 1` because the leader is consumer-only for
-    // the build-side cache; only workers all-gather into it.
-    let worker_slots = (n_procs as usize).saturating_sub(1).max(1);
+    // the build-side cache; only workers all-gather into it. n_procs >= 2 is
+    // enforced above, so subtraction is safe.
+    let worker_slots = (n_procs as usize) - 1;
     let cache_completion_offset =
         align_up_maxalign_checked(queues_end).ok_or("mpp: cache completion alignment overflow")?;
     let cache_completion_size = (n_cache_sources as usize)
@@ -403,13 +414,31 @@ impl MppBuildCache {
 
 /// Per-participant return: handles for the process's row (senders) and
 /// column (receivers) in the multiplexed `n_procs × n_procs` grid.
+///
+/// Self-loop slots (`slot(this_proc, this_proc)`) are skipped to avoid two
+/// `shm_mq_attach` calls + two `on_dsm_detach` callbacks per process for a
+/// queue nothing reads. As a consequence, `outbound_senders` and
+/// `inbound_receivers` each have `n_procs - 1` entries; the index gymnastics
+/// to translate `proc_idx` ↔ slice index are handled by
+/// [`MppMesh::inbound_drain`] in the runtime.
 pub struct ProcAttach {
-    /// `outbound_senders[r]` writes to `slot(this_proc, r)`. One entry per
-    /// receiver process, including the self-loop `slot(this_proc, this_proc)`.
+    /// `outbound_senders[i]` writes to `slot(this_proc, peer_proc(i))` where
+    /// `peer_proc(i) = i if i < this_proc else i + 1` (skipping the self-loop).
     pub outbound_senders: Vec<ShmMqSender>,
-    /// `inbound_receivers[s]` reads from `slot(s, this_proc)`. One entry per
-    /// sender process, including the self-loop.
+    /// `inbound_receivers[i]` reads from `slot(peer_proc(i), this_proc)`,
+    /// same skip-self-loop mapping as `outbound_senders`.
     pub inbound_receivers: Vec<ShmMqReceiver>,
+}
+
+/// Translate a peer index (`0..n_procs - 1`) into a process index
+/// (`0..n_procs`) by skipping the self-loop slot.
+#[inline]
+pub fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
+    if peer_idx < this_proc {
+        peer_idx
+    } else {
+        peer_idx + 1
+    }
 }
 
 /// Initialize the DSM region as the leader (`proc_idx = 0`). Writes the
@@ -501,23 +530,22 @@ unsafe fn attach_proc_row_and_column(
     seg: *mut pg_sys::dsm_segment,
 ) -> ProcAttach {
     let n_procs = header.n_procs;
-    let mut outbound_senders = Vec::with_capacity(n_procs as usize);
-    let mut inbound_receivers = Vec::with_capacity(n_procs as usize);
+    let peer_count = (n_procs - 1) as usize; // n_procs >= 2 is layout invariant
+    let mut outbound_senders = Vec::with_capacity(peer_count);
+    let mut inbound_receivers = Vec::with_capacity(peer_count);
 
-    // Senders: this process's row. `outbound_senders[r]` writes to slot(this, r).
-    for r in 0..n_procs {
+    // Senders: this process's row, skipping the self-loop slot(this, this).
+    for peer_idx in 0..(n_procs - 1) {
+        let r = peer_proc_for_index(this_proc, peer_idx);
         let off = header.slot_offset(this_proc, r) as usize;
         let mq_addr = unsafe { base.add(off) };
         let mq = mq_addr.cast::<pg_sys::shm_mq>();
         outbound_senders.push(unsafe { ShmMqSender::attach(seg, mq) });
     }
 
-    // Receivers: this process's column. `inbound_receivers[s]` reads from
-    // slot(s, this). The self-loop slot was already attached as sender
-    // above; `shm_mq_set_receiver` is a separate operation on the same
-    // queue handle, so the double-attach (once as sender, once as receiver)
-    // on the self-loop is safe.
-    for s in 0..n_procs {
+    // Receivers: this process's column, skipping the self-loop slot(this, this).
+    for peer_idx in 0..(n_procs - 1) {
+        let s = peer_proc_for_index(this_proc, peer_idx);
         let off = header.slot_offset(s, this_proc) as usize;
         let mq_addr = unsafe { base.add(off) };
         let mq = mq_addr.cast::<pg_sys::shm_mq>();
@@ -645,6 +673,21 @@ mod tests {
         let l = compute_dsm_layout(2, 64 * 1024, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64).is_ok());
+    }
+
+    #[test]
+    fn header_validate_rejects_wrong_version() {
+        // Bumping `MPP_DSM_HEADER_VERSION` without rejecting old-version
+        // headers would let an attached worker silently read the wrong
+        // layout. This test pins the version gate so v1 → v2 (and any
+        // future bump) actually trips `validate`.
+        let l = compute_dsm_layout(2, 64 * 1024, 0, 0, 0).unwrap();
+        let mut h = MppDsmHeader::from_layout(&l);
+        h.header_version = MPP_DSM_HEADER_VERSION.wrapping_sub(1);
+        let err = h
+            .validate(l.region_total as u64)
+            .expect_err("wrong version must fail");
+        assert!(err.contains("DSM header version mismatch"), "got: {err}");
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -400,12 +400,17 @@ impl MppBuildCache {
 
     /// Spin until all `n_workers` have signalled completion for `source`.
     /// Yields to PG via `check_for_interrupts!` so `statement_timeout` works.
+    /// `check_for_interrupts!` pulls in PG runtime symbols and is gated out of
+    /// `cargo test` builds; the lib tests in this file never reach
+    /// `wait_complete`, but the gate keeps the symbol off the test-binary link
+    /// line even if the linker fails to DCE the function.
     pub fn wait_complete(&self, source: u32) {
         let counter = unsafe { &*self.completion_ptr(source) };
         loop {
             if counter.load(std::sync::atomic::Ordering::Acquire) >= self.n_workers {
                 return;
             }
+            #[cfg(not(test))]
             pgrx::check_for_interrupts!();
             std::hint::spin_loop();
         }

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -15,32 +15,38 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! N×K DSM layout for the coordinator/worker MPP architecture.
+//! Multiplexed N×N DSM layout for the natural-shape MPP architecture.
 //!
 //! Each MPP query allocates a single DSM region containing:
 //!
 //! ```text
-//!   +--- MppDsmHeader (repr C, 56 bytes, MAXALIGN-padded) ----+
-//!   |    magic, version, n_workers, n_partitions, queue_bytes |
-//!   |    plan_offset, plan_len, queues_offset, region_total   |
-//!   +---------------------------------------------------------+
-//!   | plan bytes (bincode-serialized worker fragment)         |
-//!   +---------------------------------------------------------+
-//!   | padding to MAXALIGN                                     |
-//!   +---------------------------------------------------------+
-//!   | shm_mq queue array: n_workers × n_partitions slots      |
-//!   |   slot(w, p) = queues_offset                            |
-//!   |             + (w * n_partitions + p) * queue_bytes      |
-//!   +---------------------------------------------------------+
+//!   +--- MppDsmHeader (repr C, MAXALIGN-padded) -------------+
+//!   |    magic, version, n_procs, queue_bytes               |
+//!   |    plan_offset, plan_len, queues_offset, region_total |
+//!   |    cache_per_slot, cache_offsets, n_cache_sources     |
+//!   +-------------------------------------------------------+
+//!   | plan bytes (bincode-serialized worker fragment)       |
+//!   +-------------------------------------------------------+
+//!   | padding to MAXALIGN                                   |
+//!   +-------------------------------------------------------+
+//!   | shm_mq queue array: n_procs × n_procs slots           |
+//!   |   slot(sender, receiver) = queues_offset              |
+//!   |     + (sender * n_procs + receiver) * queue_bytes     |
+//!   +-------------------------------------------------------+
 //! ```
 //!
-//! - `n_workers` is the number of producer-side participants (== leader-as-
-//!   worker-0 + parallel workers). Leader is index 0.
-//! - `n_partitions` is the consumer-side partition count for the single
-//!   network boundary the DF-D fork's planner emits under
-//!   `in_process_mode=on`. Multi-stage / multi-boundary layouts are tracked
-//!   on the natural-shape follow-up (PR #5060) and would generalise the
-//!   `worker × partition` slot indexing to a richer grid.
+//! - `n_procs` is the total participant count (1 leader + N parallel workers).
+//!   Leader is `proc_idx = 0`; workers are `proc_idx = ParallelWorkerNumber + 1`.
+//! - Every process attaches as **sender** to its row (`slot(this, *)`) and as
+//!   **receiver** to its column (`slot(*, this)`). The grid is uniform and
+//!   independent of plan shape: a single multiplexed queue per process-pair
+//!   carries frames for any number of logical `(stage_id, partition)`
+//!   channels, demultiplexed on the receive side via the [`MppFrameHeader`]
+//!   prefix introduced in M1.a.
+//! - Self-loops (`slot(k, k)`) are included on purpose. They are rarely the
+//!   hot path (an embedded query usually keeps single-process traffic
+//!   off-mesh), but keeping the topology symmetric simplifies the attach
+//!   protocol and the routing math in [`super::runtime::ShmMqWorkerTransport`].
 
 use std::ffi::c_void;
 use std::mem::size_of;
@@ -52,7 +58,9 @@ use crate::postgres::customscan::mpp::mesh::{
 };
 
 pub const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
-pub const MPP_DSM_HEADER_VERSION: u32 = 1;
+/// V2: switched from `n_workers × n_partitions` grid to multiplexed
+/// `n_procs × n_procs` grid (M1.b of the natural-shape track).
+pub const MPP_DSM_HEADER_VERSION: u32 = 2;
 
 /// Absolute cap on DSM region size. 16 GiB is two orders of magnitude beyond
 /// any realistic workload; the cap fails early on a pathologically oversized
@@ -61,18 +69,17 @@ pub const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 
 /// C-repr header at offset 0 of the DSM region.
 ///
-/// Field ordering keeps every member naturally aligned: six `u32`s (24 bytes
-/// including the explicit `_pad0`) followed by nine `u64`s (72 bytes). 96
-/// bytes total with no internal padding on every supported target.
+/// Field ordering: four `u32`s (16 bytes), eight `u64`s (64 bytes). 80 bytes
+/// total with no internal padding on every supported target.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct MppDsmHeader {
     pub magic: u32,
     pub header_version: u32,
-    pub n_workers: u32,
-    pub n_partitions: u32,
+    /// Total participant count. Leader is `proc_idx = 0`; workers are
+    /// `proc_idx = ParallelWorkerNumber + 1`. The shm_mq grid is `n_procs × n_procs`.
+    pub n_procs: u32,
     pub n_cache_sources: u32,
-    pub _pad0: u32,
     pub queue_bytes: u64,
     pub plan_offset: u64,
     pub plan_len: u64,
@@ -89,10 +96,8 @@ impl MppDsmHeader {
         Self {
             magic: MPP_DSM_MAGIC,
             header_version: MPP_DSM_HEADER_VERSION,
-            n_workers: layout.n_workers,
-            n_partitions: layout.n_partitions,
+            n_procs: layout.n_procs,
             n_cache_sources: layout.n_cache_sources,
-            _pad0: 0,
             queue_bytes: layout.queue_bytes as u64,
             plan_offset: layout.plan_offset as u64,
             plan_len: layout.plan_len as u64,
@@ -112,8 +117,8 @@ impl MppDsmHeader {
         if self.header_version != MPP_DSM_HEADER_VERSION {
             return Err("mpp: DSM header version mismatch");
         }
-        if self.n_workers == 0 || self.n_partitions == 0 {
-            return Err("mpp: header n_workers/n_partitions must both be > 0");
+        if self.n_procs == 0 {
+            return Err("mpp: header n_procs must be > 0");
         }
         if self.region_total != region_total {
             return Err("mpp: DSM region_total in header disagrees with attached size");
@@ -131,20 +136,27 @@ impl MppDsmHeader {
         Ok(())
     }
 
-    /// Byte offset (relative to DSM base) of the queue at `(worker, partition)`.
-    pub fn slot_offset(&self, worker: u32, partition: u32) -> u64 {
-        debug_assert!(worker < self.n_workers);
-        debug_assert!(partition < self.n_partitions);
-        let slot = (worker as u64) * (self.n_partitions as u64) + (partition as u64);
+    /// Byte offset (relative to DSM base) of the queue at `(sender_proc, receiver_proc)`.
+    ///
+    /// Every process attaches as sender for its row (`slot(this, *)`) and as
+    /// receiver for its column (`slot(*, this)`). Self-loops (`slot(k, k)`)
+    /// are present in the grid but rarely used at runtime.
+    pub fn slot_offset(&self, sender_proc: u32, receiver_proc: u32) -> u64 {
+        debug_assert!(sender_proc < self.n_procs);
+        debug_assert!(receiver_proc < self.n_procs);
+        let slot = (sender_proc as u64) * (self.n_procs as u64) + (receiver_proc as u64);
         self.queues_offset + slot * self.queue_bytes
     }
 
-    /// Byte offset of the build-side cache slot at `(source, worker)`.
+    /// Byte offset of the build-side cache slot at `(source, worker)`. The
+    /// build-cache region is sized as `n_cache_sources × (n_procs - 1)` to
+    /// match the worker-only producer count (leader does not write the cache).
     #[cfg(test)]
     pub fn cache_data_slot_offset(&self, source: u32, worker: u32) -> u64 {
         debug_assert!(source < self.n_cache_sources);
-        debug_assert!(worker < self.n_workers);
-        let slot = (source as u64) * (self.n_workers as u64) + (worker as u64);
+        let worker_slots = self.n_procs.saturating_sub(1);
+        debug_assert!(worker < worker_slots);
+        let slot = (source as u64) * (worker_slots as u64) + (worker as u64);
         self.cache_data_offset + slot * self.cache_per_slot
     }
 }
@@ -152,8 +164,7 @@ impl MppDsmHeader {
 /// Pure-math layout for [`compute_dsm_layout`].
 #[derive(Debug, Clone, Copy)]
 pub struct DsmLayout {
-    pub n_workers: u32,
-    pub n_partitions: u32,
+    pub n_procs: u32,
     pub n_cache_sources: u32,
     pub queue_bytes: usize,
     pub cache_per_slot: usize,
@@ -168,23 +179,25 @@ pub struct DsmLayout {
 
 /// Compute the DSM region size and field offsets for one MPP query.
 ///
+/// `n_procs` is the total participant count (1 leader + N workers). The
+/// shm_mq grid is `n_procs × n_procs`; each process attaches as sender to its
+/// row and receiver to its column.
+///
 /// `n_cache_sources` is the number of non-partitioning sources to allocate
 /// build-side cache slots for. `cache_per_slot` is the bytes reserved for
 /// each (source, worker) pair (worst-case per-worker IPC payload). Pass 0
-/// for both if no cache is needed.
+/// for both if no cache is needed. The cache region is sized using
+/// worker-only slots (`n_procs - 1`) since the leader does not write the
+/// build-side cache.
 pub fn compute_dsm_layout(
-    n_workers: u32,
-    n_partitions: u32,
+    n_procs: u32,
     queue_bytes: usize,
     plan_len: usize,
     n_cache_sources: u32,
     cache_per_slot: usize,
 ) -> Result<DsmLayout, &'static str> {
-    if n_workers == 0 {
-        return Err("mpp: n_workers must be > 0");
-    }
-    if n_partitions == 0 {
-        return Err("mpp: n_partitions must be > 0");
+    if n_procs == 0 {
+        return Err("mpp: n_procs must be > 0");
     }
     let queue_bytes = aligned_queue_bytes(queue_bytes);
     if queue_bytes == 0 {
@@ -198,9 +211,9 @@ pub fn compute_dsm_layout(
         .ok_or("mpp: plan offset+len overflow")?;
     let queues_offset =
         align_up_maxalign_checked(plan_end).ok_or("mpp: queues alignment overflow")?;
-    let total_slots = (n_workers as usize)
-        .checked_mul(n_partitions as usize)
-        .ok_or("mpp: n_workers × n_partitions overflow")?;
+    let total_slots = (n_procs as usize)
+        .checked_mul(n_procs as usize)
+        .ok_or("mpp: n_procs × n_procs overflow")?;
     let queues_bytes = total_slots
         .checked_mul(queue_bytes)
         .ok_or("mpp: queues bytes overflow")?;
@@ -210,8 +223,12 @@ pub fn compute_dsm_layout(
 
     // Build-side cache region. Layout:
     //   completion: n_cache_sources × u32  (atomic counter)
-    //   lengths:    n_cache_sources × n_workers × u32  (actual bytes written)
-    //   data:       n_cache_sources × n_workers × cache_per_slot
+    //   lengths:    n_cache_sources × worker_slots × u32  (actual bytes written)
+    //   data:       n_cache_sources × worker_slots × cache_per_slot
+    //
+    // `worker_slots = n_procs - 1` because the leader is consumer-only for
+    // the build-side cache; only workers all-gather into it.
+    let worker_slots = (n_procs as usize).saturating_sub(1).max(1);
     let cache_completion_offset =
         align_up_maxalign_checked(queues_end).ok_or("mpp: cache completion alignment overflow")?;
     let cache_completion_size = (n_cache_sources as usize)
@@ -224,7 +241,7 @@ pub fn compute_dsm_layout(
     )
     .ok_or("mpp: cache lengths alignment overflow")?;
     let cache_lengths_size = (n_cache_sources as usize)
-        .checked_mul(n_workers as usize)
+        .checked_mul(worker_slots)
         .and_then(|x| x.checked_mul(size_of::<u32>()))
         .ok_or("mpp: cache lengths size overflow")?;
     let cache_data_offset = align_up_maxalign_checked(
@@ -234,7 +251,7 @@ pub fn compute_dsm_layout(
     )
     .ok_or("mpp: cache data alignment overflow")?;
     let cache_data_size = (n_cache_sources as usize)
-        .checked_mul(n_workers as usize)
+        .checked_mul(worker_slots)
         .and_then(|x| x.checked_mul(cache_per_slot))
         .ok_or("mpp: cache data size overflow")?;
     let region_total = cache_data_offset
@@ -244,8 +261,7 @@ pub fn compute_dsm_layout(
         return Err("mpp: DSM region exceeds MPP_DSM_MAX_BYTES");
     }
     Ok(DsmLayout {
-        n_workers,
-        n_partitions,
+        n_procs,
         n_cache_sources,
         queue_bytes,
         cache_per_slot,
@@ -263,7 +279,7 @@ pub fn compute_dsm_layout(
 ///
 /// Held on every participant's customscan state. Workers use it to write their
 /// own slice and read back peer slices via the all-gather barrier; the leader
-/// holds it inert (no slot reserved for it; consumer-only this iteration).
+/// holds it inert (consumer-only for the cache — leader doesn't write a slice).
 ///
 /// `Send + Sync` is asserted because the underlying DSM mapping is shared
 /// memory accessed by multiple processes; access is coordinated via atomic
@@ -271,6 +287,8 @@ pub fn compute_dsm_layout(
 #[derive(Debug)]
 pub struct MppBuildCache {
     base: *mut u8,
+    /// Number of worker slots in the cache. Equals `n_procs - 1` since the
+    /// leader is consumer-only for the cache.
     pub n_workers: u32,
     pub n_sources: u32,
     pub cache_per_slot: usize,
@@ -291,7 +309,8 @@ impl MppBuildCache {
     pub unsafe fn from_header(base: *mut u8, header: &MppDsmHeader) -> Self {
         Self {
             base,
-            n_workers: header.n_workers,
+            // Workers-only — leader is consumer-only for the build cache.
+            n_workers: header.n_procs.saturating_sub(1).max(1),
             n_sources: header.n_cache_sources,
             cache_per_slot: header.cache_per_slot as usize,
             completion_offset: header.cache_completion_offset as usize,
@@ -382,29 +401,27 @@ impl MppBuildCache {
     }
 }
 
-/// Leader-side return: handles to all senders + receivers for participant 0.
-pub struct LeaderAttach {
-    /// Senders this participant uses to push rows to consumer partitions.
-    /// `outbound_senders[p]` writes to `slot(0, p)`.
+/// Per-participant return: handles for the process's row (senders) and
+/// column (receivers) in the multiplexed `n_procs × n_procs` grid.
+pub struct ProcAttach {
+    /// `outbound_senders[r]` writes to `slot(this_proc, r)`. One entry per
+    /// receiver process, including the self-loop `slot(this_proc, this_proc)`.
     pub outbound_senders: Vec<ShmMqSender>,
-    /// Receivers this participant reads from (one per producer worker for
-    /// each consumer partition the leader owns). The leader IS the consumer,
-    /// so it owns ALL `n_partitions` columns of the queue grid; for each
-    /// consumer partition `p` it has `n_workers` inbound queues from the
-    /// producers.
+    /// `inbound_receivers[s]` reads from `slot(s, this_proc)`. One entry per
+    /// sender process, including the self-loop.
     pub inbound_receivers: Vec<ShmMqReceiver>,
 }
 
-/// Worker-side return: just the senders. Workers don't consume; everything
-/// flows toward the leader.
-pub struct WorkerAttach {
-    /// `outbound_senders[p]` writes to `slot(this_worker, p)`.
-    pub outbound_senders: Vec<ShmMqSender>,
-}
-
-/// Initialize the DSM region as the leader. Writes the header, copies plan
-/// bytes, calls `shm_mq_create` on every queue slot, and attaches the leader's
-/// senders + all inbound receivers.
+/// Initialize the DSM region as the leader (`proc_idx = 0`). Writes the
+/// header, copies the plan bytes, calls `shm_mq_create` on every queue slot,
+/// and attaches the leader's row + column handles.
+///
+/// In the multiplexed `n_procs × n_procs` grid, every process — leader
+/// included — is a full participant: sender for its row, receiver for its
+/// column. The leader is responsible for the one-time `shm_mq_create` on
+/// every queue (workers cannot, since the region is uninitialized at their
+/// attach time), then performs its own `set_sender` / `set_receiver` calls
+/// on its row and column slots.
 ///
 /// # Safety
 /// - `coordinate` must point to the start of a DSM region of size
@@ -416,7 +433,7 @@ pub unsafe fn leader_init(
     seg: *mut pg_sys::dsm_segment,
     layout: &DsmLayout,
     plan_bytes: &[u8],
-) -> Result<LeaderAttach, String> {
+) -> Result<ProcAttach, String> {
     if coordinate.is_null() {
         return Err("mpp: leader_init given null coordinate".into());
     }
@@ -446,30 +463,75 @@ pub unsafe fn leader_init(
         );
     }
 
-    // Create every shm_mq slot. Each slot is `queue_bytes` aligned bytes; we
-    // pass the address to `shm_mq_create` which initializes the ring buffer.
-    // The leader is a consumer-only participant (leader-as-worker-0 is
-    // deferred), so it attaches as receiver to every slot but as sender to
-    // none — workers attach to their own row in `worker_attach`.
-    let mut inbound_receivers =
-        Vec::with_capacity((layout.n_workers as usize) * (layout.n_partitions as usize));
-    for w in 0..layout.n_workers {
-        for p in 0..layout.n_partitions {
-            let off = (w as usize) * (layout.n_partitions as usize) + (p as usize);
-            let mq_addr = unsafe { base.add(layout.queues_offset + off * layout.queue_bytes) };
-            let mq = unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.queue_bytes) };
-            inbound_receivers.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
+    // One-time create of every shm_mq slot. Workers cannot do this — the
+    // region is uninitialized at their attach time — so the leader runs
+    // `shm_mq_create` for all `n_procs²` slots even though it only attaches
+    // to its own row and column below.
+    let header = MppDsmHeader::from_layout(layout);
+    let n_procs = layout.n_procs;
+    for s in 0..n_procs {
+        for r in 0..n_procs {
+            let off = header.slot_offset(s, r) as usize;
+            let mq_addr = unsafe { base.add(off) };
+            unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.queue_bytes) };
         }
     }
 
-    Ok(LeaderAttach {
-        outbound_senders: Vec::new(),
-        inbound_receivers,
-    })
+    Ok(unsafe { attach_proc_row_and_column(base, &header, 0, seg) })
 }
 
-/// Attach to the leader-initialized DSM region as worker `worker_index` (1-based:
-/// PG's `ParallelWorkerNumber + 1`, since participant 0 is the leader).
+/// Attach to the leader-initialized DSM region as `proc_idx` (`0 = leader`,
+/// `1..N = parallel workers`).
+///
+/// Workers use this from `initialize_worker_custom_scan` via `worker_attach`;
+/// the leader uses it inline at the end of `leader_init`. Each process
+/// attaches as sender to its row and receiver to its column of the
+/// `n_procs × n_procs` grid, including the self-loop at `(this, this)`.
+///
+/// # Safety
+/// - `base` must point to a DSM region whose header has been validated.
+/// - `header.slot_offset(s, r)` must already point at a slot initialized by
+///   `shm_mq_create` (the leader does this in `leader_init`).
+/// - `seg` may be NULL on workers — `shm_mq_attach` skips its on-detach
+///   callback when so.
+unsafe fn attach_proc_row_and_column(
+    base: *mut u8,
+    header: &MppDsmHeader,
+    this_proc: u32,
+    seg: *mut pg_sys::dsm_segment,
+) -> ProcAttach {
+    let n_procs = header.n_procs;
+    let mut outbound_senders = Vec::with_capacity(n_procs as usize);
+    let mut inbound_receivers = Vec::with_capacity(n_procs as usize);
+
+    // Senders: this process's row. `outbound_senders[r]` writes to slot(this, r).
+    for r in 0..n_procs {
+        let off = header.slot_offset(this_proc, r) as usize;
+        let mq_addr = unsafe { base.add(off) };
+        let mq = mq_addr.cast::<pg_sys::shm_mq>();
+        outbound_senders.push(unsafe { ShmMqSender::attach(seg, mq) });
+    }
+
+    // Receivers: this process's column. `inbound_receivers[s]` reads from
+    // slot(s, this). The self-loop slot was already attached as sender
+    // above; `shm_mq_set_receiver` is a separate operation on the same
+    // queue handle, so the double-attach (once as sender, once as receiver)
+    // on the self-loop is safe.
+    for s in 0..n_procs {
+        let off = header.slot_offset(s, this_proc) as usize;
+        let mq_addr = unsafe { base.add(off) };
+        let mq = mq_addr.cast::<pg_sys::shm_mq>();
+        inbound_receivers.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
+    }
+
+    ProcAttach {
+        outbound_senders,
+        inbound_receivers,
+    }
+}
+
+/// Attach to the leader-initialized DSM region as `proc_idx` (1-based for
+/// workers: PG's `ParallelWorkerNumber + 1`).
 ///
 /// # Safety
 /// - `coordinate` must be the DSM region pointer the leader initialized.
@@ -481,9 +543,9 @@ pub unsafe fn leader_init(
 pub unsafe fn worker_attach(
     coordinate: *mut c_void,
     region_total: u64,
-    worker_index: u32,
+    proc_idx: u32,
     seg: *mut pg_sys::dsm_segment,
-) -> Result<(MppDsmHeader, Vec<u8>, WorkerAttach), String> {
+) -> Result<(MppDsmHeader, Vec<u8>, ProcAttach), String> {
     if coordinate.is_null() {
         return Err("mpp: worker_attach given null coordinate".into());
     }
@@ -492,10 +554,15 @@ pub unsafe fn worker_attach(
     header
         .validate(region_total)
         .map_err(|e| format!("mpp: worker DSM validate: {e}"))?;
-    if worker_index >= header.n_workers {
+    if proc_idx == 0 {
+        return Err(
+            "mpp: worker_attach must be called with proc_idx >= 1 (proc 0 is leader)".into(),
+        );
+    }
+    if proc_idx >= header.n_procs {
         return Err(format!(
-            "mpp: worker_index {worker_index} not in 0..{}",
-            header.n_workers
+            "mpp: proc_idx {proc_idx} not in 1..{}",
+            header.n_procs
         ));
     }
 
@@ -508,19 +575,8 @@ pub unsafe fn worker_attach(
         .to_vec()
     };
 
-    // Attach as sender to every (worker_index, p) slot. `ShmMqSender::attach`
-    // already calls `shm_mq_set_sender(mq, MyProc)` internally — calling it
-    // a second time here trips PG's `Assert("mq->mq_sender == NULL")` and
-    // aborts the worker.
-    let mut outbound_senders = Vec::with_capacity(header.n_partitions as usize);
-    for p in 0..header.n_partitions {
-        let off = header.slot_offset(worker_index, p) as usize;
-        let mq_addr = unsafe { base.add(off) };
-        let mq = mq_addr.cast::<pg_sys::shm_mq>();
-        outbound_senders.push(unsafe { ShmMqSender::attach(seg, mq) });
-    }
-
-    Ok((header, plan_bytes, WorkerAttach { outbound_senders }))
+    let attach = unsafe { attach_proc_row_and_column(base, &header, proc_idx, seg) };
+    Ok((header, plan_bytes, attach))
 }
 
 #[cfg(test)]
@@ -529,57 +585,55 @@ mod tests {
 
     #[test]
     fn compute_dsm_layout_works() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0).unwrap();
-        assert_eq!(l.n_workers, 4);
-        assert_eq!(l.n_partitions, 1);
-        // No cache reserved → cache regions all sit at queues_end (after MAXALIGN).
+        let l = compute_dsm_layout(4, 64 * 1024, 1024, 0, 0).unwrap();
+        assert_eq!(l.n_procs, 4);
+        // Grid is n_procs × n_procs = 16 slots.
         let aligned = aligned_queue_bytes(64 * 1024);
-        let queues_size = 4 * aligned;
+        let queues_size = 16 * aligned;
         assert!(l.region_total >= l.queues_offset + queues_size);
     }
 
     #[test]
     fn compute_dsm_layout_with_cache() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 2, 1024 * 1024).unwrap();
-        let cache_data_size = 2 * 4 * 1024 * 1024; // 2 sources × 4 workers × 1 MiB
+        // n_procs=4 → 3 worker slots in the cache (leader excluded).
+        let l = compute_dsm_layout(4, 64 * 1024, 1024, 2, 1024 * 1024).unwrap();
+        let cache_data_size = 2 * 3 * 1024 * 1024; // 2 sources × 3 worker slots × 1 MiB
         assert_eq!(l.region_total, l.cache_data_offset + cache_data_size);
     }
 
     #[test]
-    fn compute_dsm_layout_rejects_zero_workers() {
-        assert!(compute_dsm_layout(0, 1, 64 * 1024, 0, 0, 0).is_err());
-    }
-
-    #[test]
-    fn compute_dsm_layout_rejects_zero_partitions() {
-        assert!(compute_dsm_layout(2, 0, 64 * 1024, 0, 0, 0).is_err());
+    fn compute_dsm_layout_rejects_zero_procs() {
+        assert!(compute_dsm_layout(0, 64 * 1024, 0, 0, 0).is_err());
     }
 
     #[test]
     fn compute_dsm_layout_rejects_oversize() {
-        assert!(compute_dsm_layout(u32::MAX, u32::MAX, 64 * 1024, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(u32::MAX, 64 * 1024, 0, 0, 0).is_err());
     }
 
     #[test]
-    fn header_slot_offset_is_row_major() {
-        let l = compute_dsm_layout(3, 4, 64 * 1024, 0, 0, 0).unwrap();
+    fn header_slot_offset_is_row_major_over_n_procs() {
+        // 4 procs → 4×4 = 16 slots, row-major over (sender, receiver).
+        let l = compute_dsm_layout(4, 64 * 1024, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         let aligned = h.queue_bytes;
         assert_eq!(h.slot_offset(0, 0), h.queues_offset);
         assert_eq!(h.slot_offset(0, 1), h.queues_offset + aligned);
         assert_eq!(h.slot_offset(1, 0), h.queues_offset + 4 * aligned);
-        assert_eq!(h.slot_offset(2, 3), h.queues_offset + 11 * aligned);
+        // Self-loop on proc 3: (3,3) → row 3, col 3 → slot 15.
+        assert_eq!(h.slot_offset(3, 3), h.queues_offset + 15 * aligned);
     }
 
     #[test]
     fn header_cache_offsets() {
-        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 2, 1024).unwrap();
+        // n_procs=4 → 3 worker slots in the cache.
+        let l = compute_dsm_layout(4, 64 * 1024, 0, 2, 1024).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         // (source=0, worker=0) is the first slot.
         assert_eq!(h.cache_data_slot_offset(0, 0), h.cache_data_offset);
         // (source=0, worker=1) is one slot later.
         assert_eq!(h.cache_data_slot_offset(0, 1), h.cache_data_offset + 1024);
-        // (source=1, worker=0) is n_workers slots in.
+        // (source=1, worker=0) is `worker_slots` slots in.
         assert_eq!(
             h.cache_data_slot_offset(1, 0),
             h.cache_data_offset + 3 * 1024
@@ -588,14 +642,14 @@ mod tests {
 
     #[test]
     fn header_validate_accepts_self() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 64 * 1024, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64).is_ok());
     }
 
     #[test]
     fn header_validate_rejects_size_mismatch() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 64 * 1024, 0, 0, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64 + 1).is_err());
     }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -45,7 +45,7 @@ use crate::postgres::customscan::mpp::dsm::{
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
-    DrainBuffer, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
+    DrainHandle, MppFrameHeader, MppReceiver, MppSender,
 };
 use crate::postgres::customscan::mpp::MppParticipantConfig;
 
@@ -181,10 +181,10 @@ pub unsafe fn leader_setup(
     // up the right drain in O(1) given a sender_proc from the natural-shape
     // gather; the self-loop entry at index 0 is `None`.
     //
-    // The drain still uses a single-buffer per inbound queue. Multi-channel
-    // demux (one buffer per `(stage_id, partition)` on the same queue) is
-    // the M2 follow-up; the natural-shape single-stage gather has exactly
-    // one channel per queue so the single-buffer model still applies.
+    // M2.b: each `DrainHandle` owns a per-`(stage_id, partition)` sub-buffer
+    // registry, so one shm_mq queue can multiplex frames from many logical
+    // channels — the sub-buffer is created lazily on first frame OR by
+    // `WorkerConnection::stream_partition` registering ahead of time.
     let _ = n_partitions;
     let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
         Vec::with_capacity(total_procs as usize);
@@ -197,11 +197,7 @@ pub unsafe fn leader_setup(
             "peer_proc_for_index must produce sender_proc indices in order"
         );
         let mpp_recv = MppReceiver::new(Box::new(shm_recv));
-        let buffer = DrainBuffer::new(1);
-        inbound_drains.push(Some(Arc::new(DrainHandle::cooperative(
-            vec![mpp_recv],
-            buffer,
-        ))));
+        inbound_drains.push(Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv]))));
     }
 
     let mesh = Arc::new(MppMesh {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -170,46 +170,48 @@ pub unsafe fn leader_setup(
 
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
 
-    // M1.b: the leader is now a full participant in the multiplexed grid
-    // (sender for its row, receiver for its column). For continuity with the
-    // current single-stage routing, we adapt the leader's column receivers
-    // (slot(*, 0)) into per-sender DrainHandles indexed by sender_proc.
+    // M1.c: build the proc-pair indexed mesh. The leader is `proc_idx = 0`;
+    // its inbound queues are `slot(*, 0)`, one per sender_proc. The self-loop
+    // entry at index 0 is set to `None` — slot(0, 0) is the leader-to-leader
+    // queue, which the natural-shape gather doesn't traverse. For every
+    // sender_proc in 1..n_procs (the workers), we install a cooperative drain
+    // that pulls frames from `slot(sender_proc, 0)` and parses each
+    // [`MppFrameHeader`] before delivering the batch to the consumer side.
     //
-    // The legacy MppMesh was indexed by (producer_worker, consumer_partition)
-    // with consumer_partition driven by the plan's network-boundary fanout.
-    // The natural-shape plan emits NetworkCoalesceExec(consumer_tc=1, ...)
-    // at the top, meaning *one* leader consumer partition for the worker→
-    // leader gather — so partition is effectively always 0. We expose the
-    // mesh under the same `(worker, partition)` keying with `n_partitions=1`
-    // for the gather case; the multiplexed routing logic in M1.c will replace
-    // this with per-(stage_id, sender_proc, partition) sub-buffers.
-    //
-    // The leader's own outbound row senders + self-loop receiver are dropped
-    // for now — the leader is consumer-only at the single network boundary
-    // this single-stage path exercises. Multi-stage senders (when the leader
-    // hosts a producer task) come with M2.
+    // The drain still uses a single-buffer per inbound queue. Multi-channel
+    // demux (one buffer per `(stage_id, partition)` on the same queue) is
+    // the M2 follow-up; the natural-shape single-stage gather has exactly
+    // one channel per queue so the single-buffer model still applies.
     let _ = n_partitions;
-    let mut inbound_receivers = attach.inbound_receivers;
-    // Drop the self-loop receiver — slot(0, 0) would be the leader sending
-    // to itself, which isn't a path the single-stage code uses.
-    if !inbound_receivers.is_empty() {
-        inbound_receivers.remove(0);
-    }
-    let mut drains = Vec::with_capacity(inbound_receivers.len());
-    for shm_recv in inbound_receivers {
+    let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
+        Vec::with_capacity(total_procs as usize);
+    let mut receivers = attach.inbound_receivers;
+    for sender_proc in 0..total_procs {
+        if sender_proc == 0 {
+            // Self-loop slot(0, 0) is unused by the gather path; drop the
+            // receiver so peer ShmMqSender::attach on slot(0, 0) doesn't
+            // see a perpetually-attached counterpart.
+            inbound_drains.push(None);
+            // Receivers were collected in `for s in 0..n_procs` order; the
+            // self-loop is at index 0 — drop it.
+            if !receivers.is_empty() {
+                receivers.remove(0);
+            }
+            continue;
+        }
+        let shm_recv = receivers.remove(0);
         let mpp_recv = MppReceiver::new(Box::new(shm_recv));
         let buffer = DrainBuffer::new(1);
-        drains.push(Arc::new(DrainHandle::cooperative(vec![mpp_recv], buffer)));
+        inbound_drains.push(Some(Arc::new(DrainHandle::cooperative(
+            vec![mpp_recv],
+            buffer,
+        ))));
     }
 
-    // n_workers = total_procs - 1 (workers only), n_partitions = 1 (the leader
-    // is the sole gather consumer). MppMesh.drains is indexed
-    // worker * n_partitions + partition = worker * 1 + 0 = worker.
-    let worker_count = total_procs.saturating_sub(1).max(1);
     let mesh = Arc::new(MppMesh {
-        n_workers: worker_count,
-        n_partitions: 1,
-        drains,
+        this_proc: 0,
+        n_procs: total_procs,
+        inbound_drains,
     });
 
     // Drop the leader's own outbound senders — the leader doesn't yet host

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -41,13 +41,24 @@ use crate::gucs::{
     mpp_worker_count as gucs_mpp_worker_count,
 };
 use crate::postgres::customscan::mpp::dsm::{
-    compute_dsm_layout, leader_init, worker_attach, MppBuildCache,
+    compute_dsm_layout, leader_init, peer_proc_for_index, worker_attach, MppBuildCache,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
     DrainBuffer, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
 };
 use crate::postgres::customscan::mpp::MppParticipantConfig;
+
+/// Stage id stamped onto frames in the natural-shape single-stage gather.
+/// All worker→leader traffic in M1's single-stage path carries this stage id.
+/// M2 introduces multi-stage pipelines and replaces this constant with
+/// plan-driven stage ids derived from each `NetworkBoundary.input_stage.num`.
+const NATURAL_GATHER_STAGE_ID: u32 = 0;
+
+/// Consumer-side partition stamped on natural-shape gather frames. The
+/// natural plan emits `NetworkCoalesceExec(consumer_tc=1, input_tc=N)` at the
+/// top, so there is exactly one consumer partition on the leader.
+const NATURAL_GATHER_PARTITION: u32 = 0;
 
 /// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >= 3`.
 /// Customscan path-builders gate `parallel_workers` on this.
@@ -86,16 +97,7 @@ pub fn mpp_queue_size() -> usize {
 /// `n_cache_sources` is the number of non-partitioning sources the build-side
 /// all-gather cache should reserve slots for; pass 0 to skip caching. The
 /// cache region is sized using worker-only slots (leader does not write).
-///
-/// `n_partitions` is preserved as an arg for callers that still think in the
-/// single-stage worker→leader gather frame; the multiplexed grid does not
-/// need it for sizing, so it's currently unused. M2's plan-driven sizing will
-/// supersede this parameter.
-pub fn estimate_dsm_size(
-    plan_bytes_len: usize,
-    _n_partitions: u32,
-    n_cache_sources: u32,
-) -> Result<usize, String> {
+pub fn estimate_dsm_size(plan_bytes_len: usize, n_cache_sources: u32) -> Result<usize, String> {
     let layout = compute_dsm_layout(
         n_procs(),
         mpp_queue_size(),
@@ -171,12 +173,13 @@ pub unsafe fn leader_setup(
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
 
     // M1.c: build the proc-pair indexed mesh. The leader is `proc_idx = 0`;
-    // its inbound queues are `slot(*, 0)`, one per sender_proc. The self-loop
-    // entry at index 0 is set to `None` — slot(0, 0) is the leader-to-leader
-    // queue, which the natural-shape gather doesn't traverse. For every
-    // sender_proc in 1..n_procs (the workers), we install a cooperative drain
-    // that pulls frames from `slot(sender_proc, 0)` and parses each
-    // [`MppFrameHeader`] before delivering the batch to the consumer side.
+    // its inbound queues are `slot(*, 0)` for every peer (workers 1..n_procs).
+    // `attach.inbound_receivers` is already peer-indexed (self-loop skipped),
+    // so receiver[i] corresponds to peer_proc_for_index(0, i) = i + 1.
+    //
+    // The mesh stores `inbound_drains[sender_proc]` so `runtime.rs` can look
+    // up the right drain in O(1) given a sender_proc from the natural-shape
+    // gather; the self-loop entry at index 0 is `None`.
     //
     // The drain still uses a single-buffer per inbound queue. Multi-channel
     // demux (one buffer per `(stage_id, partition)` on the same queue) is
@@ -185,21 +188,14 @@ pub unsafe fn leader_setup(
     let _ = n_partitions;
     let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
         Vec::with_capacity(total_procs as usize);
-    let mut receivers = attach.inbound_receivers;
-    for sender_proc in 0..total_procs {
-        if sender_proc == 0 {
-            // Self-loop slot(0, 0) is unused by the gather path; drop the
-            // receiver so peer ShmMqSender::attach on slot(0, 0) doesn't
-            // see a perpetually-attached counterpart.
-            inbound_drains.push(None);
-            // Receivers were collected in `for s in 0..n_procs` order; the
-            // self-loop is at index 0 — drop it.
-            if !receivers.is_empty() {
-                receivers.remove(0);
-            }
-            continue;
-        }
-        let shm_recv = receivers.remove(0);
+    inbound_drains.push(None); // self-loop slot at sender_proc = 0
+    for (peer_idx, shm_recv) in attach.inbound_receivers.into_iter().enumerate() {
+        let sender_proc = peer_proc_for_index(0, peer_idx as u32);
+        debug_assert_eq!(
+            sender_proc as usize,
+            inbound_drains.len(),
+            "peer_proc_for_index must produce sender_proc indices in order"
+        );
         let mpp_recv = MppReceiver::new(Box::new(shm_recv));
         let buffer = DrainBuffer::new(1);
         inbound_drains.push(Some(Arc::new(DrainHandle::cooperative(
@@ -263,26 +259,27 @@ pub unsafe fn worker_setup(
     let (header, plan_bytes, attach) =
         unsafe { worker_attach(coordinate, region_total, proc_idx, seg) }?;
 
-    // Pick out the worker→leader sender. In the multiplexed grid this is
-    // `outbound_senders[0]` (leader is at proc 0); the single-stage path
-    // gathers everything onto leader proc 0. Frames carry the natural-shape
-    // gather header `(stage_id=0, partition=0)` since the current path
-    // emits one NetworkCoalesceExec(consumer_tc=1, input_tc=N) at the top.
+    // Pick out the worker→leader sender. With self-loops skipped, the worker's
+    // peer-indexed row starts at peer_idx=0 → sender_proc=0 (leader). So
+    // `outbound_senders[0]` writes to `slot(this_proc, 0)`, the worker→leader
+    // queue. Frames carry the natural-shape gather header
+    // `(stage_id=0, partition=0)` since the current path emits
+    // one `NetworkCoalesceExec(consumer_tc=1, input_tc=N)` at the top.
     //
-    // M1.c will replace this with per-target-proc senders that multiplex
-    // many (stage_id, partition) channels over one shm_mq queue.
+    // M2 will replace this with per-target-proc senders that multiplex many
+    // (stage_id, partition) channels over one shm_mq queue.
     let mut row = attach.outbound_senders;
     if row.is_empty() {
         return Err("mpp: worker_attach returned empty senders row".into());
     }
-    // outbound_senders[0] writes to slot(this_proc, 0) — i.e. to leader.
-    // Drop the rest (self-loop + peer slots are unused in single-stage path).
+    // Sanity: with self-loop skipped, peer_idx 0 maps to sender_proc 0 (leader).
+    debug_assert_eq!(peer_proc_for_index(proc_idx, 0), 0);
     let leader_sender = row.remove(0);
     drop(row);
     drop(attach.inbound_receivers); // unused in single-stage worker
     let outbound_senders = vec![MppSender::with_header(
         Box::new(leader_sender),
-        MppFrameHeader::batch(0, 0),
+        MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
     )];
 
     let build_cache = if header.n_cache_sources > 0 {
@@ -300,7 +297,7 @@ pub unsafe fn worker_setup(
         plan_bytes,
         participant_config: MppParticipantConfig {
             participant_index: worker_number as u32,
-            total_participants: worker_count,
+            total_workers: worker_count,
         },
         build_cache,
     })

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -277,8 +277,25 @@ pub unsafe fn worker_setup(
     let leader_sender = row.remove(0);
     drop(row);
     drop(attach.inbound_receivers); // unused in single-stage worker
+
+    // M2.a: instead of one MppSender (header partition=0), share the single
+    // shm_mq queue across `n_partitions` senders, each tagged with a different
+    // partition. The worker's producer fragment in the natural plan outputs
+    // multiple hash partitions per task; `run_producer_fragment` drives one
+    // sender per output partition. They all multiplex over the same
+    // shm_mq queue and the leader's drain demuxes by frame header.
+    //
+    // The actual `n_partitions` is determined from the physical plan at
+    // worker exec time (since the worker is what knows how many partitions
+    // the fragment emits). For now, we hand back one Arc to the channel; the
+    // caller (aggregatescan::exec_mpp_worker) clones it into N senders.
+    let shared_channel: Arc<dyn crate::postgres::customscan::mpp::transport::BatchChannelSender> =
+        Arc::new(leader_sender);
+    // Build a one-element vec for back-compat with the existing call site;
+    // the exec path will clone the Arc out of `outbound_senders[0]` and
+    // expand to the right number of senders once the physical plan is built.
     let outbound_senders = vec![MppSender::with_header(
-        Box::new(leader_sender),
+        Arc::clone(&shared_channel),
         MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
     )];
 

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -45,7 +45,8 @@ use crate::postgres::customscan::mpp::dsm::{
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
-    DrainHandle, MppFrameHeader, MppReceiver, MppSender,
+    in_proc_channel, BatchChannelSender, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
+    SELF_LOOP_CAPACITY,
 };
 use crate::postgres::customscan::mpp::MppParticipantConfig;
 
@@ -293,7 +294,7 @@ pub unsafe fn worker_setup(
     debug_assert_eq!(
         outbound_senders.iter().filter(|s| s.is_some()).count(),
         (total_procs as usize).saturating_sub(1),
-        "worker outbound senders: expected {} non-self-loop entries",
+        "worker outbound senders: expected {} non-self-loop entries before self-loop install",
         total_procs.saturating_sub(1)
     );
 
@@ -309,6 +310,25 @@ pub unsafe fn worker_setup(
         inbound_drains[sender_proc as usize] =
             Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv])));
     }
+    // M2.d.3: install a self-loop in-proc channel for `slot(this_proc, this_proc)`.
+    // Peer-mesh hash routing can land producer-side and consumer-side tasks
+    // for the same `(stage, partition)` on the same worker, in which case the
+    // shm_mq grid's unattached diagonal would surface as "outbound_senders[this_proc]
+    // is None". The in-proc channel keeps frame routing uniform from the
+    // dispatcher's perspective: senders push, the DrainHandle reads via the
+    // same `BatchChannelReceiver` contract as shm_mq, and the M2.b sub-buffer
+    // registry demuxes per `(stage_id, partition)`.
+    let (self_tx, self_rx) = in_proc_channel(SELF_LOOP_CAPACITY);
+    let self_tx_arc: Arc<dyn BatchChannelSender> = Arc::new(self_tx);
+    outbound_senders[proc_idx as usize] = Some(MppSender::with_header(
+        Arc::clone(&self_tx_arc),
+        MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
+    ));
+    inbound_drains[proc_idx as usize] =
+        Some(Arc::new(DrainHandle::cooperative(vec![MppReceiver::new(
+            Box::new(self_rx),
+        )])));
+
     let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drains));
 
     let build_cache = if header.n_cache_sources > 0 {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -215,9 +215,18 @@ pub unsafe fn leader_setup(
 /// Returned to a worker from [`worker_setup`]. The customscan reads the plan
 /// bytes, runs the plan, and pushes resulting batches through `outbound_senders`.
 pub struct MppWorkerState {
-    /// Per-partition outbound senders this worker writes to.
-    /// `outbound_senders[p]` writes to `slot(this_worker, p)`.
-    pub outbound_senders: Vec<MppSender>,
+    /// `outbound_senders[proc_idx]` is the sender that writes to
+    /// `slot(this_proc, proc_idx)`. The entry at `proc_idx == this_proc` is
+    /// `None` because the self-loop slot is never attached (matches the
+    /// leader's `inbound_drains` shape).
+    ///
+    /// M2.d wires each fragment's per-partition output sender to the right
+    /// proc by looking up `outbound_senders[dest_proc]` from the
+    /// [`crate::postgres::customscan::mpp::assignment::TaskAssignment`]
+    /// table. Each `MppSender` wraps an `Arc<dyn BatchChannelSender>` so
+    /// callers can `clone_with_header` to multiplex `(stage_id, partition)`
+    /// channels onto one shm_mq queue.
+    pub outbound_senders: Vec<Option<MppSender>>,
     /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via
     /// the `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
     pub plan_bytes: Vec<u8>,
@@ -225,6 +234,13 @@ pub struct MppWorkerState {
     /// Build-side all-gather cache. The worker writes its 1/N slice for each
     /// non-partitioning source, then reads back peer slices after the barrier.
     pub build_cache: Option<Arc<MppBuildCache>>,
+    /// Worker's MppMesh — same shape as the leader's. `inbound_drains[sender_proc]`
+    /// pulls frames from `slot(sender_proc, this_proc)`. Workers consume from
+    /// peers when running consumer fragments (e.g. a `FinalPartitioned`
+    /// aggregate above a `NetworkShuffleExec` peer-mesh). Read by
+    /// M2.d.3's multi-fragment dispatcher in `aggregatescan::exec_mpp_worker`.
+    #[allow(dead_code)]
+    pub mesh: Arc<MppMesh>,
 }
 
 /// Body of `initialize_worker_custom_scan`. Reads the header, attaches as
@@ -250,46 +266,50 @@ pub unsafe fn worker_setup(
 
     let (header, plan_bytes, attach) =
         unsafe { worker_attach(coordinate, region_total, proc_idx, seg) }?;
+    let total_procs = header.n_procs;
 
-    // Pick out the worker→leader sender. With self-loops skipped, the worker's
-    // peer-indexed row starts at peer_idx=0 → sender_proc=0 (leader). So
-    // `outbound_senders[0]` writes to `slot(this_proc, 0)`, the worker→leader
-    // queue. Frames carry the natural-shape gather header
-    // `(stage_id=0, partition=0)` since the current path emits
-    // one `NetworkCoalesceExec(consumer_tc=1, input_tc=N)` at the top.
-    //
-    // M2 will replace this with per-target-proc senders that multiplex many
-    // (stage_id, partition) channels over one shm_mq queue.
-    let mut row = attach.outbound_senders;
-    if row.is_empty() {
-        return Err("mpp: worker_attach returned empty senders row".into());
+    // M2.d: build per-proc-indexed outbound senders. Each MppSender wraps the
+    // queue's `Arc<dyn BatchChannelSender>` so per-(stage_id, partition)
+    // clones can multiplex over the same shm_mq slot. The slot at
+    // proc_idx==this_proc is `None` because self-loops are never attached
+    // (`compute_dsm_layout` reserves the bytes but `worker_attach` skips
+    // them).
+    let mut outbound_senders: Vec<Option<MppSender>> = (0..total_procs).map(|_| None).collect();
+    for (peer_idx, shm_send) in attach.outbound_senders.into_iter().enumerate() {
+        let target_proc = peer_proc_for_index(proc_idx, peer_idx as u32);
+        debug_assert!(target_proc != proc_idx);
+        debug_assert!(target_proc < total_procs);
+        let shared: Arc<dyn crate::postgres::customscan::mpp::transport::BatchChannelSender> =
+            Arc::new(shm_send);
+        // Default header: the per-fragment dispatcher in
+        // `aggregatescan::exec_mpp_worker` immediately `clone_with_header`s
+        // these to the right `(stage_id, partition)` per output partition,
+        // so the default placeholder header is never observed on the wire.
+        outbound_senders[target_proc as usize] = Some(MppSender::with_header(
+            Arc::clone(&shared),
+            MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
+        ));
     }
-    // Sanity: with self-loop skipped, peer_idx 0 maps to sender_proc 0 (leader).
-    debug_assert_eq!(peer_proc_for_index(proc_idx, 0), 0);
-    let leader_sender = row.remove(0);
-    drop(row);
-    drop(attach.inbound_receivers); // unused in single-stage worker
+    debug_assert_eq!(
+        outbound_senders.iter().filter(|s| s.is_some()).count(),
+        (total_procs as usize).saturating_sub(1),
+        "worker outbound senders: expected {} non-self-loop entries",
+        total_procs.saturating_sub(1)
+    );
 
-    // M2.a: instead of one MppSender (header partition=0), share the single
-    // shm_mq queue across `n_partitions` senders, each tagged with a different
-    // partition. The worker's producer fragment in the natural plan outputs
-    // multiple hash partitions per task; `run_producer_fragment` drives one
-    // sender per output partition. They all multiplex over the same
-    // shm_mq queue and the leader's drain demuxes by frame header.
-    //
-    // The actual `n_partitions` is determined from the physical plan at
-    // worker exec time (since the worker is what knows how many partitions
-    // the fragment emits). For now, we hand back one Arc to the channel; the
-    // caller (aggregatescan::exec_mpp_worker) clones it into N senders.
-    let shared_channel: Arc<dyn crate::postgres::customscan::mpp::transport::BatchChannelSender> =
-        Arc::new(leader_sender);
-    // Build a one-element vec for back-compat with the existing call site;
-    // the exec path will clone the Arc out of `outbound_senders[0]` and
-    // expand to the right number of senders once the physical plan is built.
-    let outbound_senders = vec![MppSender::with_header(
-        Arc::clone(&shared_channel),
-        MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
-    )];
+    // M2.d: build the worker's MppMesh. Inbound drains pull frames from each
+    // peer proc's `slot(peer_proc, this_proc)` queue; per-(stage_id, partition)
+    // sub-buffers (M2.b) demux frames into the right consumer fragment.
+    let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
+        (0..total_procs).map(|_| None).collect();
+    for (peer_idx, shm_recv) in attach.inbound_receivers.into_iter().enumerate() {
+        let sender_proc = peer_proc_for_index(proc_idx, peer_idx as u32);
+        debug_assert!(sender_proc != proc_idx);
+        let mpp_recv = MppReceiver::new(Box::new(shm_recv));
+        inbound_drains[sender_proc as usize] =
+            Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv])));
+    }
+    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drains));
 
     let build_cache = if header.n_cache_sources > 0 {
         Some(Arc::new(unsafe {
@@ -300,7 +320,7 @@ pub unsafe fn worker_setup(
     };
 
     // For MppParticipantConfig, expose worker-only counts (N producer workers).
-    let worker_count = header.n_procs.saturating_sub(1).max(1);
+    let worker_count = total_procs.saturating_sub(1).max(1);
     Ok(MppWorkerState {
         outbound_senders,
         plan_bytes,
@@ -309,5 +329,6 @@ pub unsafe fn worker_setup(
             total_workers: worker_count,
         },
         build_cache,
+        mesh,
     })
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -79,20 +79,25 @@ pub fn mpp_queue_size() -> usize {
 }
 
 /// Body of `estimate_dsm_custom_scan`. Returns total DSM bytes the leader
-/// will need for plan + N×K queue mesh + build-side cache. `N` is the *worker*
-/// count (`mpp_worker_count - 1`); the leader is a consumer-only participant
-/// in this iteration, so its slot is omitted from the mesh.
+/// will need for the plan + multiplexed `n_procs × n_procs` queue mesh +
+/// build-side cache. `n_procs` is the total participant count (leader +
+/// `producer_worker_count()` parallel workers).
 ///
 /// `n_cache_sources` is the number of non-partitioning sources the build-side
-/// all-gather cache should reserve slots for; pass 0 to skip caching.
+/// all-gather cache should reserve slots for; pass 0 to skip caching. The
+/// cache region is sized using worker-only slots (leader does not write).
+///
+/// `n_partitions` is preserved as an arg for callers that still think in the
+/// single-stage worker→leader gather frame; the multiplexed grid does not
+/// need it for sizing, so it's currently unused. M2's plan-driven sizing will
+/// supersede this parameter.
 pub fn estimate_dsm_size(
     plan_bytes_len: usize,
-    n_partitions: u32,
+    _n_partitions: u32,
     n_cache_sources: u32,
 ) -> Result<usize, String> {
     let layout = compute_dsm_layout(
-        producer_worker_count(),
-        n_partitions,
+        n_procs(),
         mpp_queue_size(),
         plan_bytes_len,
         n_cache_sources,
@@ -102,11 +107,16 @@ pub fn estimate_dsm_size(
     Ok(layout.region_total)
 }
 
-/// Number of producer workers in the mesh: `mpp_worker_count - 1`. The leader
-/// is a consumer-only participant for now (leader-as-worker-0 deferred); its
-/// slot is omitted, so PG launches exactly this many parallel workers.
+/// Number of producer workers PG should launch as `parallel_workers`.
+/// `mpp_worker_count - 1` because participant 0 is the leader.
 pub fn producer_worker_count() -> u32 {
     mpp_worker_count().saturating_sub(1).max(1)
+}
+
+/// Total participant count: 1 leader + N producer workers. This is the
+/// dimension of the multiplexed `n_procs × n_procs` shm_mq grid.
+pub fn n_procs() -> u32 {
+    mpp_worker_count()
 }
 
 /// Returned to the leader from [`leader_setup`]. The customscan stashes this
@@ -148,10 +158,9 @@ pub unsafe fn leader_setup(
     plan_bytes: Vec<u8>,
     n_cache_sources: u32,
 ) -> Result<MppLeaderState, String> {
-    let n_workers = producer_worker_count();
+    let total_procs = n_procs();
     let layout = compute_dsm_layout(
-        n_workers,
-        n_partitions,
+        total_procs,
         mpp_queue_size(),
         plan_bytes.len(),
         n_cache_sources,
@@ -161,33 +170,53 @@ pub unsafe fn leader_setup(
 
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
 
-    // Build per-(worker, partition) cooperative drain handles. Each handle
-    // owns one MppReceiver + one DrainBuffer; the consumer side calls
-    // `try_drain_pass` inline on the backend thread (pgrx-safe) when
-    // pulling batches.
-    let mut drains = Vec::with_capacity(attach.inbound_receivers.len());
-    for shm_recv in attach.inbound_receivers {
+    // M1.b: the leader is now a full participant in the multiplexed grid
+    // (sender for its row, receiver for its column). For continuity with the
+    // current single-stage routing, we adapt the leader's column receivers
+    // (slot(*, 0)) into per-sender DrainHandles indexed by sender_proc.
+    //
+    // The legacy MppMesh was indexed by (producer_worker, consumer_partition)
+    // with consumer_partition driven by the plan's network-boundary fanout.
+    // The natural-shape plan emits NetworkCoalesceExec(consumer_tc=1, ...)
+    // at the top, meaning *one* leader consumer partition for the worker→
+    // leader gather — so partition is effectively always 0. We expose the
+    // mesh under the same `(worker, partition)` keying with `n_partitions=1`
+    // for the gather case; the multiplexed routing logic in M1.c will replace
+    // this with per-(stage_id, sender_proc, partition) sub-buffers.
+    //
+    // The leader's own outbound row senders + self-loop receiver are dropped
+    // for now — the leader is consumer-only at the single network boundary
+    // this single-stage path exercises. Multi-stage senders (when the leader
+    // hosts a producer task) come with M2.
+    let _ = n_partitions;
+    let mut inbound_receivers = attach.inbound_receivers;
+    // Drop the self-loop receiver — slot(0, 0) would be the leader sending
+    // to itself, which isn't a path the single-stage code uses.
+    if !inbound_receivers.is_empty() {
+        inbound_receivers.remove(0);
+    }
+    let mut drains = Vec::with_capacity(inbound_receivers.len());
+    for shm_recv in inbound_receivers {
         let mpp_recv = MppReceiver::new(Box::new(shm_recv));
         let buffer = DrainBuffer::new(1);
         drains.push(Arc::new(DrainHandle::cooperative(vec![mpp_recv], buffer)));
     }
 
+    // n_workers = total_procs - 1 (workers only), n_partitions = 1 (the leader
+    // is the sole gather consumer). MppMesh.drains is indexed
+    // worker * n_partitions + partition = worker * 1 + 0 = worker.
+    let worker_count = total_procs.saturating_sub(1).max(1);
     let mesh = Arc::new(MppMesh {
-        n_workers,
-        n_partitions,
+        n_workers: worker_count,
+        n_partitions: 1,
         drains,
     });
 
-    // Drop the leader's own producer slot senders — the leader doesn't
-    // produce in this iteration, so its slot would never receive data.
-    // Dropping them now means peer receivers observe Detached at first
-    // poll and short-circuit cleanly. (When leader-as-worker-0 lands,
-    // we'll route these into a Tokio-spawned producer subplan instead.)
+    // Drop the leader's own outbound senders — the leader doesn't yet host
+    // a producer fragment in single-stage mode.
     drop(attach.outbound_senders);
 
-    // The leader doesn't read or write the build-side cache — workers attach
-    // to it via DSM offset, and Postgres owns the DSM segment's lifetime.
-    // `n_cache_sources` is sized into the layout for the worker side.
+    // Cache region is sized into the layout for workers. Leader doesn't touch.
     let _ = n_cache_sources;
 
     Ok(MppLeaderState { mesh, pcxt })
@@ -225,23 +254,34 @@ pub unsafe fn worker_setup(
     if worker_number < 0 {
         return Err("mpp: worker_number < 0".into());
     }
-    // Leader is consumer-only, so all parallel workers map directly to mesh
-    // slots: ParallelWorkerNumber 0..N-1 maps to slot 0..N-1.
-    let worker_index = worker_number as u32;
+    // M1.b: leader is now `proc_idx = 0`, workers are `1..n_procs`. Worker N
+    // maps from PG's `ParallelWorkerNumber = N` to `proc_idx = N + 1`.
+    let proc_idx = (worker_number as u32) + 1;
 
     let (header, plan_bytes, attach) =
-        unsafe { worker_attach(coordinate, region_total, worker_index, seg) }?;
+        unsafe { worker_attach(coordinate, region_total, proc_idx, seg) }?;
 
-    // Each `outbound_senders[p]` writes to consumer partition `p` of the
-    // network boundary. Stamp every outgoing batch with that partition (and
-    // stage_id=0 — the current architecture is single-stage; multi-stage tags
-    // arrive with M2). The receiver demuxes on this header once M1.c lands.
-    let outbound_senders = attach
-        .outbound_senders
-        .into_iter()
-        .enumerate()
-        .map(|(p, s)| MppSender::with_header(Box::new(s), MppFrameHeader::batch(0, p as u32)))
-        .collect();
+    // Pick out the worker→leader sender. In the multiplexed grid this is
+    // `outbound_senders[0]` (leader is at proc 0); the single-stage path
+    // gathers everything onto leader proc 0. Frames carry the natural-shape
+    // gather header `(stage_id=0, partition=0)` since the current path
+    // emits one NetworkCoalesceExec(consumer_tc=1, input_tc=N) at the top.
+    //
+    // M1.c will replace this with per-target-proc senders that multiplex
+    // many (stage_id, partition) channels over one shm_mq queue.
+    let mut row = attach.outbound_senders;
+    if row.is_empty() {
+        return Err("mpp: worker_attach returned empty senders row".into());
+    }
+    // outbound_senders[0] writes to slot(this_proc, 0) — i.e. to leader.
+    // Drop the rest (self-loop + peer slots are unused in single-stage path).
+    let leader_sender = row.remove(0);
+    drop(row);
+    drop(attach.inbound_receivers); // unused in single-stage worker
+    let outbound_senders = vec![MppSender::with_header(
+        Box::new(leader_sender),
+        MppFrameHeader::batch(0, 0),
+    )];
 
     let build_cache = if header.n_cache_sources > 0 {
         Some(Arc::new(unsafe {
@@ -251,12 +291,14 @@ pub unsafe fn worker_setup(
         None
     };
 
+    // For MppParticipantConfig, expose worker-only counts (N producer workers).
+    let worker_count = header.n_procs.saturating_sub(1).max(1);
     Ok(MppWorkerState {
         outbound_senders,
         plan_bytes,
         participant_config: MppParticipantConfig {
-            participant_index: worker_index,
-            total_participants: header.n_workers,
+            participant_index: worker_number as u32,
+            total_participants: worker_count,
         },
         build_cache,
     })

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -45,7 +45,7 @@ use crate::postgres::customscan::mpp::dsm::{
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
-    DrainBuffer, DrainHandle, MppReceiver, MppSender,
+    DrainBuffer, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
 };
 use crate::postgres::customscan::mpp::MppParticipantConfig;
 
@@ -232,10 +232,15 @@ pub unsafe fn worker_setup(
     let (header, plan_bytes, attach) =
         unsafe { worker_attach(coordinate, region_total, worker_index, seg) }?;
 
+    // Each `outbound_senders[p]` writes to consumer partition `p` of the
+    // network boundary. Stamp every outgoing batch with that partition (and
+    // stage_id=0 — the current architecture is single-stage; multi-stage tags
+    // arrive with M2). The receiver demuxes on this header once M1.c lands.
     let outbound_senders = attach
         .outbound_senders
         .into_iter()
-        .map(|s| MppSender::new(Box::new(s)))
+        .enumerate()
+        .map(|(p, s)| MppSender::with_header(Box::new(s), MppFrameHeader::batch(0, p as u32)))
         .collect();
 
     let build_cache = if header.n_cache_sources > 0 {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -200,11 +200,7 @@ pub unsafe fn leader_setup(
         inbound_drains.push(Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv]))));
     }
 
-    let mesh = Arc::new(MppMesh {
-        this_proc: 0,
-        n_procs: total_procs,
-        inbound_drains,
-    });
+    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_drains));
 
     // Drop the leader's own outbound senders — the leader doesn't yet host
     // a producer fragment in single-stage mode.

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -67,6 +67,14 @@ pub struct ShmMqSender {
 
 // SAFETY: see struct doc.
 unsafe impl Send for ShmMqSender {}
+// SAFETY: `MppSender` ensures all `send_*` paths execute on the attach
+// thread (a `debug_assert!` in `send_bytes` / `try_send_bytes` pins this),
+// so cross-thread sharing of `&ShmMqSender` never actually crosses threads
+// at the FFI boundary. The Sync bound exists so multiple `MppSender`s can
+// hold `Arc<dyn BatchChannelSender>` clones of the same underlying queue
+// — the M2 multi-partition fan-out pattern — without the type system
+// rejecting the `Arc::clone` at compile time.
+unsafe impl Sync for ShmMqSender {}
 
 impl ShmMqSender {
     /// # Safety

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -25,6 +25,7 @@
 //! that reads all inbound queues into a spillable local buffer — this decouples
 //! consumer-side backpressure from producer-side backpressure.
 
+pub mod assignment;
 pub mod dsm;
 pub mod glue;
 pub mod mesh;

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -30,6 +30,7 @@ pub mod dsm;
 pub mod glue;
 pub mod mesh;
 pub mod runtime;
+pub mod task_estimator;
 pub mod transport;
 pub mod worker;
 pub mod worker_fragments;

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -32,6 +32,7 @@ pub mod mesh;
 pub mod runtime;
 pub mod transport;
 pub mod worker;
+pub mod worker_fragments;
 
 use serde::{Deserialize, Serialize};
 

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -36,16 +36,19 @@ use serde::{Deserialize, Serialize};
 
 /// Describes this participant's position in an MPP query. Held by
 /// [`glue::MppLeaderState`] / [`glue::MppWorkerState`] so the AggregateScan
-/// worker path can size the in-process planner via `total_participants`.
+/// worker path can size the in-process planner via `total_workers`.
 /// The DF-D fork's `WorkerResolver` derives task identity from its own indexing,
 /// so this is a diagnostic / sizing hand-off — not a `SessionConfig`
 /// extension.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MppParticipantConfig {
-    /// 0-based index of this participant. The leader is always index 0.
+    /// 0-based worker index (`ParallelWorkerNumber`). Workers only — the
+    /// leader has no `MppParticipantConfig` since it doesn't run a worker
+    /// fragment in the single-stage gather path.
     pub participant_index: u32,
-    /// Total number of participants (leader + workers).
-    pub total_participants: u32,
+    /// Number of producer workers in the mesh (= `n_procs - 1`; the leader
+    /// is consumer-only in the single-stage gather path).
+    pub total_workers: u32,
 }
 
 /// Emit a runtime trace when `paradedb.mpp_debug` is on.

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -57,12 +57,29 @@ pub struct MppParticipantConfig {
 /// Emit a runtime trace when `paradedb.mpp_debug` is on.
 ///
 /// Routed through `pgrx::warning!` so the line appears in the Postgres server log
-/// (and in CI benchmark logs). No-op when the GUC is off.
+/// (and in CI benchmark logs). No-op when the GUC is off, and no-op in `cargo
+/// test` builds: `pgrx::warning!` expands to a call into PG's `ereport`
+/// machinery (`CurrentMemoryContext`, `PG_exception_stack`,
+/// `error_context_stack`, `CopyErrorData`), which the plain `cargo test
+/// --no-default-features` link line does not provide. Production builds
+/// (`cargo pgrx install`, the cdylib) link against PG and resolve these at
+/// load time, so gating only the `#[cfg(test)]` lib-test build is enough.
+#[cfg(not(test))]
 #[macro_export]
 macro_rules! mpp_log {
     ($($arg:tt)*) => {
         if $crate::gucs::mpp_debug() {
             pgrx::warning!($($arg)*);
         }
+    };
+}
+
+/// `cargo test` variant: no-op. `format_args!` is invoked solely to silence
+/// "unused variable" / "unused import" warnings at the call sites.
+#[cfg(test)]
+#[macro_export]
+macro_rules! mpp_log {
+    ($($arg:tt)*) => {
+        { let _ = format_args!($($arg)*); }
     };
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -161,9 +161,15 @@ impl WorkerConnection for ShmMqWorkerConnection {
         // Today's single-stage gather has one logical channel per inbound
         // queue (the natural plan emits NetworkCoalesceExec(consumer_tc=1)
         // at the top, so the leader has one partition to merge from each
-        // sender_proc). `partition` is therefore always 0; we keep the
-        // value parsed for the M2 sub-buffer registry that demuxes by it.
-        let _ = partition;
+        // sender_proc). `partition` is therefore always 0. M2's sub-buffer
+        // registry demuxes by partition; until then, assert defensively so
+        // an unexpected non-zero partition fails loudly in dev rather than
+        // silently routing to the wrong channel.
+        debug_assert_eq!(
+            partition, 0,
+            "M1 single-channel design: ShmMqWorkerConnection::stream_partition \
+             only supports partition=0 in the natural-shape gather path"
+        );
         let drain = self.mesh.inbound_drain(self.sender_proc).ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerConnection: no inbound drain for sender_proc={} \

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -48,29 +48,49 @@ use url::Url;
 use crate::postgres::customscan::mpp::transport::{DrainHandle, DrainItem};
 
 /// Runtime handle the customscan populates at DSM-init time.
+///
+/// M1.c restructured this from a `(worker, partition)`-indexed grid to a
+/// per-sender-proc map. Each shm_mq queue (one per `(sender_proc, this_proc)`
+/// pair in the V2 DSM grid) is multi-channel: frames from any number of
+/// `(stage_id, partition)` logical channels can arrive on one queue, tagged
+/// by [`MppFrameHeader`]. M2 will introduce a sub-buffer registry indexed by
+/// `(stage_id, partition)` so a single drain can fan frames out to multiple
+/// consumers. For now, the single-stage gather path treats each queue as
+/// carrying one channel — the per-`(stage_id, partition)` registry sits at
+/// `n_inbound_per_sender = 1` and is implicit.
 pub struct MppMesh {
-    /// Number of producer workers (including leader-as-worker-0).
-    pub n_workers: u32,
-    /// Number of consumer-side partitions on the leader.
-    pub n_partitions: u32,
-    /// One [`DrainHandle`] per `(worker, partition)` pair on the leader,
-    /// indexed `worker * n_partitions + partition`. Workers receive their
-    /// own slice of senders separately (see
-    /// [`crate::postgres::customscan::mpp::dsm::WorkerAttach`]).
-    pub drains: Vec<Arc<DrainHandle>>,
+    /// This process's `proc_idx` (= 0 for the leader, `ParallelWorkerNumber + 1`
+    /// for workers). Frames addressed to this proc arrive on `slot(*, this_proc)`.
+    pub this_proc: u32,
+    /// Total participant count. Mostly for bounds checking the sender_proc
+    /// lookups in [`ShmMqWorkerTransport::open`].
+    pub n_procs: u32,
+    /// `inbound_drains[sender_proc]` is the cooperative drain that pulls
+    /// frames from `slot(sender_proc, this_proc)`. `None` for entries the
+    /// process doesn't consume from (self-loop, currently). The natural-shape
+    /// gather installs drains for every `sender_proc != this_proc`.
+    pub inbound_drains: Vec<Option<Arc<DrainHandle>>>,
 }
 
 impl MppMesh {
-    pub fn drain(&self, worker: u32, partition: u32) -> Option<&Arc<DrainHandle>> {
-        if worker >= self.n_workers || partition >= self.n_partitions {
-            return None;
-        }
-        self.drains
-            .get((worker as usize) * (self.n_partitions as usize) + (partition as usize))
+    /// Look up the drain that owns frames coming from `sender_proc`. Returns
+    /// `None` if no drain is installed (out-of-range or the self-loop slot,
+    /// which the single-stage gather skips).
+    pub fn inbound_drain(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
+        let idx = sender_proc as usize;
+        self.inbound_drains.get(idx).and_then(|slot| slot.as_ref())
     }
 }
 
 /// Implements the DF-D fork's [`WorkerTransport`] over the leader's [`MppMesh`].
+///
+/// `open(input_stage, target_task)` translates the DF-D `(stage, task)`
+/// addressing into the proc-pair grid: `target_task` selects which `sender_proc`
+/// hosts the producer-side task, and the returned [`WorkerConnection`] pulls
+/// from that proc's inbound drain. For the natural-shape single-stage gather
+/// the mapping is `sender_proc = target_task + 1` (workers start at proc 1;
+/// leader is proc 0 and is the consumer here). M2 generalizes this to a
+/// plan-driven `(stage_id, task) -> proc_idx` assignment table.
 pub struct ShmMqWorkerTransport {
     mesh: Arc<MppMesh>,
 }
@@ -79,37 +99,57 @@ impl ShmMqWorkerTransport {
     pub fn new(mesh: Arc<MppMesh>) -> Self {
         Self { mesh }
     }
+
+    /// `(stage_id, task)` → `sender_proc` assignment. Single-stage heuristic
+    /// for now: task 0..N-1 maps to proc 1..N (skipping the leader). M2
+    /// replaces this with a plan-driven lookup table.
+    fn sender_proc_for_task(&self, _stage_id: u32, target_task: u32) -> u32 {
+        target_task + 1
+    }
 }
 
 impl WorkerTransport for ShmMqWorkerTransport {
     fn open(
         &self,
-        _input_stage: &Stage,
+        input_stage: &Stage,
         _target_partitions: Range<usize>,
         target_task: usize,
         _ctx: &Arc<TaskContext>,
     ) -> Result<Box<dyn WorkerConnection>> {
-        let worker = u32::try_from(target_task).map_err(|_| {
+        let target_task_u32 = u32::try_from(target_task).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerTransport: target_task={target_task} > u32::MAX"
             ))
         })?;
-        if worker >= self.mesh.n_workers {
+        let stage_id = u32::try_from(input_stage.num()).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "ShmMqWorkerTransport: input_stage.num()={} > u32::MAX",
+                input_stage.num()
+            ))
+        })?;
+        let sender_proc = self.sender_proc_for_task(stage_id, target_task_u32);
+        if sender_proc >= self.mesh.n_procs {
             return Err(DataFusionError::Internal(format!(
-                "ShmMqWorkerTransport: target_task={worker} >= n_workers={}",
-                self.mesh.n_workers
+                "ShmMqWorkerTransport: sender_proc={sender_proc} >= n_procs={} \
+                 (stage_id={stage_id}, target_task={target_task})",
+                self.mesh.n_procs
             )));
         }
         Ok(Box::new(ShmMqWorkerConnection {
             mesh: Arc::clone(&self.mesh),
-            worker,
+            sender_proc,
+            stage_id,
         }))
     }
 }
 
 struct ShmMqWorkerConnection {
     mesh: Arc<MppMesh>,
-    worker: u32,
+    sender_proc: u32,
+    // `stage_id` of the boundary's `input_stage`. Held for diagnostics today;
+    // M2's sub-buffer registry will key on it.
+    #[allow(dead_code)]
+    stage_id: u32,
 }
 
 impl WorkerConnection for ShmMqWorkerConnection {
@@ -118,15 +158,17 @@ impl WorkerConnection for ShmMqWorkerConnection {
         partition: usize,
         _on_metadata: OnMetadataCallback,
     ) -> Result<WorkerPartitionStream> {
-        let partition_u32 = u32::try_from(partition).map_err(|_| {
+        // Today's single-stage gather has one logical channel per inbound
+        // queue (the natural plan emits NetworkCoalesceExec(consumer_tc=1)
+        // at the top, so the leader has one partition to merge from each
+        // sender_proc). `partition` is therefore always 0; we keep the
+        // value parsed for the M2 sub-buffer registry that demuxes by it.
+        let _ = partition;
+        let drain = self.mesh.inbound_drain(self.sender_proc).ok_or_else(|| {
             DataFusionError::Internal(format!(
-                "ShmMqWorkerConnection: partition={partition} > u32::MAX"
-            ))
-        })?;
-        let drain = self.mesh.drain(self.worker, partition_u32).ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "ShmMqWorkerConnection: no drain for (worker={}, partition={partition_u32})",
-                self.worker
+                "ShmMqWorkerConnection: no inbound drain for sender_proc={} \
+                 (stage_id={}, this_proc={})",
+                self.sender_proc, self.stage_id, self.mesh.this_proc
             ))
         })?;
         let drain = Arc::clone(drain);

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -134,20 +134,20 @@ impl MppMesh {
     /// can drain inbound peer data inline — preventing the N×N symmetric-send
     /// deadlock when every peer is simultaneously stalled waiting for space.
     ///
-    /// Returns the first error if any drain's `poll_drain_pass` errors;
+    /// Returns the first error if any drain's `try_drain_pass` errors;
     /// otherwise `Ok(())` after all drains have been polled. Drains that
     /// have already detached are skipped silently (their slot is still
     /// `Some`, but their inner `coop_receivers` Vec entry is `None`).
     pub fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
         for drain in self.inbound_drains.iter().flatten() {
-            drain.poll_drain_pass()?;
+            drain.try_drain_pass()?;
         }
         Ok(())
     }
 }
 
 impl CooperativeDrainSet for MppMesh {
-    fn poll_drain_pass(&self) -> Result<(), DataFusionError> {
+    fn try_drain_pass(&self) -> Result<(), DataFusionError> {
         self.drain_all_inbound()
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -38,7 +38,6 @@ use std::sync::{Arc, OnceLock};
 use async_trait::async_trait;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
-use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{
     OnMetadataCallback, Stage, WorkerConnection, WorkerPartitionStream, WorkerResolver,
     WorkerTransport,
@@ -46,7 +45,7 @@ use datafusion_distributed::{
 use url::Url;
 
 use crate::postgres::customscan::mpp::assignment::TaskAssignment;
-use crate::postgres::customscan::mpp::transport::{DrainHandle, DrainItem};
+use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, DrainHandle, DrainItem};
 
 /// Runtime handle the customscan populates at DSM-init time.
 ///
@@ -127,6 +126,29 @@ impl MppMesh {
     /// installed yet.
     pub fn task_assignment(&self) -> Option<&Arc<TaskAssignment>> {
         self.task_assignment.get()
+    }
+
+    /// Pull from every installed inbound drain. Called from
+    /// [`crate::postgres::customscan::mpp::transport::MppSender`]'s
+    /// cooperative-send spin so a producer stalled on a full outbound queue
+    /// can drain inbound peer data inline — preventing the N×N symmetric-send
+    /// deadlock when every peer is simultaneously stalled waiting for space.
+    ///
+    /// Returns the first error if any drain's `poll_drain_pass` errors;
+    /// otherwise `Ok(())` after all drains have been polled. Drains that
+    /// have already detached are skipped silently (their slot is still
+    /// `Some`, but their inner `coop_receivers` Vec entry is `None`).
+    pub fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
+        for drain in self.inbound_drains.iter().flatten() {
+            drain.poll_drain_pass()?;
+        }
+        Ok(())
+    }
+}
+
+impl CooperativeDrainSet for MppMesh {
+    fn poll_drain_pass(&self) -> Result<(), DataFusionError> {
+        self.drain_all_inbound()
     }
 }
 
@@ -296,64 +318,5 @@ impl WorkerResolver for MppWorkerResolver {
     fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
         let url = Url::parse("http://mpp.local/").expect("static URL parses");
         Ok(vec![url; self.n_workers])
-    }
-}
-
-/// Worker-side [`WorkerTransport`] that resolves nested network boundaries
-/// (such as a `NetworkBroadcastExec` on the build side of a `HashJoin`) by
-/// executing the boundary's `input_stage.plan` locally on the worker.
-///
-/// In the DF-D fork's gRPC distributed model, every worker would pull the
-/// broadcast data from a designated source via a Flight stream. In our
-/// in-process model the producer fragment that workers run already contains
-/// these network boundary nodes (the worker re-plans from the same logical
-/// plan as the leader), and rather than fan a broadcast across an in-process
-/// mesh we just have each worker re-execute the build-side plan locally —
-/// it's a small index scan, cheap enough that duplicating the work across
-/// `n_workers` producers is preferable to wiring a second mesh.
-///
-/// The worker's session must keep `input_stage.plan = Some(...)` (i.e. the
-/// DF-D fork's `prepare_plan` is *not* invoked on the worker side because we
-/// drop into `find_worker_fragment` below the leader's `DistributedExec`).
-pub struct LocalExecWorkerTransport;
-
-impl WorkerTransport for LocalExecWorkerTransport {
-    fn open(
-        &self,
-        input_stage: &Stage,
-        _target_partitions: Range<usize>,
-        _target_task: usize,
-        ctx: &Arc<TaskContext>,
-    ) -> Result<Box<dyn WorkerConnection>> {
-        let plan = input_stage.plan().cloned().ok_or_else(|| {
-            DataFusionError::Internal(
-                "LocalExecWorkerTransport: input_stage.plan is None — \
-                 worker re-plan must keep the boundary's input subtree intact"
-                    .into(),
-            )
-        })?;
-        Ok(Box::new(LocalExecWorkerConnection {
-            plan,
-            ctx: Arc::clone(ctx),
-        }))
-    }
-}
-
-struct LocalExecWorkerConnection {
-    plan: Arc<dyn ExecutionPlan>,
-    ctx: Arc<TaskContext>,
-}
-
-impl WorkerConnection for LocalExecWorkerConnection {
-    fn stream_partition(
-        &self,
-        partition: usize,
-        _on_metadata: OnMetadataCallback,
-    ) -> Result<WorkerPartitionStream> {
-        let stream = self.plan.execute(partition, Arc::clone(&self.ctx))?;
-        // SendableRecordBatchStream is already `Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>`;
-        // the WorkerPartitionStream alias drops the schema bound, so the
-        // existing pinned box satisfies it directly.
-        Ok(stream)
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -146,9 +146,9 @@ impl WorkerTransport for ShmMqWorkerTransport {
 struct ShmMqWorkerConnection {
     mesh: Arc<MppMesh>,
     sender_proc: u32,
-    // `stage_id` of the boundary's `input_stage`. Held for diagnostics today;
-    // M2's sub-buffer registry will key on it.
-    #[allow(dead_code)]
+    /// `stage_id` of the boundary's `input_stage`. Passed to
+    /// `DrainHandle::register_channel` so the sub-buffer this connection
+    /// streams from sees only frames tagged with the same `(stage_id, p)`.
     stage_id: u32,
 }
 

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -110,12 +110,17 @@ impl MppMesh {
         self.inbound_drains.get(idx).and_then(|slot| slot.as_ref())
     }
 
-    /// Install the plan-derived task assignment table. Idempotent in spirit
-    /// — a second call after the first wins is a logic bug, but
-    /// `OnceLock::set` silently no-ops in that case so callers don't have
-    /// to special-case it.
+    /// Install the plan-derived task assignment table. The first call wins;
+    /// a second call is a logic bug (e.g. a re-entrant exec path overwriting
+    /// the table mid-query). `OnceLock::set` silently no-ops in that case
+    /// so production stays correct, but a `debug_assert!` surfaces the bug
+    /// in dev/CI builds.
     pub fn install_assignment(&self, assignment: Arc<TaskAssignment>) {
-        let _ = self.task_assignment.set(assignment);
+        let install_was_first = self.task_assignment.set(assignment).is_ok();
+        debug_assert!(
+            install_was_first,
+            "MppMesh::install_assignment called twice — second call ignored"
+        );
     }
 
     /// Read the installed assignment table, or `None` if it hasn't been
@@ -153,11 +158,21 @@ impl ShmMqWorkerTransport {
     /// `NetworkCoalesceExec(consumer_tc=1, input_tc=N)` gather working
     /// while M2.d wires up per-worker meshes that install the assignment
     /// from the worker side too.
+    ///
+    /// If the table IS installed but doesn't carry an entry, that's a
+    /// plan-walk bug — the natural-shape plans M2.c targets always emit
+    /// matching entries. `debug_assert!` surfaces this in dev/CI so the
+    /// silent fallback doesn't hide a wrong-routing bug.
     fn sender_proc_for_task(&self, stage_id: u32, target_task: u32) -> u32 {
         if let Some(a) = self.mesh.task_assignment() {
             if let Some(p) = a.proc_for(stage_id, target_task) {
                 return p;
             }
+            debug_assert!(
+                false,
+                "TaskAssignment installed but missing (stage_id={stage_id}, task={target_task}); \
+                 falling back to task+1 — likely a plan-walk bug"
+            );
         }
         target_task + 1
     }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -158,18 +158,16 @@ impl WorkerConnection for ShmMqWorkerConnection {
         partition: usize,
         _on_metadata: OnMetadataCallback,
     ) -> Result<WorkerPartitionStream> {
-        // Today's single-stage gather has one logical channel per inbound
-        // queue (the natural plan emits NetworkCoalesceExec(consumer_tc=1)
-        // at the top, so the leader has one partition to merge from each
-        // sender_proc). `partition` is therefore always 0. M2's sub-buffer
-        // registry demuxes by partition; until then, assert defensively so
-        // an unexpected non-zero partition fails loudly in dev rather than
-        // silently routing to the wrong channel.
-        debug_assert_eq!(
-            partition, 0,
-            "M1 single-channel design: ShmMqWorkerConnection::stream_partition \
-             only supports partition=0 in the natural-shape gather path"
-        );
+        // M2.a (in progress): the natural plan can have consumer_tc > 1
+        // on inner boundaries (peer-mesh shuffles), so this is called with
+        // partition > 0. The full demux story — one DrainBuffer per
+        // (stage_id, sender_proc, partition) — is M2.b. For now we route
+        // every partition into the single inbound DrainBuffer for the
+        // sender_proc, which only works when the consumer side has exactly
+        // one logical partition per sender (the natural-shape gather case).
+        // Multi-partition consumers will see interleaved frames until
+        // M2.b lands.
+        let _ = partition;
         let drain = self.mesh.inbound_drain(self.sender_proc).ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerConnection: no inbound drain for sender_proc={} \

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -33,7 +33,7 @@
 //!   address satisfies the API.
 
 use std::ops::Range;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 use async_trait::async_trait;
 use datafusion::common::{DataFusionError, Result};
@@ -45,6 +45,7 @@ use datafusion_distributed::{
 };
 use url::Url;
 
+use crate::postgres::customscan::mpp::assignment::TaskAssignment;
 use crate::postgres::customscan::mpp::transport::{DrainHandle, DrainItem};
 
 /// Runtime handle the customscan populates at DSM-init time.
@@ -53,11 +54,16 @@ use crate::postgres::customscan::mpp::transport::{DrainHandle, DrainItem};
 /// per-sender-proc map. Each shm_mq queue (one per `(sender_proc, this_proc)`
 /// pair in the V2 DSM grid) is multi-channel: frames from any number of
 /// `(stage_id, partition)` logical channels can arrive on one queue, tagged
-/// by [`MppFrameHeader`]. M2 will introduce a sub-buffer registry indexed by
-/// `(stage_id, partition)` so a single drain can fan frames out to multiple
-/// consumers. For now, the single-stage gather path treats each queue as
-/// carrying one channel — the per-`(stage_id, partition)` registry sits at
-/// `n_inbound_per_sender = 1` and is implicit.
+/// by [`MppFrameHeader`]. M2.b added the sub-buffer registry per
+/// [`DrainHandle`] so a single drain can fan frames out to multiple
+/// consumers keyed on `(stage_id, partition)`.
+///
+/// M2.c added [`Self::task_assignment`] — the plan-driven
+/// `(stage_id, task_idx) → proc_idx` table installed after physical-plan
+/// build. [`ShmMqWorkerTransport::open`] consults it to route
+/// `(input_stage, target_task)` requests to the right inbound drain.
+///
+/// [`MppFrameHeader`]: crate::postgres::customscan::mpp::transport::MppFrameHeader
 pub struct MppMesh {
     /// This process's `proc_idx` (= 0 for the leader, `ParallelWorkerNumber + 1`
     /// for workers). Frames addressed to this proc arrive on `slot(*, this_proc)`.
@@ -70,15 +76,52 @@ pub struct MppMesh {
     /// process doesn't consume from (self-loop, currently). The natural-shape
     /// gather installs drains for every `sender_proc != this_proc`.
     pub inbound_drains: Vec<Option<Arc<DrainHandle>>>,
+    /// Plan-driven `(stage_id, task_idx) → proc_idx` table. Installed by
+    /// [`Self::install_assignment`] right after the leader builds the
+    /// physical plan; read by [`ShmMqWorkerTransport::open`] at execute
+    /// time. `OnceLock` because the table is logically immutable for the
+    /// lifetime of the query — install once, read many. If `get()` returns
+    /// `None`, the transport falls back to the M1 heuristic to keep the
+    /// single-stage gather working during incremental rollout.
+    task_assignment: OnceLock<Arc<TaskAssignment>>,
 }
 
 impl MppMesh {
+    /// Build a fresh mesh with the assignment table unset. Use
+    /// [`Self::install_assignment`] after the physical plan is available.
+    pub fn new(
+        this_proc: u32,
+        n_procs: u32,
+        inbound_drains: Vec<Option<Arc<DrainHandle>>>,
+    ) -> Self {
+        Self {
+            this_proc,
+            n_procs,
+            inbound_drains,
+            task_assignment: OnceLock::new(),
+        }
+    }
+
     /// Look up the drain that owns frames coming from `sender_proc`. Returns
     /// `None` if no drain is installed (out-of-range or the self-loop slot,
     /// which the single-stage gather skips).
     pub fn inbound_drain(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
         let idx = sender_proc as usize;
         self.inbound_drains.get(idx).and_then(|slot| slot.as_ref())
+    }
+
+    /// Install the plan-derived task assignment table. Idempotent in spirit
+    /// — a second call after the first wins is a logic bug, but
+    /// `OnceLock::set` silently no-ops in that case so callers don't have
+    /// to special-case it.
+    pub fn install_assignment(&self, assignment: Arc<TaskAssignment>) {
+        let _ = self.task_assignment.set(assignment);
+    }
+
+    /// Read the installed assignment table, or `None` if it hasn't been
+    /// installed yet.
+    pub fn task_assignment(&self) -> Option<&Arc<TaskAssignment>> {
+        self.task_assignment.get()
     }
 }
 
@@ -87,10 +130,13 @@ impl MppMesh {
 /// `open(input_stage, target_task)` translates the DF-D `(stage, task)`
 /// addressing into the proc-pair grid: `target_task` selects which `sender_proc`
 /// hosts the producer-side task, and the returned [`WorkerConnection`] pulls
-/// from that proc's inbound drain. For the natural-shape single-stage gather
-/// the mapping is `sender_proc = target_task + 1` (workers start at proc 1;
-/// leader is proc 0 and is the consumer here). M2 generalizes this to a
-/// plan-driven `(stage_id, task) -> proc_idx` assignment table.
+/// from that proc's inbound drain.
+///
+/// M2.c routes via the mesh's plan-driven [`TaskAssignment`] table. If the
+/// table is uninstalled (e.g. during incremental rollout) the transport
+/// falls back to the legacy single-stage heuristic
+/// `sender_proc = target_task + 1` so the natural-shape gather keeps
+/// working.
 pub struct ShmMqWorkerTransport {
     mesh: Arc<MppMesh>,
 }
@@ -100,10 +146,19 @@ impl ShmMqWorkerTransport {
         Self { mesh }
     }
 
-    /// `(stage_id, task)` → `sender_proc` assignment. Single-stage heuristic
-    /// for now: task 0..N-1 maps to proc 1..N (skipping the leader). M2
-    /// replaces this with a plan-driven lookup table.
-    fn sender_proc_for_task(&self, _stage_id: u32, target_task: u32) -> u32 {
+    /// `(stage_id, task)` → `sender_proc`. Consults the installed
+    /// [`TaskAssignment`]; falls back to `task + 1` if the table isn't
+    /// populated or doesn't carry an entry for the requested key. The
+    /// fallback matches M1's single-stage heuristic and keeps the
+    /// `NetworkCoalesceExec(consumer_tc=1, input_tc=N)` gather working
+    /// while M2.d wires up per-worker meshes that install the assignment
+    /// from the worker side too.
+    fn sender_proc_for_task(&self, stage_id: u32, target_task: u32) -> u32 {
+        if let Some(a) = self.mesh.task_assignment() {
+            if let Some(p) = a.proc_for(stage_id, target_task) {
+                return p;
+            }
+        }
         target_task + 1
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -158,16 +158,11 @@ impl WorkerConnection for ShmMqWorkerConnection {
         partition: usize,
         _on_metadata: OnMetadataCallback,
     ) -> Result<WorkerPartitionStream> {
-        // M2.a (in progress): the natural plan can have consumer_tc > 1
-        // on inner boundaries (peer-mesh shuffles), so this is called with
-        // partition > 0. The full demux story — one DrainBuffer per
-        // (stage_id, sender_proc, partition) — is M2.b. For now we route
-        // every partition into the single inbound DrainBuffer for the
-        // sender_proc, which only works when the consumer side has exactly
-        // one logical partition per sender (the natural-shape gather case).
-        // Multi-partition consumers will see interleaved frames until
-        // M2.b lands.
-        let _ = partition;
+        let partition_u32 = u32::try_from(partition).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "ShmMqWorkerConnection: partition={partition} > u32::MAX"
+            ))
+        })?;
         let drain = self.mesh.inbound_drain(self.sender_proc).ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerConnection: no inbound drain for sender_proc={} \
@@ -176,9 +171,14 @@ impl WorkerConnection for ShmMqWorkerConnection {
             ))
         })?;
         let drain = Arc::clone(drain);
+        // M2.b: ask the drain for the sub-buffer dedicated to this
+        // `(stage_id, partition)` channel. Frames the worker emits with a
+        // matching header land here; frames tagged with other partitions go
+        // to their own sub-buffers, so this consumer only sees its slice.
+        let buffer = drain.register_channel(self.stage_id, partition_u32);
         // Cooperative pull loop: pgrx requires shm_mq FFI on the backend
         // thread, so the drain pass runs inline here. Each iteration drains
-        // the receiver into the buffer (max 256 batches), then pops one
+        // the receiver into the registry (max 256 batches), then pops one
         // batch out to yield, then yields back to Tokio so sibling tasks
         // (e.g. the leader's own producer subplan) can advance.
         //
@@ -195,7 +195,7 @@ impl WorkerConnection for ShmMqWorkerConnection {
                     yield Err(e);
                     return;
                 }
-                match drain.buffer().try_pop() {
+                match buffer.try_pop() {
                     Some(DrainItem::Batch(batch)) => yield Ok(batch),
                     Some(DrainItem::Eof) => break,
                     None => tokio::task::yield_now().await,

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -227,6 +227,11 @@ impl WorkerTransport for ShmMqWorkerTransport {
                 self.mesh.n_procs
             )));
         }
+        crate::mpp_log!(
+            "mpp transport::open this_proc={} stage_id={stage_id} target_task={target_task} \
+             → sender_proc={sender_proc}",
+            self.mesh.this_proc
+        );
         Ok(Box::new(ShmMqWorkerConnection {
             mesh: Arc::clone(&self.mesh),
             sender_proc,
@@ -268,6 +273,13 @@ impl WorkerConnection for ShmMqWorkerConnection {
         // matching header land here; frames tagged with other partitions go
         // to their own sub-buffers, so this consumer only sees its slice.
         let buffer = drain.register_channel(self.stage_id, partition_u32);
+        crate::mpp_log!(
+            "mpp transport::stream_partition this_proc={} sender_proc={} stage_id={} \
+             partition={partition_u32} (register_channel)",
+            self.mesh.this_proc,
+            self.sender_proc,
+            self.stage_id,
+        );
         // Cooperative pull loop: pgrx requires shm_mq FFI on the backend
         // thread, so the drain pass runs inline here. Each iteration drains
         // the receiver into the registry (max 256 batches), then pops one

--- a/pg_search/src/postgres/customscan/mpp/task_estimator.rs
+++ b/pg_search/src/postgres/customscan/mpp/task_estimator.rs
@@ -36,9 +36,16 @@
 //! from the missing input tasks.
 //!
 //! Installed via [`datafusion_distributed::SessionStateBuilderExt::with_distributed_task_estimator`]
-//! in front of the default per-leaf estimator, so non-canonical leaves
-//! (`PgSearchScanPlan` and friends) fall through to the default. With
-//! this estimator in place, the dispatcher's
+//! in front of the default per-leaf estimator. The DF-D fork's
+//! `CombinedTaskEstimator` iterates registered estimators and returns
+//! the FIRST `Some(_)` — registration order, not a "biggest task_count
+//! wins" tiebreak. (That tiebreak runs at the per-stage layer across
+//! distinct leaves, not within one leaf's estimator chain.) So this
+//! estimator returns `Some(Maximum(1))` for canonical-replica memory
+//! leaves and `None` everywhere else; the default `Desired(n_workers)`
+//! estimator handles the fallthrough.
+//!
+//! With this estimator in place, the dispatcher's
 //! [`FragmentRouting::Broadcast`] short-circuit becomes a defensive
 //! `debug_assert!(fragment.task_idx == 0)` rather than a load-bearing
 //! correctness patch — see the doc on

--- a/pg_search/src/postgres/customscan/mpp/task_estimator.rs
+++ b/pg_search/src/postgres/customscan/mpp/task_estimator.rs
@@ -1,0 +1,156 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Planner-level companion to the dispatcher's
+//! [`FragmentRouting::Broadcast`] runtime guard.
+//!
+//! pg_search's natural-shape Aggregate plan canonical-replicates the
+//! HashJoin build subtree across all workers via the `mpp build all-gather`
+//! step. That step replaces the per-worker scan of the canonical source
+//! with a single `DataSourceExec(MemorySourceConfig)` that returns the
+//! fully replicated data. The DF-D fork's default task estimator would
+//! still annotate this leaf with `Desired(n_workers)`, so the resulting
+//! `NetworkBroadcastExec` would be built with `input_task_count =
+//! n_workers` and each input task would emit the full canonical data —
+//! the consumer's `select_all` then over-counts by `input_task_count`.
+//!
+//! [`BroadcastBuildSideOneTaskEstimator`] caps every all-gather memory
+//! leaf at `TaskEstimation::maximum(1)`, which propagates up the build
+//! subtree and produces a `NetworkBroadcastExec(input_task_count=1)`. The
+//! single producer emits the canonical data once per consumer task, and
+//! the consumer's `select_all` sees one real stream + empty placeholders
+//! from the missing input tasks.
+//!
+//! Installed via [`datafusion_distributed::SessionStateBuilderExt::with_distributed_task_estimator`]
+//! in front of the default per-leaf estimator, so non-canonical leaves
+//! (`PgSearchScanPlan` and friends) fall through to the default. With
+//! this estimator in place, the dispatcher's
+//! [`FragmentRouting::Broadcast`] short-circuit becomes a defensive
+//! `debug_assert!(fragment.task_idx == 0)` rather than a load-bearing
+//! correctness patch — see the doc on
+//! [`crate::postgres::customscan::mpp::worker_fragments::FragmentRouting::Broadcast`].
+
+use std::sync::Arc;
+
+use datafusion::config::ConfigOptions;
+use datafusion::datasource::memory::DataSourceExec;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_datasource::memory::MemorySourceConfig;
+use datafusion_distributed::{TaskEstimation, TaskEstimator};
+
+/// Caps every `DataSourceExec(MemorySourceConfig)` leaf at task_count=1.
+///
+/// In pg_search the only call site that produces this exact pair is
+/// `memory_exec_for_cached` in `scan/table_provider.rs`, which materialises
+/// the all-gathered canonical replica of an MPP build subtree. Capping the
+/// leaf at 1 propagates up through `BroadcastExec` and tells
+/// `_distribute_plan` to build a `NetworkBroadcastExec` with
+/// `input_task_count = 1`.
+#[derive(Debug)]
+pub struct BroadcastBuildSideOneTaskEstimator;
+
+impl TaskEstimator for BroadcastBuildSideOneTaskEstimator {
+    fn task_estimation(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        _: &ConfigOptions,
+    ) -> Option<TaskEstimation> {
+        if !plan.children().is_empty() {
+            return None;
+        }
+        let exec = plan.as_any().downcast_ref::<DataSourceExec>()?;
+        if exec
+            .data_source()
+            .as_any()
+            .downcast_ref::<MemorySourceConfig>()
+            .is_some()
+        {
+            Some(TaskEstimation::maximum(1))
+        } else {
+            None
+        }
+    }
+
+    fn scale_up_leaf_node(
+        &self,
+        _: &Arc<dyn ExecutionPlan>,
+        _: usize,
+        _: &ConfigOptions,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::Int32Array;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::arrow::record_batch::RecordBatch;
+    use datafusion::physical_plan::empty::EmptyExec;
+
+    fn cfg() -> ConfigOptions {
+        ConfigOptions::default()
+    }
+
+    #[test]
+    fn memory_leaf_is_capped_at_one() {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1, 2, 3]))],
+        )
+        .expect("build batch");
+        let exec: Arc<dyn ExecutionPlan> =
+            MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None)
+                .expect("build MemoryExec");
+        let est = BroadcastBuildSideOneTaskEstimator;
+        let out = est.task_estimation(&exec, &cfg()).expect("estimation");
+        // `TaskEstimation::maximum(1)` is what propagates up to
+        // `NetworkBroadcastExec::input_task_count = 1`.
+        assert_eq!(out.task_count.as_usize(), 1);
+        // `task_count` is `Maximum`, not `Desired` — confirm the variant
+        // so an accidental refactor that promotes it to `Desired` (and
+        // therefore loses the "hard cap" behaviour) breaks the test.
+        assert!(matches!(
+            out.task_count,
+            datafusion_distributed::TaskCountAnnotation::Maximum(1)
+        ));
+    }
+
+    #[test]
+    fn non_memory_leaf_falls_through() {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let est = BroadcastBuildSideOneTaskEstimator;
+        assert!(est.task_estimation(&plan, &cfg()).is_none());
+    }
+
+    #[test]
+    fn scale_up_is_a_no_op() {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let batch = RecordBatch::try_new(
+            Arc::clone(&schema),
+            vec![Arc::new(Int32Array::from(vec![1]))],
+        )
+        .expect("build batch");
+        let exec: Arc<dyn ExecutionPlan> =
+            MemorySourceConfig::try_new_exec(&[vec![batch]], schema, None).expect("build");
+        let est = BroadcastBuildSideOneTaskEstimator;
+        assert!(est.scale_up_leaf_node(&exec, 7, &cfg()).is_none());
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -457,7 +457,7 @@ pub trait BatchChannelReceiver: Send {
 /// (`nowait=false`) touches `WaitLatch`/`CHECK_FOR_INTERRUPTS`, which is not
 /// safe off-thread. See [`crate::postgres::customscan::mpp::mesh::ShmMqSender`]
 /// for the safety contract.
-pub trait BatchChannelSender: Send {
+pub trait BatchChannelSender: Send + Sync {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError>;
 
     /// Non-blocking variant. Returns `Ok(true)` on success, `Ok(false)`
@@ -479,7 +479,12 @@ pub trait BatchChannelSender: Send {
 /// our drain pulls peer-shipped rows out of our inbound queues, which
 /// frees peers' outbound-to-us send space, which lets their sends un-stall.
 pub struct MppSender {
-    channel: Box<dyn BatchChannelSender>,
+    /// Underlying byte channel. Held behind `Arc` so multiple `MppSender`s
+    /// can share one `shm_mq` queue while tagging frames with different
+    /// `(stage_id, partition)` headers — the multiplexed path's natural
+    /// pattern. Clone the Arc, build a new `MppSender` with a different
+    /// header, both write into the same queue.
+    channel: Arc<dyn BatchChannelSender>,
     cooperative_drain: Option<Arc<DrainHandle>>,
     /// Frame header prepended to every outgoing batch. Identifies the logical
     /// `(stage_id, partition)` channel the receiver demultiplexes on. For the
@@ -513,9 +518,11 @@ unsafe impl Sync for MppSender {}
 
 impl MppSender {
     /// Construct a sender that tags every outgoing batch with `header`.
-    /// Production call sites build one `MppSender` per consumer partition and
-    /// pass `MppFrameHeader::batch(0, p)`.
-    pub fn with_header(channel: Box<dyn BatchChannelSender>, header: MppFrameHeader) -> Self {
+    /// Production call sites clone one shared `Arc<dyn BatchChannelSender>`
+    /// across N senders, each with a different `MppFrameHeader::batch(stage, p)`
+    /// — the multiplexed pattern for fanning multiple partitions over one
+    /// shm_mq queue.
+    pub fn with_header(channel: Arc<dyn BatchChannelSender>, header: MppFrameHeader) -> Self {
         Self {
             channel,
             cooperative_drain: None,
@@ -527,7 +534,7 @@ impl MppSender {
     /// Construct a sender with the default `(stage_id=0, partition=0)` header.
     /// Used by tests where the header carries no actionable routing info.
     #[cfg(test)]
-    pub fn new(channel: Box<dyn BatchChannelSender>) -> Self {
+    pub fn new(channel: Arc<dyn BatchChannelSender>) -> Self {
         Self::with_header(channel, MppFrameHeader::batch(0, 0))
     }
 
@@ -537,6 +544,19 @@ impl MppSender {
     #[allow(dead_code)]
     pub fn header(&self) -> MppFrameHeader {
         self.header
+    }
+
+    /// Build a new `MppSender` that shares this sender's underlying channel
+    /// but tags every frame with `header` instead. Used by callers that know
+    /// the physical plan's output partition count and need one sender per
+    /// partition, all multiplexed over the same shm_mq queue.
+    pub fn clone_with_header(&self, header: MppFrameHeader) -> Self {
+        Self {
+            channel: Arc::clone(&self.channel),
+            cooperative_drain: self.cooperative_drain.as_ref().map(Arc::clone),
+            header,
+            scratch: std::cell::RefCell::new(Vec::new()),
+        }
     }
 
     /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
@@ -1216,7 +1236,7 @@ mod tests {
     #[test]
     fn in_proc_channel_round_trips_through_mpp_sender_receiver() {
         let (tx, rx) = in_proc_channel(8);
-        let sender = MppSender::new(Box::new(tx));
+        let sender = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
 
         sender.send_batch(&sample_batch(4)).unwrap();
@@ -1235,7 +1255,7 @@ mod tests {
     #[test]
     fn drain_thread_drains_single_source() {
         let (tx, rx) = in_proc_channel(4);
-        let sender = MppSender::new(Box::new(tx));
+        let sender = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
 
@@ -1261,7 +1281,7 @@ mod tests {
     #[test]
     fn drain_handle_shutdown_joins_cleanly() {
         let (tx, rx) = in_proc_channel(4);
-        let sender = MppSender::new(Box::new(tx));
+        let sender = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
         let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
@@ -1282,7 +1302,7 @@ mod tests {
         // drop the handle. The Drop impl must cancel the buffer and join the
         // thread without hanging.
         let (tx, rx) = in_proc_channel(4);
-        let _sender_kept_alive = MppSender::new(Box::new(tx));
+        let _sender_kept_alive = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
         let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
@@ -1317,8 +1337,8 @@ mod tests {
         let buffer = DrainBuffer::new(2);
         let drain_join = spawn_drain_thread(DrainConfig::new(receivers, StdArc::clone(&buffer)));
 
-        let tx0_send = MppSender::new(Box::new(tx0));
-        let tx1_send = MppSender::new(Box::new(tx1));
+        let tx0_send = MppSender::new(Arc::new(tx0));
+        let tx1_send = MppSender::new(Arc::new(tx1));
         let batch_template = sample_batch(1);
 
         let p0 = {
@@ -1444,8 +1464,8 @@ mod tests {
         ];
         let buffer = DrainBuffer::new(2);
         let drain_join = spawn_drain_thread(DrainConfig::new(receivers, StdArc::clone(&buffer)));
-        let tx0_send = MppSender::new(Box::new(tx0));
-        let tx1_send = MppSender::new(Box::new(tx1));
+        let tx0_send = MppSender::new(Arc::new(tx0));
+        let tx1_send = MppSender::new(Arc::new(tx1));
 
         let per_source = batches / 2;
         let round_trip_start = Instant::now();

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -18,7 +18,13 @@
 //! Transport layer for MPP shuffle.
 //!
 //! Layout:
-//! - [`encode_batch`] / [`decode_batch`] serialize `RecordBatch` via Arrow IPC.
+//! - [`MppFrameHeader`] is a fixed 16-byte prefix every wire message carries.
+//!   It tags the payload with `(stage_id, partition)` so a single underlying
+//!   queue can multiplex frames for many logical channels — the foundation
+//!   the multi-stage natural-shape path needs.
+//! - [`encode_frame_into`] / [`decode_frame`] serialize a `RecordBatch` with a
+//!   header prefix via Arrow IPC. [`encode_batch`] / [`decode_batch`] are
+//!   test-only header-less wrappers retained for codec round-trip tests.
 //! - [`DrainBuffer`] is the local per-participant queue that the drain thread
 //!   writes into and the DataFusion consumer reads from. It decouples
 //!   consumer-side backpressure from producer-side backpressure: the drain thread
@@ -42,11 +48,124 @@ use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::common::DataFusionError;
 
-/// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message.
+/// Magic bytes "MPPF" (MPP Frame) at the start of every wire message.
+/// Lets receivers reject misrouted / corrupt frames before they hit Arrow IPC.
+pub const MPP_FRAME_MAGIC: u32 = 0x4D505046;
+
+/// Wire-format size of [`MppFrameHeader`] in bytes. Asserted at compile time
+/// below via `const _: ()`.
+pub const MPP_FRAME_HEADER_SIZE: usize = 16;
+
+/// Kind of payload following [`MppFrameHeader`].
 ///
-/// Test-only allocating wrapper for [`encode_batch_into`]; production hot paths
-/// reuse a scratch `Vec` so the ~500 KB/batch allocator traffic the 25M GROUP BY
-/// benchmark once spent 19 s on stays out of the critical loop.
+/// `Batch` is the common case — header is followed by an Arrow IPC stream
+/// containing one `RecordBatch`. `Eof` carries no payload and signals the
+/// receiver that the named `(stage_id, partition)` channel is finished, even
+/// though the underlying shm_mq queue may still carry frames for other
+/// channels.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MppFrameKind {
+    Batch = 0,
+    Eof = 1,
+}
+
+/// 16-byte prefix on every transport frame.
+///
+/// The fixed layout `[magic, flags, stage_id, partition]` (4×u32) is what
+/// senders prepend before the Arrow IPC stream bytes and what receivers parse
+/// before deciding which sub-buffer the payload belongs to. The `flags` field
+/// is reserved for future use beyond `MppFrameKind`; bit 0 carries the kind,
+/// bits 1..31 must be zero.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MppFrameHeader {
+    pub magic: u32,
+    pub flags: u32,
+    pub stage_id: u32,
+    pub partition: u32,
+}
+
+const _: () = {
+    // shm_mq slot layout calculations depend on this being exact.
+    assert!(std::mem::size_of::<MppFrameHeader>() == MPP_FRAME_HEADER_SIZE);
+};
+
+impl MppFrameHeader {
+    /// Build a `Batch` header for the given `(stage_id, partition)`.
+    pub fn batch(stage_id: u32, partition: u32) -> Self {
+        Self {
+            magic: MPP_FRAME_MAGIC,
+            flags: MppFrameKind::Batch as u32,
+            stage_id,
+            partition,
+        }
+    }
+
+    /// Build an `Eof` header for the given `(stage_id, partition)`. Carries no
+    /// payload; receivers route it to the sub-buffer's source-done counter.
+    /// Used by M1.c's multi-channel sender wiring; tests exercise it now.
+    #[allow(dead_code)]
+    pub fn eof(stage_id: u32, partition: u32) -> Self {
+        Self {
+            magic: MPP_FRAME_MAGIC,
+            flags: MppFrameKind::Eof as u32,
+            stage_id,
+            partition,
+        }
+    }
+
+    /// Read the kind out of `flags`. Returns an error if `flags` is unknown,
+    /// which catches wire-format drift early.
+    pub fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
+        match self.flags {
+            0 => Ok(MppFrameKind::Batch),
+            1 => Ok(MppFrameKind::Eof),
+            other => Err(DataFusionError::Internal(format!(
+                "mpp: unknown frame kind flags={other:#x}"
+            ))),
+        }
+    }
+
+    /// Serialize into the first `MPP_FRAME_HEADER_SIZE` bytes of `out`.
+    /// `out.len()` must be `>= MPP_FRAME_HEADER_SIZE`.
+    fn write_to(&self, out: &mut [u8]) {
+        debug_assert!(out.len() >= MPP_FRAME_HEADER_SIZE);
+        out[0..4].copy_from_slice(&self.magic.to_le_bytes());
+        out[4..8].copy_from_slice(&self.flags.to_le_bytes());
+        out[8..12].copy_from_slice(&self.stage_id.to_le_bytes());
+        out[12..16].copy_from_slice(&self.partition.to_le_bytes());
+    }
+
+    /// Parse from the first `MPP_FRAME_HEADER_SIZE` bytes of `bytes`. Returns
+    /// `Err` if the slice is too short or the magic doesn't match.
+    fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
+        if bytes.len() < MPP_FRAME_HEADER_SIZE {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: frame too short for header ({} < {})",
+                bytes.len(),
+                MPP_FRAME_HEADER_SIZE
+            )));
+        }
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        if magic != MPP_FRAME_MAGIC {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: bad frame magic {magic:#x} (expected {MPP_FRAME_MAGIC:#x})"
+            )));
+        }
+        Ok(Self {
+            magic,
+            flags: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+            stage_id: u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
+            partition: u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
+        })
+    }
+}
+
+/// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message,
+/// header-less. Test-only allocating wrapper retained for codec round-trip
+/// tests; production code paths go through [`encode_frame_into`] so the wire
+/// format always carries an [`MppFrameHeader`].
 #[cfg(test)]
 pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
     let mut buf = Vec::with_capacity(1024);
@@ -55,9 +174,11 @@ pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
 }
 
 /// Serialize `batch` into `buf`, clearing `buf` first so the caller's
-/// already-allocated capacity is reused. Caller is expected to hold `buf`
-/// alive across many encode calls (one per sender) so the peak-sized
-/// allocation amortizes.
+/// already-allocated capacity is reused. Header-less; production senders call
+/// [`encode_frame_into`] which inlines the same IPC stream after a header.
+/// Retained as a public helper for codec round-trip tests and external
+/// (header-less) consumers.
+#[allow(dead_code)]
 pub fn encode_batch_into(batch: &RecordBatch, buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
     buf.clear();
     let mut writer = StreamWriter::try_new(&mut *buf, batch.schema_ref())?;
@@ -66,13 +187,84 @@ pub fn encode_batch_into(batch: &RecordBatch, buf: &mut Vec<u8>) -> Result<(), D
     Ok(())
 }
 
-/// Inverse of [`encode_batch`]. Expects exactly one batch per message.
+/// Serialize `batch` into `buf` with a 16-byte [`MppFrameHeader`] prefix
+/// addressing it to `(stage_id, partition)`. Wire format:
+///
+/// ```text
+/// [ magic | flags | stage_id | partition ] [ Arrow IPC stream bytes ]
+/// |---------- 16 bytes --------|           |---- variable ----|
+/// ```
+///
+/// Caller is expected to hold `buf` alive across many encodes so the peak-sized
+/// allocation amortizes (~500 KB/batch on the 25M GROUP BY bench).
+pub fn encode_frame_into(
+    header: MppFrameHeader,
+    batch: &RecordBatch,
+    buf: &mut Vec<u8>,
+) -> Result<(), DataFusionError> {
+    buf.clear();
+    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
+    header.write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
+    let mut writer = StreamWriter::try_new(&mut *buf, batch.schema_ref())?;
+    writer.write(batch)?;
+    writer.finish()?;
+    Ok(())
+}
+
+/// Serialize a payload-less [`MppFrameKind::Eof`] frame for `(stage_id, partition)`
+/// into `buf`. The shm_mq peer reads this as a 16-byte message and routes it to
+/// the sub-buffer's source-done counter without touching Arrow IPC.
+/// Used by M1.c's multi-channel sender wiring; tests exercise it now.
+#[allow(dead_code)]
+pub fn encode_eof_frame_into(
+    stage_id: u32,
+    partition: u32,
+    buf: &mut Vec<u8>,
+) -> Result<(), DataFusionError> {
+    buf.clear();
+    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
+    MppFrameHeader::eof(stage_id, partition).write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
+    Ok(())
+}
+
+/// Inverse of [`encode_batch`]. Expects exactly one batch per message,
+/// header-less. Test-only.
+#[cfg(test)]
 pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusionError> {
     let mut reader = StreamReader::try_new(bytes, None)?;
     let batch = reader.next().ok_or_else(|| {
         DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_batch".into())
     })??;
     Ok(batch)
+}
+
+/// Inverse of [`encode_frame_into`]. Parses the 16-byte header and, for
+/// `Batch` frames, decodes the trailing Arrow IPC stream. `Eof` frames return
+/// `(header, None)` — receivers branch on `header.kind()` to decide routing.
+pub fn decode_frame(
+    bytes: &[u8],
+) -> Result<(MppFrameHeader, Option<RecordBatch>), DataFusionError> {
+    let header = MppFrameHeader::parse(bytes)?;
+    match header.kind()? {
+        MppFrameKind::Eof => {
+            if bytes.len() != MPP_FRAME_HEADER_SIZE {
+                return Err(DataFusionError::Internal(format!(
+                    "mpp: Eof frame carries payload ({} > {})",
+                    bytes.len(),
+                    MPP_FRAME_HEADER_SIZE
+                )));
+            }
+            Ok((header, None))
+        }
+        MppFrameKind::Batch => {
+            let payload = &bytes[MPP_FRAME_HEADER_SIZE..];
+            let mut reader = StreamReader::try_new(payload, None)?;
+            let batch = reader.next().ok_or_else(|| {
+                DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_frame".into())
+            })??;
+            Ok((header, Some(batch)))
+        }
+    }
 }
 
 /// Local queue that sits between the drain thread and the DataFusion consumer.
@@ -276,7 +468,16 @@ pub trait BatchChannelSender: Send {
 pub struct MppSender {
     channel: Box<dyn BatchChannelSender>,
     cooperative_drain: Option<Arc<DrainHandle>>,
-    /// Scratch buffer reused across every `encode_batch_into` on this
+    /// Frame header prepended to every outgoing batch. Identifies the logical
+    /// `(stage_id, partition)` channel the receiver demultiplexes on. For the
+    /// current single-stage architecture this is `(stage_id=0, partition=p)`
+    /// where `p` is the consumer-side partition this sender feeds. The header
+    /// is per-sender for now so existing call sites don't have to thread
+    /// `(stage_id, partition)` through every `send_batch_traced`; once
+    /// multiplexed senders carry multiple `(stage_id, partition)` channels
+    /// over a single shm_mq queue, the header moves to a per-call argument.
+    header: MppFrameHeader,
+    /// Scratch buffer reused across every `encode_frame_into` on this
     /// sender. Sized by the first batch; subsequent batches clear and
     /// re-fill without reallocating. Interior mutability lets the caller
     /// keep the `&self` signature (senders live inside `ShuffleWiring`
@@ -298,12 +499,30 @@ pub struct MppSender {
 unsafe impl Sync for MppSender {}
 
 impl MppSender {
-    pub fn new(channel: Box<dyn BatchChannelSender>) -> Self {
+    /// Construct a sender that tags every outgoing batch with `header`.
+    /// Production call sites build one `MppSender` per consumer partition and
+    /// pass `MppFrameHeader::batch(0, p)`.
+    pub fn with_header(channel: Box<dyn BatchChannelSender>, header: MppFrameHeader) -> Self {
         Self {
             channel,
             cooperative_drain: None,
+            header,
             scratch: std::cell::RefCell::new(Vec::new()),
         }
+    }
+
+    /// Construct a sender with the default `(stage_id=0, partition=0)` header.
+    /// Used by tests where the header carries no actionable routing info.
+    #[cfg(test)]
+    pub fn new(channel: Box<dyn BatchChannelSender>) -> Self {
+        Self::with_header(channel, MppFrameHeader::batch(0, 0))
+    }
+
+    /// Frame header this sender stamps onto every outgoing batch.
+    /// Consumed by M1.c's multi-channel sender wiring (DEAD until then).
+    #[allow(dead_code)]
+    pub fn header(&self) -> MppFrameHeader {
+        self.header
     }
 
     /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
@@ -357,7 +576,7 @@ impl MppSender {
         stats: &mut SendBatchStats,
     ) -> Result<(), DataFusionError> {
         let t_enc = Instant::now();
-        encode_batch_into(batch, scratch)?;
+        encode_frame_into(self.header, batch, scratch)?;
         stats.encode += t_enc.elapsed();
         let Some(drain) = self.cooperative_drain.as_ref() else {
             // No drain attached (unit tests, in-proc channels): fall
@@ -450,8 +669,9 @@ impl MppReceiver {
 
     pub fn try_recv_batch(&self) -> RecvBatchOutcome {
         match self.channel.try_recv() {
-            RecvOutcome::Bytes(bytes) => match decode_batch(&bytes) {
-                Ok(batch) => RecvBatchOutcome::Batch(batch),
+            RecvOutcome::Bytes(bytes) => match decode_frame(&bytes) {
+                Ok((header, Some(batch))) => RecvBatchOutcome::Batch { header, batch },
+                Ok((header, None)) => RecvBatchOutcome::Eof { header },
                 Err(e) => RecvBatchOutcome::Error(e),
             },
             RecvOutcome::Empty => RecvBatchOutcome::Empty,
@@ -460,10 +680,28 @@ impl MppReceiver {
     }
 }
 
-/// Decoded result of an [`MppReceiver::try_recv_batch`].
+/// Decoded result of an [`MppReceiver::try_recv_batch`]. Carries the parsed
+/// [`MppFrameHeader`] so the drain thread can route the payload to the right
+/// `(stage_id, partition)` sub-buffer once multi-stage multiplexing lands.
+/// Today's positional design ignores `header` because there is exactly one
+/// channel per queue; M1.c starts consuming the field for routing.
 #[derive(Debug)]
 pub enum RecvBatchOutcome {
-    Batch(RecordBatch),
+    Batch {
+        // Consumed by M1.c's per-(stage_id, partition) demux.
+        #[allow(dead_code)]
+        header: MppFrameHeader,
+        batch: RecordBatch,
+    },
+    /// A payload-less `Eof` frame for `header.(stage_id, partition)`. The
+    /// underlying shm_mq queue is still attached; the sender is announcing
+    /// that this logical channel is done. Used by the multiplexed design to
+    /// per-channel-EOF without dropping the whole queue.
+    Eof {
+        // Consumed by M1.c's per-(stage_id, partition) demux.
+        #[allow(dead_code)]
+        header: MppFrameHeader,
+    },
     Empty,
     Detached,
     Error(DataFusionError),
@@ -612,8 +850,22 @@ impl DrainHandle {
             };
             for _ in 0..MAX_BATCHES_PER_SOURCE_PER_PASS {
                 match rx.try_recv_batch() {
-                    RecvBatchOutcome::Batch(b) => {
-                        self.buffer.push_batch(b);
+                    RecvBatchOutcome::Batch { header: _, batch } => {
+                        // Single-channel positional design: every frame on
+                        // this queue belongs to the one channel this drain
+                        // serves, so the header tag is informational. The
+                        // multiplexed path (M1.c) will route per-header.
+                        self.buffer.push_batch(batch);
+                    }
+                    RecvBatchOutcome::Eof { header: _ } => {
+                        // Per-channel Eof frames are produced by senders that
+                        // host multiple channels on one queue. The current
+                        // single-channel positional design never sees them;
+                        // when it does (M1.c+), the routing logic moves here.
+                        // For now, treat as source-done.
+                        *slot = None;
+                        self.buffer.notify_source_done();
+                        break;
                     }
                     RecvBatchOutcome::Empty => break,
                     RecvBatchOutcome::Detached => {
@@ -691,9 +943,15 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
             }
             all_done = false;
             match rx.try_recv_batch() {
-                RecvBatchOutcome::Batch(batch) => {
+                RecvBatchOutcome::Batch { header: _, batch } => {
                     got_any = true;
                     buffer.push_batch(batch);
+                }
+                RecvBatchOutcome::Eof { header: _ } => {
+                    // Per-channel Eof frame: single-channel positional design
+                    // treats it as a source-done signal. See `poll_drain_pass`.
+                    done[i] = true;
+                    buffer.notify_source_done();
                 }
                 RecvBatchOutcome::Empty => {}
                 RecvBatchOutcome::Detached => {
@@ -797,6 +1055,75 @@ mod tests {
     }
 
     #[test]
+    fn frame_round_trips_a_batch_with_header() {
+        let orig = sample_batch(64);
+        let header = MppFrameHeader::batch(7, 3);
+        let mut buf = Vec::with_capacity(1024);
+        encode_frame_into(header, &orig, &mut buf).expect("encode_frame");
+
+        let (parsed, batch_opt) = decode_frame(&buf).expect("decode_frame");
+        assert_eq!(parsed, header);
+        assert_eq!(parsed.kind().unwrap(), MppFrameKind::Batch);
+        let batch = batch_opt.expect("Batch frame must carry a payload");
+        assert_eq!(batch.num_rows(), 64);
+        assert_eq!(batch.schema(), orig.schema());
+    }
+
+    #[test]
+    fn frame_round_trips_eof() {
+        let mut buf = Vec::new();
+        encode_eof_frame_into(2, 5, &mut buf).expect("encode_eof");
+        assert_eq!(buf.len(), MPP_FRAME_HEADER_SIZE);
+
+        let (header, batch_opt) = decode_frame(&buf).expect("decode_frame");
+        assert_eq!(header, MppFrameHeader::eof(2, 5));
+        assert_eq!(header.kind().unwrap(), MppFrameKind::Eof);
+        assert!(batch_opt.is_none());
+    }
+
+    #[test]
+    fn frame_rejects_short_message() {
+        let too_short = vec![0u8; MPP_FRAME_HEADER_SIZE - 1];
+        let err = decode_frame(&too_short).expect_err("short frame must fail");
+        assert!(format!("{err}").contains("too short"));
+    }
+
+    #[test]
+    fn frame_rejects_bad_magic() {
+        let mut bad = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        // Magic is the first 4 bytes; zeroing them is enough.
+        let err = decode_frame(&bad).expect_err("bad magic must fail");
+        assert!(format!("{err}").contains("bad frame magic"));
+        // And a non-zero garbage prefix also fails.
+        bad[0..4].copy_from_slice(&0xDEADBEEF_u32.to_le_bytes());
+        let err = decode_frame(&bad).expect_err("bad magic must fail");
+        assert!(format!("{err}").contains("bad frame magic"));
+    }
+
+    #[test]
+    fn frame_rejects_unknown_kind() {
+        let header = MppFrameHeader {
+            magic: MPP_FRAME_MAGIC,
+            flags: 0xFFFF_FFFF,
+            stage_id: 0,
+            partition: 0,
+        };
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        let err = decode_frame(&buf).expect_err("unknown kind must fail");
+        assert!(format!("{err}").contains("unknown frame kind"));
+    }
+
+    #[test]
+    fn frame_eof_with_payload_is_rejected() {
+        let mut buf = Vec::with_capacity(32);
+        encode_eof_frame_into(0, 0, &mut buf).expect("encode_eof");
+        buf.push(0xAB); // smuggle a payload byte after the Eof header
+        let err = decode_frame(&buf).expect_err("Eof+payload must fail");
+        assert!(format!("{err}").contains("Eof frame carries payload"));
+    }
+
+    #[test]
     fn codec_round_trips_many_batch_sizes() {
         for rows in [0, 1, 7, 64, 1024] {
             let orig = sample_batch(rows);
@@ -866,7 +1193,7 @@ mod tests {
         std::mem::drop(sender);
 
         match receiver.try_recv_batch() {
-            RecvBatchOutcome::Batch(b) => assert_eq!(b.num_rows(), 4),
+            RecvBatchOutcome::Batch { header: _, batch } => assert_eq!(batch.num_rows(), 4),
             other => panic!("expected batch, got {other:?}"),
         }
         assert!(matches!(

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -226,8 +226,10 @@ pub fn encode_frame_into(
 /// Serialize a payload-less [`MppFrameKind::Eof`] frame for `(stage_id, partition)`
 /// into `buf`. The shm_mq peer reads this as a 16-byte message and routes it to
 /// the sub-buffer's source-done counter without touching Arrow IPC.
-/// Consumed by M2's per-channel EOF signalling; exercised in tests today.
-#[allow(dead_code)]
+/// Consumed by [`MppSender::send_eof_traced`] when a producer fragment's
+/// per-partition stream exhausts, so the receiver's `(stage_id, partition)`
+/// sub-buffer transitions to `Eof` even though the multiplexed shm_mq queue
+/// stays attached for other channels.
 pub fn encode_eof_frame_into(
     stage_id: u32,
     partition: u32,
@@ -619,6 +621,58 @@ impl MppSender {
         let result = self.send_with_scratch(batch, &mut scratch, stats).await;
         self.scratch.replace(scratch);
         result
+    }
+
+    /// Send a payload-less [`MppFrameKind::Eof`] frame so the receiver's
+    /// `(stage_id, partition)` sub-buffer transitions to `Eof` and the
+    /// consumer's pull loop terminates cleanly.
+    ///
+    /// Producer fragments must call this exactly once per
+    /// `(stage_id, partition)` channel after the local stream exhausts.
+    /// Without it the multiplexed shm_mq queue stays attached (other
+    /// channels still flow) and the consumer sub-buffer never reaches
+    /// `sources_done == 1`. The receive-side
+    /// [`DrainHandle::poll_drain_pass`] decodes the frame and calls
+    /// `notify_source_done` on the matching sub-buffer.
+    ///
+    /// Uses the same cooperative-spin path as
+    /// [`Self::send_batch_traced`] so a full outbound queue doesn't
+    /// deadlock the EOF send. `stats.spin_iters` / `send_wait` capture
+    /// any contention.
+    pub async fn send_eof_traced(&self, stats: &mut SendBatchStats) -> Result<(), DataFusionError> {
+        let mut scratch = self.scratch.replace(Vec::new());
+        let result = self.send_eof_with_scratch(&mut scratch, stats).await;
+        self.scratch.replace(scratch);
+        result
+    }
+
+    async fn send_eof_with_scratch(
+        &self,
+        scratch: &mut Vec<u8>,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
+        encode_eof_frame_into(self.header.stage_id, self.header.partition, scratch)?;
+        let Some(drain) = self.cooperative_drain.as_ref() else {
+            return self.channel.send_bytes(scratch);
+        };
+        let mut first_try = true;
+        let t_wait_start = Instant::now();
+        loop {
+            #[cfg(not(test))]
+            pgrx::check_for_interrupts!();
+            if self.channel.try_send_bytes(scratch)? {
+                if !first_try {
+                    stats.send_wait += t_wait_start.elapsed();
+                }
+                return Ok(());
+            }
+            first_try = false;
+            stats.spin_iters += 1;
+            let t_drain = Instant::now();
+            drain.poll_drain_pass()?;
+            stats.coop_drain_in_spin += t_drain.elapsed();
+            tokio::task::yield_now().await;
+        }
     }
 
     async fn send_with_scratch(

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -462,12 +462,27 @@ pub trait BatchChannelSender: Send + Sync {
     }
 }
 
+/// Pluggable "drain everything inbound" hook for [`MppSender`]'s cooperative
+/// send spin. The peer-mesh deadlock-breaking pattern needs the producer to
+/// pump ALL inbound queues (not just one) while waiting for a full outbound,
+/// so the implementation typically delegates to
+/// `MppMesh::drain_all_inbound()` which iterates every per-sender-proc drain.
+pub trait CooperativeDrainSet: Send + Sync {
+    fn poll_drain_pass(&self) -> Result<(), DataFusionError>;
+}
+
+impl CooperativeDrainSet for DrainHandle {
+    fn poll_drain_pass(&self) -> Result<(), DataFusionError> {
+        DrainHandle::poll_drain_pass(self)
+    }
+}
+
 /// High-level sender: encodes a `RecordBatch` then pushes bytes through the
 /// underlying channel.
 ///
 /// With `cooperative_drain` set, `send_batch` breaks the symmetric-send
 /// deadlock on a single-threaded tokio runtime by interleaving send-retries
-/// with `DrainHandle::try_drain_pass` on the same mesh's inbound side.
+/// with `CooperativeDrainSet::try_drain_pass` on the same mesh's inbound side.
 /// Each participant's sender doing the same guarantees mutual progress:
 /// our drain pulls peer-shipped rows out of our inbound queues, which
 /// frees peers' outbound-to-us send space, which lets their sends un-stall.
@@ -478,7 +493,7 @@ pub struct MppSender {
     /// pattern. Clone the Arc, build a new `MppSender` with a different
     /// header, both write into the same queue.
     channel: Arc<dyn BatchChannelSender>,
-    cooperative_drain: Option<Arc<DrainHandle>>,
+    cooperative_drain: Option<Arc<dyn CooperativeDrainSet>>,
     /// Frame header prepended to every outgoing batch. Identifies the logical
     /// `(stage_id, partition)` channel the receiver demultiplexes on. For the
     /// current single-stage architecture this is `(stage_id=0, partition=p)`
@@ -550,6 +565,16 @@ impl MppSender {
             header,
             scratch: std::cell::RefCell::new(Vec::new()),
         }
+    }
+
+    /// Attach a [`CooperativeDrainSet`] so [`Self::send_batch_traced`]'s spin
+    /// can drain inbound peer traffic while waiting for outbound space.
+    /// Required for peer-mesh fragments where every worker is both sender and
+    /// consumer; without it, symmetric full-queue stalls deadlock the
+    /// single-threaded Tokio runtime.
+    pub fn with_cooperative_drain(mut self, drain: Arc<dyn CooperativeDrainSet>) -> Self {
+        self.cooperative_drain = Some(drain);
+        self
     }
 
     /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
@@ -1124,21 +1149,31 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
     }
 }
 
-/// SPSC channel pair for unit tests and in-process single-worker validation.
-/// Bounded capacity via `std::sync::mpsc::sync_channel` so tests can exercise
-/// backpressure (`send` blocks when full).
-#[cfg(test)]
+/// SPSC channel pair for two use cases:
+/// - Unit tests (bounded capacity, exercising backpressure).
+/// - Production self-loop slots: when a worker's fragment emits a partition
+///   destined for its OWN proc (e.g. peer-mesh hash routing where consumer
+///   task t lands on the same worker as producer task t), the shm_mq grid
+///   leaves the `slot(this_proc, this_proc)` diagonal unattached. M2.d's
+///   dispatcher routes those self-loops through this in-proc channel
+///   instead, sharing the same `BatchChannelSender`/`BatchChannelReceiver`
+///   abstraction as shm_mq so the drain / sub-buffer registry needs no
+///   special-case for them.
+///
+/// Production callers pass a very large `capacity` (so the channel is
+/// effectively unbounded under steady state) — the current-thread Tokio
+/// runtime interleaves producer and consumer fragments via
+/// `yield_now().await`, so backpressure would be benign, but unbounded
+/// avoids any chance of a self-deadlock if the producer never yields.
 pub fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
     (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
 }
 
-#[cfg(test)]
 pub struct InProcSender {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
 }
 
-#[cfg(test)]
 pub struct InProcReceiver {
     // The std::sync::mpsc receiver is !Sync; wrap in a Mutex so the drain
     // thread can hold it behind a `Box<dyn BatchChannelReceiver>` (which is
@@ -1148,16 +1183,24 @@ pub struct InProcReceiver {
     rx: Mutex<std::sync::mpsc::Receiver<Vec<u8>>>,
 }
 
-#[cfg(test)]
 impl BatchChannelSender for InProcSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
         self.tx.send(bytes.to_vec()).map_err(|_| {
             DataFusionError::Execution("mpp: in-proc channel detached during send".into())
         })
     }
+
+    fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
+        match self.tx.try_send(bytes.to_vec()) {
+            Ok(()) => Ok(true),
+            Err(std::sync::mpsc::TrySendError::Full(_)) => Ok(false),
+            Err(std::sync::mpsc::TrySendError::Disconnected(_)) => Err(DataFusionError::Execution(
+                "mpp: in-proc channel detached during try_send".into(),
+            )),
+        }
+    }
 }
 
-#[cfg(test)]
 impl BatchChannelReceiver for InProcReceiver {
     fn try_recv(&self) -> RecvOutcome {
         let rx = self.rx.lock().expect("InProcReceiver mutex poisoned");
@@ -1168,6 +1211,13 @@ impl BatchChannelReceiver for InProcReceiver {
         }
     }
 }
+
+/// Effectively unbounded capacity for self-loop in-proc channels. The
+/// `std::sync::mpsc::sync_channel` API requires a numeric capacity; this
+/// constant picks one large enough that production workloads won't reach
+/// it but small enough that a runaway producer (e.g. infinite-loop bug)
+/// won't allocate billions of `Vec<u8>` before OOM.
+pub const SELF_LOOP_CAPACITY: usize = 1 << 20;
 
 #[cfg(test)]
 mod tests {

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -73,10 +73,13 @@ pub enum MppFrameKind {
 /// 16-byte prefix on every transport frame.
 ///
 /// The fixed layout `[magic, flags, stage_id, partition]` (4×u32) is what
-/// senders prepend before the Arrow IPC stream bytes and what receivers parse
-/// before deciding which sub-buffer the payload belongs to. The `flags` field
-/// is reserved for future use beyond `MppFrameKind`; bit 0 carries the kind,
-/// bits 1..31 must be zero.
+/// senders prepend before the Arrow IPC stream bytes and what receivers
+/// parse before deciding which sub-buffer the payload belongs to.
+///
+/// The `flags` word currently encodes `MppFrameKind` in its low byte (mask
+/// `0x0000_00FF`); the upper 24 bits are reserved-must-be-zero and are
+/// validated at parse time so a future use can repurpose them without a
+/// wire-format break.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MppFrameHeader {
@@ -85,6 +88,9 @@ pub struct MppFrameHeader {
     pub stage_id: u32,
     pub partition: u32,
 }
+
+/// Bit mask in [`MppFrameHeader::flags`] for the [`MppFrameKind`] discriminant.
+const FRAME_KIND_MASK: u32 = 0x0000_00FF;
 
 const _: () = {
     // shm_mq slot layout calculations depend on this being exact.
@@ -104,7 +110,7 @@ impl MppFrameHeader {
 
     /// Build an `Eof` header for the given `(stage_id, partition)`. Carries no
     /// payload; receivers route it to the sub-buffer's source-done counter.
-    /// Used by M1.c's multi-channel sender wiring; tests exercise it now.
+    /// Consumed by M2's per-channel EOF signalling; exercised in tests today.
     #[allow(dead_code)]
     pub fn eof(stage_id: u32, partition: u32) -> Self {
         Self {
@@ -115,14 +121,21 @@ impl MppFrameHeader {
         }
     }
 
-    /// Read the kind out of `flags`. Returns an error if `flags` is unknown,
-    /// which catches wire-format drift early.
+    /// Read the kind out of `flags`. Returns an error if the kind byte is
+    /// unknown or if any reserved upper bit is set, which catches wire-format
+    /// drift early.
     pub fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
-        match self.flags {
+        let reserved = self.flags & !FRAME_KIND_MASK;
+        if reserved != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: reserved frame flag bits set ({reserved:#x})"
+            )));
+        }
+        match self.flags & FRAME_KIND_MASK {
             0 => Ok(MppFrameKind::Batch),
             1 => Ok(MppFrameKind::Eof),
             other => Err(DataFusionError::Internal(format!(
-                "mpp: unknown frame kind flags={other:#x}"
+                "mpp: unknown frame kind {other:#x}"
             ))),
         }
     }
@@ -214,7 +227,7 @@ pub fn encode_frame_into(
 /// Serialize a payload-less [`MppFrameKind::Eof`] frame for `(stage_id, partition)`
 /// into `buf`. The shm_mq peer reads this as a 16-byte message and routes it to
 /// the sub-buffer's source-done counter without touching Arrow IPC.
-/// Used by M1.c's multi-channel sender wiring; tests exercise it now.
+/// Consumed by M2's per-channel EOF signalling; exercised in tests today.
 #[allow(dead_code)]
 pub fn encode_eof_frame_into(
     stage_id: u32,
@@ -519,7 +532,8 @@ impl MppSender {
     }
 
     /// Frame header this sender stamps onto every outgoing batch.
-    /// Consumed by M1.c's multi-channel sender wiring (DEAD until then).
+    /// Consumed by M2's per-channel sender pool when sender per-call
+    /// re-tagging lands; today this getter is for diagnostics only.
     #[allow(dead_code)]
     pub fn header(&self) -> MppFrameHeader {
         self.header
@@ -1104,7 +1118,7 @@ mod tests {
     fn frame_rejects_unknown_kind() {
         let header = MppFrameHeader {
             magic: MPP_FRAME_MAGIC,
-            flags: 0xFFFF_FFFF,
+            flags: 0x42, // unknown kind byte, no reserved bits set
             stage_id: 0,
             partition: 0,
         };
@@ -1112,6 +1126,22 @@ mod tests {
         header.write_to(&mut buf);
         let err = decode_frame(&buf).expect_err("unknown kind must fail");
         assert!(format!("{err}").contains("unknown frame kind"));
+    }
+
+    #[test]
+    fn frame_rejects_reserved_flag_bits() {
+        // Any bit above the low byte of `flags` is reserved-must-be-zero;
+        // setting one should trip `kind()` before the kind byte is consulted.
+        let header = MppFrameHeader {
+            magic: MPP_FRAME_MAGIC,
+            flags: 0x0000_0100, // bit 8 set, kind byte 0 (would be Batch)
+            stage_id: 0,
+            partition: 0,
+        };
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        let err = decode_frame(&buf).expect_err("reserved bit must fail");
+        assert!(format!("{err}").contains("reserved frame flag bits"));
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -639,6 +639,15 @@ impl MppSender {
     /// [`Self::send_batch_traced`] so a full outbound queue doesn't
     /// deadlock the EOF send. `stats.spin_iters` / `send_wait` capture
     /// any contention.
+    ///
+    /// Symmetric-EOF safety: when every peer reaches EOF simultaneously
+    /// with full outbound queues, each peer's cooperative
+    /// [`CooperativeDrainSet::poll_drain_pass`] inside the spin pulls
+    /// peer-sent frames out of its own inbound queues, freeing space
+    /// the peers are blocked on. Progress is monotone — at least one
+    /// `try_send_bytes` succeeds per spin iteration somewhere in the
+    /// mesh, so symmetric stalls resolve within a few iterations
+    /// rather than deadlocking.
     pub async fn send_eof_traced(&self, stats: &mut SendBatchStats) -> Result<(), DataFusionError> {
         let mut scratch = self.scratch.replace(Vec::new());
         let result = self.send_eof_with_scratch(&mut scratch, stats).await;

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -35,7 +35,7 @@
 //! The shm_mq-backed sender/receiver and drain thread spawn logic build on
 //! top of these primitives.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::task::Waker;
 #[cfg(test)]
@@ -781,20 +781,50 @@ pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusi
     thread::spawn(move || drain_loop(config))
 }
 
-/// RAII wrapper around a drain thread's `JoinHandle` and its `DrainBuffer`.
+/// Per-`(stage_id, partition)` sub-buffer registry owned by a cooperative
+/// [`DrainHandle`]. The handle serves one sender_proc — that proc's shm_mq
+/// queue carries frames for many logical channels, each tagged by the
+/// [`MppFrameHeader`] prefix. `try_drain_pass` looks up the right sub-buffer
+/// on every frame and pushes the payload into it, so consumers waiting on
+/// `(stage_id=s, partition=p)` see only frames matching that key.
 ///
-/// On drop, the handle cancels the buffer (unblocking the drain thread if it
-/// is sleeping on an empty cycle) and joins the thread. This guarantees the
-/// drain thread never outlives the query's DSM segment — if `ExecEndCustomScan`
-/// panics after dropping the handle, the thread has already been torn down
-/// and cannot touch the freed shm_mq memory.
+/// Each entry is a `DrainBuffer::new(1)` because exactly one source (the
+/// sender_proc this handle serves) emits frames for any given channel via
+/// this drain. When the sender_proc detaches (`Detached` outcome on the
+/// underlying receiver) `detached` flips to `true` and every existing
+/// sub-buffer is notified — any consumer blocked on `try_pop` unblocks with
+/// `DrainItem::Eof`. Sub-buffers registered *after* detach come back
+/// already EOF'd so a late consumer doesn't hang.
+#[derive(Default)]
+struct SubBufferRegistry {
+    map: HashMap<(u32, u32), Arc<DrainBuffer>>,
+    detached: bool,
+}
+
+/// RAII wrapper around a drain thread's `JoinHandle` and a
+/// per-`(stage_id, partition)` sub-buffer registry.
+///
+/// On drop, the handle cancels every sub-buffer (unblocking any waiting
+/// consumer) and joins the test-only thread if one is attached. This
+/// guarantees the drain thread never outlives the query's DSM segment — if
+/// `ExecEndCustomScan` panics after dropping the handle, the thread has
+/// already been torn down and cannot touch the freed shm_mq memory.
 ///
 /// Review finding: the prior implementation's `JoinHandle` was hanging off
 /// free-form execution state, so an error path that skipped manual cleanup
 /// left a zombie drain thread alive with dangling DSM pointers. Enforcing
 /// cancel+join via Drop closes that window.
 pub struct DrainHandle {
-    buffer: Arc<DrainBuffer>,
+    /// Cooperative variant's per-(stage_id, partition) sub-buffer registry.
+    /// Populated lazily on first frame for a channel, or up-front by callers
+    /// (e.g. `WorkerConnection::stream_partition`) that need a buffer to
+    /// wait on before any frame arrives.
+    sub_buffers: Mutex<SubBufferRegistry>,
+    /// Thread-backed (test-only) variant's single shared buffer. The
+    /// `drain_loop` writes to it directly; tests read via `Arc::clone` of
+    /// the same buffer they constructed in `DrainConfig`. The cooperative
+    /// path keeps this `None` and routes everything through `sub_buffers`.
+    legacy_buffer: Option<Arc<DrainBuffer>>,
     /// Background-thread variant: `Some(JoinHandle)`. In-proc tests still use
     /// this path — their `InProcReceiver` is an `std::sync::mpsc` wrapper, not
     /// a pg FFI call, so the drain thread is safe. Wrapped in `Mutex` so
@@ -826,7 +856,8 @@ impl DrainHandle {
         let buffer = Arc::clone(&config.buffer);
         let join = spawn_drain_thread(config);
         Self {
-            buffer,
+            sub_buffers: Mutex::new(SubBufferRegistry::default()),
+            legacy_buffer: Some(buffer),
             join: Mutex::new(Some(join)),
             coop_receivers: Mutex::new(None),
         }
@@ -837,16 +868,81 @@ impl DrainHandle {
     /// [`Self::try_drain_pass`]). No background thread. This is the correct
     /// variant for production pg backend workers — the drain work runs on
     /// the backend thread, so any pg FFI inside `shm_mq_receive` is safe.
-    pub fn cooperative(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
+    ///
+    /// Sub-buffers are populated lazily by `try_drain_pass` when a frame
+    /// arrives, or up-front by [`Self::register_channel`] when a consumer
+    /// needs a buffer to wait on before any frame has come in.
+    pub fn cooperative(receivers: Vec<MppReceiver>) -> Self {
         let wrapped = receivers.into_iter().map(Some).collect();
         Self {
-            buffer,
+            sub_buffers: Mutex::new(SubBufferRegistry::default()),
+            legacy_buffer: None,
             join: Mutex::new(None),
             coop_receivers: Mutex::new(Some(wrapped)),
         }
     }
 
-    /// Pull batches from each live receiver into the buffer. Called from
+    /// Register (or look up) the sub-buffer for `(stage_id, partition)`. The
+    /// returned `Arc<DrainBuffer>` is the canonical destination for frames
+    /// matching that key: `try_drain_pass` pushes into the same entry on
+    /// every `Batch { header, .. }` whose header matches.
+    ///
+    /// If the drain has already observed `Detached` from its underlying
+    /// receiver, the newly-created buffer comes back with `notify_source_done`
+    /// already called so a consumer registering after detach sees `Eof` on
+    /// the first `try_pop` instead of hanging forever.
+    pub fn register_channel(&self, stage_id: u32, partition: u32) -> Arc<DrainBuffer> {
+        let mut guard = self
+            .sub_buffers
+            .lock()
+            .expect("DrainHandle sub_buffers mutex poisoned");
+        let detached = guard.detached;
+        guard
+            .map
+            .entry((stage_id, partition))
+            .or_insert_with(|| {
+                let buf = DrainBuffer::new(1);
+                if detached {
+                    buf.notify_source_done();
+                }
+                buf
+            })
+            .clone()
+    }
+
+    /// Mark the drain as detached and `notify_source_done` every registered
+    /// sub-buffer. Idempotent. Used by `try_drain_pass` after `Detached` /
+    /// `Error` outcomes; also called from `Drop` for the cooperative path so
+    /// any consumer blocked on `try_pop` unblocks with `Eof` even if the
+    /// query is torn down before EOF frames flow.
+    fn mark_detached(&self) {
+        let mut guard = self
+            .sub_buffers
+            .lock()
+            .expect("DrainHandle sub_buffers mutex poisoned");
+        if guard.detached {
+            return;
+        }
+        guard.detached = true;
+        for buf in guard.map.values() {
+            buf.notify_source_done();
+        }
+    }
+
+    /// Cancel every registered sub-buffer. Called from `Drop` to unblock any
+    /// consumer waiting on a sub-buffer when the handle goes away mid-query.
+    fn cancel_sub_buffers(&self) {
+        let guard = self
+            .sub_buffers
+            .lock()
+            .expect("DrainHandle sub_buffers mutex poisoned");
+        for buf in guard.map.values() {
+            buf.cancel();
+        }
+    }
+
+    /// Pull batches from each live receiver and demux them into the
+    /// per-`(stage_id, partition)` sub-buffer registry. Called from
     /// `DrainGatherStream::poll_next` and from `MppSender::send_batch`'s
     /// cooperative spin — drain work happens on the backend thread
     /// (pgrx-safe). No-op for thread-backed handles.
@@ -866,6 +962,15 @@ impl DrainHandle {
     /// `try_send_bytes` regardless of drain progress), so the return is now
     /// just `Result<()>` so transport errors propagate instead of being
     /// silently dropped at the call site.
+    ///
+    /// Routing rules per outcome:
+    /// - `Batch { header, batch }`: look up (or lazily create) the
+    ///   `(header.stage_id, header.partition)` sub-buffer and push `batch`.
+    /// - `Eof { header }`: per-channel EOF. Resolve the sub-buffer and call
+    ///   `notify_source_done`. Other channels on the same queue keep flowing,
+    ///   so the receiver slot stays live.
+    /// - `Detached` / `Error`: queue-wide shutdown. Notify every registered
+    ///   sub-buffer, mark the handle detached, and drop the slot.
     pub fn try_drain_pass(&self) -> Result<(), DataFusionError> {
         // Bound per-source pulls per call. The upper limit exists to give
         // the caller a chance to re-try its own send between drains —
@@ -884,44 +989,31 @@ impl DrainHandle {
             };
             for _ in 0..MAX_BATCHES_PER_SOURCE_PER_PASS {
                 match rx.try_recv_batch() {
-                    RecvBatchOutcome::Batch { header: _, batch } => {
-                        // Single-channel positional design: every frame on
-                        // this queue belongs to the one channel this drain
-                        // serves, so the header tag is informational. The
-                        // multiplexed path (M1.c) will route per-header.
-                        self.buffer.push_batch(batch);
+                    RecvBatchOutcome::Batch { header, batch } => {
+                        let buf = self.register_channel(header.stage_id, header.partition);
+                        buf.push_batch(batch);
                     }
-                    RecvBatchOutcome::Eof { header: _ } => {
-                        // Per-channel Eof frames are produced by senders that
-                        // host multiple channels on one queue. The current
-                        // single-channel positional design never sees them;
-                        // when it does (M1.c+), the routing logic moves here.
-                        // For now, treat as source-done.
-                        *slot = None;
-                        self.buffer.notify_source_done();
-                        break;
+                    RecvBatchOutcome::Eof { header } => {
+                        let buf = self.register_channel(header.stage_id, header.partition);
+                        buf.notify_source_done();
+                        // Other channels may still flow on this queue, so
+                        // the receiver slot stays live.
                     }
                     RecvBatchOutcome::Empty => break,
                     RecvBatchOutcome::Detached => {
                         *slot = None;
-                        self.buffer.notify_source_done();
+                        self.mark_detached();
                         break;
                     }
                     RecvBatchOutcome::Error(e) => {
                         *slot = None;
-                        self.buffer.notify_source_done();
+                        self.mark_detached();
                         return Err(e);
                     }
                 }
             }
         }
         Ok(())
-    }
-
-    /// Access the shared buffer so consumers (typically `GatherExec`) can
-    /// `pop_front` without holding the handle itself.
-    pub fn buffer(&self) -> &Arc<DrainBuffer> {
-        &self.buffer
     }
 
     fn join_inner(&self) -> Result<(), DataFusionError> {
@@ -946,9 +1038,15 @@ impl Drop for DrainHandle {
             // Cancel and join even on the panic path. We swallow any error
             // here because Drop cannot fail; callers who care should use
             // `shutdown()` to observe the thread's result.
-            self.buffer.cancel();
+            if let Some(buf) = &self.legacy_buffer {
+                buf.cancel();
+            }
             let _ = self.join_inner();
         }
+        // Cooperative path: unblock any consumer blocked on a sub-buffer
+        // when the handle is torn down before EOF flows naturally (e.g. a
+        // query error en route to ExecEndCustomScan).
+        self.cancel_sub_buffers();
     }
 }
 
@@ -983,7 +1081,7 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
                 }
                 RecvBatchOutcome::Eof { header: _ } => {
                     // Per-channel Eof frame: single-channel positional design
-                    // treats it as a source-done signal. See `poll_drain_pass`.
+                    // treats it as a source-done signal. See `try_drain_pass`.
                     done[i] = true;
                     buffer.notify_source_done();
                 }
@@ -1529,5 +1627,160 @@ mod tests {
         for batch_rows in [128, 512, 2048, 8192, 32_768] {
             bench_throughput("probe", probe_shape_batch, batch_rows, 12_500_000);
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // M2.b — per-`(stage_id, partition)` sub-buffer registry on the
+    // cooperative `DrainHandle`.
+    //
+    // Producers stamp `MppFrameHeader::batch(stage_id, partition)` on every
+    // outgoing frame; the receiver-side cooperative drain demuxes by header
+    // into a sub-buffer per `(stage_id, partition)`. These tests use the
+    // `in_proc_channel` backend to drive `try_drain_pass` from the test
+    // thread, mirroring how the production path runs the drain inline from
+    // `DrainGatherStream::poll_next` on the backend thread.
+    // ---------------------------------------------------------------------
+
+    /// Drain a `DrainHandle::cooperative` to completion: poll until every
+    /// receiver returns `Empty`. With the `in_proc_channel` test backend the
+    /// drain observes `Detached` once the producer drops its sender, so a
+    /// bounded loop of `try_drain_pass` calls is enough to flush everything
+    /// the producer wrote.
+    fn drain_until_detached(handle: &DrainHandle) {
+        for _ in 0..64 {
+            handle.try_drain_pass().expect("try_drain_pass");
+            // After enough passes the in-proc backend reports `Detached`,
+            // which flips `mark_detached` and notifies every sub-buffer. We
+            // keep polling so any queued frames flow through first.
+        }
+    }
+
+    #[test]
+    fn drain_handle_demuxes_frames_by_header() {
+        // One queue carrying two channels — `(0, 0)` and `(0, 1)`. Each
+        // sub-buffer receives only its own batches.
+        let (tx, rx) = in_proc_channel(8);
+        let base = MppSender::new(Arc::new(tx));
+        let s00 = base.clone_with_header(MppFrameHeader::batch(0, 0));
+        let s01 = base.clone_with_header(MppFrameHeader::batch(0, 1));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        s00.send_batch(&sample_batch(2)).unwrap();
+        s01.send_batch(&sample_batch(7)).unwrap();
+        s00.send_batch(&sample_batch(3)).unwrap();
+        drop(s00);
+        drop(s01);
+        drop(base); // last sender dropped — receiver will report Detached.
+
+        let buf00 = handle.register_channel(0, 0);
+        let buf01 = handle.register_channel(0, 1);
+
+        drain_until_detached(&handle);
+
+        let mut p0_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf00.try_pop() {
+            p0_rows.push(b.num_rows());
+        }
+        let mut p1_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf01.try_pop() {
+            p1_rows.push(b.num_rows());
+        }
+        assert_eq!(p0_rows, vec![2, 3]);
+        assert_eq!(p1_rows, vec![7]);
+        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
+        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_eof_frame_closes_one_channel() {
+        // An `Eof` frame on `(0, 0)` closes that sub-buffer while frames on
+        // `(0, 1)` continue to flow on the same queue.
+        let (tx, rx) = in_proc_channel(8);
+        let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
+        let s00 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0));
+        let s01 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 1));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        s00.send_batch(&sample_batch(4)).unwrap();
+        // Hand-roll an Eof frame for (0, 0) onto the same shared channel.
+        let mut eof_buf = Vec::new();
+        encode_eof_frame_into(0, 0, &mut eof_buf).unwrap();
+        tx_arc.send_bytes(&eof_buf).unwrap();
+        // (0, 1) is still live and ships another batch after the EOF.
+        s01.send_batch(&sample_batch(6)).unwrap();
+
+        let buf00 = handle.register_channel(0, 0);
+        let buf01 = handle.register_channel(0, 1);
+
+        // Drop senders so the receiver eventually observes Detached.
+        drop(s00);
+        drop(s01);
+        drop(tx_arc);
+        drain_until_detached(&handle);
+
+        match buf00.try_pop() {
+            Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 4),
+            other => panic!("expected (0,0) batch, got {other:?}"),
+        }
+        // The Eof frame closed (0, 0) before the queue detached.
+        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
+
+        match buf01.try_pop() {
+            Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 6),
+            other => panic!("expected (0,1) batch, got {other:?}"),
+        }
+        // (0, 1) sees EOF at receiver-detach time.
+        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_detach_eofs_all_registered_sub_buffers() {
+        // No frames flow; consumer pre-registers two channels. When the
+        // sender drops and `try_drain_pass` observes `Detached`, both
+        // sub-buffers immediately surface `Eof` — without this, a consumer
+        // blocked on `try_pop` would hang past the producer's death.
+        let (tx, rx) = in_proc_channel(8);
+        drop(tx); // detach immediately
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        let buf00 = handle.register_channel(0, 0);
+        let buf01 = handle.register_channel(0, 1);
+        // No frames ever land; the next poll observes Detached and notifies.
+        handle.try_drain_pass().unwrap();
+
+        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
+        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_register_after_detach_returns_eof_buffer() {
+        // Detach first, then register. The returned buffer is already
+        // EOF'd so a late consumer doesn't block forever waiting on a
+        // channel whose source is gone.
+        let (tx, rx) = in_proc_channel(8);
+        drop(tx);
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        handle.try_drain_pass().unwrap(); // observes Detached, marks handle
+
+        let late_buf = handle.register_channel(5, 9);
+        assert!(matches!(late_buf.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_register_channel_is_idempotent() {
+        // Two calls for the same key return Arcs pointing to the same
+        // DrainBuffer instance.
+        let (_tx, rx) = in_proc_channel(8);
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        let first = handle.register_channel(2, 3);
+        let second = handle.register_channel(2, 3);
+        assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -37,7 +37,6 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
-use std::task::Waker;
 #[cfg(test)]
 use std::thread;
 use std::thread::JoinHandle;
@@ -280,15 +279,23 @@ pub fn decode_frame(
     }
 }
 
-/// Local queue that sits between the drain thread and the DataFusion consumer.
+/// Local queue between a drain (either the cooperative `poll_drain_pass`
+/// or the test-only thread variant) and the consumer that pops batches.
 ///
-/// Push side: the drain thread appends fully-deserialized batches as they arrive
-/// from inbound shm_mqs. When a source queue detaches, [`DrainBuffer::notify_source_done`]
-/// is called; once all sources are done AND the queue is empty, `pop_front` returns
+/// In the cooperative path each `DrainBuffer` corresponds to one logical
+/// channel — i.e. one `(stage_id, partition)` entry in the owning
+/// [`DrainHandle`]'s registry. `num_sources` is always `1` there because a
+/// given drain serves a single sender_proc, which is the only producer for
+/// any channel routed through it. The test-only thread path uses a single
+/// shared buffer with `num_sources = N` over an N-sender setup.
+///
+/// Push side: callers append deserialized batches; on source detach (or per-
+/// channel `Eof` frame) [`DrainBuffer::notify_source_done`] is called. Once
+/// `sources_done >= num_sources` AND the queue is empty, `try_pop` returns
 /// [`DrainItem::Eof`].
 ///
-/// Pop side: the consumer calls `pop_front` which blocks on the condvar until
-/// either a batch is available or EOF has been reached.
+/// Pop side: cooperative consumers loop on `try_pop` + `yield_now`. The
+/// test-only `pop_front` blocks on the condvar.
 #[derive(Debug)]
 pub struct DrainBuffer {
     inner: Mutex<DrainBufferInner>,
@@ -300,15 +307,10 @@ struct DrainBufferInner {
     queue: VecDeque<RecordBatch>,
     num_sources: u32,
     sources_done: u32,
-    /// Consumer-side cancel flag. When set (e.g., query cancelled), the drain
-    /// thread should stop pushing and unblock waiting consumers with EOF.
+    /// Consumer-side cancel flag. When set (e.g., query cancelled or
+    /// `DrainHandle` dropped), `try_pop`/`pop_front` returns `Eof` even
+    /// if `sources_done` hasn't reached `num_sources`.
     cancelled: bool,
-    /// Most recently registered async waker from a `poll_pop_front` caller.
-    /// Woken on push / source-done / cancel so a stream running inside a
-    /// DataFusion `poll_next` returns `Poll::Pending` without blocking the
-    /// executor thread. `Option` so we don't allocate one if the buffer is
-    /// only consumed synchronously via `pop_front`.
-    waker: Option<Waker>,
 }
 
 /// Yielded by [`DrainBuffer::pop_front`].
@@ -331,7 +333,6 @@ impl DrainBuffer {
                 num_sources,
                 sources_done: 0,
                 cancelled: false,
-                waker: None,
             }),
             cond: Condvar::new(),
         })
@@ -342,21 +343,16 @@ impl DrainBuffer {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         guard.queue.push_back(batch);
         self.cond.notify_one();
-        if let Some(w) = guard.waker.take() {
-            w.wake();
-        }
     }
 
     /// Mark one source queue as detached. Safe to call from the drain thread
-    /// after observing `SHM_MQ_DETACHED` on a given inbound queue.
+    /// after observing `SHM_MQ_DETACHED` on a given inbound queue or from
+    /// [`DrainHandle::mark_detached`] when the underlying receiver has died.
     pub fn notify_source_done(&self) {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         guard.sources_done = guard.sources_done.saturating_add(1);
         if guard.sources_done >= guard.num_sources {
             self.cond.notify_all();
-            if let Some(w) = guard.waker.take() {
-                w.wake();
-            }
         }
     }
 
@@ -365,9 +361,6 @@ impl DrainBuffer {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         guard.cancelled = true;
         self.cond.notify_all();
-        if let Some(w) = guard.waker.take() {
-            w.wake();
-        }
     }
 
     /// Block until a batch is available, EOF is reached, or the buffer is
@@ -403,22 +396,22 @@ impl DrainBuffer {
             .cancelled
     }
 
-    /// Non-blocking, non-waker variant. Returns the
-    /// front item or `DrainItem::Eof` if all sources have detached and
-    /// the queue is drained; returns `None` only when more data may yet
-    /// arrive. Cooperative consumers loop on `try_drain_pass` + `try_pop`,
-    /// yielding to the executor between iterations.
+    /// Non-blocking variant. Returns the front item, or `DrainItem::Eof` if
+    /// all sources have detached and the queue is drained, or `None` if more
+    /// data may yet arrive. Cooperative consumers loop on
+    /// `try_drain_pass` + `try_pop`, yielding to the executor between
+    /// iterations.
     pub fn try_pop(&self) -> Option<DrainItem> {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         Self::try_pop_locked(&mut guard)
     }
 
-    /// Shared body of [`try_pop`] and [`poll_pop_front`]. Returns
-    /// `Some(Batch)` if the queue has data, `Some(Eof)` if all sources
-    /// have detached or the buffer is cancelled, and `None` otherwise.
-    /// Lets the two public entry points stay in lockstep on the
-    /// "buffered data wins over cancellation/EOF" invariant locked in
-    /// by `drain_buffer_drains_buffered_before_eof`.
+    /// Shared body of [`try_pop`] and the test-only [`Self::pop_front`].
+    /// Returns `Some(Batch)` if the queue has data, `Some(Eof)` if all
+    /// sources have detached or the buffer is cancelled, and `None`
+    /// otherwise. Lets the two entry points stay in lockstep on the
+    /// "buffered data wins over cancellation/EOF" invariant locked in by
+    /// the `drain_buffer_drains_buffered_before_eof` test.
     fn try_pop_locked(guard: &mut MutexGuard<'_, DrainBufferInner>) -> Option<DrainItem> {
         if let Some(batch) = guard.queue.pop_front() {
             return Some(DrainItem::Batch(batch));
@@ -912,31 +905,45 @@ impl DrainHandle {
 
     /// Mark the drain as detached and `notify_source_done` every registered
     /// sub-buffer. Idempotent. Used by `try_drain_pass` after `Detached` /
-    /// `Error` outcomes; also called from `Drop` for the cooperative path so
-    /// any consumer blocked on `try_pop` unblocks with `Eof` even if the
-    /// query is torn down before EOF frames flow.
+    /// `Error` outcomes; the cooperative-path equivalent fires from `Drop`
+    /// via [`Self::cancel_sub_buffers`] so any consumer blocked on `try_pop`
+    /// unblocks with `Eof` even if the query is torn down before EOF frames
+    /// flow.
+    ///
+    /// Collects buffer handles under the registry lock, then notifies after
+    /// releasing it. Notifying inline would block any concurrent
+    /// [`Self::register_channel`] for as long as it takes to acquire
+    /// `DrainBuffer::inner` N times — fine today (single backend thread),
+    /// but cheap insurance against the multi-thread variant landing later.
     fn mark_detached(&self) {
-        let mut guard = self
-            .sub_buffers
-            .lock()
-            .expect("DrainHandle sub_buffers mutex poisoned");
-        if guard.detached {
-            return;
-        }
-        guard.detached = true;
-        for buf in guard.map.values() {
+        let to_notify = {
+            let mut guard = self
+                .sub_buffers
+                .lock()
+                .expect("DrainHandle sub_buffers mutex poisoned");
+            if guard.detached {
+                return;
+            }
+            guard.detached = true;
+            guard.map.values().cloned().collect::<Vec<_>>()
+        };
+        for buf in to_notify {
             buf.notify_source_done();
         }
     }
 
     /// Cancel every registered sub-buffer. Called from `Drop` to unblock any
     /// consumer waiting on a sub-buffer when the handle goes away mid-query.
+    /// Same collect-then-notify pattern as [`Self::mark_detached`].
     fn cancel_sub_buffers(&self) {
-        let guard = self
-            .sub_buffers
-            .lock()
-            .expect("DrainHandle sub_buffers mutex poisoned");
-        for buf in guard.map.values() {
+        let to_cancel = {
+            let guard = self
+                .sub_buffers
+                .lock()
+                .expect("DrainHandle sub_buffers mutex poisoned");
+            guard.map.values().cloned().collect::<Vec<_>>()
+        };
+        for buf in to_cancel {
             buf.cancel();
         }
     }
@@ -1050,6 +1057,14 @@ impl Drop for DrainHandle {
     }
 }
 
+/// Test-only thread-backed drain. Writes every observed frame into a single
+/// shared [`DrainBuffer`] — the *legacy* `num_sources = N` model the cooperative
+/// path replaced. Per-channel `Eof` frames are treated as "this source is
+/// done" (not "this logical channel within the source is done"), matching the
+/// original single-buffer semantics. Production code routes through
+/// [`DrainHandle::poll_drain_pass`] instead, which keys on the frame header.
+/// Tests that want to validate the production demux must use
+/// [`DrainHandle::cooperative`] and call `poll_drain_pass` directly.
 #[cfg(test)]
 fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
     let DrainConfig {
@@ -1782,5 +1797,59 @@ mod tests {
         let first = handle.register_channel(2, 3);
         let second = handle.register_channel(2, 3);
         assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn drain_handle_demuxes_frames_by_stage_id() {
+        // Same partition (0) for two different stage ids on the same queue.
+        // The registry's compound key keeps them on separate sub-buffers.
+        let (tx, rx) = in_proc_channel(8);
+        let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
+        let s_stage0 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0));
+        let s_stage1 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(1, 0));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        s_stage0.send_batch(&sample_batch(2)).unwrap();
+        s_stage1.send_batch(&sample_batch(9)).unwrap();
+        s_stage0.send_batch(&sample_batch(4)).unwrap();
+        drop(s_stage0);
+        drop(s_stage1);
+        drop(tx_arc);
+
+        let buf0 = handle.register_channel(0, 0);
+        let buf1 = handle.register_channel(1, 0);
+
+        drain_until_detached(&handle);
+
+        let mut stage0_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf0.try_pop() {
+            stage0_rows.push(b.num_rows());
+        }
+        let mut stage1_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf1.try_pop() {
+            stage1_rows.push(b.num_rows());
+        }
+        assert_eq!(stage0_rows, vec![2, 4]);
+        assert_eq!(stage1_rows, vec![9]);
+    }
+
+    #[test]
+    fn drain_handle_drop_cancels_registered_sub_buffers() {
+        // Dropping a cooperative DrainHandle must wake any consumer holding
+        // an Arc<DrainBuffer> from `register_channel` — otherwise a query
+        // error path that tears down the mesh would leave a consumer
+        // blocked on a buffer that will never see EOF.
+        let (_tx, rx) = in_proc_channel(8);
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        let buf_a = handle.register_channel(0, 0);
+        let buf_b = handle.register_channel(7, 3);
+        // No data ever flows; the handle is just dropped.
+        drop(handle);
+
+        assert!(matches!(buf_a.try_pop(), Some(DrainItem::Eof)));
+        assert!(matches!(buf_b.try_pop(), Some(DrainItem::Eof)));
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -281,7 +281,7 @@ pub fn decode_frame(
     }
 }
 
-/// Local queue between a drain (either the cooperative `poll_drain_pass`
+/// Local queue between a drain (either the cooperative `try_drain_pass`
 /// or the test-only thread variant) and the consumer that pops batches.
 ///
 /// In the cooperative path each `DrainBuffer` corresponds to one logical
@@ -470,12 +470,12 @@ pub trait BatchChannelSender: Send + Sync {
 /// so the implementation typically delegates to
 /// `MppMesh::drain_all_inbound()` which iterates every per-sender-proc drain.
 pub trait CooperativeDrainSet: Send + Sync {
-    fn poll_drain_pass(&self) -> Result<(), DataFusionError>;
+    fn try_drain_pass(&self) -> Result<(), DataFusionError>;
 }
 
 impl CooperativeDrainSet for DrainHandle {
-    fn poll_drain_pass(&self) -> Result<(), DataFusionError> {
-        DrainHandle::poll_drain_pass(self)
+    fn try_drain_pass(&self) -> Result<(), DataFusionError> {
+        DrainHandle::try_drain_pass(self)
     }
 }
 
@@ -632,7 +632,7 @@ impl MppSender {
     /// Without it the multiplexed shm_mq queue stays attached (other
     /// channels still flow) and the consumer sub-buffer never reaches
     /// `sources_done == 1`. The receive-side
-    /// [`DrainHandle::poll_drain_pass`] decodes the frame and calls
+    /// [`DrainHandle::try_drain_pass`] decodes the frame and calls
     /// `notify_source_done` on the matching sub-buffer.
     ///
     /// Uses the same cooperative-spin path as
@@ -642,7 +642,7 @@ impl MppSender {
     ///
     /// Symmetric-EOF safety: when every peer reaches EOF simultaneously
     /// with full outbound queues, each peer's cooperative
-    /// [`CooperativeDrainSet::poll_drain_pass`] inside the spin pulls
+    /// [`CooperativeDrainSet::try_drain_pass`] inside the spin pulls
     /// peer-sent frames out of its own inbound queues, freeing space
     /// the peers are blocked on. Progress is monotone — at least one
     /// `try_send_bytes` succeeds per spin iteration somewhere in the
@@ -678,7 +678,7 @@ impl MppSender {
             first_try = false;
             stats.spin_iters += 1;
             let t_drain = Instant::now();
-            drain.poll_drain_pass()?;
+            drain.try_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
             tokio::task::yield_now().await;
         }
@@ -1150,9 +1150,9 @@ impl Drop for DrainHandle {
 /// path replaced. Per-channel `Eof` frames are treated as "this source is
 /// done" (not "this logical channel within the source is done"), matching the
 /// original single-buffer semantics. Production code routes through
-/// [`DrainHandle::poll_drain_pass`] instead, which keys on the frame header.
+/// [`DrainHandle::try_drain_pass`] instead, which keys on the frame header.
 /// Tests that want to validate the production demux must use
-/// [`DrainHandle::cooperative`] and call `poll_drain_pass` directly.
+/// [`DrainHandle::cooperative`] and call `try_drain_pass` directly.
 #[cfg(test)]
 fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
     let DrainConfig {

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -67,25 +67,41 @@ pub async fn run_worker_fragment(
         let ctx = Arc::clone(&ctx);
         let sender = Arc::clone(sender);
         futures.push(async move {
-            let mut stream = plan.execute(partition, ctx)?;
             let mut stats = SendBatchStats::default();
-            while let Some(batch) = stream.next().await {
-                let batch = batch?;
-                if batch.num_rows() == 0 {
-                    continue;
+            // Run the partition stream to exhaustion; capture either the
+            // first error or Ok(()) so we can still emit the per-channel
+            // EOF below regardless of how the stream ended.
+            let stream_result: Result<(), DataFusionError> = async {
+                let mut stream = plan.execute(partition, ctx)?;
+                while let Some(batch) = stream.next().await {
+                    let batch = batch?;
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+                    sender
+                        .as_ref()
+                        .send_batch_traced(&batch, &mut stats)
+                        .await?;
                 }
-                sender
-                    .as_ref()
-                    .send_batch_traced(&batch, &mut stats)
-                    .await?;
+                Ok(())
             }
+            .await;
             // Signal channel EOF so the consumer's per-(stage_id, partition)
             // sub-buffer transitions to Eof. The shared shm_mq queue can't
             // be relied on to detach — multiple fragments multiplex over
             // the same queue, so dropping this partition's sender doesn't
             // close the queue.
-            sender.as_ref().send_eof_traced(&mut stats).await?;
-            Ok::<(), DataFusionError>(())
+            //
+            // CORRECTNESS: send EOF even when the stream errored. Without
+            // this, a producer-side error (e.g. mid-scan I/O failure) leaves
+            // the consumer's M2.b sub-buffer stuck at `sources_done == 0`
+            // and the leader's `select_all` blocks forever. The deadlock
+            // detector only fires under `paradedb.mpp_debug = on`, so the
+            // production hang would be silent.
+            let eof_result = sender.as_ref().send_eof_traced(&mut stats).await;
+            // Propagate the stream's error first; otherwise surface any EOF
+            // send error so failure modes don't silently disappear.
+            stream_result.and(eof_result)
         });
     }
     futures::future::try_join_all(futures).await?;

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -79,6 +79,12 @@ pub async fn run_worker_fragment(
                     .send_batch_traced(&batch, &mut stats)
                     .await?;
             }
+            // Signal channel EOF so the consumer's per-(stage_id, partition)
+            // sub-buffer transitions to Eof. The shared shm_mq queue can't
+            // be relied on to detach — multiple fragments multiplex over
+            // the same queue, so dropping this partition's sender doesn't
+            // close the queue.
+            sender.as_ref().send_eof_traced(&mut stats).await?;
             Ok::<(), DataFusionError>(())
         });
     }

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -174,24 +174,51 @@ fn collect(
 
         // Determine routing for fragments produced by this boundary's
         // input_stage tasks.
+        //
+        // NetworkShuffleExec and NetworkBroadcastExec have IDENTICAL
+        // receive-side math: both compute `off = P_c * task_index` and
+        // pull partition `off + p_local` from every input task. The
+        // producer-side routing must therefore also be the same — output
+        // partition q goes to consumer task `q / P_c`. The semantic
+        // difference (shuffle hashes rows, broadcast emits the full set
+        // to every consumer) lives entirely inside each task's plan and
+        // doesn't change how partitions map to procs at the wire layer.
+        //
+        // NetworkCoalesceExec is different: its execute consults a single
+        // input task per consumer (`target_task = group.start_task +
+        // input_task_offset`) and the producer emits one stream per
+        // consumer task in its group. For the natural-shape plan we
+        // currently target the only nested coalesce is consumer_tc=1 (the
+        // top-level gather, handled by the `parent=None` arm), so the
+        // nested-coalesce arm here is a defensive fallback for shapes the
+        // M2.d milestone doesn't yet exercise.
         let routing = match (name, parent) {
-            // Top-level gather (or any top-level boundary): consumer is leader.
+            // Top-level boundary: consumer is leader.
             (_, None) => FragmentRouting::Coalesce { dest_proc: 0 },
-            // Nested NetworkShuffleExec: hash routing.
-            ("NetworkShuffleExec", Some(pctx)) => FragmentRouting::Shuffle {
-                parent_stage_id: pctx.parent_stage_id,
-                partitions_per_consumer_task: p_c,
-            },
-            // Nested NetworkCoalesceExec / NetworkBroadcastExec: consumer is
-            // a single task in the parent stage. M2.d targets the natural-
-            // shape Aggregate plan where nested coalesce isn't expected;
-            // we still handle it as "all output → parent task 0" so the
-            // shape is supported when it does appear.
+            // Nested NetworkShuffleExec or NetworkBroadcastExec: each
+            // output partition q maps to consumer task q / p_c.
+            ("NetworkShuffleExec" | "NetworkBroadcastExec", Some(pctx)) => {
+                FragmentRouting::Shuffle {
+                    parent_stage_id: pctx.parent_stage_id,
+                    partitions_per_consumer_task: p_c,
+                }
+            }
+            // Nested NetworkCoalesceExec: consumer is a single task in
+            // the parent stage. The receive math collapses to task 0 of
+            // the parent group.
             (_, Some(pctx)) => {
                 let dest = assignment.proc_for(pctx.parent_stage_id, 0).unwrap_or(0);
                 FragmentRouting::Coalesce { dest_proc: dest }
             }
         };
+        #[cfg(not(test))]
+        {
+            crate::mpp_log!(
+                "mpp worker_fragments::collect boundary name={name} stage_id={stage_id} \
+                 p_c={p_c} parent={:?}",
+                parent.map(|p| p.parent_stage_id)
+            );
+        }
 
         let task_count = stage.tasks.len();
         if let Some(stage_plan) = stage.plan() {

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -41,6 +41,8 @@
 use std::sync::Arc;
 
 use datafusion::physical_plan::ExecutionPlan;
+#[cfg(not(test))]
+use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion_distributed::NetworkBoundaryExt;
 
 use crate::postgres::customscan::mpp::assignment::TaskAssignment;
@@ -116,6 +118,37 @@ pub fn find_worker_assignments(
 ) -> Vec<FragmentAssignment> {
     let mut out = Vec::new();
     collect(root, this_proc, assignment, None, &mut out);
+    #[cfg(not(test))]
+    {
+        crate::mpp_log!(
+            "mpp worker_fragments::find_worker_assignments this_proc={} fragments={}",
+            this_proc,
+            out.len()
+        );
+        for f in &out {
+            let n_out = f.plan.output_partitioning().partition_count();
+            match &f.routing {
+                FragmentRouting::Coalesce { dest_proc } => crate::mpp_log!(
+                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
+                     n_out={n_out} routing=Coalesce dest_proc={dest_proc}",
+                    f.stage_id,
+                    f.task_idx,
+                    f.task_count,
+                ),
+                FragmentRouting::Shuffle {
+                    parent_stage_id,
+                    partitions_per_consumer_task,
+                } => crate::mpp_log!(
+                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
+                     n_out={n_out} routing=Shuffle parent_stage_id={parent_stage_id} \
+                     partitions_per_consumer_task={partitions_per_consumer_task}",
+                    f.stage_id,
+                    f.task_idx,
+                    f.task_count,
+                ),
+            }
+        }
+    }
     out
 }
 

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -119,6 +119,16 @@ pub enum FragmentRouting {
     /// `BroadcastCanonicalReplica` vs. `BroadcastSharded` (or the
     /// short-circuit must be conditional on a planner-set sentinel).
     ///
+    /// **Planner-level cap:** the AggregateScan session installs
+    /// [`crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator`]
+    /// in front of the default leaf estimator, which caps the canonical-
+    /// replica memory leaf at `task_count = 1`. This propagates up the
+    /// build subtree and makes the DF-D planner build
+    /// `NetworkBroadcastExec` with `input_task_count = 1`. With the cap
+    /// in place the dispatcher only ever sees `task_idx == 0` fragments
+    /// for Broadcast routing — the wire-layer short-circuit becomes a
+    /// defensive fall-back (`debug_assert!` in dev, EOF-only in release).
+    ///
     /// [`NetworkBroadcastExec`]: datafusion_distributed::NetworkBroadcastExec
     Broadcast {
         /// Stage id of the immediately enclosing stage. Same semantics as

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -126,8 +126,9 @@ pub enum FragmentRouting {
     /// build subtree and makes the DF-D planner build
     /// `NetworkBroadcastExec` with `input_task_count = 1`. With the cap
     /// in place the dispatcher only ever sees `task_idx == 0` fragments
-    /// for Broadcast routing — the wire-layer short-circuit becomes a
-    /// defensive fall-back (`debug_assert!` in dev, EOF-only in release).
+    /// for Broadcast routing — the wire-layer guard is a hard
+    /// `pgrx::error!` for any `task_idx > 0` so a missed cap surfaces
+    /// loudly instead of silently mis-routing data.
     ///
     /// [`NetworkBroadcastExec`]: datafusion_distributed::NetworkBroadcastExec
     Broadcast {

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -97,16 +97,27 @@ pub enum FragmentRouting {
         /// `P_c` in the receive-side formula `off = P_c * task_index`.
         partitions_per_consumer_task: usize,
     },
-    /// Broadcast mesh ([`NetworkBroadcastExec`]). Wire-level routing math is
-    /// identical to [`Self::Shuffle`] (consumer task `q / P_c`), but the
-    /// pg_search natural-shape plan canonical-replicates the build subtree
-    /// across all workers — every input task scans the full canonical data
-    /// and the consumer's `select_all` would union duplicates. We force
-    /// `input_task_count = 1` at the wire layer by having only task 0 run
-    /// the producer plan; tasks `task_idx > 0` short-circuit to per-partition
-    /// EOF. The consumer's three input streams then yield real data from
-    /// task 0 + empty streams from the others, matching the upstream
-    /// "single producer broadcast" pattern.
+    /// Broadcast mesh ([`NetworkBroadcastExec`]) over a build subtree that
+    /// is canonical-replicated across all producer procs. Wire-level math
+    /// is identical to [`Self::Shuffle`] (output partition `q` →
+    /// consumer task `q / P_c`), but the dispatcher effectively reduces
+    /// the producer side to a single task: only `task_idx == 0` runs the
+    /// producer plan; tasks `task_idx > 0` send a per-partition EOF and
+    /// exit. The consumer's input streams merge real data from task 0
+    /// with empty streams from the others, matching upstream's
+    /// single-producer broadcast pattern.
+    ///
+    /// **INVARIANT (load-bearing for correctness):** the build subtree's
+    /// output is canonical-replicated across all producer procs. In the
+    /// AggregateScan MPP path this is enforced by the all-gather step
+    /// (`mpp build all-gather`) that pre-stages the canonical source on
+    /// every worker before plan execution. If a future planner emits a
+    /// [`NetworkBroadcastExec`] over a sharded child (e.g. each producer
+    /// task scans a different file_group), the short-circuit silently
+    /// drops `input_task_count - 1` shards' worth of data. When that
+    /// pattern is introduced, this variant must be split into
+    /// `BroadcastCanonicalReplica` vs. `BroadcastSharded` (or the
+    /// short-circuit must be conditional on a planner-set sentinel).
     ///
     /// [`NetworkBroadcastExec`]: datafusion_distributed::NetworkBroadcastExec
     Broadcast {
@@ -225,7 +236,22 @@ fn collect(
         // nested-coalesce arm here is a defensive fallback for shapes the
         // M2.d milestone doesn't yet exercise.
         let routing = match (name, parent) {
-            // Top-level boundary: consumer is leader.
+            // Top-level NetworkBroadcastExec is not a shape the natural-
+            // shape AggregateScan plan produces today (broadcast is always
+            // nested inside the HashJoin build subtree). Falling through
+            // to `Coalesce { dest_proc: 0 }` would silently send every
+            // input task's full canonical replica to the leader and
+            // `select_all` would over-count by `input_task_count`. Surface
+            // it as an error so a future planner change that hits this
+            // shape doesn't silently produce wrong answers.
+            ("NetworkBroadcastExec", None) => {
+                pgrx::error!(
+                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
+                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
+                     produce this shape; route via a NetworkCoalesceExec gather instead."
+                );
+            }
+            // Top-level boundary (gather to leader): consumer is leader proc 0.
             (_, None) => FragmentRouting::Coalesce { dest_proc: 0 },
             // Nested NetworkShuffleExec: hash-partitioned mesh. Each
             // output partition q maps to consumer task q / p_c.
@@ -236,7 +262,7 @@ fn collect(
             // Nested NetworkBroadcastExec: same wire-level math as
             // Shuffle, but the dispatcher only runs the producer plan on
             // task 0 to avoid the canonical-replica duplication described
-            // on FragmentRouting::Broadcast.
+            // on `FragmentRouting::Broadcast`.
             ("NetworkBroadcastExec", Some(pctx)) => FragmentRouting::Broadcast {
                 parent_stage_id: pctx.parent_stage_id,
                 partitions_per_consumer_task: p_c,

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -256,7 +256,22 @@ fn collect(
             // it as an error so a future planner change that hits this
             // shape doesn't silently produce wrong answers.
             ("NetworkBroadcastExec", None) => {
+                // `pgrx::error!` pulls PG runtime symbols (`CopyErrorData`,
+                // `PG_exception_stack`, `CurrentMemoryContext`,
+                // `error_context_stack`) via the ereport machinery. Reaching it
+                // from the `#[cfg(test)]` block at the bottom of this file
+                // would force the test binary to link against postgres, which
+                // `cargo test --features pgNN --no-default-features` does not.
+                // Plain `panic!` in test builds, same `!` return type as
+                // `pgrx::error!`, so the match arm still type-checks.
+                #[cfg(not(test))]
                 pgrx::error!(
+                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
+                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
+                     produce this shape; route via a NetworkCoalesceExec gather instead."
+                );
+                #[cfg(test)]
+                panic!(
                     "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
                      (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
                      produce this shape; route via a NetworkCoalesceExec gather instead."

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -1,0 +1,237 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Worker-side fragment discovery for the multi-fragment runner.
+//!
+//! [`find_worker_assignments`] walks a worker's physical plan, visits every
+//! [`datafusion_distributed::NetworkBoundary`], and collects the
+//! `(input_stage.num, task_idx, plan, routing)` tuples assigned to a given
+//! `this_proc`. The dispatcher in `aggregatescan::exec_mpp_worker` runs one
+//! fragment per returned [`FragmentAssignment`].
+//!
+//! The walker tracks a `ParentContext` per recursion level so nested
+//! boundaries know which OUTER stage's tasks consume their output. The
+//! routing math (which proc to send partition `q` to) depends on this:
+//!
+//! - **Top-level boundary** (`parent = None`): the consumer is the leader at
+//!   proc 0. Every output partition goes there.
+//! - **Nested boundary inside outer stage `S_outer.plan`**: the consumer is
+//!   one of `S_outer`'s tasks. For [`NetworkShuffleExec`] the routing is
+//!   hash-partitioned (partition `q` → consumer task `q / P_c` where `P_c`
+//!   is the per-consumer-task output count); for [`NetworkCoalesceExec`]
+//!   the routing collapses to a single consumer task.
+//!
+//! [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
+//! [`NetworkCoalesceExec`]: datafusion_distributed::NetworkCoalesceExec
+
+use std::sync::Arc;
+
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_distributed::NetworkBoundaryExt;
+
+use crate::postgres::customscan::mpp::assignment::TaskAssignment;
+
+/// One worker fragment to run for `this_proc`. The fragment is one task of a
+/// producer stage; the dispatcher runs `plan` with the matching
+/// `DistributedTaskContext { task_index: task_idx, task_count }` and routes
+/// each output partition through the channel selected by [`Self::routing`].
+#[derive(Clone)]
+pub struct FragmentAssignment {
+    /// `input_stage.num` of the boundary whose producer side this fragment
+    /// belongs to. Frames the fragment emits carry this in the
+    /// `MppFrameHeader::stage_id` field.
+    pub stage_id: u32,
+    /// Task index within the stage (0..task_count).
+    pub task_idx: usize,
+    /// Total task count for this stage (= `input_stage.tasks.len()`).
+    pub task_count: usize,
+    /// Plan to execute: the boundary's `input_stage.plan`.
+    pub plan: Arc<dyn ExecutionPlan>,
+    /// How to route each output partition to a destination proc.
+    pub routing: FragmentRouting,
+}
+
+/// Routing rule for a fragment's output partitions.
+#[derive(Clone, Debug)]
+pub enum FragmentRouting {
+    /// All output partitions go to one destination proc (`NetworkCoalesceExec`
+    /// or the top-level gather case). Frame header carries
+    /// `(stage_id, partition)` directly; consumer reads
+    /// `stream_partition(partition)`.
+    Coalesce {
+        /// Destination proc index. `0` for the leader (top-level gather),
+        /// or an `assignment.proc_for(parent_stage_id, 0)` lookup for a
+        /// nested coalesce that lands on a single consumer task.
+        dest_proc: u32,
+    },
+    /// Hash-partitioned mesh ([`NetworkShuffleExec`]). Output partition `q`
+    /// goes to consumer task `q / partitions_per_consumer_task`, hosted on
+    /// `assignment.proc_for(parent_stage_id, consumer_task_idx)`. Frame
+    /// header is `(stage_id, q)` so the consumer's
+    /// `stream_partition(P_c * task_index + p_local)` finds it via the
+    /// per-`(stage_id, partition)` sub-buffer registry.
+    ///
+    /// [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
+    Shuffle {
+        /// Stage id of the immediately enclosing stage. Consumer tasks live
+        /// here; combined with `consumer_task_idx`, they resolve to a
+        /// destination proc via `TaskAssignment::proc_for`.
+        parent_stage_id: u32,
+        /// `B.properties().output_partitioning().partition_count()`. Equal to
+        /// `P_c` in the receive-side formula `off = P_c * task_index`.
+        partitions_per_consumer_task: usize,
+    },
+}
+
+#[derive(Clone, Copy)]
+struct ParentContext {
+    /// Stage id of the enclosing stage whose plan contains this boundary.
+    /// Used as `parent_stage_id` in `FragmentRouting::Shuffle` / consumer
+    /// lookup in `FragmentRouting::Coalesce` (nested case).
+    parent_stage_id: u32,
+}
+
+/// Walk `root` (the worker's physical plan) and collect every fragment
+/// assigned to `this_proc` per `assignment`. Returns one
+/// [`FragmentAssignment`] per (stage_id, task_idx) pair hosted by this proc;
+/// the dispatcher spawns one async task per entry.
+pub fn find_worker_assignments(
+    root: &Arc<dyn ExecutionPlan>,
+    this_proc: u32,
+    assignment: &TaskAssignment,
+) -> Vec<FragmentAssignment> {
+    let mut out = Vec::new();
+    collect(root, this_proc, assignment, None, &mut out);
+    out
+}
+
+fn collect(
+    plan: &Arc<dyn ExecutionPlan>,
+    this_proc: u32,
+    assignment: &TaskAssignment,
+    parent: Option<ParentContext>,
+    out: &mut Vec<FragmentAssignment>,
+) {
+    if let Some(nb) = plan.as_ref().as_network_boundary() {
+        let stage = nb.input_stage();
+        let stage_id = stage.num() as u32;
+        // Boundary's name decides routing rule. Downcasting through the
+        // trait gives us back-pointers to the concrete type, but the
+        // dispatcher only needs the receive-side math which is identical
+        // for the embedded model whether we got here through Shuffle or
+        // Coalesce; the only distinction is the partitions-per-task math.
+        let name = plan.name();
+        // Receive-side per-consumer-task partition count: see
+        // `NetworkShuffleExec::execute`'s `off = P_c * task_index` formula.
+        let p_c = plan.properties().partitioning.partition_count();
+
+        // Determine routing for fragments produced by this boundary's
+        // input_stage tasks.
+        let routing = match (name, parent) {
+            // Top-level gather (or any top-level boundary): consumer is leader.
+            (_, None) => FragmentRouting::Coalesce { dest_proc: 0 },
+            // Nested NetworkShuffleExec: hash routing.
+            ("NetworkShuffleExec", Some(pctx)) => FragmentRouting::Shuffle {
+                parent_stage_id: pctx.parent_stage_id,
+                partitions_per_consumer_task: p_c,
+            },
+            // Nested NetworkCoalesceExec / NetworkBroadcastExec: consumer is
+            // a single task in the parent stage. M2.d targets the natural-
+            // shape Aggregate plan where nested coalesce isn't expected;
+            // we still handle it as "all output → parent task 0" so the
+            // shape is supported when it does appear.
+            (_, Some(pctx)) => {
+                let dest = assignment.proc_for(pctx.parent_stage_id, 0).unwrap_or(0);
+                FragmentRouting::Coalesce { dest_proc: dest }
+            }
+        };
+
+        let task_count = stage.tasks.len();
+        if let Some(stage_plan) = stage.plan() {
+            for task_idx in 0..task_count {
+                let owner = assignment.proc_for(stage_id, task_idx as u32);
+                if owner == Some(this_proc) {
+                    out.push(FragmentAssignment {
+                        stage_id,
+                        task_idx,
+                        task_count,
+                        plan: Arc::clone(stage_plan),
+                        routing: routing.clone(),
+                    });
+                }
+            }
+            // Recurse into the stage's plan with THIS stage as the new
+            // parent. The boundary's `children()` returns `[stage.plan]` so
+            // descending through it would double-process every nested
+            // fragment — return here to keep visit counts exact.
+            let new_parent = ParentContext {
+                parent_stage_id: stage_id,
+            };
+            collect(stage_plan, this_proc, assignment, Some(new_parent), out);
+        }
+        return;
+    }
+    // Non-boundary nodes recurse through plan children.
+    for child in plan.children() {
+        collect(child, this_proc, assignment, parent, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::empty::EmptyExec;
+
+    #[test]
+    fn boundary_free_plan_returns_no_assignments() {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let assignment = TaskAssignment::empty(4);
+        let out = find_worker_assignments(&plan, 1, &assignment);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn routing_coalesce_for_top_level_assigns_to_leader() {
+        // Smoke check of the routing enum's Coalesce branch: a top-level
+        // boundary routes to proc 0 regardless of parent.
+        let r = FragmentRouting::Coalesce { dest_proc: 0 };
+        match r {
+            FragmentRouting::Coalesce { dest_proc } => assert_eq!(dest_proc, 0),
+            _ => panic!("expected Coalesce"),
+        }
+    }
+
+    #[test]
+    fn routing_shuffle_carries_parent_and_pc() {
+        let r = FragmentRouting::Shuffle {
+            parent_stage_id: 7,
+            partitions_per_consumer_task: 3,
+        };
+        match r {
+            FragmentRouting::Shuffle {
+                parent_stage_id,
+                partitions_per_consumer_task,
+            } => {
+                assert_eq!(parent_stage_id, 7);
+                assert_eq!(partitions_per_consumer_task, 3);
+            }
+            _ => panic!("expected Shuffle"),
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -97,6 +97,27 @@ pub enum FragmentRouting {
         /// `P_c` in the receive-side formula `off = P_c * task_index`.
         partitions_per_consumer_task: usize,
     },
+    /// Broadcast mesh ([`NetworkBroadcastExec`]). Wire-level routing math is
+    /// identical to [`Self::Shuffle`] (consumer task `q / P_c`), but the
+    /// pg_search natural-shape plan canonical-replicates the build subtree
+    /// across all workers — every input task scans the full canonical data
+    /// and the consumer's `select_all` would union duplicates. We force
+    /// `input_task_count = 1` at the wire layer by having only task 0 run
+    /// the producer plan; tasks `task_idx > 0` short-circuit to per-partition
+    /// EOF. The consumer's three input streams then yield real data from
+    /// task 0 + empty streams from the others, matching the upstream
+    /// "single producer broadcast" pattern.
+    ///
+    /// [`NetworkBroadcastExec`]: datafusion_distributed::NetworkBroadcastExec
+    Broadcast {
+        /// Stage id of the immediately enclosing stage. Same semantics as
+        /// [`Self::Shuffle::parent_stage_id`].
+        parent_stage_id: u32,
+        /// `B.properties().output_partitioning().partition_count()`. Same
+        /// semantics as
+        /// [`Self::Shuffle::partitions_per_consumer_task`].
+        partitions_per_consumer_task: usize,
+    },
 }
 
 #[derive(Clone, Copy)]
@@ -141,6 +162,17 @@ pub fn find_worker_assignments(
                 } => crate::mpp_log!(
                     "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
                      n_out={n_out} routing=Shuffle parent_stage_id={parent_stage_id} \
+                     partitions_per_consumer_task={partitions_per_consumer_task}",
+                    f.stage_id,
+                    f.task_idx,
+                    f.task_count,
+                ),
+                FragmentRouting::Broadcast {
+                    parent_stage_id,
+                    partitions_per_consumer_task,
+                } => crate::mpp_log!(
+                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
+                     n_out={n_out} routing=Broadcast parent_stage_id={parent_stage_id} \
                      partitions_per_consumer_task={partitions_per_consumer_task}",
                     f.stage_id,
                     f.task_idx,
@@ -195,14 +227,20 @@ fn collect(
         let routing = match (name, parent) {
             // Top-level boundary: consumer is leader.
             (_, None) => FragmentRouting::Coalesce { dest_proc: 0 },
-            // Nested NetworkShuffleExec or NetworkBroadcastExec: each
+            // Nested NetworkShuffleExec: hash-partitioned mesh. Each
             // output partition q maps to consumer task q / p_c.
-            ("NetworkShuffleExec" | "NetworkBroadcastExec", Some(pctx)) => {
-                FragmentRouting::Shuffle {
-                    parent_stage_id: pctx.parent_stage_id,
-                    partitions_per_consumer_task: p_c,
-                }
-            }
+            ("NetworkShuffleExec", Some(pctx)) => FragmentRouting::Shuffle {
+                parent_stage_id: pctx.parent_stage_id,
+                partitions_per_consumer_task: p_c,
+            },
+            // Nested NetworkBroadcastExec: same wire-level math as
+            // Shuffle, but the dispatcher only runs the producer plan on
+            // task 0 to avoid the canonical-replica duplication described
+            // on FragmentRouting::Broadcast.
+            ("NetworkBroadcastExec", Some(pctx)) => FragmentRouting::Broadcast {
+                parent_stage_id: pctx.parent_stage_id,
+                partitions_per_consumer_task: p_c,
+            },
             // Nested NetworkCoalesceExec: consumer is a single task in
             // the parent stage. The receive math collapses to task 0 of
             // the parent group.

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -154,8 +154,8 @@ SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
-                                                                                  QUERY PLAN                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -165,18 +165,21 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
      : ┌───── DistributedExec ── Tasks: t0:[p0]
      : │ AggregateExec: mode=Final, gby=[], aggr=[agg_0]
      : │   CoalescePartitionsExec
-     : │     AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
-     : │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
-     : │         CoalescePartitionsExec
-     : │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=1, input_tasks=3
-     : │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     : │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 1 ── Tasks: t0:[p0] t1:[p1] t2:[p2]
-     :   │ BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-     :   │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
+     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+     :   │     CoalescePartitionsExec
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=3
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+     :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-(20 rows)
+     :     ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+     :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     └──────────────────────────────────────────────────
+(23 rows)
 
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
@@ -195,8 +198,8 @@ GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
 WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Gather Merge
@@ -214,21 +217,27 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                      DataFusion Physical Plan: 
                        : ┌───── DistributedExec ── Tasks: t0:[p0]
                        : │ SortPreservingMergeExec: [title@0 ASC NULLS LAST], fetch=5
-                       : │   SortExec: TopK(fetch=5), expr=[title@0 ASC NULLS LAST], preserve_partitioning=[true]
-                       : │     AggregateExec: mode=FinalPartitioned, gby=[title@0 as title], aggr=[agg_0, agg_1]
-                       : │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                       : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
                        : └──────────────────────────────────────────────────
-                       :   ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
-                       :   │ RepartitionExec: partitioning=Hash([title@0], 3), input_partitions=3
-                       :   │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[agg_0, agg_1]
-                       :   │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
-                       :   │       CoalescePartitionsExec
-                       :   │         BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-                       :   │           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                       :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                       :   │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                       :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                       :   │ SortExec: TopK(fetch=5), expr=[title@0 ASC NULLS LAST], preserve_partitioning=[true]
+                       :   │   AggregateExec: mode=FinalPartitioned, gby=[title@0 as title], aggr=[agg_0, agg_1]
+                       :   │     [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
                        :   └──────────────────────────────────────────────────
-(31 rows)
+                       :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                       :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=3
+                       :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[agg_0, agg_1]
+                       :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
+                       :     │       CoalescePartitionsExec
+                       :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=3
+                       :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                       :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                       :     └──────────────────────────────────────────────────
+                       :       ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+                       :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                       :       │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                       :       └──────────────────────────────────────────────────
+(37 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -1,0 +1,216 @@
+-- =====================================================================
+-- MPP AggregateScan: multi-stage natural-shape plan coverage.
+--
+-- Exercises the M2.d/M3 transport substrate end-to-end via post-aggregate
+-- patterns that produce a three-stage plan
+-- (NetworkCoalesceExec -> NetworkShuffleExec -> NetworkBroadcastExec):
+--   - GROUP BY one key, multiple aggregates
+--   - GROUP BY multiple keys
+--   - HAVING + ORDER BY + LIMIT
+--   - aggregation over a HashJoin with broadcast build subtree
+--
+-- Each pass runs the same query in serial mode (enable_mpp=off) then MPP
+-- mode (enable_mpp=on) and the expected.out compares them byte-for-byte
+-- — any MPP-vs-serial divergence shows up as a regression.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+CREATE TABLE mpp_postagg_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_postagg_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+CREATE INDEX mpp_postagg_files_idx ON mpp_postagg_files
+USING bm25 (id, title, category, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "category": {"fast": true}, "content": {}}'
+);
+CREATE INDEX mpp_postagg_pages_idx ON mpp_postagg_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+ANALYZE mpp_postagg_files;
+ANALYZE mpp_postagg_pages;
+-- =====================================================================
+-- Scenario 1: GROUP BY one key with multiple aggregates.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category | row_count | total_bytes | min_bytes | max_bytes 
+----------+-----------+-------------+-----------+-----------
+ cat-0    |       200 |      394380 |         4 |      4063
+ cat-1    |       200 |      397780 |        21 |      4080
+ cat-2    |       200 |      396468 |         1 |      4081
+ cat-3    |       200 |      395772 |         2 |      4082
+ cat-4    |       200 |      395076 |         3 |      4083
+(5 rows)
+
+SET paradedb.enable_mpp TO on;
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category | row_count | total_bytes | min_bytes | max_bytes 
+----------+-----------+-------------+-----------+-----------
+ cat-0    |       200 |      394380 |         4 |      4063
+ cat-1    |       200 |      397780 |        21 |      4080
+ cat-2    |       200 |      396468 |         1 |      4081
+ cat-3    |       200 |      395772 |         2 |      4082
+ cat-4    |       200 |      395076 |         3 |      4083
+(5 rows)
+
+-- =====================================================================
+-- Scenario 2: GROUP BY multiple keys.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  title   | pages_per_file 
+----------+----------+----------------
+ cat-0    | file-10  |              5
+ cat-0    | file-100 |              5
+ cat-0    | file-105 |              5
+ cat-0    | file-110 |              5
+ cat-0    | file-115 |              5
+ cat-0    | file-120 |              5
+ cat-0    | file-125 |              5
+ cat-0    | file-130 |              5
+ cat-0    | file-135 |              5
+ cat-0    | file-140 |              5
+(10 rows)
+
+SET paradedb.enable_mpp TO on;
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  title   | pages_per_file 
+----------+----------+----------------
+ cat-0    | file-10  |              5
+ cat-0    | file-100 |              5
+ cat-0    | file-105 |              5
+ cat-0    | file-110 |              5
+ cat-0    | file-115 |              5
+ cat-0    | file-120 |              5
+ cat-0    | file-125 |              5
+ cat-0    | file-130 |              5
+ cat-0    | file-135 |              5
+ cat-0    | file-140 |              5
+(10 rows)
+
+-- =====================================================================
+-- Scenario 3: HAVING + ORDER BY + LIMIT — late aggregate filtering.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  c  |   s    
+----------+-----+--------
+ cat-1    | 200 | 397780
+ cat-2    | 200 | 396468
+ cat-3    | 200 | 395772
+(3 rows)
+
+SET paradedb.enable_mpp TO on;
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  c  |   s    
+----------+-----+--------
+ cat-1    | 200 | 397780
+ cat-2    | 200 | 396468
+ cat-3    | 200 | 395772
+(3 rows)
+
+-- =====================================================================
+-- Scenario 4: Scalar COUNT(*) — falls back to serial (planner caps the
+-- task_count for scalar aggregates), but confirms MPP-on doesn't break
+-- the serial fallback path.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ count 
+-------
+  1000
+(1 row)
+
+SET paradedb.enable_mpp TO on;
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ count 
+-------
+  1000
+(1 row)
+
+-- =====================================================================
+-- Cleanup
+-- =====================================================================
+DROP TABLE mpp_postagg_pages;
+DROP TABLE mpp_postagg_files;

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -210,7 +210,68 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
 (1 row)
 
 -- =====================================================================
+-- Scenario 5: Three-table join (two HashJoins → two NetworkBroadcastExec
+-- build subtrees under one NetworkShuffleExec shuffle).
+--
+-- Exercises the walker's nested-parent context propagation across two
+-- distinct `stage_id`s simultaneously, and the dispatcher's per-channel
+-- EOF on multiple Broadcast routings + the broadcast short-circuit on
+-- task_idx > 0 for both build stages.
+-- =====================================================================
+CREATE TABLE mpp_postagg_categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    description TEXT
+);
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(0, 4) AS g;
+CREATE INDEX mpp_postagg_categories_idx ON mpp_postagg_categories
+USING bm25 (id, name, description)
+WITH (
+    key_field='id',
+    text_fields='{"name": {"fast": true}, "description": {}}'
+);
+ANALYZE mpp_postagg_categories;
+SET paradedb.enable_mpp TO off;
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
+ name  | row_count | total_bytes 
+-------+-----------+-------------
+ cat-0 |       200 |      394380
+ cat-1 |       200 |      397780
+ cat-2 |       200 |      396468
+ cat-3 |       200 |      395772
+ cat-4 |       200 |      395076
+(5 rows)
+
+SET paradedb.enable_mpp TO on;
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
+ name  | row_count | total_bytes 
+-------+-----------+-------------
+ cat-0 |       200 |      394380
+ cat-1 |       200 |      397780
+ cat-2 |       200 |      396468
+ cat-3 |       200 |      395772
+ cat-4 |       200 |      395076
+(5 rows)
+
+-- =====================================================================
 -- Cleanup
 -- =====================================================================
+DROP TABLE mpp_postagg_categories;
 DROP TABLE mpp_postagg_pages;
 DROP TABLE mpp_postagg_files;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
@@ -161,8 +161,58 @@ FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 
 -- =====================================================================
+-- Scenario 5: Three-table join (two HashJoins → two NetworkBroadcastExec
+-- build subtrees under one NetworkShuffleExec shuffle).
+--
+-- Exercises the walker's nested-parent context propagation across two
+-- distinct `stage_id`s simultaneously, and the dispatcher's per-channel
+-- EOF on multiple Broadcast routings + the broadcast short-circuit on
+-- task_idx > 0 for both build stages.
+-- =====================================================================
+
+CREATE TABLE mpp_postagg_categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    description TEXT
+);
+
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(0, 4) AS g;
+
+CREATE INDEX mpp_postagg_categories_idx ON mpp_postagg_categories
+USING bm25 (id, name, description)
+WITH (
+    key_field='id',
+    text_fields='{"name": {"fast": true}, "description": {}}'
+);
+
+ANALYZE mpp_postagg_categories;
+
+SET paradedb.enable_mpp TO off;
+
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+
+SET paradedb.enable_mpp TO on;
+
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+
+-- =====================================================================
 -- Cleanup
 -- =====================================================================
 
+DROP TABLE mpp_postagg_categories;
 DROP TABLE mpp_postagg_pages;
 DROP TABLE mpp_postagg_files;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
@@ -1,0 +1,168 @@
+-- =====================================================================
+-- MPP AggregateScan: multi-stage natural-shape plan coverage.
+--
+-- Exercises the M2.d/M3 transport substrate end-to-end via post-aggregate
+-- patterns that produce a three-stage plan
+-- (NetworkCoalesceExec -> NetworkShuffleExec -> NetworkBroadcastExec):
+--   - GROUP BY one key, multiple aggregates
+--   - GROUP BY multiple keys
+--   - HAVING + ORDER BY + LIMIT
+--   - aggregation over a HashJoin with broadcast build subtree
+--
+-- Each pass runs the same query in serial mode (enable_mpp=off) then MPP
+-- mode (enable_mpp=on) and the expected.out compares them byte-for-byte
+-- — any MPP-vs-serial divergence shows up as a regression.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+CREATE TABLE mpp_postagg_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_postagg_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+
+CREATE INDEX mpp_postagg_files_idx ON mpp_postagg_files
+USING bm25 (id, title, category, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "category": {"fast": true}, "content": {}}'
+);
+
+CREATE INDEX mpp_postagg_pages_idx ON mpp_postagg_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+
+ANALYZE mpp_postagg_files;
+ANALYZE mpp_postagg_pages;
+
+-- =====================================================================
+-- Scenario 1: GROUP BY one key with multiple aggregates.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+
+SET paradedb.enable_mpp TO on;
+
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+
+-- =====================================================================
+-- Scenario 2: GROUP BY multiple keys.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+
+SET paradedb.enable_mpp TO on;
+
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+
+-- =====================================================================
+-- Scenario 3: HAVING + ORDER BY + LIMIT — late aggregate filtering.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+
+SET paradedb.enable_mpp TO on;
+
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+
+-- =====================================================================
+-- Scenario 4: Scalar COUNT(*) — falls back to serial (planner caps the
+-- task_count for scalar aggregates), but confirms MPP-on doesn't break
+-- the serial fallback path.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+SET paradedb.enable_mpp TO on;
+
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+-- =====================================================================
+-- Cleanup
+-- =====================================================================
+
+DROP TABLE mpp_postagg_pages;
+DROP TABLE mpp_postagg_files;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Adds the multi-stage natural-shape MPP path for AggregateScan. Lets the DF-D fork's distributed planner produce its default three-stage layout — `NetworkCoalesceExec` (gather to leader) → `NetworkShuffleExec` (peer-mesh hash shuffle of partial-aggregate output) → `NetworkBroadcastExec` (HashJoin build subtree) — and routes the worker fragments through a multiplexed N×N `shm_mq` mesh. Default off behind `paradedb.enable_mpp`; stacks on top of #4988 (single-stage gather).

## Why

#4988 ships AggregateScan MPP with a single-stage gather: each worker runs the full join + partial-aggregate locally, then sends one stream of partial-aggregate rows to the leader for the final aggregate. That works at small N but loses cardinality reduction at the partial-aggregate boundary — the leader still has to merge `N × n_groups` worth of partial rows on a single thread.

The natural-shape plan moves the merge off the leader. Partial-aggregate output is hash-shuffled across the workers in a peer-mesh, every worker does its slice of the final aggregate, and only the already-reduced final-aggregate rows flow to the leader. This is the layout the DF-D planner emits by default for GROUP BY over a HashJoin; the previous single-stage path was a stepping stone, not the end state.

## How

The single-stage M2.a path had two shortcuts that don't hold for peer-mesh shuffles: one `shm_mq` queue per producer (so the queue's attach state was the EOF signal), and `(stage_id, task_idx) → proc` resolved via a `task + 1` heuristic. The natural-shape plan needs neither.

- **Wire format.** Every batch is prefixed by a 16-byte `MppFrameHeader { magic, flags, stage_id, partition }`, so one `shm_mq` queue can multiplex multiple `(stage_id, partition)` channels between the same proc pair.
- **DSM layout V2.** `n_procs × n_procs` grid of `shm_mq` queues, one slot per `(sender_proc, receiver_proc)` pair. Replaces M1's per-producer slice.
- **Sub-buffer registry inside each `DrainHandle`.** The drain decodes the frame header, looks up the matching `(stage_id, partition)` sub-buffer, pushes the batch there. Late-registering consumers (their `WorkerTransport::open` runs after the first frame arrives) get the same sub-buffer because the registry is `Mutex<HashMap>` keyed on `(stage_id, partition)` and entries are idempotent.
- **Plan-driven assignment.** `TaskAssignment::from_plan` walks every `NetworkBoundary` in the leader's physical plan and records `(stage_id, task_idx) → proc_idx` for each task. The same walk runs on workers so the table is byte-identical across procs. Round-robin policy `1 + (task_idx % n_workers)` for now; encoded as a table so future shapes can grow stages independently.
- **Multi-fragment worker dispatcher.** Worker walks its physical plan, finds every `(stage_id, task_idx)` slot the assignment table places on this proc, and runs one Tokio future per fragment via `try_join_all`. Each fragment's per-partition senders compute their destination proc from the routing rule attached to the boundary (`Coalesce` → one proc; `Shuffle` → `q / P_c` consumer task; `Broadcast` → same shuffle math but only `task_idx == 0` actually produces).
- **Cooperative drain on outbound spin.** Each fragment's sender attaches the worker's `MppMesh` as a `CooperativeDrainSet`. When an outbound queue is full, the spin pulls every inbound queue in lockstep, so symmetric peer-mesh stalls don't deadlock the single-threaded Tokio runtime.
- **Per-channel EOF.** The multiplexed queue stays attached as long as any fragment holds an outbound sender, so the M2.a queue-detach-as-EOF trick doesn't fire. Each per-partition future sends an `MppFrameKind::Eof` frame after its stream exhausts; the receive side decodes it and `notify_source_done`s the matching sub-buffer. EOF is sent on the error path too, so a producer-side error doesn't silently hang a consumer.
- **Self-loop channel.** Peer-mesh routing can land a producer's output on its own proc. The worker's outbound senders Vec gets an in-process channel at `slot(this_proc, this_proc)` so the same frame routing works whether the destination is a peer or self.
- **Broadcast cap at the planner.** pg_search's all-gather step already canonical-replicates the HashJoin build subtree on every worker, so the DF-D fork's default `input_task_count = n_workers` would scan-and-broadcast the full data on every input task and `select_all` on the consumer would over-count by `n_workers`. `BroadcastBuildSideOneTaskEstimator` caps the canonical-replica memory leaf at `task_count = 1` before `_distribute_plan` runs, so `NetworkBroadcastExec` is built with `input_task_count = 1` and only one producer actually emits. The dispatcher has a `debug_assert!(task_idx == 0)` + hard `DataFusionError` in release for any unexpected non-zero Broadcast `task_idx`, matching the top-level Broadcast handling.
- **Diagnostics.** `paradedb.mpp_debug = on` lights up traces on assignment-table construction, walker fragment decisions, transport `open()` / `stream_partition()` calls, and worker dispatch routing — plus a 30s `tokio::time::timeout` around `try_join_all` so a hang surfaces as a real error rather than spinning forever. Production cost is zero when the GUC is off.

## Reviewer's Guide

The four big modules under `pg_search/src/postgres/customscan/mpp/`:

1. `transport.rs` — `MppFrameHeader`, `DrainHandle` with the `(stage_id, partition)` sub-buffer registry, `MppSender::send_batch_traced` + `send_eof_traced` (cooperative-spin send with optional drain attached).
2. `runtime.rs` — `MppMesh` (per-proc inbound drains + assignment table + cooperative-drain impl) and `ShmMqWorkerTransport` (the fork's `WorkerTransport` impl, now routes through the assignment table).
3. `assignment.rs` + `worker_fragments.rs` — plan-driven assignment table and the worker-side walker that turns it into `FragmentAssignment { stage_id, task_idx, plan, routing }`. `FragmentRouting::{Coalesce, Shuffle, Broadcast}` is where the receive-side math from each `NetworkBoundary` flavour gets reflected on the send side.
4. `task_estimator.rs` — `BroadcastBuildSideOneTaskEstimator`, the planner-level cap that makes `NetworkBroadcastExec(input_task_count=1)` for the canonical replica.

The dispatcher itself lives in `aggregatescan/mod.rs::exec_mpp_worker`. Leader-side install is in the same file at `exec_custom_scan`.

## Tests

- pgrx regression suite — new `mpp_aggregate_postagg.sql` covers GROUP BY with multiple aggregates, GROUP BY multiple keys, HAVING + ORDER BY + LIMIT, scalar baseline, and a three-table inner join that exercises two simultaneous `NetworkBroadcastExec` stages plus the shuffle. Each scenario runs serial then MPP and `expected.out` compares byte-for-byte. Existing `mpp_aggregate` + `mpp_smoke` still pass.
- Unit tests on `transport::DrainHandle`'s sub-buffer registry (multi-stage demux, late-registration after detach, `Drop`-cancels-registered-sub-buffers), `TaskAssignment::from_plan` on a boundary-free plan, `worker_fragments::find_worker_assignments` routing rules, and `BroadcastBuildSideOneTaskEstimator`.
- `paradedb.mpp_debug = on` probe confirms the worker plan emits Broadcast fragments only with `task_idx=0, task_count=1` and that the 3-table join produces two `NetworkBroadcastExec` boundaries under the shuffle.
- Wider regression suites (`aggregate*`, `aggregate_join*`, `join*`) all pass, confirming the leader-side consumption path tolerates multi-stage natural plans without regressing single-stage or non-MPP shapes.