### PR TITLE
chore: replace deprecated action-remove-labels with gh CLI + app token

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -253,10 +253,18 @@ jobs:
       # `antithesis-stressgres`, or `antithesis-proptests` label to a PR. This
       # step removes the triggering label once the job has started so it can be
       # applied again if needed.
+      - name: Generate GitHub App Token for Label Removal
+        id: label-app-token
+        if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Maybe Remove Label
         if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.label-app-token.outputs.token }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -254,10 +254,13 @@ jobs:
       # step removes the triggering label once the job has started so it can be
       # applied again if needed.
       - name: Maybe Remove Label
-        uses: actions-ecosystem/action-remove-labels@v1
         if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
-        with:
-          labels: ${{ github.event.label.name }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "${{ github.event.label.name }}" || true
 
       - name: Checkout Git Repository
         uses: actions/checkout@v6

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -65,12 +65,22 @@ jobs:
     steps:
       # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
+      - name: Generate GitHub App Token for Label Removal
+        id: label-app-token
+        if: >-
+          github.event_name == 'pull_request' &&
+          contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Maybe Remove Label
         if: >-
           github.event_name == 'pull_request' &&
           contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.label-app-token.outputs.token }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -66,14 +66,16 @@ jobs:
       # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label
-        uses: actions-ecosystem/action-remove-labels@v1
         if: >-
           github.event_name == 'pull_request' &&
           contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-        with:
-          labels: |
-            benchmark
-            benchmark-queries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label benchmark \
+            --remove-label benchmark-queries || true
 
       - name: Determine Ref to Benchmark
         id: determine-ref

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -48,10 +48,18 @@ jobs:
     steps:
       # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
+      - name: Generate GitHub App Token for Label Removal
+        id: label-app-token
+        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-stressgres')
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
       - name: Maybe Remove Label
         if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-stressgres')
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.label-app-token.outputs.token }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -49,12 +49,14 @@ jobs:
       # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label
-        uses: actions-ecosystem/action-remove-labels@v1
-        if: github.event_name == 'pull_request' && github.event.label.name == 'benchmark' || github.event_name == 'pull_request' && github.event.label.name == 'benchmark-stressgres'
-        with:
-          labels: |
-            benchmark
-            benchmark-stressgres
+        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-stressgres')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label benchmark \
+            --remove-label benchmark-stressgres || true
 
       - name: Determine Ref to Benchmark
         id: determine-ref


### PR DESCRIPTION
## Summary
- `actions-ecosystem/action-remove-labels@v1` is unmaintained and still runs on Node.js 20, which GitHub Actions is deprecating (it now warns on every benchmark workflow run). Replaced the three usages in `antithesis-trigger-test-run.yml`, `benchmark-pg_search-benchmarks.yml`, and `benchmark-pg_search-stressgres.yml` with an inline `gh pr edit --remove-label` call using the pre-installed GitHub CLI.
- Fork PRs receive a read-only `GITHUB_TOKEN`, which made the old action fail with `Resource not accessible by integration` (and would break the `gh` swap identically). Mint a `paradedb-github-app` token via `actions/create-github-app-token@v3` for the label-removal step, matching the pattern already used in `cherry-pick.yml` and `publish-paradedb-docker.yml`.
- `|| true` preserves the prior tolerant behavior when a label is already absent.

> [!IMPORTANT]
> The `paradedb-github-bot` App must have **Pull requests: Read & write** in its repo permissions, and that permission must be accepted on the installation. Without it, the token will still 403 on `gh pr edit --remove-label`.

## Test plan
- [x] Trigger `benchmark-pg_search-stressgres` by attaching the `benchmark` or `benchmark-stressgres` label to a fork PR and confirm the label is removed once the job starts.
- [x] Trigger `benchmark-pg_search-benchmarks` by attaching the `benchmark` or `benchmark-queries` label to a fork PR and confirm removal.
- [x] Trigger `antithesis-trigger-test-run` by attaching one of `antithesis`, `antithesis-stressgres`, or `antithesis-proptests` to a fork PR and confirm the triggering label is removed.
- [x] Same three scenarios on a same-repo PR to make sure the App-token path still works.