### PR TITLE
ci: remove app token from PR label cleanup

### DIFF
--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Git ref or short SHA to report in benchmarks"
     required: true
   github_app_id:
-    description: "GitHub App client ID to authenticate with"
+    description: "GitHub App ID to authenticate with"
     required: true
   github_app_private_key:
     description: "GitHub App private key to authenticate with"
@@ -100,45 +100,25 @@ runs:
         with open(f"pg_search_tps.json", "w")  as o: json.dump(tps, o)
         with open(f"pg_search_other.json", "w") as o: json.dump(other, o)
 
-    - name: Determine Whether Benchmark Publishing Is Available
-      id: publish-auth
-      shell: bash
-      run: |
-        if [ -n "${{ inputs.github_app_id }}" ] && [ -n "${{ inputs.github_app_private_key }}" ]; then
-          echo "enabled=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "enabled=false" >> "$GITHUB_OUTPUT"
-        fi
-
     - name: Generate GitHub App Token
       id: app-token
-      if: steps.publish-auth.outputs.enabled == 'true'
       uses: actions/create-github-app-token@v3
       with:
         client-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}
 
-    - name: Explain Why Benchmark Publication Is Skipped
-      if: steps.publish-auth.outputs.enabled != 'true'
-      shell: bash
-      run: |
-        echo "::notice::Skipping benchmark publication and PR comments because GitHub App credentials are unavailable in this workflow context. This is expected for pull_request runs from forks."
-
     # Necessary to avoid "destination path is not empty" error
     - name: Cleanup Previous Benchmark Publish Working Directory
-      if: steps.app-token.outputs.token != ''
       shell: bash
       run: rm -rf ./benchmark-data-repository
 
     # we sleep for a random number of seconds to hopefully avoid conflicting with other concurrent
     # benchmark-action publish actions running in other jobs
     - name: Sleep before publish
-      if: steps.app-token.outputs.token != ''
       shell: bash
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish TPS Metrics
-      if: steps.app-token.outputs.token != ''
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - TPS"
@@ -157,19 +137,16 @@ runs:
 
     # Necessary to avoid "destination path is not empty" error
     - name: Cleanup Previous Benchmark Publish Working Directory
-      if: steps.app-token.outputs.token != ''
       shell: bash
       run: rm -rf ./benchmark-data-repository
 
     # we sleep for a random number of seconds to hopefully avoid conflicting with other concurrent
     # benchmark-action publish actions running in other jobs
     - name: Sleep before publish
-      if: steps.app-token.outputs.token != ''
       shell: bash
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish Other Metrics
-      if: steps.app-token.outputs.token != ''
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - Other Metrics"

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Git ref or short SHA to report in benchmarks"
     required: true
   github_app_id:
-    description: "GitHub App ID to authenticate with"
+    description: "GitHub App client ID to authenticate with"
     required: true
   github_app_private_key:
     description: "GitHub App private key to authenticate with"
@@ -100,25 +100,45 @@ runs:
         with open(f"pg_search_tps.json", "w")  as o: json.dump(tps, o)
         with open(f"pg_search_other.json", "w") as o: json.dump(other, o)
 
+    - name: Determine Whether Benchmark Publishing Is Available
+      id: publish-auth
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.github_app_id }}" ] && [ -n "${{ inputs.github_app_private_key }}" ]; then
+          echo "enabled=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "enabled=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: Generate GitHub App Token
       id: app-token
+      if: steps.publish-auth.outputs.enabled == 'true'
       uses: actions/create-github-app-token@v3
       with:
         client-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}
 
+    - name: Explain Why Benchmark Publication Is Skipped
+      if: steps.publish-auth.outputs.enabled != 'true'
+      shell: bash
+      run: |
+        echo "::notice::Skipping benchmark publication and PR comments because GitHub App credentials are unavailable in this workflow context. This is expected for pull_request runs from forks."
+
     # Necessary to avoid "destination path is not empty" error
     - name: Cleanup Previous Benchmark Publish Working Directory
+      if: steps.app-token.outputs.token != ''
       shell: bash
       run: rm -rf ./benchmark-data-repository
 
     # we sleep for a random number of seconds to hopefully avoid conflicting with other concurrent
     # benchmark-action publish actions running in other jobs
     - name: Sleep before publish
+      if: steps.app-token.outputs.token != ''
       shell: bash
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish TPS Metrics
+      if: steps.app-token.outputs.token != ''
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - TPS"
@@ -137,16 +157,19 @@ runs:
 
     # Necessary to avoid "destination path is not empty" error
     - name: Cleanup Previous Benchmark Publish Working Directory
+      if: steps.app-token.outputs.token != ''
       shell: bash
       run: rm -rf ./benchmark-data-repository
 
     # we sleep for a random number of seconds to hopefully avoid conflicting with other concurrent
     # benchmark-action publish actions running in other jobs
     - name: Sleep before publish
+      if: steps.app-token.outputs.token != ''
       shell: bash
       run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
 
     - name: Publish Other Metrics
+      if: steps.app-token.outputs.token != ''
       uses: benchmark-action/github-action-benchmark@v1
       with:
         name: "pg_search ${{ inputs.test_file }} Performance - Other Metrics"

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: "Git ref or short SHA to report in benchmarks"
     required: true
   github_app_id:
-    description: "GitHub App ID to authenticate with"
+    description: "GitHub App client ID to authenticate with"
     required: true
   github_app_private_key:
     description: "GitHub App private key to authenticate with"

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -253,18 +253,10 @@ jobs:
       # `antithesis-stressgres`, or `antithesis-proptests` label to a PR. This
       # step removes the triggering label once the job has started so it can be
       # applied again if needed.
-      - name: Generate GitHub App Token for Label Removal
-        id: label-app-token
-        if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-
       - name: Maybe Remove Label
         if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
         env:
-          GH_TOKEN: ${{ steps.label-app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -65,22 +65,12 @@ jobs:
     steps:
       # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
-      - name: Generate GitHub App Token for Label Removal
-        id: label-app-token
-        if: >-
-          github.event_name == 'pull_request' &&
-          contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-
       - name: Maybe Remove Label
         if: >-
           github.event_name == 'pull_request' &&
           contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)
         env:
-          GH_TOKEN: ${{ steps.label-app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -48,37 +48,15 @@ jobs:
     steps:
       # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
-      - name: Generate GitHub App Token for Label Removal
-        id: label-app-token
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.fork == false &&
-          contains(fromJson('["benchmark", "benchmark-stressgres"]'), github.event.label.name)
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-
       - name: Maybe Remove Label
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.fork == false &&
-          contains(fromJson('["benchmark", "benchmark-stressgres"]'), github.event.label.name)
+        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-stressgres')
         env:
-          GH_TOKEN: ${{ steps.label-app-token.outputs.token }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --remove-label benchmark \
             --remove-label benchmark-stressgres || true
-
-      - name: Explain Why Benchmark Label Is Left In Place
-        if: >-
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.fork == true &&
-          contains(fromJson('["benchmark", "benchmark-stressgres"]'), github.event.label.name)
-        run: |
-          echo "::notice::Leaving the benchmark label in place because forked pull_request runs do not get GitHub App credentials or a write-capable workflow token."
 
       - name: Determine Ref to Benchmark
         id: determine-ref

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -50,14 +50,20 @@ jobs:
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Generate GitHub App Token for Label Removal
         id: label-app-token
-        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-stressgres')
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          contains(fromJson('["benchmark", "benchmark-stressgres"]'), github.event.label.name)
         uses: actions/create-github-app-token@v3
         with:
           client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Maybe Remove Label
-        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-stressgres')
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          contains(fromJson('["benchmark", "benchmark-stressgres"]'), github.event.label.name)
         env:
           GH_TOKEN: ${{ steps.label-app-token.outputs.token }}
         run: |
@@ -65,6 +71,14 @@ jobs:
             --repo ${{ github.repository }} \
             --remove-label benchmark \
             --remove-label benchmark-stressgres || true
+
+      - name: Explain Why Benchmark Label Is Left In Place
+        if: >-
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == true &&
+          contains(fromJson('["benchmark", "benchmark-stressgres"]'), github.event.label.name)
+        run: |
+          echo "::notice::Leaving the benchmark label in place because forked pull_request runs do not get GitHub App credentials or a write-capable workflow token."
 
       - name: Determine Ref to Benchmark
         id: determine-ref


### PR DESCRIPTION
## Summary
- keep the `gh pr edit --remove-label` label cleanup introduced in `90f7b868`
- remove the GitHub App token minting from the three label-cleanup workflows
- clarify that `github_app_id` in the stressgres composite action is a GitHub App client ID

## Why
The GitHub App token setup added for PR label removal is the part you wanted to back out. This keeps the `gh`-based label removal implementation, but switches it back to the default workflow token.

## Impact
The three workflows still try to remove their trigger labels with `gh pr edit`, but they no longer depend on GitHub App credentials to do it.

## Validation
- `git diff --check`
- repository pre-commit hooks triggered by both commits, including YAML validation and prettier
