### PR TITLE
ci(antithesis): fix workload build context after Dockerfile flattening

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -277,7 +277,7 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           name: pg-search-antithesis-deb-${{ env.COMMIT_SHA }}
-          path: .
+          path: docker
 
       - name: Log Into Antithesis Registry
         uses: docker/login-action@v4
@@ -301,7 +301,7 @@ jobs:
       - name: Build and Push Workload Docker Image to Antithesis Registry
         uses: docker/build-push-action@v7
         with:
-          context: .
+          context: docker
           platforms: linux/amd64
           file: docker/Dockerfile.antithesis-${{ env.PG_VERSION }}
           push: true


### PR DESCRIPTION
## Summary

- The Antithesis workload build has been failing with `failed to compute cache key: ... "/bootstrap.sh": not found` (e.g. [paradedb-enterprise run 25710875381](https://github.com/paradedb/paradedb-enterprise/actions/runs/25710875381/job/75494288701)). The same bug exists here in OSS — it just hasn't tripped because nothing has run the workload build since the regression.
- Root cause: PR #5038 changed `COPY ./docker/bootstrap.sh` → `COPY ./bootstrap.sh` in all paradedb/antithesis Dockerfiles and updated `publish-paradedb-docker.yml` to `context: docker`, but missed `antithesis-trigger-test-run.yml`, which still uses `context: .`. Under that context, `COPY ./bootstrap.sh` looks for the file at the repo root, where it doesn't exist.
- Fix: switch the **workload** build to `context: docker` (matching the publish workflow) and download the `.deb` artifact into `docker/` so `COPY pg_search-...deb` resolves under the new context. The config and driver build steps keep `context: .` because their Dockerfiles reference paths outside `docker/` (e.g. `tests/antithesis/`, `stressgres/suites/antithesis/`, `docker/manifests/`).

## Test plan

- [x] Trigger the Antithesis workflow on this branch and confirm "Build and Push Workload Docker Image to Antithesis Registry" succeeds for both proptests and stressgres workloads.
- [x] Confirm the config and driver build steps still succeed (they retain `context: .`).
- [x] Confirm the resulting workload image has `/docker-entrypoint-initdb.d/10_bootstrap_paradedb.sh` and `/usr/lib/postgresql/18/lib/pg_search.so`.

A mirror fix is also needed in paradedb-enterprise (same workflow, same bug).