### PR TITLE
ci(antithesis): ping Slack on nightly run failure

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -384,3 +384,60 @@ jobs:
             custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }}
             custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg
             custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg
+
+  # Ping Slack if any of the nightly (scheduled) jobs failed. Scheduled runs only execute on
+  # paradedb-enterprise (see the `if` on `setup`), so this notification only fires there.
+  notify-slack-on-failure:
+    name: Notify Slack on Failure
+    needs: [setup, build-antithesis-pg_search-deb, antithesis-trigger-test-run]
+    if: |
+      always()
+      && github.event_name == 'schedule'
+      && (needs.setup.result == 'failure'
+          || needs.build-antithesis-pg_search-deb.result == 'failure'
+          || needs.antithesis-trigger-test-run.result == 'failure')
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+    steps:
+      - name: Determine failed jobs
+        id: failed-jobs
+        run: |
+          FAILED_JOBS=""
+          if [ "${{ needs.setup.result }}" == "failure" ]; then
+            FAILED_JOBS="Resolve Workloads, $FAILED_JOBS"
+          fi
+          if [ "${{ needs.build-antithesis-pg_search-deb.result }}" == "failure" ]; then
+            FAILED_JOBS="Build Antithesis pg_search .deb, $FAILED_JOBS"
+          fi
+          if [ "${{ needs.antithesis-trigger-test-run.result }}" == "failure" ]; then
+            FAILED_JOBS="Test pg_search via Antithesis, $FAILED_JOBS"
+          fi
+          FAILED_JOBS="${FAILED_JOBS%, }"
+          echo "failed_jobs=$FAILED_JOBS" >> "$GITHUB_OUTPUT"
+
+      - name: Send Slack notification
+        run: |
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            JSON_DATA="{
+              \"text\": \"🚨 Nightly Antithesis Run Failed - <!here>\",
+              \"attachments\": [
+                {
+                  \"color\": \"danger\",
+                  \"fields\": [
+                    {\"title\": \"Repository\", \"value\": \"${{ github.repository }}\", \"short\": true},
+                    {\"title\": \"Workflow\", \"value\": \"${{ github.workflow }}\", \"short\": true},
+                    {\"title\": \"Run ID\", \"value\": \"${{ github.run_id }}\", \"short\": true},
+                    {\"title\": \"View Logs\", \"value\": \"<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here>\", \"short\": true},
+                    {\"title\": \"Failed Jobs\", \"value\": \"${{ steps.failed-jobs.outputs.failed_jobs }}\", \"short\": false}
+                  ]
+                }
+              ]
+            }"
+
+            curl -X POST -H 'Content-type: application/json' \
+              --data "$JSON_DATA" \
+              "$SLACK_WEBHOOK_URL"
+          else
+            echo "Slack webhook not configured, skipping notification"
+          fi


### PR DESCRIPTION
## Summary

- Adds a `notify-slack-on-failure` job to the Antithesis trigger workflow, mirroring the pattern used in [terraform-paradedb-byoc's weekly E2E tests](https://github.com/paradedb/terraform-paradedb-byoc/blob/dev/.github/workflows/tests-weekly.yml).
- Guarded with `github.event_name == 'schedule'` so PR-label and `workflow_dispatch` runs stay quiet — only the nightly cron triggers a Slack ping.
- Posts to `SLACK_GITHUB_CHANNEL_WEBHOOK_URL` (the same secret used by all other paradedb workflows) with the failed job names and a link to the run.
- Scheduled runs only execute on `paradedb-enterprise` (per the existing `if` on `setup`), so in practice the notification only fires there. The file is synced from community, which is why the change lives here.

## Test plan

- [x] Confirm the workflow YAML parses (verified locally with `python3 -c 'import yaml; yaml.safe_load(...)'`).
- [x] After sync to enterprise, force a nightly failure (or trigger via `workflow_dispatch` with the `if` temporarily relaxed) and verify the Slack message renders correctly.