### PR TITLE
fix(mlt): quote key_field identifier in internal SPI lookup

### DIFF
--- a/pg_search/src/query/more_like_this.rs
+++ b/pg_search/src/query/more_like_this.rs
@@ -153,7 +153,7 @@ impl MoreLikeThisQueryBuilder {
                                 "SELECT * FROM {}.{} WHERE {} = $1",
                                 pgrx::spi::quote_identifier(heap_relation.namespace()),
                                 pgrx::spi::quote_identifier(heap_relation.name()),
-                                key_field_name
+                                pgrx::spi::quote_identifier(key_field_name.root())
                             ),
                             None,
                             unsafe {

--- a/tests/tests/mlt.rs
+++ b/tests/tests/mlt.rs
@@ -64,6 +64,44 @@ fn mlt_datetime_key(mut conn: PgConnection) {
     assert_eq!(rows, vec![2]);
 }
 
+// Regression test for https://github.com/paradedb/paradedb/issues/5065:
+// pdb.more_like_this used to construct its internal SPI SELECT with the key_field
+// column name unquoted, so a mixed-case identifier like "Id" was folded to lower
+// case and triggered `column "id" does not exist`.
+#[rstest]
+fn mlt_mixed_case_key_field_issue5065(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE mlt_mixed_case (
+        "Id" SERIAL PRIMARY KEY,
+        "Content" TEXT
+    );
+    INSERT INTO mlt_mixed_case ("Content") VALUES
+        ('aaa bbb ccc'),
+        ('aaa aaa'),
+        ('ddd eee fff'),
+        ('aaa aaa');
+    CREATE INDEX mlt_mixed_case_idx ON mlt_mixed_case
+        USING bm25 ("Id", "Content")
+        WITH (key_field = 'Id');
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<i32> = r#"
+    SELECT "Id" FROM mlt_mixed_case
+    WHERE "Id" @@@ pdb.more_like_this(1)
+    ORDER BY "Id";
+    "#
+    .fetch_scalar(&mut conn);
+    assert!(
+        !rows.is_empty(),
+        "more_like_this on a mixed-case key_field should return matches, got none"
+    );
+    assert!(
+        rows.contains(&1),
+        "more_like_this(1) should include the seed document, got {rows:?}"
+    );
+}
+
 #[rstest]
 fn mlt_scoring_nested(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);


### PR DESCRIPTION
## Summary

- `pdb.more_like_this(key_value)` raises `ERROR: column "id" does not exist` whenever the index's `key_field` column is a mixed-case PostgreSQL identifier (e.g. `"Id"`, `"DocumentId"`). Direct `@@@`-on-LHS searches (`"Content" @@@ 'foo'`) are unaffected because they don't go through the internal SPI lookup. Repro in #5065.
- Root cause: `pg_search/src/query/more_like_this.rs:152-157` builds the SPI `SELECT * FROM <ns>.<rel> WHERE <key_field> = $1` with `<ns>` and `<rel>` already routed through `pgrx::spi::quote_identifier`, but interpolates `<key_field>` verbatim via `Display`. PostgreSQL folds the unquoted reference to lowercase, so a column named `"Id"` is looked up as `id` and the SPI call fails before MLT ever runs.
- Fix: send the key field through `pgrx::spi::quote_identifier(key_field_name.root())`, matching how the namespace and relation names are already quoted on the lines immediately above. `.root()` strips the JSON sub-path (`key_field` is always a top-level column).

## Scope

The linked issue also lists JSON `term` filters (`@@@ '{"term":{"field":"Category",…}}'::jsonb`) as failing on mixed-case columns. That path does **not** go through SPI — `term()` in `pg_search/src/query/pdb_query.rs:792` resolves the field via `schema.search_field(field.root())`, a pure Tantivy schema lookup — so it isn't fixed here and I couldn't find a corresponding unquoted-identifier hazard. If it reproduces on `0.23.x` it's a separate bug; tracking it on its own issue is cleaner than bundling a speculative fix.

## Test plan

- [x] `cargo test -p tests --test mlt -- mlt_mixed_case_key_field_issue5065` — new regression test: `"Id"` / `"Content"` table, `key_field='Id'`, asserts `pdb.more_like_this(1)` returns rows. Fails on `main` with `column "id" does not exist`, passes with this change.
- [x] `cargo test -p tests --test mlt` — existing `mlt_enables_scoring_issue1747`, `mlt_datetime_key`, `mlt_scoring_nested` still pass.
- [x] `cargo pgrx regress -p pg_search --auto -- pg18 more_like_this` — golden output unchanged (`quote_identifier("id")` is a no-op for already-lowercase identifiers).
- [x] Manual repro from #5065 (`CREATE TABLE items ("Id" int primary key, "Content" text); … pdb.more_like_this(1)`) returns rows instead of erroring.

Closes #5065.
