### PR TITLE
fix: use fixed-length updates in stressgres to avoid TOAST and expose FSM race

### DIFF
--- a/stressgres/suites/logical-replication.toml
+++ b/stressgres/suites/logical-replication.toml
@@ -204,7 +204,7 @@ log_tps = false
 title = "Update 1..9"
 cancel_keycode = 'U'
 sql = """
-UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_upper(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || txid_current(), old_message = message WHERE id < 10;
+UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_length(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || lpad((txid_current() % 10000)::text, 5, '0'), old_message = message WHERE id < 10;
 """
 destinations = ["Publisher"]
 
@@ -215,7 +215,7 @@ title = "Update 10,11"
 cancel_keycode = 'U'
 sql = """
 BEGIN;
-UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_upper(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || txid_current(), old_message = message WHERE id IN (10, 11);
+UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_length(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || lpad((txid_current() % 10000)::text, 5, '0'), old_message = message WHERE id IN (10, 11);
 ABORT;
 """
 destinations = ["Publisher"]


### PR DESCRIPTION
The old UPDATE pattern in the logical-replication stressgres suite appended txid_current() to the message column every iteration, growing it past the TOAST threshold (~2KB). This caused the suite to hit the unrelated TOAST visibility race (#5076) before the FSM segment metadata race (#4935) could surface.

Changed to fixed-length updates that keep the first search term and append a small txid-derived number, staying well under the TOAST threshold. This way the suite can run long enough to exercise the FSM path.

Related: #5067 (FSM race fix), #5076 (TOAST bug)