### PR TITLE
test: widen FSM race window to prove #4935 exists

### DIFF
--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -151,11 +151,18 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone> LinkedItemList<T> {
     /// Return a Vec of all the items in this linked list
     pub unsafe fn list(&self, many: Option<usize>) -> Vec<T> {
         let mut items = vec![];
-        let (mut blockno, mut buffer) = self.get_start_blockno();
+        // TEST: Read start_blockno then DROP the header lock immediately
+        // and sleep to widen the race window. This gives atomically()+commit()
+        // time to recycle the old blocks while we're about to iterate them.
+        let mut blockno = {
+            let buffer = self.bman.get_buffer(self.header_blockno);
+            buffer.page().contents::<LinkedListData>().start_blockno
+        }; // header lock DROPPED here
+        pg_sys::pg_usleep(100_000); // 100ms — widen the race window
         let mut found = 0;
 
         'outer: while blockno != pg_sys::InvalidBlockNumber {
-            buffer = self.bman.get_buffer_exchange(blockno, buffer);
+            let buffer = self.bman.get_buffer(blockno);
             let page = buffer.page();
             let mut offsetno = pg_sys::FirstOffsetNumber;
             let max_offset = page.max_offset_number();
@@ -310,9 +317,14 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone> LinkedItemList<T> {
 
     /// Visit each entry, without mutating entries or the list structure.
     pub unsafe fn for_each(&mut self, mut f: impl FnMut(&mut BufferManager, T)) {
-        let (mut blockno, mut buffer) = self.get_start_blockno();
+        // TEST: Same race window widening as list() — see comment there.
+        let mut blockno = {
+            let buffer = self.bman().get_buffer(self.header_blockno);
+            buffer.page().contents::<LinkedListData>().start_blockno
+        }; // header lock DROPPED here
+        pg_sys::pg_usleep(100_000); // 100ms — widen the race window
         while blockno != pg_sys::InvalidBlockNumber {
-            buffer = self.bman().get_buffer_exchange(blockno, buffer);
+            let buffer = self.bman().get_buffer(blockno);
             let page = buffer.page();
             let mut offsetno = pg_sys::FirstOffsetNumber;
             let max_offset = page.max_offset_number();

--- a/stressgres/suites/logical-replication.toml
+++ b/stressgres/suites/logical-replication.toml
@@ -204,7 +204,7 @@ log_tps = false
 title = "Update 1..9"
 cancel_keycode = 'U'
 sql = """
-UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_upper(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || txid_current(), old_message = message WHERE id < 10;
+UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_length(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || lpad((txid_current() % 10000)::text, 5, '0'), old_message = message WHERE id < 10;
 """
 destinations = ["Publisher"]
 
@@ -215,7 +215,7 @@ title = "Update 10,11"
 cancel_keycode = 'U'
 sql = """
 BEGIN;
-UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_upper(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || txid_current(), old_message = message WHERE id IN (10, 11);
+UPDATE test SET message = array_to_string((string_to_array(message, ' '))[1:array_length(string_to_array(message, ' '), 1) - 1], ' ') || ' ' || lpad((txid_current() % 10000)::text, 5, '0'), old_message = message WHERE id IN (10, 11);
 ABORT;
 """
 destinations = ["Publisher"]


### PR DESCRIPTION
This branch intentionally widens the FSM race window to prove the bug from #4935 exists.

**What it does**

Adds a 100ms pg_usleep() after dropping the header lock in list() and for_each(). This gives atomically()+commit() time to recycle blocks while a reader is about to iterate them.

**Expected result**

This PR should CRASH in the stressgres suite with SIGSEGV or SegmentMetaEntryHeader::UnexpectedEnd — proving the race exists.

**Why the fix in #5067 makes this harmless**

The fix holds the header shared lock for the entire iteration. With the lock held, atomically() cannot acquire the exclusive header lock, so no blocks get recycled mid-traversal. The delay becomes irrelevant.

**This is NOT meant to be merged** — its a proof-of-concept to demonstrate the race condition.

Also includes fixed-length UPDATE to avoid TOAST interference (#5076).

Related: #5067, #4935