### PR TITLE
feat(mpp): multi-stage natural-shape AggregateScan

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=490af86#490af86f960c972d6c0f700e664ca0d5886cd55b"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=650c530#650c5307507cb4d79fc0e06b4a545a5bac04d68a"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2817,7 +2817,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5738,7 +5738,6 @@ dependencies = [
  "bytes",
  "chrono",
  "datafusion",
- "datafusion-datasource",
  "datafusion-distributed",
  "datafusion-proto",
  "decimal-bytes",
@@ -6524,7 +6523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7292,7 +7291,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7350,7 +7349,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7770,7 +7769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8405,7 +8404,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9434,7 +9433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-3cJD1N4ZC+MKPZzZbZgjlDqKci+XixH56Jh6me3QicM=";
+  cargoHash = "sha256-nIfwvxpv7RoOOa1eZGAyaoTtj6tIGS83HXQ5d2uyxEc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-nIfwvxpv7RoOOa1eZGAyaoTtj6tIGS83HXQ5d2uyxEc=";
+  cargoHash = "sha256-5bFlp5P6mqFuEUuTFKR4PUQNU0lm3O7I7TZESay40Wo=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,8 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-datasource = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "490af86" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "650c530" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -888,8 +888,8 @@ impl FilterExpr {
                         // Non-star: confirm the argument column matches.
                         // Compare by `plan_position` rather than rti so the
                         // match is robust to rti aliasing across sub-
-                        // PlannerInfos (Moe #5 dropped rti from targetlist
-                        // refs; plan_position is the canonical identity).
+                        // PlannerInfos. `plan_position` is the canonical
+                        // identity; targetlist refs don't carry rti.
                         if !agg.field_refs.is_empty() {
                             let args = PgList::<pg_sys::TargetEntry>::from_pg((*aggref).args);
                             if let Some(first_arg) = args.get_ptr(0) {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -544,8 +544,8 @@ async fn build_source_df(
 ) -> Result<DataFrame> {
     let mut scan_info = source.scan_info.clone();
 
-    // Set estimated_rows_per_worker for the table provider. In M1 we're
-    // single-threaded, so the per-worker estimate equals the total estimate.
+    // Set estimated_rows_per_worker for the table provider. The serial path is single-threaded,
+    // so the per-worker estimate equals the total estimate.
     if scan_info.estimated_rows_per_worker.is_none() {
         scan_info.estimated_rows_per_worker = Some(match scan_info.estimate {
             RowEstimate::Known(n) => n,

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -246,7 +246,7 @@ fn classify_aggregate_by_name(aggfnoid: u32) -> Option<AggKind> {
 /// Returns an error if:
 /// - An expression is neither a `Var` nor an `Aggref`
 /// - An aggregate uses DISTINCT (`aggdistinct` is set)
-/// - An aggregate is `pdb.agg()` (not supported on joins in M1)
+/// - An aggregate is `pdb.agg()` (not supported on joins)
 /// - An aggregate OID is unknown/unsupported
 /// - A `Var` references a table not in `sources`
 /// - A field name cannot be resolved

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1600,7 +1600,7 @@ impl AggregateScan {
         // call, then return null forever. Workers emit zero rows back to
         // PG; the leader assembles the result via the consumer plan.
         if let Some(scan_state::MppExecState::Worker(_)) = &df_state.mpp {
-            return Self::exec_mpp_worker(state);
+            return mpp::exec_mpp_worker(state);
         }
 
         // First call: build and execute the DataFusion plan

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -25,6 +25,7 @@ pub mod filterquery;
 pub mod groupby;
 pub mod join_targetlist;
 pub mod limit_offset;
+pub mod mpp;
 pub mod orderby;
 pub mod privdat;
 pub mod scan_state;
@@ -38,9 +39,8 @@ pub use targetlist::TargetListEntry;
 
 use std::sync::Arc;
 
-use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{
     display_plan_ascii, DistributedExec, DistributedExt, DistributedTaskContext,
     SessionStateBuilderExt,
@@ -51,22 +51,14 @@ use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_is_active, mpp_worker_count, producer_worker_count,
     worker_setup,
 };
-use crate::postgres::customscan::mpp::runtime::{
-    proc_for_task, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
-};
+use crate::postgres::customscan::mpp::runtime::{MppMesh, MppWorkerResolver, ShmMqWorkerTransport};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
-use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
-use crate::postgres::customscan::mpp::worker::run_worker_fragment;
-use crate::postgres::customscan::mpp::worker_fragments::{
-    find_worker_assignments, FragmentRouting,
-};
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
 use crate::gucs;
 
 use crate::aggregate::{NULL_SENTINEL_MAX, NULL_SENTINEL_MIN};
-use crate::api::HashSet;
 use crate::customscan::aggregatescan::build::AggregateCSClause;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexManifest;
@@ -91,7 +83,6 @@ use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
 };
-use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::dsm::{
     estimate_dsm_custom_scan, initialize_dsm_custom_scan, initialize_worker_custom_scan,
     reinitialize_dsm_custom_scan, ParallelQueryCapable,
@@ -104,7 +95,6 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::hook::query_has_paradedb_agg;
 use crate::postgres::customscan::joinscan::scan_state::{build_physical_plan, build_task_context};
 use crate::postgres::customscan::limit_offset::LimitOffset;
-use crate::postgres::customscan::parallel::list_segment_ids;
 use crate::postgres::customscan::projections::{create_placeholder_targetlist, placeholder_procid};
 use crate::postgres::customscan::solve_expr::SolvePostgresExpressions;
 use crate::postgres::customscan::{range_table, CreateUpperPathsHookArgs, CustomScan};
@@ -113,9 +103,7 @@ use crate::postgres::types::{is_datetime_type, TantivyValue};
 use crate::postgres::utils::{add_vars_to_tlist, is_unnest_func, make_text_const};
 use crate::postgres::PgSearchRelation;
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
-use crate::scan::codec::{
-    deserialize_logical_plan_with_runtime, serialize_logical_plan, PgSearchPhysicalCodecStub,
-};
+use crate::scan::codec::{serialize_logical_plan, PgSearchPhysicalCodecStub};
 use chrono::{DateTime as ChronoDateTime, Utc};
 use futures::StreamExt;
 use pgrx::{pg_sys, PgList, PgMemoryContexts, PgTupleDesc};
@@ -1202,344 +1190,6 @@ impl AggregateScan {
                 .indent(false)
                 .to_string()
         }
-    }
-
-    /// MPP worker exec: deserialize the logical plan from DSM, build the
-    /// distributed physical plan (matching what the leader produced), find
-    /// the worker fragment (the `input_stage.plan` of the bottom
-    /// `NetworkShuffleExec`), and run it via
-    /// [`mpp::worker::run_worker_fragment`] which pushes every output batch
-    /// to the leader's shm_mq queues. Workers emit zero rows back to PG;
-    /// returning `null_mut()` signals end-of-stream.
-    fn exec_mpp_worker(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
-        // Pull worker-thread inputs from the outer state before we borrow
-        // df_state mutably. parallel_state and non_partitioning_segments
-        // are required to pin each worker's PgSearchTableProvider to the
-        // right segment slice (the partitioning source) and the leader's
-        // canonical replica (the non-partitioning sources). Without them,
-        // every worker re-scans the full data and the leader-side hash
-        // partitions get the same rows from every worker.
-        let parallel_state = state.custom_state().parallel_state;
-        let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
-        let partitioning_source_idx = state
-            .custom_state()
-            .mpp_partitioning_source_idx
-            .unwrap_or(0);
-        let plan_sources_count = state
-            .custom_state()
-            .source_manifests
-            .len()
-            .max(non_partitioning_segments.len() + 1);
-
-        let df_state = state
-            .custom_state_mut()
-            .datafusion_state
-            .as_mut()
-            .expect("DataFusion state must be initialized");
-
-        if df_state.runtime.is_some() {
-            // Already drained on a prior call; just signal EOF.
-            return std::ptr::null_mut();
-        }
-        let scan_state::MppExecState::Worker(worker) = df_state.mpp.as_ref().expect("checked")
-        else {
-            unreachable!("exec_mpp_worker called outside Worker state");
-        };
-        let plan_bytes = worker.plan_bytes.clone();
-        // Worker mesh + total proc count for the dispatcher. The mesh's `ShmMqWorkerTransport`
-        // gets wired into the session below. n_workers is rederived from total_procs at the
-        // dispatcher; both forms (participant_config.total_workers, n_procs-1) agree by
-        // construction in `worker_setup`.
-        let worker_mesh = Arc::clone(&worker.mesh);
-        let this_proc = worker.mesh.this_proc;
-        let total_procs = worker.mesh.n_procs;
-        let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
-            Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
-            _ => unreachable!(),
-        };
-
-        let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => pgrx::error!("mpp worker: tokio runtime build failed: {e}"),
-        };
-        df_state.runtime = Some(runtime);
-        let runtime = df_state.runtime.as_ref().unwrap();
-        // Use a bare SessionContext for plan deserialization. The distributed planner config
-        // (worker resolver, transport, estimators, codec) is mirrored from the leader via
-        // `build_mpp_session_context` below — both procs have to agree on stage shape or
-        // `find_worker_assignments` won't line up.
-        let ctx = create_aggregate_session_context();
-
-        // Build per-source canonical segment ID sets. For the partitioning
-        // source, pull the full list out of the populated ParallelScanState
-        // (workers will then claim individual segments via `checkout_segment`
-        // inside their `PgSearchTableProvider`). For non-partitioning sources,
-        // use the segment IDs the leader snapshotted into shared memory.
-        let mut index_segment_ids: Vec<HashSet<tantivy::index::SegmentId>> =
-            vec![HashSet::default(); plan_sources_count];
-        if let Some(ps) = parallel_state {
-            let mut np_counter = 0usize;
-            for (i, slot) in index_segment_ids.iter_mut().enumerate() {
-                if i == partitioning_source_idx {
-                    *slot = unsafe { list_segment_ids(ps) };
-                } else if let Some(ids) = non_partitioning_segments.get(np_counter) {
-                    *slot = ids.clone();
-                    np_counter += 1;
-                }
-            }
-        }
-
-        let logical = match deserialize_logical_plan_with_runtime(
-            &plan_bytes,
-            &ctx.task_ctx(),
-            parallel_state,
-            None, // expr_context: bm25 search predicates don't need runtime params
-            None, // planstate: same
-            non_partitioning_segments,
-            index_segment_ids,
-        ) {
-            Ok(lp) => lp,
-            Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
-        };
-
-        // Build the worker's distributed session context. Reuses the same builder the leader
-        // runs so both procs agree on stage shape, task estimator chain, target_partitions,
-        // and codec — without that, `find_worker_assignments` returns no fragments for this
-        // worker because the worker's plan numbers stages differently from the leader's.
-        let session = Self::build_mpp_session_context(Arc::clone(&worker_mesh));
-
-        let physical_plan =
-            runtime.block_on(async { session.state().create_physical_plan(&logical).await });
-        let physical_plan = match physical_plan {
-            Ok(p) => p,
-            Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
-        };
-        // Walk the plan and collect every `(stage_id, task_idx)` slot owned
-        // by this proc under the `proc_for_task` round-robin policy. The
-        // dispatcher spawns one async task per fragment; together they form
-        // the worker's complete contribution to the distributed plan.
-        let n_workers = total_procs.saturating_sub(1).max(1);
-        let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
-        if fragments.is_empty() {
-            pgrx::warning!(
-                "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
-            );
-            return std::ptr::null_mut();
-        }
-
-        let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
-        let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
-        let session_arc = Arc::new(session);
-
-        // Two `Future` shapes share this vector: real producer-fragment
-        // futures and broadcast short-circuit EOF-only stubs. The alias
-        // keeps the `Vec<_>` declaration legible and silences
-        // clippy::type_complexity.
-        type FragmentFuture = std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
-                    + Send,
-            >,
-        >;
-        let result = runtime.block_on(async move {
-            let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
-            for fragment in &fragments {
-                let n_out = fragment.plan.output_partitioning().partition_count();
-                // Build per-output-partition senders. For each partition `q`
-                // emitted by this fragment, look up the destination proc via
-                // `fragment.routing` and clone the right outbound sender.
-                let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
-                for q in 0..n_out {
-                    let dest_proc = match &fragment.routing {
-                        FragmentRouting::Coalesce { dest_proc } => *dest_proc,
-                        FragmentRouting::Shuffle {
-                            partitions_per_consumer_task,
-                        }
-                        | FragmentRouting::Broadcast {
-                            partitions_per_consumer_task,
-                        } => {
-                            let t_c = (q / partitions_per_consumer_task) as u32;
-                            proc_for_task(n_workers, t_c)
-                        }
-                    };
-                    let base = match outbound_senders
-                        .get(dest_proc as usize)
-                        .and_then(|s| s.as_ref())
-                    {
-                        Some(s) => s,
-                        None => {
-                            return Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
-                                 (self-loop or unattached); fragment stage_id={} task_idx={}",
-                                fragment.stage_id, fragment.task_idx,
-                            )));
-                        }
-                    };
-                    let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
-                    crate::mpp_log!(
-                        "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
-                         task_idx={}) partition={q} → dest_proc={dest_proc}",
-                        fragment.stage_id,
-                        fragment.task_idx,
-                    );
-                    // Attach the worker mesh as the cooperative drain so a
-                    // full outbound shm_mq queue doesn't block the backend
-                    // thread. The spin pulls every inbound drain while
-                    // retrying the send, breaking N×N symmetric stalls.
-                    per_partition_senders.push(
-                        base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
-                            .with_cooperative_drain(
-                                Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
-                            ),
-                    );
-                }
-
-                // Broadcast invariant: fail-loud cap check.
-                //
-                // pg_search's natural-shape AggregateScan plan canonical-replicates the build
-                // subtree via the `mpp build all-gather` step. Every producer task would scan
-                // the full canonical data, and the consumer's `select_all` would over-count by
-                // `input_task_count`. The planner-level [`BroadcastBuildSideOneTaskEstimator`]
-                // caps the build subtree at task_count=1, so a correct plan produces exactly one
-                // Broadcast fragment with task_idx == 0.
-                //
-                // A non-zero `task_idx` here means the cap silently failed: maybe the estimator
-                // wasn't installed, the chain order is wrong, or a future planner pass
-                // re-expanded the build subtree. We surface this as a hard error rather than
-                // silently EOF-only-ing the fragment. The EOF-only fallback is only correct
-                // under the canonical-replica INVARIANT documented on
-                // `FragmentRouting::Broadcast`, and we'd rather fail loudly than emit a stealth
-                // correctness regression. Matches the top-level NetworkBroadcastExec treatment
-                // in `worker_fragments::collect`.
-                if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
-                    debug_assert!(
-                        fragment.task_idx == 0,
-                        "mpp dispatcher: Broadcast fragment with task_idx={} but \
-                         BroadcastBuildSideOneTaskEstimator should have capped \
-                         input_task_count at 1; plan-walk drift?",
-                        fragment.task_idx,
-                    );
-                    if fragment.task_idx != 0 {
-                        return Err(datafusion::common::DataFusionError::Internal(format!(
-                            "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
-                             (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
-                             BroadcastBuildSideOneTaskEstimator should cap input_task_count at \
-                             1. A non-zero task_idx here indicates plan-walk drift or a missing \
-                             estimator chain on this session; running the producer plan would \
-                             duplicate the canonical replica, EOF-only-ing it would drop a \
-                             real shard if the cap loss was due to a sharded build subtree. \
-                             Surface as error so the divergence is visible.",
-                            fragment.stage_id, fragment.task_idx,
-                        )));
-                    }
-                }
-
-                // Build a TaskContext seeded with the right `DistributedTaskContext` so the
-                // boundary nodes inside the fragment's plan know their
-                // `(task_index, task_count)`.
-                let cfg = session_arc
-                    .state()
-                    .config()
-                    .clone()
-                    .with_extension(Arc::new(DistributedTaskContext {
-                        task_index: fragment.task_idx,
-                        task_count: fragment.task_count,
-                    }));
-                let memory_pool =
-                    create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
-                let task_ctx = Arc::new(
-                    TaskContext::default()
-                        .with_session_config(cfg)
-                        .with_runtime(Arc::new(
-                            RuntimeEnvBuilder::new()
-                                .with_memory_pool(memory_pool)
-                                .build()
-                                .expect("Failed to create RuntimeEnv"),
-                        )),
-                );
-
-                // Wrap fragment.plan in a fresh `DistributedExec` and run
-                // `prepare_in_process_plan` to convert any nested boundaries' input stages from
-                // `Stage::Local` to `Stage::Remote`. Without this, a nested `NetworkShuffleExec`
-                // / `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task
-                // count exceeds 1; with the conversion, those boundaries dispatch through
-                // `ShmMqWorkerTransport` exactly like outer boundaries.
-                let plan = {
-                    let dist = Arc::new(datafusion_distributed::DistributedExec::new(Arc::clone(
-                        &fragment.plan,
-                    )));
-                    match dist.prepare_in_process_plan(&task_ctx) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            return Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker: prepare_in_process_plan failed for fragment \
-                                 (stage_id={}, task_idx={}): {e}",
-                                fragment.stage_id, fragment.task_idx
-                            )));
-                        }
-                    }
-                };
-                futures.push(Box::pin(run_worker_fragment(
-                    plan,
-                    per_partition_senders,
-                    task_ctx,
-                )));
-            }
-            // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue
-            // / in-proc channel are the per-partition clones owned by the spawned fragments.
-            // Without this, the originals would outlive the futures, the consumer-side drains
-            // would never observe `Detached`, and `stream_partition`'s pull loop would spin
-            // forever.
-            drop(outbound_senders);
-            crate::mpp_log!(
-                "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
-                fragments.len()
-            );
-            // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
-            // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
-            // futures, leaving their `(stage_id, partition)` sub-buffers stuck at
-            // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
-            // substrate alone (matching reasoning in `run_worker_fragment`).
-            //
-            // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
-            // within 30 s the dispatcher surfaces an error instead of letting the backend spin
-            // forever. Per-drain state shows up in the inbound drains' own traces in
-            // transport.rs / runtime.rs.
-            let join_fut = futures::future::join_all(futures);
-            let outcome: Result<(), datafusion::common::DataFusionError> =
-                if crate::gucs::mpp_debug() {
-                    match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
-                        Ok(results) => results
-                            .into_iter()
-                            .collect::<Result<Vec<_>, _>>()
-                            .map(|_| ()),
-                        Err(_) => {
-                            crate::mpp_log!(
-                                "mpp worker dispatch this_proc={this_proc} \
-                             HANG: join_all exceeded 30s"
-                            );
-                            Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
-                             deadlock detector triggered"
-                            )))
-                        }
-                    }
-                } else {
-                    join_fut
-                        .await
-                        .into_iter()
-                        .collect::<Result<Vec<_>, _>>()
-                        .map(|_| ())
-                };
-            outcome
-        });
-        if let Err(e) = result {
-            pgrx::error!("mpp worker: fragment dispatch failed: {e}");
-        }
-        std::ptr::null_mut()
     }
 
     /// Existing single-table Tantivy aggregate path.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1066,7 +1066,7 @@ impl AggregateScan {
         // mode (custom WorkerTransport registered) it clamps the Shuffle's
         // consumer_task_count to 1, which disables `NetworkShuffleExec`'s
         // per-task hash scaling. So producer output = target_partitions =
-        // n_workers (matching `build_mpp_leader_session_context`).
+        // n_workers (matching `build_mpp_session_context`).
         let n_workers = producer_worker_count();
         df_state.mpp_n_partitions = n_workers.max(1);
     }
@@ -1078,7 +1078,7 @@ impl AggregateScan {
     /// `create_physical_plan` over the leader's logical plan, returns a
     /// `DistributedExec` whose `NetworkShuffleExec`s pull batches from the
     /// shm_mq mesh at execute time.
-    fn build_mpp_leader_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
+    fn build_mpp_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
         let serial = create_aggregate_session_context();
         // Workers are procs 1..n_procs; leader is proc 0. The producer
         // count is therefore `n_procs - 1`.
@@ -1149,7 +1149,7 @@ impl AggregateScan {
             // through the constructor is the only safe way to build an `MppMesh` outside
             // `glue::leader_setup`.
             let stub_mesh = Arc::new(MppMesh::new(0, mpp_worker_count(), Vec::new()));
-            Self::build_mpp_leader_session_context(stub_mesh)
+            Self::build_mpp_session_context(stub_mesh)
         } else {
             create_aggregate_session_context()
         };
@@ -1246,11 +1246,10 @@ impl AggregateScan {
             unreachable!("exec_mpp_worker called outside Worker state");
         };
         let plan_bytes = worker.plan_bytes.clone();
-        // Worker count from the participant config: matches the leader's mesh.n_workers and is
-        // what NetworkShuffleExec uses to size its hash partitioning.
-        let n_workers = worker.participant_config.total_workers;
         // Worker mesh + total proc count for the dispatcher. The mesh's `ShmMqWorkerTransport`
-        // gets wired into the session below.
+        // gets wired into the session below. n_workers is rederived from total_procs at the
+        // dispatcher; both forms (participant_config.total_workers, n_procs-1) agree by
+        // construction in `worker_setup`.
         let worker_mesh = Arc::clone(&worker.mesh);
         let this_proc = worker.mesh.this_proc;
         let total_procs = worker.mesh.n_procs;
@@ -1268,9 +1267,10 @@ impl AggregateScan {
         };
         df_state.runtime = Some(runtime);
         let runtime = df_state.runtime.as_ref().unwrap();
-        // Use a bare SessionContext for plan deserialization; the workers
-        // need the same `with_distributed_planner` config the leader had so
-        // the resulting physical plan exposes the matching NetworkShuffleExec.
+        // Use a bare SessionContext for plan deserialization. The distributed planner config
+        // (worker resolver, transport, estimators, codec) is mirrored from the leader via
+        // `build_mpp_session_context` below — both procs have to agree on stage shape or
+        // `find_worker_assignments` won't line up.
         let ctx = create_aggregate_session_context();
 
         // Build per-source canonical segment ID sets. For the partitioning
@@ -1305,41 +1305,11 @@ impl AggregateScan {
             Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
         };
 
-        // Build state with the DF-D fork's distributed planner so create_physical_plan
-        // produces a DistributedExec wrapping NetworkShuffleExec. The
-        // target_partitions, task-estimator, broadcast-joins and codec
-        // overrides must mirror the leader (see
-        // `build_mpp_leader_session_context`); otherwise the worker re-plans
-        // a different shape and `find_worker_fragment` returns None.
-        let n_workers_us = n_workers as usize;
-        let cfg = ctx
-            .copied_config()
-            .with_target_partitions(n_workers_us.max(2));
-        let state_builder = SessionStateBuilder::new()
-            .with_default_features()
-            .with_config(cfg)
-            .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers_us))
-            // Route nested boundaries through the worker's `MppMesh` via `ShmMqWorkerTransport`.
-            // Workers running a consumer-side fragment (e.g. `FinalPartitioned` above a
-            // `NetworkShuffleExec` peer-mesh) call `WorkerTransport::open` here. The returned
-            // `ShmMqWorkerConnection` pulls from the worker's inbound drain for the producer's
-            // proc and demuxes on `(stage_id, partition)` via the sub-buffer registry.
-            .with_distributed_worker_transport(ShmMqWorkerTransport::new(Arc::clone(&worker_mesh)))
-            .with_distributed_in_process_mode(true)
-            .expect("with_distributed_in_process_mode")
-            // Same estimator chain as the leader (see `build_mpp_leader_session_context`). The
-            // build-side one-task estimator must precede the default leaf estimator so that
-            // worker physical plans match the leader's: `proc_for_task` is a pure function of
-            // `task_idx % n_workers`, so byte-identical stage numbering is what keeps
-            // producer/consumer addressing consistent across procs.
-            .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
-            .with_distributed_task_estimator(n_workers_us)
-            .with_distributed_broadcast_joins(true)
-            .expect("with_distributed_broadcast_joins")
-            .with_distributed_user_codec(PgSearchPhysicalCodecStub)
-            .with_distributed_planner();
-        let session_state = state_builder.build();
-        let session = datafusion::prelude::SessionContext::new_with_state(session_state);
+        // Build the worker's distributed session context. Reuses the same builder the leader
+        // runs so both procs agree on stage shape, task estimator chain, target_partitions,
+        // and codec — without that, `find_worker_assignments` returns no fragments for this
+        // worker because the worker's plan numbers stages differently from the leader's.
+        let session = Self::build_mpp_session_context(Arc::clone(&worker_mesh));
 
         let physical_plan =
             runtime.block_on(async { session.state().create_physical_plan(&logical).await });
@@ -2020,7 +1990,7 @@ impl AggregateScan {
                             );
                         }
                     }
-                    Self::build_mpp_leader_session_context(Arc::clone(&leader.mesh))
+                    Self::build_mpp_session_context(Arc::clone(&leader.mesh))
                 }
                 _ => create_aggregate_session_context(),
             };

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -38,10 +38,12 @@ pub use targetlist::TargetListEntry;
 
 use std::sync::Arc;
 
-use datafusion::execution::SessionStateBuilder;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::execution::{SessionStateBuilder, TaskContext};
+use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion_distributed::{
-    display_plan_ascii, DistributedExec, DistributedExt, SessionStateBuilderExt,
+    display_plan_ascii, DistributedExec, DistributedExt, DistributedTaskContext,
+    SessionStateBuilderExt,
 };
 
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
@@ -50,10 +52,14 @@ use crate::postgres::customscan::mpp::glue::{
     worker_setup,
 };
 use crate::postgres::customscan::mpp::runtime::{
-    LocalExecWorkerTransport, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
+    proc_for_task, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
 };
-use crate::postgres::customscan::mpp::transport::MppSender;
+use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
+use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
 use crate::postgres::customscan::mpp::worker::run_worker_fragment;
+use crate::postgres::customscan::mpp::worker_fragments::{
+    find_worker_assignments, FragmentRouting,
+};
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
@@ -85,6 +91,7 @@ use crate::postgres::customscan::builders::custom_scan::CustomScanBuilder;
 use crate::postgres::customscan::builders::custom_state::{
     CustomScanStateBuilder, CustomScanStateWrapper,
 };
+use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::dsm::{
     estimate_dsm_custom_scan, initialize_dsm_custom_scan, initialize_worker_custom_scan,
     reinitialize_dsm_custom_scan, ParallelQueryCapable,
@@ -692,7 +699,6 @@ impl ParallelQueryCapable for AggregateScan {
         let Some(plan_bytes) = df_state.mpp_plan_bytes.as_ref() else {
             return 0;
         };
-        let n_partitions = df_state.mpp_n_partitions;
         let plan_bytes_len = plan_bytes.len();
 
         // Capture source manifests so we can size the ParallelScanState block.
@@ -707,13 +713,7 @@ impl ParallelQueryCapable for AggregateScan {
         let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
         let mpp_offset = mpp_align(mpp_agg_pscan_offset() + pscan_size);
 
-        // Number of non-partitioning sources gets a build-cache slot per worker.
-        let n_cache_sources = state
-            .custom_state()
-            .source_manifests
-            .len()
-            .saturating_sub(1) as u32;
-        let mpp_size = match estimate_dsm_size(plan_bytes_len, n_partitions, n_cache_sources) {
+        let mpp_size = match estimate_dsm_size(plan_bytes_len) {
             Ok(sz) => sz,
             Err(e) => {
                 pgrx::warning!("mpp: estimate_dsm failed: {e}; falling back to serial");
@@ -790,27 +790,14 @@ impl ParallelQueryCapable for AggregateScan {
         // Init the MPP region.
         let mpp_coordinate =
             unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut std::os::raw::c_void };
-        let n_cache_sources = state
-            .custom_state()
-            .source_manifests
-            .len()
-            .saturating_sub(1) as u32;
-        let leader = match unsafe {
-            leader_setup(
-                mpp_coordinate,
-                seg,
-                pcxt,
-                n_partitions,
-                plan_bytes,
-                n_cache_sources,
-            )
-        } {
-            Ok(l) => l,
-            Err(e) => {
-                pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");
-                return;
-            }
-        };
+        let leader =
+            match unsafe { leader_setup(mpp_coordinate, seg, pcxt, n_partitions, plan_bytes) } {
+                Ok(l) => l,
+                Err(e) => {
+                    pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");
+                    return;
+                }
+            };
         let df_state = state
             .custom_state_mut()
             .datafusion_state
@@ -1093,7 +1080,9 @@ impl AggregateScan {
     /// shm_mq mesh at execute time.
     fn build_mpp_leader_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
         let serial = create_aggregate_session_context();
-        let n_workers = mesh.n_workers as usize;
+        // Workers are procs 1..n_procs; leader is proc 0. The producer
+        // count is therefore `n_procs - 1`.
+        let n_workers = mesh.n_procs.saturating_sub(1).max(1) as usize;
         // Four-knob unlock for actually inserting NetworkShuffleExec/etc.:
         //   1. target_partitions(N) — without this, EnforceDistribution skips
         //      every RepartitionExec, so the annotator never sees a Shuffle.
@@ -1118,6 +1107,13 @@ impl AggregateScan {
             .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
             .with_distributed_in_process_mode(true)
             .expect("with_distributed_in_process_mode")
+            // Estimator chain order matters. The DF-D fork tries each estimator in registration
+            // order until one returns Some. The build-side one-task estimator has to come first.
+            // Otherwise the default `Desired(n_workers)` leaf estimator wins, the all-gather
+            // memory leaf gets task_count = n_workers, `_distribute_plan` builds
+            // `NetworkBroadcastExec` with `input_task_count = n_workers`, and the consumer's
+            // `select_all` over-counts by n_workers. See task_estimator.rs.
+            .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
             .with_distributed_task_estimator(n_workers)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
@@ -1148,14 +1144,11 @@ impl AggregateScan {
         let custom_exprs = df_state.custom_exprs;
         let custom_scan_tlist = df_state.custom_scan_tlist;
         let ctx = if mpp_is_active() {
-            // Drain-less stub mesh: `with_distributed_planner` only reads
-            // `n_workers` for stage sizing; `ShmMqWorkerTransport::open()`
-            // is execution-time only and never runs during EXPLAIN.
-            let stub_mesh = Arc::new(MppMesh {
-                n_workers: producer_worker_count(),
-                n_partitions: 1,
-                drains: Vec::new(),
-            });
+            // Drain-less stub mesh. `with_distributed_planner` only needs `n_procs` for stage
+            // sizing, and `ShmMqWorkerTransport::open()` doesn't run during EXPLAIN. Going
+            // through the constructor is the only safe way to build an `MppMesh` outside
+            // `glue::leader_setup`.
+            let stub_mesh = Arc::new(MppMesh::new(0, mpp_worker_count(), Vec::new()));
             Self::build_mpp_leader_session_context(stub_mesh)
         } else {
             create_aggregate_session_context()
@@ -1253,14 +1246,15 @@ impl AggregateScan {
             unreachable!("exec_mpp_worker called outside Worker state");
         };
         let plan_bytes = worker.plan_bytes.clone();
-        // Worker count from the participant config (matches the leader's
-        // mesh.n_workers). `outbound_senders.len()` gives partitions-per-
-        // producer (= mpp_n_partitions), not the worker count — using it as
-        // n_workers misconfigured the planner so NetworkShuffleExec scaled
-        // its hash to mpp_n_partitions × mpp_n_partitions = 81 partitions.
-        let n_workers = worker.participant_config.total_participants;
-        let worker_idx_for_cache = worker.participant_config.participant_index;
-        let outbound_senders: Vec<MppSender> = match df_state.mpp.as_mut() {
+        // Worker count from the participant config: matches the leader's mesh.n_workers and is
+        // what NetworkShuffleExec uses to size its hash partitioning.
+        let n_workers = worker.participant_config.total_workers;
+        // Worker mesh + total proc count for the dispatcher. The mesh's `ShmMqWorkerTransport`
+        // gets wired into the session below.
+        let worker_mesh = Arc::clone(&worker.mesh);
+        let this_proc = worker.mesh.this_proc;
+        let total_procs = worker.mesh.n_procs;
+        let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
             Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
             _ => unreachable!(),
         };
@@ -1298,10 +1292,6 @@ impl AggregateScan {
             }
         }
 
-        let mpp_build_cache = match df_state.mpp.as_ref() {
-            Some(scan_state::MppExecState::Worker(w)) => w.build_cache.as_ref().map(Arc::clone),
-            _ => None,
-        };
         let logical = match deserialize_logical_plan_with_runtime(
             &plan_bytes,
             &ctx.task_ctx(),
@@ -1310,8 +1300,6 @@ impl AggregateScan {
             None, // planstate: same
             non_partitioning_segments,
             index_segment_ids,
-            mpp_build_cache,
-            worker_idx_for_cache,
         ) {
             Ok(lp) => lp,
             Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
@@ -1331,17 +1319,20 @@ impl AggregateScan {
             .with_default_features()
             .with_config(cfg)
             .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers_us))
-            // Workers may encounter nested network boundaries inside the
-            // producer fragment (e.g. a `NetworkBroadcastExec` on the build
-            // side of a `HashJoin`). Without a transport registered, the
-            // default `FlightWorkerTransport` would try to dial the empty
-            // URL and error out. The `LocalExecWorkerTransport` re-executes
-            // the boundary's input subtree locally — duplicates the build
-            // scan across workers, but for small index scans that's cheap
-            // and keeps the in-process design self-contained.
-            .with_distributed_worker_transport(LocalExecWorkerTransport)
+            // Route nested boundaries through the worker's `MppMesh` via `ShmMqWorkerTransport`.
+            // Workers running a consumer-side fragment (e.g. `FinalPartitioned` above a
+            // `NetworkShuffleExec` peer-mesh) call `WorkerTransport::open` here. The returned
+            // `ShmMqWorkerConnection` pulls from the worker's inbound drain for the producer's
+            // proc and demuxes on `(stage_id, partition)` via the sub-buffer registry.
+            .with_distributed_worker_transport(ShmMqWorkerTransport::new(Arc::clone(&worker_mesh)))
             .with_distributed_in_process_mode(true)
             .expect("with_distributed_in_process_mode")
+            // Same estimator chain as the leader (see `build_mpp_leader_session_context`). The
+            // build-side one-task estimator must precede the default leaf estimator so that
+            // worker physical plans match the leader's: `proc_for_task` is a pure function of
+            // `task_idx % n_workers`, so byte-identical stage numbering is what keeps
+            // producer/consumer addressing consistent across procs.
+            .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
             .with_distributed_task_estimator(n_workers_us)
             .with_distributed_broadcast_joins(true)
             .expect("with_distributed_broadcast_joins")
@@ -1356,58 +1347,229 @@ impl AggregateScan {
             Ok(p) => p,
             Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
         };
-        // Find the bottom NetworkShuffleExec; its input_stage.plan (==
-        // children()[0]) is the worker fragment. If the DF-D fork's planner
-        // didn't insert one (some plan shapes don't benefit from a network
-        // shuffle, or PartialReduce isn't enabled), the worker has no
-        // fragment to run — emit zero rows and let the leader produce
-        // results via its own copy. Logging at WARNING so production
-        // monitors can spot the falls-back-to-no-op case.
-        let fragment = match Self::find_worker_fragment(&physical_plan) {
-            Some(f) => f,
-            None => {
-                pgrx::warning!(
-                    "mpp worker: no NetworkShuffleExec found in distributed plan; \
-                     skipping producer-fragment run (worker emits zero rows)"
+        // Walk the plan and collect every `(stage_id, task_idx)` slot owned
+        // by this proc under the `proc_for_task` round-robin policy. The
+        // dispatcher spawns one async task per fragment; together they form
+        // the worker's complete contribution to the distributed plan.
+        let n_workers = total_procs.saturating_sub(1).max(1);
+        let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
+        if fragments.is_empty() {
+            pgrx::warning!(
+                "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
+            );
+            return std::ptr::null_mut();
+        }
+
+        let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
+        let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
+        let session_arc = Arc::new(session);
+
+        // Two `Future` shapes share this vector: real producer-fragment
+        // futures and broadcast short-circuit EOF-only stubs. The alias
+        // keeps the `Vec<_>` declaration legible and silences
+        // clippy::type_complexity.
+        type FragmentFuture = std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
+                    + Send,
+            >,
+        >;
+        let result = runtime.block_on(async move {
+            let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
+            for fragment in &fragments {
+                let n_out = fragment.plan.output_partitioning().partition_count();
+                // Build per-output-partition senders. For each partition `q`
+                // emitted by this fragment, look up the destination proc via
+                // `fragment.routing` and clone the right outbound sender.
+                let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
+                for q in 0..n_out {
+                    let dest_proc = match &fragment.routing {
+                        FragmentRouting::Coalesce { dest_proc } => *dest_proc,
+                        FragmentRouting::Shuffle {
+                            partitions_per_consumer_task,
+                        }
+                        | FragmentRouting::Broadcast {
+                            partitions_per_consumer_task,
+                        } => {
+                            let t_c = (q / partitions_per_consumer_task) as u32;
+                            proc_for_task(n_workers, t_c)
+                        }
+                    };
+                    let base = match outbound_senders
+                        .get(dest_proc as usize)
+                        .and_then(|s| s.as_ref())
+                    {
+                        Some(s) => s,
+                        None => {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
+                                 (self-loop or unattached); fragment stage_id={} task_idx={}",
+                                fragment.stage_id, fragment.task_idx,
+                            )));
+                        }
+                    };
+                    let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
+                    crate::mpp_log!(
+                        "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
+                         task_idx={}) partition={q} → dest_proc={dest_proc}",
+                        fragment.stage_id,
+                        fragment.task_idx,
+                    );
+                    // Attach the worker mesh as the cooperative drain so a
+                    // full outbound shm_mq queue doesn't block the backend
+                    // thread. The spin pulls every inbound drain while
+                    // retrying the send, breaking N×N symmetric stalls.
+                    per_partition_senders.push(
+                        base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
+                            .with_cooperative_drain(
+                                Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
+                            ),
+                    );
+                }
+
+                // Broadcast invariant: fail-loud cap check.
+                //
+                // pg_search's natural-shape AggregateScan plan canonical-replicates the build
+                // subtree via the `mpp build all-gather` step. Every producer task would scan
+                // the full canonical data, and the consumer's `select_all` would over-count by
+                // `input_task_count`. The planner-level [`BroadcastBuildSideOneTaskEstimator`]
+                // caps the build subtree at task_count=1, so a correct plan produces exactly one
+                // Broadcast fragment with task_idx == 0.
+                //
+                // A non-zero `task_idx` here means the cap silently failed: maybe the estimator
+                // wasn't installed, the chain order is wrong, or a future planner pass
+                // re-expanded the build subtree. We surface this as a hard error rather than
+                // silently EOF-only-ing the fragment. The EOF-only fallback is only correct
+                // under the canonical-replica INVARIANT documented on
+                // `FragmentRouting::Broadcast`, and we'd rather fail loudly than emit a stealth
+                // correctness regression. Matches the top-level NetworkBroadcastExec treatment
+                // in `worker_fragments::collect`.
+                if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
+                    debug_assert!(
+                        fragment.task_idx == 0,
+                        "mpp dispatcher: Broadcast fragment with task_idx={} but \
+                         BroadcastBuildSideOneTaskEstimator should have capped \
+                         input_task_count at 1; plan-walk drift?",
+                        fragment.task_idx,
+                    );
+                    if fragment.task_idx != 0 {
+                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                            "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
+                             (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
+                             BroadcastBuildSideOneTaskEstimator should cap input_task_count at \
+                             1. A non-zero task_idx here indicates plan-walk drift or a missing \
+                             estimator chain on this session; running the producer plan would \
+                             duplicate the canonical replica, EOF-only-ing it would drop a \
+                             real shard if the cap loss was due to a sharded build subtree. \
+                             Surface as error so the divergence is visible.",
+                            fragment.stage_id, fragment.task_idx,
+                        )));
+                    }
+                }
+
+                // Build a TaskContext seeded with the right `DistributedTaskContext` so the
+                // boundary nodes inside the fragment's plan know their
+                // `(task_index, task_count)`.
+                let cfg = session_arc
+                    .state()
+                    .config()
+                    .clone()
+                    .with_extension(Arc::new(DistributedTaskContext {
+                        task_index: fragment.task_idx,
+                        task_count: fragment.task_count,
+                    }));
+                let memory_pool =
+                    create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
+                let task_ctx = Arc::new(
+                    TaskContext::default()
+                        .with_session_config(cfg)
+                        .with_runtime(Arc::new(
+                            RuntimeEnvBuilder::new()
+                                .with_memory_pool(memory_pool)
+                                .build()
+                                .expect("Failed to create RuntimeEnv"),
+                        )),
                 );
-                return std::ptr::null_mut();
+
+                // Wrap fragment.plan in a fresh `DistributedExec` and run
+                // `prepare_in_process_plan` to convert any nested boundaries' input stages from
+                // `Stage::Local` to `Stage::Remote`. Without this, a nested `NetworkShuffleExec`
+                // / `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task
+                // count exceeds 1; with the conversion, those boundaries dispatch through
+                // `ShmMqWorkerTransport` exactly like outer boundaries.
+                let plan = {
+                    let dist = Arc::new(datafusion_distributed::DistributedExec::new(Arc::clone(
+                        &fragment.plan,
+                    )));
+                    match dist.prepare_in_process_plan(&task_ctx) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker: prepare_in_process_plan failed for fragment \
+                                 (stage_id={}, task_idx={}): {e}",
+                                fragment.stage_id, fragment.task_idx
+                            )));
+                        }
+                    }
+                };
+                futures.push(Box::pin(run_worker_fragment(
+                    plan,
+                    per_partition_senders,
+                    task_ctx,
+                )));
             }
-        };
-        let task_ctx = build_task_context(
-            &session,
-            &fragment,
-            unsafe { pg_sys::work_mem as usize * 1024 },
-            unsafe { pg_sys::hash_mem_multiplier },
-        );
-        let result = runtime
-            .block_on(async { run_worker_fragment(fragment, outbound_senders, task_ctx).await });
+            // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue
+            // / in-proc channel are the per-partition clones owned by the spawned fragments.
+            // Without this, the originals would outlive the futures, the consumer-side drains
+            // would never observe `Detached`, and `stream_partition`'s pull loop would spin
+            // forever.
+            drop(outbound_senders);
+            crate::mpp_log!(
+                "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
+                fragments.len()
+            );
+            // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
+            // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
+            // futures, leaving their `(stage_id, partition)` sub-buffers stuck at
+            // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
+            // substrate alone (matching reasoning in `run_worker_fragment`).
+            //
+            // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
+            // within 30 s the dispatcher surfaces an error instead of letting the backend spin
+            // forever. Per-drain state shows up in the inbound drains' own traces in
+            // transport.rs / runtime.rs.
+            let join_fut = futures::future::join_all(futures);
+            let outcome: Result<(), datafusion::common::DataFusionError> =
+                if crate::gucs::mpp_debug() {
+                    match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
+                        Ok(results) => results
+                            .into_iter()
+                            .collect::<Result<Vec<_>, _>>()
+                            .map(|_| ()),
+                        Err(_) => {
+                            crate::mpp_log!(
+                                "mpp worker dispatch this_proc={this_proc} \
+                             HANG: join_all exceeded 30s"
+                            );
+                            Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
+                             deadlock detector triggered"
+                            )))
+                        }
+                    }
+                } else {
+                    join_fut
+                        .await
+                        .into_iter()
+                        .collect::<Result<Vec<_>, _>>()
+                        .map(|_| ())
+                };
+            outcome
+        });
         if let Err(e) = result {
-            pgrx::error!("mpp worker: run_worker_fragment failed: {e}");
+            pgrx::error!("mpp worker: fragment dispatch failed: {e}");
         }
         std::ptr::null_mut()
-    }
-
-    /// Walk a DistributedExec-rooted plan and return the input subtree of
-    /// the **topmost** `NetworkShuffleExec` (the worker producer fragment).
-    /// Returns `None` if no `NetworkShuffleExec` is reachable from the root.
-    ///
-    /// Pre-order traversal returns on the first match, which is the
-    /// outermost shuffle — the one that straddles the worker→leader split.
-    /// Nested `NetworkShuffleExec`s inside the worker fragment (e.g. the
-    /// shuffles `HashJoinExec(Partitioned)` inserts on each side once the
-    /// build side crosses `hash_join_single_partition_threshold`) are
-    /// re-executed locally by `LocalExecWorkerTransport` at execute time,
-    /// so the worker only needs to find the outermost one.
-    fn find_worker_fragment(plan: &Arc<dyn ExecutionPlan>) -> Option<Arc<dyn ExecutionPlan>> {
-        if plan.name() == "NetworkShuffleExec" {
-            return plan.children().first().map(|c| Arc::clone(c));
-        }
-        for child in plan.children() {
-            if let Some(found) = Self::find_worker_fragment(child) {
-                return Some(found);
-            }
-        }
-        None
     }
 
     /// Existing single-table Tantivy aggregate path.
@@ -1507,7 +1669,7 @@ impl AggregateScan {
         // Below this line every Err carries a planner warning.
         let warn = |reason| AggregatePathDecline::Warn(reason);
 
-        // For M1, all tables must have BM25 indexes (DataFusion scans all via PgSearchTableProvider)
+        // All tables must have BM25 indexes (DataFusion scans all via PgSearchTableProvider).
         if !all_have_bm25_index(&sources) {
             return Err(warn(AggregateDeclineReason::NotAllBm25));
         }
@@ -1560,8 +1722,8 @@ impl AggregateScan {
         // FILTER `T_Var` arm is unreachable from here. But the HAVING
         // matchers need the plan tree anyway to recover a source's rti
         // from `plan_position` when matching parse-tree Vars to extracted
-        // targetlist refs (Moe #5 dropped rti from the targetlist refs
-        // themselves; the plan is the system of record now).
+        // targetlist refs: the plan is the system of record for rti, the
+        // targetlist refs themselves don't carry it.
         let outer_root_id =
             crate::postgres::customscan::joinscan::build::PlannerRootId::from(builder.args().root);
         let having_filter = unsafe {
@@ -1895,6 +2057,23 @@ impl AggregateScan {
                 unsafe { pg_sys::work_mem as usize * 1024 },
                 unsafe { pg_sys::hash_mem_multiplier },
             );
+            // Install `DistributedTaskContext` explicitly so the top boundary sees the leader's
+            // `(task_index=0, task_count=1)` identity. Skipping this would let the fork's
+            // `from_ctx` default kick in, which silently hides any planner shape that emits a
+            // different `consumer_tc` at the top boundary. Matches the worker dispatcher's setup.
+            let task_ctx = {
+                let cfg = task_ctx.session_config().clone().with_extension(Arc::new(
+                    DistributedTaskContext {
+                        task_index: 0,
+                        task_count: 1,
+                    },
+                ));
+                Arc::new(
+                    TaskContext::default()
+                        .with_session_config(cfg)
+                        .with_runtime(task_ctx.runtime_env().clone()),
+                )
+            };
             let stream = {
                 let _guard = runtime.enter();
                 match physical_plan.execute(0, task_ctx) {

--- a/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
@@ -1,0 +1,387 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! AggregateScan MPP worker exec path.
+//!
+//! Holds [`AggregateScan::exec_mpp_worker`], the body of `exec_custom_scan` when a parallel
+//! worker is running an MPP fragment. The leader's path stays in `mod.rs`; this file isolates
+//! the worker dispatcher's logical-plan deserialization, distributed-physical-plan build,
+//! fragment discovery, and `join_all`-driven async dispatch so `mod.rs` doesn't have to scroll
+//! past ~330 LOC of MPP-specific machinery to find the next non-MPP method.
+
+use std::sync::Arc;
+
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::execution::TaskContext;
+use datafusion::physical_plan::ExecutionPlanProperties;
+use datafusion_distributed::{DistributedExec, DistributedTaskContext};
+use pgrx::pg_sys;
+
+use crate::api::HashSet;
+use crate::postgres::customscan::aggregatescan::datafusion_exec::create_aggregate_session_context;
+use crate::postgres::customscan::aggregatescan::scan_state;
+use crate::postgres::customscan::aggregatescan::AggregateScan;
+use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
+use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use crate::postgres::customscan::mpp::runtime::proc_for_task;
+use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
+use crate::postgres::customscan::mpp::worker::run_worker_fragment;
+use crate::postgres::customscan::mpp::worker_fragments::{
+    find_worker_assignments, FragmentRouting,
+};
+use crate::postgres::customscan::parallel::list_segment_ids;
+use crate::scan::codec::deserialize_logical_plan_with_runtime;
+
+impl AggregateScan {
+    /// MPP worker exec: deserialize the logical plan from DSM, build the
+    /// distributed physical plan (matching what the leader produced), find
+    /// the worker fragment (the `input_stage.plan` of the bottom
+    /// `NetworkShuffleExec`), and run it via
+    /// [`mpp::worker::run_worker_fragment`] which pushes every output batch
+    /// to the leader's shm_mq queues. Workers emit zero rows back to PG;
+    /// returning `null_mut()` signals end-of-stream.
+    pub(super) fn exec_mpp_worker(
+        state: &mut CustomScanStateWrapper<Self>,
+    ) -> *mut pg_sys::TupleTableSlot {
+        // Pull worker-thread inputs from the outer state before we borrow
+        // df_state mutably. parallel_state and non_partitioning_segments
+        // are required to pin each worker's PgSearchTableProvider to the
+        // right segment slice (the partitioning source) and the leader's
+        // canonical replica (the non-partitioning sources). Without them,
+        // every worker re-scans the full data and the leader-side hash
+        // partitions get the same rows from every worker.
+        let parallel_state = state.custom_state().parallel_state;
+        let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
+        let partitioning_source_idx = state
+            .custom_state()
+            .mpp_partitioning_source_idx
+            .unwrap_or(0);
+        let plan_sources_count = state
+            .custom_state()
+            .source_manifests
+            .len()
+            .max(non_partitioning_segments.len() + 1);
+
+        let df_state = state
+            .custom_state_mut()
+            .datafusion_state
+            .as_mut()
+            .expect("DataFusion state must be initialized");
+
+        if df_state.runtime.is_some() {
+            // Already drained on a prior call; just signal EOF.
+            return std::ptr::null_mut();
+        }
+        let scan_state::MppExecState::Worker(worker) = df_state.mpp.as_ref().expect("checked")
+        else {
+            unreachable!("exec_mpp_worker called outside Worker state");
+        };
+        let plan_bytes = worker.plan_bytes.clone();
+        // Worker mesh + total proc count for the dispatcher. The mesh's `ShmMqWorkerTransport`
+        // gets wired into the session below. n_workers is rederived from total_procs at the
+        // dispatcher; both forms (participant_config.total_workers, n_procs-1) agree by
+        // construction in `worker_setup`.
+        let worker_mesh = Arc::clone(&worker.mesh);
+        let this_proc = worker.mesh.this_proc;
+        let total_procs = worker.mesh.n_procs;
+        let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
+            Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
+            _ => unreachable!(),
+        };
+
+        let runtime = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => pgrx::error!("mpp worker: tokio runtime build failed: {e}"),
+        };
+        df_state.runtime = Some(runtime);
+        let runtime = df_state.runtime.as_ref().unwrap();
+        // Use a bare SessionContext for plan deserialization. The distributed planner config
+        // (worker resolver, transport, estimators, codec) is mirrored from the leader via
+        // `build_mpp_session_context` below — both procs have to agree on stage shape or
+        // `find_worker_assignments` won't line up.
+        let ctx = create_aggregate_session_context();
+
+        // Build per-source canonical segment ID sets. For the partitioning
+        // source, pull the full list out of the populated ParallelScanState
+        // (workers will then claim individual segments via `checkout_segment`
+        // inside their `PgSearchTableProvider`). For non-partitioning sources,
+        // use the segment IDs the leader snapshotted into shared memory.
+        let mut index_segment_ids: Vec<HashSet<tantivy::index::SegmentId>> =
+            vec![HashSet::default(); plan_sources_count];
+        if let Some(ps) = parallel_state {
+            let mut np_counter = 0usize;
+            for (i, slot) in index_segment_ids.iter_mut().enumerate() {
+                if i == partitioning_source_idx {
+                    *slot = unsafe { list_segment_ids(ps) };
+                } else if let Some(ids) = non_partitioning_segments.get(np_counter) {
+                    *slot = ids.clone();
+                    np_counter += 1;
+                }
+            }
+        }
+
+        let logical = match deserialize_logical_plan_with_runtime(
+            &plan_bytes,
+            &ctx.task_ctx(),
+            parallel_state,
+            None, // expr_context: bm25 search predicates don't need runtime params
+            None, // planstate: same
+            non_partitioning_segments,
+            index_segment_ids,
+        ) {
+            Ok(lp) => lp,
+            Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
+        };
+
+        // Build the worker's distributed session context. Reuses the same builder the leader
+        // runs so both procs agree on stage shape, task estimator chain, target_partitions,
+        // and codec — without that, `find_worker_assignments` returns no fragments for this
+        // worker because the worker's plan numbers stages differently from the leader's.
+        let session = Self::build_mpp_session_context(Arc::clone(&worker_mesh));
+
+        let physical_plan =
+            runtime.block_on(async { session.state().create_physical_plan(&logical).await });
+        let physical_plan = match physical_plan {
+            Ok(p) => p,
+            Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
+        };
+        // Walk the plan and collect every `(stage_id, task_idx)` slot owned
+        // by this proc under the `proc_for_task` round-robin policy. The
+        // dispatcher spawns one async task per fragment; together they form
+        // the worker's complete contribution to the distributed plan.
+        let n_workers = total_procs.saturating_sub(1).max(1);
+        let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
+        if fragments.is_empty() {
+            pgrx::warning!(
+                "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
+            );
+            return std::ptr::null_mut();
+        }
+
+        let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
+        let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
+        let session_arc = Arc::new(session);
+
+        // Two `Future` shapes share this vector: real producer-fragment
+        // futures and broadcast short-circuit EOF-only stubs. The alias
+        // keeps the `Vec<_>` declaration legible and silences
+        // clippy::type_complexity.
+        type FragmentFuture = std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
+                    + Send,
+            >,
+        >;
+        let result = runtime.block_on(async move {
+            let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
+            for fragment in &fragments {
+                let n_out = fragment.plan.output_partitioning().partition_count();
+                // Build per-output-partition senders. For each partition `q`
+                // emitted by this fragment, look up the destination proc via
+                // `fragment.routing` and clone the right outbound sender.
+                let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
+                for q in 0..n_out {
+                    let dest_proc = match &fragment.routing {
+                        FragmentRouting::Coalesce { dest_proc } => *dest_proc,
+                        FragmentRouting::Shuffle {
+                            partitions_per_consumer_task,
+                        }
+                        | FragmentRouting::Broadcast {
+                            partitions_per_consumer_task,
+                        } => {
+                            let t_c = (q / partitions_per_consumer_task) as u32;
+                            proc_for_task(n_workers, t_c)
+                        }
+                    };
+                    let base = match outbound_senders
+                        .get(dest_proc as usize)
+                        .and_then(|s| s.as_ref())
+                    {
+                        Some(s) => s,
+                        None => {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
+                                 (self-loop or unattached); fragment stage_id={} task_idx={}",
+                                fragment.stage_id, fragment.task_idx,
+                            )));
+                        }
+                    };
+                    let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
+                    crate::mpp_log!(
+                        "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
+                         task_idx={}) partition={q} → dest_proc={dest_proc}",
+                        fragment.stage_id,
+                        fragment.task_idx,
+                    );
+                    // Attach the worker mesh as the cooperative drain so a
+                    // full outbound shm_mq queue doesn't block the backend
+                    // thread. The spin pulls every inbound drain while
+                    // retrying the send, breaking N×N symmetric stalls.
+                    per_partition_senders.push(
+                        base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
+                            .with_cooperative_drain(
+                                Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
+                            ),
+                    );
+                }
+
+                // Broadcast invariant: fail-loud cap check.
+                //
+                // pg_search's natural-shape AggregateScan plan canonical-replicates the build
+                // subtree via the `mpp build all-gather` step. Every producer task would scan
+                // the full canonical data, and the consumer's `select_all` would over-count by
+                // `input_task_count`. The planner-level [`BroadcastBuildSideOneTaskEstimator`]
+                // caps the build subtree at task_count=1, so a correct plan produces exactly one
+                // Broadcast fragment with task_idx == 0.
+                //
+                // A non-zero `task_idx` here means the cap silently failed: maybe the estimator
+                // wasn't installed, the chain order is wrong, or a future planner pass
+                // re-expanded the build subtree. We surface this as a hard error rather than
+                // silently EOF-only-ing the fragment. The EOF-only fallback is only correct
+                // under the canonical-replica INVARIANT documented on
+                // `FragmentRouting::Broadcast`, and we'd rather fail loudly than emit a stealth
+                // correctness regression. Matches the top-level NetworkBroadcastExec treatment
+                // in `worker_fragments::collect`.
+                if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
+                    debug_assert!(
+                        fragment.task_idx == 0,
+                        "mpp dispatcher: Broadcast fragment with task_idx={} but \
+                         BroadcastBuildSideOneTaskEstimator should have capped \
+                         input_task_count at 1; plan-walk drift?",
+                        fragment.task_idx,
+                    );
+                    if fragment.task_idx != 0 {
+                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                            "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
+                             (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
+                             BroadcastBuildSideOneTaskEstimator should cap input_task_count at \
+                             1. A non-zero task_idx here indicates plan-walk drift or a missing \
+                             estimator chain on this session; running the producer plan would \
+                             duplicate the canonical replica, EOF-only-ing it would drop a \
+                             real shard if the cap loss was due to a sharded build subtree. \
+                             Surface as error so the divergence is visible.",
+                            fragment.stage_id, fragment.task_idx,
+                        )));
+                    }
+                }
+
+                // Build a TaskContext seeded with the right `DistributedTaskContext` so the
+                // boundary nodes inside the fragment's plan know their
+                // `(task_index, task_count)`.
+                let cfg = session_arc
+                    .state()
+                    .config()
+                    .clone()
+                    .with_extension(Arc::new(DistributedTaskContext {
+                        task_index: fragment.task_idx,
+                        task_count: fragment.task_count,
+                    }));
+                let memory_pool =
+                    create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
+                let task_ctx = Arc::new(
+                    TaskContext::default()
+                        .with_session_config(cfg)
+                        .with_runtime(Arc::new(
+                            RuntimeEnvBuilder::new()
+                                .with_memory_pool(memory_pool)
+                                .build()
+                                .expect("Failed to create RuntimeEnv"),
+                        )),
+                );
+
+                // Wrap fragment.plan in a fresh `DistributedExec` and run
+                // `prepare_in_process_plan` to convert any nested boundaries' input stages from
+                // `Stage::Local` to `Stage::Remote`. Without this, a nested `NetworkShuffleExec`
+                // / `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task
+                // count exceeds 1; with the conversion, those boundaries dispatch through
+                // `ShmMqWorkerTransport` exactly like outer boundaries.
+                let plan = {
+                    let dist = Arc::new(DistributedExec::new(Arc::clone(&fragment.plan)));
+                    match dist.prepare_in_process_plan(&task_ctx) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker: prepare_in_process_plan failed for fragment \
+                                 (stage_id={}, task_idx={}): {e}",
+                                fragment.stage_id, fragment.task_idx
+                            )));
+                        }
+                    }
+                };
+                futures.push(Box::pin(run_worker_fragment(
+                    plan,
+                    per_partition_senders,
+                    task_ctx,
+                )));
+            }
+            // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue
+            // / in-proc channel are the per-partition clones owned by the spawned fragments.
+            // Without this, the originals would outlive the futures, the consumer-side drains
+            // would never observe `Detached`, and `stream_partition`'s pull loop would spin
+            // forever.
+            drop(outbound_senders);
+            crate::mpp_log!(
+                "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
+                fragments.len()
+            );
+            // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
+            // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
+            // futures, leaving their `(stage_id, partition)` sub-buffers stuck at
+            // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
+            // substrate alone (matching reasoning in `run_worker_fragment`).
+            //
+            // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
+            // within 30 s the dispatcher surfaces an error instead of letting the backend spin
+            // forever. Per-drain state shows up in the inbound drains' own traces in
+            // transport.rs / runtime.rs.
+            let join_fut = futures::future::join_all(futures);
+            let outcome: Result<(), datafusion::common::DataFusionError> =
+                if crate::gucs::mpp_debug() {
+                    match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
+                        Ok(results) => results
+                            .into_iter()
+                            .collect::<Result<Vec<_>, _>>()
+                            .map(|_| ()),
+                        Err(_) => {
+                            crate::mpp_log!(
+                                "mpp worker dispatch this_proc={this_proc} \
+                             HANG: join_all exceeded 30s"
+                            );
+                            Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
+                             deadlock detector triggered"
+                            )))
+                        }
+                    }
+                } else {
+                    join_fut
+                        .await
+                        .into_iter()
+                        .collect::<Result<Vec<_>, _>>()
+                        .map(|_| ())
+                };
+            outcome
+        });
+        if let Err(e) = result {
+            pgrx::error!("mpp worker: fragment dispatch failed: {e}");
+        }
+        std::ptr::null_mut()
+    }
+}

--- a/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
@@ -46,342 +46,325 @@ use crate::postgres::customscan::mpp::worker_fragments::{
 use crate::postgres::customscan::parallel::list_segment_ids;
 use crate::scan::codec::deserialize_logical_plan_with_runtime;
 
-impl AggregateScan {
-    /// MPP worker exec: deserialize the logical plan from DSM, build the
-    /// distributed physical plan (matching what the leader produced), find
-    /// the worker fragment (the `input_stage.plan` of the bottom
-    /// `NetworkShuffleExec`), and run it via
-    /// [`mpp::worker::run_worker_fragment`] which pushes every output batch
-    /// to the leader's shm_mq queues. Workers emit zero rows back to PG;
-    /// returning `null_mut()` signals end-of-stream.
-    pub(super) fn exec_mpp_worker(
-        state: &mut CustomScanStateWrapper<Self>,
-    ) -> *mut pg_sys::TupleTableSlot {
-        // Pull worker-thread inputs from the outer state before we borrow
-        // df_state mutably. parallel_state and non_partitioning_segments
-        // are required to pin each worker's PgSearchTableProvider to the
-        // right segment slice (the partitioning source) and the leader's
-        // canonical replica (the non-partitioning sources). Without them,
-        // every worker re-scans the full data and the leader-side hash
-        // partitions get the same rows from every worker.
-        let parallel_state = state.custom_state().parallel_state;
-        let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
-        let partitioning_source_idx = state
-            .custom_state()
-            .mpp_partitioning_source_idx
-            .unwrap_or(0);
-        let plan_sources_count = state
-            .custom_state()
-            .source_manifests
-            .len()
-            .max(non_partitioning_segments.len() + 1);
+/// MPP worker exec: deserialize the logical plan from DSM, build the
+/// distributed physical plan (matching what the leader produced), find
+/// the worker fragment (the `input_stage.plan` of the bottom
+/// `NetworkShuffleExec`), and run it via
+/// [`mpp::worker::run_worker_fragment`] which pushes every output batch
+/// to the leader's shm_mq queues. Workers emit zero rows back to PG;
+/// returning `null_mut()` signals end-of-stream.
+pub(super) fn exec_mpp_worker(
+    state: &mut CustomScanStateWrapper<AggregateScan>,
+) -> *mut pg_sys::TupleTableSlot {
+    // Pull worker-thread inputs from the outer state before we borrow
+    // df_state mutably. parallel_state and non_partitioning_segments
+    // are required to pin each worker's PgSearchTableProvider to the
+    // right segment slice (the partitioning source) and the leader's
+    // canonical replica (the non-partitioning sources). Without them,
+    // every worker re-scans the full data and the leader-side hash
+    // partitions get the same rows from every worker.
+    let parallel_state = state.custom_state().parallel_state;
+    let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
+    let partitioning_source_idx = state
+        .custom_state()
+        .mpp_partitioning_source_idx
+        .unwrap_or(0);
+    let plan_sources_count = state
+        .custom_state()
+        .source_manifests
+        .len()
+        .max(non_partitioning_segments.len() + 1);
 
-        let df_state = state
-            .custom_state_mut()
-            .datafusion_state
-            .as_mut()
-            .expect("DataFusion state must be initialized");
+    let df_state = state
+        .custom_state_mut()
+        .datafusion_state
+        .as_mut()
+        .expect("DataFusion state must be initialized");
 
-        if df_state.runtime.is_some() {
-            // Already drained on a prior call; just signal EOF.
-            return std::ptr::null_mut();
-        }
-        let scan_state::MppExecState::Worker(worker) = df_state.mpp.as_ref().expect("checked")
-        else {
-            unreachable!("exec_mpp_worker called outside Worker state");
-        };
-        let plan_bytes = worker.plan_bytes.clone();
-        // Worker mesh + total proc count for the dispatcher. The mesh's `ShmMqWorkerTransport`
-        // gets wired into the session below. n_workers is rederived from total_procs at the
-        // dispatcher; both forms (participant_config.total_workers, n_procs-1) agree by
-        // construction in `worker_setup`.
-        let worker_mesh = Arc::clone(&worker.mesh);
-        let this_proc = worker.mesh.this_proc;
-        let total_procs = worker.mesh.n_procs;
-        let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
-            Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
-            _ => unreachable!(),
-        };
+    if df_state.runtime.is_some() {
+        // Already drained on a prior call; just signal EOF.
+        return std::ptr::null_mut();
+    }
+    let scan_state::MppExecState::Worker(worker) = df_state.mpp.as_ref().expect("checked") else {
+        unreachable!("exec_mpp_worker called outside Worker state");
+    };
+    let plan_bytes = worker.plan_bytes.clone();
+    // Worker mesh + total proc count for the dispatcher. The mesh's `ShmMqWorkerTransport`
+    // gets wired into the session below. n_workers is rederived from total_procs at the
+    // dispatcher; both forms (proc-side total_workers, n_procs-1) agree by
+    // construction in `worker_setup`.
+    let worker_mesh = Arc::clone(&worker.mesh);
+    let this_proc = worker.mesh.this_proc;
+    let total_procs = worker.mesh.n_procs;
+    let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
+        Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
+        _ => unreachable!(),
+    };
 
-        let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => pgrx::error!("mpp worker: tokio runtime build failed: {e}"),
-        };
-        df_state.runtime = Some(runtime);
-        let runtime = df_state.runtime.as_ref().unwrap();
-        // Use a bare SessionContext for plan deserialization. The distributed planner config
-        // (worker resolver, transport, estimators, codec) is mirrored from the leader via
-        // `build_mpp_session_context` below — both procs have to agree on stage shape or
-        // `find_worker_assignments` won't line up.
-        let ctx = create_aggregate_session_context();
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => pgrx::error!("mpp worker: tokio runtime build failed: {e}"),
+    };
+    df_state.runtime = Some(runtime);
+    let runtime = df_state.runtime.as_ref().unwrap();
+    // Use a bare SessionContext for plan deserialization. The distributed planner config
+    // (worker resolver, transport, estimators, codec) is mirrored from the leader via
+    // `build_mpp_session_context` below — both procs have to agree on stage shape or
+    // `find_worker_assignments` won't line up.
+    let ctx = create_aggregate_session_context();
 
-        // Build per-source canonical segment ID sets. For the partitioning
-        // source, pull the full list out of the populated ParallelScanState
-        // (workers will then claim individual segments via `checkout_segment`
-        // inside their `PgSearchTableProvider`). For non-partitioning sources,
-        // use the segment IDs the leader snapshotted into shared memory.
-        let mut index_segment_ids: Vec<HashSet<tantivy::index::SegmentId>> =
-            vec![HashSet::default(); plan_sources_count];
-        if let Some(ps) = parallel_state {
-            let mut np_counter = 0usize;
-            for (i, slot) in index_segment_ids.iter_mut().enumerate() {
-                if i == partitioning_source_idx {
-                    *slot = unsafe { list_segment_ids(ps) };
-                } else if let Some(ids) = non_partitioning_segments.get(np_counter) {
-                    *slot = ids.clone();
-                    np_counter += 1;
-                }
+    // Build per-source canonical segment ID sets. For the partitioning
+    // source, pull the full list out of the populated ParallelScanState
+    // (workers will then claim individual segments via `checkout_segment`
+    // inside their `PgSearchTableProvider`). For non-partitioning sources,
+    // use the segment IDs the leader snapshotted into shared memory.
+    let mut index_segment_ids: Vec<HashSet<tantivy::index::SegmentId>> =
+        vec![HashSet::default(); plan_sources_count];
+    if let Some(ps) = parallel_state {
+        let mut np_counter = 0usize;
+        for (i, slot) in index_segment_ids.iter_mut().enumerate() {
+            if i == partitioning_source_idx {
+                *slot = unsafe { list_segment_ids(ps) };
+            } else if let Some(ids) = non_partitioning_segments.get(np_counter) {
+                *slot = ids.clone();
+                np_counter += 1;
             }
         }
+    }
 
-        let logical = match deserialize_logical_plan_with_runtime(
-            &plan_bytes,
-            &ctx.task_ctx(),
-            parallel_state,
-            None, // expr_context: bm25 search predicates don't need runtime params
-            None, // planstate: same
-            non_partitioning_segments,
-            index_segment_ids,
-        ) {
-            Ok(lp) => lp,
-            Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
-        };
+    let logical = match deserialize_logical_plan_with_runtime(
+        &plan_bytes,
+        &ctx.task_ctx(),
+        parallel_state,
+        None, // expr_context: bm25 search predicates don't need runtime params
+        None, // planstate: same
+        non_partitioning_segments,
+        index_segment_ids,
+    ) {
+        Ok(lp) => lp,
+        Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
+    };
 
-        // Build the worker's distributed session context. Reuses the same builder the leader
-        // runs so both procs agree on stage shape, task estimator chain, target_partitions,
-        // and codec — without that, `find_worker_assignments` returns no fragments for this
-        // worker because the worker's plan numbers stages differently from the leader's.
-        let session = Self::build_mpp_session_context(Arc::clone(&worker_mesh));
+    // Build the worker's distributed session context. Reuses the same builder the leader
+    // runs so both procs agree on stage shape, task estimator chain, target_partitions,
+    // and codec — without that, `find_worker_assignments` returns no fragments for this
+    // worker because the worker's plan numbers stages differently from the leader's.
+    let session = AggregateScan::build_mpp_session_context(Arc::clone(&worker_mesh));
 
-        let physical_plan =
-            runtime.block_on(async { session.state().create_physical_plan(&logical).await });
-        let physical_plan = match physical_plan {
-            Ok(p) => p,
-            Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
-        };
-        // Walk the plan and collect every `(stage_id, task_idx)` slot owned
-        // by this proc under the `proc_for_task` round-robin policy. The
-        // dispatcher spawns one async task per fragment; together they form
-        // the worker's complete contribution to the distributed plan.
-        let n_workers = total_procs.saturating_sub(1).max(1);
-        let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
-        if fragments.is_empty() {
-            pgrx::warning!(
-                "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
-            );
-            return std::ptr::null_mut();
-        }
+    let physical_plan =
+        runtime.block_on(async { session.state().create_physical_plan(&logical).await });
+    let physical_plan = match physical_plan {
+        Ok(p) => p,
+        Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
+    };
+    // Walk the plan and collect every `(stage_id, task_idx)` slot owned
+    // by this proc under the `proc_for_task` round-robin policy. The
+    // dispatcher spawns one async task per fragment; together they form
+    // the worker's complete contribution to the distributed plan.
+    let n_workers = total_procs.saturating_sub(1).max(1);
+    let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
+    if fragments.is_empty() {
+        pgrx::warning!(
+            "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
+        );
+        return std::ptr::null_mut();
+    }
 
-        let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
-        let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
-        let session_arc = Arc::new(session);
+    let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
+    let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
+    let session_arc = Arc::new(session);
 
-        // Two `Future` shapes share this vector: real producer-fragment
-        // futures and broadcast short-circuit EOF-only stubs. The alias
-        // keeps the `Vec<_>` declaration legible and silences
-        // clippy::type_complexity.
-        type FragmentFuture = std::pin::Pin<
-            Box<
-                dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
-                    + Send,
-            >,
-        >;
-        let result = runtime.block_on(async move {
-            let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
-            for fragment in &fragments {
-                let n_out = fragment.plan.output_partitioning().partition_count();
-                // Build per-output-partition senders. For each partition `q`
-                // emitted by this fragment, look up the destination proc via
-                // `fragment.routing` and clone the right outbound sender.
-                let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
-                for q in 0..n_out {
-                    let dest_proc = match &fragment.routing {
-                        FragmentRouting::Coalesce { dest_proc } => *dest_proc,
-                        FragmentRouting::Shuffle {
-                            partitions_per_consumer_task,
-                        }
-                        | FragmentRouting::Broadcast {
-                            partitions_per_consumer_task,
-                        } => {
-                            let t_c = (q / partitions_per_consumer_task) as u32;
-                            proc_for_task(n_workers, t_c)
-                        }
-                    };
-                    let base = match outbound_senders
-                        .get(dest_proc as usize)
-                        .and_then(|s| s.as_ref())
-                    {
-                        Some(s) => s,
-                        None => {
-                            return Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
-                                 (self-loop or unattached); fragment stage_id={} task_idx={}",
-                                fragment.stage_id, fragment.task_idx,
-                            )));
-                        }
-                    };
-                    let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
-                    crate::mpp_log!(
-                        "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
-                         task_idx={}) partition={q} → dest_proc={dest_proc}",
-                        fragment.stage_id,
-                        fragment.task_idx,
-                    );
-                    // Attach the worker mesh as the cooperative drain so a
-                    // full outbound shm_mq queue doesn't block the backend
-                    // thread. The spin pulls every inbound drain while
-                    // retrying the send, breaking N×N symmetric stalls.
-                    per_partition_senders.push(
-                        base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
-                            .with_cooperative_drain(
-                                Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
-                            ),
-                    );
-                }
-
-                // Broadcast invariant: fail-loud cap check.
-                //
-                // pg_search's natural-shape AggregateScan plan canonical-replicates the build
-                // subtree via the `mpp build all-gather` step. Every producer task would scan
-                // the full canonical data, and the consumer's `select_all` would over-count by
-                // `input_task_count`. The planner-level [`BroadcastBuildSideOneTaskEstimator`]
-                // caps the build subtree at task_count=1, so a correct plan produces exactly one
-                // Broadcast fragment with task_idx == 0.
-                //
-                // A non-zero `task_idx` here means the cap silently failed: maybe the estimator
-                // wasn't installed, the chain order is wrong, or a future planner pass
-                // re-expanded the build subtree. We surface this as a hard error rather than
-                // silently EOF-only-ing the fragment. The EOF-only fallback is only correct
-                // under the canonical-replica INVARIANT documented on
-                // `FragmentRouting::Broadcast`, and we'd rather fail loudly than emit a stealth
-                // correctness regression. Matches the top-level NetworkBroadcastExec treatment
-                // in `worker_fragments::collect`.
-                if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
-                    debug_assert!(
-                        fragment.task_idx == 0,
-                        "mpp dispatcher: Broadcast fragment with task_idx={} but \
-                         BroadcastBuildSideOneTaskEstimator should have capped \
-                         input_task_count at 1; plan-walk drift?",
-                        fragment.task_idx,
-                    );
-                    if fragment.task_idx != 0 {
+    // Two `Future` shapes share this vector: real producer-fragment
+    // futures and broadcast short-circuit EOF-only stubs. The alias
+    // keeps the `Vec<_>` declaration legible and silences
+    // clippy::type_complexity.
+    type FragmentFuture = std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
+                + Send,
+        >,
+    >;
+    let result = runtime.block_on(async move {
+        let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
+        for fragment in &fragments {
+            let n_out = fragment.plan.output_partitioning().partition_count();
+            // Build per-output-partition senders. For each partition `q`
+            // emitted by this fragment, look up the destination proc via
+            // `fragment.routing` and clone the right outbound sender.
+            let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
+            for q in 0..n_out {
+                let dest_proc = match &fragment.routing {
+                    FragmentRouting::Coalesce { dest_proc } => *dest_proc,
+                    FragmentRouting::Shuffle {
+                        partitions_per_consumer_task,
+                    }
+                    | FragmentRouting::Broadcast {
+                        partitions_per_consumer_task,
+                    } => {
+                        let t_c = (q / partitions_per_consumer_task) as u32;
+                        proc_for_task(n_workers, t_c)
+                    }
+                };
+                let base = match outbound_senders
+                    .get(dest_proc as usize)
+                    .and_then(|s| s.as_ref())
+                {
+                    Some(s) => s,
+                    None => {
                         return Err(datafusion::common::DataFusionError::Internal(format!(
-                            "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
-                             (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
-                             BroadcastBuildSideOneTaskEstimator should cap input_task_count at \
-                             1. A non-zero task_idx here indicates plan-walk drift or a missing \
-                             estimator chain on this session; running the producer plan would \
-                             duplicate the canonical replica, EOF-only-ing it would drop a \
-                             real shard if the cap loss was due to a sharded build subtree. \
-                             Surface as error so the divergence is visible.",
+                            "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
+                             (self-loop or unattached); fragment stage_id={} task_idx={}",
                             fragment.stage_id, fragment.task_idx,
                         )));
                     }
-                }
-
-                // Build a TaskContext seeded with the right `DistributedTaskContext` so the
-                // boundary nodes inside the fragment's plan know their
-                // `(task_index, task_count)`.
-                let cfg = session_arc
-                    .state()
-                    .config()
-                    .clone()
-                    .with_extension(Arc::new(DistributedTaskContext {
-                        task_index: fragment.task_idx,
-                        task_count: fragment.task_count,
-                    }));
-                let memory_pool =
-                    create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
-                let task_ctx = Arc::new(
-                    TaskContext::default()
-                        .with_session_config(cfg)
-                        .with_runtime(Arc::new(
-                            RuntimeEnvBuilder::new()
-                                .with_memory_pool(memory_pool)
-                                .build()
-                                .expect("Failed to create RuntimeEnv"),
-                        )),
+                };
+                let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
+                crate::mpp_log!(
+                    "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
+                     task_idx={}) partition={q} → dest_proc={dest_proc}",
+                    fragment.stage_id,
+                    fragment.task_idx,
                 );
-
-                // Wrap fragment.plan in a fresh `DistributedExec` and run
-                // `prepare_in_process_plan` to convert any nested boundaries' input stages from
-                // `Stage::Local` to `Stage::Remote`. Without this, a nested `NetworkShuffleExec`
-                // / `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task
-                // count exceeds 1; with the conversion, those boundaries dispatch through
-                // `ShmMqWorkerTransport` exactly like outer boundaries.
-                let plan = {
-                    let dist = Arc::new(DistributedExec::new(Arc::clone(&fragment.plan)));
-                    match dist.prepare_in_process_plan(&task_ctx) {
-                        Ok(p) => p,
-                        Err(e) => {
-                            return Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker: prepare_in_process_plan failed for fragment \
-                                 (stage_id={}, task_idx={}): {e}",
-                                fragment.stage_id, fragment.task_idx
-                            )));
-                        }
-                    }
-                };
-                futures.push(Box::pin(run_worker_fragment(
-                    plan,
-                    per_partition_senders,
-                    task_ctx,
-                )));
+                // Attach the worker mesh as the cooperative drain so a
+                // full outbound shm_mq queue doesn't block the backend
+                // thread. The spin pulls every inbound drain while
+                // retrying the send, breaking N×N symmetric stalls.
+                per_partition_senders.push(
+                    base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
+                        .with_cooperative_drain(
+                            Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
+                        ),
+                );
             }
-            // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue
-            // / in-proc channel are the per-partition clones owned by the spawned fragments.
-            // Without this, the originals would outlive the futures, the consumer-side drains
-            // would never observe `Detached`, and `stream_partition`'s pull loop would spin
-            // forever.
-            drop(outbound_senders);
-            crate::mpp_log!(
-                "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
-                fragments.len()
+
+            // Fail-loud guard for the `BroadcastBuildSideOneTaskEstimator` cap: a non-zero
+            // task_idx here means the cap silently failed (estimator missing, chain order wrong,
+            // or a future planner expanded the build subtree). Better to error than to
+            // duplicate or drop data; see the variant doc on `FragmentRouting::Broadcast`.
+            if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
+                debug_assert!(
+                    fragment.task_idx == 0,
+                    "mpp dispatcher: Broadcast fragment with task_idx={} but \
+                     BroadcastBuildSideOneTaskEstimator should have capped \
+                     input_task_count at 1; plan-walk drift?",
+                    fragment.task_idx,
+                );
+                if fragment.task_idx != 0 {
+                    return Err(datafusion::common::DataFusionError::Internal(format!(
+                        "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
+                         (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
+                         BroadcastBuildSideOneTaskEstimator should cap input_task_count at \
+                         1. A non-zero task_idx here indicates plan-walk drift or a missing \
+                         estimator chain on this session; running the producer plan would \
+                         duplicate the canonical replica, EOF-only-ing it would drop a \
+                         real shard if the cap loss was due to a sharded build subtree. \
+                         Surface as error so the divergence is visible.",
+                        fragment.stage_id, fragment.task_idx,
+                    )));
+                }
+            }
+
+            // Build a TaskContext seeded with the right `DistributedTaskContext` so the
+            // boundary nodes inside the fragment's plan know their
+            // `(task_index, task_count)`.
+            let cfg = session_arc
+                .state()
+                .config()
+                .clone()
+                .with_extension(Arc::new(DistributedTaskContext {
+                    task_index: fragment.task_idx,
+                    task_count: fragment.task_count,
+                }));
+            let memory_pool =
+                create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
+            let task_ctx = Arc::new(
+                TaskContext::default()
+                    .with_session_config(cfg)
+                    .with_runtime(Arc::new(
+                        RuntimeEnvBuilder::new()
+                            .with_memory_pool(memory_pool)
+                            .build()
+                            .expect("Failed to create RuntimeEnv"),
+                    )),
             );
-            // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
-            // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
-            // futures, leaving their `(stage_id, partition)` sub-buffers stuck at
-            // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
-            // substrate alone (matching reasoning in `run_worker_fragment`).
-            //
-            // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
-            // within 30 s the dispatcher surfaces an error instead of letting the backend spin
-            // forever. Per-drain state shows up in the inbound drains' own traces in
-            // transport.rs / runtime.rs.
-            let join_fut = futures::future::join_all(futures);
-            let outcome: Result<(), datafusion::common::DataFusionError> =
-                if crate::gucs::mpp_debug() {
-                    match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
-                        Ok(results) => results
-                            .into_iter()
-                            .collect::<Result<Vec<_>, _>>()
-                            .map(|_| ()),
-                        Err(_) => {
-                            crate::mpp_log!(
-                                "mpp worker dispatch this_proc={this_proc} \
-                             HANG: join_all exceeded 30s"
-                            );
-                            Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
-                             deadlock detector triggered"
-                            )))
-                        }
+
+            // Wrap fragment.plan in a fresh `DistributedExec` and run
+            // `prepare_in_process_plan` to convert any nested boundaries' input stages from
+            // `Stage::Local` to `Stage::Remote`. Without this, a nested `NetworkShuffleExec`
+            // / `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task
+            // count exceeds 1; with the conversion, those boundaries dispatch through
+            // `ShmMqWorkerTransport` exactly like outer boundaries.
+            let plan = {
+                let dist = Arc::new(DistributedExec::new(Arc::clone(&fragment.plan)));
+                match dist.prepare_in_process_plan(&task_ctx) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                            "mpp worker: prepare_in_process_plan failed for fragment \
+                             (stage_id={}, task_idx={}): {e}",
+                            fragment.stage_id, fragment.task_idx
+                        )));
                     }
-                } else {
-                    join_fut
-                        .await
-                        .into_iter()
-                        .collect::<Result<Vec<_>, _>>()
-                        .map(|_| ())
-                };
-            outcome
-        });
-        if let Err(e) = result {
-            pgrx::error!("mpp worker: fragment dispatch failed: {e}");
+                }
+            };
+            futures.push(Box::pin(run_worker_fragment(
+                plan,
+                per_partition_senders,
+                task_ctx,
+            )));
         }
-        std::ptr::null_mut()
+        // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue
+        // / in-proc channel are the per-partition clones owned by the spawned fragments.
+        // Without this, the originals would outlive the futures, the consumer-side drains
+        // would never observe `Detached`, and `stream_partition`'s pull loop would spin
+        // forever.
+        drop(outbound_senders);
+        crate::mpp_log!(
+            "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
+            fragments.len()
+        );
+        // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
+        // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
+        // futures, leaving their `(stage_id, partition)` channel buffers stuck at
+        // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
+        // substrate alone (matching reasoning in `run_worker_fragment`).
+        //
+        // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
+        // within 30 s the dispatcher surfaces an error instead of letting the backend spin
+        // forever. Per-drain state shows up in the inbound drains' own traces in
+        // transport.rs / runtime.rs.
+        let join_fut = futures::future::join_all(futures);
+        let outcome: Result<(), datafusion::common::DataFusionError> = if crate::gucs::mpp_debug() {
+            match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
+                Ok(results) => results
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(|_| ()),
+                Err(_) => {
+                    crate::mpp_log!(
+                        "mpp worker dispatch this_proc={this_proc} \
+                         HANG: join_all exceeded 30s"
+                    );
+                    Err(datafusion::common::DataFusionError::Internal(format!(
+                        "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
+                         deadlock detector triggered"
+                    )))
+                }
+            }
+        } else {
+            join_fut
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .map(|_| ())
+        };
+        outcome
+    });
+    if let Err(e) = result {
+        pgrx::error!("mpp worker: fragment dispatch failed: {e}");
     }
+    std::ptr::null_mut()
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
@@ -20,8 +20,8 @@
 //! Holds [`AggregateScan::exec_mpp_worker`], the body of `exec_custom_scan` when a parallel
 //! worker is running an MPP fragment. The leader's path stays in `mod.rs`; this file isolates
 //! the worker dispatcher's logical-plan deserialization, distributed-physical-plan build,
-//! fragment discovery, and `join_all`-driven async dispatch so `mod.rs` doesn't have to scroll
-//! past ~330 LOC of MPP-specific machinery to find the next non-MPP method.
+//! fragment discovery, and `join_all`-driven async dispatch so `mod.rs` keeps its focus on the
+//! leader-side trait impl and the serial Tantivy paths.
 
 use std::sync::Arc;
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1252,8 +1252,6 @@ impl CustomScan for JoinScan {
                 None,
                 vec![],
                 vec![],
-                None,
-                0,
             )
             .expect("Failed to deserialize logical plan");
             let physical_plan = runtime
@@ -1338,8 +1336,6 @@ impl CustomScan for JoinScan {
                     Some(planstate),
                     state.custom_state().non_partitioning_segments.clone(),
                     index_segment_ids,
-                    None,
-                    0,
                 )
                 .expect("Failed to deserialize logical plan");
 

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -1529,18 +1529,9 @@ mod tests {
         let bytes =
             serialize_logical_plan(&wrapped).expect("VisibilityFilterNode should serialize");
         let ctx = TaskContext::default();
-        let decoded = deserialize_logical_plan_with_runtime(
-            &bytes,
-            &ctx,
-            None,
-            None,
-            None,
-            vec![],
-            vec![],
-            None,
-            0,
-        )
-        .expect("VisibilityFilterNode should deserialize");
+        let decoded =
+            deserialize_logical_plan_with_runtime(&bytes, &ctx, None, None, None, vec![], vec![])
+                .expect("VisibilityFilterNode should deserialize");
 
         let LogicalPlan::Extension(ext) = &decoded else {
             panic!("decoded root should be Extension");

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -15,32 +15,37 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! N×K DSM layout for the coordinator/worker MPP architecture.
+//! Multiplexed N×N DSM layout for the natural-shape MPP architecture.
 //!
 //! Each MPP query allocates a single DSM region containing:
 //!
 //! ```text
-//!   +--- MppDsmHeader (repr C, 56 bytes, MAXALIGN-padded) ----+
-//!   |    magic, version, n_workers, n_partitions, queue_bytes |
-//!   |    plan_offset, plan_len, queues_offset, region_total   |
-//!   +---------------------------------------------------------+
-//!   | plan bytes (bincode-serialized worker fragment)         |
-//!   +---------------------------------------------------------+
-//!   | padding to MAXALIGN                                     |
-//!   +---------------------------------------------------------+
-//!   | shm_mq queue array: n_workers × n_partitions slots      |
-//!   |   slot(w, p) = queues_offset                            |
-//!   |             + (w * n_partitions + p) * queue_bytes      |
-//!   +---------------------------------------------------------+
+//!   +--- MppDsmHeader (repr C, MAXALIGN-padded) -------------+
+//!   |    magic, version, n_procs, queue_bytes               |
+//!   |    plan_offset, plan_len, queues_offset, region_total |
+//!   +-------------------------------------------------------+
+//!   | plan bytes (bincode-serialized worker fragment)       |
+//!   +-------------------------------------------------------+
+//!   | padding to MAXALIGN                                   |
+//!   +-------------------------------------------------------+
+//!   | shm_mq queue array: n_procs × n_procs slots           |
+//!   |   slot(sender, receiver) = queues_offset              |
+//!   |     + (sender * n_procs + receiver) * queue_bytes     |
+//!   +-------------------------------------------------------+
 //! ```
 //!
-//! - `n_workers` is the number of producer-side participants (== leader-as-
-//!   worker-0 + parallel workers). Leader is index 0.
-//! - `n_partitions` is the consumer-side partition count for the single
-//!   network boundary the DF-D fork's planner emits under
-//!   `in_process_mode=on`. Multi-stage / multi-boundary layouts are tracked
-//!   on the natural-shape follow-up (PR #5060) and would generalise the
-//!   `worker × partition` slot indexing to a richer grid.
+//! - `n_procs` is the total participant count (1 leader + N parallel workers).
+//!   Leader is `proc_idx = 0`; workers are `proc_idx = ParallelWorkerNumber + 1`.
+//! - Every process attaches as **sender** to its row (`slot(this, *)`) and as
+//!   **receiver** to its column (`slot(*, this)`). The grid is uniform and
+//!   independent of plan shape: a single multiplexed queue per process-pair
+//!   carries frames for any number of logical `(stage_id, partition)`
+//!   channels, demultiplexed on the receive side via the `MppFrameHeader`
+//!   prefix.
+//! - Self-loop slots (`slot(k, k)`) are reserved in the layout and
+//!   `shm_mq_create`'d by the leader so the slot-offset math stays a simple
+//!   row-major index, but no process attaches as sender or receiver to its
+//!   own self-loop.
 
 use std::ffi::c_void;
 use std::mem::size_of;
@@ -52,7 +57,10 @@ use crate::postgres::customscan::mpp::mesh::{
 };
 
 pub const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
-pub const MPP_DSM_HEADER_VERSION: u32 = 1;
+/// Bumped on any wire-incompatible change to the DSM header layout or to the slot-offset math,
+/// so attaching workers reject mismatched leaders loudly rather than reading garbage. Validated
+/// in [`MppDsmHeader::validate`].
+pub const MPP_DSM_HEADER_VERSION: u32 = 3;
 
 /// Absolute cap on DSM region size. 16 GiB is two orders of magnitude beyond
 /// any realistic workload; the cap fails early on a pathologically oversized
@@ -61,26 +69,20 @@ pub const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 
 /// C-repr header at offset 0 of the DSM region.
 ///
-/// Field ordering keeps every member naturally aligned: six `u32`s (24 bytes
-/// including the explicit `_pad0`) followed by nine `u64`s (72 bytes). 96
-/// bytes total with no internal padding on every supported target.
+/// Layout: three `u32`s + padding, then six `u64`s.
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct MppDsmHeader {
     pub magic: u32,
     pub header_version: u32,
-    pub n_workers: u32,
-    pub n_partitions: u32,
-    pub n_cache_sources: u32,
-    pub _pad0: u32,
+    /// Total participant count. Leader is `proc_idx = 0`; workers are
+    /// `proc_idx = ParallelWorkerNumber + 1`. The shm_mq grid is `n_procs × n_procs`.
+    pub n_procs: u32,
+    pub _pad: u32,
     pub queue_bytes: u64,
     pub plan_offset: u64,
     pub plan_len: u64,
     pub queues_offset: u64,
-    pub cache_per_slot: u64,
-    pub cache_completion_offset: u64,
-    pub cache_lengths_offset: u64,
-    pub cache_data_offset: u64,
     pub region_total: u64,
 }
 
@@ -89,18 +91,12 @@ impl MppDsmHeader {
         Self {
             magic: MPP_DSM_MAGIC,
             header_version: MPP_DSM_HEADER_VERSION,
-            n_workers: layout.n_workers,
-            n_partitions: layout.n_partitions,
-            n_cache_sources: layout.n_cache_sources,
-            _pad0: 0,
+            n_procs: layout.n_procs,
+            _pad: 0,
             queue_bytes: layout.queue_bytes as u64,
             plan_offset: layout.plan_offset as u64,
             plan_len: layout.plan_len as u64,
             queues_offset: layout.queues_offset as u64,
-            cache_per_slot: layout.cache_per_slot as u64,
-            cache_completion_offset: layout.cache_completion_offset as u64,
-            cache_lengths_offset: layout.cache_lengths_offset as u64,
-            cache_data_offset: layout.cache_data_offset as u64,
             region_total: layout.region_total as u64,
         }
     }
@@ -112,8 +108,8 @@ impl MppDsmHeader {
         if self.header_version != MPP_DSM_HEADER_VERSION {
             return Err("mpp: DSM header version mismatch");
         }
-        if self.n_workers == 0 || self.n_partitions == 0 {
-            return Err("mpp: header n_workers/n_partitions must both be > 0");
+        if self.n_procs == 0 {
+            return Err("mpp: header n_procs must be > 0");
         }
         if self.region_total != region_total {
             return Err("mpp: DSM region_total in header disagrees with attached size");
@@ -131,60 +127,42 @@ impl MppDsmHeader {
         Ok(())
     }
 
-    /// Byte offset (relative to DSM base) of the queue at `(worker, partition)`.
-    pub fn slot_offset(&self, worker: u32, partition: u32) -> u64 {
-        debug_assert!(worker < self.n_workers);
-        debug_assert!(partition < self.n_partitions);
-        let slot = (worker as u64) * (self.n_partitions as u64) + (partition as u64);
+    /// Byte offset (relative to DSM base) of the queue at `(sender_proc, receiver_proc)`.
+    ///
+    /// Every process attaches as sender for its row (`slot(this, *)`) and as
+    /// receiver for its column (`slot(*, this)`). Self-loops (`slot(k, k)`)
+    /// are present in the grid but rarely used at runtime.
+    pub fn slot_offset(&self, sender_proc: u32, receiver_proc: u32) -> u64 {
+        debug_assert!(sender_proc < self.n_procs);
+        debug_assert!(receiver_proc < self.n_procs);
+        let slot = (sender_proc as u64) * (self.n_procs as u64) + (receiver_proc as u64);
         self.queues_offset + slot * self.queue_bytes
-    }
-
-    /// Byte offset of the build-side cache slot at `(source, worker)`.
-    #[cfg(test)]
-    pub fn cache_data_slot_offset(&self, source: u32, worker: u32) -> u64 {
-        debug_assert!(source < self.n_cache_sources);
-        debug_assert!(worker < self.n_workers);
-        let slot = (source as u64) * (self.n_workers as u64) + (worker as u64);
-        self.cache_data_offset + slot * self.cache_per_slot
     }
 }
 
 /// Pure-math layout for [`compute_dsm_layout`].
 #[derive(Debug, Clone, Copy)]
 pub struct DsmLayout {
-    pub n_workers: u32,
-    pub n_partitions: u32,
-    pub n_cache_sources: u32,
+    pub n_procs: u32,
     pub queue_bytes: usize,
-    pub cache_per_slot: usize,
     pub plan_offset: usize,
     pub plan_len: usize,
     pub queues_offset: usize,
-    pub cache_completion_offset: usize,
-    pub cache_lengths_offset: usize,
-    pub cache_data_offset: usize,
     pub region_total: usize,
 }
 
 /// Compute the DSM region size and field offsets for one MPP query.
 ///
-/// `n_cache_sources` is the number of non-partitioning sources to allocate
-/// build-side cache slots for. `cache_per_slot` is the bytes reserved for
-/// each (source, worker) pair (worst-case per-worker IPC payload). Pass 0
-/// for both if no cache is needed.
+/// `n_procs` is the total participant count (1 leader + N workers). The
+/// shm_mq grid is `n_procs × n_procs`; each process attaches as sender to its
+/// row and receiver to its column.
 pub fn compute_dsm_layout(
-    n_workers: u32,
-    n_partitions: u32,
+    n_procs: u32,
     queue_bytes: usize,
     plan_len: usize,
-    n_cache_sources: u32,
-    cache_per_slot: usize,
 ) -> Result<DsmLayout, &'static str> {
-    if n_workers == 0 {
-        return Err("mpp: n_workers must be > 0");
-    }
-    if n_partitions == 0 {
-        return Err("mpp: n_partitions must be > 0");
+    if n_procs < 2 {
+        return Err("mpp: n_procs must be >= 2 (leader + at least one worker)");
     }
     let queue_bytes = aligned_queue_bytes(queue_bytes);
     if queue_bytes == 0 {
@@ -198,217 +176,69 @@ pub fn compute_dsm_layout(
         .ok_or("mpp: plan offset+len overflow")?;
     let queues_offset =
         align_up_maxalign_checked(plan_end).ok_or("mpp: queues alignment overflow")?;
-    let total_slots = (n_workers as usize)
-        .checked_mul(n_partitions as usize)
-        .ok_or("mpp: n_workers × n_partitions overflow")?;
+    let total_slots = (n_procs as usize)
+        .checked_mul(n_procs as usize)
+        .ok_or("mpp: n_procs × n_procs overflow")?;
     let queues_bytes = total_slots
         .checked_mul(queue_bytes)
         .ok_or("mpp: queues bytes overflow")?;
-    let queues_end = queues_offset
+    let region_total = queues_offset
         .checked_add(queues_bytes)
-        .ok_or("mpp: queues end overflow")?;
-
-    // Build-side cache region. Layout:
-    //   completion: n_cache_sources × u32  (atomic counter)
-    //   lengths:    n_cache_sources × n_workers × u32  (actual bytes written)
-    //   data:       n_cache_sources × n_workers × cache_per_slot
-    let cache_completion_offset =
-        align_up_maxalign_checked(queues_end).ok_or("mpp: cache completion alignment overflow")?;
-    let cache_completion_size = (n_cache_sources as usize)
-        .checked_mul(size_of::<u32>())
-        .ok_or("mpp: cache completion size overflow")?;
-    let cache_lengths_offset = align_up_maxalign_checked(
-        cache_completion_offset
-            .checked_add(cache_completion_size)
-            .ok_or("mpp: cache lengths offset overflow")?,
-    )
-    .ok_or("mpp: cache lengths alignment overflow")?;
-    let cache_lengths_size = (n_cache_sources as usize)
-        .checked_mul(n_workers as usize)
-        .and_then(|x| x.checked_mul(size_of::<u32>()))
-        .ok_or("mpp: cache lengths size overflow")?;
-    let cache_data_offset = align_up_maxalign_checked(
-        cache_lengths_offset
-            .checked_add(cache_lengths_size)
-            .ok_or("mpp: cache data offset overflow")?,
-    )
-    .ok_or("mpp: cache data alignment overflow")?;
-    let cache_data_size = (n_cache_sources as usize)
-        .checked_mul(n_workers as usize)
-        .and_then(|x| x.checked_mul(cache_per_slot))
-        .ok_or("mpp: cache data size overflow")?;
-    let region_total = cache_data_offset
-        .checked_add(cache_data_size)
         .ok_or("mpp: region total overflow")?;
     if region_total > MPP_DSM_MAX_BYTES {
         return Err("mpp: DSM region exceeds MPP_DSM_MAX_BYTES");
     }
     Ok(DsmLayout {
-        n_workers,
-        n_partitions,
-        n_cache_sources,
+        n_procs,
         queue_bytes,
-        cache_per_slot,
         plan_offset,
         plan_len,
         queues_offset,
-        cache_completion_offset,
-        cache_lengths_offset,
-        cache_data_offset,
         region_total,
     })
 }
 
-/// Runtime handle to the build-side cache region inside DSM.
+/// Per-participant return: handles for the process's row (senders) and
+/// column (receivers) in the multiplexed `n_procs × n_procs` grid.
 ///
-/// Held on every participant's customscan state. Workers use it to write their
-/// own slice and read back peer slices via the all-gather barrier; the leader
-/// holds it inert (no slot reserved for it; consumer-only this iteration).
-///
-/// `Send + Sync` is asserted because the underlying DSM mapping is shared
-/// memory accessed by multiple processes; access is coordinated via atomic
-/// completion counters and write-once length cells.
-#[derive(Debug)]
-pub struct MppBuildCache {
-    base: *mut u8,
-    pub n_workers: u32,
-    pub n_sources: u32,
-    pub cache_per_slot: usize,
-    pub completion_offset: usize,
-    pub lengths_offset: usize,
-    pub data_offset: usize,
-}
-
-unsafe impl Send for MppBuildCache {}
-unsafe impl Sync for MppBuildCache {}
-
-impl MppBuildCache {
-    /// Construct from a raw DSM base pointer and the resolved `MppDsmHeader`.
-    ///
-    /// # Safety
-    /// `base` must point to a DSM region of size `>= header.region_total` whose
-    /// header has already been validated.
-    pub unsafe fn from_header(base: *mut u8, header: &MppDsmHeader) -> Self {
-        Self {
-            base,
-            n_workers: header.n_workers,
-            n_sources: header.n_cache_sources,
-            cache_per_slot: header.cache_per_slot as usize,
-            completion_offset: header.cache_completion_offset as usize,
-            lengths_offset: header.cache_lengths_offset as usize,
-            data_offset: header.cache_data_offset as usize,
-        }
-    }
-
-    fn slot_data_ptr(&self, source: u32, worker: u32) -> *mut u8 {
-        debug_assert!(source < self.n_sources);
-        debug_assert!(worker < self.n_workers);
-        let slot = (source as usize) * (self.n_workers as usize) + (worker as usize);
-        unsafe { self.base.add(self.data_offset + slot * self.cache_per_slot) }
-    }
-
-    fn length_ptr(&self, source: u32, worker: u32) -> *mut u32 {
-        debug_assert!(source < self.n_sources);
-        debug_assert!(worker < self.n_workers);
-        let slot = (source as usize) * (self.n_workers as usize) + (worker as usize);
-        unsafe {
-            self.base
-                .add(self.lengths_offset + slot * size_of::<u32>())
-                .cast()
-        }
-    }
-
-    fn completion_ptr(&self, source: u32) -> *mut std::sync::atomic::AtomicU32 {
-        debug_assert!(source < self.n_sources);
-        unsafe {
-            self.base
-                .add(self.completion_offset + (source as usize) * size_of::<u32>())
-                .cast()
-        }
-    }
-
-    /// Worker writes its slice for `source` and atomically signals completion.
-    /// Returns an error if `bytes.len()` exceeds the per-slot cap.
-    pub fn write_slice(&self, source: u32, worker: u32, bytes: &[u8]) -> Result<(), String> {
-        if bytes.len() > self.cache_per_slot {
-            return Err(format!(
-                "mpp: build-side slice for source={source} worker={worker} is {} bytes, exceeds cap {}",
-                bytes.len(),
-                self.cache_per_slot
-            ));
-        }
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                bytes.as_ptr(),
-                self.slot_data_ptr(source, worker),
-                bytes.len(),
-            );
-            // Length is observed only after the completion increment (Release).
-            // No atomic needed for the length itself; the fence below makes the
-            // copy + length write visible to readers that observe the completion.
-            std::ptr::write_volatile(self.length_ptr(source, worker), bytes.len() as u32);
-        }
-        let counter = unsafe { &*self.completion_ptr(source) };
-        counter.fetch_add(1, std::sync::atomic::Ordering::Release);
-        Ok(())
-    }
-
-    /// Worker reads peer's slice. Caller must have already passed the barrier.
-    pub fn read_slice(&self, source: u32, worker: u32) -> Vec<u8> {
-        let len = unsafe { std::ptr::read_volatile(self.length_ptr(source, worker)) } as usize;
-        let mut out = Vec::with_capacity(len);
-        unsafe {
-            std::ptr::copy_nonoverlapping(
-                self.slot_data_ptr(source, worker),
-                out.as_mut_ptr(),
-                len,
-            );
-            out.set_len(len);
-        }
-        out
-    }
-
-    /// Spin until all `n_workers` have signalled completion for `source`.
-    /// Yields to PG via `check_for_interrupts!` so `statement_timeout` works.
-    pub fn wait_complete(&self, source: u32) {
-        let counter = unsafe { &*self.completion_ptr(source) };
-        loop {
-            if counter.load(std::sync::atomic::Ordering::Acquire) >= self.n_workers {
-                return;
-            }
-            pgrx::check_for_interrupts!();
-            std::hint::spin_loop();
-        }
-    }
-}
-
-/// Leader-side return: handles to all senders + receivers for participant 0.
-pub struct LeaderAttach {
-    /// Senders this participant uses to push rows to consumer partitions.
-    /// `outbound_senders[p]` writes to `slot(0, p)`.
+/// Self-loop slots (`slot(this_proc, this_proc)`) are skipped to avoid two
+/// `shm_mq_attach` calls + two `on_dsm_detach` callbacks per process for a
+/// queue nothing reads. As a consequence, `outbound_senders` and
+/// `inbound_receivers` each have `n_procs - 1` entries; the index gymnastics
+/// to translate `proc_idx` ↔ slice index are handled by
+/// [`MppMesh::inbound_drain`] in the runtime.
+pub struct ProcAttach {
+    /// `outbound_senders[i]` writes to `slot(this_proc, peer_proc(i))` where
+    /// `peer_proc(i) = i if i < this_proc else i + 1` (skipping the self-loop).
     pub outbound_senders: Vec<ShmMqSender>,
-    /// Receivers this participant reads from (one per producer worker for
-    /// each consumer partition the leader owns). The leader IS the consumer,
-    /// so it owns ALL `n_partitions` columns of the queue grid; for each
-    /// consumer partition `p` it has `n_workers` inbound queues from the
-    /// producers.
+    /// `inbound_receivers[i]` reads from `slot(peer_proc(i), this_proc)`,
+    /// same skip-self-loop mapping as `outbound_senders`.
     pub inbound_receivers: Vec<ShmMqReceiver>,
 }
 
-/// Worker-side return: just the senders. Workers don't consume; everything
-/// flows toward the leader.
-pub struct WorkerAttach {
-    /// `outbound_senders[p]` writes to `slot(this_worker, p)`.
-    pub outbound_senders: Vec<ShmMqSender>,
+/// Translate a peer index (`0..n_procs - 1`) into a process index
+/// (`0..n_procs`) by skipping the self-loop slot.
+#[inline]
+pub fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
+    if peer_idx < this_proc {
+        peer_idx
+    } else {
+        peer_idx + 1
+    }
 }
 
-/// Initialize the DSM region as the leader. Writes the header, copies plan
-/// bytes, calls `shm_mq_create` on every queue slot, and attaches the leader's
-/// senders + all inbound receivers.
+/// Initialize the DSM region as the leader (`proc_idx = 0`). Writes the header, copies the plan
+/// bytes, calls `shm_mq_create` on every queue slot, and attaches the leader's row + column
+/// handles.
+///
+/// In the multiplexed `n_procs × n_procs` grid, every process (leader included) is a full
+/// participant: sender for its row, receiver for its column. The leader is responsible for the
+/// one-time `shm_mq_create` on every queue (workers can't, since the region is uninitialized at
+/// their attach time), then does its own `set_sender` / `set_receiver` calls on its row and column
+/// slots.
 ///
 /// # Safety
-/// - `coordinate` must point to the start of a DSM region of size
-///   `>= layout.region_total`.
+/// - `coordinate` must point to the start of a DSM region of size `>= layout.region_total`.
 /// - `seg` must be the leader's `dsm_segment*`.
 /// - The region must be uninitialized (the leader is the first writer).
 pub unsafe fn leader_init(
@@ -416,7 +246,7 @@ pub unsafe fn leader_init(
     seg: *mut pg_sys::dsm_segment,
     layout: &DsmLayout,
     plan_bytes: &[u8],
-) -> Result<LeaderAttach, String> {
+) -> Result<ProcAttach, String> {
     if coordinate.is_null() {
         return Err("mpp: leader_init given null coordinate".into());
     }
@@ -446,44 +276,84 @@ pub unsafe fn leader_init(
         );
     }
 
-    // Create every shm_mq slot. Each slot is `queue_bytes` aligned bytes; we
-    // pass the address to `shm_mq_create` which initializes the ring buffer.
-    // The leader is a consumer-only participant (leader-as-worker-0 is
-    // deferred), so it attaches as receiver to every slot but as sender to
-    // none — workers attach to their own row in `worker_attach`.
-    let mut inbound_receivers =
-        Vec::with_capacity((layout.n_workers as usize) * (layout.n_partitions as usize));
-    for w in 0..layout.n_workers {
-        for p in 0..layout.n_partitions {
-            let off = (w as usize) * (layout.n_partitions as usize) + (p as usize);
-            let mq_addr = unsafe { base.add(layout.queues_offset + off * layout.queue_bytes) };
-            let mq = unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.queue_bytes) };
-            inbound_receivers.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
+    // One-time create of every shm_mq slot. Workers can't do this (the region is uninitialized at
+    // their attach time), so the leader runs `shm_mq_create` for all `n_procs²` slots even though
+    // it only attaches to its own row and column below.
+    let header = MppDsmHeader::from_layout(layout);
+    let n_procs = layout.n_procs;
+    for s in 0..n_procs {
+        for r in 0..n_procs {
+            let off = header.slot_offset(s, r) as usize;
+            let mq_addr = unsafe { base.add(off) };
+            unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.queue_bytes) };
         }
     }
 
-    Ok(LeaderAttach {
-        outbound_senders: Vec::new(),
-        inbound_receivers,
-    })
+    Ok(unsafe { attach_proc_row_and_column(base, &header, 0, seg) })
 }
 
-/// Attach to the leader-initialized DSM region as worker `worker_index` (1-based:
-/// PG's `ParallelWorkerNumber + 1`, since participant 0 is the leader).
+/// Attach to the leader-initialized DSM region as `proc_idx` (`0 = leader`,
+/// `1..N = parallel workers`).
+///
+/// Workers use this from `initialize_worker_custom_scan` via `worker_attach`; the leader uses it
+/// inline at the end of `leader_init`. Each process attaches as sender to its row and receiver to
+/// its column of the `n_procs × n_procs` grid, including the self-loop at `(this, this)`.
+///
+/// # Safety
+/// - `base` must point to a DSM region whose header has been validated.
+/// - `header.slot_offset(s, r)` must already point at a slot initialized by `shm_mq_create` (the
+///   leader does this in `leader_init`).
+/// - `seg` may be NULL on workers. `shm_mq_attach` skips its on-detach callback in that case.
+unsafe fn attach_proc_row_and_column(
+    base: *mut u8,
+    header: &MppDsmHeader,
+    this_proc: u32,
+    seg: *mut pg_sys::dsm_segment,
+) -> ProcAttach {
+    let n_procs = header.n_procs;
+    let peer_count = (n_procs - 1) as usize; // n_procs >= 2 is layout invariant
+    let mut outbound_senders = Vec::with_capacity(peer_count);
+    let mut inbound_receivers = Vec::with_capacity(peer_count);
+
+    // Senders: this process's row, skipping the self-loop slot(this, this).
+    for peer_idx in 0..(n_procs - 1) {
+        let r = peer_proc_for_index(this_proc, peer_idx);
+        let off = header.slot_offset(this_proc, r) as usize;
+        let mq_addr = unsafe { base.add(off) };
+        let mq = mq_addr.cast::<pg_sys::shm_mq>();
+        outbound_senders.push(unsafe { ShmMqSender::attach(seg, mq) });
+    }
+
+    // Receivers: this process's column, skipping the self-loop slot(this, this).
+    for peer_idx in 0..(n_procs - 1) {
+        let s = peer_proc_for_index(this_proc, peer_idx);
+        let off = header.slot_offset(s, this_proc) as usize;
+        let mq_addr = unsafe { base.add(off) };
+        let mq = mq_addr.cast::<pg_sys::shm_mq>();
+        inbound_receivers.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
+    }
+
+    ProcAttach {
+        outbound_senders,
+        inbound_receivers,
+    }
+}
+
+/// Attach to the leader-initialized DSM region as `proc_idx` (1-based for
+/// workers: PG's `ParallelWorkerNumber + 1`).
 ///
 /// # Safety
 /// - `coordinate` must be the DSM region pointer the leader initialized.
 /// - `region_total` must match the DSM's attached size.
-/// - `seg` may be NULL — `initialize_worker_custom_scan` does not surface
-///   the segment pointer and `shm_mq_attach` handles NULL by skipping its
-///   on-detach callback (cleanup falls back to process exit, safe for
-///   parallel-worker lifetimes).
+/// - `seg` may be NULL. `initialize_worker_custom_scan` doesn't surface the segment pointer, and
+///   `shm_mq_attach` handles NULL by skipping its on-detach callback (cleanup falls back to
+///   process exit, safe for parallel-worker lifetimes).
 pub unsafe fn worker_attach(
     coordinate: *mut c_void,
     region_total: u64,
-    worker_index: u32,
+    proc_idx: u32,
     seg: *mut pg_sys::dsm_segment,
-) -> Result<(MppDsmHeader, Vec<u8>, WorkerAttach), String> {
+) -> Result<(MppDsmHeader, Vec<u8>, ProcAttach), String> {
     if coordinate.is_null() {
         return Err("mpp: worker_attach given null coordinate".into());
     }
@@ -492,10 +362,15 @@ pub unsafe fn worker_attach(
     header
         .validate(region_total)
         .map_err(|e| format!("mpp: worker DSM validate: {e}"))?;
-    if worker_index >= header.n_workers {
+    if proc_idx == 0 {
+        return Err(
+            "mpp: worker_attach must be called with proc_idx >= 1 (proc 0 is leader)".into(),
+        );
+    }
+    if proc_idx >= header.n_procs {
         return Err(format!(
-            "mpp: worker_index {worker_index} not in 0..{}",
-            header.n_workers
+            "mpp: proc_idx {proc_idx} not in 1..{}",
+            header.n_procs
         ));
     }
 
@@ -508,19 +383,8 @@ pub unsafe fn worker_attach(
         .to_vec()
     };
 
-    // Attach as sender to every (worker_index, p) slot. `ShmMqSender::attach`
-    // already calls `shm_mq_set_sender(mq, MyProc)` internally — calling it
-    // a second time here trips PG's `Assert("mq->mq_sender == NULL")` and
-    // aborts the worker.
-    let mut outbound_senders = Vec::with_capacity(header.n_partitions as usize);
-    for p in 0..header.n_partitions {
-        let off = header.slot_offset(worker_index, p) as usize;
-        let mq_addr = unsafe { base.add(off) };
-        let mq = mq_addr.cast::<pg_sys::shm_mq>();
-        outbound_senders.push(unsafe { ShmMqSender::attach(seg, mq) });
-    }
-
-    Ok((header, plan_bytes, WorkerAttach { outbound_senders }))
+    let attach = unsafe { attach_proc_row_and_column(base, &header, proc_idx, seg) };
+    Ok((header, plan_bytes, attach))
 }
 
 #[cfg(test)]
@@ -529,73 +393,58 @@ mod tests {
 
     #[test]
     fn compute_dsm_layout_works() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 0, 0).unwrap();
-        assert_eq!(l.n_workers, 4);
-        assert_eq!(l.n_partitions, 1);
-        // No cache reserved → cache regions all sit at queues_end (after MAXALIGN).
+        let l = compute_dsm_layout(4, 64 * 1024, 1024).unwrap();
+        assert_eq!(l.n_procs, 4);
+        // Grid is n_procs × n_procs = 16 slots.
         let aligned = aligned_queue_bytes(64 * 1024);
-        let queues_size = 4 * aligned;
+        let queues_size = 16 * aligned;
         assert!(l.region_total >= l.queues_offset + queues_size);
     }
 
     #[test]
-    fn compute_dsm_layout_with_cache() {
-        let l = compute_dsm_layout(4, 1, 64 * 1024, 1024, 2, 1024 * 1024).unwrap();
-        let cache_data_size = 2 * 4 * 1024 * 1024; // 2 sources × 4 workers × 1 MiB
-        assert_eq!(l.region_total, l.cache_data_offset + cache_data_size);
-    }
-
-    #[test]
-    fn compute_dsm_layout_rejects_zero_workers() {
-        assert!(compute_dsm_layout(0, 1, 64 * 1024, 0, 0, 0).is_err());
-    }
-
-    #[test]
-    fn compute_dsm_layout_rejects_zero_partitions() {
-        assert!(compute_dsm_layout(2, 0, 64 * 1024, 0, 0, 0).is_err());
+    fn compute_dsm_layout_rejects_zero_procs() {
+        assert!(compute_dsm_layout(0, 64 * 1024, 0).is_err());
     }
 
     #[test]
     fn compute_dsm_layout_rejects_oversize() {
-        assert!(compute_dsm_layout(u32::MAX, u32::MAX, 64 * 1024, 0, 0, 0).is_err());
+        assert!(compute_dsm_layout(u32::MAX, 64 * 1024, 0).is_err());
     }
 
     #[test]
-    fn header_slot_offset_is_row_major() {
-        let l = compute_dsm_layout(3, 4, 64 * 1024, 0, 0, 0).unwrap();
+    fn header_slot_offset_is_row_major_over_n_procs() {
+        // 4 procs → 4×4 = 16 slots, row-major over (sender, receiver).
+        let l = compute_dsm_layout(4, 64 * 1024, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         let aligned = h.queue_bytes;
         assert_eq!(h.slot_offset(0, 0), h.queues_offset);
         assert_eq!(h.slot_offset(0, 1), h.queues_offset + aligned);
         assert_eq!(h.slot_offset(1, 0), h.queues_offset + 4 * aligned);
-        assert_eq!(h.slot_offset(2, 3), h.queues_offset + 11 * aligned);
-    }
-
-    #[test]
-    fn header_cache_offsets() {
-        let l = compute_dsm_layout(3, 1, 64 * 1024, 0, 2, 1024).unwrap();
-        let h = MppDsmHeader::from_layout(&l);
-        // (source=0, worker=0) is the first slot.
-        assert_eq!(h.cache_data_slot_offset(0, 0), h.cache_data_offset);
-        // (source=0, worker=1) is one slot later.
-        assert_eq!(h.cache_data_slot_offset(0, 1), h.cache_data_offset + 1024);
-        // (source=1, worker=0) is n_workers slots in.
-        assert_eq!(
-            h.cache_data_slot_offset(1, 0),
-            h.cache_data_offset + 3 * 1024
-        );
+        // Self-loop on proc 3: (3,3) → row 3, col 3 → slot 15.
+        assert_eq!(h.slot_offset(3, 3), h.queues_offset + 15 * aligned);
     }
 
     #[test]
     fn header_validate_accepts_self() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 64 * 1024, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64).is_ok());
     }
 
     #[test]
+    fn header_validate_rejects_wrong_version() {
+        let l = compute_dsm_layout(2, 64 * 1024, 0).unwrap();
+        let mut h = MppDsmHeader::from_layout(&l);
+        h.header_version = MPP_DSM_HEADER_VERSION.wrapping_sub(1);
+        let err = h
+            .validate(l.region_total as u64)
+            .expect_err("wrong version must fail");
+        assert!(err.contains("DSM header version mismatch"), "got: {err}");
+    }
+
+    #[test]
     fn header_validate_rejects_size_mismatch() {
-        let l = compute_dsm_layout(2, 2, 64 * 1024, 0, 0, 0).unwrap();
+        let l = compute_dsm_layout(2, 64 * 1024, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         assert!(h.validate(l.region_total as u64 + 1).is_err());
     }

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -73,16 +73,16 @@ const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 #[repr(C)]
 #[derive(Debug, Clone, Copy)]
 pub struct MppDsmHeader {
-    pub magic: u32,
-    pub header_version: u32,
+    pub(super) magic: u32,
+    pub(super) header_version: u32,
     /// Total participant count. Leader is `proc_idx = 0`; workers are
     /// `proc_idx = ParallelWorkerNumber + 1`. The shm_mq grid is `n_procs × n_procs`.
     pub n_procs: u32,
-    pub _pad: u32,
-    pub queue_bytes: u64,
-    pub plan_offset: u64,
-    pub plan_len: u64,
-    pub queues_offset: u64,
+    pub(super) _pad: u32,
+    pub(super) queue_bytes: u64,
+    pub(super) plan_offset: u64,
+    pub(super) plan_len: u64,
+    pub(super) queues_offset: u64,
     pub region_total: u64,
 }
 
@@ -101,7 +101,7 @@ impl MppDsmHeader {
         }
     }
 
-    pub fn validate(&self, region_total: u64) -> Result<(), &'static str> {
+    pub(super) fn validate(&self, region_total: u64) -> Result<(), &'static str> {
         if self.magic != MPP_DSM_MAGIC {
             return Err("mpp: DSM header magic mismatch");
         }
@@ -132,7 +132,7 @@ impl MppDsmHeader {
     /// Every process attaches as sender for its row (`slot(this, *)`) and as
     /// receiver for its column (`slot(*, this)`). Self-loops (`slot(k, k)`)
     /// are present in the grid but rarely used at runtime.
-    pub fn slot_offset(&self, sender_proc: u32, receiver_proc: u32) -> u64 {
+    pub(super) fn slot_offset(&self, sender_proc: u32, receiver_proc: u32) -> u64 {
         debug_assert!(sender_proc < self.n_procs);
         debug_assert!(receiver_proc < self.n_procs);
         let slot = (sender_proc as u64) * (self.n_procs as u64) + (receiver_proc as u64);
@@ -142,7 +142,7 @@ impl MppDsmHeader {
 
 /// Pure-math layout for [`compute_dsm_layout`].
 #[derive(Debug, Clone, Copy)]
-pub struct DsmLayout {
+pub(super) struct DsmLayout {
     pub n_procs: u32,
     pub queue_bytes: usize,
     pub plan_offset: usize,
@@ -207,7 +207,7 @@ pub(super) fn compute_dsm_layout(
 /// `inbound_receivers` each have `n_procs - 1` entries; the index gymnastics
 /// to translate `proc_idx` ↔ slice index are handled by
 /// [`MppMesh::inbound_drain`] in the runtime.
-pub struct ProcAttach {
+pub(super) struct ProcAttach {
     /// `outbound_senders[i]` writes to `slot(this_proc, peer_proc(i))` where
     /// `peer_proc(i) = i if i < this_proc else i + 1` (skipping the self-loop).
     pub(super) outbound_senders: Vec<ShmMqSender>,
@@ -241,7 +241,7 @@ pub(super) fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
 /// - `coordinate` must point to the start of a DSM region of size `>= layout.region_total`.
 /// - `seg` must be the leader's `dsm_segment*`.
 /// - The region must be uninitialized (the leader is the first writer).
-pub unsafe fn leader_init(
+pub(super) unsafe fn leader_init(
     coordinate: *mut c_void,
     seg: *mut pg_sys::dsm_segment,
     layout: &DsmLayout,
@@ -348,7 +348,7 @@ unsafe fn attach_proc_row_and_column(
 /// - `seg` may be NULL. `initialize_worker_custom_scan` doesn't surface the segment pointer, and
 ///   `shm_mq_attach` handles NULL by skipping its on-detach callback (cleanup falls back to
 ///   process exit, safe for parallel-worker lifetimes).
-pub unsafe fn worker_attach(
+pub(super) unsafe fn worker_attach(
     coordinate: *mut c_void,
     region_total: u64,
     proc_idx: u32,

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -34,7 +34,7 @@
 //!   +-------------------------------------------------------+
 //! ```
 //!
-//! - `n_procs` is the total participant count (1 leader + N parallel workers).
+//! - `n_procs` is the total proc count (1 leader + N parallel workers).
 //!   Leader is `proc_idx = 0`; workers are `proc_idx = ParallelWorkerNumber + 1`.
 //! - Every process attaches as **sender** to its row (`slot(this, *)`) and as
 //!   **receiver** to its column (`slot(*, this)`). The grid is uniform and
@@ -75,7 +75,7 @@ const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 pub struct MppDsmHeader {
     pub(super) magic: u32,
     pub(super) header_version: u32,
-    /// Total participant count. Leader is `proc_idx = 0`; workers are
+    /// Total proc count. Leader is `proc_idx = 0`; workers are
     /// `proc_idx = ParallelWorkerNumber + 1`. The shm_mq grid is `n_procs × n_procs`.
     pub n_procs: u32,
     pub(super) _pad: u32,
@@ -153,7 +153,7 @@ pub(super) struct DsmLayout {
 
 /// Compute the DSM region size and field offsets for one MPP query.
 ///
-/// `n_procs` is the total participant count (1 leader + N workers). The
+/// `n_procs` is the total proc count (1 leader + N workers). The
 /// shm_mq grid is `n_procs × n_procs`; each process attaches as sender to its
 /// row and receiver to its column.
 pub(super) fn compute_dsm_layout(
@@ -198,7 +198,7 @@ pub(super) fn compute_dsm_layout(
     })
 }
 
-/// Per-participant return: handles for the process's row (senders) and
+/// Per-proc return: handles for the process's row (senders) and
 /// column (receivers) in the multiplexed `n_procs × n_procs` grid.
 ///
 /// Self-loop slots (`slot(this_proc, this_proc)`) are skipped to avoid two
@@ -206,7 +206,7 @@ pub(super) fn compute_dsm_layout(
 /// queue nothing reads. As a consequence, `outbound_senders` and
 /// `inbound_receivers` each have `n_procs - 1` entries; the index gymnastics
 /// to translate `proc_idx` ↔ slice index are handled by
-/// [`MppMesh::inbound_drain`] in the runtime.
+/// [`MppMesh::inbound_receiver`] in the runtime.
 pub(super) struct ProcAttach {
     /// `outbound_senders[i]` writes to `slot(this_proc, peer_proc(i))` where
     /// `peer_proc(i) = i if i < this_proc else i + 1` (skipping the self-loop).
@@ -232,7 +232,7 @@ pub(super) fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
 /// handles.
 ///
 /// In the multiplexed `n_procs × n_procs` grid, every process (leader included) is a full
-/// participant: sender for its row, receiver for its column. The leader is responsible for the
+/// proc: sender for its row, receiver for its column. The leader is responsible for the
 /// one-time `shm_mq_create` on every queue (workers can't, since the region is uninitialized at
 /// their attach time), then does its own `set_sender` / `set_receiver` calls on its row and column
 /// slots.

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -56,16 +56,16 @@ use crate::postgres::customscan::mpp::mesh::{
     align_up_maxalign_checked, aligned_queue_bytes, ShmMqReceiver, ShmMqSender,
 };
 
-pub const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
+const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
 /// Bumped on any wire-incompatible change to the DSM header layout or to the slot-offset math,
 /// so attaching workers reject mismatched leaders loudly rather than reading garbage. Validated
 /// in [`MppDsmHeader::validate`].
-pub const MPP_DSM_HEADER_VERSION: u32 = 3;
+const MPP_DSM_HEADER_VERSION: u32 = 3;
 
 /// Absolute cap on DSM region size. 16 GiB is two orders of magnitude beyond
 /// any realistic workload; the cap fails early on a pathologically oversized
 /// request rather than asking PG for ~`usize::MAX` bytes.
-pub const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
+const MPP_DSM_MAX_BYTES: usize = 16 * 1024 * 1024 * 1024;
 
 /// C-repr header at offset 0 of the DSM region.
 ///
@@ -156,7 +156,7 @@ pub struct DsmLayout {
 /// `n_procs` is the total participant count (1 leader + N workers). The
 /// shm_mq grid is `n_procs × n_procs`; each process attaches as sender to its
 /// row and receiver to its column.
-pub fn compute_dsm_layout(
+pub(super) fn compute_dsm_layout(
     n_procs: u32,
     queue_bytes: usize,
     plan_len: usize,
@@ -210,16 +210,16 @@ pub fn compute_dsm_layout(
 pub struct ProcAttach {
     /// `outbound_senders[i]` writes to `slot(this_proc, peer_proc(i))` where
     /// `peer_proc(i) = i if i < this_proc else i + 1` (skipping the self-loop).
-    pub outbound_senders: Vec<ShmMqSender>,
+    pub(super) outbound_senders: Vec<ShmMqSender>,
     /// `inbound_receivers[i]` reads from `slot(peer_proc(i), this_proc)`,
     /// same skip-self-loop mapping as `outbound_senders`.
-    pub inbound_receivers: Vec<ShmMqReceiver>,
+    pub(super) inbound_receivers: Vec<ShmMqReceiver>,
 }
 
 /// Translate a peer index (`0..n_procs - 1`) into a process index
 /// (`0..n_procs`) by skipping the self-loop slot.
 #[inline]
-pub fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
+pub(super) fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
     if peer_idx < this_proc {
         peer_idx
     } else {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -37,32 +37,37 @@ use std::sync::Arc;
 use pgrx::pg_sys;
 
 use crate::gucs::{
-    enable_mpp, mpp_cache_per_slot, mpp_queue_size as gucs_mpp_queue_size,
-    mpp_worker_count as gucs_mpp_worker_count,
+    enable_mpp, mpp_queue_size as gucs_mpp_queue_size, mpp_worker_count as gucs_mpp_worker_count,
 };
 use crate::postgres::customscan::mpp::dsm::{
-    compute_dsm_layout, leader_init, worker_attach, MppBuildCache,
+    compute_dsm_layout, leader_init, peer_proc_for_index, worker_attach,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
-    DrainBuffer, DrainHandle, MppReceiver, MppSender,
+    in_proc_channel, BatchChannelSender, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
+    SELF_LOOP_CAPACITY,
 };
 use crate::postgres::customscan::mpp::MppParticipantConfig;
 
-/// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >= 3`.
-/// Customscan path-builders gate `parallel_workers` on this.
+/// Default stage id stamped on outbound sender headers before the per-fragment dispatcher
+/// rewrites them. Worker senders get `clone_with_header` immediately after `worker_setup`, so
+/// this placeholder is never observed on the wire.
+const NATURAL_GATHER_STAGE_ID: u32 = 0;
+
+/// Consumer-side partition stamped on natural-shape gather frames. The natural plan emits
+/// `NetworkCoalesceExec(consumer_tc=1, input_tc=N)` at the top, so there is exactly one consumer
+/// partition on the leader.
+const NATURAL_GATHER_PARTITION: u32 = 0;
+
+/// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >= 3`. Customscan
+/// path-builders gate `parallel_workers` on this.
 ///
-/// We require `>= 3` (not `>= 2`) because the leader is consumer-only in
-/// this iteration: with `mpp_worker_count = 2`, [`producer_worker_count`]
-/// returns 1, so [`crate::postgres::customscan::aggregatescan`] would size
-/// the DSM mesh as `1 × mpp_n_partitions = 1` while
-/// `with_target_partitions(2)` (clamped at 2 by `n_workers.max(2)`) makes
-/// the planner build a 2-partition shuffle. The mesh would not have a
-/// queue for the second partition. Gating at `>= 3` ensures
-/// `producer_worker_count >= 2`, so the mesh shape and the planner's
-/// shuffle width match. (Lifting this to `>= 2` is safe once
-/// leader-as-worker-0 is wired up, or once `target_partitions` is dropped
-/// to `producer_worker_count`.)
+/// `>= 3` (not `>= 2`) because the leader is consumer-only: with `mpp_worker_count = 2`,
+/// [`producer_worker_count`] returns 1, so [`crate::postgres::customscan::aggregatescan`] sizes
+/// the DSM mesh as `1 × mpp_n_partitions = 1` while `with_target_partitions(2)` (clamped by
+/// `n_workers.max(2)`) makes the planner build a 2-partition shuffle. The mesh wouldn't have a
+/// queue for the second partition. Gating at `>= 3` keeps `producer_worker_count >= 2` so mesh
+/// shape and shuffle width line up.
 pub fn mpp_is_active() -> bool {
     enable_mpp() && gucs_mpp_worker_count() >= 3
 }
@@ -78,44 +83,33 @@ pub fn mpp_queue_size() -> usize {
     gucs_mpp_queue_size()
 }
 
-/// Body of `estimate_dsm_custom_scan`. Returns total DSM bytes the leader
-/// will need for plan + N×K queue mesh + build-side cache. `N` is the *worker*
-/// count (`mpp_worker_count - 1`); the leader is a consumer-only participant
-/// in this iteration, so its slot is omitted from the mesh.
-///
-/// `n_cache_sources` is the number of non-partitioning sources the build-side
-/// all-gather cache should reserve slots for; pass 0 to skip caching.
-pub fn estimate_dsm_size(
-    plan_bytes_len: usize,
-    n_partitions: u32,
-    n_cache_sources: u32,
-) -> Result<usize, String> {
-    let layout = compute_dsm_layout(
-        producer_worker_count(),
-        n_partitions,
-        mpp_queue_size(),
-        plan_bytes_len,
-        n_cache_sources,
-        mpp_cache_per_slot(),
-    )
-    .map_err(|e| format!("mpp: estimate_dsm_size: {e}"))?;
+/// Body of `estimate_dsm_custom_scan`. Returns total DSM bytes the leader will need for the
+/// plan, the multiplexed `n_procs × n_procs` queue mesh, and the worker plan. `n_procs` is the
+/// total participant count (leader + `producer_worker_count()` parallel workers).
+pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
+    let layout = compute_dsm_layout(n_procs(), mpp_queue_size(), plan_bytes_len)
+        .map_err(|e| format!("mpp: estimate_dsm_size: {e}"))?;
     Ok(layout.region_total)
 }
 
-/// Number of producer workers in the mesh: `mpp_worker_count - 1`. The leader
-/// is a consumer-only participant for now (leader-as-worker-0 deferred); its
-/// slot is omitted, so PG launches exactly this many parallel workers.
+/// Number of producer workers PG should launch as `parallel_workers`.
+/// `mpp_worker_count - 1` because participant 0 is the leader.
 pub fn producer_worker_count() -> u32 {
     mpp_worker_count().saturating_sub(1).max(1)
 }
 
-/// Returned to the leader from [`leader_setup`]. The customscan stashes this
-/// on its execution state and consults it during `exec_custom_scan`.
+/// Total participant count: 1 leader + N producer workers. This is the
+/// dimension of the multiplexed `n_procs × n_procs` shm_mq grid.
+pub fn n_procs() -> u32 {
+    mpp_worker_count()
+}
+
+/// Returned to the leader from [`leader_setup`]. The customscan stashes this on its execution
+/// state and consults it during `exec_custom_scan`.
 ///
-/// The leader is consumer-only in this iteration, so its outbound senders
-/// (worker-0 producer slot) and `MppParticipantConfig` are not held here —
-/// they are dropped inside `leader_setup` and will be re-introduced when
-/// leader-as-worker-0 is wired up.
+/// The leader is consumer-only: it gathers fragments from worker procs but doesn't host a
+/// producer fragment itself. Its outbound senders are dropped inside `leader_setup`, and it
+/// carries no `MppParticipantConfig`.
 pub struct MppLeaderState {
     /// Runtime mesh handle. Install on the leader's `SessionContext` via
     /// `with_extension(Arc::clone(&mesh))` so `ShmMqWorkerTransport` can find
@@ -146,66 +140,69 @@ pub unsafe fn leader_setup(
     pcxt: *mut pg_sys::ParallelContext,
     n_partitions: u32,
     plan_bytes: Vec<u8>,
-    n_cache_sources: u32,
 ) -> Result<MppLeaderState, String> {
-    let n_workers = producer_worker_count();
-    let layout = compute_dsm_layout(
-        n_workers,
-        n_partitions,
-        mpp_queue_size(),
-        plan_bytes.len(),
-        n_cache_sources,
-        mpp_cache_per_slot(),
-    )
-    .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
+    let total_procs = n_procs();
+    let layout = compute_dsm_layout(total_procs, mpp_queue_size(), plan_bytes.len())
+        .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
 
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
 
-    // Build per-(worker, partition) cooperative drain handles. Each handle
-    // owns one MppReceiver + one DrainBuffer; the consumer side calls
-    // `try_drain_pass` inline on the backend thread (pgrx-safe) when
-    // pulling batches.
-    let mut drains = Vec::with_capacity(attach.inbound_receivers.len());
-    for shm_recv in attach.inbound_receivers {
+    // Build the proc-pair indexed mesh. The leader is `proc_idx = 0`; its inbound queues are
+    // `slot(*, 0)` for every peer (workers 1..n_procs). `attach.inbound_receivers` is
+    // peer-indexed with the self-loop skipped, so receiver[i] corresponds to
+    // peer_proc_for_index(0, i) = i + 1.
+    //
+    // The mesh stores `inbound_drains[sender_proc]` so `runtime.rs` can look up the right drain
+    // in O(1) given a sender_proc. The self-loop entry at index 0 is `None`.
+    //
+    // Each `DrainHandle` owns a per-`(stage_id, partition)` sub-buffer registry, so one shm_mq
+    // queue can carry frames from many logical channels. Sub-buffers are created lazily on first
+    // frame, or up-front by `WorkerConnection::stream_partition`.
+    let _ = n_partitions;
+    let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
+        Vec::with_capacity(total_procs as usize);
+    inbound_drains.push(None); // self-loop slot at sender_proc = 0
+    for (peer_idx, shm_recv) in attach.inbound_receivers.into_iter().enumerate() {
+        let sender_proc = peer_proc_for_index(0, peer_idx as u32);
+        debug_assert_eq!(
+            sender_proc as usize,
+            inbound_drains.len(),
+            "peer_proc_for_index must produce sender_proc indices in order"
+        );
         let mpp_recv = MppReceiver::new(Box::new(shm_recv));
-        let buffer = DrainBuffer::new(1);
-        drains.push(Arc::new(DrainHandle::cooperative(vec![mpp_recv], buffer)));
+        inbound_drains.push(Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv]))));
     }
 
-    let mesh = Arc::new(MppMesh {
-        n_workers,
-        n_partitions,
-        drains,
-    });
+    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_drains));
 
-    // Drop the leader's own producer slot senders — the leader doesn't
-    // produce in this iteration, so its slot would never receive data.
-    // Dropping them now means peer receivers observe Detached at first
-    // poll and short-circuit cleanly. (When leader-as-worker-0 lands,
-    // we'll route these into a Tokio-spawned producer subplan instead.)
+    // Drop the leader's own outbound senders. The leader is consumer-only and never hosts a
+    // producer fragment.
     drop(attach.outbound_senders);
-
-    // The leader doesn't read or write the build-side cache — workers attach
-    // to it via DSM offset, and Postgres owns the DSM segment's lifetime.
-    // `n_cache_sources` is sized into the layout for the worker side.
-    let _ = n_cache_sources;
 
     Ok(MppLeaderState { mesh, pcxt })
 }
 
-/// Returned to a worker from [`worker_setup`]. The customscan reads the plan
-/// bytes, runs the plan, and pushes resulting batches through `outbound_senders`.
+/// Returned to a worker from [`worker_setup`]. The customscan reads the plan bytes, runs the
+/// plan, and pushes resulting batches through `outbound_senders`.
 pub struct MppWorkerState {
-    /// Per-partition outbound senders this worker writes to.
-    /// `outbound_senders[p]` writes to `slot(this_worker, p)`.
-    pub outbound_senders: Vec<MppSender>,
-    /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via
-    /// the `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
+    /// `outbound_senders[proc_idx]` is the sender that writes to `slot(this_proc, proc_idx)`.
+    /// The entry at `proc_idx == this_proc` is `None` because the self-loop slot is never
+    /// attached (matches the leader's `inbound_drains` shape).
+    ///
+    /// Each fragment's per-partition output sender is keyed by
+    /// `outbound_senders[proc_for_task(n_workers, consumer_task)]`. Each `MppSender` wraps an
+    /// `Arc<dyn BatchChannelSender>` so callers can `clone_with_header` to multiplex
+    /// `(stage_id, partition)` channels onto one shm_mq queue.
+    pub outbound_senders: Vec<Option<MppSender>>,
+    /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via the
+    /// `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
     pub plan_bytes: Vec<u8>,
     pub participant_config: MppParticipantConfig,
-    /// Build-side all-gather cache. The worker writes its 1/N slice for each
-    /// non-partitioning source, then reads back peer slices after the barrier.
-    pub build_cache: Option<Arc<MppBuildCache>>,
+    /// Worker's MppMesh, same shape as the leader's. `inbound_drains[sender_proc]` pulls frames
+    /// from `slot(sender_proc, this_proc)`. Workers consume from peers when running consumer
+    /// fragments (e.g. a `FinalPartitioned` aggregate above a `NetworkShuffleExec` peer-mesh).
+    /// Read by the multi-fragment dispatcher in `aggregatescan::exec_mpp_worker`.
+    pub mesh: Arc<MppMesh>,
 }
 
 /// Body of `initialize_worker_custom_scan`. Reads the header, attaches as
@@ -225,34 +222,81 @@ pub unsafe fn worker_setup(
     if worker_number < 0 {
         return Err("mpp: worker_number < 0".into());
     }
-    // Leader is consumer-only, so all parallel workers map directly to mesh
-    // slots: ParallelWorkerNumber 0..N-1 maps to slot 0..N-1.
-    let worker_index = worker_number as u32;
+    // Leader is `proc_idx = 0`, workers are `1..n_procs`. Worker N maps from PG's
+    // `ParallelWorkerNumber = N` to `proc_idx = N + 1`.
+    let proc_idx = (worker_number as u32) + 1;
 
     let (header, plan_bytes, attach) =
-        unsafe { worker_attach(coordinate, region_total, worker_index, seg) }?;
+        unsafe { worker_attach(coordinate, region_total, proc_idx, seg) }?;
+    let total_procs = header.n_procs;
 
-    let outbound_senders = attach
-        .outbound_senders
-        .into_iter()
-        .map(|s| MppSender::new(Box::new(s)))
-        .collect();
+    // Build per-proc-indexed outbound senders. Each MppSender wraps the queue's
+    // `Arc<dyn BatchChannelSender>` so per-(stage_id, partition) clones can multiplex over the
+    // same shm_mq slot. The slot at proc_idx==this_proc is `None`; self-loops are never attached.
+    // `compute_dsm_layout` reserves the bytes but `worker_attach` skips them.
+    let mut outbound_senders: Vec<Option<MppSender>> = (0..total_procs).map(|_| None).collect();
+    for (peer_idx, shm_send) in attach.outbound_senders.into_iter().enumerate() {
+        let target_proc = peer_proc_for_index(proc_idx, peer_idx as u32);
+        debug_assert!(target_proc != proc_idx);
+        debug_assert!(target_proc < total_procs);
+        let shared: Arc<dyn crate::postgres::customscan::mpp::transport::BatchChannelSender> =
+            Arc::new(shm_send);
+        // Default header: the per-fragment dispatcher in `aggregatescan::exec_mpp_worker`
+        // immediately `clone_with_header`s these to the right `(stage_id, partition)` per output
+        // partition, so the default placeholder header is never observed on the wire.
+        outbound_senders[target_proc as usize] = Some(MppSender::with_header(
+            Arc::clone(&shared),
+            MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
+        ));
+    }
+    debug_assert_eq!(
+        outbound_senders.iter().filter(|s| s.is_some()).count(),
+        (total_procs as usize).saturating_sub(1),
+        "worker outbound senders: expected {} non-self-loop entries before self-loop install",
+        total_procs.saturating_sub(1)
+    );
 
-    let build_cache = if header.n_cache_sources > 0 {
-        Some(Arc::new(unsafe {
-            MppBuildCache::from_header(coordinate as *mut u8, &header)
-        }))
-    } else {
-        None
-    };
+    // Build the worker's MppMesh. Inbound drains pull frames from each peer proc's
+    // `slot(peer_proc, this_proc)` queue, and per-(stage_id, partition) sub-buffers demux them
+    // into the right consumer fragment.
+    let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
+        (0..total_procs).map(|_| None).collect();
+    for (peer_idx, shm_recv) in attach.inbound_receivers.into_iter().enumerate() {
+        let sender_proc = peer_proc_for_index(proc_idx, peer_idx as u32);
+        debug_assert!(sender_proc != proc_idx);
+        let mpp_recv = MppReceiver::new(Box::new(shm_recv));
+        inbound_drains[sender_proc as usize] =
+            Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv])));
+    }
+    // Install a self-loop in-proc channel for `slot(this_proc, this_proc)`. Peer-mesh hash
+    // routing can land producer-side and consumer-side tasks for the same `(stage, partition)`
+    // on the same worker. Without this, the shm_mq grid's unattached diagonal would surface as
+    // `outbound_senders[this_proc] = None`. The in-proc channel keeps frame routing uniform from
+    // the dispatcher's perspective: senders push, the `DrainHandle` reads via the same
+    // `BatchChannelReceiver` contract as shm_mq, and the sub-buffer registry demuxes per
+    // `(stage_id, partition)`.
+    let (self_tx, self_rx) = in_proc_channel(SELF_LOOP_CAPACITY);
+    let self_tx_arc: Arc<dyn BatchChannelSender> = Arc::new(self_tx);
+    outbound_senders[proc_idx as usize] = Some(MppSender::with_header(
+        Arc::clone(&self_tx_arc),
+        MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
+    ));
+    inbound_drains[proc_idx as usize] =
+        Some(Arc::new(DrainHandle::cooperative(vec![MppReceiver::new(
+            Box::new(self_rx),
+        )])));
 
+    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drains));
+
+    // For MppParticipantConfig, expose worker-only counts (N producer workers).
+    let worker_count = total_procs.saturating_sub(1).max(1);
     Ok(MppWorkerState {
         outbound_senders,
         plan_bytes,
         participant_config: MppParticipantConfig {
-            participant_index: worker_index,
-            total_participants: header.n_workers,
+            participant_index: worker_number as u32,
+            total_workers: worker_count,
         },
-        build_cache,
+        mesh,
     })
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -288,13 +288,11 @@ pub unsafe fn worker_setup(
 
     let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drains));
 
-    // For MppParticipantConfig, expose worker-only counts (N producer workers).
     let worker_count = total_procs.saturating_sub(1).max(1);
     Ok(MppWorkerState {
         outbound_senders,
         plan_bytes,
         participant_config: MppParticipantConfig {
-            participant_index: worker_number as u32,
             total_workers: worker_count,
         },
         mesh,

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -48,7 +48,6 @@ use crate::postgres::customscan::mpp::transport::{
     in_proc_channel, BatchChannelSender, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
     SELF_LOOP_CAPACITY,
 };
-use crate::postgres::customscan::mpp::MppParticipantConfig;
 
 /// Default stage id stamped on outbound sender headers before the per-fragment dispatcher
 /// rewrites them. Worker senders get `clone_with_header` immediately after `worker_setup`, so
@@ -109,8 +108,7 @@ pub(super) fn n_procs() -> u32 {
 /// state and consults it during `exec_custom_scan`.
 ///
 /// The leader is consumer-only: it gathers fragments from worker procs but doesn't host a
-/// producer fragment itself. Its outbound senders are dropped inside `leader_setup`, and it
-/// carries no `MppParticipantConfig`.
+/// producer fragment itself. Its outbound senders are dropped inside `leader_setup`.
 pub struct MppLeaderState {
     /// Runtime mesh handle. Install on the leader's `SessionContext` via
     /// `with_extension(Arc::clone(&mesh))` so `ShmMqWorkerTransport` can find
@@ -221,7 +219,6 @@ pub struct MppWorkerState {
     /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via the
     /// `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
     pub plan_bytes: Vec<u8>,
-    pub participant_config: MppParticipantConfig,
     /// Worker's MppMesh, same shape as the leader's. `inbound_drains[sender_proc]` pulls frames
     /// from `slot(sender_proc, this_proc)`. Workers consume from peers when running consumer
     /// fragments (e.g. a `FinalPartitioned` aggregate above a `NetworkShuffleExec` peer-mesh).
@@ -284,13 +281,9 @@ pub unsafe fn worker_setup(
 
     let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drains));
 
-    let worker_count = total_procs.saturating_sub(1).max(1);
     Ok(MppWorkerState {
         outbound_senders,
         plan_bytes,
-        participant_config: MppParticipantConfig {
-            total_workers: worker_count,
-        },
         mesh,
     })
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -72,7 +72,7 @@ pub fn mpp_is_active() -> bool {
     enable_mpp() && gucs_mpp_worker_count() >= 3
 }
 
-/// Total participant count: leader + producers. Clamped at 3 so the mesh
+/// Total proc count: leader + producers. Clamped at 3 so the mesh
 /// shape matches the planner's `target_partitions` (see [`mpp_is_active`]).
 pub fn mpp_worker_count() -> u32 {
     gucs_mpp_worker_count().max(3) as u32
@@ -85,7 +85,7 @@ pub(super) fn mpp_queue_size() -> usize {
 
 /// Body of `estimate_dsm_custom_scan`. Returns total DSM bytes the leader will need for the
 /// plan, the multiplexed `n_procs × n_procs` queue mesh, and the worker plan. `n_procs` is the
-/// total participant count (leader + `producer_worker_count()` parallel workers).
+/// total proc count (leader + `producer_worker_count()` parallel workers).
 pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
     let layout = compute_dsm_layout(n_procs(), mpp_queue_size(), plan_bytes_len)
         .map_err(|e| format!("mpp: estimate_dsm_size: {e}"))?;
@@ -93,12 +93,12 @@ pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
 }
 
 /// Number of producer workers PG should launch as `parallel_workers`.
-/// `mpp_worker_count - 1` because participant 0 is the leader.
+/// `mpp_worker_count - 1` because proc 0 is the leader.
 pub fn producer_worker_count() -> u32 {
     mpp_worker_count().saturating_sub(1).max(1)
 }
 
-/// Total participant count: 1 leader + N producer workers. This is the
+/// Total proc count: 1 leader + N producer workers. This is the
 /// dimension of the multiplexed `n_procs × n_procs` shm_mq grid.
 pub(super) fn n_procs() -> u32 {
     mpp_worker_count()
@@ -127,7 +127,7 @@ pub struct MppLeaderState {
 /// Wrap each peer-indexed `ShmMqReceiver` into an inbound cooperative drain, returned in
 /// `sender_proc`-indexed form. Slot at index `this_proc` is `None` (no self-loop drain at this
 /// stage; the worker's self-loop is installed separately, and the leader never has one).
-fn build_inbound_drains(
+fn build_inbound_receivers(
     this_proc: u32,
     total_procs: u32,
     peer_receivers: Vec<ShmMqReceiver>,
@@ -190,12 +190,12 @@ pub unsafe fn leader_setup(
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
     let _ = n_partitions;
 
-    // Each `DrainHandle` owns a per-`(stage_id, partition)` sub-buffer registry, so one shm_mq
-    // queue can carry frames from many logical channels. Sub-buffers are created lazily on first
+    // Each `DrainHandle` owns a per-`(stage_id, partition)` channel buffer registry, so one shm_mq
+    // queue can carry frames from many logical channels. Channel buffers are created lazily on first
     // frame, or up-front by `WorkerConnection::stream_partition`.
-    let inbound_drains = build_inbound_drains(0, total_procs, attach.inbound_receivers);
+    let inbound_receivers = build_inbound_receivers(0, total_procs, attach.inbound_receivers);
 
-    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_drains));
+    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_receivers));
 
     // Drop the leader's own outbound senders. The leader is consumer-only and never hosts a
     // producer fragment.
@@ -209,7 +209,7 @@ pub unsafe fn leader_setup(
 pub struct MppWorkerState {
     /// `outbound_senders[proc_idx]` is the sender that writes to `slot(this_proc, proc_idx)`.
     /// The entry at `proc_idx == this_proc` is `None` because the self-loop slot is never
-    /// attached (matches the leader's `inbound_drains` shape).
+    /// attached (matches the leader's `inbound_receivers` shape).
     ///
     /// Each fragment's per-partition output sender is keyed by
     /// `outbound_senders[proc_for_task(n_workers, consumer_task)]`. Each `MppSender` wraps an
@@ -219,7 +219,7 @@ pub struct MppWorkerState {
     /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via the
     /// `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
     pub plan_bytes: Vec<u8>,
-    /// Worker's MppMesh, same shape as the leader's. `inbound_drains[sender_proc]` pulls frames
+    /// Worker's MppMesh, same shape as the leader's. `inbound_receivers[sender_proc]` pulls frames
     /// from `slot(sender_proc, this_proc)`. Workers consume from peers when running consumer
     /// fragments (e.g. a `FinalPartitioned` aggregate above a `NetworkShuffleExec` peer-mesh).
     /// Read by the multi-fragment dispatcher in `aggregatescan::exec_mpp_worker`.
@@ -253,7 +253,8 @@ pub unsafe fn worker_setup(
 
     let mut outbound_senders =
         build_outbound_senders(proc_idx, total_procs, attach.outbound_senders);
-    let mut inbound_drains = build_inbound_drains(proc_idx, total_procs, attach.inbound_receivers);
+    let mut inbound_receivers =
+        build_inbound_receivers(proc_idx, total_procs, attach.inbound_receivers);
     debug_assert_eq!(
         outbound_senders.iter().filter(|s| s.is_some()).count(),
         (total_procs as usize).saturating_sub(1),
@@ -266,7 +267,7 @@ pub unsafe fn worker_setup(
     // on the same worker. Without this, the shm_mq grid's unattached diagonal would surface as
     // `outbound_senders[this_proc] = None`. The in-proc channel keeps frame routing uniform from
     // the dispatcher's perspective: senders push, the `DrainHandle` reads via the same
-    // `BatchChannelReceiver` contract as shm_mq, and the sub-buffer registry demuxes per
+    // `BatchChannelReceiver` contract as shm_mq, and the channel buffer registry demuxes per
     // `(stage_id, partition)`.
     let (self_tx, self_rx) = in_proc_channel(SELF_LOOP_CAPACITY);
     let self_tx_arc: Arc<dyn BatchChannelSender> = Arc::new(self_tx);
@@ -274,12 +275,12 @@ pub unsafe fn worker_setup(
         self_tx_arc,
         MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
     ));
-    inbound_drains[proc_idx as usize] =
+    inbound_receivers[proc_idx as usize] =
         Some(Arc::new(DrainHandle::cooperative(vec![MppReceiver::new(
             Box::new(self_rx),
         )])));
 
-    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drains));
+    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_receivers));
 
     Ok(MppWorkerState {
         outbound_senders,

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -42,6 +42,7 @@ use crate::gucs::{
 use crate::postgres::customscan::mpp::dsm::{
     compute_dsm_layout, leader_init, peer_proc_for_index, worker_attach,
 };
+use crate::postgres::customscan::mpp::mesh::{ShmMqReceiver, ShmMqSender};
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
     in_proc_channel, BatchChannelSender, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
@@ -125,6 +126,49 @@ pub struct MppLeaderState {
     pub pcxt: *mut pg_sys::ParallelContext,
 }
 
+/// Wrap each peer-indexed `ShmMqReceiver` into an inbound cooperative drain, returned in
+/// `sender_proc`-indexed form. Slot at index `this_proc` is `None` (no self-loop drain at this
+/// stage; the worker's self-loop is installed separately, and the leader never has one).
+fn build_inbound_drains(
+    this_proc: u32,
+    total_procs: u32,
+    peer_receivers: Vec<ShmMqReceiver>,
+) -> Vec<Option<Arc<DrainHandle>>> {
+    let mut drains: Vec<Option<Arc<DrainHandle>>> = (0..total_procs).map(|_| None).collect();
+    for (peer_idx, shm_recv) in peer_receivers.into_iter().enumerate() {
+        let sender_proc = peer_proc_for_index(this_proc, peer_idx as u32);
+        debug_assert!(sender_proc != this_proc);
+        debug_assert!(sender_proc < total_procs);
+        let mpp_recv = MppReceiver::new(Box::new(shm_recv));
+        drains[sender_proc as usize] = Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv])));
+    }
+    drains
+}
+
+/// Wrap each peer-indexed `ShmMqSender` into an outbound `MppSender` keyed by `target_proc`. The
+/// per-fragment dispatcher in `aggregatescan::exec_mpp_worker` immediately `clone_with_header`s
+/// these to the right `(stage_id, partition)`, so the default placeholder header is never
+/// observed on the wire. Slot at index `this_proc` is `None`; the worker's self-loop install
+/// fills it in afterward.
+fn build_outbound_senders(
+    this_proc: u32,
+    total_procs: u32,
+    peer_senders: Vec<ShmMqSender>,
+) -> Vec<Option<MppSender>> {
+    let mut senders: Vec<Option<MppSender>> = (0..total_procs).map(|_| None).collect();
+    for (peer_idx, shm_send) in peer_senders.into_iter().enumerate() {
+        let target_proc = peer_proc_for_index(this_proc, peer_idx as u32);
+        debug_assert!(target_proc != this_proc);
+        debug_assert!(target_proc < total_procs);
+        let shared: Arc<dyn BatchChannelSender> = Arc::new(shm_send);
+        senders[target_proc as usize] = Some(MppSender::with_header(
+            shared,
+            MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
+        ));
+    }
+    senders
+}
+
 /// Body of `initialize_dsm_custom_scan`. Allocates the queue mesh, populates
 /// the [`MppMesh`] handle, and serializes the worker plan into DSM.
 ///
@@ -146,32 +190,12 @@ pub unsafe fn leader_setup(
         .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
 
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
+    let _ = n_partitions;
 
-    // Build the proc-pair indexed mesh. The leader is `proc_idx = 0`; its inbound queues are
-    // `slot(*, 0)` for every peer (workers 1..n_procs). `attach.inbound_receivers` is
-    // peer-indexed with the self-loop skipped, so receiver[i] corresponds to
-    // peer_proc_for_index(0, i) = i + 1.
-    //
-    // The mesh stores `inbound_drains[sender_proc]` so `runtime.rs` can look up the right drain
-    // in O(1) given a sender_proc. The self-loop entry at index 0 is `None`.
-    //
     // Each `DrainHandle` owns a per-`(stage_id, partition)` sub-buffer registry, so one shm_mq
     // queue can carry frames from many logical channels. Sub-buffers are created lazily on first
     // frame, or up-front by `WorkerConnection::stream_partition`.
-    let _ = n_partitions;
-    let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
-        Vec::with_capacity(total_procs as usize);
-    inbound_drains.push(None); // self-loop slot at sender_proc = 0
-    for (peer_idx, shm_recv) in attach.inbound_receivers.into_iter().enumerate() {
-        let sender_proc = peer_proc_for_index(0, peer_idx as u32);
-        debug_assert_eq!(
-            sender_proc as usize,
-            inbound_drains.len(),
-            "peer_proc_for_index must produce sender_proc indices in order"
-        );
-        let mpp_recv = MppReceiver::new(Box::new(shm_recv));
-        inbound_drains.push(Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv]))));
-    }
+    let inbound_drains = build_inbound_drains(0, total_procs, attach.inbound_receivers);
 
     let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_drains));
 
@@ -230,25 +254,9 @@ pub unsafe fn worker_setup(
         unsafe { worker_attach(coordinate, region_total, proc_idx, seg) }?;
     let total_procs = header.n_procs;
 
-    // Build per-proc-indexed outbound senders. Each MppSender wraps the queue's
-    // `Arc<dyn BatchChannelSender>` so per-(stage_id, partition) clones can multiplex over the
-    // same shm_mq slot. The slot at proc_idx==this_proc is `None`; self-loops are never attached.
-    // `compute_dsm_layout` reserves the bytes but `worker_attach` skips them.
-    let mut outbound_senders: Vec<Option<MppSender>> = (0..total_procs).map(|_| None).collect();
-    for (peer_idx, shm_send) in attach.outbound_senders.into_iter().enumerate() {
-        let target_proc = peer_proc_for_index(proc_idx, peer_idx as u32);
-        debug_assert!(target_proc != proc_idx);
-        debug_assert!(target_proc < total_procs);
-        let shared: Arc<dyn crate::postgres::customscan::mpp::transport::BatchChannelSender> =
-            Arc::new(shm_send);
-        // Default header: the per-fragment dispatcher in `aggregatescan::exec_mpp_worker`
-        // immediately `clone_with_header`s these to the right `(stage_id, partition)` per output
-        // partition, so the default placeholder header is never observed on the wire.
-        outbound_senders[target_proc as usize] = Some(MppSender::with_header(
-            Arc::clone(&shared),
-            MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
-        ));
-    }
+    let mut outbound_senders =
+        build_outbound_senders(proc_idx, total_procs, attach.outbound_senders);
+    let mut inbound_drains = build_inbound_drains(proc_idx, total_procs, attach.inbound_receivers);
     debug_assert_eq!(
         outbound_senders.iter().filter(|s| s.is_some()).count(),
         (total_procs as usize).saturating_sub(1),
@@ -256,18 +264,6 @@ pub unsafe fn worker_setup(
         total_procs.saturating_sub(1)
     );
 
-    // Build the worker's MppMesh. Inbound drains pull frames from each peer proc's
-    // `slot(peer_proc, this_proc)` queue, and per-(stage_id, partition) sub-buffers demux them
-    // into the right consumer fragment.
-    let mut inbound_drains: Vec<Option<Arc<DrainHandle>>> =
-        (0..total_procs).map(|_| None).collect();
-    for (peer_idx, shm_recv) in attach.inbound_receivers.into_iter().enumerate() {
-        let sender_proc = peer_proc_for_index(proc_idx, peer_idx as u32);
-        debug_assert!(sender_proc != proc_idx);
-        let mpp_recv = MppReceiver::new(Box::new(shm_recv));
-        inbound_drains[sender_proc as usize] =
-            Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv])));
-    }
     // Install a self-loop in-proc channel for `slot(this_proc, this_proc)`. Peer-mesh hash
     // routing can land producer-side and consumer-side tasks for the same `(stage, partition)`
     // on the same worker. Without this, the shm_mq grid's unattached diagonal would surface as
@@ -278,7 +274,7 @@ pub unsafe fn worker_setup(
     let (self_tx, self_rx) = in_proc_channel(SELF_LOOP_CAPACITY);
     let self_tx_arc: Arc<dyn BatchChannelSender> = Arc::new(self_tx);
     outbound_senders[proc_idx as usize] = Some(MppSender::with_header(
-        Arc::clone(&self_tx_arc),
+        self_tx_arc,
         MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
     ));
     inbound_drains[proc_idx as usize] =

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -79,7 +79,7 @@ pub fn mpp_worker_count() -> u32 {
 }
 
 /// Per-edge queue size from the GUC.
-pub fn mpp_queue_size() -> usize {
+pub(super) fn mpp_queue_size() -> usize {
     gucs_mpp_queue_size()
 }
 
@@ -100,7 +100,7 @@ pub fn producer_worker_count() -> u32 {
 
 /// Total participant count: 1 leader + N producer workers. This is the
 /// dimension of the multiplexed `n_procs × n_procs` shm_mq grid.
-pub fn n_procs() -> u32 {
+pub(super) fn n_procs() -> u32 {
     mpp_worker_count()
 }
 

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -148,6 +148,14 @@ pub(super) struct ShmMqReceiver {
 // or CFI calls).
 unsafe impl Send for ShmMqReceiver {}
 
+// SAFETY: production invariant is that only the backend thread calls `try_recv` (the cooperative
+// drain runs inline on `DrainGatherStream::poll_next`; pgrx's `check_active_thread` would panic
+// on a non-backend caller anyway). `shm_mq_receive(nowait=true)` is therefore not reentered
+// concurrently on the same handle. We need `Sync` to satisfy the `BatchChannelReceiver: Send +
+// Sync` bound, which in turn lets `DrainHandle: Sync` come from the concrete types instead of
+// from the `Mutex<Vec<…>>` wrapper on `coop_receivers` having to provide it.
+unsafe impl Sync for ShmMqReceiver {}
+
 impl ShmMqReceiver {
     /// Attach as receiver to an *already-created* shm_mq.
     ///

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -37,7 +37,7 @@ use datafusion::common::DataFusionError;
 /// MAXALIGN-aligned; this rounds the user request down so every slot in a
 /// queue array is the same size and slot indexing is a simple multiply.
 #[inline]
-pub fn aligned_queue_bytes(queue_bytes: usize) -> usize {
+pub(super) fn aligned_queue_bytes(queue_bytes: usize) -> usize {
     const MAXIMUM_ALIGNOF: usize = pg_sys::MAXIMUM_ALIGNOF as usize;
     queue_bytes & !(MAXIMUM_ALIGNOF - 1)
 }
@@ -46,7 +46,7 @@ pub fn aligned_queue_bytes(queue_bytes: usize) -> usize {
 /// on overflow. Used by [`super::dsm::compute_dsm_layout`] to keep section
 /// boundaries inside the DSM region MAXALIGN-aligned.
 #[inline]
-pub fn align_up_maxalign_checked(n: usize) -> Option<usize> {
+pub(super) fn align_up_maxalign_checked(n: usize) -> Option<usize> {
     const MAXIMUM_ALIGNOF: usize = pg_sys::MAXIMUM_ALIGNOF as usize;
     let mask = MAXIMUM_ALIGNOF - 1;
     n.checked_add(mask).map(|x| x & !mask)
@@ -60,7 +60,7 @@ pub fn align_up_maxalign_checked(n: usize) -> Option<usize> {
 /// dedicated parallel-worker backend. The blocking `shm_mq_send(nowait=false)`
 /// path uses `WaitLatch` + `CHECK_FOR_INTERRUPTS` — both process-global
 /// Postgres primitives, not thread-safe off a backend thread.
-pub struct ShmMqSender {
+pub(super) struct ShmMqSender {
     inner: MessageQueueSender,
     attach_thread: std::thread::ThreadId,
 }
@@ -138,7 +138,7 @@ impl BatchChannelSender for ShmMqSender {
 /// shm_mq-backed `BatchChannelReceiver`. The leader creates the shm_mq via
 /// `shm_mq_create` during DSM init; this attaches as receiver to an already-
 /// initialized queue.
-pub struct ShmMqReceiver {
+pub(super) struct ShmMqReceiver {
     inner: MessageQueueReceiver,
 }
 

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -162,7 +162,7 @@ impl ShmMqReceiver {
     /// # Safety
     /// - `mq` must point to a shm_mq previously initialized by `shm_mq_create`.
     /// - `seg` may be NULL on workers.
-    /// - No other participant has already set itself as receiver for `mq`.
+    /// - No other proc has already set itself as receiver for `mq`.
     pub(super) unsafe fn attach_existing(
         seg: *mut pg_sys::dsm_segment,
         mq: *mut pg_sys::shm_mq,

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -81,7 +81,7 @@ impl ShmMqSender {
     /// - `mq` must point to a shm_mq region that has been `shm_mq_create`'d
     ///   at its address with the expected size and has had
     ///   `shm_mq_set_receiver` called by the peer.
-    pub unsafe fn attach(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
+    pub(super) unsafe fn attach(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
         unsafe {
             Self {
                 inner: MessageQueueSender::new(seg, mq),
@@ -155,7 +155,10 @@ impl ShmMqReceiver {
     /// - `mq` must point to a shm_mq previously initialized by `shm_mq_create`.
     /// - `seg` may be NULL on workers.
     /// - No other participant has already set itself as receiver for `mq`.
-    pub unsafe fn attach_existing(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
+    pub(super) unsafe fn attach_existing(
+        seg: *mut pg_sys::dsm_segment,
+        mq: *mut pg_sys::shm_mq,
+    ) -> Self {
         unsafe {
             pg_sys::shm_mq_set_receiver(mq, pg_sys::MyProc);
             let handle = pg_sys::shm_mq_attach(mq, seg, std::ptr::null_mut());

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -67,6 +67,13 @@ pub struct ShmMqSender {
 
 // SAFETY: see struct doc.
 unsafe impl Send for ShmMqSender {}
+// SAFETY: `MppSender` ensures all `send_*` paths execute on the attach thread (a
+// `debug_assert!` in `send_bytes` / `try_send_bytes` pins this), so cross-thread sharing of
+// `&ShmMqSender` never actually crosses threads at the FFI boundary. The Sync bound is there so
+// multiple `MppSender`s can hold `Arc<dyn BatchChannelSender>` clones of the same underlying
+// queue (the multi-partition fan-out pattern) without the type system rejecting the `Arc::clone`
+// at compile time.
+unsafe impl Sync for ShmMqSender {}
 
 impl ShmMqSender {
     /// # Safety

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -21,7 +21,7 @@
 //! workers through PostgreSQL `shm_mq` queues, so each row is scanned exactly once.
 //! Guarded by `paradedb.enable_mpp` (default off).
 //!
-//! Transport deadlock-avoidance relies on one dedicated drain thread per participant
+//! Transport deadlock-avoidance relies on one dedicated drain thread per proc
 //! that reads all inbound queues into a spillable local buffer — this decouples
 //! consumer-side backpressure from producer-side backpressure.
 
@@ -57,22 +57,4 @@ macro_rules! mpp_log {
     ($($arg:tt)*) => {
         { let _ = format_args!($($arg)*); }
     };
-}
-
-/// Fatal MPP-internal invariant breach. Same `!` return type as `pgrx::error!` /
-/// `panic!`, so it can sit in any `match` arm or expression position.
-///
-/// In production this calls `pgrx::error!`, which aborts the transaction via PG's ereport
-/// machinery. In `cargo test` the lib-test binary doesn't link against postgres, so we fall
-/// back to `panic!` with the same message. Either way the call site stays readable —
-/// `fail_loud(format!(...))` — instead of carrying a `#[cfg(not(test))] pgrx::error!` /
-/// `#[cfg(test)] panic!` arm pair at every fatal MPP invariant breach.
-#[cfg(not(test))]
-pub fn fail_loud(msg: String) -> ! {
-    pgrx::error!("{}", msg);
-}
-
-#[cfg(test)]
-pub fn fail_loud(msg: String) -> ! {
-    panic!("{}", msg);
 }

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -58,3 +58,21 @@ macro_rules! mpp_log {
         { let _ = format_args!($($arg)*); }
     };
 }
+
+/// Fatal MPP-internal invariant breach. Same `!` return type as `pgrx::error!` /
+/// `panic!`, so it can sit in any `match` arm or expression position.
+///
+/// In production this calls `pgrx::error!`, which aborts the transaction via PG's ereport
+/// machinery. In `cargo test` the lib-test binary doesn't link against postgres, so we fall
+/// back to `panic!` with the same message. Either way the call site stays readable —
+/// `fail_loud(format!(...))` — instead of carrying a `#[cfg(not(test))] pgrx::error!` /
+/// `#[cfg(test)] panic!` arm pair at every fatal MPP invariant breach.
+#[cfg(not(test))]
+pub fn fail_loud(msg: String) -> ! {
+    pgrx::error!("{}", msg);
+}
+
+#[cfg(test)]
+pub fn fail_loud(msg: String) -> ! {
+    panic!("{}", msg);
+}

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -29,34 +29,49 @@ pub mod dsm;
 pub mod glue;
 pub mod mesh;
 pub mod runtime;
+pub mod task_estimator;
 pub mod transport;
 pub mod worker;
+pub mod worker_fragments;
 
 use serde::{Deserialize, Serialize};
 
 /// Describes this participant's position in an MPP query. Held by
 /// [`glue::MppLeaderState`] / [`glue::MppWorkerState`] so the AggregateScan
-/// worker path can size the in-process planner via `total_participants`.
+/// worker path can size the in-process planner via `total_workers`.
 /// The DF-D fork's `WorkerResolver` derives task identity from its own indexing,
 /// so this is a diagnostic / sizing hand-off — not a `SessionConfig`
 /// extension.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MppParticipantConfig {
-    /// 0-based index of this participant. The leader is always index 0.
+    /// 0-based worker index (`ParallelWorkerNumber`). Workers only; the leader has no
+    /// `MppParticipantConfig` because it doesn't host a producer fragment.
     pub participant_index: u32,
-    /// Total number of participants (leader + workers).
-    pub total_participants: u32,
+    /// Number of producer workers in the mesh (= `n_procs - 1`; the leader is consumer-only).
+    pub total_workers: u32,
 }
 
 /// Emit a runtime trace when `paradedb.mpp_debug` is on.
 ///
-/// Routed through `pgrx::warning!` so the line appears in the Postgres server log
-/// (and in CI benchmark logs). No-op when the GUC is off.
+/// Routed through `pgrx::warning!` so the line lands in the Postgres server log (and CI bench
+/// logs). Gated `#[cfg(not(test))]` because `pgrx::warning!` expands to PG's `ereport` machinery,
+/// which the lib-test binary doesn't link against; see the `#[cfg(test)]` no-op stub below.
+#[cfg(not(test))]
 #[macro_export]
 macro_rules! mpp_log {
     ($($arg:tt)*) => {
         if $crate::gucs::mpp_debug() {
             pgrx::warning!($($arg)*);
         }
+    };
+}
+
+/// `cargo test` variant: no-op. `format_args!` is invoked solely to silence
+/// "unused variable" / "unused import" warnings at the call sites.
+#[cfg(test)]
+#[macro_export]
+macro_rules! mpp_log {
+    ($($arg:tt)*) => {
+        { let _ = format_args!($($arg)*); }
     };
 }

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -58,3 +58,20 @@ macro_rules! mpp_log {
         { let _ = format_args!($($arg)*); }
     };
 }
+
+/// Fatal MPP-internal invariant breach. Same `!` return type as `pgrx::error!` / `panic!`, so it
+/// can sit in any `match` arm or expression position.
+///
+/// In production this calls `pgrx::error!`, which aborts the transaction via PG's ereport
+/// machinery. The lib-test binary (built without `pg_test`) does not link those PG symbols, so
+/// the `#[cfg(test)]` arm falls back to `panic!`. Either way the call site stays readable —
+/// `fail_loud(format!(...))` — without a per-site `#[cfg]` pair.
+#[cfg(not(test))]
+pub fn fail_loud(msg: String) -> ! {
+    pgrx::error!("{}", msg);
+}
+
+#[cfg(test)]
+pub fn fail_loud(msg: String) -> ! {
+    panic!("{}", msg);
+}

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -34,17 +34,6 @@ pub mod transport;
 pub mod worker;
 pub mod worker_fragments;
 
-use serde::{Deserialize, Serialize};
-
-/// Sizing hand-off for the AggregateScan worker path. The DF-D fork's `WorkerResolver` derives
-/// task identity from its own indexing, so the only thing the worker needs from here is the
-/// producer-worker count.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct MppParticipantConfig {
-    /// Number of producer workers in the mesh (= `n_procs - 1`; the leader is consumer-only).
-    pub total_workers: u32,
-}
-
 /// Emit a runtime trace when `paradedb.mpp_debug` is on.
 ///
 /// Routed through `pgrx::warning!` so the line lands in the Postgres server log (and CI bench

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -36,17 +36,11 @@ pub mod worker_fragments;
 
 use serde::{Deserialize, Serialize};
 
-/// Describes this participant's position in an MPP query. Held by
-/// [`glue::MppLeaderState`] / [`glue::MppWorkerState`] so the AggregateScan
-/// worker path can size the in-process planner via `total_workers`.
-/// The DF-D fork's `WorkerResolver` derives task identity from its own indexing,
-/// so this is a diagnostic / sizing hand-off — not a `SessionConfig`
-/// extension.
+/// Sizing hand-off for the AggregateScan worker path. The DF-D fork's `WorkerResolver` derives
+/// task identity from its own indexing, so the only thing the worker needs from here is the
+/// producer-worker count.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MppParticipantConfig {
-    /// 0-based worker index (`ParallelWorkerNumber`). Workers only; the leader has no
-    /// `MppParticipantConfig` because it doesn't host a producer fragment.
-    pub participant_index: u32,
     /// Number of producer workers in the mesh (= `n_procs - 1`; the leader is consumer-only).
     pub total_workers: u32,
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -46,15 +46,13 @@ use url::Url;
 
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, DrainHandle, DrainItem};
 
-/// `(producer_task_idx) → proc_idx` round-robin over the worker procs.
+/// `task_idx → proc_idx` round-robin over the worker procs. The leader is `proc_idx = 0`
+/// (consumer-only), workers are `1..n_procs` (each hosts producer fragments).
 ///
-/// Leader is `proc_idx = 0`; workers are `1..n_procs`. The mapping is a pure function of
-/// `task_idx % n_workers`, so it doesn't need a side table: every proc that knows `n_workers`
-/// computes the same answer.
-///
-/// With the planner's `target_partitions = n_workers` and `distributed_task_estimator = n_workers`
-/// knobs, the natural-shape plans keep `task_idx < n_workers` in every stage we target; the
-/// modulo wraps cleanly when future shapes exceed that.
+/// A stage's task count is set by the DF-D task estimator chain, not by the worker proc count.
+/// With the natural-shape plan's `distributed_task_estimator(n_workers)`, `task_count` equals
+/// `n_workers` in every stage we emit today, so the modulo is a no-op. The wrap is defensive for
+/// future shapes where an estimator could return more tasks than producer procs.
 #[inline]
 pub fn proc_for_task(n_workers: u32, task_idx: u32) -> u32 {
     1 + (task_idx % n_workers.max(1))
@@ -64,7 +62,7 @@ pub fn proc_for_task(n_workers: u32, task_idx: u32) -> u32 {
 ///
 /// Each shm_mq queue (one per `(sender_proc, this_proc)` pair in the V2 DSM grid) is
 /// multi-channel. Frames from any number of `(stage_id, partition)` logical channels can arrive
-/// on one queue, tagged by [`MppFrameHeader`]. The sub-buffer registry on each [`DrainHandle`]
+/// on one queue, tagged by [`MppFrameHeader`]. The channel buffer registry on each [`DrainHandle`]
 /// fans them out to the matching consumers keyed on `(stage_id, partition)`.
 ///
 /// [`MppFrameHeader`]: crate::postgres::customscan::mpp::transport::MppFrameHeader
@@ -72,15 +70,15 @@ pub struct MppMesh {
     /// This process's `proc_idx` (= 0 for the leader, `ParallelWorkerNumber + 1` for workers).
     /// Frames addressed to this proc arrive on `slot(*, this_proc)`.
     pub this_proc: u32,
-    /// Total participant count. Bounds the producer/consumer proc lookups in
+    /// Total proc count. Bounds the producer/consumer proc lookups in
     /// [`ShmMqWorkerTransport::open`].
     pub n_procs: u32,
-    /// `inbound_drains[sender_proc]` is the cooperative drain that pulls frames from
+    /// `inbound_receivers[sender_proc]` is the cooperative drain that pulls frames from
     /// `slot(sender_proc, this_proc)`. `None` at the self-loop entry
     /// (`sender_proc == this_proc`); workers route those frames through an in-proc channel via
     /// `outbound_senders[this_proc]` instead. The natural-shape gather installs drains for every
     /// `sender_proc != this_proc`.
-    pub(super) inbound_drains: Vec<Option<Arc<DrainHandle>>>,
+    pub(super) inbound_receivers: Vec<Option<Arc<DrainHandle>>>,
 }
 
 impl MppMesh {
@@ -88,20 +86,22 @@ impl MppMesh {
     pub fn new(
         this_proc: u32,
         n_procs: u32,
-        inbound_drains: Vec<Option<Arc<DrainHandle>>>,
+        inbound_receivers: Vec<Option<Arc<DrainHandle>>>,
     ) -> Self {
         Self {
             this_proc,
             n_procs,
-            inbound_drains,
+            inbound_receivers,
         }
     }
 
     /// Look up the drain that owns frames coming from `sender_proc`. Returns `None` if no drain
     /// is installed (out-of-range or the self-loop slot, which the single-stage gather skips).
-    pub(super) fn inbound_drain(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
+    pub(super) fn inbound_receiver(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
         let idx = sender_proc as usize;
-        self.inbound_drains.get(idx).and_then(|slot| slot.as_ref())
+        self.inbound_receivers
+            .get(idx)
+            .and_then(|slot| slot.as_ref())
     }
 
     /// Number of worker procs (= `n_procs - 1`, since the leader is proc 0).
@@ -120,7 +120,7 @@ impl MppMesh {
     /// all drains have been polled. Drains that have already detached are skipped silently (their
     /// slot is still `Some`, but their inner `coop_receivers` Vec entry is `None`).
     pub(super) fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
-        for drain in self.inbound_drains.iter().flatten() {
+        for drain in self.inbound_receivers.iter().flatten() {
             drain.try_drain_pass()?;
         }
         Ok(())
@@ -194,7 +194,7 @@ struct ShmMqWorkerConnection {
     mesh: Arc<MppMesh>,
     sender_proc: u32,
     /// `stage_id` of the boundary's `input_stage`. Passed to `DrainHandle::register_channel` so
-    /// the sub-buffer this connection streams from sees only frames tagged with the same
+    /// the channel buffer this connection streams from sees only frames tagged with the same
     /// `(stage_id, p)`.
     stage_id: u32,
 }
@@ -206,17 +206,20 @@ impl WorkerConnection for ShmMqWorkerConnection {
                 "ShmMqWorkerConnection: partition={partition} > u32::MAX"
             ))
         })?;
-        let drain = self.mesh.inbound_drain(self.sender_proc).ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "ShmMqWorkerConnection: no inbound drain for sender_proc={} \
+        let drain = self
+            .mesh
+            .inbound_receiver(self.sender_proc)
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "ShmMqWorkerConnection: no inbound drain for sender_proc={} \
                  (stage_id={}, this_proc={})",
-                self.sender_proc, self.stage_id, self.mesh.this_proc
-            ))
-        })?;
+                    self.sender_proc, self.stage_id, self.mesh.this_proc
+                ))
+            })?;
         let drain = Arc::clone(drain);
-        // Ask the drain for the sub-buffer dedicated to this `(stage_id, partition)` channel.
+        // Ask the drain for the channel buffer dedicated to this `(stage_id, partition)` channel.
         // Frames with a matching header land here; frames tagged with other partitions go to
-        // their own sub-buffers, so this consumer only sees its slice.
+        // their own channel buffers, so this consumer only sees its slice.
         let buffer = drain.register_channel(self.stage_id, partition_u32);
         crate::mpp_log!(
             "mpp transport::stream_partition this_proc={} sender_proc={} stage_id={} \

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -80,7 +80,7 @@ pub struct MppMesh {
     /// (`sender_proc == this_proc`); workers route those frames through an in-proc channel via
     /// `outbound_senders[this_proc]` instead. The natural-shape gather installs drains for every
     /// `sender_proc != this_proc`.
-    pub inbound_drains: Vec<Option<Arc<DrainHandle>>>,
+    pub(super) inbound_drains: Vec<Option<Arc<DrainHandle>>>,
 }
 
 impl MppMesh {
@@ -99,14 +99,14 @@ impl MppMesh {
 
     /// Look up the drain that owns frames coming from `sender_proc`. Returns `None` if no drain
     /// is installed (out-of-range or the self-loop slot, which the single-stage gather skips).
-    pub fn inbound_drain(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
+    pub(super) fn inbound_drain(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
         let idx = sender_proc as usize;
         self.inbound_drains.get(idx).and_then(|slot| slot.as_ref())
     }
 
     /// Number of worker procs (= `n_procs - 1`, since the leader is proc 0).
     /// Used as the modulus in [`proc_for_task`].
-    pub fn n_workers(&self) -> u32 {
+    pub(super) fn n_workers(&self) -> u32 {
         self.n_procs.saturating_sub(1).max(1)
     }
 
@@ -119,7 +119,7 @@ impl MppMesh {
     /// Returns the first error if any drain's `try_drain_pass` errors; otherwise `Ok(())` after
     /// all drains have been polled. Drains that have already detached are skipped silently (their
     /// slot is still `Some`, but their inner `coop_receivers` Vec entry is `None`).
-    pub fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
+    pub(super) fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
         for drain in self.inbound_drains.iter().flatten() {
             drain.try_drain_pass()?;
         }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -38,39 +38,107 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
-use datafusion::physical_plan::ExecutionPlan;
+use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
 use datafusion_distributed::{
-    OnMetadataCallback, Stage, WorkerConnection, WorkerPartitionStream, WorkerResolver,
-    WorkerTransport,
+    RemoteStage, WorkerConnection, WorkerPartitionStream, WorkerResolver, WorkerTransport,
 };
 use url::Url;
 
-use crate::postgres::customscan::mpp::transport::{DrainHandle, DrainItem};
+use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, DrainHandle, DrainItem};
+
+/// `(producer_task_idx) → proc_idx` round-robin over the worker procs.
+///
+/// Leader is `proc_idx = 0`; workers are `1..n_procs`. The mapping is a pure function of
+/// `task_idx % n_workers`, so it doesn't need a side table: every proc that knows `n_workers`
+/// computes the same answer.
+///
+/// With the planner's `target_partitions = n_workers` and `distributed_task_estimator = n_workers`
+/// knobs, the natural-shape plans keep `task_idx < n_workers` in every stage we target; the
+/// modulo wraps cleanly when future shapes exceed that.
+#[inline]
+pub fn proc_for_task(n_workers: u32, task_idx: u32) -> u32 {
+    1 + (task_idx % n_workers.max(1))
+}
 
 /// Runtime handle the customscan populates at DSM-init time.
+///
+/// Each shm_mq queue (one per `(sender_proc, this_proc)` pair in the V2 DSM grid) is
+/// multi-channel. Frames from any number of `(stage_id, partition)` logical channels can arrive
+/// on one queue, tagged by [`MppFrameHeader`]. The sub-buffer registry on each [`DrainHandle`]
+/// fans them out to the matching consumers keyed on `(stage_id, partition)`.
+///
+/// [`MppFrameHeader`]: crate::postgres::customscan::mpp::transport::MppFrameHeader
 pub struct MppMesh {
-    /// Number of producer workers (including leader-as-worker-0).
-    pub n_workers: u32,
-    /// Number of consumer-side partitions on the leader.
-    pub n_partitions: u32,
-    /// One [`DrainHandle`] per `(worker, partition)` pair on the leader,
-    /// indexed `worker * n_partitions + partition`. Workers receive their
-    /// own slice of senders separately (see
-    /// [`crate::postgres::customscan::mpp::dsm::WorkerAttach`]).
-    pub drains: Vec<Arc<DrainHandle>>,
+    /// This process's `proc_idx` (= 0 for the leader, `ParallelWorkerNumber + 1` for workers).
+    /// Frames addressed to this proc arrive on `slot(*, this_proc)`.
+    pub this_proc: u32,
+    /// Total participant count. Bounds the producer/consumer proc lookups in
+    /// [`ShmMqWorkerTransport::open`].
+    pub n_procs: u32,
+    /// `inbound_drains[sender_proc]` is the cooperative drain that pulls frames from
+    /// `slot(sender_proc, this_proc)`. `None` at the self-loop entry
+    /// (`sender_proc == this_proc`); workers route those frames through an in-proc channel via
+    /// `outbound_senders[this_proc]` instead. The natural-shape gather installs drains for every
+    /// `sender_proc != this_proc`.
+    pub inbound_drains: Vec<Option<Arc<DrainHandle>>>,
 }
 
 impl MppMesh {
-    pub fn drain(&self, worker: u32, partition: u32) -> Option<&Arc<DrainHandle>> {
-        if worker >= self.n_workers || partition >= self.n_partitions {
-            return None;
+    /// Build a fresh mesh.
+    pub fn new(
+        this_proc: u32,
+        n_procs: u32,
+        inbound_drains: Vec<Option<Arc<DrainHandle>>>,
+    ) -> Self {
+        Self {
+            this_proc,
+            n_procs,
+            inbound_drains,
         }
-        self.drains
-            .get((worker as usize) * (self.n_partitions as usize) + (partition as usize))
+    }
+
+    /// Look up the drain that owns frames coming from `sender_proc`. Returns `None` if no drain
+    /// is installed (out-of-range or the self-loop slot, which the single-stage gather skips).
+    pub fn inbound_drain(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
+        let idx = sender_proc as usize;
+        self.inbound_drains.get(idx).and_then(|slot| slot.as_ref())
+    }
+
+    /// Number of worker procs (= `n_procs - 1`, since the leader is proc 0).
+    /// Used as the modulus in [`proc_for_task`].
+    pub fn n_workers(&self) -> u32 {
+        self.n_procs.saturating_sub(1).max(1)
+    }
+
+    /// Pull from every installed inbound drain. Called from
+    /// [`crate::postgres::customscan::mpp::transport::MppSender`]'s cooperative-send spin so a
+    /// producer stalled on a full outbound queue can drain inbound peer data inline. That's what
+    /// prevents the N×N symmetric-send deadlock when every peer is simultaneously stalled waiting
+    /// for space.
+    ///
+    /// Returns the first error if any drain's `try_drain_pass` errors; otherwise `Ok(())` after
+    /// all drains have been polled. Drains that have already detached are skipped silently (their
+    /// slot is still `Some`, but their inner `coop_receivers` Vec entry is `None`).
+    pub fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
+        for drain in self.inbound_drains.iter().flatten() {
+            drain.try_drain_pass()?;
+        }
+        Ok(())
+    }
+}
+
+impl CooperativeDrainSet for MppMesh {
+    fn try_drain_pass(&self) -> Result<(), DataFusionError> {
+        self.drain_all_inbound()
     }
 }
 
 /// Implements the DF-D fork's [`WorkerTransport`] over the leader's [`MppMesh`].
+///
+/// `open(input_stage, target_task)` translates the DF-D `(stage, task)`
+/// addressing into the proc-pair grid: `proc_for_task(n_workers, target_task)`
+/// selects which `sender_proc` hosts the producer-side task, and the returned
+/// [`WorkerConnection`] pulls from that proc's inbound drain.
 pub struct ShmMqWorkerTransport {
     mesh: Arc<MppMesh>,
 }
@@ -84,64 +152,88 @@ impl ShmMqWorkerTransport {
 impl WorkerTransport for ShmMqWorkerTransport {
     fn open(
         &self,
-        _input_stage: &Stage,
+        input_stage: &RemoteStage,
         _target_partitions: Range<usize>,
         target_task: usize,
         _ctx: &Arc<TaskContext>,
-    ) -> Result<Box<dyn WorkerConnection>> {
-        let worker = u32::try_from(target_task).map_err(|_| {
+        _metrics: &ExecutionPlanMetricsSet,
+    ) -> Result<Box<dyn WorkerConnection + Send + Sync>> {
+        let target_task_u32 = u32::try_from(target_task).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerTransport: target_task={target_task} > u32::MAX"
             ))
         })?;
-        if worker >= self.mesh.n_workers {
+        let stage_id = u32::try_from(input_stage.num).map_err(|_| {
+            DataFusionError::Internal(format!(
+                "ShmMqWorkerTransport: input_stage.num={} > u32::MAX",
+                input_stage.num
+            ))
+        })?;
+        let sender_proc = proc_for_task(self.mesh.n_workers(), target_task_u32);
+        if sender_proc >= self.mesh.n_procs {
             return Err(DataFusionError::Internal(format!(
-                "ShmMqWorkerTransport: target_task={worker} >= n_workers={}",
-                self.mesh.n_workers
+                "ShmMqWorkerTransport: sender_proc={sender_proc} >= n_procs={} \
+                 (stage_id={stage_id}, target_task={target_task})",
+                self.mesh.n_procs
             )));
         }
+        crate::mpp_log!(
+            "mpp transport::open this_proc={} stage_id={stage_id} target_task={target_task} \
+             → sender_proc={sender_proc}",
+            self.mesh.this_proc
+        );
         Ok(Box::new(ShmMqWorkerConnection {
             mesh: Arc::clone(&self.mesh),
-            worker,
+            sender_proc,
+            stage_id,
         }))
     }
 }
 
 struct ShmMqWorkerConnection {
     mesh: Arc<MppMesh>,
-    worker: u32,
+    sender_proc: u32,
+    /// `stage_id` of the boundary's `input_stage`. Passed to `DrainHandle::register_channel` so
+    /// the sub-buffer this connection streams from sees only frames tagged with the same
+    /// `(stage_id, p)`.
+    stage_id: u32,
 }
 
 impl WorkerConnection for ShmMqWorkerConnection {
-    fn stream_partition(
-        &self,
-        partition: usize,
-        _on_metadata: OnMetadataCallback,
-    ) -> Result<WorkerPartitionStream> {
+    fn stream_partition(&self, partition: usize) -> Result<WorkerPartitionStream> {
         let partition_u32 = u32::try_from(partition).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerConnection: partition={partition} > u32::MAX"
             ))
         })?;
-        let drain = self.mesh.drain(self.worker, partition_u32).ok_or_else(|| {
+        let drain = self.mesh.inbound_drain(self.sender_proc).ok_or_else(|| {
             DataFusionError::Internal(format!(
-                "ShmMqWorkerConnection: no drain for (worker={}, partition={partition_u32})",
-                self.worker
+                "ShmMqWorkerConnection: no inbound drain for sender_proc={} \
+                 (stage_id={}, this_proc={})",
+                self.sender_proc, self.stage_id, self.mesh.this_proc
             ))
         })?;
         let drain = Arc::clone(drain);
-        // Cooperative pull loop: pgrx requires shm_mq FFI on the backend
-        // thread, so the drain pass runs inline here. Each iteration drains
-        // the receiver into the buffer (max 256 batches), then pops one
-        // batch out to yield, then yields back to Tokio so sibling tasks
+        // Ask the drain for the sub-buffer dedicated to this `(stage_id, partition)` channel.
+        // Frames with a matching header land here; frames tagged with other partitions go to
+        // their own sub-buffers, so this consumer only sees its slice.
+        let buffer = drain.register_channel(self.stage_id, partition_u32);
+        crate::mpp_log!(
+            "mpp transport::stream_partition this_proc={} sender_proc={} stage_id={} \
+             partition={partition_u32} (register_channel)",
+            self.mesh.this_proc,
+            self.sender_proc,
+            self.stage_id,
+        );
+        // Cooperative pull loop: pgrx requires shm_mq FFI on the backend thread, so the drain
+        // pass runs inline here. Each iteration drains the receiver into the registry (max 256
+        // batches), then pops one batch out to yield, then yields back to Tokio so sibling tasks
         // (e.g. the leader's own producer subplan) can advance.
         //
-        // `pgrx::check_for_interrupts!()` at the top of every iteration so
-        // a user CANCEL or query timeout `longjmp`s out before the next
-        // drain pass; without it the cooperative spin would keep pumping
-        // batches even after the backend should have torn down. The send
-        // side has the same check inside `MppSender::send_batch_traced`'s
-        // retry loop in `transport.rs`.
+        // `pgrx::check_for_interrupts!()` at the top of every iteration so a user CANCEL or query
+        // timeout `longjmp`s out before the next drain pass; without it the cooperative spin
+        // would keep pumping batches even after the backend should have torn down. The send side
+        // has the same check inside `MppSender::send_batch_traced`'s retry loop in `transport.rs`.
         let stream = async_stream::stream! {
             loop {
                 pgrx::check_for_interrupts!();
@@ -149,7 +241,7 @@ impl WorkerConnection for ShmMqWorkerConnection {
                     yield Err(e);
                     return;
                 }
-                match drain.buffer().try_pop() {
+                match buffer.try_pop() {
                     Some(DrainItem::Batch(batch)) => yield Ok(batch),
                     Some(DrainItem::Eof) => break,
                     None => tokio::task::yield_now().await,
@@ -180,64 +272,5 @@ impl WorkerResolver for MppWorkerResolver {
     fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
         let url = Url::parse("http://mpp.local/").expect("static URL parses");
         Ok(vec![url; self.n_workers])
-    }
-}
-
-/// Worker-side [`WorkerTransport`] that resolves nested network boundaries
-/// (such as a `NetworkBroadcastExec` on the build side of a `HashJoin`) by
-/// executing the boundary's `input_stage.plan` locally on the worker.
-///
-/// In the DF-D fork's gRPC distributed model, every worker would pull the
-/// broadcast data from a designated source via a Flight stream. In our
-/// in-process model the producer fragment that workers run already contains
-/// these network boundary nodes (the worker re-plans from the same logical
-/// plan as the leader), and rather than fan a broadcast across an in-process
-/// mesh we just have each worker re-execute the build-side plan locally —
-/// it's a small index scan, cheap enough that duplicating the work across
-/// `n_workers` producers is preferable to wiring a second mesh.
-///
-/// The worker's session must keep `input_stage.plan = Some(...)` (i.e. the
-/// DF-D fork's `prepare_plan` is *not* invoked on the worker side because we
-/// drop into `find_worker_fragment` below the leader's `DistributedExec`).
-pub struct LocalExecWorkerTransport;
-
-impl WorkerTransport for LocalExecWorkerTransport {
-    fn open(
-        &self,
-        input_stage: &Stage,
-        _target_partitions: Range<usize>,
-        _target_task: usize,
-        ctx: &Arc<TaskContext>,
-    ) -> Result<Box<dyn WorkerConnection>> {
-        let plan = input_stage.plan().cloned().ok_or_else(|| {
-            DataFusionError::Internal(
-                "LocalExecWorkerTransport: input_stage.plan is None — \
-                 worker re-plan must keep the boundary's input subtree intact"
-                    .into(),
-            )
-        })?;
-        Ok(Box::new(LocalExecWorkerConnection {
-            plan,
-            ctx: Arc::clone(ctx),
-        }))
-    }
-}
-
-struct LocalExecWorkerConnection {
-    plan: Arc<dyn ExecutionPlan>,
-    ctx: Arc<TaskContext>,
-}
-
-impl WorkerConnection for LocalExecWorkerConnection {
-    fn stream_partition(
-        &self,
-        partition: usize,
-        _on_metadata: OnMetadataCallback,
-    ) -> Result<WorkerPartitionStream> {
-        let stream = self.plan.execute(partition, Arc::clone(&self.ctx))?;
-        // SendableRecordBatchStream is already `Pin<Box<dyn Stream<Item = Result<RecordBatch>> + Send>>`;
-        // the WorkerPartitionStream alias drops the schema bound, so the
-        // existing pinned box satisfies it directly.
-        Ok(stream)
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/task_estimator.rs
+++ b/pg_search/src/postgres/customscan/mpp/task_estimator.rs
@@ -15,35 +15,17 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Planner-level companion to the dispatcher's [`FragmentRouting::Broadcast`] runtime guard.
+//! Delta from upstream: caps `BroadcastExec` subtrees at `task_count = 1`.
 //!
-//! pg_search's natural-shape Aggregate plan canonical-replicates the HashJoin build subtree
-//! across all workers via the `mpp build all-gather` step. That step replaces the per-worker
-//! scan of the canonical source with a single `DataSourceExec(MemorySourceConfig)` returning the
-//! fully replicated data. Without intervention, the DF-D fork's default task estimator would
-//! annotate this leaf with `Desired(n_workers)`. The resulting `NetworkBroadcastExec` would have
-//! `input_task_count = n_workers`, every input task would emit the full canonical data, and the
-//! consumer's `select_all` would over-count by `input_task_count`.
+//! Upstream DF-D's default estimator returns `Desired(n_workers)` for memory leaves, so a
+//! `NetworkBroadcastExec` built over the canonical-replica all-gather step would get
+//! `input_task_count = n_workers`. Every producer task would re-emit the full build side and the
+//! consumer's `select_all` would over-count by `n_workers`. This estimator caps the build subtree
+//! at one task, so the wire-layer `FragmentRouting::Broadcast` only ever sees `task_idx == 0`.
 //!
-//! [`BroadcastBuildSideOneTaskEstimator`] caps every all-gather memory leaf at
-//! `TaskEstimation::maximum(1)`. That propagates up the build subtree and produces a
-//! `NetworkBroadcastExec(input_task_count=1)`. The single producer emits the canonical data once
-//! per consumer task, and the consumer's `select_all` sees one real stream plus empty
-//! placeholders from the missing input tasks.
-//!
-//! Installed via
-//! [`datafusion_distributed::SessionStateBuilderExt::with_distributed_task_estimator`] in front
-//! of the default per-leaf estimator. The DF-D fork's `CombinedTaskEstimator` iterates registered
-//! estimators and returns the FIRST `Some(_)` (registration order, not "biggest task_count
-//! wins"). That tiebreak runs at the per-stage layer across distinct leaves, not within one
-//! leaf's estimator chain. So this estimator returns `Some(Maximum(1))` for canonical-replica
-//! memory leaves and `None` everywhere else, and the default `Desired(n_workers)` estimator
+//! Registered first in the DF-D `CombinedTaskEstimator` chain, which returns the first `Some(_)`.
+//! Returns `None` for everything that isn't a `BroadcastExec`, so the default leaf estimator
 //! handles the fallthrough.
-//!
-//! With this estimator in place, the dispatcher's [`FragmentRouting::Broadcast`] short-circuit
-//! becomes a defensive `debug_assert!(fragment.task_idx == 0)` rather than a load-bearing
-//! correctness patch. See the doc on
-//! [`crate::postgres::customscan::mpp::worker_fragments::FragmentRouting::Broadcast`].
 
 use std::sync::Arc;
 
@@ -53,17 +35,9 @@ use datafusion_distributed::{BroadcastExec, TaskEstimation, TaskEstimator};
 
 /// Caps every [`BroadcastExec`] subtree at `task_count = 1`.
 ///
-/// In pg_search, every CollectLeft hash join with `broadcast_joins=true` produces a
-/// `BroadcastExec` over the (smaller) build side, and pg_search's scan model treats that build
-/// side as a single canonical replica: the same data on every worker. Capping the
-/// `BroadcastExec`'s task_count at 1 propagates upward and tells `_distribute_plan` to build a
-/// `NetworkBroadcastExec` with `input_task_count = 1`. A single producer task scans the build
-/// side and the fan-out replicates that stream to every consumer task.
-///
-/// Targeting `BroadcastExec` directly (rather than a marker wrapper on the leaf) survives
-/// DataFusion's HashJoin reordering. The planner may flip build/probe based on cost, but the
-/// `BroadcastExec` always sits above the final build side, so the cap lands at the right point
-/// no matter which source ends up there.
+/// Targeting `BroadcastExec` directly (instead of marking the leaf) survives DataFusion's
+/// HashJoin build/probe reordering: the `BroadcastExec` always sits above whichever side ends up
+/// as the build, so the cap lands at the right point regardless.
 #[derive(Debug)]
 pub struct BroadcastBuildSideOneTaskEstimator;
 

--- a/pg_search/src/postgres/customscan/mpp/task_estimator.rs
+++ b/pg_search/src/postgres/customscan/mpp/task_estimator.rs
@@ -1,0 +1,140 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Planner-level companion to the dispatcher's [`FragmentRouting::Broadcast`] runtime guard.
+//!
+//! pg_search's natural-shape Aggregate plan canonical-replicates the HashJoin build subtree
+//! across all workers via the `mpp build all-gather` step. That step replaces the per-worker
+//! scan of the canonical source with a single `DataSourceExec(MemorySourceConfig)` returning the
+//! fully replicated data. Without intervention, the DF-D fork's default task estimator would
+//! annotate this leaf with `Desired(n_workers)`. The resulting `NetworkBroadcastExec` would have
+//! `input_task_count = n_workers`, every input task would emit the full canonical data, and the
+//! consumer's `select_all` would over-count by `input_task_count`.
+//!
+//! [`BroadcastBuildSideOneTaskEstimator`] caps every all-gather memory leaf at
+//! `TaskEstimation::maximum(1)`. That propagates up the build subtree and produces a
+//! `NetworkBroadcastExec(input_task_count=1)`. The single producer emits the canonical data once
+//! per consumer task, and the consumer's `select_all` sees one real stream plus empty
+//! placeholders from the missing input tasks.
+//!
+//! Installed via
+//! [`datafusion_distributed::SessionStateBuilderExt::with_distributed_task_estimator`] in front
+//! of the default per-leaf estimator. The DF-D fork's `CombinedTaskEstimator` iterates registered
+//! estimators and returns the FIRST `Some(_)` (registration order, not "biggest task_count
+//! wins"). That tiebreak runs at the per-stage layer across distinct leaves, not within one
+//! leaf's estimator chain. So this estimator returns `Some(Maximum(1))` for canonical-replica
+//! memory leaves and `None` everywhere else, and the default `Desired(n_workers)` estimator
+//! handles the fallthrough.
+//!
+//! With this estimator in place, the dispatcher's [`FragmentRouting::Broadcast`] short-circuit
+//! becomes a defensive `debug_assert!(fragment.task_idx == 0)` rather than a load-bearing
+//! correctness patch. See the doc on
+//! [`crate::postgres::customscan::mpp::worker_fragments::FragmentRouting::Broadcast`].
+
+use std::sync::Arc;
+
+use datafusion::config::ConfigOptions;
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_distributed::{BroadcastExec, TaskEstimation, TaskEstimator};
+
+/// Caps every [`BroadcastExec`] subtree at `task_count = 1`.
+///
+/// In pg_search, every CollectLeft hash join with `broadcast_joins=true` produces a
+/// `BroadcastExec` over the (smaller) build side, and pg_search's scan model treats that build
+/// side as a single canonical replica: the same data on every worker. Capping the
+/// `BroadcastExec`'s task_count at 1 propagates upward and tells `_distribute_plan` to build a
+/// `NetworkBroadcastExec` with `input_task_count = 1`. A single producer task scans the build
+/// side and the fan-out replicates that stream to every consumer task.
+///
+/// Targeting `BroadcastExec` directly (rather than a marker wrapper on the leaf) survives
+/// DataFusion's HashJoin reordering. The planner may flip build/probe based on cost, but the
+/// `BroadcastExec` always sits above the final build side, so the cap lands at the right point
+/// no matter which source ends up there.
+#[derive(Debug)]
+pub struct BroadcastBuildSideOneTaskEstimator;
+
+impl TaskEstimator for BroadcastBuildSideOneTaskEstimator {
+    fn task_estimation(
+        &self,
+        plan: &Arc<dyn ExecutionPlan>,
+        _: &ConfigOptions,
+    ) -> Option<TaskEstimation> {
+        if plan.as_any().downcast_ref::<BroadcastExec>().is_some() {
+            Some(TaskEstimation::maximum(1))
+        } else {
+            None
+        }
+    }
+
+    fn scale_up_leaf_node(
+        &self,
+        _: &Arc<dyn ExecutionPlan>,
+        _: usize,
+        _: &ConfigOptions,
+    ) -> Option<Arc<dyn ExecutionPlan>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::empty::EmptyExec;
+
+    fn cfg() -> ConfigOptions {
+        ConfigOptions::default()
+    }
+
+    fn empty_leaf() -> Arc<dyn ExecutionPlan> {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        Arc::new(EmptyExec::new(schema))
+    }
+
+    #[test]
+    fn broadcast_exec_is_capped_at_one() {
+        let inner = empty_leaf();
+        let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(inner, 1));
+        let est = BroadcastBuildSideOneTaskEstimator;
+        let out = est.task_estimation(&broadcast, &cfg()).expect("estimation");
+        // `TaskEstimation::maximum(1)` is what propagates up to
+        // `NetworkBroadcastExec::input_task_count = 1`.
+        assert_eq!(out.task_count.as_usize(), 1);
+        // `task_count` is `Maximum`, not `Desired`. Confirm the variant so an accidental
+        // refactor that promotes it to `Desired` (and therefore loses the "hard cap" behaviour)
+        // breaks the test.
+        assert!(matches!(
+            out.task_count,
+            datafusion_distributed::TaskCountAnnotation::Maximum(1)
+        ));
+    }
+
+    #[test]
+    fn non_broadcast_node_falls_through() {
+        let plan = empty_leaf();
+        let est = BroadcastBuildSideOneTaskEstimator;
+        assert!(est.task_estimation(&plan, &cfg()).is_none());
+    }
+
+    #[test]
+    fn scale_up_is_a_no_op() {
+        let inner = empty_leaf();
+        let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(inner, 1));
+        let est = BroadcastBuildSideOneTaskEstimator;
+        assert!(est.scale_up_leaf_node(&broadcast, 7, &cfg()).is_none());
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -49,11 +49,11 @@ use datafusion::common::DataFusionError;
 
 /// Magic bytes "MPPF" (MPP Frame) at the start of every wire message.
 /// Lets receivers reject misrouted / corrupt frames before they hit Arrow IPC.
-pub const MPP_FRAME_MAGIC: u32 = 0x4D505046;
+const MPP_FRAME_MAGIC: u32 = 0x4D505046;
 
 /// Wire-format size of [`MppFrameHeader`] in bytes. Asserted at compile time
 /// below via `const _: ()`.
-pub const MPP_FRAME_HEADER_SIZE: usize = 16;
+const MPP_FRAME_HEADER_SIZE: usize = 16;
 
 /// Kind of payload following [`MppFrameHeader`].
 ///
@@ -63,7 +63,7 @@ pub const MPP_FRAME_HEADER_SIZE: usize = 16;
 /// carry frames for other channels.
 #[repr(u32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MppFrameKind {
+pub(super) enum MppFrameKind {
     Batch = 0,
     Eof = 1,
 }
@@ -122,7 +122,7 @@ impl MppFrameHeader {
     /// Read the kind out of `flags`. Returns an error if the kind byte is
     /// unknown or if any reserved upper bit is set, which catches wire-format
     /// drift early.
-    pub fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
+    pub(super) fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
         let reserved = self.flags & !FRAME_KIND_MASK;
         if reserved != 0 {
             return Err(DataFusionError::Internal(format!(
@@ -183,7 +183,7 @@ impl MppFrameHeader {
 ///
 /// Caller is expected to hold `buf` alive across many encodes so the peak-sized
 /// allocation amortizes (~500 KB/batch on the 25M GROUP BY bench).
-pub fn encode_frame_into(
+fn encode_frame_into(
     header: MppFrameHeader,
     batch: &RecordBatch,
     buf: &mut Vec<u8>,
@@ -204,7 +204,7 @@ pub fn encode_frame_into(
 /// per-partition stream exhausts, so the receiver's `(stage_id, partition)`
 /// sub-buffer transitions to `Eof` even though the multiplexed shm_mq queue
 /// stays attached for other channels.
-pub fn encode_eof_frame_into(
+fn encode_eof_frame_into(
     stage_id: u32,
     partition: u32,
     buf: &mut Vec<u8>,
@@ -218,9 +218,7 @@ pub fn encode_eof_frame_into(
 /// Inverse of [`encode_frame_into`]. Parses the 16-byte header and, for `Batch` frames, decodes
 /// the trailing Arrow IPC stream. `Eof` frames return `(header, None)`. Receivers branch on
 /// `header.kind()` to decide routing.
-pub fn decode_frame(
-    bytes: &[u8],
-) -> Result<(MppFrameHeader, Option<RecordBatch>), DataFusionError> {
+fn decode_frame(bytes: &[u8]) -> Result<(MppFrameHeader, Option<RecordBatch>), DataFusionError> {
     let header = MppFrameHeader::parse(bytes)?;
     match header.kind()? {
         MppFrameKind::Eof => {
@@ -260,7 +258,7 @@ pub fn decode_frame(
 /// Pop side: cooperative consumers loop on `try_pop` + `yield_now`. The test-only `pop_front`
 /// blocks on the condvar.
 #[derive(Debug)]
-pub struct DrainBuffer {
+pub(super) struct DrainBuffer {
     inner: Mutex<DrainBufferInner>,
     cond: Condvar,
 }
@@ -277,7 +275,7 @@ struct DrainBufferInner {
 
 /// Yielded by [`DrainBuffer::pop_front`].
 #[derive(Debug)]
-pub enum DrainItem {
+pub(super) enum DrainItem {
     /// A batch produced by one of the inbound shm_mqs.
     Batch(RecordBatch),
     /// All source queues have detached and the local queue is drained.
@@ -387,7 +385,7 @@ impl DrainBuffer {
 
 /// Outcome of a single non-blocking receive attempt.
 #[derive(Debug)]
-pub enum RecvOutcome {
+pub(super) enum RecvOutcome {
     /// One serialized Arrow IPC message ready to decode.
     Bytes(Vec<u8>),
     /// No data currently available but the peer is still attached.
@@ -399,7 +397,7 @@ pub enum RecvOutcome {
 /// Non-blocking byte channel receiver. Implementations: shm_mq (production),
 /// `std::sync::mpsc` (tests). Must be `Send` because the drain thread takes
 /// ownership.
-pub trait BatchChannelReceiver: Send {
+pub(super) trait BatchChannelReceiver: Send {
     fn try_recv(&self) -> RecvOutcome;
 }
 
@@ -412,7 +410,7 @@ pub trait BatchChannelReceiver: Send {
 /// (`nowait=false`) touches `WaitLatch`/`CHECK_FOR_INTERRUPTS`, which is not
 /// safe off-thread. See [`crate::postgres::customscan::mpp::mesh::ShmMqSender`]
 /// for the safety contract.
-pub trait BatchChannelSender: Send + Sync {
+pub(super) trait BatchChannelSender: Send + Sync {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError>;
 
     /// Non-blocking variant. Returns `Ok(true)` on success, `Ok(false)`
@@ -483,7 +481,10 @@ impl MppSender {
     /// clone one shared `Arc<dyn BatchChannelSender>` across N senders, each with a different
     /// `MppFrameHeader::batch(stage, p)`. That's the multiplexed pattern for fanning multiple
     /// partitions over one shm_mq queue.
-    pub fn with_header(channel: Arc<dyn BatchChannelSender>, header: MppFrameHeader) -> Self {
+    pub(super) fn with_header(
+        channel: Arc<dyn BatchChannelSender>,
+        header: MppFrameHeader,
+    ) -> Self {
         Self {
             channel,
             cooperative_drain: None,
@@ -495,7 +496,7 @@ impl MppSender {
     /// Construct a sender with the default `(stage_id=0, partition=0)` header.
     /// Used by tests where the header carries no actionable routing info.
     #[cfg(test)]
-    pub fn new(channel: Arc<dyn BatchChannelSender>) -> Self {
+    pub(super) fn new(channel: Arc<dyn BatchChannelSender>) -> Self {
         Self::with_header(channel, MppFrameHeader::batch(0, 0))
     }
 
@@ -545,7 +546,7 @@ impl MppSender {
     ///
     /// Async because the cooperative-spin path needs to surrender the
     /// Tokio runtime back periodically — see the body comment.
-    pub async fn send_batch_traced(
+    pub(super) async fn send_batch_traced(
         &self,
         batch: &RecordBatch,
         stats: &mut SendBatchStats,
@@ -585,7 +586,10 @@ impl MppSender {
     /// on. Progress is monotone: at least one `try_send_bytes` succeeds per spin iteration
     /// somewhere in the mesh, so symmetric stalls resolve within a few iterations rather than
     /// deadlocking.
-    pub async fn send_eof_traced(&self, stats: &mut SendBatchStats) -> Result<(), DataFusionError> {
+    pub(super) async fn send_eof_traced(
+        &self,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
         let mut scratch = self.scratch.replace(Vec::new());
         let result = self.send_eof_with_scratch(&mut scratch, stats).await;
         self.scratch.replace(scratch);
@@ -693,7 +697,7 @@ impl MppSender {
 /// Per-call timing + spin metrics for [`MppSender::send_batch_traced`].
 /// All fields accumulate; callers zero or reuse as needed.
 #[derive(Default, Debug, Clone)]
-pub struct SendBatchStats {
+pub(super) struct SendBatchStats {
     /// Cumulative time spent inside `encode_frame_into` (header + Arrow IPC serialization).
     pub encode: Duration,
     /// Cumulative wall time in the send-retry spin after the first failed
@@ -710,7 +714,7 @@ pub struct SendBatchStats {
 
 /// High-level receiver: pulls bytes via the underlying channel and decodes them
 /// into `RecordBatch`. Used by the drain thread.
-pub struct MppReceiver {
+pub(super) struct MppReceiver {
     channel: Box<dyn BatchChannelReceiver>,
 }
 
@@ -719,7 +723,7 @@ impl MppReceiver {
         Self { channel }
     }
 
-    pub fn try_recv_batch(&self) -> RecvBatchOutcome {
+    pub(super) fn try_recv_batch(&self) -> RecvBatchOutcome {
         match self.channel.try_recv() {
             RecvOutcome::Bytes(bytes) => match decode_frame(&bytes) {
                 Ok((header, Some(batch))) => RecvBatchOutcome::Batch { header, batch },
@@ -736,7 +740,7 @@ impl MppReceiver {
 /// parsed [`MppFrameHeader`] so the drain thread can route the payload to
 /// the right `(stage_id, partition)` sub-buffer.
 #[derive(Debug)]
-pub enum RecvBatchOutcome {
+pub(super) enum RecvBatchOutcome {
     Batch {
         header: MppFrameHeader,
         batch: RecordBatch,
@@ -757,7 +761,7 @@ pub enum RecvBatchOutcome {
 /// (including `shm_mq_receive`) from a non-backend thread, so production never spawns a drain
 /// thread — see [`DrainHandle::cooperative`] for the cooperative path.
 #[cfg(test)]
-pub struct DrainConfig {
+struct DrainConfig {
     /// Receivers to drain. Ownership moves into the spawned thread.
     pub receivers: Vec<MppReceiver>,
     /// Destination buffer.
@@ -786,7 +790,7 @@ impl DrainConfig {
 /// done as soon as it observes a detach or decode error. When every source is
 /// done, the thread exits.
 #[cfg(test)]
-pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusionError>> {
+fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusionError>> {
     thread::spawn(move || drain_loop(config))
 }
 
@@ -795,7 +799,7 @@ pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusi
 /// never outlive the test scope even on a panic. Production code never spawns a drain thread —
 /// see [`DrainHandle`] for the cooperative variant that runs inline on the backend thread.
 #[cfg(test)]
-pub struct ThreadedDrainHandle {
+struct ThreadedDrainHandle {
     buffer: Arc<DrainBuffer>,
     join: Mutex<Option<JoinHandle<Result<(), DataFusionError>>>>,
 }
@@ -865,7 +869,7 @@ impl DrainHandle {
     /// Construct a cooperative drain handle. Sub-buffers are populated lazily by
     /// [`Self::try_drain_pass`] when a frame arrives, or up-front by [`Self::register_channel`]
     /// when a consumer needs a buffer to wait on before any frame has come in.
-    pub fn cooperative(receivers: Vec<MppReceiver>) -> Self {
+    pub(super) fn cooperative(receivers: Vec<MppReceiver>) -> Self {
         let wrapped = receivers.into_iter().map(Some).collect();
         Self {
             sub_buffers: Mutex::new(SubBufferRegistry::default()),
@@ -881,7 +885,7 @@ impl DrainHandle {
     /// If the drain has already observed `Detached` from its underlying receiver, the
     /// newly-created buffer comes back with `notify_source_done` already called so a consumer
     /// registering after detach sees `Eof` on the first `try_pop` instead of hanging forever.
-    pub fn register_channel(&self, stage_id: u32, partition: u32) -> Arc<DrainBuffer> {
+    pub(super) fn register_channel(&self, stage_id: u32, partition: u32) -> Arc<DrainBuffer> {
         let mut guard = self
             .sub_buffers
             .lock()
@@ -1095,16 +1099,16 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
 /// steady state. The current-thread Tokio runtime interleaves producer and consumer fragments
 /// via `yield_now().await`, so backpressure would be benign anyway, but unbounded rules out any
 /// chance of self-deadlock if the producer never yields.
-pub fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
+pub(super) fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
     (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
 }
 
-pub struct InProcSender {
+pub(super) struct InProcSender {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
 }
 
-pub struct InProcReceiver {
+pub(super) struct InProcReceiver {
     // The std::sync::mpsc receiver is !Sync; wrap in a Mutex so the drain
     // thread can hold it behind a `Box<dyn BatchChannelReceiver>` (which is
     // `Send + Sync`-relaxed by design, but we only need Send for the thread
@@ -1146,7 +1150,7 @@ impl BatchChannelReceiver for InProcReceiver {
 /// `std::sync::mpsc::sync_channel` API requires a numeric capacity; this constant picks one large
 /// enough that production workloads won't reach it but small enough that a runaway producer
 /// (e.g. infinite-loop bug) won't allocate billions of `Vec<u8>` before OOM.
-pub const SELF_LOOP_CAPACITY: usize = 1 << 20;
+pub(super) const SELF_LOOP_CAPACITY: usize = 1 << 20;
 
 #[cfg(test)]
 mod tests {

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -1167,22 +1167,6 @@ mod tests {
     }
 
     #[test]
-    fn codec_round_trips_a_batch() {
-        let orig = sample_batch(128);
-        let mut buf = Vec::with_capacity(1024);
-        encode_frame_into(MppFrameHeader::batch(0, 0), &orig, &mut buf).expect("encode");
-        let (_header, decoded) = decode_frame(&buf).expect("decode");
-        let decoded = decoded.expect("Batch frame must carry a payload");
-        assert_eq!(orig.schema(), decoded.schema());
-        assert_eq!(orig.num_rows(), decoded.num_rows());
-        assert_eq!(orig.num_columns(), decoded.num_columns());
-        // Equality across the whole batch
-        for col in 0..orig.num_columns() {
-            assert_eq!(orig.column(col).as_ref(), decoded.column(col).as_ref());
-        }
-    }
-
-    #[test]
     fn frame_round_trips_a_batch_with_header() {
         let orig = sample_batch(64);
         let header = MppFrameHeader::batch(7, 3);
@@ -1192,9 +1176,13 @@ mod tests {
         let (parsed, batch_opt) = decode_frame(&buf).expect("decode_frame");
         assert_eq!(parsed, header);
         assert_eq!(parsed.kind().unwrap(), MppFrameKind::Batch);
-        let batch = batch_opt.expect("Batch frame must carry a payload");
-        assert_eq!(batch.num_rows(), 64);
-        assert_eq!(batch.schema(), orig.schema());
+        let decoded = batch_opt.expect("Batch frame must carry a payload");
+        assert_eq!(decoded.num_rows(), 64);
+        assert_eq!(decoded.schema(), orig.schema());
+        assert_eq!(decoded.num_columns(), orig.num_columns());
+        for col in 0..orig.num_columns() {
+            assert_eq!(orig.column(col).as_ref(), decoded.column(col).as_ref());
+        }
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -699,17 +699,17 @@ impl MppSender {
 #[derive(Default, Debug, Clone)]
 pub(super) struct SendBatchStats {
     /// Cumulative time spent inside `encode_frame_into` (header + Arrow IPC serialization).
-    pub encode: Duration,
+    pub(super) encode: Duration,
     /// Cumulative wall time in the send-retry spin after the first failed
     /// `try_send_bytes`. Zero if the first try succeeded.
-    pub send_wait: Duration,
+    pub(super) send_wait: Duration,
     /// Cumulative time spent in `try_drain_pass` while spinning on a
     /// full outbound. A subset of `send_wait`; the remainder is the
     /// `tokio::task::yield_now()` await + the (small) cost of
     /// `try_send_bytes` itself.
-    pub coop_drain_in_spin: Duration,
+    pub(super) coop_drain_in_spin: Duration,
     /// Count of `try_send_bytes` calls that returned `Ok(false)` (full).
-    pub spin_iters: u64,
+    pub(super) spin_iters: u64,
 }
 
 /// High-level receiver: pulls bytes via the underlying channel and decodes them
@@ -763,18 +763,18 @@ pub(super) enum RecvBatchOutcome {
 #[cfg(test)]
 struct DrainConfig {
     /// Receivers to drain. Ownership moves into the spawned thread.
-    pub receivers: Vec<MppReceiver>,
+    receivers: Vec<MppReceiver>,
     /// Destination buffer.
-    pub buffer: Arc<DrainBuffer>,
+    buffer: Arc<DrainBuffer>,
     /// How long to sleep when every receiver is empty but some are still
     /// attached. Tuning: small values reduce end-of-batch latency but raise
     /// CPU; 1 ms is a safe default until we integrate with WaitLatch.
-    pub idle_sleep: Duration,
+    idle_sleep: Duration,
 }
 
 #[cfg(test)]
 impl DrainConfig {
-    pub fn new(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
+    fn new(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
         Self {
             receivers,
             buffer,

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -22,8 +22,8 @@
 //!   payload with `(stage_id, partition)`, so one underlying queue can carry frames for many
 //!   logical channels at once. That's what the multi-stage natural-shape path needs.
 //! - [`encode_frame_into`] / [`decode_frame`] serialize a `RecordBatch` with a header prefix via
-//!   Arrow IPC. [`encode_batch`] / [`decode_batch`] are test-only header-less wrappers for codec
-//!   round-trip tests.
+//!   Arrow IPC. They're the only codec entry points; tests round-trip through the same path so
+//!   the wire format under test always matches production.
 //! - [`DrainBuffer`] is the local per-participant queue that the drain thread
 //!   writes into and the DataFusion consumer reads from. It decouples
 //!   consumer-side backpressure from producer-side backpressure: the drain thread
@@ -173,19 +173,6 @@ impl MppFrameHeader {
     }
 }
 
-/// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message,
-/// header-less. Test-only; production code paths go through
-/// [`encode_frame_into`] so the wire format always carries an [`MppFrameHeader`].
-#[cfg(test)]
-pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
-    let mut buf = Vec::with_capacity(1024);
-    let mut writer = StreamWriter::try_new(&mut buf, batch.schema_ref())?;
-    writer.write(batch)?;
-    writer.finish()?;
-    drop(writer);
-    Ok(buf)
-}
-
 /// Serialize `batch` into `buf` with a 16-byte [`MppFrameHeader`] prefix
 /// addressing it to `(stage_id, partition)`. Wire format:
 ///
@@ -226,17 +213,6 @@ pub fn encode_eof_frame_into(
     buf.resize(MPP_FRAME_HEADER_SIZE, 0);
     MppFrameHeader::eof(stage_id, partition).write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
     Ok(())
-}
-
-/// Inverse of [`encode_batch`]. Expects exactly one batch per message,
-/// header-less. Test-only.
-#[cfg(test)]
-pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusionError> {
-    let mut reader = StreamReader::try_new(bytes, None)?;
-    let batch = reader.next().ok_or_else(|| {
-        DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_batch".into())
-    })??;
-    Ok(batch)
 }
 
 /// Inverse of [`encode_frame_into`]. Parses the 16-byte header and, for `Batch` frames, decodes
@@ -718,7 +694,7 @@ impl MppSender {
 /// All fields accumulate; callers zero or reuse as needed.
 #[derive(Default, Debug, Clone)]
 pub struct SendBatchStats {
-    /// Cumulative time spent inside `encode_batch` (Arrow IPC serialization).
+    /// Cumulative time spent inside `encode_frame_into` (header + Arrow IPC serialization).
     pub encode: Duration,
     /// Cumulative wall time in the send-retry spin after the first failed
     /// `try_send_bytes`. Zero if the first try succeeded.
@@ -1193,8 +1169,10 @@ mod tests {
     #[test]
     fn codec_round_trips_a_batch() {
         let orig = sample_batch(128);
-        let bytes = encode_batch(&orig).expect("encode");
-        let decoded = decode_batch(&bytes).expect("decode");
+        let mut buf = Vec::with_capacity(1024);
+        encode_frame_into(MppFrameHeader::batch(0, 0), &orig, &mut buf).expect("encode");
+        let (_header, decoded) = decode_frame(&buf).expect("decode");
+        let decoded = decoded.expect("Batch frame must carry a payload");
         assert_eq!(orig.schema(), decoded.schema());
         assert_eq!(orig.num_rows(), decoded.num_rows());
         assert_eq!(orig.num_columns(), decoded.num_columns());
@@ -1292,10 +1270,12 @@ mod tests {
 
     #[test]
     fn codec_round_trips_many_batch_sizes() {
+        let mut buf = Vec::with_capacity(1024);
         for rows in [0, 1, 7, 64, 1024] {
             let orig = sample_batch(rows);
-            let bytes = encode_batch(&orig).expect("encode");
-            let decoded = decode_batch(&bytes).expect("decode");
+            encode_frame_into(MppFrameHeader::batch(0, 0), &orig, &mut buf).expect("encode");
+            let (_header, decoded) = decode_frame(&buf).expect("decode");
+            let decoded = decoded.expect("Batch frame must carry a payload");
             assert_eq!(orig.num_rows(), decoded.num_rows());
         }
     }
@@ -1566,8 +1546,11 @@ mod tests {
         // separately. Real queries encode inside the hot path per batch.
         let enc_start = Instant::now();
         let mut enc_bytes = 0usize;
+        let mut enc_buf = Vec::with_capacity(1024);
         for _ in 0..batches {
-            enc_bytes += encode_batch(&template).expect("encode").len();
+            encode_frame_into(MppFrameHeader::batch(0, 0), &template, &mut enc_buf)
+                .expect("encode");
+            enc_bytes += enc_buf.len();
         }
         let enc_elapsed = enc_start.elapsed();
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -18,7 +18,12 @@
 //! Transport layer for MPP shuffle.
 //!
 //! Layout:
-//! - [`encode_batch`] / [`decode_batch`] serialize `RecordBatch` via Arrow IPC.
+//! - [`MppFrameHeader`] is a fixed 16-byte prefix every wire message carries. It tags the
+//!   payload with `(stage_id, partition)`, so one underlying queue can carry frames for many
+//!   logical channels at once. That's what the multi-stage natural-shape path needs.
+//! - [`encode_frame_into`] / [`decode_frame`] serialize a `RecordBatch` with a header prefix via
+//!   Arrow IPC. [`encode_batch`] / [`decode_batch`] are test-only header-less wrappers for codec
+//!   round-trip tests.
 //! - [`DrainBuffer`] is the local per-participant queue that the drain thread
 //!   writes into and the DataFusion consumer reads from. It decouples
 //!   consumer-side backpressure from producer-side backpressure: the drain thread
@@ -29,9 +34,8 @@
 //! The shm_mq-backed sender/receiver and drain thread spawn logic build on
 //! top of these primitives.
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
-use std::task::Waker;
 #[cfg(test)]
 use std::thread;
 use std::thread::JoinHandle;
@@ -42,31 +46,190 @@ use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::common::DataFusionError;
 
-/// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message.
+/// Magic bytes "MPPF" (MPP Frame) at the start of every wire message.
+/// Lets receivers reject misrouted / corrupt frames before they hit Arrow IPC.
+pub const MPP_FRAME_MAGIC: u32 = 0x4D505046;
+
+/// Wire-format size of [`MppFrameHeader`] in bytes. Asserted at compile time
+/// below via `const _: ()`.
+pub const MPP_FRAME_HEADER_SIZE: usize = 16;
+
+/// Kind of payload following [`MppFrameHeader`].
 ///
-/// Test-only allocating wrapper for [`encode_batch_into`]; production hot paths
-/// reuse a scratch `Vec` so the ~500 KB/batch allocator traffic the 25M GROUP BY
-/// benchmark once spent 19 s on stays out of the critical loop.
+/// `Batch` is the common case. The header is followed by an Arrow IPC stream containing one
+/// `RecordBatch`. `Eof` carries no payload. It signals the receiver that the named
+/// `(stage_id, partition)` channel is done, even though the underlying shm_mq queue may still
+/// carry frames for other channels.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MppFrameKind {
+    Batch = 0,
+    Eof = 1,
+}
+
+/// 16-byte prefix on every transport frame.
+///
+/// The fixed layout `[magic, flags, stage_id, partition]` (4×u32) is what
+/// senders prepend before the Arrow IPC stream bytes and what receivers
+/// parse before deciding which sub-buffer the payload belongs to.
+///
+/// The `flags` word currently encodes `MppFrameKind` in its low byte (mask
+/// `0x0000_00FF`); the upper 24 bits are reserved-must-be-zero and are
+/// validated at parse time so a future use can repurpose them without a
+/// wire-format break.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MppFrameHeader {
+    pub magic: u32,
+    pub flags: u32,
+    pub stage_id: u32,
+    pub partition: u32,
+}
+
+/// Bit mask in [`MppFrameHeader::flags`] for the [`MppFrameKind`] discriminant.
+const FRAME_KIND_MASK: u32 = 0x0000_00FF;
+
+const _: () = {
+    // shm_mq slot layout calculations depend on this being exact.
+    assert!(std::mem::size_of::<MppFrameHeader>() == MPP_FRAME_HEADER_SIZE);
+};
+
+impl MppFrameHeader {
+    /// Build a `Batch` header for the given `(stage_id, partition)`.
+    pub fn batch(stage_id: u32, partition: u32) -> Self {
+        Self {
+            magic: MPP_FRAME_MAGIC,
+            flags: MppFrameKind::Batch as u32,
+            stage_id,
+            partition,
+        }
+    }
+
+    /// Build an `Eof` header for the given `(stage_id, partition)`. Carries no payload; receivers
+    /// route it to the sub-buffer's source-done counter. Emitted by
+    /// [`MppSender::send_eof_traced`] after a producer fragment's per-partition stream exhausts
+    /// (or errors), and consumed by the matching sub-buffer's `notify_source_done`.
+    pub fn eof(stage_id: u32, partition: u32) -> Self {
+        Self {
+            magic: MPP_FRAME_MAGIC,
+            flags: MppFrameKind::Eof as u32,
+            stage_id,
+            partition,
+        }
+    }
+
+    /// Read the kind out of `flags`. Returns an error if the kind byte is
+    /// unknown or if any reserved upper bit is set, which catches wire-format
+    /// drift early.
+    pub fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
+        let reserved = self.flags & !FRAME_KIND_MASK;
+        if reserved != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: reserved frame flag bits set ({reserved:#x})"
+            )));
+        }
+        match self.flags & FRAME_KIND_MASK {
+            0 => Ok(MppFrameKind::Batch),
+            1 => Ok(MppFrameKind::Eof),
+            other => Err(DataFusionError::Internal(format!(
+                "mpp: unknown frame kind {other:#x}"
+            ))),
+        }
+    }
+
+    /// Serialize into the first `MPP_FRAME_HEADER_SIZE` bytes of `out`.
+    /// `out.len()` must be `>= MPP_FRAME_HEADER_SIZE`.
+    fn write_to(&self, out: &mut [u8]) {
+        debug_assert!(out.len() >= MPP_FRAME_HEADER_SIZE);
+        out[0..4].copy_from_slice(&self.magic.to_le_bytes());
+        out[4..8].copy_from_slice(&self.flags.to_le_bytes());
+        out[8..12].copy_from_slice(&self.stage_id.to_le_bytes());
+        out[12..16].copy_from_slice(&self.partition.to_le_bytes());
+    }
+
+    /// Parse from the first `MPP_FRAME_HEADER_SIZE` bytes of `bytes`. Returns
+    /// `Err` if the slice is too short or the magic doesn't match.
+    fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
+        if bytes.len() < MPP_FRAME_HEADER_SIZE {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: frame too short for header ({} < {})",
+                bytes.len(),
+                MPP_FRAME_HEADER_SIZE
+            )));
+        }
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        if magic != MPP_FRAME_MAGIC {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: bad frame magic {magic:#x} (expected {MPP_FRAME_MAGIC:#x})"
+            )));
+        }
+        Ok(Self {
+            magic,
+            flags: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+            stage_id: u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
+            partition: u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
+        })
+    }
+}
+
+/// Serialize one `RecordBatch` as a self-contained Arrow IPC Stream message,
+/// header-less. Test-only; production code paths go through
+/// [`encode_frame_into`] so the wire format always carries an [`MppFrameHeader`].
 #[cfg(test)]
 pub fn encode_batch(batch: &RecordBatch) -> Result<Vec<u8>, DataFusionError> {
     let mut buf = Vec::with_capacity(1024);
-    encode_batch_into(batch, &mut buf)?;
+    let mut writer = StreamWriter::try_new(&mut buf, batch.schema_ref())?;
+    writer.write(batch)?;
+    writer.finish()?;
+    drop(writer);
     Ok(buf)
 }
 
-/// Serialize `batch` into `buf`, clearing `buf` first so the caller's
-/// already-allocated capacity is reused. Caller is expected to hold `buf`
-/// alive across many encode calls (one per sender) so the peak-sized
-/// allocation amortizes.
-pub fn encode_batch_into(batch: &RecordBatch, buf: &mut Vec<u8>) -> Result<(), DataFusionError> {
+/// Serialize `batch` into `buf` with a 16-byte [`MppFrameHeader`] prefix
+/// addressing it to `(stage_id, partition)`. Wire format:
+///
+/// ```text
+/// [ magic | flags | stage_id | partition ] [ Arrow IPC stream bytes ]
+/// |---------- 16 bytes --------|           |---- variable ----|
+/// ```
+///
+/// Caller is expected to hold `buf` alive across many encodes so the peak-sized
+/// allocation amortizes (~500 KB/batch on the 25M GROUP BY bench).
+pub fn encode_frame_into(
+    header: MppFrameHeader,
+    batch: &RecordBatch,
+    buf: &mut Vec<u8>,
+) -> Result<(), DataFusionError> {
     buf.clear();
+    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
+    header.write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
     let mut writer = StreamWriter::try_new(&mut *buf, batch.schema_ref())?;
     writer.write(batch)?;
     writer.finish()?;
     Ok(())
 }
 
-/// Inverse of [`encode_batch`]. Expects exactly one batch per message.
+/// Serialize a payload-less [`MppFrameKind::Eof`] frame for `(stage_id, partition)`
+/// into `buf`. The shm_mq peer reads this as a 16-byte message and routes it to
+/// the sub-buffer's source-done counter without touching Arrow IPC.
+/// Consumed by [`MppSender::send_eof_traced`] when a producer fragment's
+/// per-partition stream exhausts, so the receiver's `(stage_id, partition)`
+/// sub-buffer transitions to `Eof` even though the multiplexed shm_mq queue
+/// stays attached for other channels.
+pub fn encode_eof_frame_into(
+    stage_id: u32,
+    partition: u32,
+    buf: &mut Vec<u8>,
+) -> Result<(), DataFusionError> {
+    buf.clear();
+    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
+    MppFrameHeader::eof(stage_id, partition).write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
+    Ok(())
+}
+
+/// Inverse of [`encode_batch`]. Expects exactly one batch per message,
+/// header-less. Test-only.
+#[cfg(test)]
 pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusionError> {
     let mut reader = StreamReader::try_new(bytes, None)?;
     let batch = reader.next().ok_or_else(|| {
@@ -75,15 +238,50 @@ pub fn decode_batch(bytes: &[u8]) -> Result<RecordBatch, DataFusionError> {
     Ok(batch)
 }
 
-/// Local queue that sits between the drain thread and the DataFusion consumer.
+/// Inverse of [`encode_frame_into`]. Parses the 16-byte header and, for `Batch` frames, decodes
+/// the trailing Arrow IPC stream. `Eof` frames return `(header, None)`. Receivers branch on
+/// `header.kind()` to decide routing.
+pub fn decode_frame(
+    bytes: &[u8],
+) -> Result<(MppFrameHeader, Option<RecordBatch>), DataFusionError> {
+    let header = MppFrameHeader::parse(bytes)?;
+    match header.kind()? {
+        MppFrameKind::Eof => {
+            if bytes.len() != MPP_FRAME_HEADER_SIZE {
+                return Err(DataFusionError::Internal(format!(
+                    "mpp: Eof frame carries payload ({} > {})",
+                    bytes.len(),
+                    MPP_FRAME_HEADER_SIZE
+                )));
+            }
+            Ok((header, None))
+        }
+        MppFrameKind::Batch => {
+            let payload = &bytes[MPP_FRAME_HEADER_SIZE..];
+            let mut reader = StreamReader::try_new(payload, None)?;
+            let batch = reader.next().ok_or_else(|| {
+                DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_frame".into())
+            })??;
+            Ok((header, Some(batch)))
+        }
+    }
+}
+
+/// Local queue between a drain (either the cooperative `try_drain_pass` or the test-only thread
+/// variant) and the consumer that pops batches.
 ///
-/// Push side: the drain thread appends fully-deserialized batches as they arrive
-/// from inbound shm_mqs. When a source queue detaches, [`DrainBuffer::notify_source_done`]
-/// is called; once all sources are done AND the queue is empty, `pop_front` returns
-/// [`DrainItem::Eof`].
+/// In the cooperative path each `DrainBuffer` corresponds to one logical channel: one
+/// `(stage_id, partition)` entry in the owning [`DrainHandle`]'s registry. `num_sources` is
+/// always `1` there because a given drain serves a single sender_proc, which is the only producer
+/// for any channel routed through it. The test-only thread path uses a single shared buffer with
+/// `num_sources = N` over an N-sender setup.
 ///
-/// Pop side: the consumer calls `pop_front` which blocks on the condvar until
-/// either a batch is available or EOF has been reached.
+/// Push side: callers append deserialized batches; on source detach (or per-channel `Eof` frame)
+/// [`DrainBuffer::notify_source_done`] is called. Once `sources_done >= num_sources` AND the
+/// queue is empty, `try_pop` returns [`DrainItem::Eof`].
+///
+/// Pop side: cooperative consumers loop on `try_pop` + `yield_now`. The test-only `pop_front`
+/// blocks on the condvar.
 #[derive(Debug)]
 pub struct DrainBuffer {
     inner: Mutex<DrainBufferInner>,
@@ -95,15 +293,9 @@ struct DrainBufferInner {
     queue: VecDeque<RecordBatch>,
     num_sources: u32,
     sources_done: u32,
-    /// Consumer-side cancel flag. When set (e.g., query cancelled), the drain
-    /// thread should stop pushing and unblock waiting consumers with EOF.
+    /// Consumer-side cancel flag. When set (e.g., query cancelled or `DrainHandle` dropped),
+    /// `try_pop`/`pop_front` returns `Eof` even if `sources_done` hasn't reached `num_sources`.
     cancelled: bool,
-    /// Most recently registered async waker from a `poll_pop_front` caller.
-    /// Woken on push / source-done / cancel so a stream running inside a
-    /// DataFusion `poll_next` returns `Poll::Pending` without blocking the
-    /// executor thread. `Option` so we don't allocate one if the buffer is
-    /// only consumed synchronously via `pop_front`.
-    waker: Option<Waker>,
 }
 
 /// Yielded by [`DrainBuffer::pop_front`].
@@ -126,7 +318,6 @@ impl DrainBuffer {
                 num_sources,
                 sources_done: 0,
                 cancelled: false,
-                waker: None,
             }),
             cond: Condvar::new(),
         })
@@ -137,21 +328,16 @@ impl DrainBuffer {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         guard.queue.push_back(batch);
         self.cond.notify_one();
-        if let Some(w) = guard.waker.take() {
-            w.wake();
-        }
     }
 
     /// Mark one source queue as detached. Safe to call from the drain thread
-    /// after observing `SHM_MQ_DETACHED` on a given inbound queue.
+    /// after observing `SHM_MQ_DETACHED` on a given inbound queue or from
+    /// [`DrainHandle::mark_detached`] when the underlying receiver has died.
     pub fn notify_source_done(&self) {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         guard.sources_done = guard.sources_done.saturating_add(1);
         if guard.sources_done >= guard.num_sources {
             self.cond.notify_all();
-            if let Some(w) = guard.waker.take() {
-                w.wake();
-            }
         }
     }
 
@@ -160,9 +346,6 @@ impl DrainBuffer {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         guard.cancelled = true;
         self.cond.notify_all();
-        if let Some(w) = guard.waker.take() {
-            w.wake();
-        }
     }
 
     /// Block until a batch is available, EOF is reached, or the buffer is
@@ -198,22 +381,22 @@ impl DrainBuffer {
             .cancelled
     }
 
-    /// Non-blocking, non-waker variant. Returns the
-    /// front item or `DrainItem::Eof` if all sources have detached and
-    /// the queue is drained; returns `None` only when more data may yet
-    /// arrive. Cooperative consumers loop on `try_drain_pass` + `try_pop`,
-    /// yielding to the executor between iterations.
+    /// Non-blocking variant. Returns the front item, or `DrainItem::Eof` if
+    /// all sources have detached and the queue is drained, or `None` if more
+    /// data may yet arrive. Cooperative consumers loop on
+    /// `try_drain_pass` + `try_pop`, yielding to the executor between
+    /// iterations.
     pub fn try_pop(&self) -> Option<DrainItem> {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         Self::try_pop_locked(&mut guard)
     }
 
-    /// Shared body of [`try_pop`] and [`poll_pop_front`]. Returns
-    /// `Some(Batch)` if the queue has data, `Some(Eof)` if all sources
-    /// have detached or the buffer is cancelled, and `None` otherwise.
-    /// Lets the two public entry points stay in lockstep on the
-    /// "buffered data wins over cancellation/EOF" invariant locked in
-    /// by `drain_buffer_drains_buffered_before_eof`.
+    /// Shared body of [`try_pop`] and the test-only [`Self::pop_front`].
+    /// Returns `Some(Batch)` if the queue has data, `Some(Eof)` if all
+    /// sources have detached or the buffer is cancelled, and `None`
+    /// otherwise. Lets the two entry points stay in lockstep on the
+    /// "buffered data wins over cancellation/EOF" invariant locked in by
+    /// the `drain_buffer_drains_buffered_before_eof` test.
     fn try_pop_locked(guard: &mut MutexGuard<'_, DrainBufferInner>) -> Option<DrainItem> {
         if let Some(batch) = guard.queue.pop_front() {
             return Some(DrainItem::Batch(batch));
@@ -252,7 +435,7 @@ pub trait BatchChannelReceiver: Send {
 /// (`nowait=false`) touches `WaitLatch`/`CHECK_FOR_INTERRUPTS`, which is not
 /// safe off-thread. See [`crate::postgres::customscan::mpp::mesh::ShmMqSender`]
 /// for the safety contract.
-pub trait BatchChannelSender: Send {
+pub trait BatchChannelSender: Send + Sync {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError>;
 
     /// Non-blocking variant. Returns `Ok(true)` on success, `Ok(false)`
@@ -264,23 +447,44 @@ pub trait BatchChannelSender: Send {
     }
 }
 
-/// High-level sender: encodes a `RecordBatch` then pushes bytes through the
-/// underlying channel.
+/// Pluggable "drain everything inbound" hook for [`MppSender`]'s cooperative send spin. The
+/// peer-mesh deadlock-breaking pattern needs the producer to pump ALL inbound queues (not just
+/// one) while waiting for a full outbound, so the implementation typically delegates to
+/// `MppMesh::drain_all_inbound()` which iterates every per-sender-proc drain.
+pub trait CooperativeDrainSet: Send + Sync {
+    fn try_drain_pass(&self) -> Result<(), DataFusionError>;
+}
+
+impl CooperativeDrainSet for DrainHandle {
+    fn try_drain_pass(&self) -> Result<(), DataFusionError> {
+        DrainHandle::try_drain_pass(self)
+    }
+}
+
+/// High-level sender: encodes a `RecordBatch` then pushes bytes through the underlying channel.
 ///
-/// With `cooperative_drain` set, `send_batch` breaks the symmetric-send
-/// deadlock on a single-threaded tokio runtime by interleaving send-retries
-/// with `DrainHandle::try_drain_pass` on the same mesh's inbound side.
-/// Each participant's sender doing the same guarantees mutual progress:
-/// our drain pulls peer-shipped rows out of our inbound queues, which
-/// frees peers' outbound-to-us send space, which lets their sends un-stall.
+/// With `cooperative_drain` set, `send_batch` breaks the symmetric-send deadlock on a
+/// single-threaded tokio runtime by interleaving send-retries with
+/// `CooperativeDrainSet::try_drain_pass` on the same mesh's inbound side. Each participant's
+/// sender doing the same guarantees mutual progress: our drain pulls peer-shipped rows out of
+/// our inbound queues, which frees peers' outbound-to-us send space, which lets their sends
+/// un-stall.
 pub struct MppSender {
-    channel: Box<dyn BatchChannelSender>,
-    cooperative_drain: Option<Arc<DrainHandle>>,
-    /// Scratch buffer reused across every `encode_batch_into` on this
-    /// sender. Sized by the first batch; subsequent batches clear and
-    /// re-fill without reallocating. Interior mutability lets the caller
-    /// keep the `&self` signature (senders live inside `ShuffleWiring`
-    /// behind a shared borrow during `process_batch`).
+    /// Underlying byte channel. Held behind `Arc` so multiple `MppSender`s can share one
+    /// `shm_mq` queue while tagging frames with different `(stage_id, partition)` headers, which
+    /// is the multiplexed path's natural pattern. Clone the Arc, build a new `MppSender` with a
+    /// different header, both write into the same queue.
+    channel: Arc<dyn BatchChannelSender>,
+    cooperative_drain: Option<Arc<dyn CooperativeDrainSet>>,
+    /// Frame header prepended to every outgoing batch. Identifies the logical
+    /// `(stage_id, partition)` channel the receiver demultiplexes on. Per-sender rather than
+    /// per-call: each partition gets its own `MppSender` via `clone_with_header`, all sharing
+    /// the underlying `Arc<dyn BatchChannelSender>` of a single shm_mq queue.
+    header: MppFrameHeader,
+    /// Scratch buffer reused across every `encode_frame_into` on this sender. Sized by the first
+    /// batch; subsequent batches clear and re-fill without reallocating. Interior mutability
+    /// lets the caller keep the `&self` signature (senders live inside `ShuffleWiring` behind a
+    /// shared borrow during `process_batch`).
     scratch: std::cell::RefCell<Vec<u8>>,
 }
 
@@ -298,12 +502,47 @@ pub struct MppSender {
 unsafe impl Sync for MppSender {}
 
 impl MppSender {
-    pub fn new(channel: Box<dyn BatchChannelSender>) -> Self {
+    /// Construct a sender that tags every outgoing batch with `header`. Production call sites
+    /// clone one shared `Arc<dyn BatchChannelSender>` across N senders, each with a different
+    /// `MppFrameHeader::batch(stage, p)`. That's the multiplexed pattern for fanning multiple
+    /// partitions over one shm_mq queue.
+    pub fn with_header(channel: Arc<dyn BatchChannelSender>, header: MppFrameHeader) -> Self {
         Self {
             channel,
             cooperative_drain: None,
+            header,
             scratch: std::cell::RefCell::new(Vec::new()),
         }
+    }
+
+    /// Construct a sender with the default `(stage_id=0, partition=0)` header.
+    /// Used by tests where the header carries no actionable routing info.
+    #[cfg(test)]
+    pub fn new(channel: Arc<dyn BatchChannelSender>) -> Self {
+        Self::with_header(channel, MppFrameHeader::batch(0, 0))
+    }
+
+    /// Build a new `MppSender` that shares this sender's underlying channel
+    /// but tags every frame with `header` instead. Used by callers that know
+    /// the physical plan's output partition count and need one sender per
+    /// partition, all multiplexed over the same shm_mq queue.
+    pub fn clone_with_header(&self, header: MppFrameHeader) -> Self {
+        Self {
+            channel: Arc::clone(&self.channel),
+            cooperative_drain: self.cooperative_drain.as_ref().map(Arc::clone),
+            header,
+            scratch: std::cell::RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Attach a [`CooperativeDrainSet`] so [`Self::send_batch_traced`]'s spin
+    /// can drain inbound peer traffic while waiting for outbound space.
+    /// Required for peer-mesh fragments where every worker is both sender and
+    /// consumer; without it, symmetric full-queue stalls deadlock the
+    /// single-threaded Tokio runtime.
+    pub fn with_cooperative_drain(mut self, drain: Arc<dyn CooperativeDrainSet>) -> Self {
+        self.cooperative_drain = Some(drain);
+        self
     }
 
     /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
@@ -350,6 +589,61 @@ impl MppSender {
         result
     }
 
+    /// Send a payload-less [`MppFrameKind::Eof`] frame so the receiver's `(stage_id, partition)`
+    /// sub-buffer transitions to `Eof` and the consumer's pull loop terminates cleanly.
+    ///
+    /// Producer fragments must call this exactly once per `(stage_id, partition)` channel after
+    /// the local stream exhausts. Without it the multiplexed shm_mq queue stays attached (other
+    /// channels still flow) and the consumer sub-buffer never reaches `sources_done == 1`. The
+    /// receive-side [`DrainHandle::try_drain_pass`] decodes the frame and calls
+    /// `notify_source_done` on the matching sub-buffer.
+    ///
+    /// Uses the same cooperative-spin path as [`Self::send_batch_traced`] so a full outbound
+    /// queue doesn't deadlock the EOF send. `stats.spin_iters` / `send_wait` capture any
+    /// contention.
+    ///
+    /// Symmetric-EOF safety: when every peer reaches EOF simultaneously with full outbound
+    /// queues, each peer's cooperative [`CooperativeDrainSet::try_drain_pass`] inside the spin
+    /// pulls peer-sent frames out of its own inbound queues, freeing space the peers are blocked
+    /// on. Progress is monotone: at least one `try_send_bytes` succeeds per spin iteration
+    /// somewhere in the mesh, so symmetric stalls resolve within a few iterations rather than
+    /// deadlocking.
+    pub async fn send_eof_traced(&self, stats: &mut SendBatchStats) -> Result<(), DataFusionError> {
+        let mut scratch = self.scratch.replace(Vec::new());
+        let result = self.send_eof_with_scratch(&mut scratch, stats).await;
+        self.scratch.replace(scratch);
+        result
+    }
+
+    async fn send_eof_with_scratch(
+        &self,
+        scratch: &mut Vec<u8>,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
+        encode_eof_frame_into(self.header.stage_id, self.header.partition, scratch)?;
+        let Some(drain) = self.cooperative_drain.as_ref() else {
+            return self.channel.send_bytes(scratch);
+        };
+        let mut first_try = true;
+        let t_wait_start = Instant::now();
+        loop {
+            #[cfg(not(test))]
+            pgrx::check_for_interrupts!();
+            if self.channel.try_send_bytes(scratch)? {
+                if !first_try {
+                    stats.send_wait += t_wait_start.elapsed();
+                }
+                return Ok(());
+            }
+            first_try = false;
+            stats.spin_iters += 1;
+            let t_drain = Instant::now();
+            drain.try_drain_pass()?;
+            stats.coop_drain_in_spin += t_drain.elapsed();
+            tokio::task::yield_now().await;
+        }
+    }
+
     async fn send_with_scratch(
         &self,
         batch: &RecordBatch,
@@ -357,7 +651,7 @@ impl MppSender {
         stats: &mut SendBatchStats,
     ) -> Result<(), DataFusionError> {
         let t_enc = Instant::now();
-        encode_batch_into(batch, scratch)?;
+        encode_frame_into(self.header, batch, scratch)?;
         stats.encode += t_enc.elapsed();
         let Some(drain) = self.cooperative_drain.as_ref() else {
             // No drain attached (unit tests, in-proc channels): fall
@@ -450,8 +744,9 @@ impl MppReceiver {
 
     pub fn try_recv_batch(&self) -> RecvBatchOutcome {
         match self.channel.try_recv() {
-            RecvOutcome::Bytes(bytes) => match decode_batch(&bytes) {
-                Ok(batch) => RecvBatchOutcome::Batch(batch),
+            RecvOutcome::Bytes(bytes) => match decode_frame(&bytes) {
+                Ok((header, Some(batch))) => RecvBatchOutcome::Batch { header, batch },
+                Ok((header, None)) => RecvBatchOutcome::Eof { header },
                 Err(e) => RecvBatchOutcome::Error(e),
             },
             RecvOutcome::Empty => RecvBatchOutcome::Empty,
@@ -460,10 +755,22 @@ impl MppReceiver {
     }
 }
 
-/// Decoded result of an [`MppReceiver::try_recv_batch`].
+/// Decoded result of an [`MppReceiver::try_recv_batch`]. Carries the
+/// parsed [`MppFrameHeader`] so the drain thread can route the payload to
+/// the right `(stage_id, partition)` sub-buffer.
 #[derive(Debug)]
 pub enum RecvBatchOutcome {
-    Batch(RecordBatch),
+    Batch {
+        header: MppFrameHeader,
+        batch: RecordBatch,
+    },
+    /// A payload-less `Eof` frame for `header.(stage_id, partition)`. The
+    /// underlying shm_mq queue is still attached. The sender is just
+    /// signalling that this logical channel is done, so we can EOF
+    /// per-channel without dropping the whole queue.
+    Eof {
+        header: MppFrameHeader,
+    },
     Empty,
     Detached,
     Error(DataFusionError),
@@ -509,20 +816,42 @@ pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusi
     thread::spawn(move || drain_loop(config))
 }
 
-/// RAII wrapper around a drain thread's `JoinHandle` and its `DrainBuffer`.
+/// Per-`(stage_id, partition)` sub-buffer registry owned by a cooperative [`DrainHandle`]. The
+/// handle serves one sender_proc, whose shm_mq queue carries frames for many logical channels,
+/// each tagged by the [`MppFrameHeader`] prefix. `try_drain_pass` looks up the right sub-buffer
+/// on every frame and pushes the payload into it. Consumers waiting on
+/// `(stage_id=s, partition=p)` only see frames matching that key.
 ///
-/// On drop, the handle cancels the buffer (unblocking the drain thread if it
-/// is sleeping on an empty cycle) and joins the thread. This guarantees the
-/// drain thread never outlives the query's DSM segment — if `ExecEndCustomScan`
-/// panics after dropping the handle, the thread has already been torn down
-/// and cannot touch the freed shm_mq memory.
+/// Each entry is a `DrainBuffer::new(1)` because exactly one source (the sender_proc this handle
+/// serves) emits frames for any given channel via this drain. When the sender_proc detaches
+/// (`Detached` outcome on the underlying receiver), `detached` flips to `true` and every existing
+/// sub-buffer is notified, so any consumer blocked on `try_pop` unblocks with `DrainItem::Eof`.
+/// Sub-buffers registered *after* detach come back already EOF'd so a late consumer doesn't hang.
+#[derive(Default)]
+struct SubBufferRegistry {
+    map: HashMap<(u32, u32), Arc<DrainBuffer>>,
+    detached: bool,
+}
+
+/// RAII wrapper around a drain thread's `JoinHandle` and a per-`(stage_id, partition)`
+/// sub-buffer registry.
 ///
-/// Review finding: the prior implementation's `JoinHandle` was hanging off
-/// free-form execution state, so an error path that skipped manual cleanup
-/// left a zombie drain thread alive with dangling DSM pointers. Enforcing
-/// cancel+join via Drop closes that window.
+/// On drop, the handle cancels every sub-buffer (unblocking any waiting consumer) and joins the
+/// test-only thread if one is attached. The drain thread can therefore never outlive the query's
+/// DSM segment: if `ExecEndCustomScan` panics after dropping the handle, the thread is already
+/// torn down and can't touch the freed shm_mq memory. Owning cancel + join in `Drop` (rather
+/// than expecting callers to clean up on every error path) keeps that guarantee unconditional.
 pub struct DrainHandle {
-    buffer: Arc<DrainBuffer>,
+    /// Cooperative variant's per-(stage_id, partition) sub-buffer registry. Populated lazily on
+    /// first frame for a channel, or up-front by callers (e.g.
+    /// `WorkerConnection::stream_partition`) that need a buffer to wait on before any frame
+    /// arrives.
+    sub_buffers: Mutex<SubBufferRegistry>,
+    /// Thread-backed (test-only) variant's single shared buffer. The `drain_loop` writes to it
+    /// directly; tests read via `Arc::clone` of the same buffer they constructed in
+    /// `DrainConfig`. The cooperative path keeps this `None` and routes everything through
+    /// `sub_buffers`.
+    legacy_buffer: Option<Arc<DrainBuffer>>,
     /// Background-thread variant: `Some(JoinHandle)`. In-proc tests still use
     /// this path — their `InProcReceiver` is an `std::sync::mpsc` wrapper, not
     /// a pg FFI call, so the drain thread is safe. Wrapped in `Mutex` so
@@ -554,7 +883,8 @@ impl DrainHandle {
         let buffer = Arc::clone(&config.buffer);
         let join = spawn_drain_thread(config);
         Self {
-            buffer,
+            sub_buffers: Mutex::new(SubBufferRegistry::default()),
+            legacy_buffer: Some(buffer),
             join: Mutex::new(Some(join)),
             coop_receivers: Mutex::new(None),
         }
@@ -565,35 +895,113 @@ impl DrainHandle {
     /// [`Self::try_drain_pass`]). No background thread. This is the correct
     /// variant for production pg backend workers — the drain work runs on
     /// the backend thread, so any pg FFI inside `shm_mq_receive` is safe.
-    pub fn cooperative(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
+    ///
+    /// Sub-buffers are populated lazily by `try_drain_pass` when a frame
+    /// arrives, or up-front by [`Self::register_channel`] when a consumer
+    /// needs a buffer to wait on before any frame has come in.
+    pub fn cooperative(receivers: Vec<MppReceiver>) -> Self {
         let wrapped = receivers.into_iter().map(Some).collect();
         Self {
-            buffer,
+            sub_buffers: Mutex::new(SubBufferRegistry::default()),
+            legacy_buffer: None,
             join: Mutex::new(None),
             coop_receivers: Mutex::new(Some(wrapped)),
         }
     }
 
-    /// Pull batches from each live receiver into the buffer. Called from
-    /// `DrainGatherStream::poll_next` and from `MppSender::send_batch`'s
-    /// cooperative spin — drain work happens on the backend thread
+    /// Register (or look up) the sub-buffer for `(stage_id, partition)`. The returned
+    /// `Arc<DrainBuffer>` is the canonical destination for frames matching that key:
+    /// `try_drain_pass` pushes into the same entry on every `Batch { header, .. }` whose header
+    /// matches.
+    ///
+    /// If the drain has already observed `Detached` from its underlying receiver, the
+    /// newly-created buffer comes back with `notify_source_done` already called so a consumer
+    /// registering after detach sees `Eof` on the first `try_pop` instead of hanging forever.
+    pub fn register_channel(&self, stage_id: u32, partition: u32) -> Arc<DrainBuffer> {
+        let mut guard = self
+            .sub_buffers
+            .lock()
+            .expect("DrainHandle sub_buffers mutex poisoned");
+        let detached = guard.detached;
+        guard
+            .map
+            .entry((stage_id, partition))
+            .or_insert_with(|| {
+                let buf = DrainBuffer::new(1);
+                if detached {
+                    buf.notify_source_done();
+                }
+                buf
+            })
+            .clone()
+    }
+
+    /// Mark the drain as detached and `notify_source_done` every registered sub-buffer.
+    /// Idempotent. Used by `try_drain_pass` after `Detached` / `Error` outcomes; the
+    /// cooperative-path equivalent fires from `Drop` via [`Self::cancel_sub_buffers`] so any
+    /// consumer blocked on `try_pop` unblocks with `Eof` even if the query is torn down before
+    /// EOF frames flow.
+    ///
+    /// Collects buffer handles under the registry lock, then notifies after releasing it.
+    /// Notifying inline would block any concurrent [`Self::register_channel`] for as long as it
+    /// takes to acquire `DrainBuffer::inner` N times. Fine today (single backend thread), but
+    /// cheap insurance against the multi-thread variant landing later.
+    fn mark_detached(&self) {
+        let to_notify = {
+            let mut guard = self
+                .sub_buffers
+                .lock()
+                .expect("DrainHandle sub_buffers mutex poisoned");
+            if guard.detached {
+                return;
+            }
+            guard.detached = true;
+            guard.map.values().cloned().collect::<Vec<_>>()
+        };
+        for buf in to_notify {
+            buf.notify_source_done();
+        }
+    }
+
+    /// Cancel every registered sub-buffer. Called from `Drop` to unblock any consumer waiting on
+    /// a sub-buffer when the handle goes away mid-query. Same collect-then-notify pattern as
+    /// [`Self::mark_detached`].
+    fn cancel_sub_buffers(&self) {
+        let to_cancel = {
+            let guard = self
+                .sub_buffers
+                .lock()
+                .expect("DrainHandle sub_buffers mutex poisoned");
+            guard.map.values().cloned().collect::<Vec<_>>()
+        };
+        for buf in to_cancel {
+            buf.cancel();
+        }
+    }
+
+    /// Pull batches from each live receiver and demux them into the per-`(stage_id, partition)`
+    /// sub-buffer registry. Called from `DrainGatherStream::poll_next` and from
+    /// `MppSender::send_batch`'s cooperative spin. Drain work happens on the backend thread
     /// (pgrx-safe). No-op for thread-backed handles.
     ///
-    /// Each pass drains *every available* batch from each receiver (up to
-    /// a safety cap). Pulling only one batch per source per call means
-    /// that under steady producer pressure the cooperative sender's
-    /// spin-loop cannot keep up — we'd fall N:1 behind peers' sends and
-    /// the mesh stalls once any queue fills. Draining until the receiver
-    /// reports `Empty` bounds each pass by queue depth rather than by
-    /// spin-loop iteration count.
+    /// Each pass drains *every available* batch from each receiver (up to a safety cap). Pulling
+    /// only one batch per source per call would mean that under steady producer pressure the
+    /// cooperative sender's spin-loop can't keep up: we'd fall N:1 behind peers' sends and the
+    /// mesh would stall once any queue fills. Draining until the receiver reports `Empty` bounds
+    /// each pass by queue depth rather than by spin-loop iteration count.
     ///
-    /// Returns `Ok(())` once every cooperative receiver has been pulled until
-    /// `Empty` (or detached). A previous version returned a `bool` indicating
-    /// whether any progress had been made; no caller used it (the
-    /// cooperative-spin loop in [`MppSender::send_batch`] retries on its own
-    /// `try_send_bytes` regardless of drain progress), so the return is now
-    /// just `Result<()>` so transport errors propagate instead of being
-    /// silently dropped at the call site.
+    /// Returns `Ok(())` once every cooperative receiver has been pulled until `Empty` (or
+    /// detached). Errors propagate as `Err` so a transport-level failure surfaces at the call
+    /// site rather than getting silently dropped.
+    ///
+    /// Routing rules per outcome:
+    /// - `Batch { header, batch }`: look up (or lazily create) the
+    ///   `(header.stage_id, header.partition)` sub-buffer and push `batch`.
+    /// - `Eof { header }`: per-channel EOF. Resolve the sub-buffer and call
+    ///   `notify_source_done`. Other channels on the same queue keep flowing,
+    ///   so the receiver slot stays live.
+    /// - `Detached` / `Error`: queue-wide shutdown. Notify every registered
+    ///   sub-buffer, mark the handle detached, and drop the slot.
     pub fn try_drain_pass(&self) -> Result<(), DataFusionError> {
         // Bound per-source pulls per call. The upper limit exists to give
         // the caller a chance to re-try its own send between drains —
@@ -612,30 +1020,31 @@ impl DrainHandle {
             };
             for _ in 0..MAX_BATCHES_PER_SOURCE_PER_PASS {
                 match rx.try_recv_batch() {
-                    RecvBatchOutcome::Batch(b) => {
-                        self.buffer.push_batch(b);
+                    RecvBatchOutcome::Batch { header, batch } => {
+                        let buf = self.register_channel(header.stage_id, header.partition);
+                        buf.push_batch(batch);
+                    }
+                    RecvBatchOutcome::Eof { header } => {
+                        let buf = self.register_channel(header.stage_id, header.partition);
+                        buf.notify_source_done();
+                        // Other channels may still flow on this queue, so the receiver slot
+                        // stays live.
                     }
                     RecvBatchOutcome::Empty => break,
                     RecvBatchOutcome::Detached => {
                         *slot = None;
-                        self.buffer.notify_source_done();
+                        self.mark_detached();
                         break;
                     }
                     RecvBatchOutcome::Error(e) => {
                         *slot = None;
-                        self.buffer.notify_source_done();
+                        self.mark_detached();
                         return Err(e);
                     }
                 }
             }
         }
         Ok(())
-    }
-
-    /// Access the shared buffer so consumers (typically `GatherExec`) can
-    /// `pop_front` without holding the handle itself.
-    pub fn buffer(&self) -> &Arc<DrainBuffer> {
-        &self.buffer
     }
 
     fn join_inner(&self) -> Result<(), DataFusionError> {
@@ -657,15 +1066,26 @@ impl Drop for DrainHandle {
     fn drop(&mut self) {
         let has_join = self.join.lock().unwrap().is_some();
         if has_join {
-            // Cancel and join even on the panic path. We swallow any error
-            // here because Drop cannot fail; callers who care should use
-            // `shutdown()` to observe the thread's result.
-            self.buffer.cancel();
+            // Cancel and join even on the panic path. Swallow any error here because Drop can't
+            // fail; callers who care should use `shutdown()` to observe the thread's result.
+            if let Some(buf) = &self.legacy_buffer {
+                buf.cancel();
+            }
             let _ = self.join_inner();
         }
+        // Cooperative path: unblock any consumer blocked on a sub-buffer when the handle is torn
+        // down before EOF flows naturally (e.g. a query error en route to ExecEndCustomScan).
+        self.cancel_sub_buffers();
     }
 }
 
+/// Test-only thread-backed drain. Writes every observed frame into a single shared
+/// [`DrainBuffer`] with `num_sources = N`. Per-channel `Eof` frames are treated as "this source
+/// is done" rather than "this logical channel within the source is done"; sufficient for unit
+/// tests that don't exercise per-channel demux. Production drains route through
+/// [`DrainHandle::try_drain_pass`] (cooperative variant), which keys on the frame header. Tests
+/// that need to validate production demux must use [`DrainHandle::cooperative`] and call
+/// `try_drain_pass` directly.
 #[cfg(test)]
 fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
     let DrainConfig {
@@ -691,9 +1111,15 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
             }
             all_done = false;
             match rx.try_recv_batch() {
-                RecvBatchOutcome::Batch(batch) => {
+                RecvBatchOutcome::Batch { header: _, batch } => {
                     got_any = true;
                     buffer.push_batch(batch);
+                }
+                RecvBatchOutcome::Eof { header: _ } => {
+                    // Per-channel Eof frame: single-channel positional design
+                    // treats it as a source-done signal. See `try_drain_pass`.
+                    done[i] = true;
+                    buffer.notify_source_done();
                 }
                 RecvBatchOutcome::Empty => {}
                 RecvBatchOutcome::Detached => {
@@ -719,21 +1145,28 @@ fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
     }
 }
 
-/// SPSC channel pair for unit tests and in-process single-worker validation.
-/// Bounded capacity via `std::sync::mpsc::sync_channel` so tests can exercise
-/// backpressure (`send` blocks when full).
-#[cfg(test)]
+/// SPSC channel pair for two use cases:
+/// - Unit tests (bounded capacity, exercising backpressure).
+/// - Production self-loop slots: when a worker's fragment emits a partition destined for its OWN
+///   proc (e.g. peer-mesh hash routing where consumer task t lands on the same worker as
+///   producer task t), the shm_mq grid leaves the `slot(this_proc, this_proc)` diagonal
+///   unattached. The dispatcher routes those self-loops through this in-proc channel instead.
+///   It shares the same `BatchChannelSender`/`BatchChannelReceiver` abstraction as shm_mq, so the
+///   drain and sub-buffer registry don't need a special case.
+///
+/// Production callers pass a very large `capacity` so the channel is effectively unbounded under
+/// steady state. The current-thread Tokio runtime interleaves producer and consumer fragments
+/// via `yield_now().await`, so backpressure would be benign anyway, but unbounded rules out any
+/// chance of self-deadlock if the producer never yields.
 pub fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
     (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
 }
 
-#[cfg(test)]
 pub struct InProcSender {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
 }
 
-#[cfg(test)]
 pub struct InProcReceiver {
     // The std::sync::mpsc receiver is !Sync; wrap in a Mutex so the drain
     // thread can hold it behind a `Box<dyn BatchChannelReceiver>` (which is
@@ -743,16 +1176,24 @@ pub struct InProcReceiver {
     rx: Mutex<std::sync::mpsc::Receiver<Vec<u8>>>,
 }
 
-#[cfg(test)]
 impl BatchChannelSender for InProcSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
         self.tx.send(bytes.to_vec()).map_err(|_| {
             DataFusionError::Execution("mpp: in-proc channel detached during send".into())
         })
     }
+
+    fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
+        match self.tx.try_send(bytes.to_vec()) {
+            Ok(()) => Ok(true),
+            Err(std::sync::mpsc::TrySendError::Full(_)) => Ok(false),
+            Err(std::sync::mpsc::TrySendError::Disconnected(_)) => Err(DataFusionError::Execution(
+                "mpp: in-proc channel detached during try_send".into(),
+            )),
+        }
+    }
 }
 
-#[cfg(test)]
 impl BatchChannelReceiver for InProcReceiver {
     fn try_recv(&self) -> RecvOutcome {
         let rx = self.rx.lock().expect("InProcReceiver mutex poisoned");
@@ -763,6 +1204,12 @@ impl BatchChannelReceiver for InProcReceiver {
         }
     }
 }
+
+/// Effectively unbounded capacity for self-loop in-proc channels. The
+/// `std::sync::mpsc::sync_channel` API requires a numeric capacity; this constant picks one large
+/// enough that production workloads won't reach it but small enough that a runaway producer
+/// (e.g. infinite-loop bug) won't allocate billions of `Vec<u8>` before OOM.
+pub const SELF_LOOP_CAPACITY: usize = 1 << 20;
 
 #[cfg(test)]
 mod tests {
@@ -794,6 +1241,92 @@ mod tests {
         for col in 0..orig.num_columns() {
             assert_eq!(orig.column(col).as_ref(), decoded.column(col).as_ref());
         }
+    }
+
+    #[test]
+    fn frame_round_trips_a_batch_with_header() {
+        let orig = sample_batch(64);
+        let header = MppFrameHeader::batch(7, 3);
+        let mut buf = Vec::with_capacity(1024);
+        encode_frame_into(header, &orig, &mut buf).expect("encode_frame");
+
+        let (parsed, batch_opt) = decode_frame(&buf).expect("decode_frame");
+        assert_eq!(parsed, header);
+        assert_eq!(parsed.kind().unwrap(), MppFrameKind::Batch);
+        let batch = batch_opt.expect("Batch frame must carry a payload");
+        assert_eq!(batch.num_rows(), 64);
+        assert_eq!(batch.schema(), orig.schema());
+    }
+
+    #[test]
+    fn frame_round_trips_eof() {
+        let mut buf = Vec::new();
+        encode_eof_frame_into(2, 5, &mut buf).expect("encode_eof");
+        assert_eq!(buf.len(), MPP_FRAME_HEADER_SIZE);
+
+        let (header, batch_opt) = decode_frame(&buf).expect("decode_frame");
+        assert_eq!(header, MppFrameHeader::eof(2, 5));
+        assert_eq!(header.kind().unwrap(), MppFrameKind::Eof);
+        assert!(batch_opt.is_none());
+    }
+
+    #[test]
+    fn frame_rejects_short_message() {
+        let too_short = vec![0u8; MPP_FRAME_HEADER_SIZE - 1];
+        let err = decode_frame(&too_short).expect_err("short frame must fail");
+        assert!(format!("{err}").contains("too short"));
+    }
+
+    #[test]
+    fn frame_rejects_bad_magic() {
+        // Explicit non-zero, non-magic prefix. Don't rely on the
+        // happenstance that 0u32 != MPP_FRAME_MAGIC.
+        let mut bad = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        bad[0..4].copy_from_slice(&0xCAFEBABE_u32.to_le_bytes());
+        let err = decode_frame(&bad).expect_err("bad magic must fail");
+        assert!(format!("{err}").contains("bad frame magic"));
+        bad[0..4].copy_from_slice(&0xDEADBEEF_u32.to_le_bytes());
+        let err = decode_frame(&bad).expect_err("bad magic must fail");
+        assert!(format!("{err}").contains("bad frame magic"));
+    }
+
+    #[test]
+    fn frame_rejects_unknown_kind() {
+        let header = MppFrameHeader {
+            magic: MPP_FRAME_MAGIC,
+            flags: 0x42, // unknown kind byte, no reserved bits set
+            stage_id: 0,
+            partition: 0,
+        };
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        let err = decode_frame(&buf).expect_err("unknown kind must fail");
+        assert!(format!("{err}").contains("unknown frame kind"));
+    }
+
+    #[test]
+    fn frame_rejects_reserved_flag_bits() {
+        // Any bit above the low byte of `flags` is reserved-must-be-zero;
+        // setting one should trip `kind()` before the kind byte is consulted.
+        let header = MppFrameHeader {
+            magic: MPP_FRAME_MAGIC,
+            flags: 0x0000_0100, // bit 8 set, kind byte 0 (would be Batch)
+            stage_id: 0,
+            partition: 0,
+        };
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        let err = decode_frame(&buf).expect_err("reserved bit must fail");
+        assert!(format!("{err}").contains("reserved frame flag bits"));
+    }
+
+    #[test]
+    fn frame_eof_with_payload_is_rejected() {
+        let mut buf = Vec::with_capacity(32);
+        encode_eof_frame_into(0, 0, &mut buf).expect("encode_eof");
+        buf.push(0xAB); // smuggle a payload byte after the Eof header
+        let err = decode_frame(&buf).expect_err("Eof+payload must fail");
+        assert!(format!("{err}").contains("Eof frame carries payload"));
     }
 
     #[test]
@@ -859,14 +1392,14 @@ mod tests {
     #[test]
     fn in_proc_channel_round_trips_through_mpp_sender_receiver() {
         let (tx, rx) = in_proc_channel(8);
-        let sender = MppSender::new(Box::new(tx));
+        let sender = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
 
         sender.send_batch(&sample_batch(4)).unwrap();
         std::mem::drop(sender);
 
         match receiver.try_recv_batch() {
-            RecvBatchOutcome::Batch(b) => assert_eq!(b.num_rows(), 4),
+            RecvBatchOutcome::Batch { header: _, batch } => assert_eq!(batch.num_rows(), 4),
             other => panic!("expected batch, got {other:?}"),
         }
         assert!(matches!(
@@ -878,7 +1411,7 @@ mod tests {
     #[test]
     fn drain_thread_drains_single_source() {
         let (tx, rx) = in_proc_channel(4);
-        let sender = MppSender::new(Box::new(tx));
+        let sender = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
 
@@ -904,7 +1437,7 @@ mod tests {
     #[test]
     fn drain_handle_shutdown_joins_cleanly() {
         let (tx, rx) = in_proc_channel(4);
-        let sender = MppSender::new(Box::new(tx));
+        let sender = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
         let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
@@ -925,7 +1458,7 @@ mod tests {
         // drop the handle. The Drop impl must cancel the buffer and join the
         // thread without hanging.
         let (tx, rx) = in_proc_channel(4);
-        let _sender_kept_alive = MppSender::new(Box::new(tx));
+        let _sender_kept_alive = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
         let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
@@ -960,8 +1493,8 @@ mod tests {
         let buffer = DrainBuffer::new(2);
         let drain_join = spawn_drain_thread(DrainConfig::new(receivers, StdArc::clone(&buffer)));
 
-        let tx0_send = MppSender::new(Box::new(tx0));
-        let tx1_send = MppSender::new(Box::new(tx1));
+        let tx0_send = MppSender::new(Arc::new(tx0));
+        let tx1_send = MppSender::new(Arc::new(tx1));
         let batch_template = sample_batch(1);
 
         let p0 = {
@@ -1009,20 +1542,18 @@ mod tests {
     // ---------------------------------------------------------------------
     // Throughput microbenches.
     //
-    // These are `#[ignore]` by default because they spin for seconds and
-    // spam stdout. Run with:
+    // These are `#[ignore]` by default because they spin for seconds and spam stdout. Run with:
     //
     //   cargo test --package pg_search --release \
     //       postgres::customscan::mpp::transport::tests::throughput \
     //       -- --ignored --nocapture
     //
-    // They help us bound the transport layer's cost independently of
-    // DataFusion/Tantivy. All use the `in_proc_channel` backend (same
-    // `MppSender`/`MppReceiver` trait boundary as the shm_mq one), so
-    // numbers here are an optimistic ceiling — shm_mq adds the ring-buffer
-    // copy + cross-process notification cost on top. If these numbers are
-    // already below the row rate the real query needs, we know IPC encode
-    // + channel handoff is the bottleneck without needing CI data.
+    // They help us bound the transport layer's cost independently of DataFusion/Tantivy. All use
+    // the `in_proc_channel` backend (same `MppSender`/`MppReceiver` trait boundary as the shm_mq
+    // one), so numbers here are an optimistic ceiling. shm_mq adds the ring-buffer copy +
+    // cross-process notification cost on top. If these numbers are already below the row rate
+    // the real query needs, we know IPC encode + channel handoff is the bottleneck without
+    // needing CI data.
     // ---------------------------------------------------------------------
 
     /// Row shape matching the post-Partial shuffle in
@@ -1034,7 +1565,7 @@ mod tests {
             Field::new("count_partial", DataType::UInt64, false),
             Field::new("sum_partial", DataType::Int64, false),
         ]));
-        // Titles averaging ~30 bytes — typical for the docs dataset.
+        // Titles averaging ~30 bytes, typical for the docs dataset.
         let titles = StringArray::from_iter_values(
             (0..rows).map(|i| format!("file_{i:012}_title_with_some_length")),
         );
@@ -1087,8 +1618,8 @@ mod tests {
         ];
         let buffer = DrainBuffer::new(2);
         let drain_join = spawn_drain_thread(DrainConfig::new(receivers, StdArc::clone(&buffer)));
-        let tx0_send = MppSender::new(Box::new(tx0));
-        let tx1_send = MppSender::new(Box::new(tx1));
+        let tx0_send = MppSender::new(Arc::new(tx0));
+        let tx1_send = MppSender::new(Arc::new(tx1));
 
         let per_source = batches / 2;
         let round_trip_start = Instant::now();
@@ -1152,5 +1683,209 @@ mod tests {
         for batch_rows in [128, 512, 2048, 8192, 32_768] {
             bench_throughput("probe", probe_shape_batch, batch_rows, 12_500_000);
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Per-`(stage_id, partition)` sub-buffer registry on the cooperative `DrainHandle`.
+    //
+    // Producers stamp `MppFrameHeader::batch(stage_id, partition)` on every outgoing frame, and
+    // the receiver-side cooperative drain demuxes by header into a sub-buffer per
+    // `(stage_id, partition)`. These tests use the `in_proc_channel` backend to drive
+    // `try_drain_pass` from the test thread. That mirrors how the production path runs the drain
+    // inline from `DrainGatherStream::poll_next` on the backend thread.
+    // ---------------------------------------------------------------------
+
+    /// Drain a `DrainHandle::cooperative` to completion: poll until every receiver returns
+    /// `Empty`. With the `in_proc_channel` test backend the drain observes `Detached` once the
+    /// producer drops its sender, so a bounded loop of `try_drain_pass` calls is enough to flush
+    /// everything the producer wrote.
+    fn drain_until_detached(handle: &DrainHandle) {
+        for _ in 0..64 {
+            handle.try_drain_pass().expect("try_drain_pass");
+            // After enough passes the in-proc backend reports `Detached`, which flips
+            // `mark_detached` and notifies every sub-buffer. We keep polling so any queued
+            // frames flow through first.
+        }
+    }
+
+    #[test]
+    fn drain_handle_demuxes_frames_by_header() {
+        // One queue carrying two channels: `(0, 0)` and `(0, 1)`. Each
+        // sub-buffer receives only its own batches.
+        let (tx, rx) = in_proc_channel(8);
+        let base = MppSender::new(Arc::new(tx));
+        let s00 = base.clone_with_header(MppFrameHeader::batch(0, 0));
+        let s01 = base.clone_with_header(MppFrameHeader::batch(0, 1));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        s00.send_batch(&sample_batch(2)).unwrap();
+        s01.send_batch(&sample_batch(7)).unwrap();
+        s00.send_batch(&sample_batch(3)).unwrap();
+        drop(s00);
+        drop(s01);
+        drop(base); // Last sender dropped. Receiver will report Detached.
+
+        let buf00 = handle.register_channel(0, 0);
+        let buf01 = handle.register_channel(0, 1);
+
+        drain_until_detached(&handle);
+
+        let mut p0_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf00.try_pop() {
+            p0_rows.push(b.num_rows());
+        }
+        let mut p1_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf01.try_pop() {
+            p1_rows.push(b.num_rows());
+        }
+        assert_eq!(p0_rows, vec![2, 3]);
+        assert_eq!(p1_rows, vec![7]);
+        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
+        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_eof_frame_closes_one_channel() {
+        // An `Eof` frame on `(0, 0)` closes that sub-buffer while frames on
+        // `(0, 1)` continue to flow on the same queue.
+        let (tx, rx) = in_proc_channel(8);
+        let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
+        let s00 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0));
+        let s01 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 1));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        s00.send_batch(&sample_batch(4)).unwrap();
+        // Hand-roll an Eof frame for (0, 0) onto the same shared channel.
+        let mut eof_buf = Vec::new();
+        encode_eof_frame_into(0, 0, &mut eof_buf).unwrap();
+        tx_arc.send_bytes(&eof_buf).unwrap();
+        // (0, 1) is still live and ships another batch after the EOF.
+        s01.send_batch(&sample_batch(6)).unwrap();
+
+        let buf00 = handle.register_channel(0, 0);
+        let buf01 = handle.register_channel(0, 1);
+
+        // Drop senders so the receiver eventually observes Detached.
+        drop(s00);
+        drop(s01);
+        drop(tx_arc);
+        drain_until_detached(&handle);
+
+        match buf00.try_pop() {
+            Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 4),
+            other => panic!("expected (0,0) batch, got {other:?}"),
+        }
+        // The Eof frame closed (0, 0) before the queue detached.
+        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
+
+        match buf01.try_pop() {
+            Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 6),
+            other => panic!("expected (0,1) batch, got {other:?}"),
+        }
+        // (0, 1) sees EOF at receiver-detach time.
+        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_detach_eofs_all_registered_sub_buffers() {
+        // No frames flow; consumer pre-registers two channels. When the sender drops and
+        // `try_drain_pass` observes `Detached`, both sub-buffers immediately surface `Eof`.
+        // Without that, a consumer blocked on `try_pop` would hang past the producer's death.
+        let (tx, rx) = in_proc_channel(8);
+        drop(tx); // detach immediately
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        let buf00 = handle.register_channel(0, 0);
+        let buf01 = handle.register_channel(0, 1);
+        // No frames ever land; the next poll observes Detached and notifies.
+        handle.try_drain_pass().unwrap();
+
+        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
+        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_register_after_detach_returns_eof_buffer() {
+        // Detach first, then register. The returned buffer is already
+        // EOF'd so a late consumer doesn't block forever waiting on a
+        // channel whose source is gone.
+        let (tx, rx) = in_proc_channel(8);
+        drop(tx);
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        handle.try_drain_pass().unwrap(); // observes Detached, marks handle
+
+        let late_buf = handle.register_channel(5, 9);
+        assert!(matches!(late_buf.try_pop(), Some(DrainItem::Eof)));
+    }
+
+    #[test]
+    fn drain_handle_register_channel_is_idempotent() {
+        // Two calls for the same key return Arcs pointing to the same
+        // DrainBuffer instance.
+        let (_tx, rx) = in_proc_channel(8);
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        let first = handle.register_channel(2, 3);
+        let second = handle.register_channel(2, 3);
+        assert!(Arc::ptr_eq(&first, &second));
+    }
+
+    #[test]
+    fn drain_handle_demuxes_frames_by_stage_id() {
+        // Same partition (0) for two different stage ids on the same queue.
+        // The registry's compound key keeps them on separate sub-buffers.
+        let (tx, rx) = in_proc_channel(8);
+        let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
+        let s_stage0 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0));
+        let s_stage1 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(1, 0));
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        s_stage0.send_batch(&sample_batch(2)).unwrap();
+        s_stage1.send_batch(&sample_batch(9)).unwrap();
+        s_stage0.send_batch(&sample_batch(4)).unwrap();
+        drop(s_stage0);
+        drop(s_stage1);
+        drop(tx_arc);
+
+        let buf0 = handle.register_channel(0, 0);
+        let buf1 = handle.register_channel(1, 0);
+
+        drain_until_detached(&handle);
+
+        let mut stage0_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf0.try_pop() {
+            stage0_rows.push(b.num_rows());
+        }
+        let mut stage1_rows = Vec::new();
+        while let Some(DrainItem::Batch(b)) = buf1.try_pop() {
+            stage1_rows.push(b.num_rows());
+        }
+        assert_eq!(stage0_rows, vec![2, 4]);
+        assert_eq!(stage1_rows, vec![9]);
+    }
+
+    #[test]
+    fn drain_handle_drop_cancels_registered_sub_buffers() {
+        // Dropping a cooperative DrainHandle must wake any consumer holding an Arc<DrainBuffer>
+        // from `register_channel`. Otherwise a query error path that tears down the mesh would
+        // leave a consumer blocked on a buffer that will never see EOF.
+        let (_tx, rx) = in_proc_channel(8);
+        let receiver = MppReceiver::new(Box::new(rx));
+        let handle = DrainHandle::cooperative(vec![receiver]);
+
+        let buf_a = handle.register_channel(0, 0);
+        let buf_b = handle.register_channel(7, 3);
+        // No data ever flows; the handle is just dropped.
+        drop(handle);
+
+        assert!(matches!(buf_a.try_pop(), Some(DrainItem::Eof)));
+        assert!(matches!(buf_b.try_pop(), Some(DrainItem::Eof)));
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -38,6 +38,7 @@ use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 #[cfg(test)]
 use std::thread;
+#[cfg(test)]
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
@@ -776,12 +777,9 @@ pub enum RecvBatchOutcome {
     Error(DataFusionError),
 }
 
-/// Configuration for [`spawn_drain_thread`].
-///
-/// Only used by the thread-backed drain path, which is test-only: pgrx panics
-/// on any pg FFI call (including `shm_mq_receive`) from a non-backend thread,
-/// so production uses [`DrainHandle::cooperative`] — see the notes on
-/// `DrainHandle::spawn` for details.
+/// Configuration for [`spawn_drain_thread`]. Test-only: pgrx panics on any pg FFI call
+/// (including `shm_mq_receive`) from a non-backend thread, so production never spawns a drain
+/// thread — see [`DrainHandle::cooperative`] for the cooperative path.
 #[cfg(test)]
 pub struct DrainConfig {
     /// Receivers to drain. Ownership moves into the spawned thread.
@@ -816,6 +814,38 @@ pub fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusi
     thread::spawn(move || drain_loop(config))
 }
 
+/// Test-only RAII wrapper: owns the drain thread's `JoinHandle` and the buffer it writes into.
+/// `Drop` cancels the buffer (unblocking the consumer) and joins the thread, so the thread can
+/// never outlive the test scope even on a panic. Production code never spawns a drain thread —
+/// see [`DrainHandle`] for the cooperative variant that runs inline on the backend thread.
+#[cfg(test)]
+pub struct ThreadedDrainHandle {
+    buffer: Arc<DrainBuffer>,
+    join: Mutex<Option<JoinHandle<Result<(), DataFusionError>>>>,
+}
+
+#[cfg(test)]
+impl ThreadedDrainHandle {
+    pub fn spawn(config: DrainConfig) -> Self {
+        let buffer = Arc::clone(&config.buffer);
+        let join = spawn_drain_thread(config);
+        Self {
+            buffer,
+            join: Mutex::new(Some(join)),
+        }
+    }
+}
+
+#[cfg(test)]
+impl Drop for ThreadedDrainHandle {
+    fn drop(&mut self) {
+        self.buffer.cancel();
+        if let Some(join) = self.join.lock().unwrap().take() {
+            let _ = join.join();
+        }
+    }
+}
+
 /// Per-`(stage_id, partition)` sub-buffer registry owned by a cooperative [`DrainHandle`]. The
 /// handle serves one sender_proc, whose shm_mq queue carries frames for many logical channels,
 /// each tagged by the [`MppFrameHeader`] prefix. `try_drain_pass` looks up the right sub-buffer
@@ -833,79 +863,37 @@ struct SubBufferRegistry {
     detached: bool,
 }
 
-/// RAII wrapper around a drain thread's `JoinHandle` and a per-`(stage_id, partition)`
-/// sub-buffer registry.
+/// Per-sender-proc drain: stashes the receivers and polls them inline from the cooperative spin
+/// (no background thread), demuxing each frame into a per-`(stage_id, partition)` sub-buffer.
 ///
-/// On drop, the handle cancels every sub-buffer (unblocking any waiting consumer) and joins the
-/// test-only thread if one is attached. The drain thread can therefore never outlive the query's
-/// DSM segment: if `ExecEndCustomScan` panics after dropping the handle, the thread is already
-/// torn down and can't touch the freed shm_mq memory. Owning cancel + join in `Drop` (rather
-/// than expecting callers to clean up on every error path) keeps that guarantee unconditional.
+/// Inline polling is the production requirement: pgrx's `check_active_thread` guard panics on any
+/// pg FFI call (including `shm_mq_receive`) from a non-backend thread, so the drain work has to
+/// run on the backend thread. Tests that need a true thread-backed drain use
+/// [`ThreadedDrainHandle`] instead.
+///
+/// On drop, the handle cancels every sub-buffer so any consumer blocked on `try_pop` unblocks
+/// with `Eof` — the drain can therefore never outlive its query, even on a panicked teardown.
 pub struct DrainHandle {
-    /// Cooperative variant's per-(stage_id, partition) sub-buffer registry. Populated lazily on
-    /// first frame for a channel, or up-front by callers (e.g.
-    /// `WorkerConnection::stream_partition`) that need a buffer to wait on before any frame
-    /// arrives.
+    /// Per-(stage_id, partition) sub-buffer registry. Populated lazily on first frame for a
+    /// channel, or up-front by callers (e.g. `WorkerConnection::stream_partition`) that need a
+    /// buffer to wait on before any frame arrives.
     sub_buffers: Mutex<SubBufferRegistry>,
-    /// Thread-backed (test-only) variant's single shared buffer. The `drain_loop` writes to it
-    /// directly; tests read via `Arc::clone` of the same buffer they constructed in
-    /// `DrainConfig`. The cooperative path keeps this `None` and routes everything through
-    /// `sub_buffers`.
-    legacy_buffer: Option<Arc<DrainBuffer>>,
-    /// Background-thread variant: `Some(JoinHandle)`. In-proc tests still use
-    /// this path — their `InProcReceiver` is an `std::sync::mpsc` wrapper, not
-    /// a pg FFI call, so the drain thread is safe. Wrapped in `Mutex` so
-    /// `shutdown(&self)` can take the handle without needing `&mut self` —
-    /// this lets cooperative senders hold `Arc<DrainHandle>` shares.
-    join: Mutex<Option<JoinHandle<Result<(), DataFusionError>>>>,
-    /// Cooperative variant: the receivers are owned by the handle and polled
-    /// inline from `DrainGatherStream::poll_next` via [`Self::try_drain_pass`].
-    /// Production uses this variant because any pg FFI call
-    /// (`shm_mq_receive` included) from a non-backend thread panics pgrx's
-    /// `check_active_thread` guard. `None` when the handle was spawned
-    /// instead of constructed cooperatively.
-    ///
-    /// `Send` bound on `MppReceiver` is preserved — the receivers move
-    /// thread-once at construction then are only accessed from the backend
-    /// thread; the `Mutex` is just for interior mutability, not
-    /// cross-thread coordination.
-    coop_receivers: Mutex<Option<Vec<Option<MppReceiver>>>>,
+    /// Receivers owned by the handle and polled inline from `DrainGatherStream::poll_next` via
+    /// [`Self::try_drain_pass`]. The `Send` bound on `MppReceiver` is preserved — the receivers
+    /// move thread-once at construction then are only accessed from the backend thread; the
+    /// `Mutex` is just for interior mutability, not cross-thread coordination.
+    coop_receivers: Mutex<Vec<Option<MppReceiver>>>,
 }
 
 impl DrainHandle {
-    /// Spawn a drain thread and wrap the join handle together with the buffer
-    /// it drains into. Test-only: pgrx's `check_active_thread` panics on any
-    /// pg FFI call (including `shm_mq_receive`) from a non-backend thread, so
-    /// a real mesh receiver can never drain from a std::thread worker.
-    /// Production paths must use [`Self::cooperative`] instead.
-    #[cfg(test)]
-    pub fn spawn(config: DrainConfig) -> Self {
-        let buffer = Arc::clone(&config.buffer);
-        let join = spawn_drain_thread(config);
-        Self {
-            sub_buffers: Mutex::new(SubBufferRegistry::default()),
-            legacy_buffer: Some(buffer),
-            join: Mutex::new(Some(join)),
-            coop_receivers: Mutex::new(None),
-        }
-    }
-
-    /// Construct a cooperative drain handle: the receivers are stashed in the
-    /// handle and drained inline from `DrainGatherStream::poll_next` (see
-    /// [`Self::try_drain_pass`]). No background thread. This is the correct
-    /// variant for production pg backend workers — the drain work runs on
-    /// the backend thread, so any pg FFI inside `shm_mq_receive` is safe.
-    ///
-    /// Sub-buffers are populated lazily by `try_drain_pass` when a frame
-    /// arrives, or up-front by [`Self::register_channel`] when a consumer
-    /// needs a buffer to wait on before any frame has come in.
+    /// Construct a cooperative drain handle. Sub-buffers are populated lazily by
+    /// [`Self::try_drain_pass`] when a frame arrives, or up-front by [`Self::register_channel`]
+    /// when a consumer needs a buffer to wait on before any frame has come in.
     pub fn cooperative(receivers: Vec<MppReceiver>) -> Self {
         let wrapped = receivers.into_iter().map(Some).collect();
         Self {
             sub_buffers: Mutex::new(SubBufferRegistry::default()),
-            legacy_buffer: None,
-            join: Mutex::new(None),
-            coop_receivers: Mutex::new(Some(wrapped)),
+            coop_receivers: Mutex::new(wrapped),
         }
     }
 
@@ -1009,11 +997,7 @@ impl DrainHandle {
         // indefinitely on one source and starve its own outbound.
         const MAX_BATCHES_PER_SOURCE_PER_PASS: usize = 256;
 
-        let mut guard = self.coop_receivers.lock().unwrap();
-        let Some(slots) = guard.as_mut() else {
-            // Thread-backed handle — caller should read from buffer directly.
-            return Ok(());
-        };
+        let mut slots = self.coop_receivers.lock().unwrap();
         for slot in slots.iter_mut() {
             let Some(rx) = slot.as_ref() else {
                 continue;
@@ -1046,35 +1030,12 @@ impl DrainHandle {
         }
         Ok(())
     }
-
-    fn join_inner(&self) -> Result<(), DataFusionError> {
-        let join_opt = self.join.lock().unwrap().take();
-        if let Some(join) = join_opt {
-            match join.join() {
-                Ok(res) => res,
-                Err(panic) => Err(DataFusionError::Execution(format!(
-                    "mpp: drain thread panicked: {panic:?}"
-                ))),
-            }
-        } else {
-            Ok(())
-        }
-    }
 }
 
 impl Drop for DrainHandle {
     fn drop(&mut self) {
-        let has_join = self.join.lock().unwrap().is_some();
-        if has_join {
-            // Cancel and join even on the panic path. Swallow any error here because Drop can't
-            // fail; callers who care should use `shutdown()` to observe the thread's result.
-            if let Some(buf) = &self.legacy_buffer {
-                buf.cancel();
-            }
-            let _ = self.join_inner();
-        }
-        // Cooperative path: unblock any consumer blocked on a sub-buffer when the handle is torn
-        // down before EOF flows naturally (e.g. a query error en route to ExecEndCustomScan).
+        // Unblock any consumer blocked on a sub-buffer when the handle is torn down before EOF
+        // flows naturally (e.g. a query error en route to ExecEndCustomScan).
         self.cancel_sub_buffers();
     }
 }
@@ -1440,7 +1401,8 @@ mod tests {
         let sender = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
-        let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
+        let handle =
+            ThreadedDrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
 
         sender.send_batch(&sample_batch(2)).unwrap();
         std::mem::drop(sender); // detach
@@ -1461,7 +1423,8 @@ mod tests {
         let _sender_kept_alive = MppSender::new(Arc::new(tx));
         let receiver = MppReceiver::new(Box::new(rx));
         let buffer = DrainBuffer::new(1);
-        let handle = DrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
+        let handle =
+            ThreadedDrainHandle::spawn(DrainConfig::new(vec![receiver], StdArc::clone(&buffer)));
 
         // Simulate consumer path error: drop the handle without calling
         // shutdown(). The drain thread must exit before drop returns.
@@ -1470,7 +1433,7 @@ mod tests {
         let elapsed = start.elapsed();
         assert!(
             elapsed < Duration::from_secs(2),
-            "DrainHandle::drop took too long: {elapsed:?}"
+            "ThreadedDrainHandle::drop took too long: {elapsed:?}"
         );
         // Consumer observes EOF because cancel was called.
         assert!(matches!(buffer.pop_front(), DrainItem::Eof));

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -24,7 +24,7 @@
 //! - [`encode_frame_into`] / [`decode_frame`] serialize a `RecordBatch` with a header prefix via
 //!   Arrow IPC. They're the only codec entry points; tests round-trip through the same path so
 //!   the wire format under test always matches production.
-//! - [`DrainBuffer`] is the local per-participant queue that the drain thread
+//! - [`DrainBuffer`] is the local per-proc queue that the drain thread
 //!   writes into and the DataFusion consumer reads from. It decouples
 //!   consumer-side backpressure from producer-side backpressure: the drain thread
 //!   always makes forward progress on the inbound shm_mqs, so a stalled consumer
@@ -68,7 +68,7 @@ pub(super) enum MppFrameKind {
 ///
 /// The fixed layout `[magic, flags, stage_id, partition]` (4×u32) is what
 /// senders prepend before the Arrow IPC stream bytes and what receivers
-/// parse before deciding which sub-buffer the payload belongs to.
+/// parse before deciding which channel buffer the payload belongs to.
 ///
 /// The `flags` word currently encodes `MppFrameKind` in its low byte (mask
 /// `0x0000_00FF`); the upper 24 bits are reserved-must-be-zero and are
@@ -103,9 +103,9 @@ impl MppFrameHeader {
     }
 
     /// Build an `Eof` header for the given `(stage_id, partition)`. Carries no payload; receivers
-    /// route it to the sub-buffer's source-done counter. Emitted by
+    /// route it to the channel buffer's source-done counter. Emitted by
     /// [`MppSender::send_eof_traced`] after a producer fragment's per-partition stream exhausts
-    /// (or errors), and consumed by the matching sub-buffer's `notify_source_done`.
+    /// (or errors), and consumed by the matching channel buffer's `notify_source_done`.
     pub fn eof(stage_id: u32, partition: u32) -> Self {
         Self {
             magic: MPP_FRAME_MAGIC,
@@ -195,10 +195,10 @@ fn encode_frame_into(
 
 /// Serialize a payload-less [`MppFrameKind::Eof`] frame for `(stage_id, partition)`
 /// into `buf`. The shm_mq peer reads this as a 16-byte message and routes it to
-/// the sub-buffer's source-done counter without touching Arrow IPC.
+/// the channel buffer's source-done counter without touching Arrow IPC.
 /// Consumed by [`MppSender::send_eof_traced`] when a producer fragment's
 /// per-partition stream exhausts, so the receiver's `(stage_id, partition)`
-/// sub-buffer transitions to `Eof` even though the multiplexed shm_mq queue
+/// channel buffer transitions to `Eof` even though the multiplexed shm_mq queue
 /// stays attached for other channels.
 fn encode_eof_frame_into(
     stage_id: u32,
@@ -280,7 +280,7 @@ pub(super) enum DrainItem {
 
 impl DrainBuffer {
     /// Create a drain buffer expecting `num_sources` inbound queues. For a
-    /// participant in an N-way mesh, `num_sources == N - 1` (all peers
+    /// proc in an N-proc mesh, `num_sources == N - 1` (all peers
     /// excluding self — the self-partition bypasses the buffer).
     pub fn new(num_sources: u32) -> Arc<Self> {
         Arc::new(Self {
@@ -403,7 +403,7 @@ impl CooperativeDrainSet for DrainHandle {
 ///
 /// With `cooperative_drain` set, `send_batch` breaks the symmetric-send deadlock on a
 /// single-threaded tokio runtime by interleaving send-retries with
-/// `CooperativeDrainSet::try_drain_pass` on the same mesh's inbound side. Each participant's
+/// `CooperativeDrainSet::try_drain_pass` on the same mesh's inbound side. Each proc's
 /// sender doing the same guarantees mutual progress: our drain pulls peer-shipped rows out of
 /// our inbound queues, which frees peers' outbound-to-us send space, which lets their sends
 /// un-stall.
@@ -508,13 +508,13 @@ impl MppSender {
     }
 
     /// Send a payload-less [`MppFrameKind::Eof`] frame so the receiver's `(stage_id, partition)`
-    /// sub-buffer transitions to `Eof` and the consumer's pull loop terminates cleanly.
+    /// channel buffer transitions to `Eof` and the consumer's pull loop terminates cleanly.
     ///
     /// Producer fragments must call this exactly once per `(stage_id, partition)` channel after
     /// the local stream exhausts. Without it the multiplexed shm_mq queue stays attached (other
-    /// channels still flow) and the consumer sub-buffer never reaches `sources_done == 1`. The
+    /// channels still flow) and the consumer channel buffer never reaches `sources_done == 1`. The
     /// receive-side [`DrainHandle::try_drain_pass`] decodes the frame and calls
-    /// `notify_source_done` on the matching sub-buffer.
+    /// `notify_source_done` on the matching channel buffer.
     ///
     /// Uses the same cooperative-spin path as [`Self::send_batch_traced`] so a full outbound
     /// queue doesn't deadlock the EOF send. `stats.spin_iters` / `send_wait` capture any
@@ -585,7 +585,7 @@ impl MppSender {
         // backend thread (DataFusion needs one to drive `Stream`s).
         // This spin runs *inside* a Tokio task — specifically the body
         // of `ShuffleStream::poll_next`. The deadlock the cooperative
-        // drain prevents is *cross-participant*, not same-runtime: two
+        // drain prevents is *cross-proc*, not same-runtime: two
         // peers each blocking on a full outbound and never reading the
         // other side. We break that by driving our own inbound on this
         // same OS thread via `try_drain_pass`, which pulls peer
@@ -622,7 +622,7 @@ impl MppSender {
             stats.spin_iters += 1;
             // Would-block: pull from our own mesh's inbound so peers'
             // sends to us unblock. Without this interleave two
-            // participants blocking on symmetric sends deadlock —
+            // procs blocking on symmetric sends deadlock —
             // neither gets to drain. Errors propagate so a peer
             // detaching mid-spin doesn't leave the sender looping
             // forever on a closed mesh.
@@ -678,7 +678,7 @@ impl MppReceiver {
 
 /// Decoded result of an [`MppReceiver::try_recv_batch`]. Carries the
 /// parsed [`MppFrameHeader`] so the drain thread can route the payload to
-/// the right `(stage_id, partition)` sub-buffer.
+/// the right `(stage_id, partition)` channel buffer.
 #[derive(Debug)]
 pub(super) enum RecvBatchOutcome {
     Batch {
@@ -697,38 +697,38 @@ pub(super) enum RecvBatchOutcome {
     Error(DataFusionError),
 }
 
-/// Per-`(stage_id, partition)` sub-buffer registry owned by a cooperative [`DrainHandle`]. The
+/// Per-`(stage_id, partition)` channel buffer registry owned by a cooperative [`DrainHandle`]. The
 /// handle serves one sender_proc, whose shm_mq queue carries frames for many logical channels,
-/// each tagged by the [`MppFrameHeader`] prefix. `try_drain_pass` looks up the right sub-buffer
+/// each tagged by the [`MppFrameHeader`] prefix. `try_drain_pass` looks up the right channel buffer
 /// on every frame and pushes the payload into it. Consumers waiting on
 /// `(stage_id=s, partition=p)` only see frames matching that key.
 ///
 /// Each entry is a `DrainBuffer::new(1)` because exactly one source (the sender_proc this handle
 /// serves) emits frames for any given channel via this drain. When the sender_proc detaches
 /// (`Detached` outcome on the underlying receiver), `detached` flips to `true` and every existing
-/// sub-buffer is notified, so any consumer blocked on `try_pop` unblocks with `DrainItem::Eof`.
-/// Sub-buffers registered *after* detach come back already EOF'd so a late consumer doesn't hang.
+/// channel buffer is notified, so any consumer blocked on `try_pop` unblocks with `DrainItem::Eof`.
+/// Channel buffers registered *after* detach come back already EOF'd so a late consumer doesn't hang.
 #[derive(Default)]
-struct SubBufferRegistry {
+struct ChannelBufferRegistry {
     map: HashMap<(u32, u32), Arc<DrainBuffer>>,
     detached: bool,
 }
 
 /// Per-sender-proc drain: stashes the receivers and polls them inline from the cooperative spin
-/// (no background thread), demuxing each frame into a per-`(stage_id, partition)` sub-buffer.
+/// (no background thread), demuxing each frame into a per-`(stage_id, partition)` channel buffer.
 ///
 /// Inline polling is the production requirement: pgrx's `check_active_thread` guard panics on any
 /// pg FFI call (including `shm_mq_receive`) from a non-backend thread, so the drain work has to
 /// run on the backend thread. Tests that need a true thread-backed drain use
 /// [`ThreadedDrainHandle`] instead.
 ///
-/// On drop, the handle cancels every sub-buffer so any consumer blocked on `try_pop` unblocks
+/// On drop, the handle cancels every channel buffer so any consumer blocked on `try_pop` unblocks
 /// with `Eof` — the drain can therefore never outlive its query, even on a panicked teardown.
 pub struct DrainHandle {
-    /// Per-(stage_id, partition) sub-buffer registry. Populated lazily on first frame for a
+    /// Per-(stage_id, partition) channel buffer registry. Populated lazily on first frame for a
     /// channel, or up-front by callers (e.g. `WorkerConnection::stream_partition`) that need a
     /// buffer to wait on before any frame arrives.
-    sub_buffers: Mutex<SubBufferRegistry>,
+    channel_buffers: Mutex<ChannelBufferRegistry>,
     /// Receivers owned by the handle and polled inline from `DrainGatherStream::poll_next` via
     /// [`Self::try_drain_pass`]. The `Mutex` is for interior mutability: `try_drain_pass(&self)`
     /// marks each slot as `None` after observing `Detached` so subsequent passes skip the dead
@@ -742,18 +742,18 @@ pub struct DrainHandle {
 }
 
 impl DrainHandle {
-    /// Construct a cooperative drain handle. Sub-buffers are populated lazily by
+    /// Construct a cooperative drain handle. Channel buffers are populated lazily by
     /// [`Self::try_drain_pass`] when a frame arrives, or up-front by [`Self::register_channel`]
     /// when a consumer needs a buffer to wait on before any frame has come in.
     pub(super) fn cooperative(receivers: Vec<MppReceiver>) -> Self {
         let wrapped = receivers.into_iter().map(Some).collect();
         Self {
-            sub_buffers: Mutex::new(SubBufferRegistry::default()),
+            channel_buffers: Mutex::new(ChannelBufferRegistry::default()),
             coop_receivers: Mutex::new(wrapped),
         }
     }
 
-    /// Register (or look up) the sub-buffer for `(stage_id, partition)`. The returned
+    /// Register (or look up) the channel buffer for `(stage_id, partition)`. The returned
     /// `Arc<DrainBuffer>` is the canonical destination for frames matching that key:
     /// `try_drain_pass` pushes into the same entry on every `Batch { header, .. }` whose header
     /// matches.
@@ -763,9 +763,9 @@ impl DrainHandle {
     /// registering after detach sees `Eof` on the first `try_pop` instead of hanging forever.
     pub(super) fn register_channel(&self, stage_id: u32, partition: u32) -> Arc<DrainBuffer> {
         let mut guard = self
-            .sub_buffers
+            .channel_buffers
             .lock()
-            .expect("DrainHandle sub_buffers mutex poisoned");
+            .expect("DrainHandle channel_buffers mutex poisoned");
         let detached = guard.detached;
         guard
             .map
@@ -780,9 +780,9 @@ impl DrainHandle {
             .clone()
     }
 
-    /// Mark the drain as detached and `notify_source_done` every registered sub-buffer.
+    /// Mark the drain as detached and `notify_source_done` every registered channel buffer.
     /// Idempotent. Used by `try_drain_pass` after `Detached` / `Error` outcomes; the
-    /// cooperative-path equivalent fires from `Drop` via [`Self::cancel_sub_buffers`] so any
+    /// cooperative-path equivalent fires from `Drop` via [`Self::cancel_channel_buffers`] so any
     /// consumer blocked on `try_pop` unblocks with `Eof` even if the query is torn down before
     /// EOF frames flow.
     ///
@@ -793,9 +793,9 @@ impl DrainHandle {
     fn mark_detached(&self) {
         let to_notify = {
             let mut guard = self
-                .sub_buffers
+                .channel_buffers
                 .lock()
-                .expect("DrainHandle sub_buffers mutex poisoned");
+                .expect("DrainHandle channel_buffers mutex poisoned");
             if guard.detached {
                 return;
             }
@@ -807,15 +807,15 @@ impl DrainHandle {
         }
     }
 
-    /// Cancel every registered sub-buffer. Called from `Drop` to unblock any consumer waiting on
-    /// a sub-buffer when the handle goes away mid-query. Same collect-then-notify pattern as
+    /// Cancel every registered channel buffer. Called from `Drop` to unblock any consumer waiting on
+    /// a channel buffer when the handle goes away mid-query. Same collect-then-notify pattern as
     /// [`Self::mark_detached`].
-    fn cancel_sub_buffers(&self) {
+    fn cancel_channel_buffers(&self) {
         let to_cancel = {
             let guard = self
-                .sub_buffers
+                .channel_buffers
                 .lock()
-                .expect("DrainHandle sub_buffers mutex poisoned");
+                .expect("DrainHandle channel_buffers mutex poisoned");
             guard.map.values().cloned().collect::<Vec<_>>()
         };
         for buf in to_cancel {
@@ -824,7 +824,7 @@ impl DrainHandle {
     }
 
     /// Pull batches from each live receiver and demux them into the per-`(stage_id, partition)`
-    /// sub-buffer registry. Called from `DrainGatherStream::poll_next` and from
+    /// channel buffer registry. Called from `DrainGatherStream::poll_next` and from
     /// `MppSender::send_batch`'s cooperative spin. Drain work happens on the backend thread
     /// (pgrx-safe). No-op for thread-backed handles.
     ///
@@ -840,16 +840,16 @@ impl DrainHandle {
     ///
     /// Routing rules per outcome:
     /// - `Batch { header, batch }`: look up (or lazily create) the
-    ///   `(header.stage_id, header.partition)` sub-buffer and push `batch`.
-    /// - `Eof { header }`: per-channel EOF. Resolve the sub-buffer and call
+    ///   `(header.stage_id, header.partition)` channel buffer and push `batch`.
+    /// - `Eof { header }`: per-channel EOF. Resolve the channel buffer and call
     ///   `notify_source_done`. Other channels on the same queue keep flowing,
     ///   so the receiver slot stays live.
     /// - `Detached` / `Error`: queue-wide shutdown. Notify every registered
-    ///   sub-buffer, mark the handle detached, and drop the slot.
+    ///   channel buffer, mark the handle detached, and drop the slot.
     pub fn try_drain_pass(&self) -> Result<(), DataFusionError> {
         // Bound per-source pulls per call. The upper limit exists to give
         // the caller a chance to re-try its own send between drains —
-        // otherwise a participant with a very fast peer could drain
+        // otherwise a proc with a very fast peer could drain
         // indefinitely on one source and starve its own outbound.
         const MAX_BATCHES_PER_SOURCE_PER_PASS: usize = 256;
 
@@ -890,9 +890,9 @@ impl DrainHandle {
 
 impl Drop for DrainHandle {
     fn drop(&mut self) {
-        // Unblock any consumer blocked on a sub-buffer when the handle is torn down before EOF
+        // Unblock any consumer blocked on a channel buffer when the handle is torn down before EOF
         // flows naturally (e.g. a query error en route to ExecEndCustomScan).
-        self.cancel_sub_buffers();
+        self.cancel_channel_buffers();
     }
 }
 /// SPSC channel pair for two use cases:
@@ -902,7 +902,7 @@ impl Drop for DrainHandle {
 ///   producer task t), the shm_mq grid leaves the `slot(this_proc, this_proc)` diagonal
 ///   unattached. The dispatcher routes those self-loops through this in-proc channel instead.
 ///   It shares the same `BatchChannelSender`/`BatchChannelReceiver` abstraction as shm_mq, so the
-///   drain and sub-buffer registry don't need a special case.
+///   drain and channel buffer registry don't need a special case.
 ///
 /// Production callers pass a very large `capacity` so the channel is effectively unbounded under
 /// steady state. The current-thread Tokio runtime interleaves producer and consumer fragments
@@ -1401,7 +1401,7 @@ mod tests {
 
     #[test]
     fn drain_thread_drains_n2_mesh_100k_batches() {
-        // Simulates a 2-participant mesh under load. Each of two producers
+        // Simulates a 2-proc mesh under load. Each of two producers
         // pushes 50_000 small batches through a bounded channel; the drain
         // thread interleaves and the consumer reads EOF exactly after
         // receiving all 100_000 batches. Exercises backpressure (bounded
@@ -1595,8 +1595,8 @@ mod tests {
     #[ignore]
     fn throughput_postagg_shape() {
         // Sweeps batch size to show per-batch fixed cost vs per-row cost.
-        // 1.25M total rows ≈ what one participant ships through gb_postagg at
-        // 25M scale. 625K per participant × 2 = 1.25M.
+        // 1.25M total rows ≈ what one proc ships through gb_postagg at
+        // 25M scale. 625K per proc × 2 = 1.25M.
         for batch_rows in [128, 512, 2048, 8192, 32_768] {
             bench_throughput("postagg", postagg_shape_batch, batch_rows, 1_250_000);
         }
@@ -1605,17 +1605,17 @@ mod tests {
     #[test]
     #[ignore]
     fn throughput_probe_shape() {
-        // 12.5M total rows ≈ what one participant ships through gb_right at 25M.
+        // 12.5M total rows ≈ what one proc ships through gb_right at 25M.
         for batch_rows in [128, 512, 2048, 8192, 32_768] {
             bench_throughput("probe", probe_shape_batch, batch_rows, 12_500_000);
         }
     }
 
     // ---------------------------------------------------------------------
-    // Per-`(stage_id, partition)` sub-buffer registry on the cooperative `DrainHandle`.
+    // Per-`(stage_id, partition)` channel buffer registry on the cooperative `DrainHandle`.
     //
     // Producers stamp `MppFrameHeader::batch(stage_id, partition)` on every outgoing frame, and
-    // the receiver-side cooperative drain demuxes by header into a sub-buffer per
+    // the receiver-side cooperative drain demuxes by header into a channel buffer per
     // `(stage_id, partition)`. These tests use the `in_proc_channel` backend to drive
     // `try_drain_pass` from the test thread. That mirrors how the production path runs the drain
     // inline from `DrainGatherStream::poll_next` on the backend thread.
@@ -1629,7 +1629,7 @@ mod tests {
         for _ in 0..64 {
             handle.try_drain_pass().expect("try_drain_pass");
             // After enough passes the in-proc backend reports `Detached`, which flips
-            // `mark_detached` and notifies every sub-buffer. We keep polling so any queued
+            // `mark_detached` and notifies every channel buffer. We keep polling so any queued
             // frames flow through first.
         }
     }
@@ -1637,7 +1637,7 @@ mod tests {
     #[test]
     fn drain_handle_demuxes_frames_by_header() {
         // One queue carrying two channels: `(0, 0)` and `(0, 1)`. Each
-        // sub-buffer receives only its own batches.
+        // channel buffer receives only its own batches.
         let (tx, rx) = in_proc_channel(8);
         let base = MppSender::new(Arc::new(tx));
         let s00 = base.clone_with_header(MppFrameHeader::batch(0, 0));
@@ -1673,7 +1673,7 @@ mod tests {
 
     #[test]
     fn drain_handle_eof_frame_closes_one_channel() {
-        // An `Eof` frame on `(0, 0)` closes that sub-buffer while frames on
+        // An `Eof` frame on `(0, 0)` closes that channel buffer while frames on
         // `(0, 1)` continue to flow on the same queue.
         let (tx, rx) = in_proc_channel(8);
         let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
@@ -1715,9 +1715,9 @@ mod tests {
     }
 
     #[test]
-    fn drain_handle_detach_eofs_all_registered_sub_buffers() {
+    fn drain_handle_detach_eofs_all_registered_channel_buffers() {
         // No frames flow; consumer pre-registers two channels. When the sender drops and
-        // `try_drain_pass` observes `Detached`, both sub-buffers immediately surface `Eof`.
+        // `try_drain_pass` observes `Detached`, both channel buffers immediately surface `Eof`.
         // Without that, a consumer blocked on `try_pop` would hang past the producer's death.
         let (tx, rx) = in_proc_channel(8);
         drop(tx); // detach immediately
@@ -1765,7 +1765,7 @@ mod tests {
     #[test]
     fn drain_handle_demuxes_frames_by_stage_id() {
         // Same partition (0) for two different stage ids on the same queue.
-        // The registry's compound key keeps them on separate sub-buffers.
+        // The registry's compound key keeps them on separate channel buffers.
         let (tx, rx) = in_proc_channel(8);
         let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
         let s_stage0 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0));
@@ -1798,7 +1798,7 @@ mod tests {
     }
 
     #[test]
-    fn drain_handle_drop_cancels_registered_sub_buffers() {
+    fn drain_handle_drop_cancels_registered_channel_buffers() {
         // Dropping a cooperative DrainHandle must wake any consumer holding an Arc<DrainBuffer>
         // from `register_channel`. Otherwise a query error path that tears down the mesh would
         // leave a consumer blocked on a buffer that will never see EOF.

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -397,7 +397,7 @@ pub(super) enum RecvOutcome {
 /// Non-blocking byte channel receiver. Implementations: shm_mq (production),
 /// `std::sync::mpsc` (tests). Must be `Send` because the drain thread takes
 /// ownership.
-pub(super) trait BatchChannelReceiver: Send {
+pub(super) trait BatchChannelReceiver: Send + Sync {
     fn try_recv(&self) -> RecvOutcome;
 }
 
@@ -859,9 +859,14 @@ pub struct DrainHandle {
     /// buffer to wait on before any frame arrives.
     sub_buffers: Mutex<SubBufferRegistry>,
     /// Receivers owned by the handle and polled inline from `DrainGatherStream::poll_next` via
-    /// [`Self::try_drain_pass`]. The `Send` bound on `MppReceiver` is preserved — the receivers
-    /// move thread-once at construction then are only accessed from the backend thread; the
-    /// `Mutex` is just for interior mutability, not cross-thread coordination.
+    /// [`Self::try_drain_pass`]. The `Mutex` is for interior mutability: `try_drain_pass(&self)`
+    /// marks each slot as `None` after observing `Detached` so subsequent passes skip the dead
+    /// receiver. `BatchChannelReceiver: Send + Sync` makes `Vec<Option<MppReceiver>>: Sync`
+    /// already, so the lock is no longer doubling as the `Sync` provider — replacing it with a
+    /// non-locking primitive would need either an atomic per-slot detached flag or accepting
+    /// that detached receivers get polled once per pass (fast-returning `Detached`). The lock
+    /// is uncontended in production (single backend thread) so the marginal cost is in the
+    /// type system, not the runtime.
     coop_receivers: Mutex<Vec<Option<MppReceiver>>>,
 }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -36,10 +36,6 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
-#[cfg(test)]
-use std::thread;
-#[cfg(test)]
-use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use datafusion::arrow::array::RecordBatch;
@@ -323,39 +319,6 @@ impl DrainBuffer {
         self.cond.notify_all();
     }
 
-    /// Block until a batch is available, EOF is reached, or the buffer is
-    /// cancelled.
-    ///
-    /// INVARIANT: any already-buffered batch is returned *before* honoring
-    /// either cancellation or all-sources-done. Reordering the queue pop ahead
-    /// of the cancel/eof check would silently drop buffered data on an
-    /// otherwise-clean shutdown; the
-    /// `drain_buffer_drains_buffered_before_eof` test locks this in.
-    #[cfg(test)]
-    pub fn pop_front(&self) -> DrainItem {
-        let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
-        loop {
-            if let Some(batch) = guard.queue.pop_front() {
-                return DrainItem::Batch(batch);
-            }
-            if guard.cancelled || guard.sources_done >= guard.num_sources {
-                return DrainItem::Eof;
-            }
-            guard = self.cond.wait(guard).expect("DrainBuffer mutex poisoned");
-        }
-    }
-
-    /// True if `cancel` has been called. The test-only `drain_loop` and its
-    /// tests consult this; the cooperative production path watches the flag
-    /// through `notify_source_done` fan-out instead.
-    #[cfg(test)]
-    pub fn is_cancelled(&self) -> bool {
-        self.inner
-            .lock()
-            .expect("DrainBuffer mutex poisoned")
-            .cancelled
-    }
-
     /// Non-blocking variant. Returns the front item, or `DrainItem::Eof` if
     /// all sources have detached and the queue is drained, or `None` if more
     /// data may yet arrive. Cooperative consumers loop on
@@ -493,13 +456,6 @@ impl MppSender {
         }
     }
 
-    /// Construct a sender with the default `(stage_id=0, partition=0)` header.
-    /// Used by tests where the header carries no actionable routing info.
-    #[cfg(test)]
-    pub(super) fn new(channel: Arc<dyn BatchChannelSender>) -> Self {
-        Self::with_header(channel, MppFrameHeader::batch(0, 0))
-    }
-
     /// Build a new `MppSender` that shares this sender's underlying channel
     /// but tags every frame with `header` instead. Used by callers that know
     /// the physical plan's output partition count and need one sender per
@@ -521,22 +477,6 @@ impl MppSender {
     pub fn with_cooperative_drain(mut self, drain: Arc<dyn CooperativeDrainSet>) -> Self {
         self.cooperative_drain = Some(drain);
         self
-    }
-
-    /// Test-only stats-less wrapper around [`Self::send_batch_traced`].
-    /// Production call sites (`ShuffleStream::process_batch`) always pass
-    /// a `SendBatchStats` so per-peer wall-time shows up in the EOF trace.
-    /// Wraps the async send in a tiny current-thread Tokio runtime so test
-    /// `#[test]` functions don't have to be `#[tokio::test]` and the
-    /// existing OS-thread-spawning test harnesses don't have to plumb an
-    /// async runtime themselves.
-    #[cfg(test)]
-    pub fn send_batch(&self, batch: &RecordBatch) -> Result<(), DataFusionError> {
-        let mut stats = SendBatchStats::default();
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .build()
-            .expect("test tokio runtime build");
-        rt.block_on(self.send_batch_traced(batch, &mut stats))
     }
 
     /// `send_batch` variant that accumulates per-call timings and spin
@@ -757,75 +697,6 @@ pub(super) enum RecvBatchOutcome {
     Error(DataFusionError),
 }
 
-/// Configuration for [`spawn_drain_thread`]. Test-only: pgrx panics on any pg FFI call
-/// (including `shm_mq_receive`) from a non-backend thread, so production never spawns a drain
-/// thread — see [`DrainHandle::cooperative`] for the cooperative path.
-#[cfg(test)]
-struct DrainConfig {
-    /// Receivers to drain. Ownership moves into the spawned thread.
-    receivers: Vec<MppReceiver>,
-    /// Destination buffer.
-    buffer: Arc<DrainBuffer>,
-    /// How long to sleep when every receiver is empty but some are still
-    /// attached. Tuning: small values reduce end-of-batch latency but raise
-    /// CPU; 1 ms is a safe default until we integrate with WaitLatch.
-    idle_sleep: Duration,
-}
-
-#[cfg(test)]
-impl DrainConfig {
-    fn new(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
-        Self {
-            receivers,
-            buffer,
-            idle_sleep: Duration::from_millis(1),
-        }
-    }
-}
-
-/// Spawn the dedicated drain thread.
-///
-/// Test-only: the thread round-robins through every receiver with non-blocking
-/// `try_recv`, pushes decoded batches into `buffer`, and marks each source
-/// done as soon as it observes a detach or decode error. When every source is
-/// done, the thread exits.
-#[cfg(test)]
-fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusionError>> {
-    thread::spawn(move || drain_loop(config))
-}
-
-/// Test-only RAII wrapper: owns the drain thread's `JoinHandle` and the buffer it writes into.
-/// `Drop` cancels the buffer (unblocking the consumer) and joins the thread, so the thread can
-/// never outlive the test scope even on a panic. Production code never spawns a drain thread —
-/// see [`DrainHandle`] for the cooperative variant that runs inline on the backend thread.
-#[cfg(test)]
-struct ThreadedDrainHandle {
-    buffer: Arc<DrainBuffer>,
-    join: Mutex<Option<JoinHandle<Result<(), DataFusionError>>>>,
-}
-
-#[cfg(test)]
-impl ThreadedDrainHandle {
-    pub fn spawn(config: DrainConfig) -> Self {
-        let buffer = Arc::clone(&config.buffer);
-        let join = spawn_drain_thread(config);
-        Self {
-            buffer,
-            join: Mutex::new(Some(join)),
-        }
-    }
-}
-
-#[cfg(test)]
-impl Drop for ThreadedDrainHandle {
-    fn drop(&mut self) {
-        self.buffer.cancel();
-        if let Some(join) = self.join.lock().unwrap().take() {
-            let _ = join.join();
-        }
-    }
-}
-
 /// Per-`(stage_id, partition)` sub-buffer registry owned by a cooperative [`DrainHandle`]. The
 /// handle serves one sender_proc, whose shm_mq queue carries frames for many logical channels,
 /// each tagged by the [`MppFrameHeader`] prefix. `try_drain_pass` looks up the right sub-buffer
@@ -1024,73 +895,6 @@ impl Drop for DrainHandle {
         self.cancel_sub_buffers();
     }
 }
-
-/// Test-only thread-backed drain. Writes every observed frame into a single shared
-/// [`DrainBuffer`] with `num_sources = N`. Per-channel `Eof` frames are treated as "this source
-/// is done" rather than "this logical channel within the source is done"; sufficient for unit
-/// tests that don't exercise per-channel demux. Production drains route through
-/// [`DrainHandle::try_drain_pass`] (cooperative variant), which keys on the frame header. Tests
-/// that need to validate production demux must use [`DrainHandle::cooperative`] and call
-/// `try_drain_pass` directly.
-#[cfg(test)]
-fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
-    let DrainConfig {
-        receivers,
-        buffer,
-        idle_sleep,
-    } = config;
-
-    let mut done = vec![false; receivers.len()];
-    loop {
-        // Observe cancellation before each pass so a `DrainHandle::drop` with
-        // live peer senders tears down cleanly. Without this check, the drain
-        // thread would spin `try_recv` forever because no source has detached.
-        if buffer.is_cancelled() {
-            return Ok(());
-        }
-
-        let mut got_any = false;
-        let mut all_done = true;
-        for (i, rx) in receivers.iter().enumerate() {
-            if done[i] {
-                continue;
-            }
-            all_done = false;
-            match rx.try_recv_batch() {
-                RecvBatchOutcome::Batch { header: _, batch } => {
-                    got_any = true;
-                    buffer.push_batch(batch);
-                }
-                RecvBatchOutcome::Eof { header: _ } => {
-                    // Per-channel Eof frame: single-channel positional design
-                    // treats it as a source-done signal. See `try_drain_pass`.
-                    done[i] = true;
-                    buffer.notify_source_done();
-                }
-                RecvBatchOutcome::Empty => {}
-                RecvBatchOutcome::Detached => {
-                    done[i] = true;
-                    buffer.notify_source_done();
-                }
-                RecvBatchOutcome::Error(e) => {
-                    // Treat a decode error as a fatal detach for this source
-                    // so the consumer can observe EOF and abort the query.
-                    done[i] = true;
-                    buffer.notify_source_done();
-                    return Err(e);
-                }
-            }
-        }
-
-        if all_done {
-            return Ok(());
-        }
-        if !got_any {
-            thread::sleep(idle_sleep);
-        }
-    }
-}
-
 /// SPSC channel pair for two use cases:
 /// - Unit tests (bounded capacity, exercising backpressure).
 /// - Production self-loop slots: when a worker's fragment emits a partition destined for its OWN
@@ -1164,6 +968,185 @@ mod tests {
     use datafusion::arrow::datatypes::{DataType, Field, Schema};
     use std::sync::Arc as StdArc;
     use std::thread;
+
+    use std::thread::JoinHandle;
+
+    impl DrainBuffer {
+        /// Block until a batch is available, EOF is reached, or the buffer is cancelled.
+        ///
+        /// INVARIANT: any already-buffered batch is returned *before* honoring either
+        /// cancellation or all-sources-done. Reordering the queue pop ahead of the cancel/eof
+        /// check would silently drop buffered data on an otherwise-clean shutdown; the
+        /// `drain_buffer_drains_buffered_before_eof` test locks this in.
+        fn pop_front(&self) -> DrainItem {
+            let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
+            loop {
+                if let Some(batch) = guard.queue.pop_front() {
+                    return DrainItem::Batch(batch);
+                }
+                if guard.cancelled || guard.sources_done >= guard.num_sources {
+                    return DrainItem::Eof;
+                }
+                guard = self.cond.wait(guard).expect("DrainBuffer mutex poisoned");
+            }
+        }
+
+        /// True if `cancel` has been called. The local `drain_loop` consults this; the
+        /// cooperative production path watches the flag through `notify_source_done` fan-out
+        /// instead.
+        fn is_cancelled(&self) -> bool {
+            self.inner
+                .lock()
+                .expect("DrainBuffer mutex poisoned")
+                .cancelled
+        }
+    }
+
+    impl MppSender {
+        /// Construct a sender with the default `(stage_id=0, partition=0)` header. Used where
+        /// the header carries no actionable routing info.
+        fn new(channel: Arc<dyn BatchChannelSender>) -> Self {
+            Self::with_header(channel, MppFrameHeader::batch(0, 0))
+        }
+
+        /// Stats-less wrapper around `send_batch_traced`. Production call sites
+        /// (`ShuffleStream::process_batch`) always pass a `SendBatchStats` so per-peer
+        /// wall-time shows up in the EOF trace. Wraps the async send in a tiny current-thread
+        /// Tokio runtime so `#[test]` functions don't have to be `#[tokio::test]` and the
+        /// OS-thread-spawning test harnesses don't have to plumb an async runtime themselves.
+        fn send_batch(&self, batch: &RecordBatch) -> Result<(), DataFusionError> {
+            let mut stats = SendBatchStats::default();
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .build()
+                .expect("test tokio runtime build");
+            rt.block_on(self.send_batch_traced(batch, &mut stats))
+        }
+    }
+
+    /// Configuration for `spawn_drain_thread`. pgrx panics on any pg FFI call (including
+    /// `shm_mq_receive`) from a non-backend thread, so production never spawns a drain thread —
+    /// see [`DrainHandle::cooperative`] for the cooperative path.
+    struct DrainConfig {
+        /// Receivers to drain. Ownership moves into the spawned thread.
+        receivers: Vec<MppReceiver>,
+        /// Destination buffer.
+        buffer: Arc<DrainBuffer>,
+        /// How long to sleep when every receiver is empty but some are still attached. Tuning:
+        /// small values reduce end-of-batch latency but raise CPU; 1 ms is a safe default until
+        /// we integrate with WaitLatch.
+        idle_sleep: Duration,
+    }
+
+    impl DrainConfig {
+        fn new(receivers: Vec<MppReceiver>, buffer: Arc<DrainBuffer>) -> Self {
+            Self {
+                receivers,
+                buffer,
+                idle_sleep: Duration::from_millis(1),
+            }
+        }
+    }
+
+    /// Spawn the dedicated drain thread. The thread round-robins through every receiver with
+    /// non-blocking `try_recv`, pushes decoded batches into `buffer`, and marks each source done
+    /// as soon as it observes a detach or decode error. When every source is done, the thread
+    /// exits.
+    fn spawn_drain_thread(config: DrainConfig) -> JoinHandle<Result<(), DataFusionError>> {
+        thread::spawn(move || drain_loop(config))
+    }
+
+    /// RAII wrapper: owns the drain thread's `JoinHandle` and the buffer it writes into.
+    /// `Drop` cancels the buffer (unblocking the consumer) and joins the thread, so the thread
+    /// can never outlive the test scope even on a panic.
+    struct ThreadedDrainHandle {
+        buffer: Arc<DrainBuffer>,
+        join: Mutex<Option<JoinHandle<Result<(), DataFusionError>>>>,
+    }
+
+    impl ThreadedDrainHandle {
+        fn spawn(config: DrainConfig) -> Self {
+            let buffer = Arc::clone(&config.buffer);
+            let join = spawn_drain_thread(config);
+            Self {
+                buffer,
+                join: Mutex::new(Some(join)),
+            }
+        }
+    }
+
+    impl Drop for ThreadedDrainHandle {
+        fn drop(&mut self) {
+            self.buffer.cancel();
+            if let Some(join) = self.join.lock().unwrap().take() {
+                let _ = join.join();
+            }
+        }
+    }
+
+    /// Test-only thread-backed drain. Writes every observed frame into a single shared
+    /// [`DrainBuffer`] with `num_sources = N`. Per-channel `Eof` frames are treated as "this source
+    /// is done" rather than "this logical channel within the source is done"; sufficient for unit
+    /// tests that don't exercise per-channel demux. Production drains route through
+    /// [`DrainHandle::try_drain_pass`] (cooperative variant), which keys on the frame header. Tests
+    /// that need to validate production demux must use [`DrainHandle::cooperative`] and call
+    /// `try_drain_pass` directly.
+    fn drain_loop(config: DrainConfig) -> Result<(), DataFusionError> {
+        let DrainConfig {
+            receivers,
+            buffer,
+            idle_sleep,
+        } = config;
+
+        let mut done = vec![false; receivers.len()];
+        loop {
+            // Observe cancellation before each pass so a `DrainHandle::drop` with
+            // live peer senders tears down cleanly. Without this check, the drain
+            // thread would spin `try_recv` forever because no source has detached.
+            if buffer.is_cancelled() {
+                return Ok(());
+            }
+
+            let mut got_any = false;
+            let mut all_done = true;
+            for (i, rx) in receivers.iter().enumerate() {
+                if done[i] {
+                    continue;
+                }
+                all_done = false;
+                match rx.try_recv_batch() {
+                    RecvBatchOutcome::Batch { header: _, batch } => {
+                        got_any = true;
+                        buffer.push_batch(batch);
+                    }
+                    RecvBatchOutcome::Eof { header: _ } => {
+                        // Per-channel Eof frame: single-channel positional design
+                        // treats it as a source-done signal. See `try_drain_pass`.
+                        done[i] = true;
+                        buffer.notify_source_done();
+                    }
+                    RecvBatchOutcome::Empty => {}
+                    RecvBatchOutcome::Detached => {
+                        done[i] = true;
+                        buffer.notify_source_done();
+                    }
+                    RecvBatchOutcome::Error(e) => {
+                        // Treat a decode error as a fatal detach for this source
+                        // so the consumer can observe EOF and abort the query.
+                        done[i] = true;
+                        buffer.notify_source_done();
+                        return Err(e);
+                    }
+                }
+            }
+
+            if all_done {
+                return Ok(());
+            }
+            if !got_any {
+                thread::sleep(idle_sleep);
+            }
+        }
+    }
 
     fn sample_batch(rows: i32) -> RecordBatch {
         let schema = StdArc::new(Schema::new(vec![

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -17,17 +17,14 @@
 
 //! MPP worker fragment runner.
 //!
-//! "Worker" matches the DF-D fork's terminology — every distributed task is
-//! a `WorkerConnection` on the receive side, and the fragment runner is
-//! that worker's push side.
+//! "Worker" matches the DF-D fork's terminology. Every distributed task is a `WorkerConnection`
+//! on the receive side, and the fragment runner is that worker's push side.
 //!
-//! - [`run_worker_fragment`] — PG-parallel-worker push loop. Runs the
-//!   `n_partitions` output partitions of `plan` concurrently; each batch
-//!   yielded by partition `p` is encoded and pushed through
-//!   `outbound_senders[p]`. Returns when every output stream is exhausted.
-//!   The leader is consumer-only in this iteration (see
-//!   [`crate::postgres::customscan::mpp::glue::producer_worker_count`]);
-//!   leader-as-worker-0 is a deferred follow-up.
+//! - [`run_worker_fragment`]: PG-parallel-worker push loop. Runs the `n_partitions` output
+//!   partitions of `plan` concurrently; each batch yielded by partition `p` is encoded and pushed
+//!   through `outbound_senders[p]`. Returns when every output stream is exhausted. Only producer
+//!   workers call this; the leader is consumer-only (see
+//!   [`crate::postgres::customscan::mpp::glue::producer_worker_count`]).
 
 use std::sync::Arc;
 
@@ -67,23 +64,51 @@ pub async fn run_worker_fragment(
         let ctx = Arc::clone(&ctx);
         let sender = Arc::clone(sender);
         futures.push(async move {
-            let mut stream = plan.execute(partition, ctx)?;
             let mut stats = SendBatchStats::default();
-            while let Some(batch) = stream.next().await {
-                let batch = batch?;
-                if batch.num_rows() == 0 {
-                    continue;
+            // Run the partition stream to exhaustion; capture either the
+            // first error or Ok(()) so we can still emit the per-channel
+            // EOF below regardless of how the stream ended.
+            let stream_result: Result<(), DataFusionError> = async {
+                let mut stream = plan.execute(partition, ctx)?;
+                while let Some(batch) = stream.next().await {
+                    let batch = batch?;
+                    if batch.num_rows() == 0 {
+                        continue;
+                    }
+                    sender
+                        .as_ref()
+                        .send_batch_traced(&batch, &mut stats)
+                        .await?;
                 }
-                sender
-                    .as_ref()
-                    .send_batch_traced(&batch, &mut stats)
-                    .await?;
+                Ok(())
             }
-            Ok::<(), DataFusionError>(())
+            .await;
+            // Signal channel EOF so the consumer's per-(stage_id, partition) sub-buffer transitions
+            // to Eof. Don't rely on the shared shm_mq queue detaching: multiple fragments multiplex
+            // over the same queue, so dropping this partition's sender doesn't close it.
+            //
+            // CORRECTNESS: send EOF even when the stream errored. Skip it; a producer-side error
+            // (say a mid-scan I/O failure) leaves the consumer's sub-buffer stuck at
+            // `sources_done == 0` and the leader's `select_all` blocks forever. The deadlock
+            // detector only fires under `paradedb.mpp_debug = on`; otherwise the hang is silent.
+            let eof_result = sender.as_ref().send_eof_traced(&mut stats).await;
+            // Propagate the stream's error first; otherwise surface any EOF send error so failure
+            // modes don't silently disappear.
+            stream_result.and(eof_result)
         });
     }
-    futures::future::try_join_all(futures).await?;
-    // Drop senders so peers observe Detached on their next try_recv.
+    // `join_all`, not `try_join_all`. Fail-fast `try_join_all` would cancel sibling partitions
+    // mid-`await` on the first `Err`, and a cancelled sibling never reaches its
+    // `send_eof_traced`. The consumer's sub-buffer for that channel would stay at
+    // `sources_done == 0` and the leader's `select_all` would block forever unless the backend
+    // tore down and the shm_mq queue detached. `join_all` drives every partition through its EOF
+    // send before we propagate the first error.
+    let results = futures::future::join_all(futures).await;
+    // Drop senders so peers observe `Detached` on their next try_recv even if a partition's EOF
+    // send itself errored.
     drop(senders);
+    for r in results {
+        r?;
+    }
     Ok(())
 }

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -63,11 +63,14 @@ pub async fn run_worker_fragment(
         let plan = Arc::clone(&plan);
         let ctx = Arc::clone(&ctx);
         let sender = Arc::clone(sender);
+        // Each partition must send a per-channel EOF when the stream ends, regardless of how it
+        // ended (success or error). The shm_mq queue is shared across fragments, so dropping the
+        // sender doesn't signal end-of-channel — only the EOF frame does. A `Drop`-based guard
+        // would be cleaner in principle, but `send_eof_traced` is async and runs through the
+        // cooperative-drain spin which must execute on the backend thread, so we sequence it
+        // explicitly here.
         futures.push(async move {
             let mut stats = SendBatchStats::default();
-            // Run the partition stream to exhaustion; capture either the
-            // first error or Ok(()) so we can still emit the per-channel
-            // EOF below regardless of how the stream ended.
             let stream_result: Result<(), DataFusionError> = async {
                 let mut stream = plan.execute(partition, ctx)?;
                 while let Some(batch) = stream.next().await {
@@ -83,29 +86,15 @@ pub async fn run_worker_fragment(
                 Ok(())
             }
             .await;
-            // Signal channel EOF so the consumer's per-(stage_id, partition) sub-buffer transitions
-            // to Eof. Don't rely on the shared shm_mq queue detaching: multiple fragments multiplex
-            // over the same queue, so dropping this partition's sender doesn't close it.
-            //
-            // CORRECTNESS: send EOF even when the stream errored. Skip it; a producer-side error
-            // (say a mid-scan I/O failure) leaves the consumer's sub-buffer stuck at
-            // `sources_done == 0` and the leader's `select_all` blocks forever. The deadlock
-            // detector only fires under `paradedb.mpp_debug = on`; otherwise the hang is silent.
             let eof_result = sender.as_ref().send_eof_traced(&mut stats).await;
-            // Propagate the stream's error first; otherwise surface any EOF send error so failure
-            // modes don't silently disappear.
+            // Stream error first, then any EOF-send error so neither failure mode disappears.
             stream_result.and(eof_result)
         });
     }
-    // `join_all`, not `try_join_all`. Fail-fast `try_join_all` would cancel sibling partitions
-    // mid-`await` on the first `Err`, and a cancelled sibling never reaches its
-    // `send_eof_traced`. The consumer's sub-buffer for that channel would stay at
-    // `sources_done == 0` and the leader's `select_all` would block forever unless the backend
-    // tore down and the shm_mq queue detached. `join_all` drives every partition through its EOF
-    // send before we propagate the first error.
+    // `join_all`, not `try_join_all`: fail-fast would cancel sibling partitions mid-await before
+    // they hit `send_eof_traced`, leaving the consumer's channel buffer stuck and the leader's
+    // `select_all` blocked.
     let results = futures::future::join_all(futures).await;
-    // Drop senders so peers observe `Detached` on their next try_recv even if a partition's EOF
-    // send itself errored.
     drop(senders);
     for r in results {
         r?;

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -1,0 +1,365 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Worker-side fragment discovery for the multi-fragment runner.
+//!
+//! [`find_worker_assignments`] walks a worker's physical plan, visits every
+//! [`datafusion_distributed::NetworkBoundary`], and collects the
+//! `(input_stage.num, task_idx, plan, routing)` tuples assigned to a given
+//! `this_proc`. The dispatcher in `aggregatescan::exec_mpp_worker` runs one
+//! fragment per returned [`FragmentAssignment`].
+//!
+//! The walker tracks a `ParentContext` per recursion level so nested
+//! boundaries know which OUTER stage's tasks consume their output. The
+//! routing math (which proc to send partition `q` to) depends on this:
+//!
+//! - **Top-level boundary** (`parent = None`): the consumer is the leader at
+//!   proc 0. Every output partition goes there.
+//! - **Nested boundary inside outer stage `S_outer.plan`**: the consumer is
+//!   one of `S_outer`'s tasks. For [`NetworkShuffleExec`] the routing is
+//!   hash-partitioned (partition `q` → consumer task `q / P_c` where `P_c`
+//!   is the per-consumer-task output count); for [`NetworkCoalesceExec`]
+//!   the routing collapses to a single consumer task.
+//!
+//! [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
+//! [`NetworkCoalesceExec`]: datafusion_distributed::NetworkCoalesceExec
+
+use std::sync::Arc;
+
+use datafusion::physical_plan::ExecutionPlan;
+#[cfg(not(test))]
+use datafusion::physical_plan::ExecutionPlanProperties;
+use datafusion_distributed::NetworkBoundaryExt;
+
+use crate::postgres::customscan::mpp::runtime::proc_for_task;
+
+/// One worker fragment to run for `this_proc`. The fragment is one task of a
+/// producer stage; the dispatcher runs `plan` with the matching
+/// `DistributedTaskContext { task_index: task_idx, task_count }` and routes
+/// each output partition through the channel selected by [`Self::routing`].
+#[derive(Clone)]
+pub struct FragmentAssignment {
+    /// `input_stage.num` of the boundary whose producer side this fragment
+    /// belongs to. Frames the fragment emits carry this in the
+    /// `MppFrameHeader::stage_id` field.
+    pub stage_id: u32,
+    /// Task index within the stage (0..task_count).
+    pub task_idx: usize,
+    /// Total task count for this stage (= `input_stage.tasks.len()`).
+    pub task_count: usize,
+    /// Plan to execute: the boundary's `input_stage.plan`.
+    pub plan: Arc<dyn ExecutionPlan>,
+    /// How to route each output partition to a destination proc.
+    pub routing: FragmentRouting,
+}
+
+/// Routing rule for a fragment's output partitions.
+#[derive(Clone, Debug)]
+pub enum FragmentRouting {
+    /// All output partitions go to one destination proc (`NetworkCoalesceExec`
+    /// or the top-level gather case). Frame header carries
+    /// `(stage_id, partition)` directly; consumer reads
+    /// `stream_partition(partition)`.
+    Coalesce {
+        /// Destination proc index. `0` for the leader (top-level gather),
+        /// or an `assignment.proc_for(parent_stage_id, 0)` lookup for a
+        /// nested coalesce that lands on a single consumer task.
+        dest_proc: u32,
+    },
+    /// Hash-partitioned mesh ([`NetworkShuffleExec`]). Output partition `q`
+    /// goes to consumer task `q / partitions_per_consumer_task`, hosted on
+    /// `proc_for_task(n_workers, consumer_task_idx)`. Frame header is
+    /// `(stage_id, q)` so the consumer's
+    /// `stream_partition(P_c * task_index + p_local)` finds it via the
+    /// per-`(stage_id, partition)` sub-buffer registry.
+    ///
+    /// [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
+    Shuffle {
+        /// `B.properties().output_partitioning().partition_count()`. Equal to
+        /// `P_c` in the receive-side formula `off = P_c * task_index`.
+        partitions_per_consumer_task: usize,
+    },
+    /// Broadcast mesh ([`NetworkBroadcastExec`]) over a build subtree that
+    /// is canonical-replicated across all producer procs. Wire-level math
+    /// is identical to [`Self::Shuffle`] (output partition `q` →
+    /// consumer task `q / P_c`), but the dispatcher effectively reduces
+    /// the producer side to a single task: only `task_idx == 0` runs the
+    /// producer plan; tasks `task_idx > 0` send a per-partition EOF and
+    /// exit. The consumer's input streams merge real data from task 0
+    /// with empty streams from the others, matching upstream's
+    /// single-producer broadcast pattern.
+    ///
+    /// **INVARIANT (load-bearing for correctness):** the build subtree's output is
+    /// canonical-replicated across all producer procs. In the AggregateScan MPP path this is
+    /// enforced by the all-gather step (`mpp build all-gather`) that pre-stages the canonical
+    /// source on every worker before plan execution. If a future planner emits a
+    /// [`NetworkBroadcastExec`] over a sharded child (e.g. each producer task scans a different
+    /// file_group), the short-circuit silently drops `input_task_count - 1` shards' worth of
+    /// data. When that pattern is introduced, this variant must be split into
+    /// `BroadcastCanonicalReplica` vs. `BroadcastSharded` (or the short-circuit must be
+    /// conditional on a planner-set sentinel).
+    ///
+    /// **Planner-level cap:** the AggregateScan session installs
+    /// [`crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator`]
+    /// in front of the default leaf estimator, which caps the canonical-replica memory leaf at
+    /// `task_count = 1`. This propagates up the build subtree and makes the DF-D planner build
+    /// `NetworkBroadcastExec` with `input_task_count = 1`. With the cap in place the dispatcher
+    /// only ever sees `task_idx == 0` fragments for Broadcast routing. The wire-layer guard is
+    /// a hard `pgrx::error!` for any `task_idx > 0` so a missed cap surfaces loudly instead of
+    /// silently mis-routing data.
+    ///
+    /// [`NetworkBroadcastExec`]: datafusion_distributed::NetworkBroadcastExec
+    Broadcast {
+        /// `B.properties().output_partitioning().partition_count()`. Same
+        /// semantics as
+        /// [`Self::Shuffle::partitions_per_consumer_task`].
+        partitions_per_consumer_task: usize,
+    },
+}
+
+/// Walk `root` (the worker's physical plan) and collect every fragment
+/// assigned to `this_proc` under the `proc_for_task` round-robin policy.
+/// Returns one [`FragmentAssignment`] per `(stage_id, task_idx)` pair
+/// hosted by this proc; the dispatcher spawns one async task per entry.
+pub fn find_worker_assignments(
+    root: &Arc<dyn ExecutionPlan>,
+    this_proc: u32,
+    n_workers: u32,
+) -> Vec<FragmentAssignment> {
+    let mut out = Vec::new();
+    collect(
+        root, this_proc, n_workers, /* nested = */ false, &mut out,
+    );
+    #[cfg(not(test))]
+    {
+        crate::mpp_log!(
+            "mpp worker_fragments::find_worker_assignments this_proc={} fragments={}",
+            this_proc,
+            out.len()
+        );
+        for f in &out {
+            let n_out = f.plan.output_partitioning().partition_count();
+            match &f.routing {
+                FragmentRouting::Coalesce { dest_proc } => crate::mpp_log!(
+                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
+                     n_out={n_out} routing=Coalesce dest_proc={dest_proc}",
+                    f.stage_id,
+                    f.task_idx,
+                    f.task_count,
+                ),
+                FragmentRouting::Shuffle {
+                    partitions_per_consumer_task,
+                } => crate::mpp_log!(
+                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
+                     n_out={n_out} routing=Shuffle \
+                     partitions_per_consumer_task={partitions_per_consumer_task}",
+                    f.stage_id,
+                    f.task_idx,
+                    f.task_count,
+                ),
+                FragmentRouting::Broadcast {
+                    partitions_per_consumer_task,
+                } => crate::mpp_log!(
+                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
+                     n_out={n_out} routing=Broadcast \
+                     partitions_per_consumer_task={partitions_per_consumer_task}",
+                    f.stage_id,
+                    f.task_idx,
+                    f.task_count,
+                ),
+            }
+        }
+    }
+    out
+}
+
+fn collect(
+    plan: &Arc<dyn ExecutionPlan>,
+    this_proc: u32,
+    n_workers: u32,
+    nested: bool,
+    out: &mut Vec<FragmentAssignment>,
+) {
+    if let Some(nb) = plan.as_ref().as_network_boundary() {
+        let stage = nb.input_stage();
+        let stage_id = stage.num() as u32;
+        // Boundary's name decides routing rule. Downcasting through the trait gives us
+        // back-pointers to the concrete type, but the dispatcher only needs the receive-side
+        // math which is identical for the embedded model whether we got here through Shuffle or
+        // Coalesce; the only distinction is the partitions-per-task math.
+        let name = plan.name();
+        // Receive-side per-consumer-task partition count: see
+        // `NetworkShuffleExec::execute`'s `off = P_c * task_index` formula.
+        let p_c = plan.properties().partitioning.partition_count();
+
+        // Determine routing for fragments produced by this boundary's
+        // input_stage tasks.
+        //
+        // NetworkShuffleExec and NetworkBroadcastExec have IDENTICAL receive-side math: both
+        // compute `off = P_c * task_index` and pull partition `off + p_local` from every input
+        // task. So the producer-side routing has to match: output partition q goes to consumer
+        // task `q / P_c`. The semantic difference (shuffle hashes rows, broadcast emits the full
+        // set to every consumer) lives entirely inside each task's plan and doesn't change how
+        // partitions map to procs at the wire layer.
+        //
+        // NetworkCoalesceExec is different. Its execute consults a single input task per
+        // consumer (`target_task = group.start_task + input_task_offset`), and the producer emits
+        // one stream per consumer task in its group. In the natural-shape plan we currently
+        // target, the only nested coalesce is consumer_tc=1 (the top-level gather, handled by
+        // the `parent=None` arm). The nested-coalesce arm below is a defensive fallback for
+        // shapes we don't exercise yet.
+        let routing = match (name, nested) {
+            // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan plan
+            // produces (broadcast is always nested inside the HashJoin build subtree). Falling
+            // through to `Coalesce { dest_proc: 0 }` would silently send every input task's full
+            // canonical replica to the leader and `select_all` would over-count by
+            // `input_task_count`. Surface it as an error so a future planner change that hits
+            // this shape doesn't silently produce wrong answers.
+            ("NetworkBroadcastExec", false) => {
+                // `pgrx::error!` pulls PG runtime symbols (`CopyErrorData`, `PG_exception_stack`,
+                // `CurrentMemoryContext`, `error_context_stack`) via the ereport machinery.
+                // Reaching it from the `#[cfg(test)]` block at the bottom of this file would
+                // force the test binary to link against postgres, which
+                // `cargo test --features pgNN --no-default-features` doesn't. Plain `panic!` in
+                // test builds, same `!` return type as `pgrx::error!`, so the match arm still
+                // type-checks.
+                #[cfg(not(test))]
+                pgrx::error!(
+                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
+                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
+                     produce this shape; route via a NetworkCoalesceExec gather instead."
+                );
+                #[cfg(test)]
+                panic!(
+                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
+                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
+                     produce this shape; route via a NetworkCoalesceExec gather instead."
+                );
+            }
+            // Top-level boundary (gather to leader): consumer is leader proc 0.
+            (_, false) => FragmentRouting::Coalesce { dest_proc: 0 },
+            // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps to
+            // consumer task q / p_c.
+            ("NetworkShuffleExec", true) => FragmentRouting::Shuffle {
+                partitions_per_consumer_task: p_c,
+            },
+            // Nested NetworkBroadcastExec: same wire-level math as Shuffle, but the dispatcher
+            // only runs the producer plan on task 0 to avoid the canonical-replica duplication
+            // described on `FragmentRouting::Broadcast`.
+            ("NetworkBroadcastExec", true) => FragmentRouting::Broadcast {
+                partitions_per_consumer_task: p_c,
+            },
+            // Nested NetworkCoalesceExec: consumer is a single task in the parent stage. The
+            // receive math collapses to task 0 of the parent group, so the destination proc is
+            // `proc_for_task(n_workers, 0)`.
+            ("NetworkCoalesceExec", true) => FragmentRouting::Coalesce {
+                dest_proc: proc_for_task(n_workers, 0),
+            },
+            // Any other nested boundary kind is unknown territory. Fall through to a hard error
+            // rather than silently routing to task 0 of `proc_for_task`, which would over-count
+            // or drop batches for a shape we haven't reasoned about. Surface as error so
+            // plan-walk drift is visible.
+            (other, true) => {
+                #[cfg(not(test))]
+                pgrx::error!(
+                    "mpp worker_fragments: unsupported nested boundary kind {other} \
+                     (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
+                     and NetworkCoalesceExec are recognised; routing this shape would silently \
+                     mis-route batches."
+                );
+                #[cfg(test)]
+                panic!(
+                    "mpp worker_fragments: unsupported nested boundary kind {other} \
+                     (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
+                     and NetworkCoalesceExec are recognised; routing this shape would silently \
+                     mis-route batches."
+                );
+            }
+        };
+        #[cfg(not(test))]
+        {
+            crate::mpp_log!(
+                "mpp worker_fragments::collect boundary name={name} stage_id={stage_id} \
+                 p_c={p_c} nested={nested}"
+            );
+        }
+
+        let task_count = stage.task_count();
+        if let Some(stage_plan) = stage.local_plan() {
+            for task_idx in 0..task_count {
+                let owner = proc_for_task(n_workers, task_idx as u32);
+                if owner == this_proc {
+                    out.push(FragmentAssignment {
+                        stage_id,
+                        task_idx,
+                        task_count,
+                        plan: Arc::clone(stage_plan),
+                        routing: routing.clone(),
+                    });
+                }
+            }
+            // Recurse into the stage's plan with `nested = true`. The boundary's `children()`
+            // returns `[stage.plan]`, so descending through it would double-process every nested
+            // fragment. Return here to keep visit counts exact.
+            collect(stage_plan, this_proc, n_workers, true, out);
+        }
+        return;
+    }
+    // Non-boundary nodes recurse through plan children.
+    for child in plan.children() {
+        collect(child, this_proc, n_workers, nested, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use datafusion::physical_plan::empty::EmptyExec;
+
+    #[test]
+    fn boundary_free_plan_returns_no_assignments() {
+        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
+        let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
+        let out = find_worker_assignments(&plan, 1, 3);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn routing_coalesce_for_top_level_assigns_to_leader() {
+        // Smoke check of the routing enum's Coalesce branch: a top-level
+        // boundary routes to proc 0 regardless of parent.
+        let r = FragmentRouting::Coalesce { dest_proc: 0 };
+        match r {
+            FragmentRouting::Coalesce { dest_proc } => assert_eq!(dest_proc, 0),
+            _ => panic!("expected Coalesce"),
+        }
+    }
+
+    #[test]
+    fn routing_shuffle_carries_pc() {
+        let r = FragmentRouting::Shuffle {
+            partitions_per_consumer_task: 3,
+        };
+        match r {
+            FragmentRouting::Shuffle {
+                partitions_per_consumer_task,
+            } => assert_eq!(partitions_per_consumer_task, 3),
+            _ => panic!("expected Shuffle"),
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -85,7 +85,7 @@ pub enum FragmentRouting {
     /// `proc_for_task(n_workers, consumer_task_idx)`. Frame header is
     /// `(stage_id, q)` so the consumer's
     /// `stream_partition(P_c * task_index + p_local)` finds it via the
-    /// per-`(stage_id, partition)` sub-buffer registry.
+    /// per-`(stage_id, partition)` channel buffer registry.
     ///
     /// [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
     Shuffle {
@@ -93,36 +93,17 @@ pub enum FragmentRouting {
         /// `P_c` in the receive-side formula `off = P_c * task_index`.
         partitions_per_consumer_task: usize,
     },
-    /// Broadcast mesh ([`NetworkBroadcastExec`]) over a build subtree that
-    /// is canonical-replicated across all producer procs. Wire-level math
-    /// is identical to [`Self::Shuffle`] (output partition `q` →
-    /// consumer task `q / P_c`), but the dispatcher effectively reduces
-    /// the producer side to a single task: only `task_idx == 0` runs the
-    /// producer plan; tasks `task_idx > 0` send a per-partition EOF and
-    /// exit. The consumer's input streams merge real data from task 0
-    /// with empty streams from the others, matching upstream's
-    /// single-producer broadcast pattern.
+    /// Broadcast mesh ([`NetworkBroadcastExec`]). Wire-level math matches [`Self::Shuffle`]
+    /// (`q → q / P_c`).
     ///
-    /// **INVARIANT (load-bearing for correctness):** the build subtree's output is
-    /// canonical-replicated across all producer procs. In the AggregateScan MPP path this is
-    /// enforced by the all-gather step (`mpp build all-gather`) that pre-stages the canonical
-    /// source on every worker before plan execution. If a future planner emits a
-    /// [`NetworkBroadcastExec`] over a sharded child (e.g. each producer task scans a different
-    /// file_group), the short-circuit silently drops `input_task_count - 1` shards' worth of
-    /// data. When that pattern is introduced, this variant must be split into
-    /// `BroadcastCanonicalReplica` vs. `BroadcastSharded` (or the short-circuit must be
-    /// conditional on a planner-set sentinel).
-    ///
-    /// **Planner-level cap:** the AggregateScan session installs
-    /// [`crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator`]
-    /// in front of the default leaf estimator, which caps the canonical-replica memory leaf at
-    /// `task_count = 1`. This propagates up the build subtree and makes the DF-D planner build
-    /// `NetworkBroadcastExec` with `input_task_count = 1`. With the cap in place the dispatcher
-    /// only ever sees `task_idx == 0` fragments for Broadcast routing. The wire-layer guard is
-    /// a hard `pgrx::error!` for any `task_idx > 0` so a missed cap surfaces loudly instead of
-    /// silently mis-routing data.
+    /// Delta from upstream: we cap the build subtree at `task_count = 1` via
+    /// [`BroadcastBuildSideOneTaskEstimator`], so the dispatcher only ever sees `task_idx == 0`
+    /// fragments here. The estimator relies on the AggregateScan all-gather step canonical-
+    /// replicating the build side; a future planner that emits `NetworkBroadcastExec` over a
+    /// sharded child would silently drop shards under this rule and needs a new routing variant.
     ///
     /// [`NetworkBroadcastExec`]: datafusion_distributed::NetworkBroadcastExec
+    /// [`BroadcastBuildSideOneTaskEstimator`]: crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator
     Broadcast {
         /// `B.properties().output_partitioning().partition_count()`. Same
         /// semantics as
@@ -197,31 +178,18 @@ fn collect(
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
         let stage_id = stage.num() as u32;
-        // Boundary's name decides routing rule. Downcasting through the trait gives us
-        // back-pointers to the concrete type, but the dispatcher only needs the receive-side
-        // math which is identical for the embedded model whether we got here through Shuffle or
-        // Coalesce; the only distinction is the partitions-per-task math.
         let name = plan.name();
-        // Receive-side per-consumer-task partition count: see
-        // `NetworkShuffleExec::execute`'s `off = P_c * task_index` formula.
+        // Per-consumer-task partition count from upstream's `NetworkShuffleExec::execute`
+        // receive-side formula `off = P_c * task_index`.
         let p_c = plan.properties().partitioning.partition_count();
 
-        // Determine routing for fragments produced by this boundary's
-        // input_stage tasks.
-        //
-        // NetworkShuffleExec and NetworkBroadcastExec have IDENTICAL receive-side math: both
-        // compute `off = P_c * task_index` and pull partition `off + p_local` from every input
-        // task. So the producer-side routing has to match: output partition q goes to consumer
-        // task `q / P_c`. The semantic difference (shuffle hashes rows, broadcast emits the full
-        // set to every consumer) lives entirely inside each task's plan and doesn't change how
-        // partitions map to procs at the wire layer.
-        //
-        // NetworkCoalesceExec is different. Its execute consults a single input task per
-        // consumer (`target_task = group.start_task + input_task_offset`), and the producer emits
-        // one stream per consumer task in its group. In the natural-shape plan we currently
-        // target, the only nested coalesce is consumer_tc=1 (the top-level gather, handled by
-        // the `parent=None` arm). The nested-coalesce arm below is a defensive fallback for
-        // shapes we don't exercise yet.
+        // Why we classify by `(boundary_kind, top_level)`. Upstream DF-D dispatches producers via
+        // gRPC keyed on the resolver's URLs, so worker code never has to decide where a producer's
+        // output partitions land. We don't have URLs: each shm_mq peer is push-driven, and the
+        // dispatcher here picks the destination proc for every output partition. The routing math
+        // differs by boundary kind (Shuffle / Broadcast share receive-side math but Broadcast caps
+        // to task 0; Coalesce collapses to one consumer task), and the top-level case routes to
+        // the leader.
         let routing = match (name, nested) {
             // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan plan
             // produces (broadcast is always nested inside the HashJoin build subtree). Falling
@@ -229,13 +197,11 @@ fn collect(
             // canonical replica to the leader and `select_all` would over-count by
             // `input_task_count`. Surface it as an error so a future planner change that hits
             // this shape doesn't silently produce wrong answers.
-            ("NetworkBroadcastExec", false) => {
-                crate::postgres::customscan::mpp::fail_loud(format!(
-                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
-                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
-                     produce this shape; route via a NetworkCoalesceExec gather instead."
-                ))
-            }
+            ("NetworkBroadcastExec", false) => pgrx::error!(
+                "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
+                 (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
+                 produce this shape; route via a NetworkCoalesceExec gather instead."
+            ),
             // Top-level boundary (gather to leader): consumer is leader proc 0.
             (_, false) => FragmentRouting::Coalesce { dest_proc: 0 },
             // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps to
@@ -259,12 +225,12 @@ fn collect(
             // rather than silently routing to task 0 of `proc_for_task`, which would over-count
             // or drop batches for a shape we haven't reasoned about. Surface as error so
             // plan-walk drift is visible.
-            (other, true) => crate::postgres::customscan::mpp::fail_loud(format!(
+            (other, true) => pgrx::error!(
                 "mpp worker_fragments: unsupported nested boundary kind {other} \
                  (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
                  and NetworkCoalesceExec are recognised; routing this shape would silently \
                  mis-route batches."
-            )),
+            ),
         };
         #[cfg(not(test))]
         {

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -197,11 +197,13 @@ fn collect(
             // canonical replica to the leader and `select_all` would over-count by
             // `input_task_count`. Surface it as an error so a future planner change that hits
             // this shape doesn't silently produce wrong answers.
-            ("NetworkBroadcastExec", false) => pgrx::error!(
-                "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
-                 (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
-                 produce this shape; route via a NetworkCoalesceExec gather instead."
-            ),
+            ("NetworkBroadcastExec", false) => {
+                crate::postgres::customscan::mpp::fail_loud(format!(
+                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
+                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
+                     produce this shape; route via a NetworkCoalesceExec gather instead."
+                ))
+            }
             // Top-level boundary (gather to leader): consumer is leader proc 0.
             (_, false) => FragmentRouting::Coalesce { dest_proc: 0 },
             // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps to
@@ -225,12 +227,12 @@ fn collect(
             // rather than silently routing to task 0 of `proc_for_task`, which would over-count
             // or drop batches for a shape we haven't reasoned about. Surface as error so
             // plan-walk drift is visible.
-            (other, true) => pgrx::error!(
+            (other, true) => crate::postgres::customscan::mpp::fail_loud(format!(
                 "mpp worker_fragments: unsupported nested boundary kind {other} \
                  (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
                  and NetworkCoalesceExec are recognised; routing this shape would silently \
                  mis-route batches."
-            ),
+            )),
         };
         #[cfg(not(test))]
         {

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -230,25 +230,11 @@ fn collect(
             // `input_task_count`. Surface it as an error so a future planner change that hits
             // this shape doesn't silently produce wrong answers.
             ("NetworkBroadcastExec", false) => {
-                // `pgrx::error!` pulls PG runtime symbols (`CopyErrorData`, `PG_exception_stack`,
-                // `CurrentMemoryContext`, `error_context_stack`) via the ereport machinery.
-                // Reaching it from the `#[cfg(test)]` block at the bottom of this file would
-                // force the test binary to link against postgres, which
-                // `cargo test --features pgNN --no-default-features` doesn't. Plain `panic!` in
-                // test builds, same `!` return type as `pgrx::error!`, so the match arm still
-                // type-checks.
-                #[cfg(not(test))]
-                pgrx::error!(
+                crate::postgres::customscan::mpp::fail_loud(format!(
                     "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
                      (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
                      produce this shape; route via a NetworkCoalesceExec gather instead."
-                );
-                #[cfg(test)]
-                panic!(
-                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
-                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
-                     produce this shape; route via a NetworkCoalesceExec gather instead."
-                );
+                ))
             }
             // Top-level boundary (gather to leader): consumer is leader proc 0.
             (_, false) => FragmentRouting::Coalesce { dest_proc: 0 },
@@ -273,22 +259,12 @@ fn collect(
             // rather than silently routing to task 0 of `proc_for_task`, which would over-count
             // or drop batches for a shape we haven't reasoned about. Surface as error so
             // plan-walk drift is visible.
-            (other, true) => {
-                #[cfg(not(test))]
-                pgrx::error!(
-                    "mpp worker_fragments: unsupported nested boundary kind {other} \
-                     (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
-                     and NetworkCoalesceExec are recognised; routing this shape would silently \
-                     mis-route batches."
-                );
-                #[cfg(test)]
-                panic!(
-                    "mpp worker_fragments: unsupported nested boundary kind {other} \
-                     (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
-                     and NetworkCoalesceExec are recognised; routing this shape would silently \
-                     mis-route batches."
-                );
-            }
+            (other, true) => crate::postgres::customscan::mpp::fail_loud(format!(
+                "mpp worker_fragments: unsupported nested boundary kind {other} \
+                 (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
+                 and NetworkCoalesceExec are recognised; routing this shape would silently \
+                 mis-route batches."
+            )),
         };
         #[cfg(not(test))]
         {

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -32,7 +32,6 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterNode;
-use crate::postgres::customscan::mpp::dsm::MppBuildCache;
 use crate::postgres::customscan::pg_expr_udf::{PgExprUdf, PG_EXPR_UDF_PREFIX};
 use crate::postgres::ParallelScanState;
 use crate::scan::late_materialization::{DeferredField, LateMaterializeNode};
@@ -55,13 +54,6 @@ struct PgSearchExtensionCodec {
     non_partitioning_segment_ids: Vec<HashSet<SegmentId>>,
     /// Canonical segment ID sets for all join sources, indexed by plan_position.
     index_segment_ids: Vec<HashSet<SegmentId>>,
-    /// MPP build-side all-gather cache. When set, non-partitioning
-    /// `PgSearchTableProvider`s scan only their `mpp_worker_idx`-th 1/N slice
-    /// of segments, write the slice to DSM, wait for peers, then read back the
-    /// gathered build side as Arrow batches. See `mpp/dsm.rs::MppBuildCache`.
-    mpp_build_cache: Option<Arc<MppBuildCache>>,
-    /// 0-based index of this participant among MPP producer workers.
-    mpp_worker_idx: u32,
 }
 
 unsafe impl Send for PgSearchExtensionCodec {}
@@ -241,14 +233,6 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
                     .expect("missing canonical segment IDs for non-partitioning source");
                 provider.set_canonical_segment_ids(ids);
             }
-            // If an MPP build-side cache is registered, configure the provider
-            // to do its all-gather over `np_idx` and worker `mpp_worker_idx`.
-            // The provider's scan() will scan only its 1/N slice of the
-            // segments above, write to DSM, wait for the barrier, then read
-            // back the gathered batches and stream them via `MemoryExec`.
-            if let Some(cache) = &self.mpp_build_cache {
-                provider.set_mpp_build_cache(Arc::clone(cache), np_idx as u32, self.mpp_worker_idx);
-            }
         }
         provider.set_expr_context(self.expr_context);
         provider.set_planstate(self.planstate);
@@ -383,8 +367,6 @@ pub fn deserialize_logical_plan_with_runtime(
     planstate: Option<*mut PlanState>,
     non_partitioning_segment_ids: Vec<HashSet<SegmentId>>,
     index_segment_ids: Vec<HashSet<SegmentId>>,
-    mpp_build_cache: Option<Arc<MppBuildCache>>,
-    mpp_worker_idx: u32,
 ) -> Result<LogicalPlan> {
     let codec = PgSearchExtensionCodec {
         parallel_state,
@@ -392,8 +374,6 @@ pub fn deserialize_logical_plan_with_runtime(
         planstate,
         non_partitioning_segment_ids,
         index_segment_ids,
-        mpp_build_cache,
-        mpp_worker_idx,
     };
     datafusion_proto::bytes::logical_plan_from_bytes_with_extension_codec(bytes, ctx, &codec)
 }

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -22,15 +22,11 @@ use std::sync::{Arc, OnceLock};
 
 use arrow_schema::SchemaRef;
 use async_trait::async_trait;
-use datafusion::arrow::array::RecordBatch;
-use datafusion::arrow::datatypes::Schema as ArrowSchema;
-use datafusion::arrow::ipc::reader::StreamReader;
-use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::catalog::{Session, TableProvider};
 use datafusion::common::stats::{ColumnStatistics, Precision};
 use datafusion::common::{DataFusionError, Result, Statistics};
 use datafusion::logical_expr::{Expr, TableProviderFilterPushDown, TableType};
-use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
+use datafusion::physical_plan::ExecutionPlan;
 use pgrx::pg_sys;
 use serde::{Deserialize, Serialize};
 use tantivy::index::SegmentId;
@@ -39,7 +35,6 @@ use crate::api::HashSet;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, WhichFastField};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
-use crate::postgres::customscan::mpp::dsm::MppBuildCache;
 use crate::postgres::customscan::parallel::{checkout_segment, list_segment_ids};
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
@@ -136,23 +131,6 @@ pub struct PgSearchTableProvider {
     /// and load (in get_schema) execute sequentially within the same single-threaded optimization pass.
     #[serde(with = "atomic_bool_serde")]
     late_materialization_active: AtomicBool,
-
-    /// MPP build-side all-gather cache. When set, this provider is a
-    /// non-partitioning source under MPP, and `scan()` runs the all-gather
-    /// path: scan the worker's 1/N slice of segments, write to DSM, wait for
-    /// peers, read back, return a `MemoryExec` over the gathered batches.
-    #[serde(skip)]
-    mpp_build_cache: Option<Arc<MppBuildCache>>,
-    /// Cache slot identifier (`source_idx` within the non-partitioning sources).
-    #[serde(skip)]
-    mpp_source_idx: u32,
-    /// 0-based index of this participant among MPP producer workers.
-    #[serde(skip)]
-    mpp_worker_idx: u32,
-    /// Lazy cache of the gathered build-side batches. Populated on the first
-    /// `scan()` call when `mpp_build_cache` is set; subsequent scans reuse.
-    #[serde(skip)]
-    mpp_gathered_batches: OnceLock<Arc<Vec<RecordBatch>>>,
 }
 
 mod atomic_bool_serde {
@@ -193,24 +171,7 @@ impl PgSearchTableProvider {
             canonical_segment_ids: None,
             visibility_mode: VisibilityMode::Eager,
             late_materialization_active: AtomicBool::new(false),
-            mpp_build_cache: None,
-            mpp_source_idx: 0,
-            mpp_worker_idx: 0,
-            mpp_gathered_batches: OnceLock::new(),
         }
-    }
-
-    /// Configure this provider as a non-partitioning source participating in
-    /// the MPP build-side all-gather. See `mpp/dsm.rs::MppBuildCache`.
-    pub(crate) fn set_mpp_build_cache(
-        &mut self,
-        cache: Arc<MppBuildCache>,
-        source_idx: u32,
-        worker_idx: u32,
-    ) {
-        self.mpp_build_cache = Some(cache);
-        self.mpp_source_idx = source_idx;
-        self.mpp_worker_idx = worker_idx;
     }
 
     /// Transitions the provider from Phase 1 (`Utf8View`) into Phase 2 (`Union`)
@@ -743,16 +704,6 @@ impl TableProvider for PgSearchTableProvider {
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        // MPP build-side all-gather. Only triggered for non-partitioning
-        // sources that have a build cache configured (set by the codec when
-        // the worker registered an `MppBuildCache`). First call does the
-        // gather (scan 1/N slice → write DSM → barrier → read peers); later
-        // calls reuse the cached batches via the OnceLock.
-        if self.mpp_build_cache.is_some() {
-            return self
-                .scan_mpp_all_gather(state, projection, filters, limit)
-                .await;
-        }
         self.scan_inner(
             self.canonical_segment_ids.clone(),
             state,
@@ -765,127 +716,6 @@ impl TableProvider for PgSearchTableProvider {
 }
 
 impl PgSearchTableProvider {
-    async fn scan_mpp_all_gather(
-        &self,
-        state: &dyn Session,
-        projection: Option<&Vec<usize>>,
-        filters: &[Expr],
-        limit: Option<usize>,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        let cache = self
-            .mpp_build_cache
-            .as_ref()
-            .expect("scan_mpp_all_gather called without cache");
-        let n_workers = cache.n_workers;
-        let source_idx = self.mpp_source_idx;
-        let worker_idx = self.mpp_worker_idx;
-
-        // Reuse the gathered batches from the first call.
-        if let Some(cached) = self.mpp_gathered_batches.get() {
-            return memory_exec_for_cached(cached.clone());
-        }
-
-        // Slice canonical_segment_ids deterministically (sorted by uuid_string,
-        // round-robin by worker_idx).
-        let full = self.canonical_segment_ids.clone().unwrap_or_default();
-        let my_slice: HashSet<SegmentId> = if n_workers <= 1 {
-            full.clone()
-        } else {
-            let mut sorted: Vec<SegmentId> = full.iter().copied().collect();
-            sorted.sort_by_key(|id| id.uuid_string());
-            sorted
-                .into_iter()
-                .enumerate()
-                .filter(|(i, _)| (*i as u32) % n_workers == worker_idx)
-                .map(|(_, id)| id)
-                .collect()
-        };
-
-        let t_start = std::time::Instant::now();
-
-        // Run the inner scan over the worker's 1/N slice.
-        let sub_plan = self
-            .scan_inner(Some(my_slice), state, projection, filters, limit)
-            .await?;
-        let task_ctx = state.task_ctx();
-        let n_partitions = sub_plan.output_partitioning().partition_count();
-        let mut my_batches: Vec<RecordBatch> = Vec::new();
-        for p in 0..n_partitions {
-            let mut stream = sub_plan.execute(p, Arc::clone(&task_ctx))?;
-            while let Some(b) = futures::StreamExt::next(&mut stream).await {
-                my_batches.push(b?);
-            }
-        }
-        let t_scan = t_start.elapsed();
-        let my_rows: usize = my_batches.iter().map(|b| b.num_rows()).sum();
-
-        // Encode my batches as a single Arrow IPC stream.
-        let t_encode_start = std::time::Instant::now();
-        let my_bytes = encode_batches_ipc(&my_batches)?;
-        let t_encode = t_encode_start.elapsed();
-        let my_bytes_len = my_bytes.len();
-        cache
-            .write_slice(source_idx, worker_idx, &my_bytes)
-            .map_err(DataFusionError::Internal)?;
-        let t_write = t_encode_start.elapsed() - t_encode;
-
-        // Wait until every peer has signalled completion.
-        let t_barrier_start = std::time::Instant::now();
-        cache.wait_complete(source_idx);
-        let t_barrier = t_barrier_start.elapsed();
-
-        // Read peer slices, decode, concatenate.
-        let t_read_start = std::time::Instant::now();
-        let mut all_batches: Vec<RecordBatch> =
-            Vec::with_capacity(my_batches.len() * (n_workers as usize));
-        for w in 0..n_workers {
-            let bytes = if w == worker_idx {
-                my_bytes.as_slice().to_vec()
-            } else {
-                cache.read_slice(source_idx, w)
-            };
-            if bytes.is_empty() {
-                continue;
-            }
-            let peer_batches = decode_batches_ipc(&bytes)?;
-            all_batches.extend(peer_batches);
-        }
-        let t_read = t_read_start.elapsed();
-        let all_rows: usize = all_batches.iter().map(|b| b.num_rows()).sum();
-        crate::mpp_log!(
-            "mpp build all-gather: heap_oid={} index_oid={} is_parallel={} canonical_segs={} \
-             source={} worker={}/{} my_rows={} my_bytes={} all_rows={} \
-             scan_ms={:.1} encode_ms={:.1} write_ms={:.1} barrier_ms={:.1} read_ms={:.1}",
-            self.scan_info.heaprelid,
-            self.scan_info.indexrelid,
-            self.is_parallel,
-            self.canonical_segment_ids
-                .as_ref()
-                .map(|s| s.len())
-                .unwrap_or(0),
-            source_idx,
-            worker_idx,
-            n_workers,
-            my_rows,
-            my_bytes_len,
-            all_rows,
-            t_scan.as_secs_f64() * 1000.0,
-            t_encode.as_secs_f64() * 1000.0,
-            t_write.as_secs_f64() * 1000.0,
-            t_barrier.as_secs_f64() * 1000.0,
-            t_read.as_secs_f64() * 1000.0,
-        );
-
-        let arc = Arc::new(all_batches);
-        // OnceLock: only the first writer wins; others reuse.
-        let _ = self.mpp_gathered_batches.set(Arc::clone(&arc));
-        let cached = self
-            .mpp_gathered_batches
-            .get()
-            .expect("OnceLock must be set");
-        memory_exec_for_cached(cached.clone())
-    }
-
     async fn scan_inner(
         &self,
         canonical_override: Option<HashSet<SegmentId>>,
@@ -1024,59 +854,4 @@ impl PgSearchTableProvider {
             )
         }
     }
-}
-
-/// Encode a slice of `RecordBatch`es as a single Arrow IPC stream blob.
-fn encode_batches_ipc(batches: &[RecordBatch]) -> Result<Vec<u8>> {
-    let mut buf = Vec::with_capacity(64 * 1024);
-    let schema: SchemaRef = if let Some(b) = batches.first() {
-        b.schema()
-    } else {
-        // Empty input: produce an empty IPC stream with a placeholder schema.
-        Arc::new(ArrowSchema::empty())
-    };
-    {
-        let mut writer = StreamWriter::try_new(&mut buf, &schema)
-            .map_err(|e| DataFusionError::Internal(format!("ipc writer init: {e}")))?;
-        for b in batches {
-            writer
-                .write(b)
-                .map_err(|e| DataFusionError::Internal(format!("ipc write: {e}")))?;
-        }
-        writer
-            .finish()
-            .map_err(|e| DataFusionError::Internal(format!("ipc finish: {e}")))?;
-    }
-    Ok(buf)
-}
-
-/// Decode an Arrow IPC stream blob into its `RecordBatch`es.
-fn decode_batches_ipc(bytes: &[u8]) -> Result<Vec<RecordBatch>> {
-    let cursor = std::io::Cursor::new(bytes);
-    let reader = StreamReader::try_new(cursor, None)
-        .map_err(|e| DataFusionError::Internal(format!("ipc reader init: {e}")))?;
-    let mut out = Vec::new();
-    for b in reader {
-        out.push(b.map_err(|e| DataFusionError::Internal(format!("ipc read: {e}")))?);
-    }
-    Ok(out)
-}
-
-/// Wrap a `Vec<RecordBatch>` as a single-partition `MemoryExec` for the given
-/// schema and projection. Used by the MPP build-side all-gather to expose the
-/// gathered build side to the rest of the plan without going back through
-/// Tantivy.
-fn memory_exec_for_cached(batches: Arc<Vec<RecordBatch>>) -> Result<Arc<dyn ExecutionPlan>> {
-    use datafusion_datasource::memory::MemorySourceConfig;
-    // The cached batches were produced by `scan_inner` with the caller's
-    // projection already applied — re-projecting at MemorySourceConfig level
-    // would re-index against an already-narrowed schema and panic. Use the
-    // batches' actual schema and pass `None` for projection.
-    let schema: SchemaRef = batches
-        .first()
-        .map(|b| b.schema())
-        .unwrap_or_else(|| Arc::new(ArrowSchema::empty()));
-    let partitions: Vec<Vec<RecordBatch>> = vec![(*batches).clone()];
-    let exec = MemorySourceConfig::try_new_exec(&partitions, schema, None)?;
-    Ok(exec as Arc<dyn ExecutionPlan>)
 }

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -154,8 +154,8 @@ SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
 WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
-                                                                                  QUERY PLAN                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -165,18 +165,21 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
      : ┌───── DistributedExec ── Tasks: t0:[p0]
      : │ AggregateExec: mode=Final, gby=[], aggr=[agg_0]
      : │   CoalescePartitionsExec
-     : │     AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
-     : │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
-     : │         CoalescePartitionsExec
-     : │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=1, input_tasks=3
-     : │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     : │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 1 ── Tasks: t0:[p0] t1:[p1] t2:[p2]
-     :   │ BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-     :   │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
+     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+     :   │     CoalescePartitionsExec
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+     :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-(20 rows)
+     :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+     :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     └──────────────────────────────────────────────────
+(23 rows)
 
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
@@ -195,8 +198,8 @@ GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
 WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
-                                                                                                         QUERY PLAN                                                                                                         
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Gather Merge
@@ -214,21 +217,27 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                      DataFusion Physical Plan: 
                        : ┌───── DistributedExec ── Tasks: t0:[p0]
                        : │ SortPreservingMergeExec: [title@0 ASC NULLS LAST], fetch=5
-                       : │   SortExec: TopK(fetch=5), expr=[title@0 ASC NULLS LAST], preserve_partitioning=[true]
-                       : │     AggregateExec: mode=FinalPartitioned, gby=[title@0 as title], aggr=[agg_0, agg_1]
-                       : │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                       : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
                        : └──────────────────────────────────────────────────
-                       :   ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
-                       :   │ RepartitionExec: partitioning=Hash([title@0], 3), input_partitions=3
-                       :   │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[agg_0, agg_1]
-                       :   │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
-                       :   │       CoalescePartitionsExec
-                       :   │         BroadcastExec: input_partitions=1, consumer_tasks=1, output_partitions=1
-                       :   │           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                       :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                       :   │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                       :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                       :   │ SortExec: TopK(fetch=5), expr=[title@0 ASC NULLS LAST], preserve_partitioning=[true]
+                       :   │   AggregateExec: mode=FinalPartitioned, gby=[title@0 as title], aggr=[agg_0, agg_1]
+                       :   │     [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
                        :   └──────────────────────────────────────────────────
-(31 rows)
+                       :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                       :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=3
+                       :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[agg_0, agg_1]
+                       :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
+                       :     │       CoalescePartitionsExec
+                       :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                       :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                       :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                       :     └──────────────────────────────────────────────────
+                       :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                       :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                       :       │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                       :       └──────────────────────────────────────────────────
+(37 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -1,0 +1,513 @@
+-- =====================================================================
+-- MPP AggregateScan: multi-stage natural-shape plan coverage.
+--
+-- Exercises the transport substrate end-to-end via post-aggregate
+-- patterns that produce a three-stage plan
+-- (NetworkCoalesceExec -> NetworkShuffleExec -> NetworkBroadcastExec):
+--   - GROUP BY one key, multiple aggregates
+--   - GROUP BY multiple keys
+--   - HAVING + ORDER BY + LIMIT
+--   - aggregation over a HashJoin with broadcast build subtree
+--
+-- Each pass runs the same query in serial mode (enable_mpp=off) then MPP
+-- mode (enable_mpp=on). The expected.out compares them byte-for-byte, so
+-- any MPP-vs-serial divergence shows up as a regression.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+CREATE TABLE mpp_postagg_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_postagg_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+CREATE INDEX mpp_postagg_files_idx ON mpp_postagg_files
+USING bm25 (id, title, category, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "category": {"fast": true}, "content": {}}'
+);
+CREATE INDEX mpp_postagg_pages_idx ON mpp_postagg_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+ANALYZE mpp_postagg_files;
+ANALYZE mpp_postagg_pages;
+-- =====================================================================
+-- Scenario 1: GROUP BY one key with multiple aggregates.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category | row_count | total_bytes | min_bytes | max_bytes 
+----------+-----------+-------------+-----------+-----------
+ cat-0    |       200 |      394380 |         4 |      4063
+ cat-1    |       200 |      397780 |        21 |      4080
+ cat-2    |       200 |      396468 |         1 |      4081
+ cat-3    |       200 |      395772 |         2 |      4082
+ cat-4    |       200 |      395076 |         3 |      4083
+(5 rows)
+
+SET paradedb.enable_mpp TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
+   Workers Planned: 3
+   ->  Sort
+         Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
+         Sort Key: f.category
+         ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+               Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
+               Backend: DataFusion
+               Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p)
+               Group By: category
+               Aggregates: COUNT(*), SUM(size_bytes), MIN(size_bytes), MAX(size_bytes)
+               DataFusion Physical Plan: 
+                 : ┌───── DistributedExec ── Tasks: t0:[p0]
+                 : │ CoalescePartitionsExec
+                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                 : └──────────────────────────────────────────────────
+                 :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                 :   │ AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[agg_0, agg_1, agg_2, agg_3]
+                 :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                 :   └──────────────────────────────────────────────────
+                 :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                 :     │ RepartitionExec: partitioning=Hash([category@0], 9), input_partitions=3
+                 :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[agg_0, agg_1, agg_2, agg_3]
+                 :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
+                 :     │       CoalescePartitionsExec
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :     └──────────────────────────────────────────────────
+                 :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                 :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       └──────────────────────────────────────────────────
+(34 rows)
+
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category | row_count | total_bytes | min_bytes | max_bytes 
+----------+-----------+-------------+-----------+-----------
+ cat-0    |       200 |      394380 |         4 |      4063
+ cat-1    |       200 |      397780 |        21 |      4080
+ cat-2    |       200 |      396468 |         1 |      4081
+ cat-3    |       200 |      395772 |         2 |      4082
+ cat-4    |       200 |      395076 |         3 |      4083
+(5 rows)
+
+-- =====================================================================
+-- Scenario 2: GROUP BY multiple keys.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  title   | pages_per_file 
+----------+----------+----------------
+ cat-0    | file-10  |              5
+ cat-0    | file-100 |              5
+ cat-0    | file-105 |              5
+ cat-0    | file-110 |              5
+ cat-0    | file-115 |              5
+ cat-0    | file-120 |              5
+ cat-0    | file-125 |              5
+ cat-0    | file-130 |              5
+ cat-0    | file-135 |              5
+ cat-0    | file-140 |              5
+(10 rows)
+
+SET paradedb.enable_mpp TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.category, f.title, (count(*))
+   ->  Gather Merge
+         Output: f.category, f.title, (count(*))
+         Workers Planned: 3
+         ->  Sort
+               Output: f.category, f.title, (count(*))
+               Sort Key: f.category, f.title
+               ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+                     Output: f.category, f.title, (count(*))
+                     Backend: DataFusion
+                     Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p)
+                     Group By: category, title
+                     Aggregates: COUNT(*)
+                     DataFusion Physical Plan: 
+                       : ┌───── DistributedExec ── Tasks: t0:[p0]
+                       : │ CoalescePartitionsExec
+                       : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                       : └──────────────────────────────────────────────────
+                       :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                       :   │ AggregateExec: mode=FinalPartitioned, gby=[category@0 as category, title@1 as title], aggr=[agg_0]
+                       :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                       :   └──────────────────────────────────────────────────
+                       :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                       :     │ RepartitionExec: partitioning=Hash([category@0, title@1], 9), input_partitions=3
+                       :     │   AggregateExec: mode=Partial, gby=[category@1 as category, title@0 as title], aggr=[agg_0]
+                       :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, category@2]
+                       :     │       CoalescePartitionsExec
+                       :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                       :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                       :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                       :     └──────────────────────────────────────────────────
+                       :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                       :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                       :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                       :       └──────────────────────────────────────────────────
+(36 rows)
+
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  title   | pages_per_file 
+----------+----------+----------------
+ cat-0    | file-10  |              5
+ cat-0    | file-100 |              5
+ cat-0    | file-105 |              5
+ cat-0    | file-110 |              5
+ cat-0    | file-115 |              5
+ cat-0    | file-120 |              5
+ cat-0    | file-125 |              5
+ cat-0    | file-130 |              5
+ cat-0    | file-135 |              5
+ cat-0    | file-140 |              5
+(10 rows)
+
+-- =====================================================================
+-- Scenario 3: HAVING + ORDER BY + LIMIT — late aggregate filtering.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  c  |   s    
+----------+-----+--------
+ cat-1    | 200 | 397780
+ cat-2    | 200 | 396468
+ cat-3    | 200 | 395772
+(3 rows)
+
+SET paradedb.enable_mpp TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.category, (count(*)), (sum(p.size_bytes))
+   ->  Gather Merge
+         Output: f.category, (count(*)), (sum(p.size_bytes))
+         Workers Planned: 3
+         ->  Sort
+               Output: f.category, (count(*)), (sum(p.size_bytes))
+               Sort Key: (sum(p.size_bytes)) DESC
+               ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+                     Output: f.category, (count(*)), (sum(p.size_bytes))
+                     Backend: DataFusion
+                     Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p)
+                     Group By: category
+                     Aggregates: COUNT(*), SUM(size_bytes)
+                     DataFusion Physical Plan: 
+                       : ┌───── DistributedExec ── Tasks: t0:[p0]
+                       : │ SortPreservingMergeExec: [agg_1@2 DESC], fetch=3
+                       : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                       : └──────────────────────────────────────────────────
+                       :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                       :   │ SortExec: TopK(fetch=3), expr=[agg_1@2 DESC], preserve_partitioning=[true]
+                       :   │   FilterExec: agg_0@1 > 100
+                       :   │     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[agg_0, agg_1]
+                       :   │       [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                       :   └──────────────────────────────────────────────────
+                       :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                       :     │ RepartitionExec: partitioning=Hash([category@0], 9), input_partitions=3
+                       :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[agg_0, agg_1]
+                       :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
+                       :     │       CoalescePartitionsExec
+                       :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                       :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                       :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                       :     └──────────────────────────────────────────────────
+                       :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                       :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                       :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                       :       └──────────────────────────────────────────────────
+(38 rows)
+
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ category |  c  |   s    
+----------+-----+--------
+ cat-1    | 200 | 397780
+ cat-2    | 200 | 396468
+ cat-3    | 200 | 395772
+(3 rows)
+
+-- =====================================================================
+-- Scenario 4: Scalar COUNT(*) — falls back to serial (planner caps the
+-- task_count for scalar aggregates), but confirms MPP-on doesn't break
+-- the serial fallback path. The EXPLAIN under enable_mpp=on documents
+-- that the scalar shape does not produce a multi-stage MPP plan.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ count 
+-------
+  1000
+(1 row)
+
+SET paradedb.enable_mpp TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+                                                                                   QUERY PLAN                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Backend: DataFusion
+   Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p)
+   Aggregates: COUNT(*)
+   DataFusion Physical Plan: 
+     : ┌───── DistributedExec ── Tasks: t0:[p0]
+     : │ AggregateExec: mode=Final, gby=[], aggr=[agg_0]
+     : │   CoalescePartitionsExec
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+     : └──────────────────────────────────────────────────
+     :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
+     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+     :   │     CoalescePartitionsExec
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+     :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :   └──────────────────────────────────────────────────
+     :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+     :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     └──────────────────────────────────────────────────
+(23 rows)
+
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
+ count 
+-------
+  1000
+(1 row)
+
+-- =====================================================================
+-- Scenario 5: Three-table join (two HashJoins → two NetworkBroadcastExec
+-- build subtrees under one NetworkShuffleExec shuffle).
+--
+-- Exercises the walker's nested-parent context propagation across two
+-- distinct `stage_id`s simultaneously, and the dispatcher's per-channel
+-- EOF on multiple Broadcast routings + the broadcast short-circuit on
+-- task_idx > 0 for both build stages.
+-- =====================================================================
+CREATE TABLE mpp_postagg_categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    description TEXT
+);
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(0, 4) AS g;
+CREATE INDEX mpp_postagg_categories_idx ON mpp_postagg_categories
+USING bm25 (id, name, description)
+WITH (
+    key_field='id',
+    text_fields='{"name": {"fast": true}, "description": {}}'
+);
+ANALYZE mpp_postagg_categories;
+SET paradedb.enable_mpp TO off;
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
+ name  | row_count | total_bytes 
+-------+-----------+-------------
+ cat-0 |       200 |      394380
+ cat-1 |       200 |      397780
+ cat-2 |       200 |      396468
+ cat-3 |       200 |      395772
+ cat-4 |       200 |      395076
+(5 rows)
+
+SET paradedb.enable_mpp TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather Merge
+   Output: c.name, (count(*)), (sum(p.size_bytes))
+   Workers Planned: 3
+   ->  Sort
+         Output: c.name, (count(*)), (sum(p.size_bytes))
+         Sort Key: c.name
+         ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+               Output: c.name, (count(*)), (sum(p.size_bytes))
+               Backend: DataFusion
+               Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p), mpp_postagg_categories_idx (c)
+               Group By: name
+               Aggregates: COUNT(*), SUM(size_bytes)
+               DataFusion Physical Plan: 
+                 : ┌───── DistributedExec ── Tasks: t0:[p0]
+                 : │ CoalescePartitionsExec
+                 : │   [Stage 4] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                 : └──────────────────────────────────────────────────
+                 :   ┌───── Stage 4 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                 :   │ AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[agg_0, agg_1]
+                 :   │   [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                 :   └──────────────────────────────────────────────────
+                 :     ┌───── Stage 3 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                 :     │ RepartitionExec: partitioning=Hash([name@0], 9), input_partitions=3
+                 :     │   AggregateExec: mode=Partial, gby=[name@1 as name], aggr=[agg_0, agg_1]
+                 :     │     ProjectionExec: expr=[size_bytes@1 as size_bytes, name@0 as name]
+                 :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(name@0, category@0)], projection=[name@0, size_bytes@2]
+                 :     │         CoalescePartitionsExec
+                 :     │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                 :     │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
+                 :     │           CoalescePartitionsExec
+                 :     │             [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                 :     │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :     │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :     └──────────────────────────────────────────────────
+                 :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                 :       │   PgSearchScan: segments=1, query="all"
+                 :       └──────────────────────────────────────────────────
+                 :       ┌───── Stage 2 ── Tasks: t0:[p0..p2]
+                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                 :       │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       └──────────────────────────────────────────────────
+(42 rows)
+
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
+ name  | row_count | total_bytes 
+-------+-----------+-------------
+ cat-0 |       200 |      394380
+ cat-1 |       200 |      397780
+ cat-2 |       200 |      396468
+ cat-3 |       200 |      395772
+ cat-4 |       200 |      395076
+(5 rows)
+
+-- =====================================================================
+-- Cleanup
+-- =====================================================================
+DROP TABLE mpp_postagg_categories;
+DROP TABLE mpp_postagg_pages;
+DROP TABLE mpp_postagg_files;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
@@ -1,0 +1,261 @@
+-- =====================================================================
+-- MPP AggregateScan: multi-stage natural-shape plan coverage.
+--
+-- Exercises the transport substrate end-to-end via post-aggregate
+-- patterns that produce a three-stage plan
+-- (NetworkCoalesceExec -> NetworkShuffleExec -> NetworkBroadcastExec):
+--   - GROUP BY one key, multiple aggregates
+--   - GROUP BY multiple keys
+--   - HAVING + ORDER BY + LIMIT
+--   - aggregation over a HashJoin with broadcast build subtree
+--
+-- Each pass runs the same query in serial mode (enable_mpp=off) then MPP
+-- mode (enable_mpp=on). The expected.out compares them byte-for-byte, so
+-- any MPP-vs-serial divergence shows up as a regression.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+CREATE TABLE mpp_postagg_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    category TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_postagg_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+
+CREATE INDEX mpp_postagg_files_idx ON mpp_postagg_files
+USING bm25 (id, title, category, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "category": {"fast": true}, "content": {}}'
+);
+
+CREATE INDEX mpp_postagg_pages_idx ON mpp_postagg_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+
+ANALYZE mpp_postagg_files;
+ANALYZE mpp_postagg_pages;
+
+-- =====================================================================
+-- Scenario 1: GROUP BY one key with multiple aggregates.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+
+SET paradedb.enable_mpp TO on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+
+SELECT f.category,
+       COUNT(*) AS row_count,
+       SUM(p.size_bytes) AS total_bytes,
+       MIN(p.size_bytes) AS min_bytes,
+       MAX(p.size_bytes) AS max_bytes
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+ORDER BY f.category;
+
+-- =====================================================================
+-- Scenario 2: GROUP BY multiple keys.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+
+SET paradedb.enable_mpp TO on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+
+SELECT f.category, f.title, COUNT(*) AS pages_per_file
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category, f.title
+ORDER BY f.category, f.title
+LIMIT 10;
+
+-- =====================================================================
+-- Scenario 3: HAVING + ORDER BY + LIMIT — late aggregate filtering.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+
+SET paradedb.enable_mpp TO on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+
+SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+GROUP BY f.category
+HAVING COUNT(*) > 100
+ORDER BY s DESC
+LIMIT 3;
+
+-- =====================================================================
+-- Scenario 4: Scalar COUNT(*) — falls back to serial (planner caps the
+-- task_count for scalar aggregates), but confirms MPP-on doesn't break
+-- the serial fallback path. The EXPLAIN under enable_mpp=on documents
+-- that the scalar shape does not produce a multi-stage MPP plan.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+SET paradedb.enable_mpp TO on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+SELECT COUNT(*)
+FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section';
+
+-- =====================================================================
+-- Scenario 5: Three-table join (two HashJoins → two NetworkBroadcastExec
+-- build subtrees under one NetworkShuffleExec shuffle).
+--
+-- Exercises the walker's nested-parent context propagation across two
+-- distinct `stage_id`s simultaneously, and the dispatcher's per-channel
+-- EOF on multiple Broadcast routings + the broadcast short-circuit on
+-- task_idx > 0 for both build stages.
+-- =====================================================================
+
+CREATE TABLE mpp_postagg_categories (
+    id SERIAL PRIMARY KEY,
+    name TEXT,
+    description TEXT
+);
+
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(0, 4) AS g;
+
+CREATE INDEX mpp_postagg_categories_idx ON mpp_postagg_categories
+USING bm25 (id, name, description)
+WITH (
+    key_field='id',
+    text_fields='{"name": {"fast": true}, "description": {}}'
+);
+
+ANALYZE mpp_postagg_categories;
+
+SET paradedb.enable_mpp TO off;
+
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+
+SET paradedb.enable_mpp TO on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+
+SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
+FROM mpp_postagg_files f
+JOIN mpp_postagg_pages p ON f.id = p.file_id
+JOIN mpp_postagg_categories c ON f.category = c.name
+WHERE f.content @@@ 'Section'
+GROUP BY c.name
+ORDER BY c.name;
+
+-- =====================================================================
+-- Cleanup
+-- =====================================================================
+
+DROP TABLE mpp_postagg_categories;
+DROP TABLE mpp_postagg_pages;
+DROP TABLE mpp_postagg_files;


### PR DESCRIPTION
# Ticket(s) Closed

- N/A

## What

Adds the multi-stage natural-shape MPP path for AggregateScan over a multiplexed N×N PostgreSQL `shm_mq` mesh. Default off behind `paradedb.enable_mpp`.

When the gate is on, eligible aggregate-over-join queries plan a distributed pipeline: partial aggregation pinned to worker procs over a `HashJoin` with a broadcast build subtree, hash-shuffle of partial groups by the group key, per-partition finalization, and a gather to the leader.

## Why

Aggregate-over-join is the workload class where Postgres' single-node aggregate sits on the join's hash table and finalization runs serially after the build subtree finishes. The natural-shape MPP path splits that work across `n_procs - 1` producer workers and pipelines partial-state shuffle in parallel, so the finalization barrier moves from the leader to the per-partition consumer side. The leader stays consumer-only, gathers the finalized groups, and emits to PG.

`shm_mq` is the right substrate because it lives in the existing DSM region the customscan already allocates for parallel state, gives nowait-receive semantics that play well with pgrx's `check_active_thread` (no blocking from non-backend threads), and doesn't need a separate orchestration daemon.

## How

The DSM region is a single contiguous block: header, plan bytes, then an `n_procs × n_procs` queue grid. Each proc attaches as **sender** on its row (`slot(this, *)`) and **receiver** on its column (`slot(*, this)`). One queue per directed proc-pair carries every logical channel, demultiplexed on receive via a 16-byte `MppFrameHeader` prefix that tags `(stage_id, partition)`.

The cooperative drain runs **inline on the backend thread** from `DrainGatherStream::poll_next`. That's a hard requirement: pgrx's `check_active_thread` panics on any pg FFI call (`shm_mq_receive` included) from a non-backend thread, so the drain work cannot be moved off the backend thread. The same drain is poked from the sender's cooperative spin (`try_drain_pass`) when a peer's queue fills — that's what breaks the symmetric N×N send/receive deadlock.

Per-channel sub-buffers decouple consumer-side backpressure from producer-side backpressure: the drain always makes forward progress on inbound queues, so a stalled consumer can't propagate backpressure back to remote producers.

Code organization: MPP code lives under `pg_search/src/postgres/customscan/mpp/` with a thin slice (`aggregatescan/mpp.rs`) holding the worker exec path. The pub surface from `mpp::transport` is exactly three names (`MppFrameHeader`, `MppSender`, `CooperativeDrainSet`); everything else is `pub(super)` or private.

## Reviewer's guide

Each link points at the post-state on this branch. Walk top-to-bottom for the planning → setup → wire → exec flow.

1. **Gate.** [`glue.rs:71`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/glue.rs#L71) `mpp_is_active` — true iff `enable_mpp = on` and `mpp_worker_count >= 3` (`>= 3` so the producer count `n_procs - 1` is at least 2, matching the planner's target_partitions).

2. **DSM region layout.** [`dsm.rs:75`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/dsm.rs#L75) `MppDsmHeader` and [`dsm.rs:159`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/dsm.rs#L159) `compute_dsm_layout` — header + plan bytes + `n_procs × n_procs` grid.

3. **Leader sets up the mesh.** [`glue.rs:179`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/glue.rs#L179) `leader_setup` — allocates the grid via `leader_init`, builds inbound drains for every peer (the leader is consumer-only, so outbound senders get dropped), wraps the result in `MppMesh`.

4. **Worker attaches.** [`glue.rs:237`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/glue.rs#L237) `worker_setup` — symmetric attach, plus a self-loop in-proc channel for `slot(this, this)` so peer-mesh hash routing that lands producer and consumer of the same partition on one worker stays on the uniform `BatchChannelReceiver` contract.

5. **Wire format.** [`transport.rs:83`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/transport.rs#L83) `MppFrameHeader` — 16 bytes, `[magic, flags, stage_id, partition]`. One queue carries many logical channels.

6. **Cooperative drain + per-channel demux.** [`transport.rs:856`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/transport.rs#L856) `DrainHandle` owns the receivers and a `(stage_id, partition) -> Arc<DrainBuffer>` registry. Sub-buffers are populated lazily by `try_drain_pass` or up-front by `WorkerConnection::stream_partition`.

7. **Sender backpressure.** [`transport.rs:447`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/transport.rs#L447) `MppSender::send_batch_traced` — encode into scratch, spin on `try_send_bytes`; on full, call `drain.try_drain_pass()` to pull peer inbounds on the same thread, then `yield_now().await`, retry. Breaks the symmetric stall cycle.

8. **Fragment routing on the receive side.** [`worker_fragments.rs:72`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/worker_fragments.rs#L72) `FragmentRouting` — `Coalesce` (single destination), `Shuffle` (hash-partitioned to a consumer task), `Broadcast` (canonical-replica via the one-task estimator). [`worker_fragments.rs:138`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/worker_fragments.rs#L138) `find_worker_assignments` walks the plan and collects every `(stage_id, task_idx)` slot owned by this proc.

9. **Worker exec.** [`aggregatescan/mpp.rs:57`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/aggregatescan/mpp.rs#L57) `exec_mpp_worker` — deserialize logical plan, build distributed physical plan (via the same session-context builder the leader runs, so stage numbering agrees), find fragments, build per-output-partition senders, dispatch via `run_worker_fragment` + `join_all`.

10. **Single session-context builder.** [`aggregatescan/mod.rs:1069`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/aggregatescan/mod.rs#L1069) `build_mpp_session_context` — used by leader exec, worker exec, and EXPLAIN's stub-mesh path. Both procs have to agree on stage shape; reusing the builder is how.

11. **Run a fragment.** [`worker.rs:43`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/worker.rs#L43) `run_worker_fragment` — execute the fragment's plan, fan out batches to the per-partition senders, send per-channel `Eof` frames at exhaustion so the consumer's `(stage_id, partition)` sub-buffer transitions to `Eof` without taking the whole shm_mq queue down.

12. **fail_loud invariant guard.** [`mpp/mod.rs:71`](https://github.com/paradedb/paradedb/blob/moe/mpp-attempt5-refactor/pg_search/src/postgres/customscan/mpp/mod.rs#L71) — `pgrx::error!` in prod, `panic!` in test (the lib-test binary doesn't link Postgres). Used for MPP-internal invariant breaches like an unrecognised nested boundary kind.

## Tests

- `cargo check --tests --features pg18` clean.
- `cargo clippy --tests --features pg18 -- -D warnings` clean.
- `cargo test --package pg_search --lib --features pg18 postgres::customscan::mpp` passes — covers the codec, drain buffer, drain handle, sub-buffer registry, in-proc channel, frame round-trip, and an N=2 mesh 100k-batch throughput run.
- Regression coverage lives in `pg_search/tests/pg_regress/sql/mpp_*.sql`.