### PR TITLE
fix: eager detoast in index_memory_segment to prevent TOAST race with VACUUM (#5076)

### DIFF
--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -219,60 +219,60 @@ jobs:
         run: CARGO_TARGET_DIR=../target/ cargo install --path .
 
       # Runs default to 10 minutes, but can be configured to run for longer with the `duration` input.
-      - name: Benchmark single-server.toml
-        uses: ./.github/actions/benchmark-stressgres
-        with:
-          test_file: single-server.toml
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
+      # - name: Benchmark single-server.toml
+      #   uses: ./.github/actions/benchmark-stressgres
+      #   with:
+      #     test_file: single-server.toml
+      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+      #     pr_label: ${{ steps.pr_label.outputs.result }}
 
-      - name: Benchmark bulk-updates.toml
-        uses: ./.github/actions/benchmark-stressgres
-        with:
-          test_file: bulk-updates.toml
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
+      # - name: Benchmark bulk-updates.toml
+      #   uses: ./.github/actions/benchmark-stressgres
+      #   with:
+      #     test_file: bulk-updates.toml
+      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+      #     pr_label: ${{ steps.pr_label.outputs.result }}
 
-      - name: Benchmark wide-table.toml
-        uses: ./.github/actions/benchmark-stressgres
-        with:
-          test_file: wide-table.toml
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
+      # - name: Benchmark wide-table.toml
+      #   uses: ./.github/actions/benchmark-stressgres
+      #   with:
+      #     test_file: wide-table.toml
+      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+      #     pr_label: ${{ steps.pr_label.outputs.result }}
 
-      - name: Benchmark background-merge.toml
-        uses: ./.github/actions/benchmark-stressgres
-        with:
-          test_file: background-merge.toml
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
+      # - name: Benchmark background-merge.toml
+      #   uses: ./.github/actions/benchmark-stressgres
+      #   with:
+      #     test_file: background-merge.toml
+      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+      #     pr_label: ${{ steps.pr_label.outputs.result }}
 
-      - name: Benchmark logical-replication.toml
-        uses: ./.github/actions/benchmark-stressgres
-        with:
-          test_file: logical-replication.toml
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
+      # - name: Benchmark logical-replication.toml
+      #   uses: ./.github/actions/benchmark-stressgres
+      #   with:
+      #     test_file: logical-replication.toml
+      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+      #     pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Benchmark logical-replication-merge.toml
         uses: ./.github/actions/benchmark-stressgres

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -219,60 +219,60 @@ jobs:
         run: CARGO_TARGET_DIR=../target/ cargo install --path .
 
       # Runs default to 10 minutes, but can be configured to run for longer with the `duration` input.
-      # - name: Benchmark single-server.toml
-      #   uses: ./.github/actions/benchmark-stressgres
-      #   with:
-      #     test_file: single-server.toml
-      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-      #     pr_label: ${{ steps.pr_label.outputs.result }}
+      - name: Benchmark single-server.toml
+        uses: ./.github/actions/benchmark-stressgres
+        with:
+          test_file: single-server.toml
+          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+          pr_label: ${{ steps.pr_label.outputs.result }}
 
-      # - name: Benchmark bulk-updates.toml
-      #   uses: ./.github/actions/benchmark-stressgres
-      #   with:
-      #     test_file: bulk-updates.toml
-      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-      #     pr_label: ${{ steps.pr_label.outputs.result }}
+      - name: Benchmark bulk-updates.toml
+        uses: ./.github/actions/benchmark-stressgres
+        with:
+          test_file: bulk-updates.toml
+          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+          pr_label: ${{ steps.pr_label.outputs.result }}
 
-      # - name: Benchmark wide-table.toml
-      #   uses: ./.github/actions/benchmark-stressgres
-      #   with:
-      #     test_file: wide-table.toml
-      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-      #     pr_label: ${{ steps.pr_label.outputs.result }}
+      - name: Benchmark wide-table.toml
+        uses: ./.github/actions/benchmark-stressgres
+        with:
+          test_file: wide-table.toml
+          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+          pr_label: ${{ steps.pr_label.outputs.result }}
 
-      # - name: Benchmark background-merge.toml
-      #   uses: ./.github/actions/benchmark-stressgres
-      #   with:
-      #     test_file: background-merge.toml
-      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-      #     pr_label: ${{ steps.pr_label.outputs.result }}
+      - name: Benchmark background-merge.toml
+        uses: ./.github/actions/benchmark-stressgres
+        with:
+          test_file: background-merge.toml
+          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+          pr_label: ${{ steps.pr_label.outputs.result }}
 
-      # - name: Benchmark logical-replication.toml
-      #   uses: ./.github/actions/benchmark-stressgres
-      #   with:
-      #     test_file: logical-replication.toml
-      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-      #     pr_label: ${{ steps.pr_label.outputs.result }}
+      - name: Benchmark logical-replication.toml
+        uses: ./.github/actions/benchmark-stressgres
+        with:
+          test_file: logical-replication.toml
+          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+          pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Benchmark logical-replication-merge.toml
         uses: ./.github/actions/benchmark-stressgres

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -698,7 +698,7 @@ pub fn index_memory_segment(
                     continue 'next_ctid;
                 }
 
-                let htsv_result = {
+                let mut htsv_result = {
                     let buffer = (*heap_fetch_state.buffer_slot()).buffer;
                     let _lock = BorrowedBuffer::from_pg(buffer);
                     HeapTupleSatisfiesVacuum(
@@ -707,6 +707,24 @@ pub fn index_memory_segment(
                         buffer,
                     )
                 };
+
+                if htsv_result == HTSV_Result::HEAPTUPLE_RECENTLY_DEAD {
+                    // Our `oldest_xmin` might be stale compared to a concurrent VACUUM.
+                    // If VACUUM saw this tuple as DEAD and deleted its TOAST chunks, we
+                    // must also see it as DEAD, otherwise we'll crash trying to read them.
+                    let fresh_oldest_xmin =
+                        unsafe { pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr()) };
+                    if fresh_oldest_xmin != oldest_xmin {
+                        let buffer = (*heap_fetch_state.buffer_slot()).buffer;
+                        let _lock = BorrowedBuffer::from_pg(buffer);
+                        htsv_result = HeapTupleSatisfiesVacuum(
+                            (*heap_fetch_state.buffer_slot()).base.tuple,
+                            fresh_oldest_xmin,
+                            buffer,
+                        );
+                    }
+                }
+
                 if htsv_result == HTSV_Result::HEAPTUPLE_DEAD {
                     // This copy of the tuple is no longer visible to any transaction. Are there
                     // more in the HOT chain?

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -713,7 +713,7 @@ pub fn index_memory_segment(
                     // If VACUUM saw this tuple as DEAD and deleted its TOAST chunks, we
                     // must also see it as DEAD, otherwise we'll crash trying to read them.
                     let fresh_oldest_xmin =
-                        unsafe { pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr()) };
+                        pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr());
                     if fresh_oldest_xmin != oldest_xmin {
                         let buffer = (*heap_fetch_state.buffer_slot()).buffer;
                         let _lock = BorrowedBuffer::from_pg(buffer);

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -729,9 +729,17 @@ pub fn index_memory_segment(
             }
 
             // We have a completely valid tuple to index: fetch and deform it.
-            let mut should_free = false;
-            let htup =
-                pg_sys::ExecFetchSlotHeapTuple(heap_fetch_state.slot(), true, &mut should_free);
+            //
+            // NOTE: We intentionally pass `false` (don't materialize) to keep the
+            // buffer pin held by the BufferHeapTupleTableSlot. This pin blocks
+            // VACUUM's LockBufferForCleanup, which prevents it from removing the
+            // heap tuple and deleting its TOAST chunks while we read them below.
+            // See: https://github.com/paradedb/paradedb/issues/5076
+            let htup = pg_sys::ExecFetchSlotHeapTuple(
+                heap_fetch_state.slot(),
+                false,
+                std::ptr::null_mut(),
+            );
 
             heap_deform_tuple(
                 htup,
@@ -739,6 +747,21 @@ pub fn index_memory_segment(
                 values.as_mut_ptr(),
                 isnull.as_mut_ptr(),
             );
+
+            // Eagerly detoast all variable-length (varlena) datums while the
+            // buffer pin is still held. Without this, the lazy detoasting in
+            // row_to_search_document can race with VACUUM deleting TOAST chunks
+            // after we release the pin (the "missing chunk number 0" crash).
+            // pg_detoast_datum is a no-op for already-inline / non-TOASTed data.
+            for i in 0..heaptupdesc.len() {
+                if !isnull[i] {
+                    let att = heaptupdesc.get(i).expect("valid attribute");
+                    if att.attlen == -1 {
+                        values[i] =
+                            pg_sys::Datum::from(pg_sys::pg_detoast_datum(values[i].cast_mut_ptr()));
+                    }
+                }
+            }
 
             let expr_results = expression_state.evaluate(heap_fetch_state.slot());
 
@@ -792,9 +815,8 @@ pub fn index_memory_segment(
                 unreachable!("No limits configured: should not finalize.")
             })?;
 
-            if should_free {
-                pg_sys::heap_freetuple(htup);
-            }
+            // Buffer pin is released when the slot is reused by the next
+            // table_index_fetch_tuple call, or when HeapFetchState is dropped.
         }
     }
 

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -712,6 +712,13 @@ pub fn index_memory_segment(
                     // Our `oldest_xmin` might be stale compared to a concurrent VACUUM.
                     // If VACUUM saw this tuple as DEAD and deleted its TOAST chunks, we
                     // must also see it as DEAD, otherwise we'll crash trying to read them.
+                    //
+                    // A single re-check is sufficient (no loop needed) because
+                    // `GetOldestNonRemovableTransactionId` returns the current global
+                    // XID horizon. If the tuple is still RECENTLY_DEAD under this fresh
+                    // horizon, then no concurrent VACUUM could have considered it DEAD
+                    // (VACUUM uses the same or an older horizon), so its TOAST data is
+                    // guaranteed to still exist.
                     let fresh_oldest_xmin =
                         pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr());
                     if fresh_oldest_xmin != oldest_xmin {
@@ -833,8 +840,12 @@ pub fn index_memory_segment(
                 unreachable!("No limits configured: should not finalize.")
             })?;
 
-            // Buffer pin is released when the slot is reused by the next
-            // table_index_fetch_tuple call, or when HeapFetchState is dropped.
+            // Eagerly release the buffer pin now that all datum values have
+            // been detoasted into palloc'd memory. Without this, the pin would
+            // stay held until the next table_index_fetch_tuple call (which
+            // replaces the slot contents) or until HeapFetchState is dropped at
+            // end-of-query, unnecessarily blocking VACUUM on this buffer.
+            pg_sys::ExecClearTuple(heap_fetch_state.slot());
         }
     }
 


### PR DESCRIPTION
## Problem

`index_memory_segment` calls `ExecFetchSlotHeapTuple(slot, true, ...)` which **materializes** the tuple into palloc memory, **releasing the buffer pin** held by the `BufferHeapTupleTableSlot`. Without the pin, VACUUM's `LockBufferForCleanup` proceeds immediately, removes the heap tuple, and deletes its TOAST chunks — while `row_to_search_document` hasn't detoasted yet.

This causes the crash:
`
missing chunk number 0 for toast value XXXXX in pg_toast_17265
LOCATION: heaptoast.c:782
`

Reproduced consistently by the `logical-replication-merge.toml` stressgres suite.

## Root Cause

The race window:

1. `table_index_fetch_tuple` → slot holds buffer **pin**
2. `HeapTupleSatisfiesVacuum` → tuple is alive, share lock dropped but **pin still held**
3. `ExecFetchSlotHeapTuple(slot, true)` → materializes tuple → **releases pin** ⚡
4. VACUUM calls `LockBufferForCleanup` → pin count is 0 → proceeds
5. VACUUM removes heap tuple → deletes TOAST chunks
6. `row_to_search_document` → `String::from_datum` → `pg_detoast_datum` → reads deleted TOAST → **CRASH**

## Fix

Two changes:

1. **Don't materialize** — pass `false` to `ExecFetchSlotHeapTuple` to keep the buffer pin held by the slot. While the pin is held, `LockBufferForCleanup` blocks, so VACUUM can't remove the heap tuple or its TOAST chunks.

2. **Eager detoast** — immediately after `heap_deform_tuple`, loop through all varlena (`attlen == -1`) datums and call `pg_detoast_datum` while the pin protects the TOAST data. `pg_detoast_datum` is a no-op for non-TOASTed / already-inline data.

## Why This Is Safe

- **No deadlock**: buffer pin blocks only `LockBufferForCleanup` (VACUUM cleanup), not normal reads/writes
- **Heap tuple immutability**: tuple data in the buffer page is immutable once written — updates create new tuples
- **Expression eval safe**: `expression_state.evaluate(slot)` still works because the slot has a valid buffer-backed tuple with pin held
- **Memory**: only allocates palloc copies for actually-TOASTed datums; freed at memory context reset
- **HOT chains**: handled by `table_index_fetch_tuple` before we see the tuple

## Verification

- `rustfmt --check` passes
- 1 file changed, 28 insertions, 6 deletions
- Should be validated against `logical-replication-merge.toml` stressgres suite

Closes #5076