### PR TITLE
feat(antithesis): add singleton drivers for logical-replication suites

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -382,8 +382,8 @@ jobs:
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb
             custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }}
-            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg
-            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg
+            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg,logical-replication-publisher
+            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg,logical-replication-publisher
 
   # Ping Slack if any of the nightly (scheduled) jobs failed. Scheduled runs only execute on
   # paradedb-enterprise (see the `if` on `setup`), so this notification only fires there.

--- a/docker/manifests/antithesis-paradedb.yaml
+++ b/docker/manifests/antithesis-paradedb.yaml
@@ -298,3 +298,53 @@ spec:
         - ALTER DATABASE template1 SET search_path TO public,paradedb;
 
   externalClusters:
+---
+# Vanilla Postgres publisher used by the logical-replication Stressgres suites.
+# Lives outside the CNPG cluster because real-world logical-replication
+# customers typically don't control the upstream primary. Network faults between
+# this pod and the paradedb cluster are intentionally still injected by
+# Antithesis; only container stop/kill faults on this pod are excluded (see the
+# trigger workflow).
+apiVersion: v1
+kind: Service
+metadata:
+  name: logical-replication-publisher
+  namespace: default
+spec:
+  selector:
+    app: logical-replication-publisher
+  ports:
+    - port: 5432
+      targetPort: 5432
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: logical-replication-publisher
+  namespace: default
+  labels:
+    app: logical-replication-publisher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: logical-replication-publisher
+  template:
+    metadata:
+      labels:
+        app: logical-replication-publisher
+    spec:
+      containers:
+        - name: postgres
+          image: docker.io/postgres:18
+          imagePullPolicy: IfNotPresent
+          args: ["-c", "wal_level=logical"]
+          env:
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: paradedb-superuser
+                  key: password
+          ports:
+            - containerPort: 5432
+              name: postgres

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+# See stressgres/README.md about these connection strings.
+#
+# Publisher  -> vanilla Postgres pod (see docker/manifests/antithesis-paradedb.yaml).
+#               Mirrors a real-world logical-replication topology where the
+#               upstream primary is not under our control.
+# Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
+echo ""
+echo "Updating suite to use Antithesis connections..."
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres"|' /home/app/stressgres/suites/logical-replication-merge.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/logical-replication-merge.toml
+
+echo ""
+echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
+sleep 60
+
+echo ""
+echo "Running Stressgres with suite logical-replication-merge.toml..."
+# Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000
+
+echo ""
+echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -Eeuo pipefail
+
+# See stressgres/README.md about these connection strings.
+#
+# Publisher  -> vanilla Postgres pod (see docker/manifests/antithesis-paradedb.yaml).
+#               Mirrors a real-world logical-replication topology where the
+#               upstream primary is not under our control.
+# Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
+echo ""
+echo "Updating suite to use Antithesis connections..."
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres"|' /home/app/stressgres/suites/logical-replication.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/logical-replication.toml
+
+echo ""
+echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
+sleep 60
+
+echo ""
+echo "Running Stressgres with suite logical-replication.toml..."
+# Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000
+
+echo ""
+echo "Stressgres completed!"

--- a/stressgres/suites/logical-replication-merge.toml
+++ b/stressgres/suites/logical-replication-merge.toml
@@ -11,7 +11,6 @@ postgresql_conf = "Publisher"
 [server.setup]
 sql = """
 DROP TABLE IF EXISTS test CASCADE;
-CREATE EXTENSION IF NOT EXISTS pg_search;
 CREATE TABLE test (
     id SERIAL8 NOT NULL PRIMARY KEY,
     message TEXT,

--- a/stressgres/suites/logical-replication.toml
+++ b/stressgres/suites/logical-replication.toml
@@ -6,7 +6,6 @@ postgresql_conf = "Publisher"
 [server.setup]
 sql = """
 DROP TABLE IF EXISTS test CASCADE;
-CREATE EXTENSION IF NOT EXISTS pg_search;
 CREATE TABLE test (
     id SERIAL8 NOT NULL PRIMARY KEY,
     message TEXT,


### PR DESCRIPTION
## Summary

Adds OSS Antithesis singleton drivers for the two CI `logical-replication` suites that previously had no singleton (`single-server`, `bulk-updates`, `wide-table`, `background-merge`, and `vanilla-postgres` already had one).

Mirrors the enterprise pattern used for `physical-logical-replication`:
- A **vanilla Postgres 18** publisher pod (with `wal_level=logical`) that lives outside the CNPG cluster, reflecting real-world logical-replication topologies where the upstream primary is not under our control.
- Subscriber points at `paradedb-rw` (the CNPG primary, which has `pg_search`).

## Changes
- `docker/manifests/antithesis-paradedb.yaml` — add `logical-replication-publisher` Service + Deployment (vanilla Postgres 18 with `wal_level=logical`), reusing the existing `paradedb-superuser` secret.
- `stressgres/suites/logical-replication.toml`, `stressgres/suites/logical-replication-merge.toml` — drop `CREATE EXTENSION pg_search` from the **Publisher** setup. Only the Subscriber uses `pg_search`; the line was cosmetic and incompatible with a vanilla Postgres publisher (the line in the Subscriber setup is unchanged).
- `stressgres/suites/antithesis/singleton_driver_logical-replication.sh`, `singleton_driver_logical-replication-merge.sh` — new drivers that perform per-block `sed -z` rewrites of the `[server.style.Automatic]` blocks into `[server.style.With]` connection strings (Publisher → `logical-replication-publisher:5432`, Subscriber → `paradedb-rw:5432`).
- `.github/workflows/antithesis-trigger-test-run.yml` — add `logical-replication-publisher` to `container_faults_stop_exclusion_patterns` and `container_faults_kill_exclusion_patterns`, matching enterprise. Network faults to/from the publisher are intentionally still injected.

## Why
Without these, the FSM race repro in `logical-replication-merge.toml` (issue #4935, fixed by #5067) and the broader logical-replication coverage in `logical-replication.toml` were running in `benchmark-pg_search-stressgres` but had no Antithesis fault-injection equivalent — that's the half of the matrix where the bugs originally surfaced.

## Test plan
- [x] Antithesis trigger workflow picks up both new singleton drivers from `/opt/antithesis/test/v1/quickstart/`
- [x] Publisher pod (`logical-replication-publisher`) starts with `wal_level=logical` and is reachable from the stressgres-runner pod
- [x] Subscriber's `CREATE SUBSCRIPTION ... CONNECTION '@Publisher_CONNSTR@'` resolves to the publisher pod after the `sed` rewrite
- [x] `logical-replication-merge.toml` still reproduces the FSM race when run against a build without #5067
- [x] `benchmark-pg_search-stressgres` (local Stressgres, not Antithesis) still runs both suites unchanged