### PR TITLE
fix(antithesis): use correct proptest env var to disable failure persistence

### DIFF
--- a/tests/antithesis/singleton_driver_property-tests.sh
+++ b/tests/antithesis/singleton_driver_property-tests.sh
@@ -19,7 +19,7 @@ export PROPTEST_CASES="${PROPTEST_CASES:-128}"
 # Disable proptest's source-relative regression file persistence: the qgen
 # binary runs air-gapped from /home/app and can't resolve lib.rs/main.rs, which
 # otherwise spams a warning on every iteration.
-export PROPTEST_FAILURE_PERSISTENCE=off
+export PROPTEST_DISABLE_FAILURE_PERSISTENCE=1
 export RUST_BACKTRACE=1
 
 echo ""


### PR DESCRIPTION
## Summary

- `tests/antithesis/singleton_driver_property-tests.sh` was exporting `PROPTEST_FAILURE_PERSISTENCE=off`, but proptest does not recognize that name. Every iteration logged `proptest: Ignoring unknown env-var PROPTEST_FAILURE_PERSISTENCE.` followed by the `proptest: FileFailurePersistence::SourceParallel set, but failed to find lib.rs or main.rs` warning the export was supposed to silence.
- The correct knob (proptest 1.11 `config.rs:41`) is `PROPTEST_DISABLE_FAILURE_PERSISTENCE`; when present with any value, proptest sets `failure_persistence = None`. Switching to that env var actually suppresses the warning and prevents proptest from trying to persist regressions under `/home/app` in the air-gapped Antithesis runner.

Caught while triaging the latest Antithesis singleton-driver run (events.log: repeated `Ignoring unknown env-var PROPTEST_FAILURE_PERSISTENCE.` + one `Saving this and future failures in /home/app/tests/tests/qgen.proptest-regressions` line).

## Test plan

- [x] Antithesis proptests run no longer logs `Ignoring unknown env-var PROPTEST_FAILURE_PERSISTENCE.`
- [x] No `failed to find lib.rs or main.rs` warning appears on failing cases
- [x] No `qgen.proptest-regressions` file is written under `/home/app/tests/tests/`