### PR TITLE
docs: remove WAL/durability caveats

### DIFF
--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -5,9 +5,8 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/digitalocean
 ---
 
 <Note>
-  Cloud platform deployments run ParadeDB Community, which does not include WAL
-  support. This makes them suitable for hobby, development, and staging
-  environments. For production, we recommend [ParadeDB
+  Cloud platform deployments run ParadeDB Community, which do not support high
+  availability or read replicas. If these matter to you, we recommend [ParadeDB
   Enterprise](/deploy/enterprise) deployed via
   [Kubernetes](/deploy/self-hosted/kubernetes) or [BYOC](/deploy/byoc).
 </Note>

--- a/docs/deploy/cloud-platforms/railway.mdx
+++ b/docs/deploy/cloud-platforms/railway.mdx
@@ -5,9 +5,8 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/railway
 ---
 
 <Note>
-  Cloud platform deployments run ParadeDB Community, which does not include WAL
-  support. This makes them suitable for hobby, development, and staging
-  environments. For production, we recommend [ParadeDB
+  Cloud platform deployments run ParadeDB Community, which do not support high
+  availability or read replicas. If these matter to you, we recommend [ParadeDB
   Enterprise](/deploy/enterprise) deployed via
   [Kubernetes](/deploy/self-hosted/kubernetes) or [BYOC](/deploy/byoc).
 </Note>

--- a/docs/deploy/cloud-platforms/render.mdx
+++ b/docs/deploy/cloud-platforms/render.mdx
@@ -5,9 +5,8 @@ canonical: https://docs.paradedb.com/deploy/cloud-platforms/render
 ---
 
 <Note>
-  Cloud platform deployments run ParadeDB Community, which does not include WAL
-  support. This makes them suitable for hobby, development, and staging
-  environments. For production, we recommend [ParadeDB
+  Cloud platform deployments run ParadeDB Community, which do not support high
+  availability or read replicas. If these matter to you, we recommend [ParadeDB
   Enterprise](/deploy/enterprise) deployed via
   [Kubernetes](/deploy/self-hosted/kubernetes) or [BYOC](/deploy/byoc).
 </Note>

--- a/docs/deploy/enterprise.mdx
+++ b/docs/deploy/enterprise.mdx
@@ -46,10 +46,11 @@ For access to ParadeDB Enterprise, please [contact sales](mailto:sales@paradedb.
 | Buffer cache integration<sup>2</sup> | ✅                 | ✅                  |
 | **Deployment** <sup>3</sup>          |                    |
 | Maximum cluster size <sup>4</sup>    | 1                  | Unlimited           |
-| Physical (i.e. WAL) Replication      | ❌                 | ✅                  |
-| Crash Recovery                       | ❌                 | ✅                  |
-| Point in Time Recovery               | ❌                 | ✅                  |
+| Crash Recovery                       | ✅                 | ✅                  |
+| Point in Time Recovery               | ✅                 | ✅                  |
 | Logical Replication                  | ✅                 | ✅                  |
+| High Availability Support            | ❌                 | ✅                  |
+| Read Replica Support                 | ❌                 | ✅                  |
 
 <Info>
 **Footnotes**
@@ -65,6 +66,6 @@ For access to ParadeDB Enterprise, please [contact sales](mailto:sales@paradedb.
   3. All listed deployment features and limitations are specific to the BM25 index. For instance,
   ParadeDB Community supports physical/logical replication, crash recovery, etc. for heap tables and other Postgres indexes like B-Tree.
   4. In a primary-replica topology, BM25 indexes in ParadeDB Community are only available on the primary, as
-  the Community edition does not support physical (WAL) replication.
+  the Community edition does not support physical replication.
 </p>
 </Info>

--- a/docs/deploy/overview.mdx
+++ b/docs/deploy/overview.mdx
@@ -5,13 +5,9 @@ canonical: https://docs.paradedb.com/deploy/overview
 ---
 
 <Note>
-Running ParadeDB Community in a production application that serves paying customers is discouraged.
-
-This is because ParadeDB Community [does not have write-ahead log (WAL) support](/deploy/enterprise). Without WALs, data can be lost or corrupted if
-the server crashes or restarts, which would necessitate a reindex and incur downtime for your application. For more details, see [guarantees](/welcome/guarantees#aci-d).
-
-When you are ready to deploy in ParadeDB to production, [contact us](mailto:sales@paradedb.com) for access to ParadeDB Enterprise, which has WAL support.
-
+  If your application requires high availability or read replicas, you should
+  [contact us](mailto:hello@paradedb.com) for access to ParadeDB Enterprise. For
+  all other cases, you may deploy ParadeDB Community.
 </Note>
 
 There are three ways to deploy ParadeDB:
@@ -22,7 +18,7 @@ There are three ways to deploy ParadeDB:
 
 ## Cloud Platforms
 
-For hobby, development, or staging environments, ParadeDB Community can be deployed to cloud platforms with minimal setup. These all use Docker containers, which package PostgreSQL and `pg_search` together:
+ParadeDB Community is supported by several cloud platforms. These all use Docker containers, which package PostgreSQL and `pg_search` together:
 
 - [Railway](/deploy/cloud-platforms/railway) — One-click deploy to Railway
 - [Render](/deploy/cloud-platforms/render) — One-click deploy to Render

--- a/docs/welcome/guarantees.mdx
+++ b/docs/welcome/guarantees.mdx
@@ -4,13 +4,10 @@ description: ParadeDB ensures ACID compliance, concurrency, data integrity, and 
 canonical: https://docs.paradedb.com/welcome/guarantees
 ---
 
-### ACI(D)
+### ACID
 
 All reads and writes go through Postgres’ transaction engine. This means that inserts, updates, and deletes to indexed columns are atomic, consistent, and respect Postgres' [isolation levels](https://www.postgresql.org/docs/current/transaction-iso.html).
-
-Durability — the "D" in ACID — means that once a transaction is committed, its changes will survive crashes or failovers. In PostgreSQL, this guarantee is provided by the write-ahead log (WAL), which ensures that all changes are safely recorded before being applied to disk.
-
-[ParadeDB Community](https://github.com/paradedb/paradedb) does **not** write to the WAL, and therefore does not guarantee durability in the face of crashes. For production use cases that require full durability, [ParadeDB Enterprise](/deploy/enterprise) — a closed-source fork of ParadeDB for enterprise customers — includes full WAL integration.
+As of `0.24.0`, transactions are also durable, meaning they are write-ahead (WAL) logged and will survive crashes.
 
 ### Concurrency
 


### PR DESCRIPTION
## Summary

NOTE: Do not merge until WALs have actually been released

## Test plan
- [x] Render docs locally and confirm pages read sensibly.