### PR TITLE
feat(mpp): wire JoinScan through the natural-shape substrate

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -391,7 +391,6 @@ impl CustomScan for AggregateScan {
                     group_df_indices: Vec::new(),
                     mpp: None,
                     mpp_plan_bytes: None,
-                    mpp_n_partitions: 1,
                 });
                 builder.build()
             }
@@ -997,14 +996,6 @@ impl AggregateScan {
             }
         };
         df_state.mpp_plan_bytes = Some(bytes.to_vec());
-        // Each producer writes `target_partitions` partitions per worker.
-        // The DF-D fork's `_distribute_plan` is patched so that in in-process
-        // mode (custom WorkerTransport registered) it clamps the Shuffle's
-        // consumer_task_count to 1, which disables `NetworkShuffleExec`'s
-        // per-task hash scaling. So producer output = target_partitions =
-        // n_workers (matching `build_mpp_session_context`).
-        let n_workers = producer_worker_count();
-        df_state.mpp_n_partitions = n_workers.max(1);
     }
 
     /// Build the leader's distributed session context for this AggregateScan query. Thin

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -39,20 +39,16 @@ pub use targetlist::TargetListEntry;
 
 use std::sync::Arc;
 
-use datafusion::execution::{SessionStateBuilder, TaskContext};
+use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::{
-    display_plan_ascii, DistributedExec, DistributedExt, DistributedTaskContext,
-    SessionStateBuilderExt,
-};
+use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTaskContext};
 
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_is_active, mpp_worker_count, producer_worker_count,
     worker_setup,
 };
-use crate::postgres::customscan::mpp::runtime::{MppMesh, MppWorkerResolver, ShmMqWorkerTransport};
-use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
+use crate::postgres::customscan::mpp::runtime::MppMesh;
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
@@ -103,7 +99,7 @@ use crate::postgres::types::{is_datetime_type, TantivyValue};
 use crate::postgres::utils::{add_vars_to_tlist, is_unnest_func, make_text_const};
 use crate::postgres::PgSearchRelation;
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
-use crate::scan::codec::{serialize_logical_plan, PgSearchPhysicalCodecStub};
+use crate::scan::codec::serialize_logical_plan;
 use chrono::{DateTime as ChronoDateTime, Utc};
 use futures::StreamExt;
 use pgrx::{pg_sys, PgList, PgMemoryContexts, PgTupleDesc};
@@ -1059,55 +1055,14 @@ impl AggregateScan {
         df_state.mpp_n_partitions = n_workers.max(1);
     }
 
-    /// MPP leader exec helper: build a `SessionContext` that mirrors
-    /// `create_aggregate_session_context`'s rules + the DF-D fork's
-    /// `with_distributed_planner` + our `ShmMqWorkerTransport` wired to the
-    /// runtime mesh. The resulting context, when used to
-    /// `create_physical_plan` over the leader's logical plan, returns a
-    /// `DistributedExec` whose `NetworkShuffleExec`s pull batches from the
-    /// shm_mq mesh at execute time.
+    /// Build the leader's distributed session context for this AggregateScan query. Thin
+    /// wrapper over the shape-agnostic [`crate::postgres::customscan::mpp::exec_worker::
+    /// build_mpp_session_context`] that seeds with `create_aggregate_session_context()`.
     fn build_mpp_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
-        let serial = create_aggregate_session_context();
-        // Workers are procs 1..n_procs; leader is proc 0. The producer
-        // count is therefore `n_procs - 1`.
-        let n_workers = mesh.n_procs.saturating_sub(1).max(1) as usize;
-        // Four-knob unlock for actually inserting NetworkShuffleExec/etc.:
-        //   1. target_partitions(N) — without this, EnforceDistribution skips
-        //      every RepartitionExec, so the annotator never sees a Shuffle.
-        //   2. distributed_task_estimator(N) — without this, leaves default to
-        //      Maximum(1) and `_distribute_plan` elides every shuffle.
-        //   3. distributed_broadcast_joins(true) — CollectLeft HashJoins
-        //      otherwise cap their stage's task_count to Maximum(1) and
-        //      propagate that cap upward, eliding shuffles above the join.
-        //   4. distributed_user_codec — the DF-D fork's prepare_plan unconditionally
-        //      encodes worker subplans for gRPC shipment; without a codec for
-        //      our custom physical execs, encoding errors before execution.
-        //      In our model the encoded bytes are never observed (workers
-        //      re-plan from the logical plan in DSM), so the codec is a stub.
-        let cfg = serial
-            .copied_config()
-            .with_target_partitions(n_workers.max(2));
-
-        let state_builder = SessionStateBuilder::new()
-            .with_default_features()
-            .with_config(cfg)
-            .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers))
-            .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
-            .with_distributed_in_process_mode(true)
-            .expect("with_distributed_in_process_mode")
-            // Estimator chain order matters. The DF-D fork tries each estimator in registration
-            // order until one returns Some. The build-side one-task estimator has to come first.
-            // Otherwise the default `Desired(n_workers)` leaf estimator wins, the all-gather
-            // memory leaf gets task_count = n_workers, `_distribute_plan` builds
-            // `NetworkBroadcastExec` with `input_task_count = n_workers`, and the consumer's
-            // `select_all` over-counts by n_workers. See task_estimator.rs.
-            .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
-            .with_distributed_task_estimator(n_workers)
-            .with_distributed_broadcast_joins(true)
-            .expect("with_distributed_broadcast_joins")
-            .with_distributed_user_codec(PgSearchPhysicalCodecStub)
-            .with_distributed_planner();
-        datafusion::prelude::SessionContext::new_with_state(state_builder.build())
+        crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context(
+            create_aggregate_session_context(),
+            mesh,
+        )
     }
 
     /// Rebuild and render the DataFusion physical plan into the explainer.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -719,7 +719,6 @@ impl ParallelQueryCapable for AggregateScan {
         let Some(plan_bytes) = df_state.mpp_plan_bytes.take() else {
             return;
         };
-        let n_partitions = df_state.mpp_n_partitions;
         let seg = unsafe { (*pcxt).seg };
 
         // Capture manifests + size the ParallelScanState block.
@@ -774,14 +773,13 @@ impl ParallelQueryCapable for AggregateScan {
         // Init the MPP region.
         let mpp_coordinate =
             unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut std::os::raw::c_void };
-        let leader =
-            match unsafe { leader_setup(mpp_coordinate, seg, pcxt, n_partitions, plan_bytes) } {
-                Ok(l) => l,
-                Err(e) => {
-                    pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");
-                    return;
-                }
-            };
+        let leader = match unsafe { leader_setup(mpp_coordinate, seg, pcxt, plan_bytes) } {
+            Ok(l) => l,
+            Err(e) => {
+                pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");
+                return;
+            }
+        };
         let df_state = state
             .custom_state_mut()
             .datafusion_state

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -45,8 +45,9 @@ use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTas
 
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, mpp_is_active, mpp_worker_count, producer_worker_count,
-    worker_setup,
+    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, mpp_worker_count,
+    producer_worker_count, pscan_offset, read_custom_scan_header, worker_setup,
+    write_custom_scan_header, CustomScanMppHeader,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 
@@ -625,53 +626,6 @@ impl CustomScan for AggregateScan {
     }
 }
 
-/// MPP DSM hook impl. The query's serialized worker-fragment plan bytes are
-/// stashed on the customscan state by `begin_custom_scan` so estimate +
-/// initialize see the same bytes; without that we'd have to re-build the
-/// plan twice. The serialization itself happens via the
-/// `PgSearchExtensionCodec` and the DF-D fork's `DistributedCodec` so
-/// `NetworkShuffleExec` round-trips through the worker side.
-/// DSM layout used by AggregateScan in MPP mode:
-///
-/// ```text
-/// [0 .. 8)                     u64 mpp_offset            (offset to MPP region)
-/// [8 .. 16)                    u64 partitioning_source_idx
-/// [pscan_offset .. mpp_offset) ParallelScanState (variable size)
-/// [mpp_offset .. total)        MPP region (header + queues + plan_bytes)
-/// ```
-///
-/// Workers don't carry the source manifests the leader saw, so the
-/// MPP-region offset and the partitioning-source index are stamped into
-/// the first 16 bytes by the leader and read back by workers — neither
-/// has to be re-derived.
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct MppAggDsmHeader {
-    mpp_offset: u64,
-    partitioning_source_idx: u64,
-}
-
-const MPP_AGG_DSM_HEADER_SIZE: usize = std::mem::size_of::<MppAggDsmHeader>();
-
-fn mpp_align(n: usize) -> usize {
-    let a = pg_sys::MAXIMUM_ALIGNOF as usize;
-    n.next_multiple_of(a)
-}
-
-fn mpp_agg_pscan_offset() -> usize {
-    mpp_align(MPP_AGG_DSM_HEADER_SIZE)
-}
-
-unsafe fn mpp_agg_read_header(coordinate: *const std::os::raw::c_void) -> MppAggDsmHeader {
-    unsafe { *(coordinate as *const MppAggDsmHeader) }
-}
-
-unsafe fn mpp_agg_write_header(coordinate: *mut std::os::raw::c_void, header: MppAggDsmHeader) {
-    unsafe {
-        *(coordinate as *mut MppAggDsmHeader) = header;
-    }
-}
-
 impl ParallelQueryCapable for AggregateScan {
     fn estimate_dsm_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
@@ -695,7 +649,7 @@ impl ParallelQueryCapable for AggregateScan {
             .collect();
         let partitioning_idx = Self::partitioning_source_idx(state);
         let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
-        let mpp_offset = mpp_align(mpp_agg_pscan_offset() + pscan_size);
+        let mpp_offset = mpp_align(pscan_offset() + pscan_size);
 
         let mpp_size = match estimate_dsm_size(plan_bytes_len) {
             Ok(sz) => sz,
@@ -731,16 +685,16 @@ impl ParallelQueryCapable for AggregateScan {
             .map(|m| m.segment_count())
             .collect();
         let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
-        let pscan_offset = mpp_agg_pscan_offset();
+        let pscan_offset = pscan_offset();
         let mpp_offset = mpp_align(pscan_offset + pscan_size);
 
         // Stamp the MPP-region offset and partitioning-source index into
         // the DSM header so workers can skip past the ParallelScanState
         // block and key index_segment_ids the same way as the leader.
         unsafe {
-            mpp_agg_write_header(
+            write_custom_scan_header(
                 coordinate,
-                MppAggDsmHeader {
+                CustomScanMppHeader {
                     mpp_offset: mpp_offset as u64,
                     partitioning_source_idx: partitioning_idx as u64,
                 },
@@ -794,7 +748,7 @@ impl ParallelQueryCapable for AggregateScan {
         coordinate: *mut std::os::raw::c_void,
     ) {
         // Reset the ParallelScanState header so a re-execution re-claims segments.
-        let pscan_offset = mpp_agg_pscan_offset();
+        let pscan_offset = pscan_offset();
         let pscan_state =
             unsafe { (coordinate as *mut u8).add(pscan_offset) as *mut ParallelScanState };
         if !pscan_state.is_null() {
@@ -813,9 +767,9 @@ impl ParallelQueryCapable for AggregateScan {
 
         // Read the MPP-region offset + partitioning-source index from the
         // DSM header.
-        let header = unsafe { mpp_agg_read_header(coordinate) };
+        let header = unsafe { read_custom_scan_header(coordinate) };
         let mpp_offset = header.mpp_offset as usize;
-        let pscan_offset = mpp_agg_pscan_offset();
+        let pscan_offset = pscan_offset();
         state.custom_state_mut().mpp_partitioning_source_idx =
             Some(header.partitioning_source_idx as usize);
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
@@ -17,52 +17,34 @@
 
 //! AggregateScan MPP worker exec path.
 //!
-//! Holds [`AggregateScan::exec_mpp_worker`], the body of `exec_custom_scan` when a parallel
-//! worker is running an MPP fragment. The leader's path stays in `mod.rs`; this file isolates
-//! the worker dispatcher's logical-plan deserialization, distributed-physical-plan build,
-//! fragment discovery, and `join_all`-driven async dispatch so `mod.rs` keeps its focus on the
-//! leader-side trait impl and the serial Tantivy paths.
+//! Thin wrapper over [`mpp::exec_worker::run_mpp_worker`]: pulls AggregateScan-specific inputs
+//! (parallel_state, source_manifests, partitioning source index, the worker's plan bytes and
+//! mesh) out of the typed state, builds the aggregate-profile seed `SessionContext`, hands the
+//! whole thing to the shape-agnostic dispatcher.
 
 use std::sync::Arc;
 
-use datafusion::execution::runtime_env::RuntimeEnvBuilder;
-use datafusion::execution::TaskContext;
-use datafusion::physical_plan::ExecutionPlanProperties;
-use datafusion_distributed::{DistributedExec, DistributedTaskContext};
 use pgrx::pg_sys;
 
-use crate::api::HashSet;
 use crate::postgres::customscan::aggregatescan::datafusion_exec::create_aggregate_session_context;
 use crate::postgres::customscan::aggregatescan::scan_state;
 use crate::postgres::customscan::aggregatescan::AggregateScan;
 use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
-use crate::postgres::customscan::datafusion::memory::create_memory_pool;
-use crate::postgres::customscan::mpp::runtime::proc_for_task;
-use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
-use crate::postgres::customscan::mpp::worker::run_worker_fragment;
-use crate::postgres::customscan::mpp::worker_fragments::{
-    find_worker_assignments, FragmentRouting,
-};
-use crate::postgres::customscan::parallel::list_segment_ids;
-use crate::scan::codec::deserialize_logical_plan_with_runtime;
+use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
+use crate::postgres::customscan::mpp::transport::MppSender;
 
-/// MPP worker exec: deserialize the logical plan from DSM, build the
-/// distributed physical plan (matching what the leader produced), find
-/// the worker fragment (the `input_stage.plan` of the bottom
-/// `NetworkShuffleExec`), and run it via
-/// [`mpp::worker::run_worker_fragment`] which pushes every output batch
-/// to the leader's shm_mq queues. Workers emit zero rows back to PG;
+/// MPP worker exec: extract inputs from AggregateScan's state, build the aggregate-profile seed
+/// context, hand off to the shape-agnostic dispatcher. Workers emit zero rows back to PG;
 /// returning `null_mut()` signals end-of-stream.
 pub(super) fn exec_mpp_worker(
     state: &mut CustomScanStateWrapper<AggregateScan>,
 ) -> *mut pg_sys::TupleTableSlot {
-    // Pull worker-thread inputs from the outer state before we borrow
-    // df_state mutably. parallel_state and non_partitioning_segments
-    // are required to pin each worker's PgSearchTableProvider to the
-    // right segment slice (the partitioning source) and the leader's
-    // canonical replica (the non-partitioning sources). Without them,
-    // every worker re-scans the full data and the leader-side hash
-    // partitions get the same rows from every worker.
+    // Pull worker-thread inputs from the outer state before we borrow df_state mutably.
+    // parallel_state and non_partitioning_segments are required to pin each worker's
+    // PgSearchTableProvider to the right segment slice (the partitioning source) and the
+    // leader's canonical replica (the non-partitioning sources). Without them, every worker
+    // re-scans the full data and the leader-side hash partitions get the same rows from
+    // every worker.
     let parallel_state = state.custom_state().parallel_state;
     let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
     let partitioning_source_idx = state
@@ -89,13 +71,7 @@ pub(super) fn exec_mpp_worker(
         unreachable!("exec_mpp_worker called outside Worker state");
     };
     let plan_bytes = worker.plan_bytes.clone();
-    // Worker mesh + total proc count for the dispatcher. The mesh's `ShmMqWorkerTransport`
-    // gets wired into the session below. n_workers is rederived from total_procs at the
-    // dispatcher; both forms (proc-side total_workers, n_procs-1) agree by
-    // construction in `worker_setup`.
     let worker_mesh = Arc::clone(&worker.mesh);
-    let this_proc = worker.mesh.this_proc;
-    let total_procs = worker.mesh.n_procs;
     let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
         Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
         _ => unreachable!(),
@@ -110,261 +86,25 @@ pub(super) fn exec_mpp_worker(
     };
     df_state.runtime = Some(runtime);
     let runtime = df_state.runtime.as_ref().unwrap();
-    // Use a bare SessionContext for plan deserialization. The distributed planner config
-    // (worker resolver, transport, estimators, codec) is mirrored from the leader via
-    // `build_mpp_session_context` below — both procs have to agree on stage shape or
-    // `find_worker_assignments` won't line up.
-    let ctx = create_aggregate_session_context();
 
-    // Build per-source canonical segment ID sets. For the partitioning
-    // source, pull the full list out of the populated ParallelScanState
-    // (workers will then claim individual segments via `checkout_segment`
-    // inside their `PgSearchTableProvider`). For non-partitioning sources,
-    // use the segment IDs the leader snapshotted into shared memory.
-    let mut index_segment_ids: Vec<HashSet<tantivy::index::SegmentId>> =
-        vec![HashSet::default(); plan_sources_count];
-    if let Some(ps) = parallel_state {
-        let mut np_counter = 0usize;
-        for (i, slot) in index_segment_ids.iter_mut().enumerate() {
-            if i == partitioning_source_idx {
-                *slot = unsafe { list_segment_ids(ps) };
-            } else if let Some(ids) = non_partitioning_segments.get(np_counter) {
-                *slot = ids.clone();
-                np_counter += 1;
-            }
-        }
-    }
+    // Use a bare aggregate-profile context for plan deserialization. The distributed planner
+    // config (worker resolver, transport, estimators, codec) is layered on top inside
+    // `run_mpp_worker` via `build_mpp_session_context`. Both procs have to agree on stage shape;
+    // this is how.
+    let seed_ctx = create_aggregate_session_context();
 
-    let logical = match deserialize_logical_plan_with_runtime(
-        &plan_bytes,
-        &ctx.task_ctx(),
-        parallel_state,
-        None, // expr_context: bm25 search predicates don't need runtime params
-        None, // planstate: same
-        non_partitioning_segments,
-        index_segment_ids,
-    ) {
-        Ok(lp) => lp,
-        Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
-    };
-
-    // Build the worker's distributed session context. Reuses the same builder the leader
-    // runs so both procs agree on stage shape, task estimator chain, target_partitions,
-    // and codec — without that, `find_worker_assignments` returns no fragments for this
-    // worker because the worker's plan numbers stages differently from the leader's.
-    let session = AggregateScan::build_mpp_session_context(Arc::clone(&worker_mesh));
-
-    let physical_plan =
-        runtime.block_on(async { session.state().create_physical_plan(&logical).await });
-    let physical_plan = match physical_plan {
-        Ok(p) => p,
-        Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
-    };
-    // Walk the plan and collect every `(stage_id, task_idx)` slot owned
-    // by this proc under the `proc_for_task` round-robin policy. The
-    // dispatcher spawns one async task per fragment; together they form
-    // the worker's complete contribution to the distributed plan.
-    let n_workers = total_procs.saturating_sub(1).max(1);
-    let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
-    if fragments.is_empty() {
-        pgrx::warning!(
-            "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
-        );
-        return std::ptr::null_mut();
-    }
-
-    let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
-    let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
-    let session_arc = Arc::new(session);
-
-    // Two `Future` shapes share this vector: real producer-fragment
-    // futures and broadcast short-circuit EOF-only stubs. The alias
-    // keeps the `Vec<_>` declaration legible and silences
-    // clippy::type_complexity.
-    type FragmentFuture = std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
-                + Send,
-        >,
-    >;
-    let result = runtime.block_on(async move {
-        let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
-        for fragment in &fragments {
-            let n_out = fragment.plan.output_partitioning().partition_count();
-            // Build per-output-partition senders. For each partition `q`
-            // emitted by this fragment, look up the destination proc via
-            // `fragment.routing` and clone the right outbound sender.
-            let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
-            for q in 0..n_out {
-                let dest_proc = match &fragment.routing {
-                    FragmentRouting::Coalesce { dest_proc } => *dest_proc,
-                    FragmentRouting::Shuffle {
-                        partitions_per_consumer_task,
-                    }
-                    | FragmentRouting::Broadcast {
-                        partitions_per_consumer_task,
-                    } => {
-                        let t_c = (q / partitions_per_consumer_task) as u32;
-                        proc_for_task(n_workers, t_c)
-                    }
-                };
-                let base = match outbound_senders
-                    .get(dest_proc as usize)
-                    .and_then(|s| s.as_ref())
-                {
-                    Some(s) => s,
-                    None => {
-                        return Err(datafusion::common::DataFusionError::Internal(format!(
-                            "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
-                             (self-loop or unattached); fragment stage_id={} task_idx={}",
-                            fragment.stage_id, fragment.task_idx,
-                        )));
-                    }
-                };
-                let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
-                crate::mpp_log!(
-                    "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
-                     task_idx={}) partition={q} → dest_proc={dest_proc}",
-                    fragment.stage_id,
-                    fragment.task_idx,
-                );
-                // Attach the worker mesh as the cooperative drain so a
-                // full outbound shm_mq queue doesn't block the backend
-                // thread. The spin pulls every inbound drain while
-                // retrying the send, breaking N×N symmetric stalls.
-                per_partition_senders.push(
-                    base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
-                        .with_cooperative_drain(
-                            Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
-                        ),
-                );
-            }
-
-            // Fail-loud guard for the `BroadcastBuildSideOneTaskEstimator` cap: a non-zero
-            // task_idx here means the cap silently failed (estimator missing, chain order wrong,
-            // or a future planner expanded the build subtree). Better to error than to
-            // duplicate or drop data; see the variant doc on `FragmentRouting::Broadcast`.
-            if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
-                debug_assert!(
-                    fragment.task_idx == 0,
-                    "mpp dispatcher: Broadcast fragment with task_idx={} but \
-                     BroadcastBuildSideOneTaskEstimator should have capped \
-                     input_task_count at 1; plan-walk drift?",
-                    fragment.task_idx,
-                );
-                if fragment.task_idx != 0 {
-                    return Err(datafusion::common::DataFusionError::Internal(format!(
-                        "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
-                         (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
-                         BroadcastBuildSideOneTaskEstimator should cap input_task_count at \
-                         1. A non-zero task_idx here indicates plan-walk drift or a missing \
-                         estimator chain on this session; running the producer plan would \
-                         duplicate the canonical replica, EOF-only-ing it would drop a \
-                         real shard if the cap loss was due to a sharded build subtree. \
-                         Surface as error so the divergence is visible.",
-                        fragment.stage_id, fragment.task_idx,
-                    )));
-                }
-            }
-
-            // Build a TaskContext seeded with the right `DistributedTaskContext` so the
-            // boundary nodes inside the fragment's plan know their
-            // `(task_index, task_count)`.
-            let cfg = session_arc
-                .state()
-                .config()
-                .clone()
-                .with_extension(Arc::new(DistributedTaskContext {
-                    task_index: fragment.task_idx,
-                    task_count: fragment.task_count,
-                }));
-            let memory_pool =
-                create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
-            let task_ctx = Arc::new(
-                TaskContext::default()
-                    .with_session_config(cfg)
-                    .with_runtime(Arc::new(
-                        RuntimeEnvBuilder::new()
-                            .with_memory_pool(memory_pool)
-                            .build()
-                            .expect("Failed to create RuntimeEnv"),
-                    )),
-            );
-
-            // Wrap fragment.plan in a fresh `DistributedExec` and run
-            // `prepare_in_process_plan` to convert any nested boundaries' input stages from
-            // `Stage::Local` to `Stage::Remote`. Without this, a nested `NetworkShuffleExec`
-            // / `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task
-            // count exceeds 1; with the conversion, those boundaries dispatch through
-            // `ShmMqWorkerTransport` exactly like outer boundaries.
-            let plan = {
-                let dist = Arc::new(DistributedExec::new(Arc::clone(&fragment.plan)));
-                match dist.prepare_in_process_plan(&task_ctx) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        return Err(datafusion::common::DataFusionError::Internal(format!(
-                            "mpp worker: prepare_in_process_plan failed for fragment \
-                             (stage_id={}, task_idx={}): {e}",
-                            fragment.stage_id, fragment.task_idx
-                        )));
-                    }
-                }
-            };
-            futures.push(Box::pin(run_worker_fragment(
-                plan,
-                per_partition_senders,
-                task_ctx,
-            )));
-        }
-        // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue
-        // / in-proc channel are the per-partition clones owned by the spawned fragments.
-        // Without this, the originals would outlive the futures, the consumer-side drains
-        // would never observe `Detached`, and `stream_partition`'s pull loop would spin
-        // forever.
-        drop(outbound_senders);
-        crate::mpp_log!(
-            "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
-            fragments.len()
-        );
-        // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
-        // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
-        // futures, leaving their `(stage_id, partition)` channel buffers stuck at
-        // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
-        // substrate alone (matching reasoning in `run_worker_fragment`).
-        //
-        // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
-        // within 30 s the dispatcher surfaces an error instead of letting the backend spin
-        // forever. Per-drain state shows up in the inbound drains' own traces in
-        // transport.rs / runtime.rs.
-        let join_fut = futures::future::join_all(futures);
-        let outcome: Result<(), datafusion::common::DataFusionError> = if crate::gucs::mpp_debug() {
-            match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
-                Ok(results) => results
-                    .into_iter()
-                    .collect::<Result<Vec<_>, _>>()
-                    .map(|_| ()),
-                Err(_) => {
-                    crate::mpp_log!(
-                        "mpp worker dispatch this_proc={this_proc} \
-                         HANG: join_all exceeded 30s"
-                    );
-                    Err(datafusion::common::DataFusionError::Internal(format!(
-                        "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
-                         deadlock detector triggered"
-                    )))
-                }
-            }
-        } else {
-            join_fut
-                .await
-                .into_iter()
-                .collect::<Result<Vec<_>, _>>()
-                .map(|_| ())
-        };
-        outcome
-    });
-    if let Err(e) = result {
-        pgrx::error!("mpp worker: fragment dispatch failed: {e}");
-    }
+    run_mpp_worker(
+        MppWorkerInputs {
+            parallel_state,
+            non_partitioning_segments,
+            partitioning_source_idx,
+            plan_sources_count,
+            plan_bytes,
+            worker_mesh,
+            outbound_senders,
+        },
+        seed_ctx,
+        runtime,
+    );
     std::ptr::null_mut()
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -77,24 +77,17 @@ pub struct DataFusionAggState {
     /// leader this carries the runtime mesh + outbound senders for the
     /// leader-as-worker-0 producer subplan; on workers it carries the
     /// outbound senders for this worker plus the deserialized fragment plan.
-    #[allow(dead_code)]
     pub mpp: Option<MppExecState>,
     /// Serialized logical-plan bytes that the leader writes into DSM and
     /// workers read back. Computed by `begin_custom_scan` when MPP is
     /// active; consulted by `estimate_dsm_custom_scan` and
     /// `initialize_dsm_custom_scan`.
-    #[allow(dead_code)]
     pub mpp_plan_bytes: Option<Vec<u8>>,
-    /// MPP cut shape (consumer-partition count K). Computed alongside
-    /// `mpp_plan_bytes`; used to size the DSM mesh.
-    #[allow(dead_code)]
-    pub mpp_n_partitions: u32,
 }
 
 /// Per-query MPP state. Distinct variants for leader vs worker because the
 /// two participate differently: the leader runs the consumer plan plus a
 /// producer subplan (as worker 0); workers run only the producer subplan.
-#[allow(dead_code)]
 pub enum MppExecState {
     Leader(crate::postgres::customscan::mpp::glue::MppLeaderState),
     Worker(crate::postgres::customscan::mpp::glue::MppWorkerState),

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -899,8 +899,7 @@ impl ParallelQueryCapable for JoinScan {
 
         let mpp_coordinate = unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut c_void };
         let seg = unsafe { (*pcxt).seg };
-        let n_partitions = state.custom_state().mpp_n_partitions;
-        match unsafe { leader_setup(mpp_coordinate, seg, pcxt, n_partitions, plan_bytes) } {
+        match unsafe { leader_setup(mpp_coordinate, seg, pcxt, plan_bytes) } {
             Ok(leader) => {
                 state.custom_state_mut().mpp = Some(MppExecState::Leader(leader));
             }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1421,7 +1421,6 @@ impl CustomScan for JoinScan {
             if mpp_is_active() && unsafe { pg_sys::ParallelWorkerNumber } == -1 {
                 if let Some(bytes) = state.custom_state().logical_plan.clone() {
                     state.custom_state_mut().mpp_plan_bytes = Some(bytes.to_vec());
-                    state.custom_state_mut().mpp_n_partitions = producer_worker_count().max(1);
                     let partitioning_idx =
                         state.custom_state().join_clause.partitioning_source_index();
                     state.custom_state_mut().mpp_partitioning_source_idx = Some(partitioning_idx);

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -180,9 +180,11 @@ use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_f
 use crate::postgres::customscan::joinscan::scan_state::MppExecState;
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
-    read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
+    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, mpp_worker_count,
+    producer_worker_count, pscan_offset, read_custom_scan_header, worker_setup,
+    write_custom_scan_header, CustomScanMppHeader,
 };
+use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::parallel::compute_nworkers;
 use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::customscan::{CustomScan, JoinPathlistHookArgs};
@@ -195,9 +197,11 @@ use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
+use datafusion_distributed::{display_plan_ascii, DistributedExec};
 use futures::StreamExt;
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
+use std::sync::Arc;
 
 #[derive(Default)]
 pub struct JoinScan;
@@ -1053,6 +1057,18 @@ impl JoinScan {
     }
 }
 
+impl JoinScan {
+    /// Build the leader's distributed session context for this JoinScan query. Thin wrapper
+    /// over the shared [`crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context`]
+    /// that seeds with `create_datafusion_session_context(SessionContextProfile::Join)`.
+    fn build_mpp_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
+        crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context(
+            create_datafusion_session_context(SessionContextProfile::Join),
+            mesh,
+        )
+    }
+}
+
 impl CustomScan for JoinScan {
     const NAME: &'static CStr = c"ParadeDB Join Scan";
     type Args = JoinPathlistHookArgs;
@@ -1338,11 +1354,18 @@ impl CustomScan for JoinScan {
                 );
                 return;
             }
-            // For plain EXPLAIN, reconstruct the plan using the same session
-            // configuration that execution uses so `VisibilityFilterExec`
-            // appears in the displayed plan, matching EXPLAIN ANALYZE.
+            // For plain EXPLAIN, reconstruct the plan using the same session configuration
+            // that execution uses so `VisibilityFilterExec` appears in the displayed plan,
+            // matching EXPLAIN ANALYZE. When MPP is active, use a drain-less stub mesh so the
+            // distributed planner runs and the displayed plan shows `DistributedExec` + stages.
+            // `ShmMqWorkerTransport::open()` doesn't run during EXPLAIN, so the stub is safe.
             let expr_context = crate::postgres::utils::ExprContextGuard::new();
-            let ctx = create_datafusion_session_context(SessionContextProfile::Join);
+            let ctx = if mpp_is_active() {
+                let stub_mesh = Arc::new(MppMesh::new(0, mpp_worker_count(), Vec::new()));
+                Self::build_mpp_session_context(stub_mesh)
+            } else {
+                create_datafusion_session_context(SessionContextProfile::Join)
+            };
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .build()
                 .expect("Failed to create tokio runtime");
@@ -1359,9 +1382,19 @@ impl CustomScan for JoinScan {
             let physical_plan = runtime
                 .block_on(build_physical_plan(&ctx, logical_plan))
                 .expect("Failed to create execution plan");
-            let displayable = displayable(physical_plan.as_ref());
             explainer.add_text("DataFusion Physical Plan", "");
-            for line in displayable.indent(false).to_string().lines() {
+            let rendered = if physical_plan
+                .as_any()
+                .downcast_ref::<DistributedExec>()
+                .is_some()
+            {
+                display_plan_ascii(physical_plan.as_ref(), false)
+            } else {
+                displayable(physical_plan.as_ref())
+                    .indent(false)
+                    .to_string()
+            };
+            for line in rendered.lines() {
                 explainer.add_text("  ", line);
             }
         }
@@ -1447,7 +1480,29 @@ impl CustomScan for JoinScan {
                 let index_segment_ids =
                     Self::build_index_segment_ids(state, &join_clause, &plan_sources);
 
-                let ctx = create_datafusion_session_context(SessionContextProfile::Join);
+                // Leader session context: when MPP is active and we're the leader, layer the
+                // DF-D fork's distributed-planner knobs over the Join profile so the resulting
+                // physical plan is a `DistributedExec`. Without this, the leader builds a serial
+                // plan and the worker fragments would have nothing to consume from.
+                let ctx = match state.custom_state().mpp.as_ref() {
+                    Some(MppExecState::Leader(leader)) => {
+                        let pcxt = leader.pcxt;
+                        if !pcxt.is_null() {
+                            let launched = (*pcxt).nworkers_launched as u32;
+                            let expected = producer_worker_count();
+                            if launched < expected {
+                                pgrx::error!(
+                                    "mpp join: PG launched {launched} of {expected} requested \
+                                     parallel workers; missing slots would hang the query. Retry, \
+                                     or raise `max_parallel_workers` / \
+                                     `max_parallel_workers_per_gather` so PG can launch the full set."
+                                );
+                            }
+                        }
+                        Self::build_mpp_session_context(Arc::clone(&leader.mesh))
+                    }
+                    _ => create_datafusion_session_context(SessionContextProfile::Join),
+                };
                 let logical_plan = deserialize_logical_plan_with_runtime(
                     &plan_bytes,
                     &ctx.task_ctx(),

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -180,7 +180,8 @@ use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_f
 use crate::postgres::customscan::joinscan::scan_state::MppExecState;
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, mpp_is_active, producer_worker_count, worker_setup,
+    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
+    read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
 };
 use crate::postgres::customscan::parallel::compute_nworkers;
 use crate::postgres::customscan::parameterized_value::ParameterizedValue;
@@ -200,38 +201,6 @@ use std::ffi::{c_void, CStr};
 
 #[derive(Default)]
 pub struct JoinScan;
-
-/// JoinScan-specific MPP DSM header. Sits between the ParallelScanState block and the MPP
-/// region in the customscan's DSM coordinate, telling workers where the MPP region begins and
-/// which source they're partitioning over. Same shape as `aggregatescan`'s
-/// `MppAggDsmHeader`; can be unified in a follow-up.
-#[repr(C)]
-#[derive(Clone, Copy)]
-struct MppJoinDsmHeader {
-    mpp_offset: u64,
-    partitioning_source_idx: u64,
-}
-
-const MPP_JOIN_DSM_HEADER_SIZE: usize = std::mem::size_of::<MppJoinDsmHeader>();
-
-fn mpp_join_align(n: usize) -> usize {
-    let a = pg_sys::MAXIMUM_ALIGNOF as usize;
-    n.next_multiple_of(a)
-}
-
-fn mpp_join_pscan_offset() -> usize {
-    mpp_join_align(MPP_JOIN_DSM_HEADER_SIZE)
-}
-
-unsafe fn mpp_join_read_header(coordinate: *const std::os::raw::c_void) -> MppJoinDsmHeader {
-    unsafe { *(coordinate as *const MppJoinDsmHeader) }
-}
-
-unsafe fn mpp_join_write_header(coordinate: *mut std::os::raw::c_void, header: MppJoinDsmHeader) {
-    unsafe {
-        *(coordinate as *mut MppJoinDsmHeader) = header;
-    }
-}
 
 /// Output of [`JoinScan::try_build_join_custom_path`] when activation succeeds.
 struct BuiltJoinPath {
@@ -815,7 +784,7 @@ impl ParallelQueryCapable for JoinScan {
         else {
             return pscan_size as pg_sys::Size;
         };
-        let mpp_offset = mpp_join_align(mpp_join_pscan_offset() + pscan_size);
+        let mpp_offset = mpp_align(pscan_offset() + pscan_size);
         let mpp_size = match estimate_dsm_size(plan_bytes_len) {
             Ok(sz) => sz,
             Err(e) => {
@@ -838,13 +807,9 @@ impl ParallelQueryCapable for JoinScan {
         let mpp_active = mpp_is_active() && state.custom_state().mpp_plan_bytes.is_some();
 
         // Compute layout: when MPP active, header at offset 0, ParallelScanState at
-        // mpp_join_pscan_offset(), MPP region right after. When MPP inactive, ParallelScanState
+        // pscan_offset(), MPP region right after. When MPP inactive, ParallelScanState
         // sits at offset 0 and we leave the rest of the coordinate untouched.
-        let pscan_offset = if mpp_active {
-            mpp_join_pscan_offset()
-        } else {
-            0
-        };
+        let pscan_offset = if mpp_active { pscan_offset() } else { 0 };
         let pscan_state =
             unsafe { (coordinate as *mut u8).add(pscan_offset) as *mut ParallelScanState };
         assert!(!pscan_state.is_null(), "coordinate is null");
@@ -886,11 +851,11 @@ impl ParallelQueryCapable for JoinScan {
             .map(SearchIndexManifest::segment_count)
             .collect();
         let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
-        let mpp_offset = mpp_join_align(pscan_offset + pscan_size);
+        let mpp_offset = mpp_align(pscan_offset + pscan_size);
         unsafe {
-            mpp_join_write_header(
+            write_custom_scan_header(
                 coordinate,
-                MppJoinDsmHeader {
+                CustomScanMppHeader {
                     mpp_offset: mpp_offset as u64,
                     partitioning_source_idx: partitioning_idx as u64,
                 },
@@ -928,13 +893,9 @@ impl ParallelQueryCapable for JoinScan {
     ) {
         // Worker layout follows the leader: if MPP is active the leader stamped a
         // `MppJoinDsmHeader` at offset 0 and put the ParallelScanState at
-        // `mpp_join_pscan_offset()`. If MPP is off the ParallelScanState sits at offset 0.
+        // `pscan_offset()`. If MPP is off the ParallelScanState sits at offset 0.
         let mpp_active = mpp_is_active();
-        let pscan_offset = if mpp_active {
-            mpp_join_pscan_offset()
-        } else {
-            0
-        };
+        let pscan_offset = if mpp_active { pscan_offset() } else { 0 };
         let pscan_state =
             unsafe { (coordinate as *mut u8).add(pscan_offset) as *mut ParallelScanState };
         assert!(!pscan_state.is_null(), "coordinate is null");
@@ -953,7 +914,7 @@ impl ParallelQueryCapable for JoinScan {
 
         // MPP worker: read the header to find where the MPP region starts + which source we're
         // partitioning over. Hand the MPP region to `worker_setup`.
-        let header = unsafe { mpp_join_read_header(coordinate) };
+        let header = unsafe { read_custom_scan_header(coordinate) };
         let mpp_offset = header.mpp_offset as usize;
         state.custom_state_mut().mpp_partitioning_source_idx =
             Some(header.partitioning_source_idx as usize);

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -139,6 +139,7 @@
 //! - [`explain`]: EXPLAIN output formatting.
 
 pub mod build;
+pub mod mpp;
 pub mod planner;
 pub mod planning;
 pub mod predicate;
@@ -176,12 +177,17 @@ use crate::postgres::customscan::builders::custom_state::{
 use crate::postgres::customscan::dsm::ParallelQueryCapable;
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
+use crate::postgres::customscan::joinscan::scan_state::MppExecState;
 use crate::postgres::customscan::limit_offset::LimitOffset;
+use crate::postgres::customscan::mpp::glue::{
+    estimate_dsm_size, leader_setup, mpp_is_active, producer_worker_count, worker_setup,
+};
 use crate::postgres::customscan::parallel::compute_nworkers;
 use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::customscan::{CustomScan, JoinPathlistHookArgs};
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
+use crate::postgres::ParallelScanArgs;
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::{deserialize_logical_plan_with_runtime, serialize_logical_plan};
 use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
@@ -194,6 +200,38 @@ use std::ffi::{c_void, CStr};
 
 #[derive(Default)]
 pub struct JoinScan;
+
+/// JoinScan-specific MPP DSM header. Sits between the ParallelScanState block and the MPP
+/// region in the customscan's DSM coordinate, telling workers where the MPP region begins and
+/// which source they're partitioning over. Same shape as `aggregatescan`'s
+/// `MppAggDsmHeader`; can be unified in a follow-up.
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct MppJoinDsmHeader {
+    mpp_offset: u64,
+    partitioning_source_idx: u64,
+}
+
+const MPP_JOIN_DSM_HEADER_SIZE: usize = std::mem::size_of::<MppJoinDsmHeader>();
+
+fn mpp_join_align(n: usize) -> usize {
+    let a = pg_sys::MAXIMUM_ALIGNOF as usize;
+    n.next_multiple_of(a)
+}
+
+fn mpp_join_pscan_offset() -> usize {
+    mpp_join_align(MPP_JOIN_DSM_HEADER_SIZE)
+}
+
+unsafe fn mpp_join_read_header(coordinate: *const std::os::raw::c_void) -> MppJoinDsmHeader {
+    unsafe { *(coordinate as *const MppJoinDsmHeader) }
+}
+
+unsafe fn mpp_join_write_header(coordinate: *mut std::os::raw::c_void, header: MppJoinDsmHeader) {
+    unsafe {
+        *(coordinate as *mut MppJoinDsmHeader) = header;
+    }
+}
 
 /// Output of [`JoinScan::try_build_join_custom_path`] when activation succeeds.
 struct BuiltJoinPath {
@@ -651,7 +689,11 @@ impl JoinScan {
             (src.scan_info.segment_count, src.scan_info.estimate)
         };
 
-        let nworkers = if consider_parallel {
+        let nworkers = if mpp_is_active() {
+            // MPP needs exactly `producer_worker_count()` workers to match the n_procs x n_procs
+            // mesh dimensions. Override the heuristic-based parallel-worker count.
+            producer_worker_count() as usize
+        } else if consider_parallel {
             let declares_sorted_output = !join_clause.order_by.is_empty();
             compute_nworkers(
                 declares_sorted_output,
@@ -760,21 +802,52 @@ impl ParallelQueryCapable for JoinScan {
             .map(SearchIndexManifest::segment_count)
             .collect();
 
-        ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false)
+        let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
+
+        // MPP: reserve a JoinScan header + the multiplexed N×N shm_mq grid past the
+        // ParallelScanState block. Layout: [MppJoinDsmHeader | ParallelScanState | MPP region].
+        // Workers read mpp_offset out of the header to skip past the ParallelScanState block.
+        let Some(plan_bytes_len) = state
+            .custom_state()
+            .mpp_plan_bytes
+            .as_ref()
+            .map(|b| b.len())
+        else {
+            return pscan_size as pg_sys::Size;
+        };
+        let mpp_offset = mpp_join_align(mpp_join_pscan_offset() + pscan_size);
+        let mpp_size = match estimate_dsm_size(plan_bytes_len) {
+            Ok(sz) => sz,
+            Err(e) => {
+                pgrx::warning!("mpp join: estimate_dsm failed: {e}; falling back to serial");
+                return pscan_size as pg_sys::Size;
+            }
+        };
+        (mpp_offset + mpp_size) as pg_sys::Size
     }
 
     fn initialize_dsm_custom_scan(
         state: &mut CustomScanStateWrapper<Self>,
-        _pcxt: *mut pg_sys::ParallelContext,
+        pcxt: *mut pg_sys::ParallelContext,
         coordinate: *mut c_void,
     ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
-        assert!(!pscan_state.is_null(), "coordinate is null");
-
         Self::ensure_source_manifests(state);
 
         let join_clause = state.custom_state().join_clause.clone();
         let partitioning_idx = join_clause.partitioning_source_index();
+        let mpp_active = mpp_is_active() && state.custom_state().mpp_plan_bytes.is_some();
+
+        // Compute layout: when MPP active, header at offset 0, ParallelScanState at
+        // mpp_join_pscan_offset(), MPP region right after. When MPP inactive, ParallelScanState
+        // sits at offset 0 and we leave the rest of the coordinate untouched.
+        let pscan_offset = if mpp_active {
+            mpp_join_pscan_offset()
+        } else {
+            0
+        };
+        let pscan_state =
+            unsafe { (coordinate as *mut u8).add(pscan_offset) as *mut ParallelScanState };
+        assert!(!pscan_state.is_null(), "coordinate is null");
 
         unsafe {
             let all_sources: Vec<&[tantivy::SegmentReader]> = state
@@ -783,7 +856,7 @@ impl ParallelQueryCapable for JoinScan {
                 .iter()
                 .map(|manifest| manifest.segment_readers())
                 .collect();
-            let args = crate::postgres::ParallelScanArgs {
+            let args = ParallelScanArgs {
                 all_sources,
                 partitioning_source_idx: partitioning_idx,
                 query: vec![], // JoinScan passes query via PrivateData, not shared state
@@ -793,11 +866,48 @@ impl ParallelQueryCapable for JoinScan {
         }
 
         // Read the canonical non-partitioning segment ID sets from shared memory.
-        // The leader uses these in exec_custom_scan to populate the execution codec.
         let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
-
         state.custom_state_mut().parallel_state = Some(pscan_state);
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
+
+        if !mpp_active {
+            return;
+        }
+
+        // MPP: write the JoinScan DSM header, then call `leader_setup` over the MPP region.
+        let plan_bytes = match state.custom_state_mut().mpp_plan_bytes.take() {
+            Some(b) => b,
+            None => return,
+        };
+        let all_nsegments: Vec<usize> = state
+            .custom_state()
+            .source_manifests
+            .iter()
+            .map(SearchIndexManifest::segment_count)
+            .collect();
+        let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
+        let mpp_offset = mpp_join_align(pscan_offset + pscan_size);
+        unsafe {
+            mpp_join_write_header(
+                coordinate,
+                MppJoinDsmHeader {
+                    mpp_offset: mpp_offset as u64,
+                    partitioning_source_idx: partitioning_idx as u64,
+                },
+            )
+        };
+
+        let mpp_coordinate = unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut c_void };
+        let seg = unsafe { (*pcxt).seg };
+        let n_partitions = state.custom_state().mpp_n_partitions;
+        match unsafe { leader_setup(mpp_coordinate, seg, pcxt, n_partitions, plan_bytes) } {
+            Ok(leader) => {
+                state.custom_state_mut().mpp = Some(MppExecState::Leader(leader));
+            }
+            Err(e) => {
+                pgrx::warning!("mpp join: leader_setup failed: {e}; falling back to serial");
+            }
+        }
     }
 
     fn reinitialize_dsm_custom_scan(
@@ -817,26 +927,58 @@ impl ParallelQueryCapable for JoinScan {
         _toc: *mut pg_sys::shm_toc,
         coordinate: *mut c_void,
     ) {
-        let pscan_state = coordinate.cast::<ParallelScanState>();
+        // Worker layout follows the leader: if MPP is active the leader stamped a
+        // `MppJoinDsmHeader` at offset 0 and put the ParallelScanState at
+        // `mpp_join_pscan_offset()`. If MPP is off the ParallelScanState sits at offset 0.
+        let mpp_active = mpp_is_active();
+        let pscan_offset = if mpp_active {
+            mpp_join_pscan_offset()
+        } else {
+            0
+        };
+        let pscan_state =
+            unsafe { (coordinate as *mut u8).add(pscan_offset) as *mut ParallelScanState };
         assert!(!pscan_state.is_null(), "coordinate is null");
 
         state.custom_state_mut().parallel_state = Some(pscan_state);
 
         // Workers must wait for the leader to finish populating the segment pool.
-        unsafe {
-            (*pscan_state).wait_for_initialization();
-        }
+        unsafe { (*pscan_state).wait_for_initialization() };
 
-        // Read the canonical non-partitioning segment ID sets that the leader wrote to
-        // shared memory.  These are used in exec_custom_scan to ensure every worker opens
-        // each replicated source with MvccSatisfies::ParallelWorker, which pins the
-        // visible segment list to exactly what the leader snapshotted.
         let non_partitioning_segments = unsafe { (*pscan_state).non_partitioning_segment_ids() };
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
 
-        // We don't need to deserialize query from parallel state for JoinScan
-        // because the full plan (including query) is serialized in PrivateData
-        // and available to the worker via the plan.
+        if !mpp_active {
+            return;
+        }
+
+        // MPP worker: read the header to find where the MPP region starts + which source we're
+        // partitioning over. Hand the MPP region to `worker_setup`.
+        let header = unsafe { mpp_join_read_header(coordinate) };
+        let mpp_offset = header.mpp_offset as usize;
+        state.custom_state_mut().mpp_partitioning_source_idx =
+            Some(header.partitioning_source_idx as usize);
+        let mpp_coordinate = unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut c_void };
+        let region_total = unsafe {
+            (*mpp_coordinate.cast::<crate::postgres::customscan::mpp::dsm::MppDsmHeader>())
+                .region_total
+        };
+        let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+        match unsafe {
+            worker_setup(
+                mpp_coordinate,
+                region_total,
+                worker_number,
+                std::ptr::null_mut(),
+            )
+        } {
+            Ok(worker) => {
+                state.custom_state_mut().mpp = Some(MppExecState::Worker(worker));
+            }
+            Err(e) => {
+                pgrx::warning!("mpp join: worker_setup failed: {e}; falling back to serial");
+            }
+        }
     }
 }
 
@@ -1279,6 +1421,19 @@ impl CustomScan for JoinScan {
                 state.custom_state_mut().result_slot = Some(state.csstate.ss.ps.ps_ResultTupleSlot);
                 state.runtime_context = state.csstate.ss.ps.ps_ExprContext;
             }
+            // MPP: stash the leader's serialized logical plan so estimate_dsm / initialize_dsm
+            // can write it into the DSM region. Only the leader runs this branch
+            // (`ParallelWorkerNumber == -1`); workers read the bytes back from DSM in
+            // initialize_worker_custom_scan via `worker_setup`.
+            if mpp_is_active() && unsafe { pg_sys::ParallelWorkerNumber } == -1 {
+                if let Some(bytes) = state.custom_state().logical_plan.clone() {
+                    state.custom_state_mut().mpp_plan_bytes = Some(bytes.to_vec());
+                    state.custom_state_mut().mpp_n_partitions = producer_worker_count().max(1);
+                    let partitioning_idx =
+                        state.custom_state().join_clause.partitioning_source_index();
+                    state.custom_state_mut().mpp_partitioning_source_idx = Some(partitioning_idx);
+                }
+            }
         }
     }
 
@@ -1287,6 +1442,11 @@ impl CustomScan for JoinScan {
     }
 
     fn exec_custom_scan(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
+        // MPP worker dispatch: producer-side fragments emit nothing back to PG. Route to the
+        // MPP exec helper and return null_mut() to signal end-of-stream.
+        if matches!(state.custom_state().mpp, Some(MppExecState::Worker(_))) {
+            return JoinScan::exec_mpp_worker(state);
+        }
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
                 let runtime = tokio::runtime::Builder::new_current_thread()

--- a/pg_search/src/postgres/customscan/joinscan/mpp.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mpp.rs
@@ -1,0 +1,101 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! JoinScan MPP worker exec path.
+//!
+//! Thin wrapper over [`mpp::exec_worker::run_mpp_worker`]: pulls JoinScan-specific inputs out
+//! of the typed state, builds the join-profile seed `SessionContext`, hands the whole thing
+//! to the shape-agnostic dispatcher.
+
+use std::sync::Arc;
+
+use pgrx::pg_sys;
+
+use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
+use crate::postgres::customscan::joinscan::scan_state as join_scan_state;
+use crate::postgres::customscan::joinscan::scan_state::{MppExecState, SessionContextProfile};
+use crate::postgres::customscan::joinscan::JoinScan;
+use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
+use crate::postgres::customscan::mpp::transport::MppSender;
+// `create_datafusion_session_context` lives in joinscan::scan_state and isn't pub from
+// crate root, so import via the joinscan module path.
+use crate::postgres::customscan::joinscan::scan_state::create_datafusion_session_context;
+
+impl JoinScan {
+    /// MPP worker exec: extract inputs from JoinScan's state, build the join-profile seed
+    /// context, hand off to the shape-agnostic dispatcher. Workers emit zero rows back to PG;
+    /// returning `null_mut()` signals end-of-stream.
+    pub(super) fn exec_mpp_worker(
+        state: &mut CustomScanStateWrapper<Self>,
+    ) -> *mut pg_sys::TupleTableSlot {
+        let parallel_state = state.custom_state().parallel_state;
+        let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
+        let partitioning_source_idx = state
+            .custom_state()
+            .mpp_partitioning_source_idx
+            .unwrap_or(0);
+        let plan_sources_count = state
+            .custom_state()
+            .source_manifests
+            .len()
+            .max(non_partitioning_segments.len() + 1);
+
+        // Already drained on a prior call; just signal EOF.
+        if state.custom_state().runtime.is_some() {
+            return std::ptr::null_mut();
+        }
+
+        let join_scan_state::MppExecState::Worker(worker) =
+            state.custom_state().mpp.as_ref().expect("checked")
+        else {
+            unreachable!("exec_mpp_worker called outside Worker state");
+        };
+        let plan_bytes = worker.plan_bytes.clone();
+        let worker_mesh = Arc::clone(&worker.mesh);
+        let outbound_senders: Vec<Option<MppSender>> = match state.custom_state_mut().mpp.as_mut() {
+            Some(MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
+            _ => unreachable!(),
+        };
+
+        let runtime = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(rt) => rt,
+            Err(e) => pgrx::error!("mpp join worker: tokio runtime build failed: {e}"),
+        };
+        state.custom_state_mut().runtime = Some(runtime);
+        let runtime = state.custom_state().runtime.as_ref().unwrap();
+
+        let seed_ctx = create_datafusion_session_context(SessionContextProfile::Join);
+
+        run_mpp_worker(
+            MppWorkerInputs {
+                parallel_state,
+                non_partitioning_segments,
+                partitioning_source_idx,
+                plan_sources_count,
+                plan_bytes,
+                worker_mesh,
+                outbound_senders,
+            },
+            seed_ctx,
+            runtime,
+        );
+        std::ptr::null_mut()
+    }
+}

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -259,8 +259,6 @@ pub struct JoinScanState {
     /// Stashed in `begin_custom_scan` when MPP is active; consumed by `estimate_dsm` /
     /// `initialize_dsm`.
     pub mpp_plan_bytes: Option<Vec<u8>>,
-    /// MPP producer-partition count. Sized by `producer_worker_count()` at plan time.
-    pub mpp_n_partitions: u32,
     /// Which entry in `plan.sources()` is the partitioning source. Stamped into the DSM header
     /// by the leader; read back by workers in `exec_mpp_worker` to key `index_segment_ids`.
     pub mpp_partitioning_source_idx: Option<usize>,

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -267,7 +267,6 @@ pub struct JoinScanState {
 }
 
 /// Per-query MPP state for JoinScan. Same shape as `aggregatescan::scan_state::MppExecState`.
-#[allow(dead_code)]
 pub enum MppExecState {
     Leader(crate::postgres::customscan::mpp::glue::MppLeaderState),
     Worker(crate::postgres::customscan::mpp::glue::MppWorkerState),

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -250,6 +250,27 @@ pub struct JoinScanState {
     /// Dropping manifests early would release the pins and allow segment recycling
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
+
+    /// MPP-specific state. `Some` only when `paradedb.enable_mpp = on` and the query qualifies.
+    /// On the leader this carries the runtime mesh; on workers it carries the worker's outbound
+    /// senders, mesh, and plan bytes copied out of DSM.
+    pub mpp: Option<MppExecState>,
+    /// Serialized logical-plan bytes that the leader writes into DSM and workers read back.
+    /// Stashed in `begin_custom_scan` when MPP is active; consumed by `estimate_dsm` /
+    /// `initialize_dsm`.
+    pub mpp_plan_bytes: Option<Vec<u8>>,
+    /// MPP producer-partition count. Sized by `producer_worker_count()` at plan time.
+    pub mpp_n_partitions: u32,
+    /// Which entry in `plan.sources()` is the partitioning source. Stamped into the DSM header
+    /// by the leader; read back by workers in `exec_mpp_worker` to key `index_segment_ids`.
+    pub mpp_partitioning_source_idx: Option<usize>,
+}
+
+/// Per-query MPP state for JoinScan. Same shape as `aggregatescan::scan_state::MppExecState`.
+#[allow(dead_code)]
+pub enum MppExecState {
+    Leader(crate::postgres::customscan::mpp::glue::MppLeaderState),
+    Worker(crate::postgres::customscan::mpp::glue::MppWorkerState),
 }
 
 impl JoinScanState {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -1,0 +1,399 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Shape-agnostic MPP worker exec dispatcher.
+//!
+//! The natural-shape MPP path is the same flow for every customscan that opts in: deserialize
+//! the leader's logical plan from DSM, build a distributed physical plan with the same session
+//! config the leader ran, walk it to find this proc's fragments, and dispatch them via
+//! [`run_worker_fragment`] + `join_all`. The only customscan-specific pieces are the seed
+//! `SessionContext` (different `SessionContextProfile`) and where the inputs come from in
+//! per-scan state.
+//!
+//! This module isolates the shape-agnostic logic. Per-scan wrappers (`AggregateScan::exec_mpp_worker`,
+//! `JoinScan::exec_mpp_worker`) extract their inputs into [`MppWorkerInputs`], build their seed
+//! `SessionContext`, and call [`run_mpp_worker`].
+
+use std::sync::Arc;
+
+use datafusion::execution::runtime_env::RuntimeEnvBuilder;
+use datafusion::execution::{SessionStateBuilder, TaskContext};
+use datafusion::physical_plan::ExecutionPlanProperties;
+use datafusion::prelude::SessionContext;
+use datafusion_distributed::{
+    DistributedExec, DistributedExt, DistributedTaskContext, SessionStateBuilderExt,
+};
+use pgrx::pg_sys;
+use tantivy::index::SegmentId;
+
+use crate::api::HashSet;
+use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use crate::postgres::customscan::mpp::runtime::{
+    proc_for_task, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
+};
+use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
+use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
+use crate::postgres::customscan::mpp::worker::run_worker_fragment;
+use crate::postgres::customscan::mpp::worker_fragments::{
+    find_worker_assignments, FragmentRouting,
+};
+use crate::postgres::customscan::parallel::list_segment_ids;
+use crate::postgres::ParallelScanState;
+use crate::scan::codec::{deserialize_logical_plan_with_runtime, PgSearchPhysicalCodecStub};
+
+/// Bundle of inputs the worker dispatcher needs. Per-scan `exec_mpp_worker` wrappers populate
+/// this from their typed state and hand it to [`run_mpp_worker`].
+pub(crate) struct MppWorkerInputs {
+    /// The leader's `ParallelScanState`, used to claim the partitioning source's segment slice.
+    pub parallel_state: Option<*mut ParallelScanState>,
+    /// Canonical segment ID sets for non-partitioning sources, snapshotted by the leader.
+    pub non_partitioning_segments: Vec<HashSet<SegmentId>>,
+    /// Index (in the codec's per-source layout) of the source the workers partition over.
+    pub partitioning_source_idx: usize,
+    /// Total number of sources in the plan. Used to size the codec's per-source segment-ID Vec.
+    pub plan_sources_count: usize,
+    /// Leader's serialized logical plan, copied out of DSM during `worker_setup`.
+    pub plan_bytes: Vec<u8>,
+    /// This worker's `MppMesh` handle.
+    pub worker_mesh: Arc<MppMesh>,
+    /// This worker's outbound senders, keyed by destination `proc_idx`. The dispatcher takes
+    /// ownership; consumers see `Detached` once these drop.
+    pub outbound_senders: Vec<Option<MppSender>>,
+}
+
+/// Build the worker/leader distributed session context. Same builder both procs run so they
+/// agree on stage shape, task estimator chain, target_partitions, and codec. Without that,
+/// `find_worker_assignments` returns no fragments because the worker's plan numbers stages
+/// differently from the leader's.
+///
+/// `seed` is the customscan's serial session context (`create_aggregate_session_context()` for
+/// AggregateScan, `create_datafusion_session_context(SessionContextProfile::Join)` for JoinScan).
+/// The function copies its config and layers the distributed-planner knobs on top.
+pub(crate) fn build_mpp_session_context(
+    seed: SessionContext,
+    mesh: Arc<MppMesh>,
+) -> SessionContext {
+    // Workers are procs 1..n_procs; leader is proc 0. The producer count is `n_procs - 1`.
+    let n_workers = mesh.n_procs.saturating_sub(1).max(1) as usize;
+    // Four-knob unlock for actually inserting NetworkShuffleExec/etc.:
+    //   1. target_partitions(N) — without this, EnforceDistribution skips every
+    //      RepartitionExec, so the annotator never sees a Shuffle.
+    //   2. distributed_task_estimator(N) — without this, leaves default to Maximum(1) and
+    //      `_distribute_plan` elides every shuffle.
+    //   3. distributed_broadcast_joins(true) — CollectLeft HashJoins otherwise cap their
+    //      stage's task_count to Maximum(1) and propagate that cap upward, eliding shuffles
+    //      above the join.
+    //   4. distributed_user_codec — the DF-D fork's prepare_plan unconditionally encodes
+    //      worker subplans for gRPC shipment; without a codec for our custom physical execs,
+    //      encoding errors before execution. In our model the encoded bytes are never observed
+    //      (workers re-plan from the logical plan in DSM), so the codec is a stub.
+    let cfg = seed
+        .copied_config()
+        .with_target_partitions(n_workers.max(2));
+
+    let state_builder = SessionStateBuilder::new()
+        .with_default_features()
+        .with_config(cfg)
+        .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers))
+        .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
+        .with_distributed_in_process_mode(true)
+        .expect("with_distributed_in_process_mode")
+        // Estimator chain order matters. The DF-D fork tries each estimator in registration
+        // order until one returns Some. The build-side one-task estimator has to come first.
+        // Otherwise the default `Desired(n_workers)` leaf estimator wins, the all-gather
+        // memory leaf gets task_count = n_workers, `_distribute_plan` builds
+        // `NetworkBroadcastExec` with `input_task_count = n_workers`, and the consumer's
+        // `select_all` over-counts by n_workers. See task_estimator.rs.
+        .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
+        .with_distributed_task_estimator(n_workers)
+        .with_distributed_broadcast_joins(true)
+        .expect("with_distributed_broadcast_joins")
+        .with_distributed_user_codec(PgSearchPhysicalCodecStub)
+        .with_distributed_planner();
+    SessionContext::new_with_state(state_builder.build())
+}
+
+/// Shape-agnostic body of `exec_mpp_worker`. Runs to completion on the caller's tokio runtime,
+/// pgrx::error!s on fatal failures, returns normally on EOF (the customscan's
+/// `exec_custom_scan` then returns `null_mut()` to signal end-of-stream to PG).
+///
+/// `seed_ctx` is a bare serial `SessionContext` used only for plan deserialization
+/// (`ctx.task_ctx()`). The distributed planner config is built separately via
+/// [`build_mpp_session_context`] over the same seed.
+pub(crate) fn run_mpp_worker(
+    inputs: MppWorkerInputs,
+    seed_ctx: SessionContext,
+    runtime: &tokio::runtime::Runtime,
+) {
+    let MppWorkerInputs {
+        parallel_state,
+        non_partitioning_segments,
+        partitioning_source_idx,
+        plan_sources_count,
+        plan_bytes,
+        worker_mesh,
+        outbound_senders,
+    } = inputs;
+
+    let this_proc = worker_mesh.this_proc;
+    let total_procs = worker_mesh.n_procs;
+
+    // Build per-source canonical segment ID sets. For the partitioning source, pull the full
+    // list out of the populated ParallelScanState (workers will then claim individual segments
+    // via `checkout_segment` inside their `PgSearchTableProvider`). For non-partitioning sources,
+    // use the segment IDs the leader snapshotted into shared memory.
+    let mut index_segment_ids: Vec<HashSet<SegmentId>> =
+        vec![HashSet::default(); plan_sources_count];
+    if let Some(ps) = parallel_state {
+        let mut np_counter = 0usize;
+        for (i, slot) in index_segment_ids.iter_mut().enumerate() {
+            if i == partitioning_source_idx {
+                *slot = unsafe { list_segment_ids(ps) };
+            } else if let Some(ids) = non_partitioning_segments.get(np_counter) {
+                *slot = ids.clone();
+                np_counter += 1;
+            }
+        }
+    }
+
+    let logical = match deserialize_logical_plan_with_runtime(
+        &plan_bytes,
+        &seed_ctx.task_ctx(),
+        parallel_state,
+        None, // expr_context: bm25 search predicates don't need runtime params
+        None, // planstate: same
+        non_partitioning_segments,
+        index_segment_ids,
+    ) {
+        Ok(lp) => lp,
+        Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
+    };
+
+    let session = build_mpp_session_context(seed_ctx, Arc::clone(&worker_mesh));
+
+    let physical_plan =
+        runtime.block_on(async { session.state().create_physical_plan(&logical).await });
+    let physical_plan = match physical_plan {
+        Ok(p) => p,
+        Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
+    };
+
+    // Walk the plan and collect every `(stage_id, task_idx)` slot owned by this proc under the
+    // `proc_for_task` round-robin policy. The dispatcher spawns one async task per fragment;
+    // together they form the worker's complete contribution to the distributed plan.
+    let n_workers = total_procs.saturating_sub(1).max(1);
+    let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
+    if fragments.is_empty() {
+        pgrx::warning!(
+            "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
+        );
+        return;
+    }
+
+    let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
+    let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
+    let session_arc = Arc::new(session);
+
+    // Two `Future` shapes share this vector: real producer-fragment futures and broadcast
+    // short-circuit EOF-only stubs. The alias keeps the `Vec<_>` declaration legible and silences
+    // clippy::type_complexity.
+    type FragmentFuture = std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), datafusion::common::DataFusionError>>
+                + Send,
+        >,
+    >;
+    let result = runtime.block_on(async move {
+        let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
+        for fragment in &fragments {
+            let n_out = fragment.plan.output_partitioning().partition_count();
+            // Build per-output-partition senders. For each partition `q` emitted by this
+            // fragment, look up the destination proc via `fragment.routing` and clone the right
+            // outbound sender.
+            let mut per_partition_senders: Vec<MppSender> = Vec::with_capacity(n_out);
+            for q in 0..n_out {
+                let dest_proc = match &fragment.routing {
+                    FragmentRouting::Coalesce { dest_proc } => *dest_proc,
+                    FragmentRouting::Shuffle {
+                        partitions_per_consumer_task,
+                    }
+                    | FragmentRouting::Broadcast {
+                        partitions_per_consumer_task,
+                    } => {
+                        let t_c = (q / partitions_per_consumer_task) as u32;
+                        proc_for_task(n_workers, t_c)
+                    }
+                };
+                let base = match outbound_senders
+                    .get(dest_proc as usize)
+                    .and_then(|s| s.as_ref())
+                {
+                    Some(s) => s,
+                    None => {
+                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                            "mpp worker dispatch: outbound_senders[{dest_proc}] is None \
+                             (self-loop or unattached); fragment stage_id={} task_idx={}",
+                            fragment.stage_id, fragment.task_idx,
+                        )));
+                    }
+                };
+                let q_u32 = u32::try_from(q).unwrap_or(u32::MAX);
+                crate::mpp_log!(
+                    "mpp worker dispatch this_proc={this_proc} fragment(stage_id={}, \
+                     task_idx={}) partition={q} → dest_proc={dest_proc}",
+                    fragment.stage_id,
+                    fragment.task_idx,
+                );
+                // Attach the worker mesh as the cooperative drain so a full outbound shm_mq
+                // queue doesn't block the backend thread. The spin pulls every inbound drain
+                // while retrying the send, breaking N×N symmetric stalls.
+                per_partition_senders.push(
+                    base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
+                        .with_cooperative_drain(
+                            Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
+                        ),
+                );
+            }
+
+            // Broadcast invariant: fail-loud cap check.
+            //
+            // The natural-shape plan canonical-replicates the build subtree via the `mpp build
+            // all-gather` step. Every producer task would scan the full canonical data, and the
+            // consumer's `select_all` would over-count by `input_task_count`. The planner-level
+            // `BroadcastBuildSideOneTaskEstimator` caps the build subtree at task_count=1, so a
+            // correct plan produces exactly one Broadcast fragment with task_idx == 0.
+            //
+            // A non-zero `task_idx` here means the cap silently failed: maybe the estimator
+            // wasn't installed, the chain order is wrong, or a future planner pass re-expanded
+            // the build subtree. We surface this as a hard error rather than silently
+            // EOF-only-ing the fragment.
+            if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
+                debug_assert!(
+                    fragment.task_idx == 0,
+                    "mpp dispatcher: Broadcast fragment with task_idx={} but \
+                     BroadcastBuildSideOneTaskEstimator should have capped \
+                     input_task_count at 1; plan-walk drift?",
+                    fragment.task_idx,
+                );
+                if fragment.task_idx != 0 {
+                    return Err(datafusion::common::DataFusionError::Internal(format!(
+                        "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
+                         (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
+                         BroadcastBuildSideOneTaskEstimator should cap input_task_count at 1. \
+                         A non-zero task_idx here indicates plan-walk drift or a missing \
+                         estimator chain on this session.",
+                        fragment.stage_id, fragment.task_idx,
+                    )));
+                }
+            }
+
+            // Build a TaskContext seeded with the right `DistributedTaskContext` so the boundary
+            // nodes inside the fragment's plan know their `(task_index, task_count)`.
+            let cfg = session_arc
+                .state()
+                .config()
+                .clone()
+                .with_extension(Arc::new(DistributedTaskContext {
+                    task_index: fragment.task_idx,
+                    task_count: fragment.task_count,
+                }));
+            let memory_pool =
+                create_memory_pool(&fragment.plan, work_mem_bytes, hash_mem_multiplier);
+            let task_ctx = Arc::new(
+                TaskContext::default()
+                    .with_session_config(cfg)
+                    .with_runtime(Arc::new(
+                        RuntimeEnvBuilder::new()
+                            .with_memory_pool(memory_pool)
+                            .build()
+                            .expect("Failed to create RuntimeEnv"),
+                    )),
+            );
+
+            // Wrap fragment.plan in a fresh `DistributedExec` and run `prepare_in_process_plan`
+            // to convert any nested boundaries' input stages from `Stage::Local` to
+            // `Stage::Remote`. Without this, a nested `NetworkShuffleExec` /
+            // `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task count
+            // exceeds 1; with the conversion, those boundaries dispatch through
+            // `ShmMqWorkerTransport` exactly like outer boundaries.
+            let plan = {
+                let dist = Arc::new(DistributedExec::new(Arc::clone(&fragment.plan)));
+                match dist.prepare_in_process_plan(&task_ctx) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        return Err(datafusion::common::DataFusionError::Internal(format!(
+                            "mpp worker: prepare_in_process_plan failed for fragment \
+                             (stage_id={}, task_idx={}): {e}",
+                            fragment.stage_id, fragment.task_idx
+                        )));
+                    }
+                }
+            };
+            futures.push(Box::pin(run_worker_fragment(
+                plan,
+                per_partition_senders,
+                task_ctx,
+            )));
+        }
+        // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue /
+        // in-proc channel are the per-partition clones owned by the spawned fragments. Without
+        // this, the originals would outlive the futures, the consumer-side drains would never
+        // observe `Detached`, and `stream_partition`'s pull loop would spin forever.
+        drop(outbound_senders);
+        crate::mpp_log!(
+            "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",
+            fragments.len()
+        );
+        // `join_all`, not `try_join_all`. Fail-fast cancellation would drop sibling fragments
+        // mid-`await`, and a cancelled `run_worker_fragment` cancels its inner partition
+        // futures, leaving their `(stage_id, partition)` sub-buffers stuck at
+        // `sources_done == 0` on the consumer side. Per-channel EOF is load-bearing on the
+        // substrate alone (matching reasoning in `run_worker_fragment`).
+        //
+        // Deadlock detector. Under `paradedb.mpp_debug`, if any fragment hasn't completed
+        // within 30 s the dispatcher surfaces an error instead of letting the backend spin
+        // forever.
+        let join_fut = futures::future::join_all(futures);
+        let outcome: Result<(), datafusion::common::DataFusionError> = if crate::gucs::mpp_debug() {
+            match tokio::time::timeout(std::time::Duration::from_secs(30), join_fut).await {
+                Ok(results) => results
+                    .into_iter()
+                    .collect::<Result<Vec<_>, _>>()
+                    .map(|_| ()),
+                Err(_) => {
+                    crate::mpp_log!(
+                        "mpp worker dispatch this_proc={this_proc} HANG: join_all exceeded 30s"
+                    );
+                    Err(datafusion::common::DataFusionError::Internal(format!(
+                        "mpp worker dispatch (proc={this_proc}): join_all exceeded 30s; \
+                         deadlock detector triggered"
+                    )))
+                }
+            }
+        } else {
+            join_fut
+                .await
+                .into_iter()
+                .collect::<Result<Vec<_>, _>>()
+                .map(|_| ())
+        };
+        outcome
+    });
+    if let Err(e) = result {
+        pgrx::error!("mpp worker: fragment dispatch failed: {e}");
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -105,8 +105,13 @@ pub(crate) fn build_mpp_session_context(
         .copied_config()
         .with_target_partitions(n_workers.max(2));
 
-    let state_builder = SessionStateBuilder::new()
-        .with_default_features()
+    // Start from the seed's existing state so the customscan's query planner (`PgSearchQueryPlanner`),
+    // optimizer rules, and registered extensions all carry over. JoinScan relies on this for
+    // `VisibilityFilterNode` -> `VisibilityFilterExec` translation; AggregateScan's plan happens
+    // not to use any custom logical nodes but inheriting the planner is still the correct
+    // default. We then override `with_config` (bumps `target_partitions`) and layer the
+    // distributed-planner knobs on top.
+    let state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
         .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers))
         .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -180,7 +180,6 @@ pub unsafe fn leader_setup(
     coordinate: *mut c_void,
     seg: *mut pg_sys::dsm_segment,
     pcxt: *mut pg_sys::ParallelContext,
-    n_partitions: u32,
     plan_bytes: Vec<u8>,
 ) -> Result<MppLeaderState, String> {
     let total_procs = n_procs();
@@ -188,7 +187,6 @@ pub unsafe fn leader_setup(
         .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
 
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
-    let _ = n_partitions;
 
     // Each `DrainHandle` owns a per-`(stage_id, partition)` channel buffer registry, so one shm_mq
     // queue can carry frames from many logical channels. Channel buffers are created lazily on first

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -78,6 +78,68 @@ pub fn mpp_worker_count() -> u32 {
     gucs_mpp_worker_count().max(3) as u32
 }
 
+/// Customscan-side header at offset 0 of the DSM coordinate that the leader hands to
+/// `leader_setup` / workers see in `initialize_worker_custom_scan`. Tells workers where the
+/// MPP region begins (past the customscan's `ParallelScanState` block) and which entry in
+/// `plan.sources()` is the partitioning source.
+///
+/// DSM layout used by every customscan opting into MPP:
+///
+/// ```text
+/// [0 .. 8)                       u64 mpp_offset            (offset to MPP region)
+/// [8 .. 16)                      u64 partitioning_source_idx
+/// [pscan_offset .. mpp_offset)   ParallelScanState (variable size)
+/// [mpp_offset .. total)          MPP region (MppDsmHeader + queues + plan_bytes)
+/// ```
+///
+/// Workers don't carry the source manifests the leader saw, so these two `u64`s let them skip
+/// past the `ParallelScanState` block and key `index_segment_ids` the same way as the leader.
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct CustomScanMppHeader {
+    pub mpp_offset: u64,
+    pub partitioning_source_idx: u64,
+}
+
+const CUSTOM_SCAN_MPP_HEADER_SIZE: usize = std::mem::size_of::<CustomScanMppHeader>();
+
+/// Round `n` up to the nearest `MAXIMUM_ALIGNOF` boundary. Used to align section boundaries
+/// inside the customscan's DSM coordinate so the `ParallelScanState` block and the MPP region
+/// each start on aligned bytes.
+pub fn mpp_align(n: usize) -> usize {
+    let a = pg_sys::MAXIMUM_ALIGNOF as usize;
+    n.next_multiple_of(a)
+}
+
+/// Byte offset of the `ParallelScanState` block within the customscan's DSM coordinate. Lives
+/// right after the [`CustomScanMppHeader`], MAXALIGN-padded.
+pub fn pscan_offset() -> usize {
+    mpp_align(CUSTOM_SCAN_MPP_HEADER_SIZE)
+}
+
+/// Read the [`CustomScanMppHeader`] stamped by the leader at offset 0 of the DSM coordinate.
+///
+/// # Safety
+/// `coordinate` must point at a DSM coordinate that the leader populated via
+/// [`write_custom_scan_header`]. Callers in `initialize_worker_custom_scan` get this pointer
+/// from PG and are responsible for confirming it's the expected layout.
+pub unsafe fn read_custom_scan_header(coordinate: *const c_void) -> CustomScanMppHeader {
+    unsafe { *(coordinate as *const CustomScanMppHeader) }
+}
+
+/// Stamp the [`CustomScanMppHeader`] at offset 0 of the DSM coordinate so workers can read
+/// `mpp_offset` and `partitioning_source_idx` without re-deriving them from manifests.
+///
+/// # Safety
+/// `coordinate` must point at the leader's DSM coordinate from `initialize_dsm_custom_scan`,
+/// with at least `size_of::<CustomScanMppHeader>()` bytes writable. The customscan's
+/// `estimate_dsm_custom_scan` is responsible for reserving the space.
+pub unsafe fn write_custom_scan_header(coordinate: *mut c_void, header: CustomScanMppHeader) {
+    unsafe {
+        *(coordinate as *mut CustomScanMppHeader) = header;
+    }
+}
+
 /// Per-edge queue size from the GUC.
 pub(super) fn mpp_queue_size() -> usize {
     gucs_mpp_queue_size()

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -63,11 +63,11 @@ const NATURAL_GATHER_PARTITION: u32 = 0;
 /// path-builders gate `parallel_workers` on this.
 ///
 /// `>= 3` (not `>= 2`) because the leader is consumer-only: with `mpp_worker_count = 2`,
-/// [`producer_worker_count`] returns 1, so [`crate::postgres::customscan::aggregatescan`] sizes
-/// the DSM mesh as `1 × mpp_n_partitions = 1` while `with_target_partitions(2)` (clamped by
-/// `n_workers.max(2)`) makes the planner build a 2-partition shuffle. The mesh wouldn't have a
-/// queue for the second partition. Gating at `>= 3` keeps `producer_worker_count >= 2` so mesh
-/// shape and shuffle width line up.
+/// [`producer_worker_count`] returns 1 and the DSM mesh has one producer row, while
+/// `with_target_partitions(2)` (clamped by `n_workers.max(2)` in `build_mpp_session_context`)
+/// makes the planner build a 2-partition shuffle. The mesh wouldn't have a queue for the
+/// second partition. Gating at `>= 3` keeps `producer_worker_count >= 2` so mesh shape and
+/// shuffle width line up.
 pub fn mpp_is_active() -> bool {
     enable_mpp() && gucs_mpp_worker_count() >= 3
 }

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -26,6 +26,7 @@
 //! consumer-side backpressure from producer-side backpressure.
 
 pub mod dsm;
+pub mod exec_worker;
 pub mod glue;
 pub mod mesh;
 pub mod runtime;

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -123,8 +123,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                            QUERY PLAN                                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Gather Merge
@@ -137,17 +137,27 @@ LIMIT 10;
                Limit: 10
                Order By: f.title asc, p.size_bytes asc
                DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
-                 :   TantivyLookupExec: decode=[title]
-                 :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
-                 :       VisibilityFilterExec: tables=[p, f]
-                 :         ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
-                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
-                 :             CooperativeExec
-                 :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-                 :             CooperativeExec
-                 :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(22 rows)
+                 : ┌───── DistributedExec ── Tasks: t0:[p0]
+                 : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
+                 : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                 : └──────────────────────────────────────────────────
+                 :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+                 :   │ TantivyLookupExec: decode=[title]
+                 :   │   SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+                 :   │     VisibilityFilterExec: tables=[p, f]
+                 :   │       ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
+                 :   │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
+                 :   │           CoalescePartitionsExec
+                 :   │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                 :   │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :   │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :   └──────────────────────────────────────────────────
+                 :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                 :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                 :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :     └──────────────────────────────────────────────────
+(32 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -1,0 +1,175 @@
+-- =====================================================================
+-- End-to-end MPP exercise on JoinScan.
+--
+-- Same dataset shape as mpp_aggregate.sql but the queries don't
+-- aggregate — they project columns through a JOIN under a LIMIT,
+-- which is what JoinScan activates on. Two passes: serial baseline
+-- (enable_mpp = off) and MPP path (enable_mpp = on). Results must
+-- match across the two passes; the EXPLAIN trees differ.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+-- Force parallel even on this tiny dataset; otherwise the cost-based
+-- planner picks the serial JoinScan and MPP never activates.
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+-- =====================================================================
+-- Test data (mirrors mpp_aggregate.sql)
+-- =====================================================================
+CREATE TABLE mpp_join_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_join_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+INSERT INTO mpp_join_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+CREATE INDEX mpp_join_files_idx ON mpp_join_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+CREATE INDEX mpp_join_pages_idx ON mpp_join_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+ANALYZE mpp_join_files;
+ANALYZE mpp_join_pages;
+-- =====================================================================
+-- Pass 1: serial baseline (enable_mpp = off)
+--
+-- The non-MPP JoinScan path produces the correctness baseline for
+-- pass 2.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.title, p.size_bytes
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: f.title, p.size_bytes
+         Relation Tree: p INNER f
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: f.title asc, p.size_bytes asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   TantivyLookupExec: decode=[title]
+           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+           :       VisibilityFilterExec: tables=[p, f]
+           :         ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
+           :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(19 rows)
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+  title  | size_bytes 
+---------+------------
+ file-1  |        616
+ file-1  |       1312
+ file-1  |       2008
+ file-1  |       2704
+ file-1  |       3400
+ file-10 |        153
+ file-10 |       1465
+ file-10 |       2161
+ file-10 |       2857
+ file-10 |       3553
+(10 rows)
+
+-- =====================================================================
+-- Pass 2: MPP path (enable_mpp = on). Same query, same results.
+-- EXPLAIN tree should switch to a `Gather -> Parallel Custom Scan`
+-- shape, exercising the JoinScan MPP wiring (DSM init, shm_mq mesh,
+-- fragment dispatch, leader-side NetworkCoalesceExec gather).
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+                                                                                            QUERY PLAN                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.title, p.size_bytes
+   ->  Gather Merge
+         Output: f.title, p.size_bytes
+         Workers Planned: 3
+         ->  Parallel Custom Scan (ParadeDB Join Scan)
+               Output: f.title, p.size_bytes
+               Relation Tree: p INNER f
+               Join Cond: f.id = p.file_id
+               Limit: 10
+               Order By: f.title asc, p.size_bytes asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   TantivyLookupExec: decode=[title]
+                 :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+                 :       VisibilityFilterExec: tables=[p, f]
+                 :         ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
+                 :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
+                 :             CooperativeExec
+                 :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :             CooperativeExec
+                 :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(22 rows)
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+  title  | size_bytes 
+---------+------------
+ file-1  |        616
+ file-1  |       1312
+ file-1  |       2008
+ file-1  |       2704
+ file-1  |       3400
+ file-10 |        153
+ file-10 |       1465
+ file-10 |       2161
+ file-10 |       2857
+ file-10 |       3553
+(10 rows)
+
+-- =====================================================================
+-- Cleanup
+-- =====================================================================
+DROP TABLE mpp_join_pages;
+DROP TABLE mpp_join_files;

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -1,0 +1,118 @@
+-- =====================================================================
+-- End-to-end MPP exercise on JoinScan.
+--
+-- Same dataset shape as mpp_aggregate.sql but the queries don't
+-- aggregate — they project columns through a JOIN under a LIMIT,
+-- which is what JoinScan activates on. Two passes: serial baseline
+-- (enable_mpp = off) and MPP path (enable_mpp = on). Results must
+-- match across the two passes; the EXPLAIN trees differ.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+-- Force parallel even on this tiny dataset; otherwise the cost-based
+-- planner picks the serial JoinScan and MPP never activates.
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+-- =====================================================================
+-- Test data (mirrors mpp_aggregate.sql)
+-- =====================================================================
+
+CREATE TABLE mpp_join_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_join_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+
+INSERT INTO mpp_join_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+
+CREATE INDEX mpp_join_files_idx ON mpp_join_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+
+CREATE INDEX mpp_join_pages_idx ON mpp_join_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+
+ANALYZE mpp_join_files;
+ANALYZE mpp_join_pages;
+
+-- =====================================================================
+-- Pass 1: serial baseline (enable_mpp = off)
+--
+-- The non-MPP JoinScan path produces the correctness baseline for
+-- pass 2.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+-- =====================================================================
+-- Pass 2: MPP path (enable_mpp = on). Same query, same results.
+-- EXPLAIN tree should switch to a `Gather -> Parallel Custom Scan`
+-- shape, exercising the JoinScan MPP wiring (DSM init, shm_mq mesh,
+-- fragment dispatch, leader-side NetworkCoalesceExec gather).
+-- =====================================================================
+
+SET paradedb.enable_mpp TO on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+-- =====================================================================
+-- Cleanup
+-- =====================================================================
+
+DROP TABLE mpp_join_pages;
+DROP TABLE mpp_join_files;


### PR DESCRIPTION
# Ticket(s) Closed

- N/A

## What

Wires JoinScan through the natural-shape MPP path AggregateScan already uses, behind the same `paradedb.enable_mpp` gate. Plain joins under MPP-on used to silently fall back to the serial path. Now they go through the same shm_mq mesh, the same fragment dispatcher, the same gather to the leader.

Stacked on top of #5082.

## Why

The `mpp/` substrate was always shape-agnostic. Transport, the DSM grid, the frame header, the cooperative drain, the fragment walker — none of them care whether the customscan above is an aggregate or a join. The only thing tying the worker dispatcher to AggregateScan was the seed `SessionContext` profile (`Aggregate` vs `Join`) and where it pulled inputs from in typed state. So the wiring was free as long as we extracted the dispatcher out into a shape-generic helper first.

## How

Pulled the dispatcher into `mpp::exec_worker`. Both customscans now bundle their typed inputs into `MppWorkerInputs`, hand a profile-specific seed context to the shared `run_mpp_worker`, and let it drive. AggregateScan's wrapper got slimmer in the process; JoinScan got its wrapper for free with the same shape.

JoinScan picks up the standard wiring around it: the `producer_worker_count()` override on `nworkers` when MPP is active, the DSM hook branches that call `leader_setup` / `worker_setup`, the `exec_custom_scan` dispatch.

Two pieces of duplication that the JoinScan wiring would have made worse got unified instead. The 16-byte header at offset 0 of the customscan's DSM coordinate (`mpp_offset` + `partitioning_source_idx`) now lives once in `mpp::glue` as `CustomScanMppHeader`, with the matching `mpp_align` / `pscan_offset` / read+write helpers. And the long-dropped `n_partitions` parameter on `leader_setup` that the refactor branch had carried forward is gone here too.

The regression test surfaced a real bug. JoinScan's logical plan carries `VisibilityFilterNode`, a pg_search custom logical extension that needs `PgSearchQueryPlanner` to translate into the matching physical exec. The shared session-context builder was rebuilding from `SessionStateBuilder::new()` and only carrying the seed's `config`, which dropped the query planner. AggregateScan happens not to use any custom logical nodes, so the bug stayed invisible on the aggregate path. One-line fix: `SessionStateBuilder::new_from_existing(seed.state())` so the seed's planners flow through, then override config and layer the distributed knobs on top.

## Reviewer's guide

Each link points at the post-state on this branch.

1. **Generic dispatcher** — [`mpp/exec_worker.rs`](https://github.com/paradedb/paradedb/blob/moe/mpp-joinscan-natural-shape/pg_search/src/postgres/customscan/mpp/exec_worker.rs). `MppWorkerInputs`, `build_mpp_session_context`, `run_mpp_worker`. The `new_from_existing` fix is at the top of `build_mpp_session_context`.
2. **Shared DSM coord helpers** — [`mpp/glue.rs`](https://github.com/paradedb/paradedb/blob/moe/mpp-joinscan-natural-shape/pg_search/src/postgres/customscan/mpp/glue.rs). `CustomScanMppHeader` + its align/offset/read/write helpers.
3. **AggregateScan wrapper** — [`aggregatescan/mpp.rs`](https://github.com/paradedb/paradedb/blob/moe/mpp-joinscan-natural-shape/pg_search/src/postgres/customscan/aggregatescan/mpp.rs).
4. **JoinScan state + planner gate + DSM hooks** — [`joinscan/scan_state.rs`](https://github.com/paradedb/paradedb/blob/moe/mpp-joinscan-natural-shape/pg_search/src/postgres/customscan/joinscan/scan_state.rs) for the new MPP fields, [`joinscan/mod.rs`](https://github.com/paradedb/paradedb/blob/moe/mpp-joinscan-natural-shape/pg_search/src/postgres/customscan/joinscan/mod.rs) for the `nworkers` override and the MPP branches.
5. **JoinScan exec wrapper** — [`joinscan/mpp.rs`](https://github.com/paradedb/paradedb/blob/moe/mpp-joinscan-natural-shape/pg_search/src/postgres/customscan/joinscan/mpp.rs).
6. **Regression test** — [`pg_search/tests/pg_regress/sql/mpp_joinscan.sql`](https://github.com/paradedb/paradedb/blob/moe/mpp-joinscan-natural-shape/pg_search/tests/pg_regress/sql/mpp_joinscan.sql). Same query twice, MPP off vs on.

## Tests

- `cargo check --tests --features pg18` clean.
- `cargo clippy --tests --features pg18 -- -D warnings` clean.
- `cargo test --package pg_search --lib --features pg18 postgres::customscan::mpp` passes.
- `cargo pgrx regress --package pg_search --resetdb --auto pg18 <test>` passes for `mpp_aggregate`, `mpp_aggregate_postagg`, `mpp_smoke`, and the new `mpp_joinscan`.