### PR TITLE
ci: disable logical-replication-merge stressgres benchmark

### DIFF
--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -274,16 +274,17 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
 
-      - name: Benchmark logical-replication-merge.toml
-        uses: ./.github/actions/benchmark-stressgres
-        with:
-          test_file: logical-replication-merge.toml
-          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-          pr_label: ${{ steps.pr_label.outputs.result }}
+      # Disabled pending https://github.com/paradedb/paradedb/issues/5076
+      # - name: Benchmark logical-replication-merge.toml
+      #   uses: ./.github/actions/benchmark-stressgres
+      #   with:
+      #     test_file: logical-replication-merge.toml
+      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+      #     pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Notify Slack on Failure (push only)
         if: failure() && github.event_name == 'push'


### PR DESCRIPTION
## Summary
- Comments out the `logical-replication-merge.toml` stressgres step in `benchmark-pg_search-stressgres.yml` pending investigation of #5076.

## Test plan
- [x] CI passes without running the disabled step