### PR TITLE
docs: note macOS ICU workaround for cargo pgrx init

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -34,7 +34,8 @@ Then install `cargo-pgrx` and let it bootstrap a managed PostgreSQL installation
 
 ```bash
 cargo install --locked cargo-pgrx --version 0.18.0
-# On macOS, if `cargo pgrx init` fails with ICU-related errors, run:
+# On macOS, if `cargo pgrx init` fails with ICU-related errors, run (the
+# icu4c version may differ depending on what Homebrew has installed):
 # export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c@78/lib/pkgconfig:$PKG_CONFIG_PATH"
 cargo pgrx init
 ```

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -34,6 +34,8 @@ Then install `cargo-pgrx` and let it bootstrap a managed PostgreSQL installation
 
 ```bash
 cargo install --locked cargo-pgrx --version 0.18.0
+# On macOS, if `cargo pgrx init` fails with ICU-related errors, run:
+# export PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c@78/lib/pkgconfig:$PKG_CONFIG_PATH"
 cargo pgrx init
 ```
 


### PR DESCRIPTION
## Summary
- Adds a comment in the `cargo pgrx init` block of the `pg_search` README pointing macOS users at the `PKG_CONFIG_PATH` override for `icu4c@78` when `cargo pgrx init` fails with ICU-related errors.

## Test plan
- [x] README renders correctly with the new comment inside the bash block.