### PR TITLE
docs: note PRs that balloon in scope will not be reviewed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,8 @@ All changes to ParadeDB happen through GitHub Pull Requests. Here is the recomme
 4. Install [prek](https://github.com/j178/prek) hooks within your fork with `prek install` to ensure code quality and consistency with upstream.
 5. Make your changes. If you've added new functionality, please add tests. We will not merge a feature without appropriate tests.
 6. Open a pull request towards the `main` branch. Ensure that all tests and checks pass. Note that the ParadeDB repository has pull request title linting in place and follows the [Conventional Commits spec](https://github.com/amannn/action-semantic-pull-request).
-7. Congratulations! Our team will review your pull request.
+7. Keep your pull request focused on the scope of its associated issue. Pull requests that balloon in scope (e.g. bundling unrelated refactors, tangential cleanups, or additional features into a single change) will not be reviewed or merged. If you discover related work that should be done, please open a separate issue and pull request for it.
+8. Congratulations! Our team will review your pull request.
 
 ### Documentation
 


### PR DESCRIPTION
## Summary
- Add a note to `CONTRIBUTING.md` clarifying that pull requests which balloon in scope (bundling unrelated refactors, tangential cleanups, or extra features) will not be reviewed or merged, and asking contributors to open a separate issue/PR for related work.

## Test plan
- [x] Documentation-only change; no functional impact.