### PR TITLE
ci: remove antithesis trigger label immediately on internal PRs

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -45,6 +45,25 @@ env:
   PG_VERSION: "18"
 
 jobs:
+  # Remove the triggering label as soon as the workflow starts, so it can be
+  # re-applied to re-run. Runs in its own job (rather than as a step in the long
+  # build job) so internal PRs see the label removed within seconds instead of
+  # after the ~40-minute .deb build.
+  remove-trigger-label:
+    name: Remove Trigger Label
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Remove Label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "${{ github.event.label.name }}"
+
   # Resolve which workload(s) to run based on the trigger:
   # - schedule: all
   # - workflow_dispatch: from `inputs.workload` (default all)
@@ -249,19 +268,6 @@ jobs:
         workload: ${{ fromJSON(needs.setup.outputs.workloads) }}
 
     steps:
-      # The job can be triggered manually by attaching the `antithesis`,
-      # `antithesis-stressgres`, or `antithesis-proptests` label to a PR. This
-      # step removes the triggering label once the job has started so it can be
-      # applied again if needed.
-      - name: Maybe Remove Label
-        if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --remove-label "${{ github.event.label.name }}" || true
-
       - name: Checkout Git Repository
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -45,30 +45,16 @@ env:
   PG_VERSION: "18"
 
 jobs:
-  # Remove the triggering label as soon as the workflow starts, so it can be
-  # re-applied to re-run. Runs in its own job (rather than as a step in the long
-  # build job) so internal PRs see the label removed within seconds instead of
-  # after the ~40-minute .deb build.
-  remove-trigger-label:
-    name: Remove Trigger Label
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name)
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Remove Label
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr edit ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --remove-label "${{ github.event.label.name }}"
-
   # Resolve which workload(s) to run based on the trigger:
   # - schedule: all
   # - workflow_dispatch: from `inputs.workload` (default all)
   # - pull_request labeled: `antithesis` => all, `antithesis-stressgres` => stressgres,
   #   `antithesis-proptests` => proptests, anything else => skip
+  #
+  # For pull_request triggers, also removes the triggering label up front so it
+  # can be re-applied to re-run. Doing it here (rather than as a step in the
+  # long build job) makes internal PRs see the label removed within seconds
+  # instead of after the ~40-minute .deb build.
   setup:
     name: Resolve Workloads
     runs-on: ubuntu-latest
@@ -76,9 +62,20 @@ jobs:
       (github.event_name == 'schedule' && github.repository == 'paradedb/paradedb-enterprise')
       || github.event_name == 'workflow_dispatch'
       || (github.event_name == 'pull_request' && contains(fromJSON('["antithesis","antithesis-stressgres","antithesis-proptests"]'), github.event.label.name))
+    permissions:
+      pull-requests: write
     outputs:
       workloads: ${{ steps.compute.outputs.workloads }}
     steps:
+      - name: Remove Trigger Label
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --remove-label "${{ github.event.label.name }}"
+
       - id: compute
         env:
           EVENT: ${{ github.event_name }}

--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -52,9 +52,7 @@ jobs:
   #   `antithesis-proptests` => proptests, anything else => skip
   #
   # For pull_request triggers, also removes the triggering label up front so it
-  # can be re-applied to re-run. Doing it here (rather than as a step in the
-  # long build job) makes internal PRs see the label removed within seconds
-  # instead of after the ~40-minute .deb build.
+  # can be re-applied to re-run.
   setup:
     name: Resolve Workloads
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Extract `Maybe Remove Label` from the `antithesis-trigger-test-run` job into a new top-level `remove-trigger-label` job that runs as soon as the `labeled` event fires (no `needs:`).
- Drop the `|| true` so failed label removals fail the job instead of being silently swallowed.
- Add explicit `permissions: pull-requests: write` on the new job (workflow had no permissions block).

## Why
Today the label-removal step sits inside `antithesis-trigger-test-run`, which `needs: build-antithesis-pg_search-deb`. The build takes ~40 minutes, so on internal-branch PRs the trigger label stays visible long after the run has started. If the build fails, the trigger job never runs and the label is stuck for good.

For fork-originated PRs, the default `GITHUB_TOKEN` is read-only regardless of `permissions:`, so label removal still fails there — but that failure is now visible instead of swallowed.

## Test plan
- [x] Apply `antithesis-stressgres` to an internal-branch PR and confirm the label disappears within ~30s (independent of the build job).
- [x] Confirm `antithesis-trigger-test-run` still runs end-to-end without the removed step.
- [x] Apply `antithesis` and confirm both workloads are still resolved by `setup`.