### PR TITLE
fix(mpp): serialize concurrent sends on the same shm_mq handle

### DIFF
--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -63,6 +63,14 @@ pub(super) fn align_up_maxalign_checked(n: usize) -> Option<usize> {
 pub(super) struct ShmMqSender {
     inner: MessageQueueSender,
     attach_thread: std::thread::ThreadId,
+    /// Async serialization lock around the shm_mq handle. Held by [`MppSender::send_*_traced`]
+    /// across the cooperative-drain spin to keep partial sends from interleaving — see the
+    /// [`BatchChannelSender::send_lock`] doc and PG's `shm_mq_send` invariants. Multiple
+    /// [`MppSender`] clones share the same `Arc<dyn BatchChannelSender>` to multiplex
+    /// `(stage_id, partition)` channels onto one shm_mq, and yielding between `try_send_bytes`
+    /// retries can otherwise stitch one sender's length prefix to another sender's payload and
+    /// corrupt the queue.
+    send_lock: tokio::sync::Mutex<()>,
 }
 
 // SAFETY: see struct doc.
@@ -86,6 +94,7 @@ impl ShmMqSender {
             Self {
                 inner: MessageQueueSender::new(seg, mq),
                 attach_thread: std::thread::current().id(),
+                send_lock: tokio::sync::Mutex::new(()),
             }
         }
     }
@@ -132,6 +141,10 @@ impl BatchChannelSender for ShmMqSender {
                 )))
             }
         }
+    }
+
+    fn send_lock(&self) -> &tokio::sync::Mutex<()> {
+        &self.send_lock
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -63,14 +63,6 @@ pub(super) fn align_up_maxalign_checked(n: usize) -> Option<usize> {
 pub(super) struct ShmMqSender {
     inner: MessageQueueSender,
     attach_thread: std::thread::ThreadId,
-    /// Async serialization lock around the shm_mq handle. Held by [`MppSender::send_*_traced`]
-    /// across the cooperative-drain spin to keep partial sends from interleaving — see the
-    /// [`BatchChannelSender::send_lock`] doc and PG's `shm_mq_send` invariants. Multiple
-    /// [`MppSender`] clones share the same `Arc<dyn BatchChannelSender>` to multiplex
-    /// `(stage_id, partition)` channels onto one shm_mq, and yielding between `try_send_bytes`
-    /// retries can otherwise stitch one sender's length prefix to another sender's payload and
-    /// corrupt the queue.
-    send_lock: tokio::sync::Mutex<()>,
 }
 
 // SAFETY: see struct doc.
@@ -94,7 +86,6 @@ impl ShmMqSender {
             Self {
                 inner: MessageQueueSender::new(seg, mq),
                 attach_thread: std::thread::current().id(),
-                send_lock: tokio::sync::Mutex::new(()),
             }
         }
     }
@@ -141,10 +132,6 @@ impl BatchChannelSender for ShmMqSender {
                 )))
             }
         }
-    }
-
-    fn send_lock(&self) -> &tokio::sync::Mutex<()> {
-        &self.send_lock
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -148,11 +148,9 @@ impl MppFrameHeader {
     /// `Err` if the slice is too short or the magic doesn't match.
     fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
         if bytes.len() < MPP_FRAME_HEADER_SIZE {
-            // Diagnostic: a recent benchmark run on origin/main produced a 12-byte frame on the
-            // leader's inbound queue for the `aggregate_join_groupby` query at 100k scale. No
-            // encoder in this file produces sub-16-byte output, so the source is something
-            // outside the MPP layer. Hex-dump the bytes so the next benchmark surfaces what's
-            // actually arriving and we can chase the producer.
+            // No encoder in this file emits sub-header output, so a short frame means the
+            // shm_mq stitched together payloads from different senders. Hex-dump the bytes
+            // so the source is identifiable from log output without a debugger.
             let hex = bytes
                 .iter()
                 .map(|b| format!("{b:02x}"))
@@ -394,20 +392,12 @@ pub(super) trait BatchChannelSender: Send + Sync {
         self.send_bytes(bytes).map(|()| true)
     }
 
-    /// Async serialization lock held across multi-call sends. PG's `shm_mq_send` docs spell out
-    /// the invariant: once a send returns `SHM_MQ_WOULD_BLOCK`, the next call on the same handle
-    /// must repeat the *same* `(nbytes, data)` arguments — "changing the length or payload will
-    /// corrupt the queue." Multiple [`MppSender`] clones share one underlying
-    /// `Arc<dyn BatchChannelSender>` (the multiplexed `(stage_id, partition)` pattern), and the
-    /// cooperative-drain spin in `send_with_scratch` yields between retries. Without this lock,
-    /// task A's partial send can interleave with task B's full send, sending B's payload as a
-    /// continuation of A's length prefix and producing a garbled queue. The receiver then reads
-    /// a corrupted length and errors with "invalid message size" or "frame too short for header".
-    ///
-    /// `send_with_scratch` / `send_eof_with_scratch` / `send_request_with_scratch` acquire this
-    /// lock before the spin and hold it until the message is fully written. In-proc channels
-    /// don't need serialization (each send is atomic) but return a per-instance mutex anyway so
-    /// the call site stays uniform.
+    /// Async lock the send paths hold across the cooperative-drain spin so two tasks can't
+    /// interleave partial writes on the same handle. PG's `shm_mq_send` requires the same
+    /// `(nbytes, data)` on retry after `SHM_MQ_WOULD_BLOCK`. Multiple [`MppSender`] clones
+    /// multiplex onto one channel, and the spin's `yield_now().await` would otherwise let a
+    /// sibling task land a different payload mid-message and corrupt the queue. In-proc
+    /// channels return a per-instance mutex too, just to keep the call sites uniform.
     fn send_lock(&self) -> &tokio::sync::Mutex<()>;
 }
 
@@ -452,17 +442,12 @@ pub struct MppSender {
     scratch: std::cell::RefCell<Vec<u8>>,
 }
 
-// SAFETY: `MppSender` lives inside `ShuffleWiring`, which is owned by a
-// single `ShuffleExec` running on a single backend thread. The async
-// `send_batch_traced` future captures `&self` and contains a Tokio
-// `yield_now().await`; the compiler conservatively requires the future
-// to be `Send`, which forces `&MppSender: Send` and therefore
-// `MppSender: Sync`. At runtime the future is created and consumed on
-// the same thread (DataFusion's current-thread runtime on the backend),
-// so there is no actual cross-thread aliasing of the inner `RefCell` or
-// of the `Box<dyn BatchChannelSender>`. This mirrors the same
-// single-thread-by-construction contract that justifies
-// `unsafe impl Send for ShmMqSender` over in `mesh.rs`.
+// SAFETY: only `scratch: RefCell<Vec<u8>>` and the trait-object `Arc`s are `!Sync`. Callers
+// compose `send_*_traced` futures via `tokio::spawn` / `join_all`, which makes the compiler
+// require `&Self: Send` and therefore `Self: Sync`. At runtime those futures run on the
+// current-thread tokio runtime pinned to the PG backend thread, so the cell is never actually
+// observed from another thread. Same single-thread-by-construction contract as
+// `unsafe impl Send for ShmMqSender` in `mesh.rs`.
 unsafe impl Sync for MppSender {}
 
 impl MppSender {
@@ -505,13 +490,12 @@ impl MppSender {
         self
     }
 
-    /// `send_batch` variant that accumulates per-call timings and spin
-    /// counts into `stats`. Callers that report these at EOF (e.g.,
-    /// `ShuffleStream`) use this to diagnose where time goes when the
-    /// outbound queue is full.
+    /// `send_batch` variant that accumulates per-call timings and spin counts into `stats`.
+    /// Callers that report at EOF (e.g. `ShuffleStream`) use this to diagnose where time
+    /// goes when the outbound queue is full.
     ///
-    /// Async because the cooperative-spin path needs to surrender the
-    /// Tokio runtime back periodically — see the body comment.
+    /// Async because the spin awaits the per-handle send lock and yields between
+    /// `try_send_bytes` retries; see `send_with_scratch`.
     pub(super) async fn send_batch_traced(
         &self,
         batch: &RecordBatch,
@@ -571,9 +555,8 @@ impl MppSender {
         let Some(drain) = self.cooperative_drain.as_ref() else {
             return self.channel.send_bytes(scratch);
         };
-        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
-        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
-        // same handle, and yield_now().await would otherwise let another task in mid-send.
+        // Lock the channel before the spin so a sibling task can't interleave a different
+        // partial write through the shared shm_mq handle. See `BatchChannelSender::send_lock`.
         let _send_guard = self.channel.send_lock().lock().await;
         let mut first_try = true;
         let t_wait_start = Instant::now();
@@ -609,45 +592,24 @@ impl MppSender {
             // back to the blocking send path.
             return self.channel.send_bytes(scratch);
         };
-        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
-        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
-        // same handle, and yield_now().await would otherwise let another task in mid-send.
-        //
-        // Long-term plan: replace `shm_mq` with an explicit ring buffer + async-friendly
-        // signaling (cf. #4184's strategy) so the partial-send invariant goes away and this
-        // per-handle serialization can be lifted.
+        // Lock the channel before the spin so a sibling task can't interleave a different
+        // partial write through the shared shm_mq handle. See `BatchChannelSender::send_lock`.
+        // Long-term, switching shm_mq for an async-friendly ring buffer (cf. #4184) drops the
+        // partial-send invariant entirely and removes the need for this lock.
         let _send_guard = self.channel.send_lock().lock().await;
         let mut first_try = true;
         let t_wait_start = Instant::now();
-        // Mental model: a current-thread Tokio runtime lives on the
-        // backend thread (DataFusion needs one to drive `Stream`s).
-        // This spin runs *inside* a Tokio task — specifically the body
-        // of `ShuffleStream::poll_next`. The deadlock the cooperative
-        // drain prevents is *cross-proc*, not same-runtime: two
-        // peers each blocking on a full outbound and never reading the
-        // other side. We break that by driving our own inbound on this
-        // same OS thread via `try_drain_pass`, which pulls peer
-        // batches that have already arrived and frees their slots so
-        // peers' writers can advance.
-        //
-        // The `tokio::task::yield_now().await` between iterations
-        // hands the runtime back to the executor each spin. Today's
-        // MPP topology is linear (`ChainExec` polls inline, no
-        // `RepartitionExec` / `CoalescePartitions` driver above the
-        // shuffle), so there are no sibling Tokio tasks ready to run
-        // and yielding is effectively a no-op cost. Once the planner
-        // grows a parallel operator above us, those siblings start
-        // making forward progress during this yield instead of
-        // starving.
+        // The spin runs inside a tokio task on the backend thread's current-thread runtime
+        // (DataFusion needs one to drive `Stream`s). The deadlock we're breaking is
+        // *cross-proc*: two peers each blocked on a full outbound. `try_drain_pass` pulls
+        // peer batches off our inbound on the same OS thread, freeing their slots so their
+        // sends advance. `yield_now().await` between iterations hands the runtime back to
+        // siblings if any are ready, mostly a no-op under today's linear MPP topology.
         loop {
-            // `pgrx::check_for_interrupts!()` pulls in PG symbols
-            // (`ProcessInterrupts`, `PG_exception_stack`,
-            // `CopyErrorData`, …) that aren't linked into the crate's
-            // `--tests` / llvm-cov build. This fn is reached from
-            // `#[cfg(test)]` code in this file and `shuffle.rs`, so
-            // gate the check out of test builds; `InProc` channels
-            // used in tests never block, so the send side of the loop
-            // returns on the first iteration anyway.
+            // Gate the check out of test builds. `pgrx::check_for_interrupts!()` pulls in PG
+            // symbols (`ProcessInterrupts`, etc.) that the `--tests` / llvm-cov build can't
+            // link. `InProc` channels used in tests never block, so the loop returns on the
+            // first iteration anyway.
             #[cfg(not(test))]
             pgrx::check_for_interrupts!();
             if self.channel.try_send_bytes(scratch)? {
@@ -658,12 +620,10 @@ impl MppSender {
             }
             first_try = false;
             stats.spin_iters += 1;
-            // Would-block: pull from our own mesh's inbound so peers'
-            // sends to us unblock. Without this interleave two
-            // procs blocking on symmetric sends deadlock —
-            // neither gets to drain. Errors propagate so a peer
-            // detaching mid-spin doesn't leave the sender looping
-            // forever on a closed mesh.
+            // Would-block. Pull from our inbound so peers' outbound-to-us frees up and their
+            // sends to us unblock; without this, symmetric full-queue sends deadlock. Errors
+            // propagate so a peer detaching mid-spin doesn't leave us spinning on a closed
+            // mesh.
             let t_drain = Instant::now();
             drain.try_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -605,8 +605,7 @@ impl MppSender {
         // or the queue corrupts. Two `MppSender` clones can share one underlying
         // `Arc<dyn BatchChannelSender>` (that's how `(stage_id, partition)` channels multiplex
         // onto one shm_mq), so a yield between the WOULD_BLOCK and the retry used to let another
-        // task slip in a `try_send_bytes` with different bytes. That's the "frame too short for
-        // header (12 < 16)" / "invalid message size" corruption we were hitting in CI.
+        // task slip in a `try_send_bytes` with different bytes.
         //
         // The earlier fix gated the spin behind a per-handle `tokio::sync::Mutex`, which was
         // correct but serialized every multiplexed sender through one lock and tanked the

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -148,10 +148,10 @@ impl MppFrameHeader {
     /// `Err` if the slice is too short or the magic doesn't match.
     fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
         if bytes.len() < MPP_FRAME_HEADER_SIZE {
-            // No encoder in this file emits sub-`MPP_FRAME_HEADER_SIZE` output, so a frame
-            // landing here means the underlying shm_mq stitched together payloads from
-            // different senders. Hex-dump the bytes so the source is identifiable from log
-            // output alone (without re-running under a debugger).
+            // No encoder in this file emits sub-`MPP_FRAME_HEADER_SIZE` output, so any frame
+            // landing here means something corrupted the shm_mq stream upstream of `parse`.
+            // Hex-dump the bytes so the source is identifiable from log output alone (no
+            // debugger re-run needed).
             let hex = bytes
                 .iter()
                 .map(|b| format!("{b:02x}"))
@@ -435,17 +435,20 @@ pub struct MppSender {
     scratch: std::cell::RefCell<Vec<u8>>,
 }
 
-// SAFETY: `MppSender` lives inside `ShuffleWiring`, which is owned by a
-// single `ShuffleExec` running on a single backend thread. The async
-// `send_batch_traced` future captures `&self` and contains a Tokio
-// `yield_now().await`; the compiler conservatively requires the future
-// to be `Send`, which forces `&MppSender: Send` and therefore
-// `MppSender: Sync`. At runtime the future is created and consumed on
-// the same thread (DataFusion's current-thread runtime on the backend),
-// so there is no actual cross-thread aliasing of the inner `RefCell` or
-// of the `Box<dyn BatchChannelSender>`. This mirrors the same
-// single-thread-by-construction contract that justifies
-// `unsafe impl Send for ShmMqSender` over in `mesh.rs`.
+// SAFETY: `MppSender`'s only `!Sync` fields are the `RefCell<Vec<u8>>` scratch buffer and
+// the `Arc<dyn BatchChannelSender>` / `Arc<dyn CooperativeDrainSet>` trait objects (whose
+// concrete impls — `ShmMqSender` in `mesh.rs`, the `MppMesh` cooperative-drain — likewise
+// rely on a "constructed and consumed on the attach thread" contract enforced by
+// `debug_assert!`s at every FFI call site). The `async fn send_batch_traced` etc. futures
+// capture `&self`, and downstream call sites compose those futures via `tokio::spawn` /
+// `futures::future::join_all`, so the compiler infers `Send` on the futures, which forces
+// `&MppSender: Send` and therefore `MppSender: Sync`. At runtime every `MppSender` value
+// is constructed and consumed on one PG backend thread, and the tokio runtime driving the
+// futures is always `Builder::new_current_thread()` (verified in `exec_worker.rs` /
+// `joinscan/mod.rs` / `aggregatescan/mod.rs`), so the `RefCell` borrows are non-aliasing
+// in practice and the `Arc` clones never cross threads at the FFI boundary. Same single-
+// thread-by-construction contract that justifies `unsafe impl Send for ShmMqSender` in
+// `mesh.rs`.
 unsafe impl Sync for MppSender {}
 
 impl MppSender {
@@ -493,8 +496,9 @@ impl MppSender {
     /// `ShuffleStream`) use this to diagnose where time goes when the
     /// outbound queue is full.
     ///
-    /// Async because the cooperative-spin path needs to surrender the
-    /// Tokio runtime back periodically — see the body comment.
+    /// Async for call-site uniformity with the rest of the transport entry points; the body
+    /// itself does NOT suspend inside the partial-send window — see the spin comment on
+    /// `send_with_scratch` for the invariant.
     pub(super) async fn send_batch_traced(
         &self,
         batch: &RecordBatch,
@@ -647,10 +651,10 @@ pub(super) struct SendBatchStats {
     /// Cumulative wall time in the send-retry spin after the first failed
     /// `try_send_bytes`. Zero if the first try succeeded.
     pub(super) send_wait: Duration,
-    /// Cumulative time spent in `try_drain_pass` while spinning on a
-    /// full outbound. A subset of `send_wait`; the remainder is the
-    /// `tokio::task::yield_now()` await + the (small) cost of
-    /// `try_send_bytes` itself.
+    /// Cumulative time spent in `try_drain_pass` while spinning on a full outbound. A subset
+    /// of `send_wait`; the remainder is `try_send_bytes` itself + loop-control overhead. (The
+    /// spin no longer yields the runtime — see the partial-send invariant on
+    /// `send_with_scratch` for why.)
     pub(super) coop_drain_in_spin: Duration,
     /// Count of `try_send_bytes` calls that returned `Ok(false)` (full).
     pub(super) spin_iters: u64,

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -393,22 +393,6 @@ pub(super) trait BatchChannelSender: Send + Sync {
     fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
         self.send_bytes(bytes).map(|()| true)
     }
-
-    /// Async serialization lock held across multi-call sends. PG's `shm_mq_send` docs spell out
-    /// the invariant: once a send returns `SHM_MQ_WOULD_BLOCK`, the next call on the same handle
-    /// must repeat the *same* `(nbytes, data)` arguments — "changing the length or payload will
-    /// corrupt the queue." Multiple [`MppSender`] clones share one underlying
-    /// `Arc<dyn BatchChannelSender>` (the multiplexed `(stage_id, partition)` pattern), and the
-    /// cooperative-drain spin in `send_with_scratch` yields between retries. Without this lock,
-    /// task A's partial send can interleave with task B's full send, sending B's payload as a
-    /// continuation of A's length prefix and producing a garbled queue. The receiver then reads
-    /// a corrupted length and errors with "invalid message size" or "frame too short for header".
-    ///
-    /// `send_with_scratch` / `send_eof_with_scratch` / `send_request_with_scratch` acquire this
-    /// lock before the spin and hold it until the message is fully written. In-proc channels
-    /// don't need serialization (each send is atomic) but return a per-instance mutex anyway so
-    /// the call site stays uniform.
-    fn send_lock(&self) -> &tokio::sync::Mutex<()>;
 }
 
 /// Pluggable "drain everything inbound" hook for [`MppSender`]'s cooperative send spin. The
@@ -571,10 +555,16 @@ impl MppSender {
         let Some(drain) = self.cooperative_drain.as_ref() else {
             return self.channel.send_bytes(scratch);
         };
-        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
-        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
-        // same handle, and yield_now().await would otherwise let another task in mid-send.
-        let _send_guard = self.channel.send_lock().lock().await;
+        // No yield_now inside the spin — that's what makes this safe without a per-handle lock.
+        // PG's shm_mq partial-send invariant says: once `try_send_bytes` returns WOULD_BLOCK with
+        // partial bytes on the wire, the next call on the same handle must repeat the *same*
+        // `(nbytes, data)` or the queue corrupts. With no `.await` between WOULD_BLOCK and the
+        // retry, no other tokio task on the current-thread runtime can sneak in a `try_send_bytes`
+        // with different bytes — the spin is atomic from the scheduler's POV. Skipping the lock
+        // also skips the contention that made multiplexed senders serialize through one mutex.
+        // Cross-process deadlock breaking still works: `drain.try_drain_pass` pulls peer batches
+        // out of our inbound every iteration, freeing peers' outbound slots so their sends
+        // unstall and ours eventually fits.
         let mut first_try = true;
         let t_wait_start = Instant::now();
         loop {
@@ -591,7 +581,6 @@ impl MppSender {
             let t_drain = Instant::now();
             drain.try_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
-            tokio::task::yield_now().await;
         }
     }
 
@@ -609,32 +598,35 @@ impl MppSender {
             // back to the blocking send path.
             return self.channel.send_bytes(scratch);
         };
-        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
-        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
-        // same handle, and yield_now().await would otherwise let another task in mid-send.
-        let _send_guard = self.channel.send_lock().lock().await;
+        // Why there's no yield_now in this spin (and no send_lock either):
+        //
+        // PG's `shm_mq_send` invariant: once a call returns SHM_MQ_WOULD_BLOCK with partial bytes
+        // on the wire, the next call on the same handle has to repeat the *same* `(nbytes, data)`
+        // or the queue corrupts. Two `MppSender` clones can share one underlying
+        // `Arc<dyn BatchChannelSender>` (that's how `(stage_id, partition)` channels multiplex
+        // onto one shm_mq), so a yield between the WOULD_BLOCK and the retry used to let another
+        // task slip in a `try_send_bytes` with different bytes. That's the "frame too short for
+        // header (12 < 16)" / "invalid message size" corruption we were hitting in CI.
+        //
+        // The earlier fix gated the spin behind a per-handle `tokio::sync::Mutex`, which was
+        // correct but serialized every multiplexed sender through one lock and tanked the
+        // aggregate_join benchmarks by ~2×. This version keeps correctness by removing the only
+        // `.await` inside the partial-send window. On the current-thread tokio runtime, with no
+        // await between WOULD_BLOCK and retry, no other tokio task can interleave a
+        // `try_send_bytes` — the spin is atomic from the scheduler's POV, so a lock is redundant.
+        //
+        // Cross-process deadlock breaking still works the same way. The two procs each spin on
+        // full outbounds; each one's `drain.try_drain_pass` pulls peer batches out of its own
+        // inbound queues, which frees the peer's outbound-to-us slots, which lets the peer's
+        // sender advance, which eventually drains our outbound and lets us advance too. Peer
+        // progress happens in a different OS process — it doesn't need us to yield to make it.
+        //
+        // Trade-off: while the spin is running, other tokio tasks on this thread (sibling
+        // producers, the local consumer draining the `DrainBuffer`) don't get a turn. In
+        // practice each spin completes within a few iterations once the peer drains its end, so
+        // the latency hit is bounded and a lot smaller than the lock contention it replaces.
         let mut first_try = true;
         let t_wait_start = Instant::now();
-        // Mental model: a current-thread Tokio runtime lives on the
-        // backend thread (DataFusion needs one to drive `Stream`s).
-        // This spin runs *inside* a Tokio task — specifically the body
-        // of `ShuffleStream::poll_next`. The deadlock the cooperative
-        // drain prevents is *cross-proc*, not same-runtime: two
-        // peers each blocking on a full outbound and never reading the
-        // other side. We break that by driving our own inbound on this
-        // same OS thread via `try_drain_pass`, which pulls peer
-        // batches that have already arrived and frees their slots so
-        // peers' writers can advance.
-        //
-        // The `tokio::task::yield_now().await` between iterations
-        // hands the runtime back to the executor each spin. Today's
-        // MPP topology is linear (`ChainExec` polls inline, no
-        // `RepartitionExec` / `CoalescePartitions` driver above the
-        // shuffle), so there are no sibling Tokio tasks ready to run
-        // and yielding is effectively a no-op cost. Once the planner
-        // grows a parallel operator above us, those siblings start
-        // making forward progress during this yield instead of
-        // starving.
         loop {
             // `pgrx::check_for_interrupts!()` pulls in PG symbols
             // (`ProcessInterrupts`, `PG_exception_stack`,
@@ -663,7 +655,6 @@ impl MppSender {
             let t_drain = Instant::now();
             drain.try_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
-            tokio::task::yield_now().await;
         }
     }
 }
@@ -944,23 +935,11 @@ impl Drop for DrainHandle {
 /// chance of self-deadlock if the producer never yields.
 pub(super) fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
-    (
-        InProcSender {
-            tx,
-            send_lock: tokio::sync::Mutex::new(()),
-        },
-        InProcReceiver { rx: Mutex::new(rx) },
-    )
+    (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
 }
 
 pub(super) struct InProcSender {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
-    /// Per-instance lock so the [`BatchChannelSender::send_lock`] contract holds even when an
-    /// in-proc channel ends up in a code path that would otherwise need serialization. In-proc
-    /// `send_bytes` is already atomic (each call pushes a complete `Vec<u8>`), so the lock is
-    /// effectively a no-op here, but keeping it uniform with `ShmMqSender` avoids special-casing
-    /// the caller.
-    send_lock: tokio::sync::Mutex<()>,
 }
 
 pub(super) struct InProcReceiver {
@@ -987,10 +966,6 @@ impl BatchChannelSender for InProcSender {
                 "mpp: in-proc channel detached during try_send".into(),
             )),
         }
-    }
-
-    fn send_lock(&self) -> &tokio::sync::Mutex<()> {
-        &self.send_lock
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -564,7 +564,7 @@ impl MppSender {
         // also skips the contention that made multiplexed senders serialize through one mutex.
         // Cross-process deadlock breaking still works: `drain.try_drain_pass` pulls peer batches
         // out of our inbound every iteration, freeing peers' outbound slots so their sends
-        // unstall and ours eventually fits.
+        // unblock and ours eventually fits.
         let mut first_try = true;
         let t_wait_start = Instant::now();
         loop {

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -148,10 +148,11 @@ impl MppFrameHeader {
     /// `Err` if the slice is too short or the magic doesn't match.
     fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
         if bytes.len() < MPP_FRAME_HEADER_SIZE {
-            // No encoder in this file emits sub-`MPP_FRAME_HEADER_SIZE` output, so any frame
-            // landing here means something corrupted the shm_mq stream upstream of `parse`.
-            // Hex-dump the bytes so the source is identifiable from log output alone (no
-            // debugger re-run needed).
+            // Diagnostic: a recent benchmark run on origin/main produced a 12-byte frame on the
+            // leader's inbound queue for the `aggregate_join_groupby` query at 100k scale. No
+            // encoder in this file produces sub-16-byte output, so the source is something
+            // outside the MPP layer. Hex-dump the bytes so the next benchmark surfaces what's
+            // actually arriving and we can chase the producer.
             let hex = bytes
                 .iter()
                 .map(|b| format!("{b:02x}"))
@@ -392,6 +393,22 @@ pub(super) trait BatchChannelSender: Send + Sync {
     fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
         self.send_bytes(bytes).map(|()| true)
     }
+
+    /// Async serialization lock held across multi-call sends. PG's `shm_mq_send` docs spell out
+    /// the invariant: once a send returns `SHM_MQ_WOULD_BLOCK`, the next call on the same handle
+    /// must repeat the *same* `(nbytes, data)` arguments — "changing the length or payload will
+    /// corrupt the queue." Multiple [`MppSender`] clones share one underlying
+    /// `Arc<dyn BatchChannelSender>` (the multiplexed `(stage_id, partition)` pattern), and the
+    /// cooperative-drain spin in `send_with_scratch` yields between retries. Without this lock,
+    /// task A's partial send can interleave with task B's full send, sending B's payload as a
+    /// continuation of A's length prefix and producing a garbled queue. The receiver then reads
+    /// a corrupted length and errors with "invalid message size" or "frame too short for header".
+    ///
+    /// `send_with_scratch` / `send_eof_with_scratch` / `send_request_with_scratch` acquire this
+    /// lock before the spin and hold it until the message is fully written. In-proc channels
+    /// don't need serialization (each send is atomic) but return a per-instance mutex anyway so
+    /// the call site stays uniform.
+    fn send_lock(&self) -> &tokio::sync::Mutex<()>;
 }
 
 /// Pluggable "drain everything inbound" hook for [`MppSender`]'s cooperative send spin. The
@@ -435,20 +452,17 @@ pub struct MppSender {
     scratch: std::cell::RefCell<Vec<u8>>,
 }
 
-// SAFETY: `MppSender`'s only `!Sync` fields are the `RefCell<Vec<u8>>` scratch buffer and
-// the `Arc<dyn BatchChannelSender>` / `Arc<dyn CooperativeDrainSet>` trait objects (whose
-// concrete impls — `ShmMqSender` in `mesh.rs`, the `MppMesh` cooperative-drain — likewise
-// rely on a "constructed and consumed on the attach thread" contract enforced by
-// `debug_assert!`s at every FFI call site). The `async fn send_batch_traced` etc. futures
-// capture `&self`, and downstream call sites compose those futures via `tokio::spawn` /
-// `futures::future::join_all`, so the compiler infers `Send` on the futures, which forces
-// `&MppSender: Send` and therefore `MppSender: Sync`. At runtime every `MppSender` value
-// is constructed and consumed on one PG backend thread, and the tokio runtime driving the
-// futures is always `Builder::new_current_thread()` (verified in `exec_worker.rs` /
-// `joinscan/mod.rs` / `aggregatescan/mod.rs`), so the `RefCell` borrows are non-aliasing
-// in practice and the `Arc` clones never cross threads at the FFI boundary. Same single-
-// thread-by-construction contract that justifies `unsafe impl Send for ShmMqSender` in
-// `mesh.rs`.
+// SAFETY: `MppSender` lives inside `ShuffleWiring`, which is owned by a
+// single `ShuffleExec` running on a single backend thread. The async
+// `send_batch_traced` future captures `&self` and contains a Tokio
+// `yield_now().await`; the compiler conservatively requires the future
+// to be `Send`, which forces `&MppSender: Send` and therefore
+// `MppSender: Sync`. At runtime the future is created and consumed on
+// the same thread (DataFusion's current-thread runtime on the backend),
+// so there is no actual cross-thread aliasing of the inner `RefCell` or
+// of the `Box<dyn BatchChannelSender>`. This mirrors the same
+// single-thread-by-construction contract that justifies
+// `unsafe impl Send for ShmMqSender` over in `mesh.rs`.
 unsafe impl Sync for MppSender {}
 
 impl MppSender {
@@ -496,9 +510,8 @@ impl MppSender {
     /// `ShuffleStream`) use this to diagnose where time goes when the
     /// outbound queue is full.
     ///
-    /// Async for call-site uniformity with the rest of the transport entry points; the body
-    /// itself does NOT suspend inside the partial-send window — see the spin comment on
-    /// `send_with_scratch` for the invariant.
+    /// Async because the cooperative-spin path needs to surrender the
+    /// Tokio runtime back periodically — see the body comment.
     pub(super) async fn send_batch_traced(
         &self,
         batch: &RecordBatch,
@@ -558,11 +571,10 @@ impl MppSender {
         let Some(drain) = self.cooperative_drain.as_ref() else {
             return self.channel.send_bytes(scratch);
         };
-        // Same partial-send / no-`.await` invariant as `send_with_scratch`; see that comment
-        // for the full rationale. TL;DR: PG's `shm_mq_send` requires the same `(nbytes,
-        // data)` on retry after WOULD_BLOCK, so keeping the spin awaitless prevents another
-        // multiplexed sender on the current-thread runtime from interleaving a different
-        // payload on the same handle.
+        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
+        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
+        // same handle, and yield_now().await would otherwise let another task in mid-send.
+        let _send_guard = self.channel.send_lock().lock().await;
         let mut first_try = true;
         let t_wait_start = Instant::now();
         loop {
@@ -579,6 +591,7 @@ impl MppSender {
             let t_drain = Instant::now();
             drain.try_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
+            tokio::task::yield_now().await;
         }
     }
 
@@ -596,20 +609,36 @@ impl MppSender {
             // back to the blocking send path.
             return self.channel.send_bytes(scratch);
         };
-        // PG's `shm_mq_send` partial-send invariant: after WOULD_BLOCK, the next call on the
-        // same handle must repeat the same `(nbytes, data)`. Multiple `MppSender` clones can
-        // share one handle (multiplexed `(stage_id, partition)` channels), so an `.await`
-        // here would let another task interleave a different payload and corrupt the queue.
-        // Keep the spin awaitless — on the current-thread runtime that's enough to make it
-        // atomic from the scheduler's POV and a per-handle lock isn't needed. Cross-process
-        // deadlock breaking still works because `drain.try_drain_pass` frees peer outbound
-        // slots from a different OS process, which doesn't depend on us yielding here.
+        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
+        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
+        // same handle, and yield_now().await would otherwise let another task in mid-send.
         //
         // Long-term plan: replace `shm_mq` with an explicit ring buffer + async-friendly
-        // signaling (cf. #4184's strategy) so the partial-send invariant goes away and the
-        // spin can yield cooperatively.
+        // signaling (cf. #4184's strategy) so the partial-send invariant goes away and this
+        // per-handle serialization can be lifted.
+        let _send_guard = self.channel.send_lock().lock().await;
         let mut first_try = true;
         let t_wait_start = Instant::now();
+        // Mental model: a current-thread Tokio runtime lives on the
+        // backend thread (DataFusion needs one to drive `Stream`s).
+        // This spin runs *inside* a Tokio task — specifically the body
+        // of `ShuffleStream::poll_next`. The deadlock the cooperative
+        // drain prevents is *cross-proc*, not same-runtime: two
+        // peers each blocking on a full outbound and never reading the
+        // other side. We break that by driving our own inbound on this
+        // same OS thread via `try_drain_pass`, which pulls peer
+        // batches that have already arrived and frees their slots so
+        // peers' writers can advance.
+        //
+        // The `tokio::task::yield_now().await` between iterations
+        // hands the runtime back to the executor each spin. Today's
+        // MPP topology is linear (`ChainExec` polls inline, no
+        // `RepartitionExec` / `CoalescePartitions` driver above the
+        // shuffle), so there are no sibling Tokio tasks ready to run
+        // and yielding is effectively a no-op cost. Once the planner
+        // grows a parallel operator above us, those siblings start
+        // making forward progress during this yield instead of
+        // starving.
         loop {
             // `pgrx::check_for_interrupts!()` pulls in PG symbols
             // (`ProcessInterrupts`, `PG_exception_stack`,
@@ -638,6 +667,7 @@ impl MppSender {
             let t_drain = Instant::now();
             drain.try_drain_pass()?;
             stats.coop_drain_in_spin += t_drain.elapsed();
+            tokio::task::yield_now().await;
         }
     }
 }
@@ -651,10 +681,10 @@ pub(super) struct SendBatchStats {
     /// Cumulative wall time in the send-retry spin after the first failed
     /// `try_send_bytes`. Zero if the first try succeeded.
     pub(super) send_wait: Duration,
-    /// Cumulative time spent in `try_drain_pass` while spinning on a full outbound. A subset
-    /// of `send_wait`; the remainder is `try_send_bytes` itself + loop-control overhead. (The
-    /// spin no longer yields the runtime — see the partial-send invariant on
-    /// `send_with_scratch` for why.)
+    /// Cumulative time spent in `try_drain_pass` while spinning on a
+    /// full outbound. A subset of `send_wait`; the remainder is the
+    /// `tokio::task::yield_now()` await + the (small) cost of
+    /// `try_send_bytes` itself.
     pub(super) coop_drain_in_spin: Duration,
     /// Count of `try_send_bytes` calls that returned `Ok(false)` (full).
     pub(super) spin_iters: u64,
@@ -918,11 +948,23 @@ impl Drop for DrainHandle {
 /// chance of self-deadlock if the producer never yields.
 pub(super) fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
-    (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
+    (
+        InProcSender {
+            tx,
+            send_lock: tokio::sync::Mutex::new(()),
+        },
+        InProcReceiver { rx: Mutex::new(rx) },
+    )
 }
 
 pub(super) struct InProcSender {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
+    /// Per-instance lock so the [`BatchChannelSender::send_lock`] contract holds even when an
+    /// in-proc channel ends up in a code path that would otherwise need serialization. In-proc
+    /// `send_bytes` is already atomic (each call pushes a complete `Vec<u8>`), so the lock is
+    /// effectively a no-op here, but keeping it uniform with `ShmMqSender` avoids special-casing
+    /// the caller.
+    send_lock: tokio::sync::Mutex<()>,
 }
 
 pub(super) struct InProcReceiver {
@@ -949,6 +991,10 @@ impl BatchChannelSender for InProcSender {
                 "mpp: in-proc channel detached during try_send".into(),
             )),
         }
+    }
+
+    fn send_lock(&self) -> &tokio::sync::Mutex<()> {
+        &self.send_lock
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -393,6 +393,22 @@ pub(super) trait BatchChannelSender: Send + Sync {
     fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
         self.send_bytes(bytes).map(|()| true)
     }
+
+    /// Async serialization lock held across multi-call sends. PG's `shm_mq_send` docs spell out
+    /// the invariant: once a send returns `SHM_MQ_WOULD_BLOCK`, the next call on the same handle
+    /// must repeat the *same* `(nbytes, data)` arguments — "changing the length or payload will
+    /// corrupt the queue." Multiple [`MppSender`] clones share one underlying
+    /// `Arc<dyn BatchChannelSender>` (the multiplexed `(stage_id, partition)` pattern), and the
+    /// cooperative-drain spin in `send_with_scratch` yields between retries. Without this lock,
+    /// task A's partial send can interleave with task B's full send, sending B's payload as a
+    /// continuation of A's length prefix and producing a garbled queue. The receiver then reads
+    /// a corrupted length and errors with "invalid message size" or "frame too short for header".
+    ///
+    /// `send_with_scratch` / `send_eof_with_scratch` / `send_request_with_scratch` acquire this
+    /// lock before the spin and hold it until the message is fully written. In-proc channels
+    /// don't need serialization (each send is atomic) but return a per-instance mutex anyway so
+    /// the call site stays uniform.
+    fn send_lock(&self) -> &tokio::sync::Mutex<()>;
 }
 
 /// Pluggable "drain everything inbound" hook for [`MppSender`]'s cooperative send spin. The
@@ -555,6 +571,10 @@ impl MppSender {
         let Some(drain) = self.cooperative_drain.as_ref() else {
             return self.channel.send_bytes(scratch);
         };
+        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
+        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
+        // same handle, and yield_now().await would otherwise let another task in mid-send.
+        let _send_guard = self.channel.send_lock().lock().await;
         let mut first_try = true;
         let t_wait_start = Instant::now();
         loop {
@@ -589,6 +609,10 @@ impl MppSender {
             // back to the blocking send path.
             return self.channel.send_bytes(scratch);
         };
+        // Hold the channel's send lock across the entire spin. See `BatchChannelSender::send_lock`
+        // for the why — shm_mq can't tolerate two senders interleaving partial writes on the
+        // same handle, and yield_now().await would otherwise let another task in mid-send.
+        let _send_guard = self.channel.send_lock().lock().await;
         let mut first_try = true;
         let t_wait_start = Instant::now();
         // Mental model: a current-thread Tokio runtime lives on the
@@ -920,11 +944,23 @@ impl Drop for DrainHandle {
 /// chance of self-deadlock if the producer never yields.
 pub(super) fn in_proc_channel(capacity: usize) -> (InProcSender, InProcReceiver) {
     let (tx, rx) = std::sync::mpsc::sync_channel::<Vec<u8>>(capacity);
-    (InProcSender { tx }, InProcReceiver { rx: Mutex::new(rx) })
+    (
+        InProcSender {
+            tx,
+            send_lock: tokio::sync::Mutex::new(()),
+        },
+        InProcReceiver { rx: Mutex::new(rx) },
+    )
 }
 
 pub(super) struct InProcSender {
     tx: std::sync::mpsc::SyncSender<Vec<u8>>,
+    /// Per-instance lock so the [`BatchChannelSender::send_lock`] contract holds even when an
+    /// in-proc channel ends up in a code path that would otherwise need serialization. In-proc
+    /// `send_bytes` is already atomic (each call pushes a complete `Vec<u8>`), so the lock is
+    /// effectively a no-op here, but keeping it uniform with `ShmMqSender` avoids special-casing
+    /// the caller.
+    send_lock: tokio::sync::Mutex<()>,
 }
 
 pub(super) struct InProcReceiver {
@@ -951,6 +987,10 @@ impl BatchChannelSender for InProcSender {
                 "mpp: in-proc channel detached during try_send".into(),
             )),
         }
+    }
+
+    fn send_lock(&self) -> &tokio::sync::Mutex<()> {
+        &self.send_lock
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -148,8 +148,18 @@ impl MppFrameHeader {
     /// `Err` if the slice is too short or the magic doesn't match.
     fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
         if bytes.len() < MPP_FRAME_HEADER_SIZE {
+            // Diagnostic: a recent benchmark run on origin/main produced a 12-byte frame on the
+            // leader's inbound queue for the `aggregate_join_groupby` query at 100k scale. No
+            // encoder in this file produces sub-16-byte output, so the source is something
+            // outside the MPP layer. Hex-dump the bytes so the next benchmark surfaces what's
+            // actually arriving and we can chase the producer.
+            let hex = bytes
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<Vec<_>>()
+                .join(" ");
             return Err(DataFusionError::Internal(format!(
-                "mpp: frame too short for header ({} < {})",
+                "mpp: frame too short for header ({} < {}); bytes = [{hex}]",
                 bytes.len(),
                 MPP_FRAME_HEADER_SIZE
             )));

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -148,11 +148,10 @@ impl MppFrameHeader {
     /// `Err` if the slice is too short or the magic doesn't match.
     fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
         if bytes.len() < MPP_FRAME_HEADER_SIZE {
-            // Diagnostic: a recent benchmark run on origin/main produced a 12-byte frame on the
-            // leader's inbound queue for the `aggregate_join_groupby` query at 100k scale. No
-            // encoder in this file produces sub-16-byte output, so the source is something
-            // outside the MPP layer. Hex-dump the bytes so the next benchmark surfaces what's
-            // actually arriving and we can chase the producer.
+            // No encoder in this file emits sub-`MPP_FRAME_HEADER_SIZE` output, so a frame
+            // landing here means the underlying shm_mq stitched together payloads from
+            // different senders. Hex-dump the bytes so the source is identifiable from log
+            // output alone (without re-running under a debugger).
             let hex = bytes
                 .iter()
                 .map(|b| format!("{b:02x}"))
@@ -555,16 +554,11 @@ impl MppSender {
         let Some(drain) = self.cooperative_drain.as_ref() else {
             return self.channel.send_bytes(scratch);
         };
-        // No yield_now inside the spin — that's what makes this safe without a per-handle lock.
-        // PG's shm_mq partial-send invariant says: once `try_send_bytes` returns WOULD_BLOCK with
-        // partial bytes on the wire, the next call on the same handle must repeat the *same*
-        // `(nbytes, data)` or the queue corrupts. With no `.await` between WOULD_BLOCK and the
-        // retry, no other tokio task on the current-thread runtime can sneak in a `try_send_bytes`
-        // with different bytes — the spin is atomic from the scheduler's POV. Skipping the lock
-        // also skips the contention that made multiplexed senders serialize through one mutex.
-        // Cross-process deadlock breaking still works: `drain.try_drain_pass` pulls peer batches
-        // out of our inbound every iteration, freeing peers' outbound slots so their sends
-        // unblock and ours eventually fits.
+        // Same partial-send / no-`.await` invariant as `send_with_scratch`; see that comment
+        // for the full rationale. TL;DR: PG's `shm_mq_send` requires the same `(nbytes,
+        // data)` on retry after WOULD_BLOCK, so keeping the spin awaitless prevents another
+        // multiplexed sender on the current-thread runtime from interleaving a different
+        // payload on the same handle.
         let mut first_try = true;
         let t_wait_start = Instant::now();
         loop {
@@ -598,32 +592,18 @@ impl MppSender {
             // back to the blocking send path.
             return self.channel.send_bytes(scratch);
         };
-        // Why there's no yield_now in this spin (and no send_lock either):
+        // PG's `shm_mq_send` partial-send invariant: after WOULD_BLOCK, the next call on the
+        // same handle must repeat the same `(nbytes, data)`. Multiple `MppSender` clones can
+        // share one handle (multiplexed `(stage_id, partition)` channels), so an `.await`
+        // here would let another task interleave a different payload and corrupt the queue.
+        // Keep the spin awaitless — on the current-thread runtime that's enough to make it
+        // atomic from the scheduler's POV and a per-handle lock isn't needed. Cross-process
+        // deadlock breaking still works because `drain.try_drain_pass` frees peer outbound
+        // slots from a different OS process, which doesn't depend on us yielding here.
         //
-        // PG's `shm_mq_send` invariant: once a call returns SHM_MQ_WOULD_BLOCK with partial bytes
-        // on the wire, the next call on the same handle has to repeat the *same* `(nbytes, data)`
-        // or the queue corrupts. Two `MppSender` clones can share one underlying
-        // `Arc<dyn BatchChannelSender>` (that's how `(stage_id, partition)` channels multiplex
-        // onto one shm_mq), so a yield between the WOULD_BLOCK and the retry used to let another
-        // task slip in a `try_send_bytes` with different bytes.
-        //
-        // The earlier fix gated the spin behind a per-handle `tokio::sync::Mutex`, which was
-        // correct but serialized every multiplexed sender through one lock and tanked the
-        // aggregate_join benchmarks by ~2×. This version keeps correctness by removing the only
-        // `.await` inside the partial-send window. On the current-thread tokio runtime, with no
-        // await between WOULD_BLOCK and retry, no other tokio task can interleave a
-        // `try_send_bytes` — the spin is atomic from the scheduler's POV, so a lock is redundant.
-        //
-        // Cross-process deadlock breaking still works the same way. The two procs each spin on
-        // full outbounds; each one's `drain.try_drain_pass` pulls peer batches out of its own
-        // inbound queues, which frees the peer's outbound-to-us slots, which lets the peer's
-        // sender advance, which eventually drains our outbound and lets us advance too. Peer
-        // progress happens in a different OS process — it doesn't need us to yield to make it.
-        //
-        // Trade-off: while the spin is running, other tokio tasks on this thread (sibling
-        // producers, the local consumer draining the `DrainBuffer`) don't get a turn. In
-        // practice each spin completes within a few iterations once the peer drains its end, so
-        // the latency hit is bounded and a lot smaller than the lock contention it replaces.
+        // Long-term plan: replace `shm_mq` with an explicit ring buffer + async-friendly
+        // signaling (cf. #4184's strategy) so the partial-send invariant goes away and the
+        // spin can yield cooperatively.
         let mut first_try = true;
         let t_wait_start = Instant::now();
         loop {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Fixes the benchmark workflow that's been failing on `main` since #5082 landed (https://github.com/paradedb/paradedb/actions/runs/26077021525/job/76670054238). The `aggregate_join_groupby - alternative 2` query (MPP + aggregate + GROUP BY over a JOIN at 100k stackoverflow scale) errors with either "frame too short for header (12 < 16)" or "invalid message size 1985348632576000 in shared memory queue". Both shapes are the same underlying corruption — a shm_mq queue's length prefix got stitched to someone else's payload.

## Why

PG's `shm_mq_send` documents it directly:

> When nowait = true ... if the buffer becomes full, we return SHM_MQ_WOULD_BLOCK. In this case, the caller should call this function again, with the same arguments. (Once begun, the sending of a message cannot be aborted except by detaching from the queue; changing the length or payload will corrupt the queue.)

Our cooperative-drain spin in `MppSender::send_*_traced` does `tokio::task::yield_now().await` between `try_send_bytes` retries so peer inbound queues keep draining. The multiplexed transport has multiple `MppSender` clones sharing one underlying `Arc<dyn BatchChannelSender>` (that's how `(stage_id, partition)` channels share an shm_mq). Without serialization, after task A's `try_send_bytes` returns `WOULD_BLOCK` with a partial write, the `yield_now().await` lets task B call `try_send_bytes` on the same handle with different bytes. PG stitches A's length prefix to B's payload and the queue's now garbled.

## How

`BatchChannelSender::send_lock()` exposes a `tokio::sync::Mutex<()>` per shm_mq handle. The send paths (`MppSender::send_batch_traced` / `send_eof_traced`) acquire it before entering the cooperative-drain spin and hold it across `yield_now().await`. Two `MppSender` clones sharing one underlying channel now serialize naturally, so the interleave that corrupts the queue can't happen.

This PR has been through a couple of iterations:

- An earlier revision (`c1a6bb1`, since reverted) dropped the lock and instead removed the only `.await` from inside the partial-send window, on the theory that an awaitless spin would be cheaper. The benchmark didn't agree — see the standing perf section below.
- The current version (`fbc5ed0f`) reverts that to keep the more obviously-correct lock-based serialization, matching the recommendation from review.

The hex-dump diagnostic from `b338f70e` stays. It cost nothing and would catch a regression of the same shape if it recurs.

## Standing perf regression (separate from this PR)

The CI benchmark on this branch reports `aggregate_join_groupby - alternative 2` ~1.88× slower and `aggregate_join_topk_count - alternative 2` ~2.17× slower than the pre-#5082 baseline at 20M rows. The non-MPP alternatives on the same queries are flat (~1.00×), so the regression is on the multi-stage MPP path that landed in #5082 / #5092 — not on the transport changes in this PR.

The earlier "drop the lock" revision was based on the theory that the per-handle `tokio::sync::Mutex` was the bottleneck. The bench data didn't bear that out: removing the lock did not change the ratio, which is consistent with a held mutex and an awaitless spin having the same effect on a current-thread runtime (both block sibling tokio tasks until the send completes). The regression's root cause is elsewhere in the post-#5082 multi-stage path and is tracked as separate follow-up work.

Longer term, replacing `shm_mq` with an explicit ring buffer + async-friendly signaling (cf. #4184's strategy) lifts the partial-send invariant entirely and removes the need for per-handle send serialization at all. A code-comment pointer to that follow-up sits at the top of `send_with_scratch`.

## Tests

- 30 sequential runs of the failing query locally on synthetic 100k posts / 1M comments. The bug doesn't reproduce reliably at that scale on my hardware. The interleave needs `WOULD_BLOCK` pressure, which is more likely at the CI scale (real Stack Overflow body sizes, 48 segments per index, 96 cores). CI benchmark on this branch will be the final word.
