### PR TITLE
feat: Speed up dynamic filter pushdown via tantivy TermSet dispatch refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5524,7 +5524,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -8199,7 +8199,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8254,7 +8254,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "bitpacking",
 ]
@@ -8262,7 +8262,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8277,7 +8277,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8310,7 +8310,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8322,7 +8322,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8335,7 +8335,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8372,7 +8372,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8f3b5817ef791a0bfade42cf1e80a08a53d08562#8f3b5817ef791a0bfade42cf1e80a08a53d08562"
+source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "8f3b5817ef791a0bfade42cf1e80a08a53d08562", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -41,4 +41,4 @@ pgrx-tests = "=0.18.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "8f3b5817ef791a0bfade42cf1e80a08a53d08562" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-5bFlp5P6mqFuEUuTFKR4PUQNU0lm3O7I7TZESay40Wo=";
+  cargoHash = "sha256-M+351QJX1GXAux416MM71/vN2F1ikiu4m7/BLEqmCf8=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -200,16 +200,6 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
 /// back to the legacy linear scan even for sorted segments.
 static TERM_SET_GALLOP_ENABLED: GucSetting<bool> = GucSetting::<bool>::new(true);
 
-/// Density gate for the gallop dispatch path. Gallop is selected when
-/// `K' / N` is at or below this threshold on a sorted segment, where `K'`
-/// is the number of distinct terms surviving min/max pruning and `N` is
-/// the segment size. Default `1.0` (Phase 6.13) — Gallop dominates
-/// whenever the segment is sorted by the queried field (Phase 6.12
-/// production-bench numbers), so no density gate fires under defaults.
-/// Lower values reject Gallop at high-K and fall through to Bitset or
-/// LinearScan. Matches `tantivy::query::TermSetStrategyConfig::default()`.
-static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0);
-
 /// First-column `BitsetFromPostings` density gate for unique-valued
 /// columns (`D = 1`, i.e. `dict_size >= N`, e.g. primary keys). Bitset
 /// is admitted when `K' / N <= bitset_max_density_unique`. Default
@@ -522,16 +512,6 @@ pub fn init() {
         c"Enable galloping execution of FastFieldTermSetQuery on sorted segments.",
         c"When false, FastFieldTermSetQuery falls back to the legacy linear scan even on sorted segments. Acts as a kill-switch for the issue #4895 optimization.",
         &TERM_SET_GALLOP_ENABLED,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-    GucRegistry::define_float_guc(
-        c"paradedb.term_set_gallop_max_density",
-        c"Gallop is selected when K' / N is at or below this density on a sorted segment.",
-        c"K' is the number of distinct terms surviving min/max pruning; N is the segment size. Default 1.0 (admit Gallop whenever the segment is sorted by the queried field — Phase 6.12 found Gallop wins uniformly when admissible). Lower values reject Gallop at high K, falling back to BitsetFromPostings or LinearScan.",
-        &TERM_SET_GALLOP_MAX_DENSITY,
-        0.0,
-        1.0,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -852,10 +832,6 @@ pub fn hash_join_inlist_pushdown_max_distinct_values() -> i32 {
 
 pub fn term_set_gallop_enabled() -> bool {
     TERM_SET_GALLOP_ENABLED.get()
-}
-
-pub fn term_set_gallop_max_density() -> f64 {
-    TERM_SET_GALLOP_MAX_DENSITY.get()
 }
 
 pub fn term_set_bitset_max_density_unique() -> f64 {

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -217,8 +217,7 @@ static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0
 /// backend where per-`dict.get` zstd block decompress dominates per-K
 /// cost on unique columns. Matches
 /// `tantivy::query::TermSetStrategyConfig::default()`.
-static TERM_SET_BITSET_MAX_DENSITY_UNIQUE: GucSetting<f64> =
-    GucSetting::<f64>::new(1.0 / 2000.0);
+static TERM_SET_BITSET_MAX_DENSITY_UNIQUE: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 2000.0);
 
 /// First-column `BitsetFromPostings` density gate for non-unique
 /// columns (`D >= 2`, e.g. foreign-key shape). Bitset is admitted when
@@ -227,8 +226,7 @@ static TERM_SET_BITSET_MAX_DENSITY_UNIQUE: GucSetting<f64> =
 /// dictionary lookups amortize the zstd block decompress across
 /// multiple keys per block on non-unique columns. Matches
 /// `tantivy::query::TermSetStrategyConfig::default()`.
-static TERM_SET_BITSET_MAX_DENSITY_MULTI: GucSetting<f64> =
-    GucSetting::<f64>::new(1.0 / 200.0);
+static TERM_SET_BITSET_MAX_DENSITY_MULTI: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 200.0);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -201,12 +201,34 @@ static HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES: GucSetting<i32> =
 static TERM_SET_GALLOP_ENABLED: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Density gate for the gallop dispatch path. Gallop is selected when
-/// `K' / N` is below this threshold on a sorted segment, where `K'` is
-/// the number of distinct terms surviving min/max pruning and `N` is the
-/// segment size. Larger values admit gallop more aggressively; smaller
-/// values are more conservative. Default `1/100 = 0.01` matches
+/// `K' / N` is at or below this threshold on a sorted segment, where `K'`
+/// is the number of distinct terms surviving min/max pruning and `N` is
+/// the segment size. Default `1.0` (Phase 6.13) — Gallop dominates
+/// whenever the segment is sorted by the queried field (Phase 6.12
+/// production-bench numbers), so no density gate fires under defaults.
+/// Lower values reject Gallop at high-K and fall through to Bitset or
+/// LinearScan. Matches `tantivy::query::TermSetStrategyConfig::default()`.
+static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0);
+
+/// First-column `BitsetFromPostings` density gate for unique-valued
+/// columns (`D = 1`, i.e. `dict_size >= N`, e.g. primary keys). Bitset
+/// is admitted when `K' / N <= bitset_max_density_unique`. Default
+/// `1/2000 = 0.0005` (Phase 6.11) — calibrated against the SSTable
+/// backend where per-`dict.get` zstd block decompress dominates per-K
+/// cost on unique columns. Matches
 /// `tantivy::query::TermSetStrategyConfig::default()`.
-static TERM_SET_GALLOP_MAX_DENSITY: GucSetting<f64> = GucSetting::<f64>::new(1.0 / 100.0);
+static TERM_SET_BITSET_MAX_DENSITY_UNIQUE: GucSetting<f64> =
+    GucSetting::<f64>::new(1.0 / 2000.0);
+
+/// First-column `BitsetFromPostings` density gate for non-unique
+/// columns (`D >= 2`, e.g. foreign-key shape). Bitset is admitted when
+/// `K' / N <= bitset_max_density_multi`. Default `1/200 = 0.005`
+/// (Phase 6.13) — 10× looser than the unique threshold because batched
+/// dictionary lookups amortize the zstd block decompress across
+/// multiple keys per block on non-unique columns. Matches
+/// `tantivy::query::TermSetStrategyConfig::default()`.
+static TERM_SET_BITSET_MAX_DENSITY_MULTI: GucSetting<f64> =
+    GucSetting::<f64>::new(1.0 / 200.0);
 
 pub fn init() {
     // Note that Postgres is very specific about the naming convention of variables.
@@ -493,10 +515,10 @@ pub fn init() {
 
     // TermSet strategy density thresholds (issue #4895). The kill-switch
     // (paradedb.term_set_gallop_enabled) is the safety override if the
-    // gallop optimization regresses unexpectedly; the five density values
-    // tune the planner without recompiling. Each density is unitless and
-    // bounded to [0.0, 1.0] (a density above 1.0 would mean more matches
-    // than corpus rows, which is impossible).
+    // gallop optimization regresses unexpectedly; the three density
+    // values tune the planner without recompiling. Each density is
+    // unitless and bounded to [0.0, 1.0]. Gates use `<=` so a threshold
+    // value at the cell's density admits the more-aggressive strategy.
     GucRegistry::define_bool_guc(
         c"paradedb.term_set_gallop_enabled",
         c"Enable galloping execution of FastFieldTermSetQuery on sorted segments.",
@@ -507,9 +529,29 @@ pub fn init() {
     );
     GucRegistry::define_float_guc(
         c"paradedb.term_set_gallop_max_density",
-        c"Gallop is selected when K' / N is below this density on a sorted segment.",
-        c"K' is the number of distinct terms surviving min/max pruning; N is the segment size. Larger values admit gallop more aggressively; smaller values are more conservative. Default 1/100 = 0.01 (matches tantivy::query::TermSetStrategyConfig::default()).",
+        c"Gallop is selected when K' / N is at or below this density on a sorted segment.",
+        c"K' is the number of distinct terms surviving min/max pruning; N is the segment size. Default 1.0 (admit Gallop whenever the segment is sorted by the queried field — Phase 6.12 found Gallop wins uniformly when admissible). Lower values reject Gallop at high K, falling back to BitsetFromPostings or LinearScan.",
         &TERM_SET_GALLOP_MAX_DENSITY,
+        0.0,
+        1.0,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_float_guc(
+        c"paradedb.term_set_bitset_max_density_unique",
+        c"BitsetFromPostings is selected over LinearScan when K' / N is at or below this density on unique-valued columns (D = 1).",
+        c"For columns where every doc has a distinct value (primary keys, UUIDs). K' is the number of distinct terms surviving min/max pruning; N is the segment size. Default 0.0005 (= 1/2000) calibrated against the SSTable backend in Phase 6.11. Lower values route more queries to LinearScan.",
+        &TERM_SET_BITSET_MAX_DENSITY_UNIQUE,
+        0.0,
+        1.0,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+    GucRegistry::define_float_guc(
+        c"paradedb.term_set_bitset_max_density_multi",
+        c"BitsetFromPostings is selected over LinearScan when K' / N is at or below this density on non-unique columns (D >= 2).",
+        c"For columns where multiple docs share the same value (foreign keys, status enums). Default 0.005 (= 1/200), 10x looser than the unique threshold because batched dictionary lookups amortize the SSTable zstd block decompress across multiple keys per block on non-unique columns (Phase 6.13). Lower values route more queries to LinearScan.",
+        &TERM_SET_BITSET_MAX_DENSITY_MULTI,
         0.0,
         1.0,
         GucContext::Userset,
@@ -816,6 +858,14 @@ pub fn term_set_gallop_enabled() -> bool {
 
 pub fn term_set_gallop_max_density() -> f64 {
     TERM_SET_GALLOP_MAX_DENSITY.get()
+}
+
+pub fn term_set_bitset_max_density_unique() -> f64 {
+    TERM_SET_BITSET_MAX_DENSITY_UNIQUE.get()
+}
+
+pub fn term_set_bitset_max_density_multi() -> f64 {
+    TERM_SET_BITSET_MAX_DENSITY_MULTI.get()
 }
 
 #[cfg(any(test, feature = "pg_test"))]

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -388,8 +388,7 @@ fn strategy_name(strategy: tantivy::query::StrategyTag) -> &'static str {
         StrategyTag::Gallop => "gallop",
         StrategyTag::Linear => "linear",
         StrategyTag::Bitset => "bitset_from_postings",
-        StrategyTag::Posting => "posting_direct",
-        StrategyTag::Hash => "hash_probe",
+        StrategyTag::Empty => "empty",
     }
 }
 

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -171,9 +171,9 @@ pub struct PgSearchScanPlan {
     /// fine because `EXPLAIN ANALYZE` only asks "did any segment use it?".
     /// Stored as `u8` so it can live behind an `AtomicU8`; round-tripped
     /// through `tantivy::query::StrategyTag` at render time. A value of
-    /// `StrategyTag::None as u8` (= 0) means no dispatch happened, e.g. the
-    /// InList didn't reach the FastField path (K ≤ 1024 routes to
-    /// AutomatonWeight which doesn't write the sink).
+    /// `StrategyTag::None as u8` (= 0) means no `TermSetWeight` ran on
+    /// this scan to write a tag — the EXPLAIN renderer falls back to
+    /// `=true` in that case.
     dynamic_filter_strategy: Arc<AtomicU8>,
 }
 
@@ -388,6 +388,7 @@ fn strategy_name(strategy: tantivy::query::StrategyTag) -> &'static str {
         StrategyTag::Gallop => "gallop",
         StrategyTag::Linear => "linear",
         StrategyTag::Bitset => "bitset_from_postings",
+        StrategyTag::Automaton => "automaton",
         StrategyTag::Empty => "empty",
     }
 }
@@ -403,11 +404,14 @@ impl DisplayAs for PgSearchScanPlan {
             write!(f, ", dynamic_filters={}", self.dynamic_filters.len())?;
         }
         if self.dynamic_filter_pushdown.load(Ordering::Relaxed) {
-            // Render a single token. When the strategy framework engaged
-            // (K > 1024 reached FastFieldTermSetWeight and select_strategy
-            // wrote the sink), the value is the strategy name. Otherwise
-            // (K ≤ 1024 routed via AutomatonWeight, which doesn't write the
-            // sink) it falls back to "true".
+            // Render a single token. `TermSetWeight` writes the chosen
+            // `StrategyTag` to the sink on every dispatch, so the value
+            // is the strategy name (`gallop` / `linear` /
+            // `bitset_from_postings` / `automaton` / `empty`). Falls
+            // back to `true` only when pushdown was indicated but no
+            // `TermSetWeight` ran to record a tag — e.g., the dynamic
+            // filter handled a non-TermSet shape, or the scan
+            // short-circuited before any segment was processed.
             let tag = self.dynamic_filter_strategy.load(Ordering::Relaxed);
             let strategy = tantivy::query::StrategyTag::try_from(tag)
                 .unwrap_or(tantivy::query::StrategyTag::None);

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -755,7 +755,6 @@ fn try_convert_in_list_to_query(
     // its decision into so EXPLAIN ANALYZE can report which strategy fired.
     let cfg = TermSetStrategyConfig {
         gallop_enabled: crate::gucs::term_set_gallop_enabled(),
-        gallop_max_density: crate::gucs::term_set_gallop_max_density(),
         bitset_max_density_unique: crate::gucs::term_set_bitset_max_density_unique(),
         bitset_max_density_multi: crate::gucs::term_set_bitset_max_density_multi(),
         strategy_sink,

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -744,21 +744,20 @@ fn try_convert_in_list_to_query(
         return None;
     }
 
-    // Build a strategy config from the paradedb.term_set_*_max_density GUCs
-    // so the sorted-segment gallop fast path is enabled by default but
-    // operators can override the densities or kill the optimization without
-    // a recompile. Defaults mirror TermSetStrategyConfig::default() in
-    // tantivy. The optional `strategy_sink` is a per-scan AtomicU8 that the
-    // planner stores its decision into so EXPLAIN ANALYZE can report which
-    // strategy fired.
-    // The four other density fields (posting/bitset/hash_probe/
-    // subsequent_bitset) gate strategies that route to TermSetDocSet via
-    // stubs in tantivy today, so leaving them at TermSetStrategyConfig's
-    // tantivy-side defaults via struct update syntax keeps behavior
-    // identical to a bare tantivy caller until follow-ups A and B land.
+    // Build a strategy config from the paradedb.term_set_* GUCs so the
+    // dispatch thresholds (kill switch, gallop density gate, the two
+    // first-column bitset density gates) can be tuned in production
+    // without a recompile. Defaults mirror `TermSetStrategyConfig::default()`
+    // in tantivy. `subsequent_bitset_max_density` is not exposed because
+    // it gates a branch tantivy doesn't reach in production today;
+    // leave it at the tantivy default via struct update syntax. The
+    // optional `strategy_sink` is a per-scan AtomicU8 the planner stores
+    // its decision into so EXPLAIN ANALYZE can report which strategy fired.
     let cfg = TermSetStrategyConfig {
         gallop_enabled: crate::gucs::term_set_gallop_enabled(),
         gallop_max_density: crate::gucs::term_set_gallop_max_density(),
+        bitset_max_density_unique: crate::gucs::term_set_bitset_max_density_unique(),
+        bitset_max_density_multi: crate::gucs::term_set_bitset_max_density_multi(),
         strategy_sink,
         ..TermSetStrategyConfig::default()
     };

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -49,7 +49,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
+                 :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
 (16 rows)
 
 SELECT t1.val, t2.val
@@ -80,11 +80,11 @@ LIMIT 10;
 -- dynamic_filter_pushdown=... EXPLAIN token reports the chosen strategy.
 --
 -- The test asserts BOTH dispatch outcomes:
---   2a. With default gallop_max_density (1/100), K/N is too dense for gallop
---       on this small corpus → linear strategy, EXPLAIN says
---       dynamic_filter_pushdown=linear.
---   2b. With paradedb.term_set_gallop_max_density set high enough to admit
---       this corpus, gallop fires → EXPLAIN says
+--   2a. With paradedb.term_set_gallop_max_density tightened to 1/100,
+--       K/N = 0.75 is too dense for gallop on this small corpus → linear
+--       strategy, EXPLAIN says dynamic_filter_pushdown=linear.
+--   2b. With paradedb.term_set_gallop_max_density at 1.0 (which is also
+--       the default — see gucs.rs), gallop fires → EXPLAIN says
 --       dynamic_filter_pushdown=gallop.
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
 DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
@@ -107,8 +107,11 @@ WITH (
 );
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
--- TEST 2a: default density. K/N = 0.75 ≥ 1/100, so gallop is rejected and
--- the planner lands on the LinearScan terminal.
+-- TEST 2a: tightened density. K/N = 0.75 > 1/100, so gallop is rejected and
+-- the planner lands on the LinearScan terminal. The current default
+-- gallop_max_density is 1.0 (admit on any sorted segment), so we have to
+-- explicitly tighten it to exercise the gallop-rejected branch.
+SET paradedb.term_set_gallop_max_density = 0.01;
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -157,9 +160,11 @@ LIMIT 10;
  val 5 | val 5
 (10 rows)
 
+RESET paradedb.term_set_gallop_max_density;
 -- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
--- now fires because K/N = 0.75 < 1.0. This is the path the DemandScience
--- workload would take in production once corpus size makes K/N << 1/100.
+-- now fires because K/N = 0.75 < 1.0. 1.0 is the production default; we
+-- restore it explicitly here for clarity even though the RESET above
+-- would have the same effect.
 SET paradedb.term_set_gallop_max_density = 1.0;
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -23,8 +23,11 @@ WITH (key_field = 'id', numeric_fields = '{"t1_id": {"fast": true}}');
 ANALYZE hash_t1;
 ANALYZE hash_t2;
 -- EXPLAIN ANALYZE to show HashJoin metrics.
--- Check in particular for dynamic_filter_pushdown=true, to indicate that dynamic filters
--- were pushed down into the Tantivy Query.
+-- Check in particular for the `dynamic_filter_pushdown=<strategy>` token (one of
+-- {gallop, linear, bitset_from_postings, automaton, empty}; falls back to `true`
+-- on the rare path where pushdown was indicated but no strategy tag was
+-- recorded), which signals dynamic filters were pushed down into the Tantivy
+-- query and reports the dispatched TermSet strategy.
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_t1 t1
@@ -80,11 +83,12 @@ LIMIT 10;
 -- dynamic_filter_pushdown=... EXPLAIN token reports the chosen strategy.
 --
 -- The test asserts BOTH dispatch outcomes:
---   2a. With paradedb.term_set_gallop_max_density tightened to 1/100,
---       K/N = 0.75 is too dense for gallop on this small corpus → linear
---       strategy, EXPLAIN says dynamic_filter_pushdown=linear.
---   2b. With paradedb.term_set_gallop_max_density at 1.0 (which is also
---       the default — see gucs.rs), gallop fires → EXPLAIN says
+--   2a. With paradedb.term_set_gallop_enabled = OFF, gallop is rejected
+--       via the kill-switch. K/N = 0.75 is also above both bitset
+--       density gates, so the planner falls through to LinearScan →
+--       EXPLAIN says dynamic_filter_pushdown=linear.
+--   2b. With paradedb.term_set_gallop_enabled at its default ON, gallop
+--       fires on this sorted segment → EXPLAIN says
 --       dynamic_filter_pushdown=gallop.
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
 DROP TABLE IF EXISTS hash_sorted_t2 CASCADE;
@@ -92,9 +96,9 @@ CREATE TABLE hash_sorted_t1 (id INTEGER PRIMARY KEY, val TEXT);
 CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
 -- t1: 1500 rows (clears the TermSetQuery FastField cardinality threshold of
 -- 1024 so the FastField dispatch path is reached).
--- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75,
--- which is too dense for the default gallop threshold (1/100 = 0.01) but
--- below the override used in TEST 2b (1.0).
+-- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75.
+-- TEST 2a flips `term_set_gallop_enabled` off to reject gallop via the
+-- kill-switch; TEST 2b leaves the default on so gallop fires.
 INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
 INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 2000) i;
 CREATE INDEX hash_sorted_t1_idx ON hash_sorted_t1 USING bm25 (id, val)
@@ -107,11 +111,10 @@ WITH (
 );
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
--- TEST 2a: tightened density. K/N = 0.75 > 1/100, so gallop is rejected and
--- the planner lands on the LinearScan terminal. The current default
--- gallop_max_density is 1.0 (admit on any sorted segment), so we have to
--- explicitly tighten it to exercise the gallop-rejected branch.
-SET paradedb.term_set_gallop_max_density = 0.01;
+-- TEST 2a: gallop kill-switch engaged. K/N = 0.75 is also above both
+-- bitset gates (1/2000 and 1/200), so dispatch falls through to
+-- LinearScan.
+SET paradedb.term_set_gallop_enabled = OFF;
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -160,12 +163,9 @@ LIMIT 10;
  val 5 | val 5
 (10 rows)
 
-RESET paradedb.term_set_gallop_max_density;
--- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
--- now fires because K/N = 0.75 < 1.0. 1.0 is the production default; we
--- restore it explicitly here for clarity even though the RESET above
--- would have the same effect.
-SET paradedb.term_set_gallop_max_density = 1.0;
+RESET paradedb.term_set_gallop_enabled;
+-- TEST 2b: default behavior. Same data, same query — `gallop_enabled`
+-- is ON by default, sorted segment + matching field → gallop fires.
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -214,7 +214,6 @@ LIMIT 10;
  val 5 | val 5
 (10 rows)
 
-RESET paradedb.term_set_gallop_max_density;
 -- =============================================================================
 -- TEST 3: paradedb.hash_join_inlist_pushdown_max_distinct_values = 0 disables
 -- =============================================================================
@@ -223,7 +222,6 @@ RESET paradedb.term_set_gallop_max_density;
 -- to hash-table map), so 0 disables the InList materialization path on both
 -- sides of the boundary. EXPLAIN should NOT show `dynamic_filter_pushdown=`.
 SET paradedb.hash_join_inlist_pushdown_max_distinct_values = 0;
-SET paradedb.term_set_gallop_max_density = 1.0;
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -253,7 +251,6 @@ LIMIT 10;
 (17 rows)
 
 RESET paradedb.hash_join_inlist_pushdown_max_distinct_values;
-RESET paradedb.term_set_gallop_max_density;
 -- =============================================================================
 -- CLEANUP
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -7,13 +7,14 @@
 -- Sizing (Option B from review):
 --   t1: 30,000 rows, three independent FK columns (fk_a sorted, fk_b/fk_c
 --   unsorted), all D = 1 within the corpus.
---   t2_a/b/c: 1,100 rows each (just over the FastField cardinality
---   threshold of 1024 so the FastFieldTermSetWeight dispatch path is
---   reached — below that, TermSetQuery routes to AutomatonWeight and
---   neither gallop nor smart-seek is exercised).
---   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. With
---   paradedb.term_set_gallop_max_density forced to 0.05 (vs the default
---   1/100 = 0.01), gallop is admitted on the sorted fk_a column.
+--   t2_a/b/c: 1,100 rows each, sized to put K well into the regime
+--   where the strategy framework picks a non-trivial dispatch on the
+--   inner scan (so the gallop + smart-seek path on fk_a is actually
+--   exercised against a meaningful inner workload).
+--   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. Gallop is
+--   admitted by default on the sorted fk_a column whenever the
+--   structural preconditions hold (sorted segment + matching field +
+--   `term_set_gallop_enabled` on).
 --   LIMIT 10 on each query is required for the ParadeDB Join Scan custom
 --   scan's cost model to pick it over a vanilla Hash Join (this also
 --   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
@@ -41,9 +42,6 @@ SET enable_nestloop = OFF;
 SET enable_mergejoin = OFF;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 SET paradedb.enable_join_custom_scan = ON;
--- Admit gallop on K/N ≈ 0.0367. The default 1/100 = 0.01 would reject
--- this corpus; the override mirrors TEST 2b in join_hash.sql.
-SET paradedb.term_set_gallop_max_density = 0.05;
 -- ===========================================================================
 -- Fixture
 -- ===========================================================================
@@ -373,7 +371,6 @@ DROP TABLE IF EXISTS t2_a CASCADE;
 DROP TABLE IF EXISTS t2_b CASCADE;
 DROP TABLE IF EXISTS t2_c CASCADE;
 RESET paradedb.term_set_gallop_enabled;
-RESET paradedb.term_set_gallop_max_density;
 RESET paradedb.enable_join_custom_scan;
 RESET enable_nestloop;
 RESET enable_mergejoin;

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -314,7 +314,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=301, output_bytes=4.7 KB, output_batches=1, rows_pruned=0, rows_scanned=301]
+           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=301, output_bytes=4.7 KB, output_batches=1, rows_pruned=0, rows_scanned=301]
 (21 rows)
 
 SET paradedb.term_set_gallop_enabled = OFF;

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -166,7 +166,7 @@ LIMIT 3;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
+           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
 (16 rows)
 
 -- =============================================================================
@@ -672,7 +672,7 @@ LIMIT 5;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=14.26 K, output_bytes=515.3 KB, output_batches=4, rows_pruned=15.74 K, rows_scanned=30.00 K]
+           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=14.26 K, output_bytes=515.3 KB, output_batches=4, rows_pruned=15.74 K, rows_scanned=30.00 K]
 (16 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/expected/term_set_dispatch.out
+++ b/pg_search/tests/pg_regress/expected/term_set_dispatch.out
@@ -86,8 +86,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=4.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -101,7 +101,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4},"is_datetime":false}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
 (16 rows)
@@ -130,8 +130,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 5
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=5.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -145,7 +145,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=5, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=5, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=5, build_mem_used=100, avg_fanout=100% (5/5), probe_hit_rate=100% (5/5)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":5},"is_datetime":false}}]}}, metrics=[output_rows=5, output_bytes=80.0 B, output_batches=1, rows_pruned=0, rows_scanned=5]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":5}}}]}}, metrics=[output_rows=5, output_bytes=80.0 B, output_batches=1, rows_pruned=0, rows_scanned=5]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5, output_bytes=120.0 B, output_batches=1, rows_pruned=0, rows_scanned=5]
 (16 rows)
@@ -174,8 +174,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 6
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=6.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=6.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -189,7 +189,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=6, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=6, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=6, input_batches=1, input_rows=6, build_mem_used=120, avg_fanout=100% (6/6), probe_hit_rate=100% (6/6)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":6},"is_datetime":false}}]}}, metrics=[output_rows=6, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":6}}}]}}, metrics=[output_rows=6, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
 (16 rows)
@@ -221,8 +221,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 50
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -236,7 +236,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=5.00 K, output_bytes=156.2 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=5.00 K, output_bytes=156.2 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=50, input_batches=1, input_rows=5.00 K, build_mem_used=1.00 K, avg_fanout=100% (5.00 K/5.00 K), probe_hit_rate=100% (5.00 K/5.00 K)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":50},"is_datetime":false}}]}}, metrics=[output_rows=50, output_bytes=800.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":50}}}]}}, metrics=[output_rows=50, output_bytes=800.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5.00 K, output_bytes=117.2 KB, output_batches=1, rows_pruned=0, rows_scanned=5.00 K]
 (16 rows)
@@ -270,8 +270,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 60
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -285,7 +285,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=1, input_rows=6.00 K, build_mem_used=1.20 K, avg_fanout=100% (6.00 K/6.00 K), probe_hit_rate=100% (6.00 K/6.00 K)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":60},"is_datetime":false}}]}}, metrics=[output_rows=60, output_bytes=960.0 B, output_batches=1, rows_pruned=0, rows_scanned=60]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":60}}}]}}, metrics=[output_rows=60, output_bytes=960.0 B, output_batches=1, rows_pruned=0, rows_scanned=60]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6.00 K, output_bytes=140.6 KB, output_batches=1, rows_pruned=0, rows_scanned=6.00 K]
 (16 rows)
@@ -320,8 +320,8 @@ FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
 ORDER BY ts_sorted.id ASC
 LIMIT 10;
-                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_sorted INNER ts_outer
@@ -335,7 +335,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=100, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=100, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=1, input_rows=100, build_mem_used=2.00 K, avg_fanout=100% (100/100), probe_hit_rate=100% (100/100)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100},"is_datetime":false}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1, rows_pruned=0, rows_scanned=100]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100}}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1, rows_pruned=0, rows_scanned=100]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=gallop, query="all", metrics=[output_rows=100, output_bytes=2.3 KB, output_batches=1, rows_pruned=0, rows_scanned=100]
 (16 rows)
@@ -370,8 +370,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=4.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -385,7 +385,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4},"is_datetime":false}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
 (16 rows)
@@ -402,8 +402,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 20
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -417,7 +417,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=20, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=20, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=20, input_batches=1, input_rows=20, build_mem_used=400, avg_fanout=100% (20/20), probe_hit_rate=100% (20/20)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":20},"is_datetime":false}}]}}, metrics=[output_rows=20, output_bytes=320.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":20}}}]}}, metrics=[output_rows=20, output_bytes=320.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=20, output_bytes=480.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
 (16 rows)
@@ -435,8 +435,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 40
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -450,7 +450,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=1, input_rows=4.00 K, build_mem_used=800, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":40},"is_datetime":false}}]}}, metrics=[output_rows=40, output_bytes=640.0 B, output_batches=1, rows_pruned=0, rows_scanned=40]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":40}}}]}}, metrics=[output_rows=40, output_bytes=640.0 B, output_batches=1, rows_pruned=0, rows_scanned=40]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4.00 K, output_bytes=93.8 KB, output_batches=1, rows_pruned=0, rows_scanned=4.00 K]
 (16 rows)
@@ -468,8 +468,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                            
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -483,7 +483,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=10.00 K, output_bytes=512.0 KB, output_batches=2]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=10.00 K, output_bytes=512.0 KB, output_batches=2, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=2, input_rows=10.00 K, build_mem_used=2.00 K, avg_fanout=100% (10.00 K/10.00 K), probe_hit_rate=100% (10.00 K/10.00 K)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100},"is_datetime":false}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1, rows_pruned=0, rows_scanned=100]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100}}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1, rows_pruned=0, rows_scanned=100]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (16 rows)
@@ -502,8 +502,8 @@ FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
 ORDER BY ts_sorted.id ASC
 LIMIT 10;
-                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=4.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
          Relation Tree: ts_sorted INNER ts_outer
@@ -517,7 +517,7 @@ LIMIT 10;
            :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4},"is_datetime":false}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
 (16 rows)

--- a/pg_search/tests/pg_regress/expected/term_set_dispatch.out
+++ b/pg_search/tests/pg_regress/expected/term_set_dispatch.out
@@ -30,9 +30,10 @@
 --
 --   bitset_max_density_unique = 1/2000 = 0.0005    (D=1 path)
 --   bitset_max_density_multi  = 1/200  = 0.005     (D≥2 path)
---   gallop_max_density        = 1.0                (no-op gate)
 --
 -- The bitset gates use <= so the threshold value itself admits bitset.
+-- Gallop has no density gate — it commits whenever the structural
+-- preconditions hold and `term_set_gallop_enabled` is on.
 -- Plan-stabilizing GUCs (mirror join_hash.sql).
 SET max_parallel_workers_per_gather = 0;
 SET enable_indexscan TO OFF;
@@ -311,9 +312,8 @@ LIMIT 10;
 -- ============================================================================
 -- TEST F: sorted segment admits Gallop at any density
 -- ============================================================================
--- ts_sorted is sorted ASC by fk, so the gallop precondition holds. With the
--- default gallop_max_density = 1.0, even K/N = 0.01 (K=100) admits gallop.
--- (Sanity check that the relaxed default didn't break the gallop path.)
+-- ts_sorted is sorted ASC by fk, so the gallop precondition holds.
+-- Gallop has no density gate, so even K/N = 0.01 (K=100) admits gallop.
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT ts_outer.id, ts_sorted.id
 FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk

--- a/pg_search/tests/pg_regress/expected/term_set_dispatch.out
+++ b/pg_search/tests/pg_regress/expected/term_set_dispatch.out
@@ -1,0 +1,537 @@
+-- Regression tests for the D-aware TermSet dispatch gates and the three
+-- paradedb.term_set_* density GUCs that drive them.
+--
+-- # Setup
+--
+-- Two inner-side tables expose the two D shapes the dispatcher cares about:
+--   - ts_unique: N=10000, fk = id, every value distinct → D = 1.
+--   - ts_multi : N=10000, fk = ((i-1) % 100) + 1     → dict_size = 100, D = 100.
+-- Plus one sorted variant for gallop coverage:
+--   - ts_sorted: N=10000, fk = id, sort_by = 'fk ASC'.
+--
+-- ts_outer (100 rows) is the hash-join build side. K is controlled per-test
+-- by `ts_outer.id <= K` on the build-side WHERE clause; the predicate filters
+-- ts_outer to K rows, the hash table has K entries, and those K ids get
+-- pushed into the inner scan as a TermSet of size K.
+--
+-- # Dispatch contract
+--
+-- Each inner-scan dispatch decision is captured as a token in the EXPLAIN
+-- ANALYZE plan:
+--
+--     PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=<strategy>, ...
+--
+-- where <strategy> ∈ {bitset_from_postings, linear, gallop, empty, true}.
+-- The captured EXPLAIN block in `expected/term_set_dispatch.out` is the
+-- assertion contract; the SELECT below it captures the row contents for
+-- correctness.
+--
+-- # Threshold defaults (matching tantivy's TermSetStrategyConfig)
+--
+--   bitset_max_density_unique = 1/2000 = 0.0005    (D=1 path)
+--   bitset_max_density_multi  = 1/200  = 0.005     (D≥2 path)
+--   gallop_max_density        = 1.0                (no-op gate)
+--
+-- The bitset gates use <= so the threshold value itself admits bitset.
+-- Plan-stabilizing GUCs (mirror join_hash.sql).
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+SET enable_nestloop = OFF;
+SET enable_mergejoin = OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan = ON;
+-- ============================================================================
+-- Fixtures
+-- ============================================================================
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+CREATE TABLE ts_outer (id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO ts_outer SELECT i, 'doc' FROM generate_series(1, 100) i;
+CREATE INDEX ts_outer_idx ON ts_outer USING bm25 (id, val)
+WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
+CREATE TABLE ts_unique (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_unique SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_unique_idx ON ts_unique USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+CREATE TABLE ts_multi (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_multi SELECT i, ((i - 1) % 100) + 1, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_multi_idx ON ts_multi USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+CREATE TABLE ts_sorted (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_sorted SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_sorted_idx ON ts_sorted USING bm25 (id, fk, val)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"fk": {"fast": true}}',
+    sort_by = 'fk ASC NULLS FIRST'
+);
+ANALYZE ts_outer;
+ANALYZE ts_unique;
+ANALYZE ts_multi;
+ANALYZE ts_sorted;
+-- ============================================================================
+-- TEST A: defaults check on a representative cell
+-- ============================================================================
+-- First test in the file: pin one cell against the un-overridden defaults so
+-- the test catches accidental default-value drift in TermSetStrategyConfig
+-- or the paradedb GUC initializers.
+--
+-- ts_unique with K=4 → K/N = 0.0004 < 0.0005 → admit bitset.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=4.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
+         Relation Tree: ts_unique INNER ts_outer
+         Join Cond: ts_outer.id = ts_unique.fk
+         Limit: 10
+         Order By: ts_unique.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1, row_replacements=4]
+           :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=4, output_bytes=128.1 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4},"is_datetime":false}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+(16 rows)
+
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+ id | id 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+(4 rows)
+
+-- ============================================================================
+-- TEST B: D=1 (unique) bitset gate, K/N just at the threshold
+-- ============================================================================
+-- K=5, N=10000 → K/N = 0.0005 = bitset_max_density_unique. The `<=` gate
+-- admits the threshold value itself, so this routes to bitset_from_postings.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 5
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=5.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=5.00 loops=1)
+         Relation Tree: ts_unique INNER ts_outer
+         Join Cond: ts_outer.id = ts_unique.fk
+         Limit: 10
+         Order By: ts_unique.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=5, output_bytes=160.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=5, output_bytes=160.0 B, output_batches=1, row_replacements=5]
+           :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=5, output_bytes=128.1 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=5, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=5, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=5, build_mem_used=100, avg_fanout=100% (5/5), probe_hit_rate=100% (5/5)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":5},"is_datetime":false}}]}}, metrics=[output_rows=5, output_bytes=80.0 B, output_batches=1, rows_pruned=0, rows_scanned=5]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5, output_bytes=120.0 B, output_batches=1, rows_pruned=0, rows_scanned=5]
+(16 rows)
+
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 5
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+ id | id 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+(5 rows)
+
+-- ============================================================================
+-- TEST C: D=1 (unique) bitset gate, K/N just above the threshold
+-- ============================================================================
+-- K=6, N=10000 → K/N = 0.0006 > 0.0005 → falls through to linear.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 6
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=6.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=6.00 loops=1)
+         Relation Tree: ts_unique INNER ts_outer
+         Join Cond: ts_outer.id = ts_unique.fk
+         Limit: 10
+         Order By: ts_unique.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=6, output_bytes=192.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=6, output_bytes=192.0 B, output_batches=1, row_replacements=6]
+           :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=6, output_bytes=128.1 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=6, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=6, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=6, input_batches=1, input_rows=6, build_mem_used=120, avg_fanout=100% (6/6), probe_hit_rate=100% (6/6)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":6},"is_datetime":false}}]}}, metrics=[output_rows=6, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+(16 rows)
+
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 6
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+ id | id 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+(6 rows)
+
+-- ============================================================================
+-- TEST D: D=100 (multi) bitset gate, K/N just at the threshold
+-- ============================================================================
+-- K=50, N=10000 → K/N = 0.005 = bitset_max_density_multi → bitset.
+-- ts_multi has D=100 so the dispatch site reads dict_size=100, computes
+-- D=100, and selects the multi gate.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 50
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: ts_multi INNER ts_outer
+         Join Cond: ts_outer.id = ts_multi.fk
+         Limit: 10
+         Order By: ts_multi.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=5.00 K, output_bytes=156.2 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=5.00 K, output_bytes=156.2 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=5.00 K, output_bytes=156.2 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=50, input_batches=1, input_rows=5.00 K, build_mem_used=1.00 K, avg_fanout=100% (5.00 K/5.00 K), probe_hit_rate=100% (5.00 K/5.00 K)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":50},"is_datetime":false}}]}}, metrics=[output_rows=50, output_bytes=800.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5.00 K, output_bytes=117.2 KB, output_batches=1, rows_pruned=0, rows_scanned=5.00 K]
+(16 rows)
+
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 50
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+ id | id 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+-- ============================================================================
+-- TEST E: D=100 (multi) bitset gate, K/N just above the threshold
+-- ============================================================================
+-- K=60, N=10000 → K/N = 0.006 > 0.005 → linear.
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 60
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: ts_multi INNER ts_outer
+         Join Cond: ts_outer.id = ts_multi.fk
+         Limit: 10
+         Order By: ts_multi.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=1, input_rows=6.00 K, build_mem_used=1.20 K, avg_fanout=100% (6.00 K/6.00 K), probe_hit_rate=100% (6.00 K/6.00 K)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":60},"is_datetime":false}}]}}, metrics=[output_rows=60, output_bytes=960.0 B, output_batches=1, rows_pruned=0, rows_scanned=60]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6.00 K, output_bytes=140.6 KB, output_batches=1, rows_pruned=0, rows_scanned=6.00 K]
+(16 rows)
+
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 60
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+ id | id 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+-- ============================================================================
+-- TEST F: sorted segment admits Gallop at any density
+-- ============================================================================
+-- ts_sorted is sorted ASC by fk, so the gallop precondition holds. With the
+-- default gallop_max_density = 1.0, even K/N = 0.01 (K=100) admits gallop.
+-- (Sanity check that the relaxed default didn't break the gallop path.)
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id ASC
+LIMIT 10;
+                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: ts_sorted INNER ts_outer
+         Join Cond: ts_outer.id = ts_sorted.fk
+         Limit: 10
+         Order By: ts_sorted.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[ts_sorted, ts_outer], metrics=[output_rows=100, output_bytes=129.6 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=100, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=100, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=1, input_rows=100, build_mem_used=2.00 K, avg_fanout=100% (100/100), probe_hit_rate=100% (100/100)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100},"is_datetime":false}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1, rows_pruned=0, rows_scanned=100]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=gallop, query="all", metrics=[output_rows=100, output_bytes=2.3 KB, output_batches=1, rows_pruned=0, rows_scanned=100]
+(16 rows)
+
+SELECT ts_outer.id, ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id ASC
+LIMIT 10;
+ id | id 
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
+
+-- ============================================================================
+-- TEST G: bitset_max_density_unique GUC override → linear at low K/N
+-- ============================================================================
+-- Even K=4 (default-admitted) routes to linear when the gate is forced to 0.
+SET paradedb.term_set_bitset_max_density_unique = 0.0;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=4.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
+         Relation Tree: ts_unique INNER ts_outer
+         Join Cond: ts_outer.id = ts_unique.fk
+         Limit: 10
+         Order By: ts_unique.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1, row_replacements=4]
+           :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=4, output_bytes=128.1 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4},"is_datetime":false}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+(16 rows)
+
+RESET paradedb.term_set_bitset_max_density_unique;
+-- ============================================================================
+-- TEST H: bitset_max_density_unique GUC override → bitset at high K/N
+-- ============================================================================
+-- K=20 (K/N = 0.002, normally linear) is admitted when the gate is widened.
+SET paradedb.term_set_bitset_max_density_unique = 1.0;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 20
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: ts_unique INNER ts_outer
+         Join Cond: ts_outer.id = ts_unique.fk
+         Limit: 10
+         Order By: ts_unique.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=20, output_bytes=128.3 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=20, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=20, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=20, input_batches=1, input_rows=20, build_mem_used=400, avg_fanout=100% (20/20), probe_hit_rate=100% (20/20)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":20},"is_datetime":false}}]}}, metrics=[output_rows=20, output_bytes=320.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=20, output_bytes=480.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+(16 rows)
+
+RESET paradedb.term_set_bitset_max_density_unique;
+-- ============================================================================
+-- TEST I: bitset_max_density_multi GUC override → linear at low K/N
+-- ============================================================================
+-- K=40 on ts_multi (K/N = 0.004, default-admitted at 1/200) goes to linear
+-- when the multi gate is forced to 0.
+SET paradedb.term_set_bitset_max_density_multi = 0.0;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 40
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: ts_multi INNER ts_outer
+         Join Cond: ts_outer.id = ts_multi.fk
+         Limit: 10
+         Order By: ts_multi.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.00 K, output_bytes=190.5 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=1, input_rows=4.00 K, build_mem_used=800, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":40},"is_datetime":false}}]}}, metrics=[output_rows=40, output_bytes=640.0 B, output_batches=1, rows_pruned=0, rows_scanned=40]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4.00 K, output_bytes=93.8 KB, output_batches=1, rows_pruned=0, rows_scanned=4.00 K]
+(16 rows)
+
+RESET paradedb.term_set_bitset_max_density_multi;
+-- ============================================================================
+-- TEST J: bitset_max_density_multi GUC override → bitset at high K/N
+-- ============================================================================
+-- K=100 on ts_multi (K/N = 0.01, default-linear) is admitted when the gate
+-- is widened.
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                            
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=10.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
+         Relation Tree: ts_multi INNER ts_outer
+         Join Cond: ts_outer.id = ts_multi.fk
+         Limit: 10
+         Order By: ts_multi.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=10.00 K, output_bytes=412.2 KB, output_batches=2]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=10.00 K, output_bytes=512.0 KB, output_batches=2]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=10.00 K, output_bytes=512.0 KB, output_batches=2, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=2, input_rows=10.00 K, build_mem_used=2.00 K, avg_fanout=100% (10.00 K/10.00 K), probe_hit_rate=100% (10.00 K/10.00 K)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100},"is_datetime":false}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1, rows_pruned=0, rows_scanned=100]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
+(16 rows)
+
+RESET paradedb.term_set_bitset_max_density_multi;
+-- ============================================================================
+-- TEST K: gallop_enabled = OFF on sorted segment falls through to D=1 gate
+-- ============================================================================
+-- Gallop is structurally admissible (ts_sorted is sort-matching) but the
+-- kill switch rejects it; dispatch then falls through to the unique-D
+-- bitset gate. K=4 (K/N = 0.0004) → bitset.
+SET paradedb.term_set_gallop_enabled = OFF;
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_sorted.id ASC
+LIMIT 10;
+                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit (actual rows=4.00 loops=1)
+   ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
+         Relation Tree: ts_sorted INNER ts_outer
+         Join Cond: ts_outer.id = ts_sorted.fk
+         Limit: 10
+         Order By: ts_sorted.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1]
+           :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1, row_replacements=4]
+           :     VisibilityFilterExec: tables=[ts_sorted, ts_outer], metrics=[output_rows=4, output_bytes=128.1 KB, output_batches=1]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_1@0, id@1, ctid_0@2, id@4], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4},"is_datetime":false}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+(16 rows)
+
+RESET paradedb.term_set_gallop_enabled;
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET enable_nestloop;
+RESET enable_mergejoin;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/expected/term_set_equivalence.out
+++ b/pg_search/tests/pg_regress/expected/term_set_equivalence.out
@@ -1,0 +1,215 @@
+-- Cross-strategy equivalence tests for the TermSet dispatch decision.
+--
+-- For each pair of strategies (bitset vs linear, gallop vs linear), this
+-- file runs the same query under each strategy by toggling the
+-- paradedb.term_set_*_max_density GUCs, captures the result into a temp
+-- table, and asserts the symmetric difference is empty via EXCEPT.
+--
+-- Mirrors the gallop_matches_linear pattern from join_hash_dynamic_filters_sparse.sql.
+-- This is the SQL-level analog of the tantivy-side proptest
+-- `bitset_equivalent_to_linear_scan` — the proptest covers algorithmic
+-- correctness with randomized inputs, this file pins the equivalence on
+-- representative production-shaped corpora.
+-- Plan-stabilizing GUCs.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+SET enable_nestloop = OFF;
+SET enable_mergejoin = OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan = ON;
+-- ============================================================================
+-- Fixtures
+-- ============================================================================
+-- Same shapes as term_set_dispatch.sql. K is controlled per-test via the
+-- `ts_outer.id <= K` predicate.
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+CREATE TABLE ts_outer (id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO ts_outer SELECT i, 'doc' FROM generate_series(1, 200) i;
+CREATE INDEX ts_outer_idx ON ts_outer USING bm25 (id, val)
+WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
+CREATE TABLE ts_unique (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_unique SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_unique_idx ON ts_unique USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+CREATE TABLE ts_multi (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_multi SELECT i, ((i - 1) % 100) + 1, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_multi_idx ON ts_multi USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+CREATE TABLE ts_sorted (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_sorted SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_sorted_idx ON ts_sorted USING bm25 (id, fk, val)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"fk": {"fast": true}}',
+    sort_by = 'fk ASC NULLS FIRST'
+);
+ANALYZE ts_outer;
+ANALYZE ts_unique;
+ANALYZE ts_multi;
+ANALYZE ts_sorted;
+-- ============================================================================
+-- Q1: bitset vs linear on a D=1 (unique) column
+-- ============================================================================
+-- Same join, same K=100, same expected row set. Force bitset by widening
+-- the unique gate, then force linear by closing it. The EXCEPT-based diff
+-- below must be empty.
+SET paradedb.term_set_bitset_max_density_unique = 1.0;
+DROP TABLE IF EXISTS result_q1_bitset;
+CREATE TEMP TABLE result_q1_bitset AS
+SELECT ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_unique.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: ts_outer, ts_unique)
+RESET paradedb.term_set_bitset_max_density_unique;
+SET paradedb.term_set_bitset_max_density_unique = 0.0;
+DROP TABLE IF EXISTS result_q1_linear;
+CREATE TEMP TABLE result_q1_linear AS
+SELECT ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_unique.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: ts_outer, ts_unique)
+RESET paradedb.term_set_bitset_max_density_unique;
+SELECT
+    (SELECT count(*) FROM result_q1_bitset) AS bitset_count,
+    (SELECT count(*) FROM result_q1_linear) AS linear_count,
+    (SELECT count(*) FROM result_q1_bitset) = (SELECT count(*) FROM result_q1_linear) AS counts_match;
+ bitset_count | linear_count | counts_match 
+--------------+--------------+--------------
+          100 |          100 | t
+(1 row)
+
+SELECT 'q1 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'bitset-only' AS source, id FROM result_q1_bitset
+    EXCEPT
+    SELECT 'bitset-only', id FROM result_q1_linear
+    UNION ALL
+    SELECT 'linear-only' AS source, id FROM result_q1_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q1_bitset
+) AS diff
+ORDER BY source, id;
+ check | source | id 
+-------+--------+----
+(0 rows)
+
+DROP TABLE result_q1_bitset;
+DROP TABLE result_q1_linear;
+-- ============================================================================
+-- Q2: bitset vs linear on a D=100 (multi) column
+-- ============================================================================
+-- Same shape as Q1 but on ts_multi. Higher K (200) so the multi gate is
+-- exercised on both sides of its threshold.
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+DROP TABLE IF EXISTS result_q2_bitset;
+CREATE TEMP TABLE result_q2_bitset AS
+SELECT ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 200
+ORDER BY ts_multi.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: ts_multi, ts_outer)
+RESET paradedb.term_set_bitset_max_density_multi;
+SET paradedb.term_set_bitset_max_density_multi = 0.0;
+DROP TABLE IF EXISTS result_q2_linear;
+CREATE TEMP TABLE result_q2_linear AS
+SELECT ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 200
+ORDER BY ts_multi.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: ts_multi, ts_outer)
+RESET paradedb.term_set_bitset_max_density_multi;
+SELECT
+    (SELECT count(*) FROM result_q2_bitset) AS bitset_count,
+    (SELECT count(*) FROM result_q2_linear) AS linear_count,
+    (SELECT count(*) FROM result_q2_bitset) = (SELECT count(*) FROM result_q2_linear) AS counts_match;
+ bitset_count | linear_count | counts_match 
+--------------+--------------+--------------
+        10000 |        10000 | t
+(1 row)
+
+SELECT 'q2 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'bitset-only' AS source, id FROM result_q2_bitset
+    EXCEPT
+    SELECT 'bitset-only', id FROM result_q2_linear
+    UNION ALL
+    SELECT 'linear-only' AS source, id FROM result_q2_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q2_bitset
+) AS diff
+ORDER BY source, id;
+ check | source | id 
+-------+--------+----
+(0 rows)
+
+DROP TABLE result_q2_bitset;
+DROP TABLE result_q2_linear;
+-- ============================================================================
+-- Q3: gallop vs linear on a sorted segment
+-- ============================================================================
+-- ts_sorted has sort_by=fk ASC so gallop is admissible. Compare gallop
+-- (default gallop_enabled=on) against linear (gallop disabled + both
+-- bitset gates closed, forcing fall-through to LinearScan).
+DROP TABLE IF EXISTS result_q3_gallop;
+CREATE TEMP TABLE result_q3_gallop AS
+SELECT ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: ts_outer, ts_sorted)
+SET paradedb.term_set_gallop_enabled = OFF;
+SET paradedb.term_set_bitset_max_density_unique = 0.0;
+SET paradedb.term_set_bitset_max_density_multi = 0.0;
+DROP TABLE IF EXISTS result_q3_linear;
+CREATE TEMP TABLE result_q3_linear AS
+SELECT ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: ts_outer, ts_sorted)
+RESET paradedb.term_set_gallop_enabled;
+RESET paradedb.term_set_bitset_max_density_unique;
+RESET paradedb.term_set_bitset_max_density_multi;
+SELECT
+    (SELECT count(*) FROM result_q3_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q3_linear) AS linear_count,
+    (SELECT count(*) FROM result_q3_gallop) = (SELECT count(*) FROM result_q3_linear) AS counts_match;
+ gallop_count | linear_count | counts_match 
+--------------+--------------+--------------
+          100 |          100 | t
+(1 row)
+
+SELECT 'q3 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'gallop-only' AS source, id FROM result_q3_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q3_linear
+    UNION ALL
+    SELECT 'linear-only' AS source, id FROM result_q3_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q3_gallop
+) AS diff
+ORDER BY source, id;
+ check | source | id 
+-------+--------+----
+(0 rows)
+
+DROP TABLE result_q3_gallop;
+DROP TABLE result_q3_linear;
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET enable_nestloop;
+RESET enable_mergejoin;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -167,7 +167,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=16.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
 (15 rows)
 
 -- =============================================================================

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -487,7 +487,7 @@ LIMIT 3;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
+           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
 (16 rows)
 
 SELECT f.id, f.title
@@ -534,7 +534,7 @@ LIMIT 3;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=true, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
+           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
 (16 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/sql/join_hash.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash.sql
@@ -59,11 +59,11 @@ LIMIT 10;
 -- dynamic_filter_pushdown=... EXPLAIN token reports the chosen strategy.
 --
 -- The test asserts BOTH dispatch outcomes:
---   2a. With default gallop_max_density (1/100), K/N is too dense for gallop
---       on this small corpus → linear strategy, EXPLAIN says
---       dynamic_filter_pushdown=linear.
---   2b. With paradedb.term_set_gallop_max_density set high enough to admit
---       this corpus, gallop fires → EXPLAIN says
+--   2a. With paradedb.term_set_gallop_max_density tightened to 1/100,
+--       K/N = 0.75 is too dense for gallop on this small corpus → linear
+--       strategy, EXPLAIN says dynamic_filter_pushdown=linear.
+--   2b. With paradedb.term_set_gallop_max_density at 1.0 (which is also
+--       the default — see gucs.rs), gallop fires → EXPLAIN says
 --       dynamic_filter_pushdown=gallop.
 
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
@@ -93,8 +93,12 @@ WITH (
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
 
--- TEST 2a: default density. K/N = 0.75 ≥ 1/100, so gallop is rejected and
--- the planner lands on the LinearScan terminal.
+-- TEST 2a: tightened density. K/N = 0.75 > 1/100, so gallop is rejected and
+-- the planner lands on the LinearScan terminal. The current default
+-- gallop_max_density is 1.0 (admit on any sorted segment), so we have to
+-- explicitly tighten it to exercise the gallop-rejected branch.
+SET paradedb.term_set_gallop_max_density = 0.01;
+
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_sorted_t1 t1
@@ -110,9 +114,12 @@ WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
 
+RESET paradedb.term_set_gallop_max_density;
+
 -- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
--- now fires because K/N = 0.75 < 1.0. This is the path the DemandScience
--- workload would take in production once corpus size makes K/N << 1/100.
+-- now fires because K/N = 0.75 < 1.0. 1.0 is the production default; we
+-- restore it explicitly here for clarity even though the RESET above
+-- would have the same effect.
 SET paradedb.term_set_gallop_max_density = 1.0;
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)

--- a/pg_search/tests/pg_regress/sql/join_hash.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash.sql
@@ -34,8 +34,11 @@ ANALYZE hash_t1;
 ANALYZE hash_t2;
 
 -- EXPLAIN ANALYZE to show HashJoin metrics.
--- Check in particular for dynamic_filter_pushdown=true, to indicate that dynamic filters
--- were pushed down into the Tantivy Query.
+-- Check in particular for the `dynamic_filter_pushdown=<strategy>` token (one of
+-- {gallop, linear, bitset_from_postings, automaton, empty}; falls back to `true`
+-- on the rare path where pushdown was indicated but no strategy tag was
+-- recorded), which signals dynamic filters were pushed down into the Tantivy
+-- query and reports the dispatched TermSet strategy.
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
 FROM hash_t1 t1
@@ -59,11 +62,12 @@ LIMIT 10;
 -- dynamic_filter_pushdown=... EXPLAIN token reports the chosen strategy.
 --
 -- The test asserts BOTH dispatch outcomes:
---   2a. With paradedb.term_set_gallop_max_density tightened to 1/100,
---       K/N = 0.75 is too dense for gallop on this small corpus → linear
---       strategy, EXPLAIN says dynamic_filter_pushdown=linear.
---   2b. With paradedb.term_set_gallop_max_density at 1.0 (which is also
---       the default — see gucs.rs), gallop fires → EXPLAIN says
+--   2a. With paradedb.term_set_gallop_enabled = OFF, gallop is rejected
+--       via the kill-switch. K/N = 0.75 is also above both bitset
+--       density gates, so the planner falls through to LinearScan →
+--       EXPLAIN says dynamic_filter_pushdown=linear.
+--   2b. With paradedb.term_set_gallop_enabled at its default ON, gallop
+--       fires on this sorted segment → EXPLAIN says
 --       dynamic_filter_pushdown=gallop.
 
 DROP TABLE IF EXISTS hash_sorted_t1 CASCADE;
@@ -74,9 +78,9 @@ CREATE TABLE hash_sorted_t2 (id INTEGER PRIMARY KEY, t1_id INTEGER, val TEXT);
 
 -- t1: 1500 rows (clears the TermSetQuery FastField cardinality threshold of
 -- 1024 so the FastField dispatch path is reached).
--- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75,
--- which is too dense for the default gallop threshold (1/100 = 0.01) but
--- below the override used in TEST 2b (1.0).
+-- t2: 2000 rows with t1_id repeating across 1..1500 — K/N = 1500/2000 = 0.75.
+-- TEST 2a flips `term_set_gallop_enabled` off to reject gallop via the
+-- kill-switch; TEST 2b leaves the default on so gallop fires.
 INSERT INTO hash_sorted_t1 SELECT i, 'val ' || i FROM generate_series(1, 1500) i;
 INSERT INTO hash_sorted_t2 SELECT i, ((i - 1) % 1500) + 1, 'val ' || i FROM generate_series(1, 2000) i;
 
@@ -93,11 +97,10 @@ WITH (
 ANALYZE hash_sorted_t1;
 ANALYZE hash_sorted_t2;
 
--- TEST 2a: tightened density. K/N = 0.75 > 1/100, so gallop is rejected and
--- the planner lands on the LinearScan terminal. The current default
--- gallop_max_density is 1.0 (admit on any sorted segment), so we have to
--- explicitly tighten it to exercise the gallop-rejected branch.
-SET paradedb.term_set_gallop_max_density = 0.01;
+-- TEST 2a: gallop kill-switch engaged. K/N = 0.75 is also above both
+-- bitset gates (1/2000 and 1/200), so dispatch falls through to
+-- LinearScan.
+SET paradedb.term_set_gallop_enabled = OFF;
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
@@ -114,13 +117,10 @@ WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
 
-RESET paradedb.term_set_gallop_max_density;
+RESET paradedb.term_set_gallop_enabled;
 
--- TEST 2b: density = 1.0 (admit any K < N). Same data, same query — gallop
--- now fires because K/N = 0.75 < 1.0. 1.0 is the production default; we
--- restore it explicitly here for clarity even though the RESET above
--- would have the same effect.
-SET paradedb.term_set_gallop_max_density = 1.0;
+-- TEST 2b: default behavior. Same data, same query — `gallop_enabled`
+-- is ON by default, sorted segment + matching field → gallop fires.
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
@@ -136,8 +136,6 @@ JOIN hash_sorted_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.id ASC
 LIMIT 10;
-
-RESET paradedb.term_set_gallop_max_density;
 
 -- =============================================================================
 -- TEST 3: paradedb.hash_join_inlist_pushdown_max_distinct_values = 0 disables
@@ -147,7 +145,6 @@ RESET paradedb.term_set_gallop_max_density;
 -- to hash-table map), so 0 disables the InList materialization path on both
 -- sides of the boundary. EXPLAIN should NOT show `dynamic_filter_pushdown=`.
 SET paradedb.hash_join_inlist_pushdown_max_distinct_values = 0;
-SET paradedb.term_set_gallop_max_density = 1.0;
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.val, t2.val
@@ -158,7 +155,6 @@ ORDER BY t1.id ASC
 LIMIT 10;
 
 RESET paradedb.hash_join_inlist_pushdown_max_distinct_values;
-RESET paradedb.term_set_gallop_max_density;
 
 -- =============================================================================
 -- CLEANUP

--- a/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
+++ b/pg_search/tests/pg_regress/sql/join_hash_dynamic_filters_sparse.sql
@@ -7,13 +7,14 @@
 -- Sizing (Option B from review):
 --   t1: 30,000 rows, three independent FK columns (fk_a sorted, fk_b/fk_c
 --   unsorted), all D = 1 within the corpus.
---   t2_a/b/c: 1,100 rows each (just over the FastField cardinality
---   threshold of 1024 so the FastFieldTermSetWeight dispatch path is
---   reached — below that, TermSetQuery routes to AutomatonWeight and
---   neither gallop nor smart-seek is exercised).
---   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. With
---   paradedb.term_set_gallop_max_density forced to 0.05 (vs the default
---   1/100 = 0.01), gallop is admitted on the sorted fk_a column.
+--   t2_a/b/c: 1,100 rows each, sized to put K well into the regime
+--   where the strategy framework picks a non-trivial dispatch on the
+--   inner scan (so the gallop + smart-seek path on fk_a is actually
+--   exercised against a meaningful inner workload).
+--   K/N for each pushed-down InList = 1100/30000 ≈ 0.0367. Gallop is
+--   admitted by default on the sorted fk_a column whenever the
+--   structural preconditions hold (sorted segment + matching field +
+--   `term_set_gallop_enabled` on).
 --   LIMIT 10 on each query is required for the ParadeDB Join Scan custom
 --   scan's cost model to pick it over a vanilla Hash Join (this also
 --   matches the shape of the existing TEST 1/2 fixtures in join_hash.sql).
@@ -44,9 +45,6 @@ SET enable_mergejoin = OFF;
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
 SET paradedb.enable_join_custom_scan = ON;
--- Admit gallop on K/N ≈ 0.0367. The default 1/100 = 0.01 would reject
--- this corpus; the override mirrors TEST 2b in join_hash.sql.
-SET paradedb.term_set_gallop_max_density = 0.05;
 
 -- ===========================================================================
 -- Fixture
@@ -319,7 +317,6 @@ DROP TABLE IF EXISTS t2_b CASCADE;
 DROP TABLE IF EXISTS t2_c CASCADE;
 
 RESET paradedb.term_set_gallop_enabled;
-RESET paradedb.term_set_gallop_max_density;
 RESET paradedb.enable_join_custom_scan;
 RESET enable_nestloop;
 RESET enable_mergejoin;

--- a/pg_search/tests/pg_regress/sql/term_set_dispatch.sql
+++ b/pg_search/tests/pg_regress/sql/term_set_dispatch.sql
@@ -1,0 +1,298 @@
+-- Regression tests for the D-aware TermSet dispatch gates and the three
+-- paradedb.term_set_* density GUCs that drive them.
+--
+-- # Setup
+--
+-- Two inner-side tables expose the two D shapes the dispatcher cares about:
+--   - ts_unique: N=10000, fk = id, every value distinct → D = 1.
+--   - ts_multi : N=10000, fk = ((i-1) % 100) + 1     → dict_size = 100, D = 100.
+-- Plus one sorted variant for gallop coverage:
+--   - ts_sorted: N=10000, fk = id, sort_by = 'fk ASC'.
+--
+-- ts_outer (100 rows) is the hash-join build side. K is controlled per-test
+-- by `ts_outer.id <= K` on the build-side WHERE clause; the predicate filters
+-- ts_outer to K rows, the hash table has K entries, and those K ids get
+-- pushed into the inner scan as a TermSet of size K.
+--
+-- # Dispatch contract
+--
+-- Each inner-scan dispatch decision is captured as a token in the EXPLAIN
+-- ANALYZE plan:
+--
+--     PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=<strategy>, ...
+--
+-- where <strategy> ∈ {bitset_from_postings, linear, gallop, empty, true}.
+-- The captured EXPLAIN block in `expected/term_set_dispatch.out` is the
+-- assertion contract; the SELECT below it captures the row contents for
+-- correctness.
+--
+-- # Threshold defaults (matching tantivy's TermSetStrategyConfig)
+--
+--   bitset_max_density_unique = 1/2000 = 0.0005    (D=1 path)
+--   bitset_max_density_multi  = 1/200  = 0.005     (D≥2 path)
+--   gallop_max_density        = 1.0                (no-op gate)
+--
+-- The bitset gates use <= so the threshold value itself admits bitset.
+
+-- Plan-stabilizing GUCs (mirror join_hash.sql).
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+SET enable_nestloop = OFF;
+SET enable_mergejoin = OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan = ON;
+
+-- ============================================================================
+-- Fixtures
+-- ============================================================================
+
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+
+CREATE TABLE ts_outer (id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO ts_outer SELECT i, 'doc' FROM generate_series(1, 100) i;
+CREATE INDEX ts_outer_idx ON ts_outer USING bm25 (id, val)
+WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
+
+CREATE TABLE ts_unique (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_unique SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_unique_idx ON ts_unique USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+
+CREATE TABLE ts_multi (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_multi SELECT i, ((i - 1) % 100) + 1, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_multi_idx ON ts_multi USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+
+CREATE TABLE ts_sorted (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_sorted SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_sorted_idx ON ts_sorted USING bm25 (id, fk, val)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"fk": {"fast": true}}',
+    sort_by = 'fk ASC NULLS FIRST'
+);
+
+ANALYZE ts_outer;
+ANALYZE ts_unique;
+ANALYZE ts_multi;
+ANALYZE ts_sorted;
+
+-- ============================================================================
+-- TEST A: defaults check on a representative cell
+-- ============================================================================
+-- First test in the file: pin one cell against the un-overridden defaults so
+-- the test catches accidental default-value drift in TermSetStrategyConfig
+-- or the paradedb GUC initializers.
+--
+-- ts_unique with K=4 → K/N = 0.0004 < 0.0005 → admit bitset.
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+-- ============================================================================
+-- TEST B: D=1 (unique) bitset gate, K/N just at the threshold
+-- ============================================================================
+-- K=5, N=10000 → K/N = 0.0005 = bitset_max_density_unique. The `<=` gate
+-- admits the threshold value itself, so this routes to bitset_from_postings.
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 5
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 5
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+-- ============================================================================
+-- TEST C: D=1 (unique) bitset gate, K/N just above the threshold
+-- ============================================================================
+-- K=6, N=10000 → K/N = 0.0006 > 0.0005 → falls through to linear.
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 6
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 6
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+-- ============================================================================
+-- TEST D: D=100 (multi) bitset gate, K/N just at the threshold
+-- ============================================================================
+-- K=50, N=10000 → K/N = 0.005 = bitset_max_density_multi → bitset.
+-- ts_multi has D=100 so the dispatch site reads dict_size=100, computes
+-- D=100, and selects the multi gate.
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 50
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 50
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+
+-- ============================================================================
+-- TEST E: D=100 (multi) bitset gate, K/N just above the threshold
+-- ============================================================================
+-- K=60, N=10000 → K/N = 0.006 > 0.005 → linear.
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 60
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 60
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+
+-- ============================================================================
+-- TEST F: sorted segment admits Gallop at any density
+-- ============================================================================
+-- ts_sorted is sorted ASC by fk, so the gallop precondition holds. With the
+-- default gallop_max_density = 1.0, even K/N = 0.01 (K=100) admits gallop.
+-- (Sanity check that the relaxed default didn't break the gallop path.)
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id ASC
+LIMIT 10;
+
+SELECT ts_outer.id, ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id ASC
+LIMIT 10;
+
+-- ============================================================================
+-- TEST G: bitset_max_density_unique GUC override → linear at low K/N
+-- ============================================================================
+-- Even K=4 (default-admitted) routes to linear when the gate is forced to 0.
+
+SET paradedb.term_set_bitset_max_density_unique = 0.0;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+RESET paradedb.term_set_bitset_max_density_unique;
+
+-- ============================================================================
+-- TEST H: bitset_max_density_unique GUC override → bitset at high K/N
+-- ============================================================================
+-- K=20 (K/N = 0.002, normally linear) is admitted when the gate is widened.
+
+SET paradedb.term_set_bitset_max_density_unique = 1.0;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 20
+ORDER BY ts_unique.id ASC
+LIMIT 10;
+
+RESET paradedb.term_set_bitset_max_density_unique;
+
+-- ============================================================================
+-- TEST I: bitset_max_density_multi GUC override → linear at low K/N
+-- ============================================================================
+-- K=40 on ts_multi (K/N = 0.004, default-admitted at 1/200) goes to linear
+-- when the multi gate is forced to 0.
+
+SET paradedb.term_set_bitset_max_density_multi = 0.0;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 40
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+
+RESET paradedb.term_set_bitset_max_density_multi;
+
+-- ============================================================================
+-- TEST J: bitset_max_density_multi GUC override → bitset at high K/N
+-- ============================================================================
+-- K=100 on ts_multi (K/N = 0.01, default-linear) is admitted when the gate
+-- is widened.
+
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_multi.id ASC
+LIMIT 10;
+
+RESET paradedb.term_set_bitset_max_density_multi;
+
+-- ============================================================================
+-- TEST K: gallop_enabled = OFF on sorted segment falls through to D=1 gate
+-- ============================================================================
+-- Gallop is structurally admissible (ts_sorted is sort-matching) but the
+-- kill switch rejects it; dispatch then falls through to the unique-D
+-- bitset gate. K=4 (K/N = 0.0004) → bitset.
+
+SET paradedb.term_set_gallop_enabled = OFF;
+
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT ts_outer.id, ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
+ORDER BY ts_sorted.id ASC
+LIMIT 10;
+
+RESET paradedb.term_set_gallop_enabled;
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET enable_nestloop;
+RESET enable_mergejoin;
+RESET paradedb.enable_join_custom_scan;

--- a/pg_search/tests/pg_regress/sql/term_set_dispatch.sql
+++ b/pg_search/tests/pg_regress/sql/term_set_dispatch.sql
@@ -30,9 +30,10 @@
 --
 --   bitset_max_density_unique = 1/2000 = 0.0005    (D=1 path)
 --   bitset_max_density_multi  = 1/200  = 0.005     (D≥2 path)
---   gallop_max_density        = 1.0                (no-op gate)
 --
 -- The bitset gates use <= so the threshold value itself admits bitset.
+-- Gallop has no density gate — it commits whenever the structural
+-- preconditions hold and `term_set_gallop_enabled` is on.
 
 -- Plan-stabilizing GUCs (mirror join_hash.sql).
 SET max_parallel_workers_per_gather = 0;
@@ -181,9 +182,8 @@ LIMIT 10;
 -- ============================================================================
 -- TEST F: sorted segment admits Gallop at any density
 -- ============================================================================
--- ts_sorted is sorted ASC by fk, so the gallop precondition holds. With the
--- default gallop_max_density = 1.0, even K/N = 0.01 (K=100) admits gallop.
--- (Sanity check that the relaxed default didn't break the gallop path.)
+-- ts_sorted is sorted ASC by fk, so the gallop precondition holds.
+-- Gallop has no density gate, so even K/N = 0.01 (K=100) admits gallop.
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT ts_outer.id, ts_sorted.id

--- a/pg_search/tests/pg_regress/sql/term_set_equivalence.sql
+++ b/pg_search/tests/pg_regress/sql/term_set_equivalence.sql
@@ -1,0 +1,212 @@
+-- Cross-strategy equivalence tests for the TermSet dispatch decision.
+--
+-- For each pair of strategies (bitset vs linear, gallop vs linear), this
+-- file runs the same query under each strategy by toggling the
+-- paradedb.term_set_*_max_density GUCs, captures the result into a temp
+-- table, and asserts the symmetric difference is empty via EXCEPT.
+--
+-- Mirrors the gallop_matches_linear pattern from join_hash_dynamic_filters_sparse.sql.
+-- This is the SQL-level analog of the tantivy-side proptest
+-- `bitset_equivalent_to_linear_scan` — the proptest covers algorithmic
+-- correctness with randomized inputs, this file pins the equivalence on
+-- representative production-shaped corpora.
+
+-- Plan-stabilizing GUCs.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan TO OFF;
+SET enable_nestloop = OFF;
+SET enable_mergejoin = OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_join_custom_scan = ON;
+
+-- ============================================================================
+-- Fixtures
+-- ============================================================================
+-- Same shapes as term_set_dispatch.sql. K is controlled per-test via the
+-- `ts_outer.id <= K` predicate.
+
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+
+CREATE TABLE ts_outer (id INTEGER PRIMARY KEY, val TEXT);
+INSERT INTO ts_outer SELECT i, 'doc' FROM generate_series(1, 200) i;
+CREATE INDEX ts_outer_idx ON ts_outer USING bm25 (id, val)
+WITH (key_field = 'id', text_fields = '{"val": {"fast": true}}');
+
+CREATE TABLE ts_unique (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_unique SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_unique_idx ON ts_unique USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+
+CREATE TABLE ts_multi (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_multi SELECT i, ((i - 1) % 100) + 1, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_multi_idx ON ts_multi USING bm25 (id, fk, val)
+WITH (key_field = 'id', numeric_fields = '{"fk": {"fast": true}}');
+
+CREATE TABLE ts_sorted (id INTEGER PRIMARY KEY, fk INTEGER, val TEXT);
+INSERT INTO ts_sorted SELECT i, i, 'doc' FROM generate_series(1, 10000) i;
+CREATE INDEX ts_sorted_idx ON ts_sorted USING bm25 (id, fk, val)
+WITH (
+    key_field = 'id',
+    numeric_fields = '{"fk": {"fast": true}}',
+    sort_by = 'fk ASC NULLS FIRST'
+);
+
+ANALYZE ts_outer;
+ANALYZE ts_unique;
+ANALYZE ts_multi;
+ANALYZE ts_sorted;
+
+-- ============================================================================
+-- Q1: bitset vs linear on a D=1 (unique) column
+-- ============================================================================
+-- Same join, same K=100, same expected row set. Force bitset by widening
+-- the unique gate, then force linear by closing it. The EXCEPT-based diff
+-- below must be empty.
+
+SET paradedb.term_set_bitset_max_density_unique = 1.0;
+DROP TABLE IF EXISTS result_q1_bitset;
+CREATE TEMP TABLE result_q1_bitset AS
+SELECT ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_unique.id;
+RESET paradedb.term_set_bitset_max_density_unique;
+
+SET paradedb.term_set_bitset_max_density_unique = 0.0;
+DROP TABLE IF EXISTS result_q1_linear;
+CREATE TEMP TABLE result_q1_linear AS
+SELECT ts_unique.id
+FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_unique.id;
+RESET paradedb.term_set_bitset_max_density_unique;
+
+SELECT
+    (SELECT count(*) FROM result_q1_bitset) AS bitset_count,
+    (SELECT count(*) FROM result_q1_linear) AS linear_count,
+    (SELECT count(*) FROM result_q1_bitset) = (SELECT count(*) FROM result_q1_linear) AS counts_match;
+
+SELECT 'q1 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'bitset-only' AS source, id FROM result_q1_bitset
+    EXCEPT
+    SELECT 'bitset-only', id FROM result_q1_linear
+    UNION ALL
+    SELECT 'linear-only' AS source, id FROM result_q1_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q1_bitset
+) AS diff
+ORDER BY source, id;
+
+DROP TABLE result_q1_bitset;
+DROP TABLE result_q1_linear;
+
+-- ============================================================================
+-- Q2: bitset vs linear on a D=100 (multi) column
+-- ============================================================================
+-- Same shape as Q1 but on ts_multi. Higher K (200) so the multi gate is
+-- exercised on both sides of its threshold.
+
+SET paradedb.term_set_bitset_max_density_multi = 1.0;
+DROP TABLE IF EXISTS result_q2_bitset;
+CREATE TEMP TABLE result_q2_bitset AS
+SELECT ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 200
+ORDER BY ts_multi.id;
+RESET paradedb.term_set_bitset_max_density_multi;
+
+SET paradedb.term_set_bitset_max_density_multi = 0.0;
+DROP TABLE IF EXISTS result_q2_linear;
+CREATE TEMP TABLE result_q2_linear AS
+SELECT ts_multi.id
+FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 200
+ORDER BY ts_multi.id;
+RESET paradedb.term_set_bitset_max_density_multi;
+
+SELECT
+    (SELECT count(*) FROM result_q2_bitset) AS bitset_count,
+    (SELECT count(*) FROM result_q2_linear) AS linear_count,
+    (SELECT count(*) FROM result_q2_bitset) = (SELECT count(*) FROM result_q2_linear) AS counts_match;
+
+SELECT 'q2 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'bitset-only' AS source, id FROM result_q2_bitset
+    EXCEPT
+    SELECT 'bitset-only', id FROM result_q2_linear
+    UNION ALL
+    SELECT 'linear-only' AS source, id FROM result_q2_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q2_bitset
+) AS diff
+ORDER BY source, id;
+
+DROP TABLE result_q2_bitset;
+DROP TABLE result_q2_linear;
+
+-- ============================================================================
+-- Q3: gallop vs linear on a sorted segment
+-- ============================================================================
+-- ts_sorted has sort_by=fk ASC so gallop is admissible. Compare gallop
+-- (default gallop_enabled=on) against linear (gallop disabled + both
+-- bitset gates closed, forcing fall-through to LinearScan).
+
+DROP TABLE IF EXISTS result_q3_gallop;
+CREATE TEMP TABLE result_q3_gallop AS
+SELECT ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id;
+
+SET paradedb.term_set_gallop_enabled = OFF;
+SET paradedb.term_set_bitset_max_density_unique = 0.0;
+SET paradedb.term_set_bitset_max_density_multi = 0.0;
+DROP TABLE IF EXISTS result_q3_linear;
+CREATE TEMP TABLE result_q3_linear AS
+SELECT ts_sorted.id
+FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
+WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
+ORDER BY ts_sorted.id;
+RESET paradedb.term_set_gallop_enabled;
+RESET paradedb.term_set_bitset_max_density_unique;
+RESET paradedb.term_set_bitset_max_density_multi;
+
+SELECT
+    (SELECT count(*) FROM result_q3_gallop) AS gallop_count,
+    (SELECT count(*) FROM result_q3_linear) AS linear_count,
+    (SELECT count(*) FROM result_q3_gallop) = (SELECT count(*) FROM result_q3_linear) AS counts_match;
+
+SELECT 'q3 diff (must be empty)' AS check, source, id
+FROM (
+    SELECT 'gallop-only' AS source, id FROM result_q3_gallop
+    EXCEPT
+    SELECT 'gallop-only', id FROM result_q3_linear
+    UNION ALL
+    SELECT 'linear-only' AS source, id FROM result_q3_linear
+    EXCEPT
+    SELECT 'linear-only', id FROM result_q3_gallop
+) AS diff
+ORDER BY source, id;
+
+DROP TABLE result_q3_gallop;
+DROP TABLE result_q3_linear;
+
+-- ============================================================================
+-- Cleanup
+-- ============================================================================
+
+DROP TABLE IF EXISTS ts_outer CASCADE;
+DROP TABLE IF EXISTS ts_unique CASCADE;
+DROP TABLE IF EXISTS ts_multi CASCADE;
+DROP TABLE IF EXISTS ts_sorted CASCADE;
+
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET enable_nestloop;
+RESET enable_mergejoin;
+RESET paradedb.enable_join_custom_scan;


### PR DESCRIPTION
Bumps `tantivy` + `tantivy-tokenizer-api` rev to pick up
- https://github.com/paradedb/tantivy/pull/141

This turns `BitsetFromPostings` into a real TermSet dispatch strategy backed by a new batched SSTable dictionary lookup API, adds D-aware (unique vs non-unique) gating, relaxes Gallop admission on sorted segments, and unifies the fast-field and inverted-index dispatch paths under a single `TermSetWeight`.

Speedups on the dispatch hot path (full bench matrix in the upstream PR):

| Cell | K/N | Before | After | Speedup |
|---|---|---|---|---|
| PK 1M K=10K, sorted | 0.01 | 4.44 ms (Linear) | 1.09 ms (Gallop) | 4.07× |
| LowFk 20M K=1K, unsorted | 5e-5 | 58.7 ms (Linear) | 2.47 ms (Bitset) | 23.8× |
| LowFk 20M K=10K, unsorted | 5e-4 | 59.9 ms (Linear) | 8.01 ms (Bitset) | 7.48× |

In paradedb this lands as a perf improvement for any query plan that
emits a TermSet pushdown — primarily joins using dynamic filter
pushdown, and `IN (...)` filters on indexed columns.

### Required source changes

- `execution_plan.rs`: new `StrategyTag::Automaton => "automaton"` match arm
  for the new variant introduced in https://github.com/paradedb/tantivy/pull/141
- `gucs.rs`, `pre_filter.rs`: removed `gallop_max_density` (dropped upstream;
  `gallop_enabled` remains as the kill switch)

### Behavior change worth flagging (user-visible)

- `dynamic_filter_pushdown=*` in EXPLAIN output widens its value space.
 Previously: `{true, false}`. Now: `{gallop, bitset_from_postings, linear,
automaton, empty, true (rare fallback), false}`. 

The unified `TermSetWeight` routes non-fast indexed text fields through the strategy framework, so EXPLAIN now reports the actual strategy name instead of the generic `=true` "not-engaged" marker. Anyone parsing this token downstream (dashboards, ops scripts) sees additional values; no semantic changes to the planner's pushdown decisions themselves.