### PR TITLE
feat(mpp): dispatch-flip plumbing — leader ships subplans, worker receives them (behind GUC)

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -145,14 +145,6 @@ static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// `SET log_min_messages = DEBUG1` but invisible to CI's default WARNING capture.
 static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 
-/// Transitional opt-in for the dispatch-flip's Phase 4 receive path. When ON, the MPP worker's
-/// `ProducerTaskRegistry::prepare_task` consumes the leader-shipped subplan from
-/// `shipped_subplans` instead of building one locally from `stage_plans`. Default OFF because
-/// today's codec emits empty `Vec<ScanState>` for `PgSearchScanPlan` — a follow-up commit will
-/// add per-`PgSearchScanPlan` state reconstruction on the worker before this is safe to enable
-/// by default. CI and bench keep this off until that lands.
-static MPP_USE_SHIPPED_SUBPLANS: GucSetting<bool> = GucSetting::<bool>::new(false);
-
 /// Total number of MPP participants (leader + workers). Default 4 splits
 /// scan + shuffle + partial-aggregate work across 4 processes. PG's
 /// `max_parallel_workers_per_gather` still caps the actual worker count
@@ -569,20 +561,6 @@ pub fn init() {
         GucFlags::default(),
     );
 
-    GucRegistry::define_bool_guc(
-        c"paradedb.mpp_use_shipped_subplans",
-        c"Opt into the dispatch-flip's leader-shipped subplan path",
-        c"When enabled, the MPP worker's `ProducerTaskRegistry` consumes the per-(stage, task) \
-          subplan the leader ships via Subplan frames instead of re-building it from the \
-          locally-walked physical plan. Transitional knob: the physical codec's PgSearchScan \
-          path returns an empty `Vec<ScanState>` today, so executing a shipped subplan against \
-          a real query returns zero rows. A follow-up commit lands the per-PgSearchScan state \
-          reconstruction step; until then this is off in production and CI.",
-        &MPP_USE_SHIPPED_SUBPLANS,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
     GucRegistry::define_int_guc(
         c"paradedb.mpp_worker_count",
         c"Total MPP participants (leader + parallel workers)",
@@ -810,10 +788,6 @@ pub fn mpp_debug() -> bool {
 
 pub fn mpp_trace() -> bool {
     MPP_TRACE.get()
-}
-
-pub fn mpp_use_shipped_subplans() -> bool {
-    MPP_USE_SHIPPED_SUBPLANS.get()
 }
 
 pub fn mpp_worker_count() -> i32 {

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -145,6 +145,14 @@ static MPP_DEBUG: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// `SET log_min_messages = DEBUG1` but invisible to CI's default WARNING capture.
 static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+/// Transitional opt-in for the dispatch-flip's Phase 4 receive path. When ON, the MPP worker's
+/// `ProducerTaskRegistry::prepare_task` consumes the leader-shipped subplan from
+/// `shipped_subplans` instead of building one locally from `stage_plans`. Default OFF because
+/// today's codec emits empty `Vec<ScanState>` for `PgSearchScanPlan` — a follow-up commit will
+/// add per-`PgSearchScanPlan` state reconstruction on the worker before this is safe to enable
+/// by default. CI and bench keep this off until that lands.
+static MPP_USE_SHIPPED_SUBPLANS: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// Total number of MPP participants (leader + workers). Default 4 splits
 /// scan + shuffle + partial-aggregate work across 4 processes. PG's
 /// `max_parallel_workers_per_gather` still caps the actual worker count
@@ -561,6 +569,20 @@ pub fn init() {
         GucFlags::default(),
     );
 
+    GucRegistry::define_bool_guc(
+        c"paradedb.mpp_use_shipped_subplans",
+        c"Opt into the dispatch-flip's leader-shipped subplan path",
+        c"When enabled, the MPP worker's `ProducerTaskRegistry` consumes the per-(stage, task) \
+          subplan the leader ships via Subplan frames instead of re-building it from the \
+          locally-walked physical plan. Transitional knob: the physical codec's PgSearchScan \
+          path returns an empty `Vec<ScanState>` today, so executing a shipped subplan against \
+          a real query returns zero rows. A follow-up commit lands the per-PgSearchScan state \
+          reconstruction step; until then this is off in production and CI.",
+        &MPP_USE_SHIPPED_SUBPLANS,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
     GucRegistry::define_int_guc(
         c"paradedb.mpp_worker_count",
         c"Total MPP participants (leader + parallel workers)",
@@ -788,6 +810,10 @@ pub fn mpp_debug() -> bool {
 
 pub fn mpp_trace() -> bool {
     MPP_TRACE.get()
+}
+
+pub fn mpp_use_shipped_subplans() -> bool {
+    MPP_USE_SHIPPED_SUBPLANS.get()
 }
 
 pub fn mpp_worker_count() -> i32 {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1639,17 +1639,12 @@ impl AggregateScan {
 
             // MPP leader: walk the distributed physical plan and ship every nested per-(stage,
             // task) producer subplan to its owning worker via Subplan frames before kicking off
-            // local execution. Gated behind `paradedb.mpp_use_shipped_subplans` because the
-            // codec doesn't yet know how to encode DF-D wrapper nodes (`BroadcastExec`,
-            // `NetworkBroadcastExec`, `NetworkShuffleExec`) that appear in prepared subplans —
-            // and even if it did, the worker-side consume path is gated by the same GUC, so
-            // shipping when the GUC is off is just dead work that surfaces as an error on real
-            // queries. The follow-up commit that adds DF-D codec coverage + flips the GUC
-            // default also lifts this gate.
-            if let Some(mesh) = leader_mesh
-                .as_ref()
-                .filter(|_| crate::gucs::mpp_use_shipped_subplans())
-            {
+            // local execution. Workers stash the decoded plans in their ProducerTaskRegistry
+            // and `prepare_task` prefers them over the local re-plan path. The gate is
+            // `leader_mesh.is_some()` — true exactly when `enable_mpp` is on AND the leader
+            // setup succeeded — so no separate dispatch-flip knob; on for every MPP query,
+            // off otherwise.
+            if let Some(mesh) = leader_mesh.as_ref() {
                 if let Err(e) =
                     crate::postgres::customscan::mpp::producer_service::ship_subplans_to_workers(
                         &physical_plan,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1639,12 +1639,17 @@ impl AggregateScan {
 
             // MPP leader: walk the distributed physical plan and ship every nested per-(stage,
             // task) producer subplan to its owning worker via Subplan frames before kicking off
-            // local execution. Workers stash the decoded plans in their ProducerTaskRegistry and
-            // skip the re-plan step when a follow-up Request arrives. No-op for non-MPP plans
-            // (the helper returns early when StagePlans is empty). The Phase 3 commit on this
-            // branch wires the worker-side SubplanHandler; until then this commit silently
-            // ships bytes that workers' drain consumes and discards.
-            if let Some(mesh) = leader_mesh.as_ref() {
+            // local execution. Gated behind `paradedb.mpp_use_shipped_subplans` because the
+            // codec doesn't yet know how to encode DF-D wrapper nodes (`BroadcastExec`,
+            // `NetworkBroadcastExec`, `NetworkShuffleExec`) that appear in prepared subplans —
+            // and even if it did, the worker-side consume path is gated by the same GUC, so
+            // shipping when the GUC is off is just dead work that surfaces as an error on real
+            // queries. The follow-up commit that adds DF-D codec coverage + flips the GUC
+            // default also lifts this gate.
+            if let Some(mesh) = leader_mesh
+                .as_ref()
+                .filter(|_| crate::gucs::mpp_use_shipped_subplans())
+            {
                 if let Err(e) =
                     crate::postgres::customscan::mpp::producer_service::ship_subplans_to_workers(
                         &physical_plan,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1573,34 +1573,42 @@ impl AggregateScan {
             // `NetworkShuffleExec`s use our `ShmMqWorkerTransport` to read
             // from worker queues at execute time. Otherwise: existing serial
             // session context.
-            let ctx = match df_state.mpp.as_ref() {
-                Some(scan_state::MppExecState::Leader(leader)) => {
-                    // CustomScan parallel exec doesn't guarantee that PG
-                    // launches every worker we requested at planning time
-                    // (other queries can hold all worker slots, etc.). The
-                    // unattached `shm_mq` slots stay in init-state, the
-                    // cooperative pull never sees `Detached`, and the leader
-                    // hangs on the missing partitions. Fail loudly instead
-                    // and ask the user to retry until #5061 picks a long-term
-                    // shape (resize the mesh at exec start, or move off
-                    // CustomScan parallel workers).
-                    let pcxt = leader.pcxt;
-                    if !pcxt.is_null() {
-                        let launched = unsafe { (*pcxt).nworkers_launched } as u32;
-                        let expected = producer_worker_count();
-                        if launched < expected {
-                            pgrx::error!(
-                                "mpp aggregate: PG launched {launched} of {expected} requested \
-                                 parallel workers; missing slots would hang the query. Retry, or \
-                                 raise `max_parallel_workers` / `max_parallel_workers_per_gather` \
-                                 so PG can launch the full set. Long-term fix tracked in \
-                                 https://github.com/paradedb/paradedb/issues/5061."
-                            );
+            // Capture the leader mesh up front; we need it both for the session-context build
+            // AND for shipping subplans once the physical plan exists.
+            let leader_mesh: Option<Arc<crate::postgres::customscan::mpp::runtime::MppMesh>> =
+                match df_state.mpp.as_ref() {
+                    Some(scan_state::MppExecState::Leader(leader)) => {
+                        // CustomScan parallel exec doesn't guarantee that PG
+                        // launches every worker we requested at planning time
+                        // (other queries can hold all worker slots, etc.). The
+                        // unattached `shm_mq` slots stay in init-state, the
+                        // cooperative pull never sees `Detached`, and the leader
+                        // hangs on the missing partitions. Fail loudly instead
+                        // and ask the user to retry until #5061 picks a long-term
+                        // shape (resize the mesh at exec start, or move off
+                        // CustomScan parallel workers).
+                        let pcxt = leader.pcxt;
+                        if !pcxt.is_null() {
+                            let launched = unsafe { (*pcxt).nworkers_launched } as u32;
+                            let expected = producer_worker_count();
+                            if launched < expected {
+                                pgrx::error!(
+                                    "mpp aggregate: PG launched {launched} of {expected} requested \
+                                     parallel workers; missing slots would hang the query. Retry, or \
+                                     raise `max_parallel_workers` / `max_parallel_workers_per_gather` \
+                                     so PG can launch the full set. Long-term fix tracked in \
+                                     https://github.com/paradedb/paradedb/issues/5061."
+                                );
+                            }
                         }
+                        Some(Arc::clone(&leader.mesh))
                     }
-                    Self::build_mpp_session_context(Arc::clone(&leader.mesh))
-                }
-                _ => create_aggregate_session_context(),
+                    _ => None,
+                };
+
+            let ctx = match leader_mesh.as_ref() {
+                Some(mesh) => Self::build_mpp_session_context(Arc::clone(mesh)),
+                None => create_aggregate_session_context(),
             };
 
             let custom_exprs = df_state.custom_exprs;
@@ -1628,6 +1636,28 @@ impl AggregateScan {
                 Ok(p) => p,
                 Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
             };
+
+            // MPP leader: walk the distributed physical plan and ship every nested per-(stage,
+            // task) producer subplan to its owning worker via Subplan frames before kicking off
+            // local execution. Workers stash the decoded plans in their ProducerTaskRegistry and
+            // skip the re-plan step when a follow-up Request arrives. No-op for non-MPP plans
+            // (the helper returns early when StagePlans is empty). The Phase 3 commit on this
+            // branch wires the worker-side SubplanHandler; until then this commit silently
+            // ships bytes that workers' drain consumes and discards.
+            if let Some(mesh) = leader_mesh.as_ref() {
+                if let Err(e) =
+                    crate::postgres::customscan::mpp::producer_service::ship_subplans_to_workers(
+                        &physical_plan,
+                        mesh,
+                        &ctx,
+                        unsafe { pg_sys::work_mem as usize * 1024 },
+                        unsafe { pg_sys::hash_mem_multiplier },
+                        &runtime,
+                    )
+                {
+                    pgrx::error!("mpp leader: ship_subplans_to_workers: {e}");
+                }
+            }
 
             let task_ctx = build_task_context(
                 &ctx,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1556,13 +1556,9 @@ impl CustomScan for JoinScan {
                     .block_on(build_physical_plan(&ctx, logical_plan))
                     .expect("Failed to create execution plan");
 
-                // MPP leader: ship per-(stage, task) producer subplans. Gated by
-                // `paradedb.mpp_use_shipped_subplans` (default off) because the codec doesn't
-                // yet handle DF-D wrapper nodes — see the matching comment in aggregatescan/mod.rs.
-                if let Some(mesh) = leader_mesh
-                    .as_ref()
-                    .filter(|_| crate::gucs::mpp_use_shipped_subplans())
-                {
+                // MPP leader: ship per-(stage, task) producer subplans. Runs for every MPP
+                // query — same gate as aggregatescan/mod.rs; see the matching comment there.
+                if let Some(mesh) = leader_mesh.as_ref() {
                     if let Err(e) =
                         crate::postgres::customscan::mpp::producer_service::ship_subplans_to_workers(
                             &plan,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1556,10 +1556,13 @@ impl CustomScan for JoinScan {
                     .block_on(build_physical_plan(&ctx, logical_plan))
                     .expect("Failed to create execution plan");
 
-                // MPP leader: ship per-(stage, task) producer subplans to their owning workers
-                // via Subplan frames before kicking off local execution. Same Phase 2 wiring as
-                // aggregatescan; see the matching comment there for the Phase 3 dependency note.
-                if let Some(mesh) = leader_mesh.as_ref() {
+                // MPP leader: ship per-(stage, task) producer subplans. Gated by
+                // `paradedb.mpp_use_shipped_subplans` (default off) because the codec doesn't
+                // yet handle DF-D wrapper nodes — see the matching comment in aggregatescan/mod.rs.
+                if let Some(mesh) = leader_mesh
+                    .as_ref()
+                    .filter(|_| crate::gucs::mpp_use_shipped_subplans())
+                {
                     if let Err(e) =
                         crate::postgres::customscan::mpp::producer_service::ship_subplans_to_workers(
                             &plan,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1486,24 +1486,31 @@ impl CustomScan for JoinScan {
                 // DF-D fork's distributed-planner knobs over the Join profile so the resulting
                 // physical plan is a `DistributedExec`. Without this, the leader builds a serial
                 // plan and the worker fragments would have nothing to consume from.
-                let ctx = match state.custom_state().mpp.as_ref() {
-                    Some(MppExecState::Leader(leader)) => {
-                        let pcxt = leader.pcxt;
-                        if !pcxt.is_null() {
-                            let launched = (*pcxt).nworkers_launched as u32;
-                            let expected = producer_worker_count();
-                            if launched < expected {
-                                pgrx::error!(
-                                    "mpp join: PG launched {launched} of {expected} requested \
-                                     parallel workers; missing slots would hang the query. Retry, \
-                                     or raise `max_parallel_workers` / \
-                                     `max_parallel_workers_per_gather` so PG can launch the full set."
-                                );
+                // Same capture-then-build pattern as aggregatescan: hold a reference to the
+                // leader mesh so we can ship subplans once `build_physical_plan` returns.
+                let leader_mesh: Option<Arc<crate::postgres::customscan::mpp::runtime::MppMesh>> =
+                    match state.custom_state().mpp.as_ref() {
+                        Some(MppExecState::Leader(leader)) => {
+                            let pcxt = leader.pcxt;
+                            if !pcxt.is_null() {
+                                let launched = (*pcxt).nworkers_launched as u32;
+                                let expected = producer_worker_count();
+                                if launched < expected {
+                                    pgrx::error!(
+                                        "mpp join: PG launched {launched} of {expected} requested \
+                                         parallel workers; missing slots would hang the query. Retry, \
+                                         or raise `max_parallel_workers` / \
+                                         `max_parallel_workers_per_gather` so PG can launch the full set."
+                                    );
+                                }
                             }
+                            Some(Arc::clone(&leader.mesh))
                         }
-                        Self::build_mpp_session_context(Arc::clone(&leader.mesh))
-                    }
-                    _ => create_datafusion_session_context(SessionContextProfile::Join),
+                        _ => None,
+                    };
+                let ctx = match leader_mesh.as_ref() {
+                    Some(mesh) => Self::build_mpp_session_context(Arc::clone(mesh)),
+                    None => create_datafusion_session_context(SessionContextProfile::Join),
                 };
                 let logical_plan = deserialize_logical_plan_with_runtime(
                     &plan_bytes,
@@ -1548,6 +1555,24 @@ impl CustomScan for JoinScan {
                 let plan = runtime
                     .block_on(build_physical_plan(&ctx, logical_plan))
                     .expect("Failed to create execution plan");
+
+                // MPP leader: ship per-(stage, task) producer subplans to their owning workers
+                // via Subplan frames before kicking off local execution. Same Phase 2 wiring as
+                // aggregatescan; see the matching comment there for the Phase 3 dependency note.
+                if let Some(mesh) = leader_mesh.as_ref() {
+                    if let Err(e) =
+                        crate::postgres::customscan::mpp::producer_service::ship_subplans_to_workers(
+                            &plan,
+                            mesh,
+                            &ctx,
+                            pg_sys::work_mem as usize * 1024,
+                            pg_sys::hash_mem_multiplier,
+                            &runtime,
+                        )
+                    {
+                        pgrx::error!("mpp leader: ship_subplans_to_workers: {e}");
+                    }
+                }
 
                 let task_ctx = build_task_context(
                     &ctx,

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -248,6 +248,13 @@ pub(crate) fn run_mpp_worker(
     worker_mesh.install_request_handler(Arc::clone(&registry)
         as Arc<dyn crate::postgres::customscan::mpp::transport::RequestHandler>);
 
+    // Install the same registry as the subplan handler so leader-shipped per-(stage, task)
+    // subplans land in `registry.shipped_subplans`. Phase 3 of the dispatch flip just fills that
+    // map; Phase 4 will swap the on-Request path to consume from it. The two handler trait
+    // impls coexist on `ProducerTaskRegistry` and dispatch to disjoint code paths.
+    worker_mesh.install_subplan_handler(Arc::clone(&registry)
+        as Arc<dyn crate::postgres::customscan::mpp::transport::SubplanHandler>);
+
     // Service loop. Three pieces interleave on the single tokio task scheduler:
     //   - This loop: pumps every inbound drain, dispatching Requests.
     //   - Spawned per-partition drivers (one per Request): run plan.execute(p, ctx), push
@@ -280,10 +287,11 @@ pub(crate) fn run_mpp_worker(
         Ok(())
     });
 
-    // Break the registry ↔ mesh handler cycle so the registry's `Arc<dyn RequestHandler>` refs
-    // (one per drain) release. Without this, `registry` and `worker_mesh` keep each other alive
-    // past the function return.
+    // Break the registry ↔ mesh handler cycles so the registry's `Arc<dyn RequestHandler>` and
+    // `Arc<dyn SubplanHandler>` refs (one each per drain) release. Without this, `registry` and
+    // `worker_mesh` keep each other alive past the function return.
     worker_mesh.uninstall_request_handler();
+    worker_mesh.uninstall_subplan_handler();
     drop(registry);
 
     if let Err(e) = result {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -249,9 +249,17 @@ pub(crate) fn run_mpp_worker(
         as Arc<dyn crate::postgres::customscan::mpp::transport::RequestHandler>);
 
     // Install the same registry as the subplan handler so leader-shipped per-(stage, task)
-    // subplans land in `registry.shipped_subplans`. Phase 3 of the dispatch flip just fills that
-    // map; Phase 4 will swap the on-Request path to consume from it. The two handler trait
-    // impls coexist on `ProducerTaskRegistry` and dispatch to disjoint code paths.
+    // subplans land in `registry.shipped_subplans`. Phase 4 wires `prepare_task` to consume
+    // from that map when `paradedb.mpp_use_shipped_subplans` is on; default OFF until the
+    // follow-up commit adds per-`PgSearchScanPlan` state reconstruction.
+    //
+    // **Ordering caveat**: the `prewarm` loop above runs BEFORE this handler is installed and
+    // BEFORE the first drain pump. With the GUC ON in production, prewarm's `prepare_task`
+    // call would observe an empty `shipped_subplans` map and cache a locally-built plan in
+    // `prepared`, which subsequent `on_request` calls hit before re-checking `shipped_subplans`.
+    // The follow-up commit reorders prewarm to run AFTER handler install + a one-shot drain
+    // pump so shipped subplans are visible to the prep path. Today this is fine because the
+    // GUC is off in production.
     worker_mesh.install_subplan_handler(Arc::clone(&registry)
         as Arc<dyn crate::postgres::customscan::mpp::transport::SubplanHandler>);
 

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -45,7 +45,8 @@ use crate::postgres::customscan::mpp::runtime::{
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::parallel::list_segment_ids;
 use crate::postgres::ParallelScanState;
-use crate::scan::codec::{deserialize_logical_plan_with_runtime, PgSearchPhysicalCodecStub};
+use crate::scan::codec::deserialize_logical_plan_with_runtime;
+use crate::scan::physical_codec::PgSearchPhysicalCodec;
 
 /// Bundle of inputs the worker dispatcher needs. Per-scan `exec_mpp_worker` wrappers populate
 /// this from their typed state and hand it to [`run_mpp_worker`].
@@ -86,10 +87,13 @@ pub(crate) fn build_mpp_session_context(
     //   3. distributed_broadcast_joins(true) — CollectLeft HashJoins otherwise cap their
     //      stage's task_count to Maximum(1) and propagate that cap upward, eliding shuffles
     //      above the join.
-    //   4. distributed_user_codec — the DF-D fork's prepare_plan unconditionally encodes
-    //      worker subplans for gRPC shipment; without a codec for our custom physical execs,
-    //      encoding errors before execution. In our model the encoded bytes are never observed
-    //      (workers re-plan from the logical plan in DSM), so the codec is a stub.
+    //   4. distributed_user_codec — DF-D's `DistributedCodec::new_combined_with_user` reads
+    //      the user codec back off the config when shipping subplans (leader's
+    //      `ship_subplans_to_workers`) and when decoding them on the worker (`on_subplan`).
+    //      The real `PgSearchPhysicalCodec` round-trips our four custom execs
+    //      (`VisibilityFilterExec`, `TantivyLookupExec`, `SegmentedTopKExec`, `PgSearchScan`)
+    //      plus the five built-in aggregate UDAFs (`min`/`max`/`count`/`sum`/`avg`) that
+    //      shipped `AggregateExec` plans depend on.
     let cfg = seed
         .copied_config()
         .with_target_partitions(n_workers.max(2));
@@ -111,7 +115,7 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        .with_distributed_user_codec(PgSearchPhysicalCodecStub)
+        .with_distributed_user_codec(PgSearchPhysicalCodec)
         .with_distributed_planner()
         // Insert a `CoalesceBatchesExec` in front of every `NetworkShuffleExec` so partial-agg
         // output (often many small batches at high group cardinality) gets bundled into ~5 MB

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -259,6 +259,17 @@ impl ProducerTaskRegistry {
 /// the worker side and by [`ship_subplans_to_workers`] on the leader side. Both sites need the
 /// same TaskContext + `prepare_in_process_plan` recipe so the prepared plan they produce is
 /// bit-identical — that's the whole point of the dispatch-flip's "build once, ship many" model.
+///
+/// **Bit-identical-config-or-bust.** `session`, `work_mem_bytes`, and `hash_mem_multiplier` MUST
+/// match what the worker would supply for the same `(stage_id, task_idx)`. The dispatch-flip
+/// relies on this in two places: (1) the leader's encoded subplan has to match the worker's
+/// would-be locally-planned subplan for plan equivalence; (2) memory pools sized off
+/// `work_mem_bytes` need to match so a memory-bounded operator doesn't behave differently when
+/// the worker executes the shipped plan. Both sides feed `pg_sys::work_mem` and
+/// `pg_sys::hash_mem_multiplier`; both sides build the session through
+/// `crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context`. Any future
+/// session-config knob added on only one side breaks this invariant silently — bench-shape
+/// regressions then surface as "leader and worker disagree on the plan."
 fn prepare_stage_task(
     plan: &Arc<dyn ExecutionPlan>,
     stage_id: u32,
@@ -325,6 +336,18 @@ fn prepare_stage_task(
 /// `n_workers` is the producer-worker count (not total procs). `proc_for_task` maps
 /// `task_idx -> 1..=n_workers`, so we ship to procs 1..=n_workers and never to ourselves
 /// (proc 0).
+///
+/// **Why the leader's cooperative-drain spin is safe during ship.** The spin (inside
+/// `send_subplan_traced` / `send_pre_encoded`) calls `drain.try_drain_pass()` between
+/// `try_send` attempts. The leader's inbound drains have no `RequestHandler` or
+/// `SubplanHandler` installed at ship time — the handlers go in later in `exec_custom_scan`.
+/// If a worker happened to send a Request to the leader during this window, the
+/// `dispatch_requests` no-handler branch would silently drop it (`mpp_log!` for diag) and
+/// data would be lost. We currently rely on the invariant that workers never send Requests to
+/// the leader: `proc_for_task(n_workers, _)` always returns `1..=n_workers`, never 0, so no
+/// worker addresses a producer task to the leader. If a future planner change ever places a
+/// producer task on proc 0, this comment is wrong and the ship-time drain dispatch needs a
+/// proper handler installed before this call runs.
 pub(crate) fn ship_subplans_to_workers(
     physical_plan: &Arc<dyn ExecutionPlan>,
     leader_mesh: &Arc<MppMesh>,

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -80,7 +80,6 @@ use crate::postgres::customscan::mpp::transport::{
     CooperativeDrainSet, MppFrameHeader, RequestHandler, SubplanHandler,
 };
 use crate::postgres::customscan::mpp::worker::run_partition_driver;
-use crate::scan::physical_codec::PgSearchPhysicalCodec;
 use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 
 /// Per-`stage_id` snapshot of `(local_plan, task_count)` walked out of the worker's distributed
@@ -166,26 +165,24 @@ pub(super) struct ProducerTaskRegistry {
     prepared: Mutex<HashMap<(u32, u32), PreparedTask>>,
     /// `(stage_id, task_idx) → decoded subplan` populated by [`Self::on_subplan`] when the
     /// leader ships a per-task subplan via a [`MppFrameKind::Subplan`](crate::postgres::customscan::mpp::transport::MppFrameKind::Subplan)
-    /// frame. Phase 4 of the dispatch-flip wires `prepare_task` to prefer this map when
-    /// `paradedb.mpp_use_shipped_subplans` is on; otherwise the field is populated but unused
-    /// and the existing local-prepare path runs.
+    /// frame. `prepare_task` consults this first; when a hit lands the worker uses the
+    /// leader-prepared plan directly instead of re-running `prepare_in_process_plan` locally.
     ///
-    /// Today the GUC defaults off because the codec's `decode_pgsearch_scan` returns an empty
-    /// `Vec<ScanState>` — the shipped path is reachable but would return zero rows for any
-    /// PgSearchScan-bearing query. The follow-up PR lands per-`PgSearchScanPlan` state
-    /// reconstruction (walk the decoded plan tree on the worker, rebuild scan state from the
-    /// local `PgSearchTableProvider`) and flips the default. Until then the field exists
-    /// largely for receive-side regression coverage.
+    /// The fallback path (`stage_plans` → local `prepare_in_process_plan`) is what fires
+    /// during the brief startup window between worker launch and the first drain pass that
+    /// delivers the Subplan frames. It's also where queries land if the codec hits a gap —
+    /// today's `decode_pgsearch_scan` emits an empty `Vec<ScanState>` placeholder, so a
+    /// shipped subplan with a `PgSearchScan` leaf would return zero rows. The followup PR
+    /// fixes that with per-`PgSearchScanPlan` state reconstruction.
     ///
-    /// **Ordering hazard for the future flip.** `run_mpp_worker` calls `prewarm` for every
-    /// `(stage_id, task_idx)` this proc owns *before* installing the SubplanHandler and
-    /// pumping the drain. With the GUC ON in production, `prewarm → prepare_task` would
-    /// observe an empty `shipped_subplans` map and fall through to the local-prepare branch,
-    /// caching that result in `prepared`. By the time real Subplan frames arrive and land
-    /// here, the cache is already populated and the shipped lookup never fires for the same
-    /// `(stage_id, task_idx)`. The follow-up commit has to reorder prewarm vs. handler-install
-    /// (and pump the drain once before prewarm) so shipped subplans are visible to the prep
-    /// path. Tracking item (0) in the Phase 4 commit message.
+    /// **Ordering hazard.** `run_mpp_worker` calls `prewarm` for every `(stage_id, task_idx)`
+    /// this proc owns *before* installing the SubplanHandler and pumping the drain. The
+    /// prewarm path goes through `prepare_task`, which sees an empty `shipped_subplans` and
+    /// falls back to local-prepare — caching the locally-built plan in `prepared`. When real
+    /// Subplan frames arrive later, they land in `shipped_subplans`, but `on_request` reads
+    /// from `prepared` first via the per-`(stage, task, partition)` dedupe path. The followup
+    /// PR reorders prewarm vs. handler-install (and pumps the drain once before prewarm) so
+    /// shipped subplans are visible to the prep path.
     shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>,
     /// `(stage_id, task_idx, partition)` set of already-dispatched drivers. Repeat Requests are
     /// dropped. Without this, a consumer that re-issued `stream_partition` would cause the
@@ -276,44 +273,39 @@ impl ProducerTaskRegistry {
     }
 
     fn prepare_task(&self, stage_id: u32, task_idx: u32) -> Result<PreparedTask, DataFusionError> {
-        // Phase 4 transitional path: prefer a leader-shipped subplan when one is present in
-        // `shipped_subplans` and the user has opted in via `paradedb.mpp_use_shipped_subplans`.
-        // The opt-in guard exists because the codec's `decode_pgsearch_scan` (see
-        // `crate::scan::physical_codec`) emits an empty `Vec<ScanState>` placeholder today —
-        // executing a decoded subplan with empty scan state returns zero rows. A follow-up
-        // commit lands the per-`PgSearchScanPlan` state reconstruction step that the worker
-        // runs over the decoded plan tree before this path is safe to enable by default. Until
-        // then the GUC stays off in production and CI; the lookup is exercised by lib tests
-        // that don't touch PgSearchScan.
-        if crate::gucs::mpp_use_shipped_subplans() {
-            if let Some(shipped) = self
-                .shipped_subplans
-                .lock()
-                .expect("ProducerTaskRegistry shipped_subplans mutex poisoned")
-                .get(&(stage_id, task_idx))
-                .cloned()
-            {
-                let task_count = self
-                    .stage_plans
-                    .lookup(stage_id)
-                    .map(|(_, tc)| tc)
-                    .unwrap_or(1);
-                let task_ctx = build_task_ctx(
-                    &self.session,
-                    task_idx,
-                    task_count,
-                    self.work_mem_bytes,
-                    self.hash_mem_multiplier,
-                    &shipped,
-                )?;
-                return Ok(PreparedTask {
-                    plan: shipped,
-                    ctx: task_ctx,
-                });
-            }
+        // Prefer a leader-shipped subplan when one is present in `shipped_subplans` — that's
+        // the dispatch-flip's "build once on the leader, ship many" path. Fall back to local
+        // re-plan if nothing has been shipped for this `(stage_id, task_idx)` yet (only
+        // possible during the brief window between worker startup and the first drain pass
+        // that delivers the subplan).
+        if let Some(shipped) = self
+            .shipped_subplans
+            .lock()
+            .expect("ProducerTaskRegistry shipped_subplans mutex poisoned")
+            .get(&(stage_id, task_idx))
+            .cloned()
+        {
+            let task_count = self
+                .stage_plans
+                .lookup(stage_id)
+                .map(|(_, tc)| tc)
+                .unwrap_or(1);
+            let task_ctx = build_task_ctx(
+                &self.session,
+                task_idx,
+                task_count,
+                self.work_mem_bytes,
+                self.hash_mem_multiplier,
+                &shipped,
+            )?;
+            return Ok(PreparedTask {
+                plan: shipped,
+                ctx: task_ctx,
+            });
         }
-        // Default fallback: build the prepared plan locally from `stage_plans`, same as before
-        // the dispatch flip.
+        // Fallback: build the prepared plan locally from `stage_plans`, same recipe as
+        // pre-dispatch-flip. Used during startup races (subplan hasn't arrived yet) and as a
+        // safety net while the codec's PgSearchScan state-reconstruction story matures.
         let (plan, task_count) = self.stage_plans.lookup(stage_id).ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "mpp producer: no plan registered for stage_id={stage_id}"
@@ -455,7 +447,7 @@ pub(crate) fn ship_subplans_to_workers(
 ) -> Result<(), DataFusionError> {
     use crate::postgres::customscan::mpp::runtime::proc_for_task;
     use crate::postgres::customscan::mpp::transport::{MppFrameHeader, SendBatchStats};
-    use crate::scan::physical_codec::PgSearchPhysicalCodec;
+    use datafusion_distributed::DistributedCodec;
     use datafusion_proto::bytes::physical_plan_to_bytes_with_extension_codec;
 
     let stage_plans = StagePlans::build(physical_plan);
@@ -465,7 +457,13 @@ pub(crate) fn ship_subplans_to_workers(
     }
     let n_workers = leader_mesh.n_procs.saturating_sub(1).max(1);
 
-    let codec = PgSearchPhysicalCodec;
+    // Use DF-D's `DistributedCodec::new_combined_with_user` so DF-D's wrapper nodes
+    // (`NetworkShuffleExec`, `NetworkBroadcastExec`, `BroadcastExec`, etc.) serialize through
+    // DF-D's own codec, and our `PgSearchPhysicalCodec` only handles the leaves it knows about
+    // (`VisibilityFilterExec`, `TantivyLookupExec`, `SegmentedTopKExec`, `PgSearchScan`). The
+    // user codec is picked up from the session's distributed config; we registered it earlier
+    // via `with_distributed_user_codec`.
+    let codec = DistributedCodec::new_combined_with_user(session.state().config());
     let mut tasks: Vec<(u32, u32, usize, Arc<dyn ExecutionPlan>)> = Vec::new();
     for (stage_id, task_count) in stage_plans.iter_task_counts() {
         let (local_plan, _) = stage_plans.lookup(stage_id).expect("stage just walked");
@@ -678,14 +676,10 @@ impl RequestHandler for ProducerTaskRegistry {
 impl SubplanHandler for ProducerTaskRegistry {
     /// Receive a leader-shipped subplan for `(stage_id, task_idx)`. Decodes the bytes with
     /// [`crate::scan::physical_codec::PgSearchPhysicalCodec`] and stores the result in
-    /// `shipped_subplans` keyed by `(stage_id, task_idx)`.
-    ///
-    /// Phase 4 of the dispatch flip wires `prepare_task` to prefer the shipped subplan when
-    /// `paradedb.mpp_use_shipped_subplans` is on. Default is off because the codec emits an
-    /// empty `Vec<ScanState>` for `PgSearchScanPlan` — see the field doc on `shipped_subplans`
-    /// and `crate::scan::physical_codec::decode_pgsearch_scan` for the placeholder story.
-    /// The follow-up commit lands per-`PgSearchScanPlan` state reconstruction before flipping
-    /// the default.
+    /// `shipped_subplans` keyed by `(stage_id, task_idx)`. `prepare_task` then consumes from
+    /// that map ahead of any local re-plan. The codec's `PgSearchScan` arm still has an empty
+    /// `Vec<ScanState>` gap that the followup PR fills in — until then, plans containing a
+    /// `PgSearchScan` may emit zero rows when sourced from the shipped path.
     fn on_subplan(
         &self,
         stage_id: u32,
@@ -697,7 +691,13 @@ impl SubplanHandler for ProducerTaskRegistry {
         // the same subplan is broadcast to multiple drains) lands in the same slot. Last write
         // wins; same `(stage_id, task_idx)` from the same leader session always carries the
         // same bytes today.
-        let codec = PgSearchPhysicalCodec;
+        //
+        // Decode through `DistributedCodec::new_combined_with_user` so DF-D wrapper nodes
+        // round-trip via DF-D's codec. The leader encodes through the same combined codec, so
+        // sender and receiver must match.
+        let codec = datafusion_distributed::DistributedCodec::new_combined_with_user(
+            self.session.state().config(),
+        );
         let task_ctx = self.session.task_ctx();
         let decoded = physical_plan_from_bytes_with_extension_codec(
             payload.as_slice(),
@@ -731,7 +731,6 @@ impl SubplanHandler for ProducerTaskRegistry {
 mod tests {
     use super::*;
     use crate::index::fast_fields_helper::FFHelper;
-    use crate::scan::physical_codec::PgSearchPhysicalCodec;
     use crate::scan::tantivy_lookup_exec::TantivyLookupExec;
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::physical_plan::empty::EmptyExec;
@@ -739,14 +738,25 @@ mod tests {
     use std::sync::Arc;
 
     /// Build a `ProducerTaskRegistry` with empty mesh/stage-plans, just enough to exercise
-    /// `on_subplan` end-to-end. The mesh's `inbound_receivers` and `outbound_senders` are empty
-    /// vecs, which is fine because the test never reads from them.
+    /// `on_subplan` end-to-end. The session has `PgSearchPhysicalCodec` registered as the
+    /// distributed user codec so `DistributedCodec::new_combined_with_user` resolves our
+    /// custom execs (`TantivyLookupExec`, etc.) when it falls through past the DF-D types it
+    /// knows about. Without that registration, decode of our exec variants would miss the
+    /// user codec and surface as a decode error.
     fn test_registry() -> Arc<ProducerTaskRegistry> {
+        use crate::scan::physical_codec::PgSearchPhysicalCodec;
+        use datafusion::execution::SessionStateBuilder;
+        use datafusion_distributed::DistributedExt;
+
         let mesh = Arc::new(MppMesh::new(0, 1, Vec::new(), Vec::new()));
         let stage_plans = StagePlans {
             stages: HashMap::new(),
         };
-        let session = Arc::new(SessionContext::new());
+        let state = SessionStateBuilder::new()
+            .with_default_features()
+            .with_distributed_user_codec(PgSearchPhysicalCodec)
+            .build();
+        let session = Arc::new(SessionContext::new_with_state(state));
         Arc::new(ProducerTaskRegistry::new(
             stage_plans,
             session,
@@ -756,12 +766,13 @@ mod tests {
         ))
     }
 
-    /// Encode a minimal `TantivyLookupExec` through `PgSearchPhysicalCodec` so we have real
-    /// bytes — same shape the leader's `ship_subplans_to_workers` would produce, just without
-    /// the full distributed plan tree wrapped around it. Picking `TantivyLookupExec` because
-    /// its codec is fully runnable in `cargo test` (the `VisibilityFilterExec` codec is gated
-    /// out of test builds, see the corresponding comment in `physical_codec.rs`).
-    fn encode_test_subplan() -> Vec<u8> {
+    /// Encode a minimal `TantivyLookupExec` through `DistributedCodec::new_combined_with_user`
+    /// — same encode path the leader's `ship_subplans_to_workers` uses, so the bytes are
+    /// shape-identical to what production produces. Picking `TantivyLookupExec` because its
+    /// codec is fully runnable in `cargo test` (the `VisibilityFilterExec` codec is gated out
+    /// of test builds, see the corresponding comment in `physical_codec.rs`).
+    fn encode_test_subplan(session: &SessionContext) -> Vec<u8> {
+        use datafusion_distributed::DistributedCodec;
         let input_schema = Arc::new(Schema::new(vec![Field::new(
             "ctid",
             DataType::UInt64,
@@ -776,7 +787,7 @@ mod tests {
                 .expect("TantivyLookupExec::new"),
         ) as Arc<dyn ExecutionPlan>;
         let _ = FFHelper::empty(); // keep FFHelper import live until the codec consumes it.
-        let codec = PgSearchPhysicalCodec;
+        let codec = DistributedCodec::new_combined_with_user(session.state().config());
         physical_plan_to_bytes_with_extension_codec(plan, &codec)
             .expect("encode test subplan")
             .to_vec()
@@ -787,7 +798,7 @@ mod tests {
         let registry = test_registry();
         assert_eq!(registry.shipped_subplan_count(), 0);
 
-        let payload = encode_test_subplan();
+        let payload = encode_test_subplan(&registry.session);
         registry
             .on_subplan(7, 3, payload.clone())
             .expect("on_subplan must accept a well-formed payload");
@@ -806,7 +817,7 @@ mod tests {
     #[test]
     fn on_subplan_multiple_keys_accumulate() {
         let registry = test_registry();
-        let payload = encode_test_subplan();
+        let payload = encode_test_subplan(&registry.session);
 
         for (stage_id, task_idx) in [(0_u32, 0_u32), (0, 1), (1, 0), (1, 1)] {
             registry

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -243,46 +243,168 @@ impl ProducerTaskRegistry {
                 "mpp producer: no plan registered for stage_id={stage_id}"
             ))
         })?;
-        // Seed the TaskContext with a `DistributedTaskContext` so nested boundary nodes inside
-        // the prepared plan see `(task_index, task_count)` and address the right peer task.
-        let cfg = self
-            .session
-            .state()
-            .config()
-            .clone()
-            .with_extension(Arc::new(DistributedTaskContext {
-                task_index: task_idx as usize,
-                task_count,
-            }));
-        let memory_pool = create_memory_pool(&plan, self.work_mem_bytes, self.hash_mem_multiplier);
-        let runtime_env = RuntimeEnvBuilder::new()
-            .with_memory_pool(memory_pool)
-            .build()
-            .map_err(|e| {
-                DataFusionError::Internal(format!("mpp producer: build RuntimeEnv: {e}"))
-            })?;
-        let task_ctx = Arc::new(
-            TaskContext::default()
-                .with_session_config(cfg)
-                .with_runtime(Arc::new(runtime_env)),
-        );
-
-        // Wrap the stage's local plan in a fresh `DistributedExec` and `prepare_in_process_plan`
-        // so nested NetworkShuffleExec / NetworkBroadcastExec / NetworkCoalesceExec dispatch
-        // through `ShmMqWorkerTransport` (Stage::Remote) instead of the LocalStage path that
-        // errors when task_count > 1.
-        let dist = Arc::new(DistributedExec::new(Arc::clone(&plan)));
-        let prepared = dist.prepare_in_process_plan(&task_ctx).map_err(|e| {
-            DataFusionError::Internal(format!(
-                "mpp producer: prepare_in_process_plan failed for stage_id={stage_id} \
-                 task_idx={task_idx}: {e}"
-            ))
-        })?;
-        Ok(PreparedTask {
-            plan: prepared,
-            ctx: task_ctx,
-        })
+        prepare_stage_task(
+            &plan,
+            stage_id,
+            task_idx,
+            task_count,
+            &self.session,
+            self.work_mem_bytes,
+            self.hash_mem_multiplier,
+        )
     }
+}
+
+/// Shared `(stage_id, task_idx) -> PreparedTask` builder. Called by `ProducerTaskRegistry` on
+/// the worker side and by [`ship_subplans_to_workers`] on the leader side. Both sites need the
+/// same TaskContext + `prepare_in_process_plan` recipe so the prepared plan they produce is
+/// bit-identical — that's the whole point of the dispatch-flip's "build once, ship many" model.
+fn prepare_stage_task(
+    plan: &Arc<dyn ExecutionPlan>,
+    stage_id: u32,
+    task_idx: u32,
+    task_count: usize,
+    session: &SessionContext,
+    work_mem_bytes: usize,
+    hash_mem_multiplier: f64,
+) -> Result<PreparedTask, DataFusionError> {
+    // Seed the TaskContext with a `DistributedTaskContext` so nested boundary nodes inside the
+    // prepared plan see `(task_index, task_count)` and address the right peer task.
+    let cfg = session
+        .state()
+        .config()
+        .clone()
+        .with_extension(Arc::new(DistributedTaskContext {
+            task_index: task_idx as usize,
+            task_count,
+        }));
+    let memory_pool = create_memory_pool(plan, work_mem_bytes, hash_mem_multiplier);
+    let runtime_env = RuntimeEnvBuilder::new()
+        .with_memory_pool(memory_pool)
+        .build()
+        .map_err(|e| DataFusionError::Internal(format!("mpp producer: build RuntimeEnv: {e}")))?;
+    let task_ctx = Arc::new(
+        TaskContext::default()
+            .with_session_config(cfg)
+            .with_runtime(Arc::new(runtime_env)),
+    );
+
+    // Wrap the stage's local plan in a fresh `DistributedExec` and `prepare_in_process_plan` so
+    // nested NetworkShuffleExec / NetworkBroadcastExec / NetworkCoalesceExec dispatch through
+    // `ShmMqWorkerTransport` (Stage::Remote) instead of the LocalStage path that errors when
+    // task_count > 1.
+    let dist = Arc::new(DistributedExec::new(Arc::clone(plan)));
+    let prepared = dist.prepare_in_process_plan(&task_ctx).map_err(|e| {
+        DataFusionError::Internal(format!(
+            "mpp producer: prepare_in_process_plan failed for stage_id={stage_id} \
+             task_idx={task_idx}: {e}"
+        ))
+    })?;
+    Ok(PreparedTask {
+        plan: prepared,
+        ctx: task_ctx,
+    })
+}
+
+/// Leader-side: walk the distributed physical plan, prepare each `(stage_id, task_idx)`, encode
+/// it via [`crate::scan::physical_codec::PgSearchPhysicalCodec`], and ship the bytes to the
+/// owning worker via a [`MppFrameKind::Subplan`](crate::postgres::customscan::mpp::transport::MppFrameKind::Subplan)
+/// frame. The worker side stashes the decoded plan in its [`ProducerTaskRegistry`] so subsequent
+/// `Request` frames for the same `(stage, task)` skip the re-plan path.
+///
+/// Called once during the leader's setup, after `build_mpp_session_context` produces the
+/// distributed physical plan and before the leader starts executing its own plan
+/// (`NetworkBoundaryExec` consumers issue `Request` frames once execution kicks in — the
+/// subplans must already be at the workers by then).
+///
+/// `physical_plan` is the LEADER's distributed plan. Walking it for `NetworkBoundary` nodes
+/// gives every nested `(stage_id, local_plan, task_count)` we need to ship; the leader and
+/// workers run the same `build_mpp_session_context`, so the StagePlans the leader walks here
+/// matches the StagePlans each worker would build from its own copy.
+///
+/// `n_workers` is the producer-worker count (not total procs). `proc_for_task` maps
+/// `task_idx -> 1..=n_workers`, so we ship to procs 1..=n_workers and never to ourselves
+/// (proc 0).
+pub(crate) fn ship_subplans_to_workers(
+    physical_plan: &Arc<dyn ExecutionPlan>,
+    leader_mesh: &Arc<MppMesh>,
+    session: &SessionContext,
+    work_mem_bytes: usize,
+    hash_mem_multiplier: f64,
+    runtime: &tokio::runtime::Runtime,
+) -> Result<(), DataFusionError> {
+    use crate::postgres::customscan::mpp::runtime::proc_for_task;
+    use crate::postgres::customscan::mpp::transport::{MppFrameHeader, SendBatchStats};
+    use crate::scan::physical_codec::PgSearchPhysicalCodec;
+    use datafusion_proto::bytes::physical_plan_to_bytes_with_extension_codec;
+
+    let stage_plans = StagePlans::build(physical_plan);
+    if stage_plans.is_empty() {
+        // No NetworkBoundary nodes -> no subplans to ship. Single-proc plans hit this path.
+        return Ok(());
+    }
+    let n_workers = leader_mesh.n_procs.saturating_sub(1).max(1);
+
+    let codec = PgSearchPhysicalCodec;
+    let mut tasks: Vec<(u32, u32, usize, Arc<dyn ExecutionPlan>)> = Vec::new();
+    for (stage_id, task_count) in stage_plans.iter_task_counts() {
+        let (local_plan, _) = stage_plans.lookup(stage_id).expect("stage just walked");
+        for task_idx in 0..task_count {
+            tasks.push((
+                stage_id,
+                task_idx as u32,
+                task_count,
+                Arc::clone(&local_plan),
+            ));
+        }
+    }
+
+    runtime.block_on(async move {
+        let mut stats = SendBatchStats::default();
+        for (stage_id, task_idx, task_count, local_plan) in tasks {
+            let owner_proc = proc_for_task(n_workers, task_idx);
+
+            let prepared = prepare_stage_task(
+                &local_plan,
+                stage_id,
+                task_idx,
+                task_count,
+                session,
+                work_mem_bytes,
+                hash_mem_multiplier,
+            )?;
+
+            let bytes = physical_plan_to_bytes_with_extension_codec(prepared.plan, &codec)
+                .map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "mpp leader: encode subplan stage_id={stage_id} task_idx={task_idx}: {e}"
+                    ))
+                })?;
+
+            let header = MppFrameHeader::subplan(stage_id, task_idx)?;
+            let sender = leader_mesh
+                .outbound_sender(owner_proc, header)
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                    "mpp leader: no outbound sender to proc {owner_proc} for stage_id={stage_id} \
+                     task_idx={task_idx} (mesh detached?)"
+                ))
+                })?;
+            // Attach the leader's mesh as the cooperative drain so the spin can pull any
+            // queued-up leader-bound frames (rare during setup) without deadlocking. Even if no
+            // drain were attached the blocking send would still complete eventually — workers'
+            // own drains consume the bytes regardless of whether their SubplanHandler is
+            // installed (Phase 3) — but the explicit drain keeps this path consistent with
+            // other producer sends.
+            let sender = sender
+                .with_cooperative_drain(Arc::clone(leader_mesh) as Arc<dyn CooperativeDrainSet>);
+            sender
+                .send_subplan_traced(task_idx, bytes.as_ref(), &mut stats)
+                .await?;
+        }
+        Ok::<(), DataFusionError>(())
+    })?;
+    Ok(())
 }
 
 impl RequestHandler for ProducerTaskRegistry {

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -260,6 +260,44 @@ impl ProducerTaskRegistry {
     }
 
     fn prepare_task(&self, stage_id: u32, task_idx: u32) -> Result<PreparedTask, DataFusionError> {
+        // Phase 4 transitional path: prefer a leader-shipped subplan when one is present in
+        // `shipped_subplans` and the user has opted in via `paradedb.mpp_use_shipped_subplans`.
+        // The opt-in guard exists because the codec's `decode_pgsearch_scan` (see
+        // `crate::scan::physical_codec`) emits an empty `Vec<ScanState>` placeholder today —
+        // executing a decoded subplan with empty scan state returns zero rows. A follow-up
+        // commit lands the per-`PgSearchScanPlan` state reconstruction step that the worker
+        // runs over the decoded plan tree before this path is safe to enable by default. Until
+        // then the GUC stays off in production and CI; the lookup is exercised by lib tests
+        // that don't touch PgSearchScan.
+        if crate::gucs::mpp_use_shipped_subplans() {
+            if let Some(shipped) = self
+                .shipped_subplans
+                .lock()
+                .expect("ProducerTaskRegistry shipped_subplans mutex poisoned")
+                .get(&(stage_id, task_idx))
+                .cloned()
+            {
+                let task_count = self
+                    .stage_plans
+                    .lookup(stage_id)
+                    .map(|(_, tc)| tc)
+                    .unwrap_or(1);
+                let task_ctx = build_task_ctx(
+                    &self.session,
+                    task_idx,
+                    task_count,
+                    self.work_mem_bytes,
+                    self.hash_mem_multiplier,
+                    &shipped,
+                )?;
+                return Ok(PreparedTask {
+                    plan: shipped,
+                    ctx: task_ctx,
+                });
+            }
+        }
+        // Default fallback: build the prepared plan locally from `stage_plans`, same as before
+        // the dispatch flip.
         let (plan, task_count) = self.stage_plans.lookup(stage_id).ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "mpp producer: no plan registered for stage_id={stage_id}"
@@ -275,6 +313,39 @@ impl ProducerTaskRegistry {
             self.hash_mem_multiplier,
         )
     }
+}
+
+/// Build a per-`(stage_id, task_idx)` `TaskContext` matching what `prepare_stage_task` produces.
+/// Used by the shipped-subplan path: the decoded plan already has its `DistributedTaskContext`
+/// baked into nested boundary nodes from leader-side preparation, but the executing
+/// `TaskContext` still needs the extension layered on so any operator that re-reads it at
+/// runtime sees the right `(task_index, task_count)` shape.
+fn build_task_ctx(
+    session: &SessionContext,
+    task_idx: u32,
+    task_count: usize,
+    work_mem_bytes: usize,
+    hash_mem_multiplier: f64,
+    plan: &Arc<dyn ExecutionPlan>,
+) -> Result<Arc<TaskContext>, DataFusionError> {
+    let cfg = session
+        .state()
+        .config()
+        .clone()
+        .with_extension(Arc::new(DistributedTaskContext {
+            task_index: task_idx as usize,
+            task_count,
+        }));
+    let memory_pool = create_memory_pool(plan, work_mem_bytes, hash_mem_multiplier);
+    let runtime_env = RuntimeEnvBuilder::new()
+        .with_memory_pool(memory_pool)
+        .build()
+        .map_err(|e| DataFusionError::Internal(format!("mpp producer: build RuntimeEnv: {e}")))?;
+    Ok(Arc::new(
+        TaskContext::default()
+            .with_session_config(cfg)
+            .with_runtime(Arc::new(runtime_env)),
+    ))
 }
 
 /// Shared `(stage_id, task_idx) -> PreparedTask` builder. Called by `ProducerTaskRegistry` on

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -730,12 +730,12 @@ impl SubplanHandler for ProducerTaskRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
+    use crate::index::fast_fields_helper::FFHelper;
     use crate::scan::physical_codec::PgSearchPhysicalCodec;
+    use crate::scan::tantivy_lookup_exec::TantivyLookupExec;
     use arrow_schema::{DataType, Field, Schema};
     use datafusion::physical_plan::empty::EmptyExec;
     use datafusion_proto::bytes::physical_plan_to_bytes_with_extension_codec;
-    use pgrx::pg_sys;
     use std::sync::Arc;
 
     /// Build a `ProducerTaskRegistry` with empty mesh/stage-plans, just enough to exercise
@@ -756,11 +756,11 @@ mod tests {
         ))
     }
 
-    /// Encode a minimal `VisibilityFilterExec` through `PgSearchPhysicalCodec` so we have
-    /// real bytes — same shape the leader's `ship_subplans_to_workers` would produce, just
-    /// without the full distributed plan tree wrapped around it. Picking VisibilityFilter
-    /// because its decode path is the simplest (no PG runtime required) and the codec's
-    /// VisibilityFilter arm has full round-trip coverage in #5121.
+    /// Encode a minimal `TantivyLookupExec` through `PgSearchPhysicalCodec` so we have real
+    /// bytes — same shape the leader's `ship_subplans_to_workers` would produce, just without
+    /// the full distributed plan tree wrapped around it. Picking `TantivyLookupExec` because
+    /// its codec is fully runnable in `cargo test` (the `VisibilityFilterExec` codec is gated
+    /// out of test builds, see the corresponding comment in `physical_codec.rs`).
     fn encode_test_subplan() -> Vec<u8> {
         let input_schema = Arc::new(Schema::new(vec![Field::new(
             "ctid",
@@ -768,14 +768,14 @@ mod tests {
             false,
         )]));
         let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(input_schema));
+        // `TantivyLookupExec` with an empty deferred-field list is the minimum that still
+        // exercises the codec end-to-end. The plan's runtime behavior isn't relevant here —
+        // we only check the bytes round-trip.
         let plan = Arc::new(
-            VisibilityFilterExec::new(
-                input,
-                vec![(0_usize, pg_sys::Oid::from(16384_u32))],
-                vec!["posts".to_string()],
-            )
-            .expect("VisibilityFilterExec::new"),
+            TantivyLookupExec::new(input, Vec::new(), crate::api::HashMap::default())
+                .expect("TantivyLookupExec::new"),
         ) as Arc<dyn ExecutionPlan>;
+        let _ = FFHelper::empty(); // keep FFHelper import live until the codec consumes it.
         let codec = PgSearchPhysicalCodec;
         physical_plan_to_bytes_with_extension_codec(plan, &codec)
             .expect("encode test subplan")

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -80,6 +80,8 @@ use crate::postgres::customscan::mpp::transport::{
     CooperativeDrainSet, MppFrameHeader, RequestHandler, SubplanHandler,
 };
 use crate::postgres::customscan::mpp::worker::run_partition_driver;
+use crate::scan::physical_codec::PgSearchPhysicalCodec;
+use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 
 /// Per-`stage_id` snapshot of `(local_plan, task_count)` walked out of the worker's distributed
 /// physical plan at startup. The producer service loop consults this on every Request to find
@@ -615,13 +617,11 @@ impl SubplanHandler for ProducerTaskRegistry {
         task_idx: u32,
         payload: Vec<u8>,
     ) -> Result<(), DataFusionError> {
-        use crate::scan::physical_codec::PgSearchPhysicalCodec;
-        use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
-
         let key = (stage_id, task_idx);
-        // Dedupe — a re-shipped subplan (e.g. leader retried after a transient error) lands
-        // in the same slot. Last write wins; same `(stage_id, task_idx)` from the same leader
-        // session always carries the same bytes today.
+        // Repeat ship (e.g. leader retried after a transient error, or a future shape where
+        // the same subplan is broadcast to multiple drains) lands in the same slot. Last write
+        // wins; same `(stage_id, task_idx)` from the same leader session always carries the
+        // same bytes today.
         let codec = PgSearchPhysicalCodec;
         let task_ctx = self.session.task_ctx();
         let decoded = physical_plan_from_bytes_with_extension_codec(
@@ -634,16 +634,129 @@ impl SubplanHandler for ProducerTaskRegistry {
                 "mpp producer on_subplan: decode failed stage_id={stage_id} task_idx={task_idx}: {e}"
             ))
         })?;
-        let mut map = self
-            .shipped_subplans
-            .lock()
-            .expect("ProducerTaskRegistry shipped_subplans mutex poisoned");
-        map.insert(key, decoded);
+        let total = {
+            let mut map = self
+                .shipped_subplans
+                .lock()
+                .expect("ProducerTaskRegistry shipped_subplans mutex poisoned");
+            map.insert(key, decoded);
+            map.len()
+        };
+        // Lock dropped above before the log call. `mpp_log!` expands to `pgrx::warning!` under
+        // the debug GUC and ereport's; cheap to keep off the hot path.
         crate::mpp_log!(
             "mpp producer on_subplan: received stage_id={stage_id} task_idx={task_idx} \
-             (total shipped: {})",
-            map.len()
+             (total shipped: {total})"
         );
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
+    use crate::scan::physical_codec::PgSearchPhysicalCodec;
+    use arrow_schema::{DataType, Field, Schema};
+    use datafusion::physical_plan::empty::EmptyExec;
+    use datafusion_proto::bytes::physical_plan_to_bytes_with_extension_codec;
+    use pgrx::pg_sys;
+    use std::sync::Arc;
+
+    /// Build a `ProducerTaskRegistry` with empty mesh/stage-plans, just enough to exercise
+    /// `on_subplan` end-to-end. The mesh's `inbound_receivers` and `outbound_senders` are empty
+    /// vecs, which is fine because the test never reads from them.
+    fn test_registry() -> Arc<ProducerTaskRegistry> {
+        let mesh = Arc::new(MppMesh::new(0, 1, Vec::new(), Vec::new()));
+        let stage_plans = StagePlans {
+            stages: HashMap::new(),
+        };
+        let session = Arc::new(SessionContext::new());
+        Arc::new(ProducerTaskRegistry::new(
+            stage_plans,
+            session,
+            &mesh,
+            64 * 1024 * 1024, // work_mem
+            2.0,              // hash_mem_multiplier
+        ))
+    }
+
+    /// Encode a minimal `VisibilityFilterExec` through `PgSearchPhysicalCodec` so we have
+    /// real bytes — same shape the leader's `ship_subplans_to_workers` would produce, just
+    /// without the full distributed plan tree wrapped around it. Picking VisibilityFilter
+    /// because its decode path is the simplest (no PG runtime required) and the codec's
+    /// VisibilityFilter arm has full round-trip coverage in #5121.
+    fn encode_test_subplan() -> Vec<u8> {
+        let input_schema = Arc::new(Schema::new(vec![Field::new(
+            "ctid",
+            DataType::UInt64,
+            false,
+        )]));
+        let input: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(input_schema));
+        let plan = Arc::new(
+            VisibilityFilterExec::new(
+                input,
+                vec![(0_usize, pg_sys::Oid::from(16384_u32))],
+                vec!["posts".to_string()],
+            )
+            .expect("VisibilityFilterExec::new"),
+        ) as Arc<dyn ExecutionPlan>;
+        let codec = PgSearchPhysicalCodec;
+        physical_plan_to_bytes_with_extension_codec(plan, &codec)
+            .expect("encode test subplan")
+            .to_vec()
+    }
+
+    #[test]
+    fn on_subplan_decodes_and_stashes_in_shipped_map() {
+        let registry = test_registry();
+        assert_eq!(registry.shipped_subplan_count(), 0);
+
+        let payload = encode_test_subplan();
+        registry
+            .on_subplan(7, 3, payload.clone())
+            .expect("on_subplan must accept a well-formed payload");
+
+        assert_eq!(registry.shipped_subplan_count(), 1);
+
+        // The decoded plan is keyed by (stage_id, task_idx); not visible through a public
+        // accessor (Phase 4 will surface it through the Request path), but we can verify the
+        // key exists by re-shipping the same key and confirming the count stays at 1.
+        registry
+            .on_subplan(7, 3, payload)
+            .expect("re-ship of same key must succeed");
+        assert_eq!(registry.shipped_subplan_count(), 1);
+    }
+
+    #[test]
+    fn on_subplan_multiple_keys_accumulate() {
+        let registry = test_registry();
+        let payload = encode_test_subplan();
+
+        for (stage_id, task_idx) in [(0_u32, 0_u32), (0, 1), (1, 0), (1, 1)] {
+            registry
+                .on_subplan(stage_id, task_idx, payload.clone())
+                .expect("on_subplan");
+        }
+        assert_eq!(registry.shipped_subplan_count(), 4);
+    }
+
+    #[test]
+    fn on_subplan_surfaces_decode_error() {
+        let registry = test_registry();
+        // Garbage bytes — prost decode should fail loudly with an Internal error pointing
+        // at the failed (stage_id, task_idx) so an integration test can pinpoint the breakage.
+        let err = registry
+            .on_subplan(5, 2, vec![0xFF, 0xFE, 0xFD, 0xFC])
+            .expect_err("garbage payload must surface an error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("decode failed")
+                && msg.contains("stage_id=5")
+                && msg.contains("task_idx=2"),
+            "unexpected error: {msg}"
+        );
+        // Failed decode does NOT populate the map.
+        assert_eq!(registry.shipped_subplan_count(), 0);
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -166,10 +166,26 @@ pub(super) struct ProducerTaskRegistry {
     prepared: Mutex<HashMap<(u32, u32), PreparedTask>>,
     /// `(stage_id, task_idx) → decoded subplan` populated by [`Self::on_subplan`] when the
     /// leader ships a per-task subplan via a [`MppFrameKind::Subplan`](crate::postgres::customscan::mpp::transport::MppFrameKind::Subplan)
-    /// frame. Lives alongside `prepared` (not in place of) for this phase of the dispatch flip:
-    /// Phase 4 of the PR chain will swap the Request handler to consume from here (and to
-    /// reconstruct PgSearchScan state on top of the decoded plan, which the current codec emits
-    /// empty). Until then this map is populated, not consumed — exercised by lib tests.
+    /// frame. Phase 4 of the dispatch-flip wires `prepare_task` to prefer this map when
+    /// `paradedb.mpp_use_shipped_subplans` is on; otherwise the field is populated but unused
+    /// and the existing local-prepare path runs.
+    ///
+    /// Today the GUC defaults off because the codec's `decode_pgsearch_scan` returns an empty
+    /// `Vec<ScanState>` — the shipped path is reachable but would return zero rows for any
+    /// PgSearchScan-bearing query. The follow-up PR lands per-`PgSearchScanPlan` state
+    /// reconstruction (walk the decoded plan tree on the worker, rebuild scan state from the
+    /// local `PgSearchTableProvider`) and flips the default. Until then the field exists
+    /// largely for receive-side regression coverage.
+    ///
+    /// **Ordering hazard for the future flip.** `run_mpp_worker` calls `prewarm` for every
+    /// `(stage_id, task_idx)` this proc owns *before* installing the SubplanHandler and
+    /// pumping the drain. With the GUC ON in production, `prewarm → prepare_task` would
+    /// observe an empty `shipped_subplans` map and fall through to the local-prepare branch,
+    /// caching that result in `prepared`. By the time real Subplan frames arrive and land
+    /// here, the cache is already populated and the shipped lookup never fires for the same
+    /// `(stage_id, task_idx)`. The follow-up commit has to reorder prewarm vs. handler-install
+    /// (and pump the drain once before prewarm) so shipped subplans are visible to the prep
+    /// path. Tracking item (0) in the Phase 4 commit message.
     shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>,
     /// `(stage_id, task_idx, partition)` set of already-dispatched drivers. Repeat Requests are
     /// dropped. Without this, a consumer that re-issued `stream_partition` would cause the
@@ -201,9 +217,9 @@ impl ProducerTaskRegistry {
 
     /// Number of subplans the registry has received from the leader via
     /// [`SubplanHandler::on_subplan`](crate::postgres::customscan::mpp::transport::SubplanHandler).
-    /// Read by lib tests; production code doesn't consume this map yet (see the field doc on
-    /// `shipped_subplans`).
-    #[allow(dead_code)] // consumed by Phase 4 of the dispatch flip + the upcoming lib tests.
+    /// Used by lib tests to verify receive-side regression coverage.
+    #[allow(dead_code)] // exercised by lib tests; production reads of `shipped_subplans` go
+                        // through `prepare_task` directly, not through this accessor.
     pub(super) fn shipped_subplan_count(&self) -> usize {
         self.shipped_subplans
             .lock()
@@ -372,26 +388,14 @@ fn prepare_stage_task(
     work_mem_bytes: usize,
     hash_mem_multiplier: f64,
 ) -> Result<PreparedTask, DataFusionError> {
-    // Seed the TaskContext with a `DistributedTaskContext` so nested boundary nodes inside the
-    // prepared plan see `(task_index, task_count)` and address the right peer task.
-    let cfg = session
-        .state()
-        .config()
-        .clone()
-        .with_extension(Arc::new(DistributedTaskContext {
-            task_index: task_idx as usize,
-            task_count,
-        }));
-    let memory_pool = create_memory_pool(plan, work_mem_bytes, hash_mem_multiplier);
-    let runtime_env = RuntimeEnvBuilder::new()
-        .with_memory_pool(memory_pool)
-        .build()
-        .map_err(|e| DataFusionError::Internal(format!("mpp producer: build RuntimeEnv: {e}")))?;
-    let task_ctx = Arc::new(
-        TaskContext::default()
-            .with_session_config(cfg)
-            .with_runtime(Arc::new(runtime_env)),
-    );
+    let task_ctx = build_task_ctx(
+        session,
+        task_idx,
+        task_count,
+        work_mem_bytes,
+        hash_mem_multiplier,
+        plan,
+    )?;
 
     // Wrap the stage's local plan in a fresh `DistributedExec` and `prepare_in_process_plan` so
     // nested NetworkShuffleExec / NetworkBroadcastExec / NetworkCoalesceExec dispatch through
@@ -676,12 +680,12 @@ impl SubplanHandler for ProducerTaskRegistry {
     /// [`crate::scan::physical_codec::PgSearchPhysicalCodec`] and stores the result in
     /// `shipped_subplans` keyed by `(stage_id, task_idx)`.
     ///
-    /// Phase 3 of the dispatch flip: the receive side is wired but the Request-path
-    /// hasn't switched over yet. The decoded plan goes into a separate map so the existing
-    /// `prepared` path is untouched while we land the receiver-side machinery. Phase 4 swaps
-    /// the lookup in `on_request` to consume from `shipped_subplans` and reconstruct
-    /// `PgSearchScan` state on top of the decoded plan (the codec emits empty `states` today —
-    /// see `crate::scan::physical_codec::decode_pgsearch_scan`).
+    /// Phase 4 of the dispatch flip wires `prepare_task` to prefer the shipped subplan when
+    /// `paradedb.mpp_use_shipped_subplans` is on. Default is off because the codec emits an
+    /// empty `Vec<ScanState>` for `PgSearchScanPlan` — see the field doc on `shipped_subplans`
+    /// and `crate::scan::physical_codec::decode_pgsearch_scan` for the placeholder story.
+    /// The follow-up commit lands per-`PgSearchScanPlan` state reconstruction before flipping
+    /// the default.
     fn on_subplan(
         &self,
         stage_id: u32,

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -77,7 +77,7 @@ use datafusion_distributed::{DistributedExec, DistributedTaskContext, NetworkBou
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
-    CooperativeDrainSet, MppFrameHeader, RequestHandler,
+    CooperativeDrainSet, MppFrameHeader, RequestHandler, SubplanHandler,
 };
 use crate::postgres::customscan::mpp::worker::run_partition_driver;
 
@@ -162,6 +162,13 @@ pub(super) struct ProducerTaskRegistry {
     /// `(stage_id, task_idx) → prepared plan + TaskContext`. Lazy: first Request for a `(stage,
     /// task)` builds it; subsequent partitions of the same `(stage, task)` reuse it.
     prepared: Mutex<HashMap<(u32, u32), PreparedTask>>,
+    /// `(stage_id, task_idx) → decoded subplan` populated by [`Self::on_subplan`] when the
+    /// leader ships a per-task subplan via a [`MppFrameKind::Subplan`](crate::postgres::customscan::mpp::transport::MppFrameKind::Subplan)
+    /// frame. Lives alongside `prepared` (not in place of) for this phase of the dispatch flip:
+    /// Phase 4 of the PR chain will swap the Request handler to consume from here (and to
+    /// reconstruct PgSearchScan state on top of the decoded plan, which the current codec emits
+    /// empty). Until then this map is populated, not consumed — exercised by lib tests.
+    shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>,
     /// `(stage_id, task_idx, partition)` set of already-dispatched drivers. Repeat Requests are
     /// dropped. Without this, a consumer that re-issued `stream_partition` would cause the
     /// producer to spawn a second driver pushing duplicate frames onto the channel.
@@ -185,8 +192,21 @@ impl ProducerTaskRegistry {
             active_drivers: Arc::new(AtomicUsize::new(0)),
             first_error: Arc::new(Mutex::new(None)),
             prepared: Mutex::new(HashMap::new()),
+            shipped_subplans: Mutex::new(HashMap::new()),
             spawned: Mutex::new(HashSet::new()),
         }
+    }
+
+    /// Number of subplans the registry has received from the leader via
+    /// [`SubplanHandler::on_subplan`](crate::postgres::customscan::mpp::transport::SubplanHandler).
+    /// Read by lib tests; production code doesn't consume this map yet (see the field doc on
+    /// `shipped_subplans`).
+    #[allow(dead_code)] // consumed by Phase 4 of the dispatch flip + the upcoming lib tests.
+    pub(super) fn shipped_subplan_count(&self) -> usize {
+        self.shipped_subplans
+            .lock()
+            .expect("ProducerTaskRegistry shipped_subplans mutex poisoned")
+            .len()
     }
 
     /// Number of currently-running driver futures. Service loop reads this to know when
@@ -574,6 +594,56 @@ impl RequestHandler for ProducerTaskRegistry {
                 }
             }
         });
+        Ok(())
+    }
+}
+
+impl SubplanHandler for ProducerTaskRegistry {
+    /// Receive a leader-shipped subplan for `(stage_id, task_idx)`. Decodes the bytes with
+    /// [`crate::scan::physical_codec::PgSearchPhysicalCodec`] and stores the result in
+    /// `shipped_subplans` keyed by `(stage_id, task_idx)`.
+    ///
+    /// Phase 3 of the dispatch flip: the receive side is wired but the Request-path
+    /// hasn't switched over yet. The decoded plan goes into a separate map so the existing
+    /// `prepared` path is untouched while we land the receiver-side machinery. Phase 4 swaps
+    /// the lookup in `on_request` to consume from `shipped_subplans` and reconstruct
+    /// `PgSearchScan` state on top of the decoded plan (the codec emits empty `states` today —
+    /// see `crate::scan::physical_codec::decode_pgsearch_scan`).
+    fn on_subplan(
+        &self,
+        stage_id: u32,
+        task_idx: u32,
+        payload: Vec<u8>,
+    ) -> Result<(), DataFusionError> {
+        use crate::scan::physical_codec::PgSearchPhysicalCodec;
+        use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
+
+        let key = (stage_id, task_idx);
+        // Dedupe — a re-shipped subplan (e.g. leader retried after a transient error) lands
+        // in the same slot. Last write wins; same `(stage_id, task_idx)` from the same leader
+        // session always carries the same bytes today.
+        let codec = PgSearchPhysicalCodec;
+        let task_ctx = self.session.task_ctx();
+        let decoded = physical_plan_from_bytes_with_extension_codec(
+            payload.as_slice(),
+            &task_ctx,
+            &codec,
+        )
+        .map_err(|e| {
+            DataFusionError::Internal(format!(
+                "mpp producer on_subplan: decode failed stage_id={stage_id} task_idx={task_idx}: {e}"
+            ))
+        })?;
+        let mut map = self
+            .shipped_subplans
+            .lock()
+            .expect("ProducerTaskRegistry shipped_subplans mutex poisoned");
+        map.insert(key, decoded);
+        crate::mpp_log!(
+            "mpp producer on_subplan: received stage_id={stage_id} task_idx={task_idx} \
+             (total shipped: {})",
+            map.len()
+        );
         Ok(())
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -220,7 +220,6 @@ impl MppMesh {
     /// (proc 0) today, but installing on every drain keeps the API symmetric with
     /// [`Self::install_request_handler`] and is safe — a peer that never sends a Subplan frame
     /// never triggers the handler. Called once at worker startup.
-    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
     pub(crate) fn install_subplan_handler(&self, handler: Arc<dyn SubplanHandler>) {
         for drain in self.inbound_receivers.iter().flatten() {
             drain.set_subplan_handler(Arc::clone(&handler));
@@ -229,7 +228,6 @@ impl MppMesh {
 
     /// Drop every drain's installed subplan handler at teardown, symmetric with
     /// [`Self::uninstall_request_handler`].
-    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
     pub(crate) fn uninstall_subplan_handler(&self) {
         for drain in self.inbound_receivers.iter().flatten() {
             drain.clear_subplan_handler();

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -461,6 +461,16 @@ impl WorkerConnection for ShmMqWorkerConnection {
 /// our embedded model are PG parallel workers in the same backend tree, not
 /// URL-addressed nodes; the planner only consults `get_urls().len()` for
 /// task-count sizing, so any URL satisfies it.
+///
+/// Load-bearing invariant for the dispatch flip: every entry in the returned vec is the *same*
+/// URL. The upstream `DistributedExec::prepare_plan` uses `rand::rng().random_range(..)` to pick
+/// a start index into the resolver URLs, then deals tasks out modulo the number of URLs. With
+/// uniform URLs the start index is observationally irrelevant and the same logical plan deals
+/// stages identically on the leader and on every worker — that's what makes the leader-shipped
+/// subplan match what the worker would have re-planned locally. If a future revision deduplicates
+/// the URL list (e.g. via `HashSet`) or assigns per-worker URLs, the random start index becomes
+/// load-bearing and plan equivalence breaks silently. Don't change the duplication scheme
+/// without updating the codec's plan-equivalence audit alongside.
 #[derive(Clone)]
 pub struct MppWorkerResolver {
     n_workers: usize,

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -46,7 +46,7 @@ use url::Url;
 
 use crate::postgres::customscan::mpp::transport::{
     CooperativeDrainSet, DrainHandle, DrainItem, MppFrameHeader, MppSender, RequestHandler,
-    SendBatchStats,
+    SendBatchStats, SubplanHandler,
 };
 
 /// `task_idx → proc_idx` round-robin over the worker procs. The leader is `proc_idx = 0`
@@ -212,6 +212,27 @@ impl MppMesh {
     pub(crate) fn uninstall_request_handler(&self) {
         for drain in self.inbound_receivers.iter().flatten() {
             drain.clear_request_handler();
+        }
+    }
+
+    /// Install `handler` on every inbound drain so leader-shipped `Subplan` frames reach the
+    /// worker's `ProducerTaskRegistry`. Workers only receive Subplan frames from the leader
+    /// (proc 0) today, but installing on every drain keeps the API symmetric with
+    /// [`Self::install_request_handler`] and is safe — a peer that never sends a Subplan frame
+    /// never triggers the handler. Called once at worker startup.
+    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
+    pub(crate) fn install_subplan_handler(&self, handler: Arc<dyn SubplanHandler>) {
+        for drain in self.inbound_receivers.iter().flatten() {
+            drain.set_subplan_handler(Arc::clone(&handler));
+        }
+    }
+
+    /// Drop every drain's installed subplan handler at teardown, symmetric with
+    /// [`Self::uninstall_request_handler`].
+    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
+    pub(crate) fn uninstall_subplan_handler(&self) {
+        for drain in self.inbound_receivers.iter().flatten() {
+            drain.clear_subplan_handler();
         }
     }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -170,7 +170,6 @@ impl MppFrameHeader {
     /// Same task_idx packing as [`Self::request`]; `partition` is unused (set to 0) because the
     /// subplan applies to all output partitions of `(stage_id, task_idx)`. Errors if `task_idx`
     /// doesn't fit in 24 bits.
-    #[allow(dead_code)] // wired by Phase 2 of the dispatch-flip PR; tested via the test module.
     pub fn subplan(stage_id: u32, task_idx: u32) -> Result<Self, DataFusionError> {
         if task_idx > TASK_IDX_MAX {
             return Err(DataFusionError::Internal(format!(
@@ -383,7 +382,6 @@ fn decode_frame(bytes: &[u8]) -> Result<(MppFrameHeader, Option<RecordBatch>), D
 /// [ magic | flags=Subplan|task_idx<<8 | stage_id | partition=0 ] [ subplan_bytes ]
 /// |---------- 16 bytes --------|                                 |- variable -|
 /// ```
-#[allow(dead_code)] // wired by Phase 2 of the dispatch-flip PR; tested via the test module.
 fn encode_subplan_frame_into(
     stage_id: u32,
     task_idx: u32,
@@ -737,7 +735,6 @@ impl MppSender {
     ///
     /// Uses the same cooperative spin as `send_batch_traced` so a full outbound queue doesn't
     /// stall the leader's setup phase.
-    #[allow(dead_code)] // called by Phase 2 of the dispatch-flip PR.
     pub(super) async fn send_subplan_traced(
         &self,
         task_idx: u32,
@@ -776,10 +773,6 @@ impl MppSender {
         self.send_pre_encoded(scratch, stats).await
     }
 
-    // `send_subplan_traced` itself carries an `#[allow(dead_code)]` until Phase 2 wires it; this
-    // helper rides along on the same allow because it's only reachable through that public
-    // entry point. Drop both allows together.
-    #[allow(dead_code)]
     async fn send_subplan_with_scratch(
         &self,
         task_idx: u32,

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -1161,7 +1161,6 @@ impl DrainHandle {
     /// Install a subplan handler. Idempotent overwrite — installing twice replaces the previous
     /// handler. Wired by [`MppMesh::install_subplan_handler`] on the worker's leader-side drain
     /// so leader-shipped subplans reach the `ProducerTaskRegistry`.
-    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
     pub fn set_subplan_handler(&self, handler: Arc<dyn SubplanHandler>) {
         *self
             .subplan_handler
@@ -1171,7 +1170,6 @@ impl DrainHandle {
 
     /// Drop the installed subplan handler. Service loop calls this at teardown for symmetry with
     /// [`Self::clear_request_handler`] so both registry-side handles release together.
-    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
     pub fn clear_subplan_handler(&self) {
         *self
             .subplan_handler

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -78,6 +78,12 @@ pub(super) enum MppFrameKind {
     Batch = 0,
     Eof = 1,
     Request = 2,
+    /// Leader-to-worker control frame. Header carries `(stage_id, task_idx)` in the same shape
+    /// as `Request` (task_idx in the upper 24 bits of flags), and the payload is the
+    /// `PgSearchPhysicalCodec`-encoded subplan bytes the worker stashes in its
+    /// `ProducerTaskRegistry`. Pre-shipping subplans this way is what lets the dispatch-flip drop
+    /// the logical-plan-in-DSM scheme: workers no longer need to re-build the physical plan.
+    Subplan = 3,
 }
 
 /// 16-byte prefix on every transport frame.
@@ -160,21 +166,41 @@ impl MppFrameHeader {
         })
     }
 
+    /// Build a `Subplan` header tagging a leader-to-worker subplan ship for `(stage_id, task_idx)`.
+    /// Same task_idx packing as [`Self::request`]; `partition` is unused (set to 0) because the
+    /// subplan applies to all output partitions of `(stage_id, task_idx)`. Errors if `task_idx`
+    /// doesn't fit in 24 bits.
+    #[allow(dead_code)] // wired by Phase 2 of the dispatch-flip PR; tested via the test module.
+    pub fn subplan(stage_id: u32, task_idx: u32) -> Result<Self, DataFusionError> {
+        if task_idx > TASK_IDX_MAX {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: Subplan frame task_idx={task_idx} exceeds 24-bit max ({TASK_IDX_MAX})"
+            )));
+        }
+        Ok(Self {
+            magic: MPP_FRAME_MAGIC,
+            flags: (MppFrameKind::Subplan as u32) | (task_idx << TASK_IDX_SHIFT),
+            stage_id,
+            partition: 0,
+        })
+    }
+
     /// Read the kind out of `flags`. Errors on unknown kinds, or on non-zero upper bits for
-    /// kinds that don't use them (`Batch`/`Eof`). `Request` interprets the upper 24 bits as
-    /// `task_idx`, so reserved-bit validation is skipped there.
+    /// kinds that don't use them (`Batch`/`Eof`). `Request` and `Subplan` interpret the upper 24
+    /// bits as `task_idx`, so reserved-bit validation is skipped for those.
     pub(super) fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
         let kind = match self.flags & FRAME_KIND_MASK {
             0 => MppFrameKind::Batch,
             1 => MppFrameKind::Eof,
             2 => MppFrameKind::Request,
+            3 => MppFrameKind::Subplan,
             other => {
                 return Err(DataFusionError::Internal(format!(
                     "mpp: unknown frame kind {other:#x}"
                 )))
             }
         };
-        if !matches!(kind, MppFrameKind::Request) {
+        if !matches!(kind, MppFrameKind::Request | MppFrameKind::Subplan) {
             let reserved = self.flags & !FRAME_KIND_MASK;
             if reserved != 0 {
                 return Err(DataFusionError::Internal(format!(
@@ -296,8 +322,9 @@ fn encode_request_frame_into(
 }
 
 /// Inverse of [`encode_frame_into`]. Parses the 16-byte header and, for `Batch` frames, decodes
-/// the trailing Arrow IPC stream. `Eof` and `Request` frames return `(header, None)`. Receivers
-/// branch on `header.kind()` to decide routing.
+/// the trailing Arrow IPC stream. `Eof` and `Request` frames return `(header, None)`. `Subplan`
+/// is handled by [`MppReceiver::try_recv_batch`] before reaching this function so the raw payload
+/// stays accessible; reaching here with `Subplan` is a routing bug.
 fn decode_frame(bytes: &[u8]) -> Result<(MppFrameHeader, Option<RecordBatch>), DataFusionError> {
     let header = MppFrameHeader::parse(bytes)?;
     match header.kind()? {
@@ -329,7 +356,37 @@ fn decode_frame(bytes: &[u8]) -> Result<(MppFrameHeader, Option<RecordBatch>), D
             })??;
             Ok((header, Some(batch)))
         }
+        MppFrameKind::Subplan => Err(DataFusionError::Internal(
+            "mpp: decode_frame called on Subplan (caller should route via try_recv_batch's \
+             Subplan branch so the payload isn't lost)"
+                .into(),
+        )),
     }
+}
+
+/// Serialize a [`MppFrameKind::Subplan`] frame: 16-byte header for `(stage_id, task_idx)` followed
+/// by `subplan_bytes`. Consumed on the worker side by the installed [`SubplanHandler`] via
+/// [`DrainHandle::try_drain_pass`]'s subplan dispatch.
+///
+/// Wire layout:
+///
+/// ```text
+/// [ magic | flags=Subplan|task_idx<<8 | stage_id | partition=0 ] [ subplan_bytes ]
+/// |---------- 16 bytes --------|                                 |- variable -|
+/// ```
+#[allow(dead_code)] // wired by Phase 2 of the dispatch-flip PR; tested via the test module.
+fn encode_subplan_frame_into(
+    stage_id: u32,
+    task_idx: u32,
+    subplan_bytes: &[u8],
+    buf: &mut Vec<u8>,
+) -> Result<(), DataFusionError> {
+    buf.clear();
+    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
+    let header = MppFrameHeader::subplan(stage_id, task_idx)?;
+    header.write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
+    buf.extend_from_slice(subplan_bytes);
+    Ok(())
 }
 
 /// Local queue between a drain (either the cooperative `try_drain_pass` or the test-only thread
@@ -663,13 +720,36 @@ impl MppSender {
         result
     }
 
+    /// Ship a `(stage_id, task_idx)` subplan from the leader to its owning worker. `subplan_bytes`
+    /// is the `PgSearchPhysicalCodec` output for the worker's per-`(stage, task)` physical
+    /// subplan. The shm_mq peer reads this as a 16-byte header followed by `subplan_bytes` and
+    /// hands it to its installed [`SubplanHandler`], which decodes and stashes in the
+    /// `ProducerTaskRegistry`.
+    ///
+    /// Uses the same cooperative spin as `send_batch_traced` so a full outbound queue doesn't
+    /// stall the leader's setup phase.
+    #[allow(dead_code)] // called by Phase 2 of the dispatch-flip PR.
+    pub(super) async fn send_subplan_traced(
+        &self,
+        task_idx: u32,
+        subplan_bytes: &[u8],
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
+        let mut scratch = self.scratch.replace(Vec::new());
+        let result = self
+            .send_subplan_with_scratch(task_idx, subplan_bytes, &mut scratch, stats)
+            .await;
+        self.scratch.replace(scratch);
+        result
+    }
+
     async fn send_eof_with_scratch(
         &self,
         scratch: &mut Vec<u8>,
         stats: &mut SendBatchStats,
     ) -> Result<(), DataFusionError> {
         encode_eof_frame_into(self.header.stage_id, self.header.partition, scratch)?;
-        self.send_header_only(scratch, stats).await
+        self.send_pre_encoded(scratch, stats).await
     }
 
     async fn send_request_with_scratch(
@@ -684,13 +764,26 @@ impl MppSender {
             self.header.partition,
             scratch,
         )?;
-        self.send_header_only(scratch, stats).await
+        self.send_pre_encoded(scratch, stats).await
     }
 
-    /// Shared spin used by every header-only send path (`Eof`, `Request`). Without a cooperative
-    /// drain attached, falls through to the blocking send (in-proc test channels behave that way
-    /// and never block long enough to matter).
-    async fn send_header_only(
+    #[allow(dead_code)] // called by `send_subplan_traced`; tail-of-tree allow.
+    async fn send_subplan_with_scratch(
+        &self,
+        task_idx: u32,
+        subplan_bytes: &[u8],
+        scratch: &mut Vec<u8>,
+        stats: &mut SendBatchStats,
+    ) -> Result<(), DataFusionError> {
+        encode_subplan_frame_into(self.header.stage_id, task_idx, subplan_bytes, scratch)?;
+        self.send_pre_encoded(scratch, stats).await
+    }
+
+    /// Shared spin used by every send path that has already encoded its frame into `scratch`:
+    /// `Eof`, `Request`, and `Subplan` (the last with a payload, the others header-only). Without
+    /// a cooperative drain attached, falls through to the blocking send (in-proc test channels
+    /// behave that way and never block long enough to matter).
+    async fn send_pre_encoded(
         &self,
         scratch: &[u8],
         stats: &mut SendBatchStats,
@@ -831,21 +924,57 @@ impl MppReceiver {
     }
 
     pub(super) fn try_recv_batch(&self) -> RecvBatchOutcome {
-        match self.channel.try_recv() {
-            RecvOutcome::Bytes(bytes) => match decode_frame(&bytes) {
-                Ok((header, Some(batch))) => RecvBatchOutcome::Batch { header, batch },
-                Ok((header, None)) => match header.kind() {
-                    Ok(MppFrameKind::Request) => RecvBatchOutcome::Request { header },
-                    Ok(MppFrameKind::Eof) => RecvBatchOutcome::Eof { header },
-                    Ok(MppFrameKind::Batch) => RecvBatchOutcome::Error(DataFusionError::Internal(
-                        "mpp: decode_frame returned Batch kind with no payload".into(),
-                    )),
+        let bytes = match self.channel.try_recv() {
+            RecvOutcome::Bytes(b) => b,
+            RecvOutcome::Empty => return RecvBatchOutcome::Empty,
+            RecvOutcome::Detached => return RecvBatchOutcome::Detached,
+        };
+        let header = match MppFrameHeader::parse(&bytes) {
+            Ok(h) => h,
+            Err(e) => return RecvBatchOutcome::Error(e),
+        };
+        let kind = match header.kind() {
+            Ok(k) => k,
+            Err(e) => return RecvBatchOutcome::Error(e),
+        };
+        // Subplan has a payload (the codec-encoded subplan bytes); the other kinds either have a
+        // payload-less header (Eof, Request) or an Arrow IPC stream (Batch). Dispatch each kind
+        // inline so we don't duplicate the payload-length checks `decode_frame` does.
+        match kind {
+            MppFrameKind::Subplan => {
+                if bytes.len() <= MPP_FRAME_HEADER_SIZE {
+                    return RecvBatchOutcome::Error(DataFusionError::Internal(format!(
+                        "mpp: Subplan frame missing payload (len {} <= header size {})",
+                        bytes.len(),
+                        MPP_FRAME_HEADER_SIZE
+                    )));
+                }
+                let payload = bytes[MPP_FRAME_HEADER_SIZE..].to_vec();
+                RecvBatchOutcome::Subplan { header, payload }
+            }
+            MppFrameKind::Batch | MppFrameKind::Eof | MppFrameKind::Request => {
+                match decode_frame(&bytes) {
+                    Ok((header, Some(batch))) => RecvBatchOutcome::Batch { header, batch },
+                    Ok((header, None)) => match header.kind() {
+                        Ok(MppFrameKind::Request) => RecvBatchOutcome::Request { header },
+                        Ok(MppFrameKind::Eof) => RecvBatchOutcome::Eof { header },
+                        Ok(MppFrameKind::Batch) => {
+                            RecvBatchOutcome::Error(DataFusionError::Internal(
+                                "mpp: decode_frame returned Batch kind with no payload".into(),
+                            ))
+                        }
+                        Ok(MppFrameKind::Subplan) => {
+                            // Unreachable: we dispatched Subplan above. Surface as an internal
+                            // error in case the kind reading drifts between the two call sites.
+                            RecvBatchOutcome::Error(DataFusionError::Internal(
+                                "mpp: try_recv_batch handed Subplan to decode_frame".into(),
+                            ))
+                        }
+                        Err(e) => RecvBatchOutcome::Error(e),
+                    },
                     Err(e) => RecvBatchOutcome::Error(e),
-                },
-                Err(e) => RecvBatchOutcome::Error(e),
-            },
-            RecvOutcome::Empty => RecvBatchOutcome::Empty,
-            RecvOutcome::Detached => RecvBatchOutcome::Detached,
+                }
+            }
         }
     }
 }
@@ -865,6 +994,24 @@ pub trait RequestHandler: Send + Sync {
         stage_id: u32,
         task_idx: u32,
         partition: u32,
+    ) -> Result<(), DataFusionError>;
+}
+
+/// Worker-side dispatcher for incoming [`MppFrameKind::Subplan`] frames. The cooperative drain
+/// calls `on_subplan` whenever the leader ships a per-`(stage_id, task_idx)` physical subplan;
+/// implementations decode the bytes with [`crate::scan::physical_codec::PgSearchPhysicalCodec`]
+/// and stash the resulting `Arc<dyn ExecutionPlan>` in their `ProducerTaskRegistry` so a later
+/// `Request` for the same `(stage_id, task_idx)` finds it already prepared.
+///
+/// Dispatch happens inline on the worker's backend thread (same as `RequestHandler`), so the
+/// handler shouldn't block on async work; `prepare_in_process_plan` already ran on the leader
+/// side before the subplan was shipped.
+pub trait SubplanHandler: Send + Sync {
+    fn on_subplan(
+        &self,
+        stage_id: u32,
+        task_idx: u32,
+        payload: Vec<u8>,
     ) -> Result<(), DataFusionError>;
 }
 
@@ -890,6 +1037,15 @@ pub(super) enum RecvBatchOutcome {
     /// cooperative drain dispatches to its installed [`RequestHandler`].
     Request {
         header: MppFrameHeader,
+    },
+    /// A leader-to-worker `Subplan` frame: header carries `(stage_id, task_idx)`, payload is the
+    /// `PgSearchPhysicalCodec`-encoded subplan bytes. The cooperative drain dispatches to its
+    /// installed [`SubplanHandler`] which stashes the decoded plan in the worker's
+    /// `ProducerTaskRegistry` so a follow-up `Request` for the same `(stage_id, task_idx)` can
+    /// execute it without re-planning.
+    Subplan {
+        header: MppFrameHeader,
+        payload: Vec<u8>,
     },
     Empty,
     Detached,
@@ -950,6 +1106,11 @@ pub struct DrainHandle {
     /// at teardown — needed to break the `MppMesh ↔ DrainHandle ↔ Arc<dyn RequestHandler> ↔
     /// Weak<MppMesh>` chain on shutdown.
     request_handler: Mutex<Option<Arc<dyn RequestHandler>>>,
+    /// Installed by the worker's service loop via [`MppMesh::install_subplan_handler`] to receive
+    /// leader-shipped subplans. Lifetime parallels `request_handler`; cleared at teardown to drop
+    /// the strong `Arc<dyn SubplanHandler>` reference. Workers only install this on their drain
+    /// for the leader (proc 0) — peer-to-peer subplan shipping doesn't happen today.
+    subplan_handler: Mutex<Option<Arc<dyn SubplanHandler>>>,
 }
 
 impl DrainHandle {
@@ -968,6 +1129,7 @@ impl DrainHandle {
             coop_receivers: Mutex::new(wrapped),
             sender_proc,
             request_handler: Mutex::new(None),
+            subplan_handler: Mutex::new(None),
         }
     }
 
@@ -989,6 +1151,27 @@ impl DrainHandle {
             .request_handler
             .lock()
             .expect("DrainHandle request_handler mutex poisoned") = None;
+    }
+
+    /// Install a subplan handler. Idempotent overwrite — installing twice replaces the previous
+    /// handler. Wired by [`MppMesh::install_subplan_handler`] on the worker's leader-side drain
+    /// so leader-shipped subplans reach the `ProducerTaskRegistry`.
+    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
+    pub fn set_subplan_handler(&self, handler: Arc<dyn SubplanHandler>) {
+        *self
+            .subplan_handler
+            .lock()
+            .expect("DrainHandle subplan_handler mutex poisoned") = Some(handler);
+    }
+
+    /// Drop the installed subplan handler. Service loop calls this at teardown for symmetry with
+    /// [`Self::clear_request_handler`] so both registry-side handles release together.
+    #[allow(dead_code)] // called by Phase 3 of the dispatch-flip PR.
+    pub fn clear_subplan_handler(&self) {
+        *self
+            .subplan_handler
+            .lock()
+            .expect("DrainHandle subplan_handler mutex poisoned") = None;
     }
 
     /// True once [`Self::try_drain_pass`] has observed `Detached` from its underlying receiver.
@@ -1115,13 +1298,15 @@ impl DrainHandle {
         // indefinitely on one source and starve its own outbound.
         const MAX_BATCHES_PER_SOURCE_PER_PASS: usize = 256;
 
-        // Collect Request headers under the receiver lock, then drop the lock and dispatch
-        // outside. `on_request` can do real work on a cache miss (DF's `prepare_in_process_plan`
-        // is transform_up + codec encoding), and holding the lock across that would stall any
-        // concurrent `force_detach` and block drain progress on every other receiver too. The
-        // two phases don't need to be atomic: Request dispatch just spawns a future and pokes
-        // registry-local state. Doesn't care which Batch/Eof frames drained before or after.
+        // Collect Request and Subplan frames under the receiver lock, then drop the lock and
+        // dispatch outside. Both dispatch paths (`on_request` → DF's `prepare_in_process_plan` +
+        // codec encoding; `on_subplan` → physical-codec decode) can do real work, and holding
+        // the lock across that would stall any concurrent `force_detach` and block drain
+        // progress on every other receiver too. The two phases don't need to be atomic: Request
+        // / Subplan dispatch just pokes registry-local state, doesn't care which Batch/Eof
+        // frames drained before or after.
         let mut pending_requests: Vec<MppFrameHeader> = Vec::new();
+        let mut pending_subplans: Vec<(MppFrameHeader, Vec<u8>)> = Vec::new();
         {
             let mut slots = self.coop_receivers.lock().unwrap();
             for slot in slots.iter_mut() {
@@ -1143,6 +1328,9 @@ impl DrainHandle {
                         RecvBatchOutcome::Request { header } => {
                             pending_requests.push(header);
                         }
+                        RecvBatchOutcome::Subplan { header, payload } => {
+                            pending_subplans.push((header, payload));
+                        }
                         RecvBatchOutcome::Empty => break,
                         RecvBatchOutcome::Detached => {
                             *slot = None;
@@ -1160,6 +1348,11 @@ impl DrainHandle {
             // `slots` guard drops here, releasing `coop_receivers` before dispatch.
         }
 
+        // Subplans first: any Requests that arrived in the same pass for a `(stage_id, task_idx)`
+        // covered by these subplans need the registry populated before dispatch.
+        if !pending_subplans.is_empty() {
+            self.dispatch_subplans(pending_subplans)?;
+        }
         if !pending_requests.is_empty() {
             self.dispatch_requests(pending_requests)?;
         }
@@ -1203,6 +1396,34 @@ impl DrainHandle {
                 header.task_idx(),
                 header.partition,
             )?;
+        }
+        Ok(())
+    }
+
+    /// Forward `Subplan` frames to the installed handler. Same teardown-race semantics as
+    /// [`Self::dispatch_requests`]: if no handler is installed (worker shutting down before all
+    /// subplans arrived) we drop them silently, since the producer registry that would receive
+    /// them has already been torn down by the service loop. Any subsequent Request for the same
+    /// `(stage_id, task_idx)` would fail to find a prepared plan and surface its own error.
+    fn dispatch_subplans(
+        &self,
+        items: Vec<(MppFrameHeader, Vec<u8>)>,
+    ) -> Result<(), DataFusionError> {
+        let handler = self
+            .subplan_handler
+            .lock()
+            .expect("DrainHandle subplan_handler mutex poisoned")
+            .as_ref()
+            .map(Arc::clone);
+        let Some(handler) = handler else {
+            crate::mpp_log!(
+                "mpp drain: {} Subplan frame(s) dropped, no handler installed (teardown race)",
+                items.len()
+            );
+            return Ok(());
+        };
+        for (header, payload) in items {
+            handler.on_subplan(header.stage_id, header.task_idx(), payload)?;
         }
         Ok(())
     }
@@ -1469,6 +1690,20 @@ mod tests {
                             header.partition,
                         )));
                     }
+                    RecvBatchOutcome::Subplan { header, .. } => {
+                        // Same rationale as the Request arm: tests using `spawn_drain_thread`
+                        // don't exercise the dispatch-flip subplan-shipping path. Surface as a
+                        // hard error so a future test that accidentally produces a Subplan
+                        // doesn't silently swallow it.
+                        done[i] = true;
+                        buffer.notify_source_done();
+                        return Err(DataFusionError::Internal(format!(
+                            "mpp test drain_loop: unexpected Subplan frame \
+                             (stage_id={}, task_idx={})",
+                            header.stage_id,
+                            header.task_idx(),
+                        )));
+                    }
                     RecvBatchOutcome::Empty => {}
                     RecvBatchOutcome::Detached => {
                         done[i] = true;
@@ -1656,6 +1891,148 @@ mod tests {
         let header = MppFrameHeader::request(5, 0, 7).expect("task_idx=0 must construct");
         assert_eq!(header.kind().unwrap(), MppFrameKind::Request);
         assert_eq!(header.task_idx(), 0);
+    }
+
+    #[test]
+    fn frame_round_trips_subplan_with_payload() {
+        let payload: Vec<u8> = (0..32).collect();
+        let mut buf = Vec::with_capacity(MPP_FRAME_HEADER_SIZE + payload.len());
+        encode_subplan_frame_into(17, 3, &payload, &mut buf).expect("encode_subplan");
+        assert_eq!(buf.len(), MPP_FRAME_HEADER_SIZE + payload.len());
+
+        // `decode_frame` deliberately rejects Subplan: try_recv_batch handles it before calling
+        // `decode_frame` so the raw payload isn't lost. Pin that rejection in a test so any
+        // future re-routing that breaks the invariant fails loudly.
+        let err = decode_frame(&buf).expect_err("decode_frame must reject Subplan");
+        assert!(format!("{err}").contains("decode_frame called on Subplan"));
+
+        // The actual decode path: parse header, slice payload out of the bytes manually (mirrors
+        // try_recv_batch's Subplan branch).
+        let parsed = MppFrameHeader::parse(&buf).expect("header parse");
+        assert_eq!(parsed.kind().unwrap(), MppFrameKind::Subplan);
+        assert_eq!(parsed.stage_id, 17);
+        assert_eq!(parsed.task_idx(), 3);
+        assert_eq!(parsed.partition, 0);
+        assert_eq!(&buf[MPP_FRAME_HEADER_SIZE..], payload.as_slice());
+    }
+
+    #[test]
+    fn subplan_frame_rejects_overflowing_task_idx() {
+        let err = MppFrameHeader::subplan(0, TASK_IDX_MAX + 1)
+            .expect_err("overflow must surface as error");
+        assert!(format!("{err}").contains("exceeds 24-bit max"));
+    }
+
+    #[test]
+    fn try_recv_batch_decodes_subplan_payload() {
+        // Drive the receiver-side path: encode a Subplan frame, push it through an in-proc
+        // channel, and assert `try_recv_batch` returns `Subplan { header, payload }` with the
+        // bytes intact.
+        let (tx, rx) = in_proc_channel(8);
+        let receiver = MppReceiver::new(Box::new(rx));
+        let payload: Vec<u8> = b"hello-subplan".to_vec();
+        let mut buf = Vec::new();
+        encode_subplan_frame_into(2, 5, &payload, &mut buf).expect("encode_subplan");
+        tx.send_bytes(&buf).expect("tx send");
+
+        match receiver.try_recv_batch() {
+            RecvBatchOutcome::Subplan {
+                header,
+                payload: got,
+            } => {
+                assert_eq!(header.stage_id, 2);
+                assert_eq!(header.task_idx(), 5);
+                assert_eq!(got, payload);
+            }
+            other => panic!("expected Subplan, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn try_recv_batch_rejects_subplan_with_empty_payload() {
+        // A Subplan frame with no payload bytes is structurally broken — the codec always
+        // produces at least one byte. Surface that as a decode error rather than handing back
+        // an empty `Vec<u8>` to the SubplanHandler.
+        let (tx, rx) = in_proc_channel(8);
+        let receiver = MppReceiver::new(Box::new(rx));
+        // Hand-craft a frame: header only, no payload.
+        let header = MppFrameHeader::subplan(0, 0).expect("subplan header");
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        tx.send_bytes(&buf).expect("tx send");
+
+        match receiver.try_recv_batch() {
+            RecvBatchOutcome::Error(e) => {
+                assert!(
+                    format!("{e}").contains("Subplan frame missing payload"),
+                    "unexpected error: {e}"
+                );
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn drain_handle_dispatches_subplan_to_handler() {
+        // End-to-end: install a `SubplanHandler` on a DrainHandle, push a Subplan frame through
+        // the underlying receiver, run `try_drain_pass`, and verify the handler observed the
+        // call with the right `(stage_id, task_idx, payload)`.
+        type Captured = (u32, u32, Vec<u8>);
+        struct CapturingHandler {
+            calls: std::sync::Mutex<Vec<Captured>>,
+        }
+        impl SubplanHandler for CapturingHandler {
+            fn on_subplan(
+                &self,
+                stage_id: u32,
+                task_idx: u32,
+                payload: Vec<u8>,
+            ) -> Result<(), DataFusionError> {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push((stage_id, task_idx, payload));
+                Ok(())
+            }
+        }
+
+        let (tx, rx) = in_proc_channel(8);
+        let recv = MppReceiver::new(Box::new(rx));
+        let drain = DrainHandle::cooperative(vec![recv], Some(0));
+        let handler = std::sync::Arc::new(CapturingHandler {
+            calls: std::sync::Mutex::new(Vec::new()),
+        });
+        drain.set_subplan_handler(handler.clone() as Arc<dyn SubplanHandler>);
+
+        let payload: Vec<u8> = vec![1, 2, 3, 4, 5];
+        let mut buf = Vec::new();
+        encode_subplan_frame_into(9, 6, &payload, &mut buf).expect("encode_subplan");
+        tx.send_bytes(&buf).expect("tx send");
+
+        drain.try_drain_pass().expect("drain pass");
+        let calls = handler.calls.lock().unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0], (9, 6, payload));
+    }
+
+    #[test]
+    fn drain_handle_drops_subplan_when_handler_absent() {
+        // Teardown race: a Subplan frame arrives after `clear_subplan_handler`. The drain must
+        // not error — the registry that would receive it is already torn down, and downstream
+        // Request frames for the same (stage, task) will surface their own miss errors. Just
+        // log and continue.
+        let (tx, rx) = in_proc_channel(8);
+        let recv = MppReceiver::new(Box::new(rx));
+        let drain = DrainHandle::cooperative(vec![recv], Some(0));
+
+        let payload: Vec<u8> = vec![0xAA];
+        let mut buf = Vec::new();
+        encode_subplan_frame_into(0, 0, &payload, &mut buf).expect("encode_subplan");
+        tx.send_bytes(&buf).expect("tx send");
+
+        drain
+            .try_drain_pass()
+            .expect("drain pass tolerates missing handler");
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -208,11 +208,20 @@ impl MppFrameHeader {
                 )));
             }
         }
+        // Subplan frames don't use the `partition` field — the encoder always writes 0. Reject
+        // non-zero so a future change that accidentally encoded routing information there can't
+        // sneak past a handler that doesn't read it.
+        if matches!(kind, MppFrameKind::Subplan) && self.partition != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: Subplan frame has reserved partition field set ({})",
+                self.partition,
+            )));
+        }
         Ok(kind)
     }
 
-    /// Task index encoded in a `Request` frame's upper 24 bits. Only meaningful when `kind()` is
-    /// `Request`; returns the raw upper bits otherwise.
+    /// Task index encoded in a `Request` or `Subplan` frame's upper 24 bits. Only meaningful when
+    /// `kind()` is one of those two; returns the raw upper bits otherwise.
     pub(super) fn task_idx(&self) -> u32 {
         self.flags >> TASK_IDX_SHIFT
     }
@@ -767,7 +776,10 @@ impl MppSender {
         self.send_pre_encoded(scratch, stats).await
     }
 
-    #[allow(dead_code)] // called by `send_subplan_traced`; tail-of-tree allow.
+    // `send_subplan_traced` itself carries an `#[allow(dead_code)]` until Phase 2 wires it; this
+    // helper rides along on the same allow because it's only reachable through that public
+    // entry point. Drop both allows together.
+    #[allow(dead_code)]
     async fn send_subplan_with_scratch(
         &self,
         task_idx: u32,
@@ -1403,8 +1415,9 @@ impl DrainHandle {
     /// Forward `Subplan` frames to the installed handler. Same teardown-race semantics as
     /// [`Self::dispatch_requests`]: if no handler is installed (worker shutting down before all
     /// subplans arrived) we drop them silently, since the producer registry that would receive
-    /// them has already been torn down by the service loop. Any subsequent Request for the same
-    /// `(stage_id, task_idx)` would fail to find a prepared plan and surface its own error.
+    /// them has already been torn down by the service loop. Later phases of the dispatch-flip
+    /// wire a producer-side miss path that surfaces an error if a Request arrives for a
+    /// `(stage_id, task_idx)` whose Subplan was dropped; until then this is a no-op log entry.
     fn dispatch_subplans(
         &self,
         items: Vec<(MppFrameHeader, Vec<u8>)>,
@@ -2013,6 +2026,104 @@ mod tests {
         let calls = handler.calls.lock().unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0], (9, 6, payload));
+    }
+
+    #[test]
+    fn subplan_frame_packs_max_task_idx() {
+        // 24-bit max round-trips cleanly: header parses, kind() == Subplan, task_idx() == max.
+        let header = MppFrameHeader::subplan(1, TASK_IDX_MAX).expect("max task_idx must fit");
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        let parsed = MppFrameHeader::parse(&buf).expect("header parse");
+        assert_eq!(parsed.kind().unwrap(), MppFrameKind::Subplan);
+        assert_eq!(parsed.task_idx(), TASK_IDX_MAX);
+        assert_eq!(parsed.stage_id, 1);
+        assert_eq!(parsed.partition, 0);
+    }
+
+    #[test]
+    fn subplan_frame_rejects_nonzero_partition_field() {
+        // The encoder always writes partition=0, but a peer (or a future code change) could put
+        // routing information there by mistake. Decode must reject non-zero so it doesn't sneak
+        // past `on_subplan`, which doesn't look at partition.
+        let mut header =
+            MppFrameHeader::subplan(2, 4).expect("subplan header for the partition test");
+        header.partition = 7;
+        let err = header.kind().expect_err("non-zero partition must fail");
+        assert!(
+            format!("{err}").contains("reserved partition field set"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn drain_handle_dispatches_subplan_before_request_in_same_pass() {
+        // Pin the dispatch-ordering invariant the dispatch-flip relies on: when a Subplan and a
+        // Request for the same `(stage_id, task_idx)` arrive in the same drain pass, the
+        // SubplanHandler must run before the RequestHandler so the registry is populated by the
+        // time the request lands. Without this, a Phase 3 implementation that looks up the plan
+        // synchronously would see a miss on the very first request.
+        type Event = (&'static str, u32, u32);
+        struct OrderingHandler {
+            calls: std::sync::Arc<std::sync::Mutex<Vec<Event>>>,
+        }
+        impl SubplanHandler for OrderingHandler {
+            fn on_subplan(
+                &self,
+                stage_id: u32,
+                task_idx: u32,
+                _payload: Vec<u8>,
+            ) -> Result<(), DataFusionError> {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push(("subplan", stage_id, task_idx));
+                Ok(())
+            }
+        }
+        impl RequestHandler for OrderingHandler {
+            fn on_request(
+                &self,
+                _sender_proc: u32,
+                stage_id: u32,
+                task_idx: u32,
+                _partition: u32,
+            ) -> Result<(), DataFusionError> {
+                self.calls
+                    .lock()
+                    .unwrap()
+                    .push(("request", stage_id, task_idx));
+                Ok(())
+            }
+        }
+
+        let (tx, rx) = in_proc_channel(8);
+        let recv = MppReceiver::new(Box::new(rx));
+        let drain = DrainHandle::cooperative(vec![recv], Some(0));
+        let events = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let handler = std::sync::Arc::new(OrderingHandler {
+            calls: events.clone(),
+        });
+        drain.set_subplan_handler(handler.clone() as Arc<dyn SubplanHandler>);
+        drain.set_request_handler(handler.clone() as Arc<dyn RequestHandler>);
+
+        // Push Request first, then Subplan, into the wire. Even with this "wrong" order on the
+        // wire, dispatch-ordering inside try_drain_pass must surface Subplan first.
+        let mut req_buf = Vec::new();
+        encode_request_frame_into(7, 3, 0, &mut req_buf).expect("encode_request");
+        tx.send_bytes(&req_buf).expect("tx send request");
+
+        let payload = b"plan-bytes".to_vec();
+        let mut sub_buf = Vec::new();
+        encode_subplan_frame_into(7, 3, &payload, &mut sub_buf).expect("encode_subplan");
+        tx.send_bytes(&sub_buf).expect("tx send subplan");
+
+        drain.try_drain_pass().expect("drain pass");
+
+        let calls = events.lock().unwrap();
+        assert_eq!(calls.len(), 2, "both handlers must fire");
+        assert_eq!(calls[0], ("subplan", 7, 3), "subplan dispatched first");
+        assert_eq!(calls[1], ("request", 7, 3), "request dispatched second");
     }
 
     #[test]

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -23,9 +23,7 @@ use datafusion::common::{DFSchemaRef, DataFusionError, Result, TableReference};
 use datafusion::execution::TaskContext;
 use datafusion::functions_aggregate as dfa;
 use datafusion::logical_expr::{AggregateUDF, Extension, LogicalPlan, ScalarUDF};
-use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
-use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use datafusion_proto::protobuf::DfSchema;
 use pgrx::pg_sys::{ExprContext, Oid, PlanState};
 use tantivy::index::SegmentId;
@@ -376,53 +374,4 @@ pub fn deserialize_logical_plan_with_runtime(
         index_segment_ids,
     };
     datafusion_proto::bytes::logical_plan_from_bytes_with_extension_codec(bytes, ctx, &codec)
-}
-
-/// Stub `PhysicalExtensionCodec` registered with the fork's distributed planner
-/// (via `with_distributed_user_codec`). The fork's `DistributedExec::prepare_plan`
-/// always tries to serialize the worker subplan to ship over gRPC, even when the
-/// `WorkerTransport` is in-process (our `ShmMqWorkerTransport`). Without a codec
-/// for our custom physical execs, encoding fails before any execution starts.
-///
-/// In our model, workers re-plan from the **logical** plan we ship via DSM (see
-/// `exec_mpp_worker`); they never deserialize the encoded physical plan, and the
-/// gRPC plan-send to the fake `http://mpp.local/` URL fails silently in the
-/// fork's `JoinSet` without affecting correctness. So this codec only needs
-/// `try_encode` to succeed for the leader's physical plan walker — the encoded
-/// bytes are inert. `try_decode` is unreachable in our setup.
-#[derive(Debug)]
-pub struct PgSearchPhysicalCodecStub;
-
-impl PhysicalExtensionCodec for PgSearchPhysicalCodecStub {
-    fn try_decode(
-        &self,
-        _buf: &[u8],
-        _inputs: &[Arc<dyn ExecutionPlan>],
-        _ctx: &TaskContext,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(DataFusionError::Internal(
-            "PgSearchPhysicalCodecStub::try_decode invoked; \
-             workers re-plan from the logical plan in DSM and should never \
-             deserialize a physical subplan over the wire"
-                .into(),
-        ))
-    }
-
-    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, _buf: &mut Vec<u8>) -> Result<()> {
-        // Recognize every custom physical exec we might emit. Encode to empty
-        // bytes; the encoded plan is shipped to a stub URL that no real worker
-        // listens on, so the bytes themselves are never observed.
-        match node.name() {
-            "PgSearchScan"
-            | "VisibilityFilterExec"
-            | "VisibilityFilter"
-            | "VisibilityFilterInjection"
-            | "SegmentedTopKExec"
-            | "TantivyLookupExec"
-            | "FilterPassthroughExec" => Ok(()),
-            other => Err(DataFusionError::Internal(format!(
-                "PgSearchPhysicalCodecStub::try_encode: unrecognized custom exec {other}"
-            ))),
-        }
-    }
 }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -326,6 +326,39 @@ impl PhysicalExtensionCodec for PgSearchPhysicalCodec {
             DataFusionError::Internal(format!("PgSearchPhysicalCodec: prost encode failed: {e}"))
         })
     }
+
+    // UDAF round-trip for the same built-in aggregates the logical codec handles
+    // (`scan/codec.rs::PgSearchExtensionCodec::try_decode_udaf`). Shipped physical plans that
+    // wrap an `AggregateExec` with `count`/`sum`/etc. reach this path; without it the worker
+    // errors with "PhysicalExtensionCodec is not provided for aggregate function {name}". The
+    // encoder writes the UDF name as bytes; the decoder rebuilds via DataFusion's built-in
+    // factories. Encoding is name-only because all five aggregates are stateless built-ins.
+    fn try_decode_udaf(
+        &self,
+        name: &str,
+        _buf: &[u8],
+    ) -> Result<Arc<datafusion::logical_expr::AggregateUDF>> {
+        use datafusion::functions_aggregate as dfa;
+        match name {
+            "min" => Ok(dfa::min_max::min_udaf()),
+            "max" => Ok(dfa::min_max::max_udaf()),
+            "count" => Ok(dfa::count::count_udaf()),
+            "sum" => Ok(dfa::sum::sum_udaf()),
+            "avg" => Ok(dfa::average::avg_udaf()),
+            _ => Err(DataFusionError::NotImplemented(format!(
+                "PgSearchPhysicalCodec::try_decode_udaf: aggregate '{name}' not registered"
+            ))),
+        }
+    }
+
+    fn try_encode_udaf(
+        &self,
+        node: &datafusion::logical_expr::AggregateUDF,
+        buf: &mut Vec<u8>,
+    ) -> Result<()> {
+        buf.extend_from_slice(node.name().as_bytes());
+        Ok(())
+    }
 }
 
 // ---------- VisibilityFilterExec ----------


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Lands the dispatch-flip plumbing: leader walks its distributed physical plan, ships per-`(stage, task)` subplans to workers via the existing shm_mq, workers stash the decoded plans in `ProducerTaskRegistry::shipped_subplans`, and `prepare_task` has a code path that consumes them — gated behind `paradedb.mpp_use_shipped_subplans` (default OFF).

End-to-end activation requires a follow-up that (a) reorders `prewarm` relative to the subplan-handler install and (b) reconstructs `PgSearchScan` state on the worker from its local `PgSearchTableProvider`. Until that lands the GUC is a placeholder — flipping it ON today does not change query behavior (per the senior-engineer Phase 4 review).

## Why

PR #5121 introduced a real `PgSearchPhysicalCodec` for our four custom execs but the codec was unused — the stub kept getting registered with the distributed planner. This PR is the consumer: leader uses the codec to serialize subplans, worker uses it to decode them. That gets us most of the way to upstream DF-D's "leader serializes, workers execute" model without requiring upstream's gRPC transport, since shm_mq already carries everything else.

The reason the dispatch isn't actually flipped yet: `decode_pgsearch_scan` returns an empty `Vec<ScanState>` placeholder (the codec PR called this out in `physical_codec.rs:701-704`). Executing a shipped subplan against a real query would return zero rows for any `PgSearchScan`-bearing plan. The state-reconstruction step is integration-test-worthy work that wants a session of its own.

## How — 4 phases, each followed by an independent code review

### Phase 1 (commits `db6263836`, `b8c001ac1`) — transport substrate

New `MppFrameKind::Subplan` variant, `MppFrameHeader::subplan(stage_id, task_idx)` constructor, `encode_subplan_frame_into` helper, `RecvBatchOutcome::Subplan { header, payload }`, `SubplanHandler` trait, `DrainHandle::set_subplan_handler` / `clear_subplan_handler`, `MppMesh::install_subplan_handler` / `uninstall_subplan_handler`, `MppSender::send_subplan_traced`, and `dispatch_subplans` in `try_drain_pass` (Subplans dispatched BEFORE Requests in the same pass so a Request for a newly-shipped `(stage, task)` finds the registry populated).

Wire format mirrors Request: 4-byte magic, 4-byte flags (kind in low byte, task_idx in upper 24 bits), 4-byte stage_id, 4-byte partition (reserved=0 for Subplan, validated at decode).

Review feedback applied: parse-time `partition == 0` check for Subplan; a test that pins the dispatch-ordering invariant (Subplan before Request in the same pass even when written in reverse order); a TASK_IDX_MAX round-trip test; doc-comment cleanups.

### Phase 2 (commits `c09f2774a`, `45765b078`) — leader-side dispatch

Extracted `prepare_stage_task` from `ProducerTaskRegistry::prepare_task` so both leader and worker call exactly the same `TaskContext` + `prepare_in_process_plan` recipe — bit-identical prepared plans are what makes the dispatch flip's "build once, ship many" model work.

New `ship_subplans_to_workers(plan, mesh, session, work_mem, hash_mem, runtime)` walks the leader's distributed plan with `StagePlans`, prepares + serializes each `(stage_id, task_idx)`, fetches an outbound `MppSender` for the owning proc (`proc_for_task`), attaches the leader mesh as cooperative drain, and ships via `send_subplan_traced`. Hooked into the MPP leader path of both `aggregatescan/mod.rs` and `joinscan/mod.rs`.

Review feedback applied: comment that `MppWorkerResolver` uniform URLs neutralize the upstream `random_range` start-index (load-bearing invariant); bit-identical-config-or-bust contract documented on `prepare_stage_task`; safety note about why the leader's cooperative-drain spin during ship doesn't lose Request frames (leader hosts no producer tasks under `proc_for_task` semantics).

### Phase 3 (commits `cbdf8c6d7`, `60ed9c8ed`) — worker-side reception

`ProducerTaskRegistry` now implements `SubplanHandler` in addition to `RequestHandler`. `on_subplan` decodes the bytes via `PgSearchPhysicalCodec` and stashes the result in a new `shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>` field. Worker's `run_mpp_worker` installs the registry as both handlers and uninstalls both at teardown for symmetric Arc-cycle release.

The dispatch isn't flipped in this phase — the new map is populated, not consumed. Phase 4 wires the consume path.

Review feedback applied: three lib tests that round-trip a real `PgSearchPhysicalCodec`-encoded payload through `on_subplan` (single-key happy path, multi-key accumulation, decode-error surfacing); imports hoisted to top of file; `shipped_subplans` mutex guard dropped before the log call.

### Phase 4 (commits `42ddcc94e`, `d7f5cd9e0`) — transitional flip behind GUC

`prepare_task` now first checks `paradedb.mpp_use_shipped_subplans` (default OFF). When ON and the `(stage_id, task_idx)` exists in `shipped_subplans`, returns a `PreparedTask` built from the shipped plan; otherwise falls through to the existing local-prepare path.

Review feedback applied: `prepare_stage_task` now calls the shared `build_task_ctx` helper instead of duplicating the TaskContext recipe; stale doc comments updated to reflect what Phase 4 actually did (GUC-gated `prepare_task` consume) vs. what was originally planned (`on_request` swap).

**Substantive review finding documented (fix deferred to follow-up):** `run_mpp_worker` runs `prewarm` BEFORE `install_subplan_handler`. With the GUC ON in production, `prewarm → prepare_task` observes an empty `shipped_subplans` map and caches a locally-built plan in `prepared`, which subsequent `on_request` calls hit before re-checking `shipped_subplans`. The follow-up PR reorders prewarm vs. handler-install (and pumps a one-shot drain pass) so shipped subplans are visible to the prep path. The current shape is safe because the GUC is off in production.

## Follow-ups (in landing order)

0. **Reorder `prewarm` after `install_subplan_handler` + one drain pump**, so the shipped subplans are visible to the prep path. One commit, no behavior change because GUC stays off, but unblocks (1).
1. **`PgSearchScan` state reconstruction** — encode `partition_recipes_json` on the leader; on the worker, walk the decoded plan tree and rebuild `Vec<ScanState>` for each `PgSearchScanPlan` from the local `PgSearchTableProvider`. Same recipe for `FFHelper` reconstruction in `TantivyLookupExec` / `SegmentedTopKExec`. Integration tests via `cargo pgrx test` against `aggregate_join_groupby` / `semi_join_filter` shapes.
2. **Flip `paradedb.mpp_use_shipped_subplans` default to ON** once (1) lands.
3. **Drop the logical-plan-in-DSM scheme** + worker's `create_physical_plan` call. Until (2) flips ON, both paths must coexist; dropping the logical-plan code before flipping is a footgun.
4. **Replace `PgSearchPhysicalCodecStub` registration** with the real codec.
5. **Plan-equivalence debug guard** — when both `shipped_subplans[(s,t)]` and a prewarmed `prepared[(s,t)]` exist for the same key, `debug_assert` their encoded forms match. Cheap insurance against optimizer non-determinism.

## Tests

Each phase landed with lib tests, and each phase had its own independent senior-engineer review pass:

- Phase 1 transport tests: 9 covering wire format, kind packing, `try_recv_batch` Subplan path, drain dispatch, teardown-race no-handler path, and the dispatch-ordering invariant.
- Phase 3 producer_service tests: 3 covering `on_subplan` happy path, multi-key accumulation, and decode-error surfacing.

66/66 mpp lib tests pass. clippy `-D warnings` clean for both default and `--tests` profiles. The dispatch-flip plumbing is exercised end-to-end via lib tests; the GUC-ON path stays exercised-via-lib-tests until the follow-up state-reconstruction work makes it runtime-safe.

## Scope this PR explicitly does NOT take

The full dispatch flip — the actual swap from "ship logical plan, re-plan on worker" to "ship physical subplan, execute directly." That's what the 6 follow-up items above add up to. The PR description on each phase commit lists the deferred work; this PR is the foundation those build on.