### PR TITLE
feat(mpp): reconstruct PgSearchScan/FFHelper runtime state from shipped subplans

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -602,6 +602,9 @@ async fn build_source_df(
     if let Some(idx) = np_idx {
         provider.set_non_partitioning_index(idx);
     }
+    // Absolute plan_position for the physical codec's worker-side reconstruction. See the
+    // `plan_position` field doc on `PgSearchTableProvider`.
+    provider.set_plan_position(plan_position);
     // HeapFilter queries (e.g. `=` on a column indexed via a
     // `pdb.literal(...)` cast) compile to runtime Postgres expressions
     // that can only be evaluated with a live ExprContext + PlanState.

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -1059,6 +1059,9 @@ fn build_source_df<'a>(
         if let Some(idx) = np_idx {
             provider.set_non_partitioning_index(idx);
         }
+        // Record the absolute plan position; consumed by the physical codec's worker-side
+        // reconstruction to index into the registry's per-source segment-ID `Vec`.
+        provider.set_plan_position(plan_position);
 
         if let Some(ref sort_order) = scan_info.sort_order {
             required_early.insert(sort_order.field_name.as_ref().to_string());

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -51,7 +51,9 @@ use crate::scan::physical_codec::PgSearchPhysicalCodec;
 /// Bundle of inputs the worker dispatcher needs. Per-scan `exec_mpp_worker` wrappers populate
 /// this from their typed state and hand it to [`run_mpp_worker`].
 pub(crate) struct MppWorkerInputs {
-    /// The leader's `ParallelScanState`, used to claim the partitioning source's segment slice.
+    /// Worker's view of the shared `ParallelScanState` (the DSM-attached state the leader
+    /// populated), used to claim the partitioning source's segment slice and to rebuild
+    /// PgSearchScan runtime state on decoded shipped subplans.
     pub parallel_state: Option<*mut ParallelScanState>,
     /// Canonical segment ID sets for non-partitioning sources, snapshotted by the leader.
     pub non_partitioning_segments: Vec<HashSet<SegmentId>>,
@@ -211,14 +213,14 @@ pub(crate) fn run_mpp_worker(
     let session_arc = Arc::new(session);
     // Pass the per-source canonical segment-ID sets + the ParallelScanState pointer down so the
     // registry can rebuild PgSearchScan / FFHelper runtime state when decoding leader-shipped
-    // subplans. The clone is cheap (each `HashSet<SegmentId>` is tens to thousands of UUIDs).
+    // subplans.
     let registry = Arc::new(ProducerTaskRegistry::new(
         stage_plans,
         session_arc,
         &worker_mesh,
         work_mem_bytes,
         hash_mem_multiplier,
-        index_segment_ids.clone(),
+        index_segment_ids,
         parallel_state,
     ));
 

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -224,6 +224,33 @@ pub(crate) fn run_mpp_worker(
         parallel_state,
     ));
 
+    // Install the request handler on every inbound drain. The cooperative drain dispatches
+    // each `Request` frame to `registry.on_request`, which spawns a driver future on the same
+    // tokio runtime backing this `block_on`.
+    worker_mesh.install_request_handler(Arc::clone(&registry)
+        as Arc<dyn crate::postgres::customscan::mpp::transport::RequestHandler>);
+
+    // Install the subplan handler so leader-shipped per-(stage, task) subplans land in
+    // `registry.shipped_subplans`. `ProducerTaskRegistry::prepare_task` consults this map
+    // first; on a hit the shipped subplan is used directly. Must be installed BEFORE the
+    // initial drain pump below so any Subplan frames already buffered get routed.
+    worker_mesh.install_subplan_handler(Arc::clone(&registry)
+        as Arc<dyn crate::postgres::customscan::mpp::transport::SubplanHandler>);
+
+    // Pump the drain once to deliver any Subplan frames that landed before the handlers were
+    // installed. The leader ships subplans early (before its own NetworkBoundaryExec consumers
+    // issue Requests), so the worker's first drain pump usually finds a full set of Subplan
+    // frames waiting. Pumping here puts those into `shipped_subplans` before the prewarm loop
+    // calls `prepare_task` — otherwise prewarm would observe an empty map and fall back to
+    // local-prepare, caching a locally-built plan in `prepared` that subsequent `on_request`
+    // calls would hit before the shipped subplan check.
+    if let Err(e) = worker_mesh.drain_all_inbound() {
+        pgrx::warning!(
+            "mpp worker (proc={this_proc}): initial drain pump failed: {e}; prewarm may fall \
+             back to local-prepare for shipped (stage, task) pairs"
+        );
+    }
+
     // Pre-warm `(stage, task) → (prepared_plan, TaskContext)` for every task this proc owns.
     // Without this, the first Request per task pays the full
     // `DistributedExec::prepare_in_process_plan` cost (transform_up + codec encoding) on the
@@ -234,7 +261,9 @@ pub(crate) fn run_mpp_worker(
     // the natural-shape estimator chain works out to `task_idx mod n_workers == this_proc - 1`).
     // We also prewarm `task_idx == 0` on every proc to cover the broadcast cap: with
     // `BroadcastBuildSideOneTaskEstimator` Stage 1 has one task, and every consumer requests
-    // it from the proc that owns task 0. Cheap and load-bearing.
+    // it from the proc that owns task 0. Cheap and load-bearing — the leader only ships
+    // `(stage, 0)` to the owner proc, so non-owner procs hit the local-prepare fallback for
+    // that pair (the broadcast prewarm is what populates their `prepared` cache).
     let n_workers = worker_mesh.n_procs.saturating_sub(1).max(1);
     let stage_task_counts: Vec<(u32, usize)> = registry.iter_task_counts().collect();
     for (stage_id, task_count) in stage_task_counts {
@@ -252,27 +281,6 @@ pub(crate) fn run_mpp_worker(
             }
         }
     }
-
-    // Install the registry as the request handler on every inbound drain. The cooperative drain
-    // dispatches each `Request` frame to `registry.on_request`, which spawns a driver future on
-    // the same tokio runtime backing this `block_on`.
-    worker_mesh.install_request_handler(Arc::clone(&registry)
-        as Arc<dyn crate::postgres::customscan::mpp::transport::RequestHandler>);
-
-    // Install the same registry as the subplan handler so leader-shipped per-(stage, task)
-    // subplans land in `registry.shipped_subplans`. Phase 4 wires `prepare_task` to consume
-    // from that map when `paradedb.mpp_use_shipped_subplans` is on; default OFF until the
-    // follow-up commit adds per-`PgSearchScanPlan` state reconstruction.
-    //
-    // **Ordering caveat**: the `prewarm` loop above runs BEFORE this handler is installed and
-    // BEFORE the first drain pump. With the GUC ON in production, prewarm's `prepare_task`
-    // call would observe an empty `shipped_subplans` map and cache a locally-built plan in
-    // `prepared`, which subsequent `on_request` calls hit before re-checking `shipped_subplans`.
-    // The follow-up commit reorders prewarm to run AFTER handler install + a one-shot drain
-    // pump so shipped subplans are visible to the prep path. Today this is fine because the
-    // GUC is off in production.
-    worker_mesh.install_subplan_handler(Arc::clone(&registry)
-        as Arc<dyn crate::postgres::customscan::mpp::transport::SubplanHandler>);
 
     // Service loop. Three pieces interleave on the single tokio task scheduler:
     //   - This loop: pumps every inbound drain, dispatching Requests.

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -174,7 +174,7 @@ pub(crate) fn run_mpp_worker(
         None,
         None,
         non_partitioning_segments,
-        index_segment_ids,
+        index_segment_ids.clone(),
     ) {
         Ok(lp) => lp,
         Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
@@ -209,12 +209,17 @@ pub(crate) fn run_mpp_worker(
     let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
     let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
     let session_arc = Arc::new(session);
+    // Pass the per-source canonical segment-ID sets + the ParallelScanState pointer down so the
+    // registry can rebuild PgSearchScan / FFHelper runtime state when decoding leader-shipped
+    // subplans. The clone is cheap (each `HashSet<SegmentId>` is tens to thousands of UUIDs).
     let registry = Arc::new(ProducerTaskRegistry::new(
         stage_plans,
         session_arc,
         &worker_mesh,
         work_mem_bytes,
         hash_mem_multiplier,
+        index_segment_ids.clone(),
+        parallel_state,
     ));
 
     // Pre-warm `(stage, task) → (prepared_plan, TaskContext)` for every task this proc owns.

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -237,18 +237,20 @@ pub(crate) fn run_mpp_worker(
     worker_mesh.install_subplan_handler(Arc::clone(&registry)
         as Arc<dyn crate::postgres::customscan::mpp::transport::SubplanHandler>);
 
-    // Pump the drain once to deliver any Subplan frames that landed before the handlers were
-    // installed. The leader ships subplans early (before its own NetworkBoundaryExec consumers
-    // issue Requests), so the worker's first drain pump usually finds a full set of Subplan
-    // frames waiting. Pumping here puts those into `shipped_subplans` before the prewarm loop
-    // calls `prepare_task` — otherwise prewarm would observe an empty map and fall back to
-    // local-prepare, caching a locally-built plan in `prepared` that subsequent `on_request`
-    // calls would hit before the shipped subplan check.
+    // Pump the drain once to deliver any Subplan frames that already landed before the
+    // handlers were installed. Pumping here puts those into `shipped_subplans` so the prewarm
+    // loop below calls `prepare_task` against a populated map. Workers can still enter
+    // `run_mpp_worker` before the leader's `ship_subplans_to_workers` completes (no PG-level
+    // barrier syncs the two — leader runs in `ExecutorRun`, worker in `end_custom_scan` on
+    // its first poll), so this pump only catches what's already there; the rest of the
+    // protection lives in `ProducerTaskRegistry::on_subplan`, which invalidates any cached
+    // locally-prepared entry when a shipped subplan arrives later.
+    //
+    // Drain failures at startup are fatal — partial Subplan dispatch leaves the worker with
+    // a mixed shipped/local plan map, which silently breaks the "build once, ship many"
+    // invariant. Surface as `error!` so the query aborts instead of producing wrong rows.
     if let Err(e) = worker_mesh.drain_all_inbound() {
-        pgrx::warning!(
-            "mpp worker (proc={this_proc}): initial drain pump failed: {e}; prewarm may fall \
-             back to local-prepare for shipped (stage, task) pairs"
-        );
+        pgrx::error!("mpp worker (proc={this_proc}): initial drain pump failed: {e}");
     }
 
     // Pre-warm `(stage, task) → (prepared_plan, TaskContext)` for every task this proc owns.
@@ -259,11 +261,11 @@ pub(crate) fn run_mpp_worker(
     //
     // `proc_for_task(n_workers, t) == this_proc` picks the tasks this worker hosts (which under
     // the natural-shape estimator chain works out to `task_idx mod n_workers == this_proc - 1`).
-    // We also prewarm `task_idx == 0` on every proc to cover the broadcast cap: with
-    // `BroadcastBuildSideOneTaskEstimator` Stage 1 has one task, and every consumer requests
-    // it from the proc that owns task 0. Cheap and load-bearing — the leader only ships
-    // `(stage, 0)` to the owner proc, so non-owner procs hit the local-prepare fallback for
-    // that pair (the broadcast prewarm is what populates their `prepared` cache).
+    // We also prewarm `task_idx == 0` on every proc as a defensive cache: under the current
+    // estimator chain `proc_for_task(_, 0) == 1` always, so the broadcast Requests only ever
+    // land on proc 1 and non-owner procs never serve them. If a future estimator change
+    // re-routes broadcast tasks, those non-owner caches turn from defensive into load-bearing
+    // without code changes here.
     let n_workers = worker_mesh.n_procs.saturating_sub(1).max(1);
     let stage_task_counts: Vec<(u32, usize)> = registry.iter_task_counts().collect();
     for (stage_id, task_count) in stage_task_counts {

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -341,8 +341,10 @@ impl ProducerTaskRegistry {
             });
         }
         // Fallback: build the prepared plan locally from `stage_plans`, same recipe as
-        // pre-dispatch-flip. Used during startup races (subplan hasn't arrived yet) and as a
-        // safety net while the codec's PgSearchScan state-reconstruction story matures.
+        // pre-dispatch-flip. Two surviving uses after the state-reconstruction PR:
+        //   1. `broadcast_zero` prewarm on non-owner procs — the leader ships `(stage, 0)`
+        //      to the task-0 owner only, so non-owner procs prewarm via local-prepare.
+        //   2. Tests / future paths that drive `prepare_task` without a shipped subplan map.
         //
         // No reconstruction context: this path goes through `DistributedExec
         // ::prepare_in_process_plan` over `stage_plans` directly, never through the physical

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -159,12 +159,12 @@ pub(super) struct ProducerTaskRegistry {
     mesh: Weak<MppMesh>,
     work_mem_bytes: usize,
     hash_mem_multiplier: f64,
-    /// Per-source canonical segment ID sets, indexed by `plan_position`. The dispatch-flip
-    /// Reconstruction context layered onto each `TaskContext` built in [`build_task_ctx`].
-    /// Carries the per-source canonical segment IDs (indexed by absolute `plan_position`) and
-    /// the worker's `ParallelScanState` pointer. Read by the physical codec's
-    /// `decode_pgsearch_scan` to rebuild `Vec<ScanState>` on shipped subplans. Empty on test
-    /// paths that don't go through `run_mpp_worker`.
+    /// Reconstruction context layered onto each `TaskContext` built in [`build_task_ctx`] and
+    /// onto the per-decode `TaskContext` in [`Self::on_subplan`]. Carries the per-source
+    /// canonical segment IDs (indexed by absolute `plan_position`) and the worker's
+    /// `ParallelScanState` pointer. Read by the physical codec's `decode_pgsearch_scan` to
+    /// rebuild `Vec<ScanState>` on shipped subplans. Empty on test paths that don't go through
+    /// `run_mpp_worker`.
     reconstruction_context: Arc<MppReconstructionContext>,
     active_drivers: Arc<AtomicUsize>,
     /// First driver error observed since startup. The service loop polls this between
@@ -176,24 +176,21 @@ pub(super) struct ProducerTaskRegistry {
     prepared: Mutex<HashMap<(u32, u32), PreparedTask>>,
     /// `(stage_id, task_idx) → decoded subplan` populated by [`Self::on_subplan`] when the
     /// leader ships a per-task subplan via a [`MppFrameKind::Subplan`](crate::postgres::customscan::mpp::transport::MppFrameKind::Subplan)
-    /// frame. `prepare_task` consults this first; when a hit lands the worker uses the
-    /// leader-prepared plan directly instead of re-running `prepare_in_process_plan` locally.
+    /// frame. `prepare_task` consults this first; on a hit the worker uses the leader-prepared
+    /// plan directly instead of re-running `prepare_in_process_plan` locally.
     ///
-    /// The fallback path (`stage_plans` → local `prepare_in_process_plan`) is what fires
-    /// during the brief startup window between worker launch and the first drain pass that
-    /// delivers the Subplan frames. It's also where queries land if the codec hits a gap —
-    /// today's `decode_pgsearch_scan` emits an empty `Vec<ScanState>` placeholder, so a
-    /// shipped subplan with a `PgSearchScan` leaf would return zero rows. The followup PR
-    /// fixes that with per-`PgSearchScanPlan` state reconstruction.
+    /// `run_mpp_worker` installs the SubplanHandler and runs one drain pump BEFORE prewarming,
+    /// so the bulk of leader-shipped subplans land in this map before `prepare_task` is ever
+    /// called. A subset can still arrive after prewarm — workers can enter `run_mpp_worker`
+    /// before the leader's `ship_subplans_to_workers` completes (there's no PG-level barrier
+    /// between leader's `ExecutorRun` and worker's `end_custom_scan`), in which case prewarm
+    /// caches a locally-prepared entry in `prepared`. `on_subplan` invalidates that cache on
+    /// late-arriving subplans so the next `on_request` re-runs `prepare_task` and picks up the
+    /// shipped version.
     ///
-    /// **Ordering hazard.** `run_mpp_worker` calls `prewarm` for every `(stage_id, task_idx)`
-    /// this proc owns *before* installing the SubplanHandler and pumping the drain. The
-    /// prewarm path goes through `prepare_task`, which sees an empty `shipped_subplans` and
-    /// falls back to local-prepare — caching the locally-built plan in `prepared`. When real
-    /// Subplan frames arrive later, they land in `shipped_subplans`, but `on_request` reads
-    /// from `prepared` first via the per-`(stage, task, partition)` dedupe path. The followup
-    /// PR reorders prewarm vs. handler-install (and pumps the drain once before prewarm) so
-    /// shipped subplans are visible to the prep path.
+    /// The fallback path (`stage_plans` → local `prepare_in_process_plan`) still fires for
+    /// `(stage, task)` pairs the leader never ships — broadcast tasks under the current
+    /// estimator (`proc_for_task(_, 0) == 1`) on non-owner procs, plus test paths.
     shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>,
     /// `(stage_id, task_idx, partition)` set of already-dispatched drivers. Repeat Requests are
     /// dropped. Without this, a consumer that re-issued `stream_partition` would cause the
@@ -786,6 +783,24 @@ impl SubplanHandler for ProducerTaskRegistry {
             map.insert(key, decoded);
             map.len()
         };
+        // Invalidate any cached `prepared` entry for the same `(stage, task)` so the next
+        // `on_request` re-runs `prepare_task` and picks up the freshly-shipped subplan
+        // instead of a stale locally-prepared one. This closes the leader-vs-worker process
+        // race: workers can enter `run_mpp_worker` before the leader's `ship_subplans_to_workers`
+        // call completes, so prewarm may cache a locally-prepared plan that `on_request`
+        // would otherwise keep returning even after the shipped subplan arrives.
+        let prev_prepared = self
+            .prepared
+            .lock()
+            .expect("ProducerTaskRegistry prepared mutex poisoned")
+            .remove(&key);
+        if prev_prepared.is_some() {
+            crate::mpp_log!(
+                "mpp producer on_subplan: invalidated stale locally-prepared cache for \
+                 stage_id={stage_id} task_idx={task_idx}; subsequent Requests will re-prepare \
+                 from the shipped subplan"
+            );
+        }
         // Lock dropped above before the log call. `mpp_log!` expands to `pgrx::warning!` under
         // the debug GUC and ereport's; cheap to keep off the hot path.
         crate::mpp_log!(

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -343,6 +343,11 @@ impl ProducerTaskRegistry {
         // Fallback: build the prepared plan locally from `stage_plans`, same recipe as
         // pre-dispatch-flip. Used during startup races (subplan hasn't arrived yet) and as a
         // safety net while the codec's PgSearchScan state-reconstruction story matures.
+        //
+        // No reconstruction context: this path goes through `DistributedExec
+        // ::prepare_in_process_plan` over `stage_plans` directly, never through the physical
+        // codec's `decode_pgsearch_scan`, so the extension would never be read. Pass `None`
+        // so it's clear from the call site that the fallback is by-design extension-free.
         let (plan, task_count) = self.stage_plans.lookup(stage_id).ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "mpp producer: no plan registered for stage_id={stage_id}"
@@ -356,7 +361,7 @@ impl ProducerTaskRegistry {
             &self.session,
             self.work_mem_bytes,
             self.hash_mem_multiplier,
-            Some(Arc::clone(&self.reconstruction_context)),
+            None,
         )
     }
 }
@@ -748,7 +753,19 @@ impl SubplanHandler for ProducerTaskRegistry {
         let codec = datafusion_distributed::DistributedCodec::new_combined_with_user(
             self.session.state().config(),
         );
-        let task_ctx = self.session.task_ctx();
+        // The codec's `decode_pgsearch_scan` reaches into the task ctx's session config to
+        // pick up an `MppReconstructionContext` extension. Without it, shipped subplans land
+        // with an empty `Vec<ScanState>` placeholder and the scan emits zero rows. Layer the
+        // registry's reconstruction context onto a decode-local task ctx; the regular
+        // session task ctx doesn't carry it because the session is built before the registry
+        // exists.
+        let decode_cfg = self
+            .session
+            .state()
+            .config()
+            .clone()
+            .with_extension(Arc::clone(&self.reconstruction_context));
+        let task_ctx = Arc::new(TaskContext::default().with_session_config(decode_cfg));
         let decoded = physical_plan_from_bytes_with_extension_codec(
             payload.as_slice(),
             &task_ctx,

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -64,8 +64,6 @@
 //!    `run_mpp_worker`.
 
 use std::collections::HashMap;
-
-use crate::api::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
@@ -75,9 +73,10 @@ use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{DistributedExec, DistributedTaskContext, NetworkBoundaryExt};
-
+use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 use tantivy::index::SegmentId;
 
+use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
@@ -85,7 +84,6 @@ use crate::postgres::customscan::mpp::transport::{
 };
 use crate::postgres::customscan::mpp::worker::run_partition_driver;
 use crate::postgres::ParallelScanState;
-use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 
 /// Per-`stage_id` snapshot of `(local_plan, task_count)` walked out of the worker's distributed
 /// physical plan at startup. The producer service loop consults this on every Request to find
@@ -207,12 +205,21 @@ pub(super) struct ProducerTaskRegistry {
     spawned: Mutex<HashSet<(u32, u32, u32)>>,
 }
 
-// SAFETY: `parallel_state: *mut ParallelScanState` makes the auto-derived `Send + Sync` go away.
-// In practice the pointer is into PG's DSM segment, valid for the lifetime of the parallel
-// context, and only dereferenced from the worker's backend thread (the runtime tokio uses on
-// the worker is current-thread, pinned to the backend). The registry's other handlers
-// (`on_request`, `on_subplan`) are invoked from the cooperative-drain spin which also runs on
-// the same backend thread. Cross-thread access is therefore impossible by construction.
+// SAFETY: `parallel_state: *mut ParallelScanState` makes the auto-derived `Send + Sync` go away,
+// but both bounds are required (`RequestHandler` and `SubplanHandler` are both `: Send + Sync`).
+//
+// Provenance: the pointer is the worker's view of PG's DSM-attached shared state — set up in the
+// custom-scan executor state (see `MppWorkerInputs::parallel_state` and the customscan
+// `parallel_state` field), passed into `run_mpp_worker` for the lifetime of that call. The
+// `ParallelScanState` outlives `run_mpp_worker` because PG won't tear down the executor state
+// (and DSM mapping) while the worker is still inside `ExecutorRun`.
+//
+// Threading: the only runtime the registry's handlers run on is the worker's `current_thread`
+// tokio runtime (pinned to the PG backend thread; see `aggregatescan/mpp.rs` and `joinscan/mpp.rs`).
+// `on_request`/`on_subplan` are invoked from the cooperative-drain spin on that same thread, and
+// the per-partition driver futures `tokio::spawn`ed from `on_request` poll on it too. Cross-thread
+// access is therefore impossible by construction. Same pattern that covers `ShmMqSender` and
+// `MppSender` in `mesh.rs` / `transport.rs`.
 unsafe impl Send for ProducerTaskRegistry {}
 unsafe impl Sync for ProducerTaskRegistry {}
 
@@ -787,15 +794,16 @@ mod tests {
             .with_distributed_user_codec(PgSearchPhysicalCodec)
             .build();
         let session = Arc::new(SessionContext::new_with_state(state));
+        // index_segment_ids + parallel_state stay empty/None in lib tests; the reconstruction
+        // walker (Phase 2+) is exercised by integration tests instead.
         Arc::new(ProducerTaskRegistry::new(
             stage_plans,
             session,
             &mesh,
-            64 * 1024 * 1024, // work_mem
-            2.0,              // hash_mem_multiplier
-            Vec::new(),       // index_segment_ids — empty in tests; reconstruction is exercised
-            //                                    by integration tests
-            None, // parallel_state — none in tests
+            64 * 1024 * 1024,
+            2.0,
+            Vec::new(),
+            None,
         ))
     }
 

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -84,6 +84,7 @@ use crate::postgres::customscan::mpp::transport::{
 };
 use crate::postgres::customscan::mpp::worker::run_partition_driver;
 use crate::postgres::ParallelScanState;
+use crate::scan::physical_codec::MppReconstructionContext;
 
 /// Per-`stage_id` snapshot of `(local_plan, task_count)` walked out of the worker's distributed
 /// physical plan at startup. The producer service loop consults this on every Request to find
@@ -159,17 +160,12 @@ pub(super) struct ProducerTaskRegistry {
     work_mem_bytes: usize,
     hash_mem_multiplier: f64,
     /// Per-source canonical segment ID sets, indexed by `plan_position`. The dispatch-flip
-    /// reconstruction step uses these to rebuild `Vec<ScanState>` for `PgSearchScanPlan` nodes
-    /// inside leader-shipped subplans: the codec carries only declarative fields, the runtime
-    /// state has to come from the worker's local PG-side data. Empty on test paths that don't
-    /// touch reconstruction.
-    #[allow(dead_code)] // consumed by the reconstruction walker landing in Phase 2.
-    index_segment_ids: Vec<HashSet<SegmentId>>,
-    /// Worker's `ParallelScanState`, threaded down so reconstruction can claim segments for the
-    /// partitioning source the same way `PgSearchTableProvider` does on the existing re-plan
-    /// path. `None` on test paths and on single-proc runs that don't have a parallel context.
-    #[allow(dead_code)] // consumed by the reconstruction walker landing in Phase 2.
-    parallel_state: Option<*mut ParallelScanState>,
+    /// Reconstruction context layered onto each `TaskContext` built in [`build_task_ctx`].
+    /// Carries the per-source canonical segment IDs (indexed by absolute `plan_position`) and
+    /// the worker's `ParallelScanState` pointer. Read by the physical codec's
+    /// `decode_pgsearch_scan` to rebuild `Vec<ScanState>` on shipped subplans. Empty on test
+    /// paths that don't go through `run_mpp_worker`.
+    reconstruction_context: Arc<MppReconstructionContext>,
     active_drivers: Arc<AtomicUsize>,
     /// First driver error observed since startup. The service loop polls this between
     /// `try_drain_pass` iterations and bails out so the worker surfaces a concrete failure
@@ -233,14 +229,17 @@ impl ProducerTaskRegistry {
         index_segment_ids: Vec<HashSet<SegmentId>>,
         parallel_state: Option<*mut ParallelScanState>,
     ) -> Self {
+        let reconstruction_context = Arc::new(MppReconstructionContext {
+            index_segment_ids,
+            parallel_state,
+        });
         Self {
             stage_plans,
             session,
             mesh: Arc::downgrade(mesh),
             work_mem_bytes,
             hash_mem_multiplier,
-            index_segment_ids,
-            parallel_state,
+            reconstruction_context,
             active_drivers: Arc::new(AtomicUsize::new(0)),
             first_error: Arc::new(Mutex::new(None)),
             prepared: Mutex::new(HashMap::new()),
@@ -334,6 +333,7 @@ impl ProducerTaskRegistry {
                 self.work_mem_bytes,
                 self.hash_mem_multiplier,
                 &shipped,
+                Some(Arc::clone(&self.reconstruction_context)),
             )?;
             return Ok(PreparedTask {
                 plan: shipped,
@@ -356,6 +356,7 @@ impl ProducerTaskRegistry {
             &self.session,
             self.work_mem_bytes,
             self.hash_mem_multiplier,
+            Some(Arc::clone(&self.reconstruction_context)),
         )
     }
 }
@@ -365,6 +366,9 @@ impl ProducerTaskRegistry {
 /// baked into nested boundary nodes from leader-side preparation, but the executing
 /// `TaskContext` still needs the extension layered on so any operator that re-reads it at
 /// runtime sees the right `(task_index, task_count)` shape.
+///
+/// `reconstruction_context` is layered on only when the caller is a worker (the leader's
+/// `ship_subplans_to_workers` passes `None` because it never decodes — it only encodes).
 fn build_task_ctx(
     session: &SessionContext,
     task_idx: u32,
@@ -372,15 +376,20 @@ fn build_task_ctx(
     work_mem_bytes: usize,
     hash_mem_multiplier: f64,
     plan: &Arc<dyn ExecutionPlan>,
+    reconstruction_context: Option<Arc<MppReconstructionContext>>,
 ) -> Result<Arc<TaskContext>, DataFusionError> {
-    let cfg = session
-        .state()
-        .config()
-        .clone()
-        .with_extension(Arc::new(DistributedTaskContext {
-            task_index: task_idx as usize,
-            task_count,
-        }));
+    let mut cfg =
+        session
+            .state()
+            .config()
+            .clone()
+            .with_extension(Arc::new(DistributedTaskContext {
+                task_index: task_idx as usize,
+                task_count,
+            }));
+    if let Some(recon) = reconstruction_context {
+        cfg = cfg.with_extension(recon);
+    }
     let memory_pool = create_memory_pool(plan, work_mem_bytes, hash_mem_multiplier);
     let runtime_env = RuntimeEnvBuilder::new()
         .with_memory_pool(memory_pool)
@@ -408,6 +417,7 @@ fn build_task_ctx(
 /// `crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context`. Any future
 /// session-config knob added on only one side breaks this invariant silently — bench-shape
 /// regressions then surface as "leader and worker disagree on the plan."
+#[allow(clippy::too_many_arguments)]
 fn prepare_stage_task(
     plan: &Arc<dyn ExecutionPlan>,
     stage_id: u32,
@@ -416,6 +426,7 @@ fn prepare_stage_task(
     session: &SessionContext,
     work_mem_bytes: usize,
     hash_mem_multiplier: f64,
+    reconstruction_context: Option<Arc<MppReconstructionContext>>,
 ) -> Result<PreparedTask, DataFusionError> {
     let task_ctx = build_task_ctx(
         session,
@@ -424,6 +435,7 @@ fn prepare_stage_task(
         work_mem_bytes,
         hash_mem_multiplier,
         plan,
+        reconstruction_context,
     )?;
 
     // Wrap the stage's local plan in a fresh `DistributedExec` and `prepare_in_process_plan` so
@@ -527,6 +539,7 @@ pub(crate) fn ship_subplans_to_workers(
                 session,
                 work_mem_bytes,
                 hash_mem_multiplier,
+                None, // leader never decodes — only encodes; no reconstruction context.
             )?;
 
             let bytes = physical_plan_to_bytes_with_extension_codec(prepared.plan, &codec)

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -63,7 +63,9 @@
 //!    is what guarantees no driver futures outlive the loop, so no mesh refs leak past
 //!    `run_mpp_worker`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
+
+use crate::api::HashSet;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
@@ -74,12 +76,15 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{DistributedExec, DistributedTaskContext, NetworkBoundaryExt};
 
+use tantivy::index::SegmentId;
+
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
     CooperativeDrainSet, MppFrameHeader, RequestHandler, SubplanHandler,
 };
 use crate::postgres::customscan::mpp::worker::run_partition_driver;
+use crate::postgres::ParallelScanState;
 use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
 
 /// Per-`stage_id` snapshot of `(local_plan, task_count)` walked out of the worker's distributed
@@ -155,6 +160,18 @@ pub(super) struct ProducerTaskRegistry {
     mesh: Weak<MppMesh>,
     work_mem_bytes: usize,
     hash_mem_multiplier: f64,
+    /// Per-source canonical segment ID sets, indexed by `plan_position`. The dispatch-flip
+    /// reconstruction step uses these to rebuild `Vec<ScanState>` for `PgSearchScanPlan` nodes
+    /// inside leader-shipped subplans: the codec carries only declarative fields, the runtime
+    /// state has to come from the worker's local PG-side data. Empty on test paths that don't
+    /// touch reconstruction.
+    #[allow(dead_code)] // consumed by the reconstruction walker landing in Phase 2.
+    index_segment_ids: Vec<HashSet<SegmentId>>,
+    /// Worker's `ParallelScanState`, threaded down so reconstruction can claim segments for the
+    /// partitioning source the same way `PgSearchTableProvider` does on the existing re-plan
+    /// path. `None` on test paths and on single-proc runs that don't have a parallel context.
+    #[allow(dead_code)] // consumed by the reconstruction walker landing in Phase 2.
+    parallel_state: Option<*mut ParallelScanState>,
     active_drivers: Arc<AtomicUsize>,
     /// First driver error observed since startup. The service loop polls this between
     /// `try_drain_pass` iterations and bails out so the worker surfaces a concrete failure
@@ -190,6 +207,15 @@ pub(super) struct ProducerTaskRegistry {
     spawned: Mutex<HashSet<(u32, u32, u32)>>,
 }
 
+// SAFETY: `parallel_state: *mut ParallelScanState` makes the auto-derived `Send + Sync` go away.
+// In practice the pointer is into PG's DSM segment, valid for the lifetime of the parallel
+// context, and only dereferenced from the worker's backend thread (the runtime tokio uses on
+// the worker is current-thread, pinned to the backend). The registry's other handlers
+// (`on_request`, `on_subplan`) are invoked from the cooperative-drain spin which also runs on
+// the same backend thread. Cross-thread access is therefore impossible by construction.
+unsafe impl Send for ProducerTaskRegistry {}
+unsafe impl Sync for ProducerTaskRegistry {}
+
 impl ProducerTaskRegistry {
     pub(super) fn new(
         stage_plans: StagePlans,
@@ -197,6 +223,8 @@ impl ProducerTaskRegistry {
         mesh: &Arc<MppMesh>,
         work_mem_bytes: usize,
         hash_mem_multiplier: f64,
+        index_segment_ids: Vec<HashSet<SegmentId>>,
+        parallel_state: Option<*mut ParallelScanState>,
     ) -> Self {
         Self {
             stage_plans,
@@ -204,11 +232,13 @@ impl ProducerTaskRegistry {
             mesh: Arc::downgrade(mesh),
             work_mem_bytes,
             hash_mem_multiplier,
+            index_segment_ids,
+            parallel_state,
             active_drivers: Arc::new(AtomicUsize::new(0)),
             first_error: Arc::new(Mutex::new(None)),
             prepared: Mutex::new(HashMap::new()),
             shipped_subplans: Mutex::new(HashMap::new()),
-            spawned: Mutex::new(HashSet::new()),
+            spawned: Mutex::new(HashSet::default()),
         }
     }
 
@@ -763,6 +793,9 @@ mod tests {
             &mesh,
             64 * 1024 * 1024, // work_mem
             2.0,              // hash_mem_multiplier
+            Vec::new(),       // index_segment_ids — empty in tests; reconstruction is exercised
+            //                                    by integration tests
+            None, // parallel_state — none in tests
         ))
     }
 

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -175,6 +175,14 @@ pub struct PgSearchScanPlan {
     /// InList didn't reach the FastField path (K ≤ 1024 routes to
     /// AutomatonWeight which doesn't write the sink).
     dynamic_filter_strategy: Arc<AtomicU8>,
+    /// `serde_json` bytes of the `PgSearchTableProvider` that produced this scan.
+    /// Populated by `PgSearchTableProvider::create_scan` on the leader; consumed by
+    /// the physical codec on the worker to reconstruct the `Vec<ScanState>` that
+    /// can't ride over the wire (tantivy `SegmentReader` handles, raw pgrx pointers).
+    ///
+    /// `None` for paths that don't go through `PgSearchTableProvider::create_scan`
+    /// (the codec's worker-side decoder builds plans directly, tests, etc.).
+    serialized_table_provider: Option<Vec<u8>>,
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -259,7 +267,23 @@ impl PgSearchScanPlan {
             dynamic_filter_pushdown: Arc::new(AtomicBool::new(false)),
             sort_order: sort_order.cloned(),
             dynamic_filter_strategy: Arc::new(AtomicU8::new(0)),
+            serialized_table_provider: None,
         }
+    }
+
+    /// Builder-style setter for the serialized `PgSearchTableProvider` blob. See the
+    /// `serialized_table_provider` field doc.
+    #[must_use]
+    pub fn with_serialized_table_provider(mut self, bytes: Vec<u8>) -> Self {
+        self.serialized_table_provider = Some(bytes);
+        self
+    }
+
+    /// Borrowed view of the serialized `PgSearchTableProvider` bytes carried on this scan,
+    /// or `None` if the scan wasn't constructed via the production `create_scan` path.
+    #[allow(dead_code)] // consumed by the physical-codec encoder in the next commit.
+    pub fn serialized_table_provider(&self) -> Option<&[u8]> {
+        self.serialized_table_provider.as_deref()
     }
 
     /// Produce a plan identical to `dyn_plan` but with `dynamic_filters` emptied.
@@ -314,7 +338,7 @@ impl PgSearchScanPlan {
         let states: Vec<ScanState> = taken.into_iter().flatten().map(|u| u.0).collect();
 
         let schema = scan.properties.eq_properties.schema().clone();
-        let new_plan = PgSearchScanPlan::new(
+        let mut new_plan = PgSearchScanPlan::new(
             states,
             schema,
             scan.query_for_display.clone(),
@@ -324,6 +348,9 @@ impl PgSearchScanPlan {
             scan.indexrelid,
             scan.deferred_ctid_plan_position,
         );
+        if let Some(bytes) = scan.serialized_table_provider.clone() {
+            new_plan = new_plan.with_serialized_table_provider(bytes);
+        }
         Ok(Arc::new(new_plan))
     }
 
@@ -716,6 +743,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                 dynamic_filter_strategy: Arc::new(AtomicU8::new(
                     self.dynamic_filter_strategy.load(Ordering::Relaxed),
                 )),
+                serialized_table_provider: self.serialized_table_provider.clone(),
             });
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -512,6 +512,29 @@ fn encode_tantivy_lookup(node: &dyn ExecutionPlan) -> Result<TantivyLookupProto>
     })
 }
 
+/// Walk an `Arc<dyn ExecutionPlan>` and collect `(indexrelid → Arc<FFHelper>)` mappings from
+/// every `PgSearchScanPlan` node that carries a non-`None` `ffhelper`. Matches what the leader
+/// does in `LateMaterializePlanner::plan_extension` via the private
+/// `late_materialization::extract_ff_helper` function.
+///
+/// The Phase 2 reconstruction of `PgSearchScanPlan` produces real per-scan `FFHelper`s; this
+/// walk lets downstream execs (`TantivyLookupExec`, `SegmentedTopKExec`) reuse them without
+/// re-opening the index — same identity, same fast-field cache as the leader-side plan.
+fn collect_ffhelpers_from_input(
+    plan: &Arc<dyn ExecutionPlan>,
+    out: &mut crate::api::HashMap<u32, std::sync::Arc<crate::index::fast_fields_helper::FFHelper>>,
+) {
+    use crate::scan::execution_plan::PgSearchScanPlan;
+    if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
+        if let Some(ff) = scan.ffhelper() {
+            out.insert(scan.indexrelid, ff);
+        }
+    }
+    for child in plan.children() {
+        collect_ffhelpers_from_input(child, out);
+    }
+}
+
 fn decode_tantivy_lookup(
     proto: TantivyLookupProto,
     inputs: &[Arc<dyn ExecutionPlan>],
@@ -547,19 +570,20 @@ fn decode_tantivy_lookup(
         })
         .collect::<Result<_>>()?;
 
-    // FFHelper map population: at production runtime (worker thread inside a PG backend) we'd
-    // open each `indexrelid` via `pg_sys::RelationIdGetRelation`, build a `SearchIndexReader`,
-    // and call `FFHelper::with_fields(reader, deferred fields on that index)`. That requires
-    // PG-backend context which `TaskContext` doesn't surface, so the actual wiring lands in the
-    // dispatch-flip commit alongside a `with_index_open` helper. For the codec PR scope (this
-    // commit) we hand back an empty `FFHelper` per relid — round-trip tests verify field shape,
-    // and any pre-dispatch-flip caller that tries to *execute* the decoded plan will trip a
-    // clear error on the first lookup miss.
-    let ffhelpers: HashMap<u32, std::sync::Arc<FFHelper>> = proto
-        .indexrelids
-        .into_iter()
-        .map(|relid| (relid, std::sync::Arc::new(FFHelper::empty())))
-        .collect();
+    // Reconstruct the FFHelper map from the input plan's PgSearchScanPlan nodes. Phase 2's
+    // reconstruction in `decode_pgsearch_scan` builds real FFHelpers; walking the inputs here
+    // pulls them out keyed by indexrelid, the same recipe the leader uses
+    // (`LateMaterializePlanner` calls `extract_ff_helper`). Fall back to an empty `FFHelper`
+    // for any indexrelid in the proto that isn't present in the input walk — that can only
+    // happen if a scan reconstruction fell back to the empty-states placeholder, and the
+    // resulting downstream lookup miss will surface as a clear error at the next access.
+    let mut ffhelpers: HashMap<u32, std::sync::Arc<FFHelper>> = HashMap::default();
+    collect_ffhelpers_from_input(&input, &mut ffhelpers);
+    for relid in &proto.indexrelids {
+        ffhelpers
+            .entry(*relid)
+            .or_insert_with(|| std::sync::Arc::new(FFHelper::empty()));
+    }
 
     let exec = TantivyLookupExec::new(input, deferred_fields, ffhelpers)?;
     Ok(Arc::new(exec))
@@ -693,12 +717,19 @@ fn decode_segmented_topk(
         })
         .collect::<Result<_>>()?;
 
-    // Same placeholder caveat as `decode_tantivy_lookup` — the real `FFHelper` for each index
-    // gets wired by the dispatch-flip commit, which has access to PG-backend state. Until then
-    // we hand back an empty helper that's structurally correct but won't service runtime
-    // fast-field lookups.
-    let _ = proto.indexrelids; // currently unused at decode time; reserved for the rebuild path.
-    let ffhelper = std::sync::Arc::new(FFHelper::empty());
+    // SegmentedTopKExec takes a single FFHelper — the leader picks `target_indexrelid`
+    // (`segmented_topk_rule.rs:271`) and pulls the FFHelper from the parent TantivyLookupExec
+    // by that key. Mirror that here: walk the input plan for FFHelpers and pick the entry
+    // matching the first deferred-column's indexrelid (the proto's `indexrelids` is already
+    // single-element when SegmentedTopK lands — `segmented_topk_rule.rs:260-269` falls back
+    // to a non-pushdown SortExec when the sort spans multiple indexes).
+    let mut input_ffhelpers: crate::api::HashMap<u32, std::sync::Arc<FFHelper>> =
+        crate::api::HashMap::default();
+    collect_ffhelpers_from_input(&input, &mut input_ffhelpers);
+    let target_indexrelid = proto.indexrelids.first().copied().unwrap_or(0);
+    let ffhelper = input_ffhelpers
+        .remove(&target_indexrelid)
+        .unwrap_or_else(|| std::sync::Arc::new(FFHelper::empty()));
 
     let exec = SegmentedTopKExec::new(
         input,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -226,6 +226,13 @@ struct PgSearchScanProto {
     /// Dynamic filters as serialized `PhysicalExprNode`s, in plan order.
     #[prost(bytes, repeated, tag = "8")]
     pub dynamic_filters: Vec<Vec<u8>>,
+    /// `serde_json` bytes of the `PgSearchTableProvider` that built this scan on the leader.
+    /// Workers deserialize, inject runtime context (segment IDs by `plan_position`,
+    /// `parallel_state`, `expr_context`/`planstate`), and replay `scan_inner` to rebuild the
+    /// per-partition `Vec<ScanState>`. Empty for scans that didn't go through the production
+    /// `create_scan` path (test fixtures).
+    #[prost(bytes, tag = "9")]
+    pub table_provider_json: Vec<u8>,
 }
 
 const DEFERRED_CTID_NONE: u32 = u32::MAX;
@@ -767,12 +774,20 @@ fn encode_pgsearch_scan(node: &dyn ExecutionPlan) -> Result<PgSearchScanProto> {
         })
         .collect::<Result<_>>()?;
 
-    // `partition_recipes_json` is intentionally empty at the codec PR scope. The
-    // `Vec<ScanState>` holds tantivy handles + raw pgrx pointers that can't ship over the wire;
-    // workers rebuild it from the table provider in the dispatch-flip commit, where PG-backed
-    // segment ID claims are reachable. Leaving the wire field in place so the proto layout is
-    // forward-compatible — the dispatch-flip commit fills it in without bumping the version.
+    // `partition_recipes_json` is now superseded by the `table_provider_json` blob below:
+    // workers replay `scan_inner` to rebuild the per-partition `Vec<ScanState>` from scratch
+    // rather than reading per-partition recipes off the wire. Left as an empty Vec on the
+    // proto so deployments mid-rollout don't see a wire-shape mismatch; can be retired once
+    // the dispatch-flip lands in stable.
     let partition_recipes_json: Vec<String> = Vec::new();
+
+    // Ship the serialized `PgSearchTableProvider` populated by `create_scan` (Phase 2b). If
+    // the scan didn't go through `create_scan` (test fixtures), the field is `None` and we
+    // ship an empty Vec — workers detect the empty payload and skip reconstruction.
+    let table_provider_json = scan
+        .serialized_table_provider()
+        .map(|s| s.to_vec())
+        .unwrap_or_default();
 
     Ok(PgSearchScanProto {
         indexrelid: scan.indexrelid,
@@ -783,6 +798,7 @@ fn encode_pgsearch_scan(node: &dyn ExecutionPlan) -> Result<PgSearchScanProto> {
         deferred_fields_json,
         deferred_ctid_plan_position,
         dynamic_filters,
+        table_provider_json,
     })
 }
 
@@ -846,12 +862,12 @@ fn decode_pgsearch_scan(
         None
     };
 
-    // Empty states: the codec PR doesn't ship segment data. Worker-side execution before the
-    // dispatch-flip commit would just emit zero rows from this scan. Round-trip tests verify
-    // only the declarative fields.
+    // Empty states placeholder. Phase 2d wires the actual reconstruction (deserialize
+    // `proto.table_provider_json`, inject runtime context, call `scan_inner`).
     let states: Vec<crate::scan::execution_plan::ScanState> = Vec::new();
-    let _ = proto.partition_recipes_json; // reserved for the dispatch-flip commit.
+    let _ = proto.partition_recipes_json; // superseded by `table_provider_json` (Phase 2c).
     let _ = proto.dynamic_filters; // dynamic filters are re-pushed via FilterPushdown after construction; nothing to do here yet.
+    let _ = proto.table_provider_json; // consumed by the reconstruction landing in Phase 2d.
 
     let plan = PgSearchScanPlan::new(
         states,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -237,6 +237,33 @@ struct PgSearchScanProto {
 
 const DEFERRED_CTID_NONE: u32 = u32::MAX;
 
+/// Per-task reconstruction context attached to the worker's `TaskContext` via
+/// `SessionConfig::with_extension`. Read by `decode_pgsearch_scan` to look up the per-source
+/// canonical segment IDs (by `plan_position`) and the `ParallelScanState` pointer when
+/// rebuilding the runtime half of a shipped `PgSearchScanPlan`.
+///
+/// The producer-side dispatcher ([`crate::postgres::customscan::mpp::producer_service::ProducerTaskRegistry::prepare_task`])
+/// constructs this from the registry's fields and layers it onto the `TaskContext` that drives
+/// `PhysicalExtensionCodec::try_decode`.
+#[derive(Debug)]
+pub struct MppReconstructionContext {
+    /// Canonical segment ID sets indexed by absolute `plan_position` (full join source list
+    /// index). For non-MPP / serial paths this stays empty and the codec falls back to leaving
+    /// the scan's `Vec<ScanState>` empty.
+    pub index_segment_ids: Vec<crate::api::HashSet<tantivy::index::SegmentId>>,
+    /// Worker's view of the DSM-attached `ParallelScanState`. Injected on the deserialized
+    /// `PgSearchTableProvider` when `is_parallel()` is true so the partitioning-source scan
+    /// claims segments through the same shared state the rest of the worker is using.
+    pub parallel_state: Option<*mut crate::postgres::ParallelScanState>,
+}
+
+// SAFETY: the raw `*mut ParallelScanState` makes the auto-derived `Send + Sync` go away. Same
+// lifetime / threading story as `ProducerTaskRegistry`: the pointer is the worker's view of
+// PG's DSM-attached shared state, valid for the lifetime of the worker's customscan execution,
+// and only dereferenced on the worker's backend thread (current-thread tokio, FFI-pinned).
+unsafe impl Send for MppReconstructionContext {}
+unsafe impl Sync for MppReconstructionContext {}
+
 /// The real physical codec. Replaces `PgSearchPhysicalCodecStub` once the dispatch-flip PR
 /// lands; until then it's exercised exclusively via round-trip unit tests in this module.
 ///

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -513,9 +513,9 @@ fn encode_tantivy_lookup(node: &dyn ExecutionPlan) -> Result<TantivyLookupProto>
 }
 
 /// Walk an `Arc<dyn ExecutionPlan>` and collect `(indexrelid → Arc<FFHelper>)` mappings from
-/// every `PgSearchScanPlan` node that carries a non-`None` `ffhelper`. Matches what the leader
-/// does in `LateMaterializePlanner::plan_extension` via the private
-/// `late_materialization::extract_ff_helper` function.
+/// every `PgSearchScanPlan` node that carries deferred fields and a non-`None` `ffhelper`.
+/// Matches the leader's `late_materialization::extract_ff_helper` exactly — both the
+/// `has_deferred_fields()` gate and the `ffhelper().is_some()` gate.
 ///
 /// The Phase 2 reconstruction of `PgSearchScanPlan` produces real per-scan `FFHelper`s; this
 /// walk lets downstream execs (`TantivyLookupExec`, `SegmentedTopKExec`) reuse them without
@@ -526,8 +526,10 @@ fn collect_ffhelpers_from_input(
 ) {
     use crate::scan::execution_plan::PgSearchScanPlan;
     if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
-        if let Some(ff) = scan.ffhelper() {
-            out.insert(scan.indexrelid, ff);
+        if scan.has_deferred_fields() {
+            if let Some(ff) = scan.ffhelper() {
+                out.insert(scan.indexrelid, ff);
+            }
         }
     }
     for child in plan.children() {
@@ -538,7 +540,7 @@ fn collect_ffhelpers_from_input(
 fn decode_tantivy_lookup(
     proto: TantivyLookupProto,
     inputs: &[Arc<dyn ExecutionPlan>],
-    _ctx: &TaskContext,
+    ctx: &TaskContext,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     use crate::api::HashMap;
     use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper};
@@ -573,16 +575,33 @@ fn decode_tantivy_lookup(
     // Reconstruct the FFHelper map from the input plan's PgSearchScanPlan nodes. Phase 2's
     // reconstruction in `decode_pgsearch_scan` builds real FFHelpers; walking the inputs here
     // pulls them out keyed by indexrelid, the same recipe the leader uses
-    // (`LateMaterializePlanner` calls `extract_ff_helper`). Fall back to an empty `FFHelper`
-    // for any indexrelid in the proto that isn't present in the input walk — that can only
-    // happen if a scan reconstruction fell back to the empty-states placeholder, and the
-    // resulting downstream lookup miss will surface as a clear error at the next access.
+    // (`LateMaterializePlanner` calls `extract_ff_helper`, gated identically by both
+    // `has_deferred_fields()` and `ffhelper().is_some()`).
+    //
+    // In production (`MppReconstructionContext` present on the TaskContext) every relid in
+    // `proto.indexrelids` must be covered by the walk — substituting `FFHelper::empty()`
+    // would panic later (segment_caches OOB at first access). Hard-error at decode time so
+    // the failure points at the right layer. Round-trip tests that use `EmptyExec` inputs
+    // (no PgSearchScanPlan to walk) intentionally fall through to empty FFHelpers — they
+    // exercise wire-shape, not runtime semantics, and the test ctx lacks the extension.
+    let in_production = ctx
+        .session_config()
+        .get_extension::<MppReconstructionContext>()
+        .is_some();
     let mut ffhelpers: HashMap<u32, std::sync::Arc<FFHelper>> = HashMap::default();
     collect_ffhelpers_from_input(&input, &mut ffhelpers);
     for relid in &proto.indexrelids {
-        ffhelpers
-            .entry(*relid)
-            .or_insert_with(|| std::sync::Arc::new(FFHelper::empty()));
+        if !ffhelpers.contains_key(relid) {
+            if in_production {
+                return Err(DataFusionError::Internal(format!(
+                    "decode_tantivy_lookup: missing reconstructed FFHelper for indexrelid={relid}; \
+                     the input PgSearchScan must have fallen back to the empty-states placeholder. \
+                     Check that `MppReconstructionContext` is attached to the worker's TaskContext \
+                     in `on_subplan` and that `table_provider_json` is non-empty on the wire."
+                )));
+            }
+            ffhelpers.insert(*relid, std::sync::Arc::new(FFHelper::empty()));
+        }
     }
 
     let exec = TantivyLookupExec::new(input, deferred_fields, ffhelpers)?;
@@ -720,16 +739,42 @@ fn decode_segmented_topk(
     // SegmentedTopKExec takes a single FFHelper — the leader picks `target_indexrelid`
     // (`segmented_topk_rule.rs:271`) and pulls the FFHelper from the parent TantivyLookupExec
     // by that key. Mirror that here: walk the input plan for FFHelpers and pick the entry
-    // matching the first deferred-column's indexrelid (the proto's `indexrelids` is already
-    // single-element when SegmentedTopK lands — `segmented_topk_rule.rs:260-269` falls back
-    // to a non-pushdown SortExec when the sort spans multiple indexes).
+    // matching the first deferred-column's indexrelid.
+    //
+    // `segmented_topk_rule.rs:260-269` enforces a single-relid invariant on the leader
+    // (returns `Ok(None)` if the deferred-column set is empty or spans multiple relids), so
+    // in production an empty `proto.indexrelids` or a missing walker entry is a hard failure
+    // — `FFHelper::empty()` would panic later (segment_caches OOB). Round-trip tests with
+    // `EmptyExec` inputs fall through to empty (same rationale as `decode_tantivy_lookup`).
+    let in_production = ctx
+        .session_config()
+        .get_extension::<MppReconstructionContext>()
+        .is_some();
     let mut input_ffhelpers: crate::api::HashMap<u32, std::sync::Arc<FFHelper>> =
         crate::api::HashMap::default();
     collect_ffhelpers_from_input(&input, &mut input_ffhelpers);
-    let target_indexrelid = proto.indexrelids.first().copied().unwrap_or(0);
-    let ffhelper = input_ffhelpers
-        .remove(&target_indexrelid)
-        .unwrap_or_else(|| std::sync::Arc::new(FFHelper::empty()));
+    let ffhelper = match proto.indexrelids.first().copied() {
+        Some(rid) => match input_ffhelpers.remove(&rid) {
+            Some(ff) => ff,
+            None if in_production => {
+                return Err(DataFusionError::Internal(format!(
+                    "decode_segmented_topk: missing reconstructed FFHelper for \
+                     target_indexrelid={rid}; the input PgSearchScan / TantivyLookup must have \
+                     fallen back to placeholders"
+                )));
+            }
+            None => std::sync::Arc::new(FFHelper::empty()),
+        },
+        None if in_production => {
+            return Err(DataFusionError::Internal(
+                "decode_segmented_topk: proto.indexrelids is empty; SegmentedTopK requires \
+                 exactly one deferred-column indexrelid (enforced by \
+                 segmented_topk_rule.rs:260-269)"
+                    .into(),
+            ));
+        }
+        None => std::sync::Arc::new(FFHelper::empty()),
+    };
 
     let exec = SegmentedTopKExec::new(
         input,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -833,11 +833,58 @@ fn encode_pgsearch_scan(node: &dyn ExecutionPlan) -> Result<PgSearchScanProto> {
 fn decode_pgsearch_scan(
     proto: PgSearchScanProto,
     _inputs: &[Arc<dyn ExecutionPlan>],
-    _ctx: &TaskContext,
+    ctx: &TaskContext,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     use crate::scan::execution_plan::PgSearchScanPlan;
+    use crate::scan::table_provider::PgSearchTableProvider;
 
-    // Rebuild the arrow schema from the proto DfSchema.
+    // The reconstruction path: if the leader shipped a serialized `PgSearchTableProvider`
+    // AND the worker's `TaskContext` carries an `MppReconstructionContext` extension, replay
+    // `scan_inner` on the worker so the resulting plan carries real per-partition
+    // `ScanState`s (tantivy `SegmentReader` handles, MVCC visibility, FFHelper) instead of
+    // the empty placeholder that workers used before this commit.
+    //
+    // If either piece is missing — `table_provider_json` empty (test fixtures), or no
+    // extension (codec called outside the MPP worker path) — fall back to the
+    // empty-placeholder shape so callers that round-trip the wire format don't crash.
+    let recon = ctx
+        .session_config()
+        .get_extension::<MppReconstructionContext>();
+    if let (false, Some(recon)) = (proto.table_provider_json.is_empty(), recon) {
+        let mut provider: PgSearchTableProvider =
+            serde_json::from_slice(&proto.table_provider_json).map_err(|e| {
+                DataFusionError::Internal(format!(
+                    "decode_pgsearch_scan: PgSearchTableProvider JSON decode failed: {e}"
+                ))
+            })?;
+
+        // Mirror `PgSearchExtensionCodec::try_decode_table_provider`. `parallel_state` goes
+        // on every parallel scan; `canonical_segment_ids` is injected only for
+        // non-partitioning sources — the partitioning source falls through to the
+        // `parallel_state`-driven throttled-claim path inside `scan_inner` so the worker
+        // dynamically claims segments the same way the existing re-plan path does.
+        if provider.is_parallel() {
+            provider.set_parallel_state(recon.parallel_state);
+        }
+        if provider.non_partitioning_index().is_some() {
+            if let Some(plan_pos) = provider.plan_position() {
+                if let Some(ids) = recon.index_segment_ids.get(plan_pos) {
+                    provider.set_canonical_segment_ids(ids.clone());
+                }
+            }
+        }
+        // `expr_context` and `planstate` aren't plumbed in this commit. The existing
+        // re-plan path on the worker also gets them via the logical codec from the leader's
+        // `MppWorkerInputs`; reconstruction will need them when a shipped query carries
+        // runtime PG expressions (prepared-statement params, runtime-resolved casts).
+        // Follow-up; for now `provider.scan_inner` errors visibly with a missing-planstate
+        // message if a query hits that path.
+
+        return provider.scan_sync();
+    }
+
+    // Fallback: empty-placeholder shape. Used by round-trip tests and by any future caller
+    // that hits this codec without setting up an `MppReconstructionContext`.
     let df_schema_proto = proto.schema.ok_or_else(|| {
         DataFusionError::Internal("decode_pgsearch_scan: missing schema field".into())
     })?;
@@ -880,7 +927,6 @@ fn decode_pgsearch_scan(
         Some(proto.deferred_ctid_plan_position as usize)
     };
 
-    // Same FFHelper-placeholder caveat as the other execs: dispatch-flip wires the real one.
     let ffhelper = if !deferred_fields.is_empty() || deferred_ctid_plan_position.is_some() {
         Some(std::sync::Arc::new(
             crate::index::fast_fields_helper::FFHelper::empty(),
@@ -889,12 +935,9 @@ fn decode_pgsearch_scan(
         None
     };
 
-    // Empty states placeholder. Phase 2d wires the actual reconstruction (deserialize
-    // `proto.table_provider_json`, inject runtime context, call `scan_inner`).
     let states: Vec<crate::scan::execution_plan::ScanState> = Vec::new();
     let _ = proto.partition_recipes_json; // superseded by `table_provider_json` (Phase 2c).
     let _ = proto.dynamic_filters; // dynamic filters are re-pushed via FilterPushdown after construction; nothing to do here yet.
-    let _ = proto.table_provider_json; // consumed by the reconstruction landing in Phase 2d.
 
     let plan = PgSearchScanPlan::new(
         states,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -261,6 +261,13 @@ pub struct MppReconstructionContext {
 // lifetime / threading story as `ProducerTaskRegistry`: the pointer is the worker's view of
 // PG's DSM-attached shared state, valid for the lifetime of the worker's customscan execution,
 // and only dereferenced on the worker's backend thread (current-thread tokio, FFI-pinned).
+//
+// **Invariant**: the `Arc<MppReconstructionContext>` is laid into `SessionConfig::with_extension`
+// and may be transitively cloned into TaskContexts that DataFusion / DF-D pass into operators.
+// All of those run on the worker's current-thread tokio runtime, pinned to the PG backend
+// thread (pgrx 0.18 single-thread FFI ABI). If a future change spawns codec or operator work
+// onto a multi-threaded runtime, this `Send` becomes a soundness hole — there's no synthesis
+// path that would allow `*mut ParallelScanState` to safely cross threads.
 unsafe impl Send for MppReconstructionContext {}
 unsafe impl Sync for MppReconstructionContext {}
 
@@ -801,11 +808,12 @@ fn encode_pgsearch_scan(node: &dyn ExecutionPlan) -> Result<PgSearchScanProto> {
         })
         .collect::<Result<_>>()?;
 
-    // `partition_recipes_json` is now superseded by the `table_provider_json` blob below:
+    // `partition_recipes_json` (proto tag 4) is now superseded by `table_provider_json`:
     // workers replay `scan_inner` to rebuild the per-partition `Vec<ScanState>` from scratch
-    // rather than reading per-partition recipes off the wire. Left as an empty Vec on the
-    // proto so deployments mid-rollout don't see a wire-shape mismatch; can be retired once
-    // the dispatch-flip lands in stable.
+    // rather than reading per-partition recipes off the wire. Left as an empty Vec for one
+    // release so deployments mid-rollout don't see a wire-shape mismatch; retire in the
+    // follow-up that lands after dispatch-flip stabilises (mark tag 4 `reserved` then to
+    // prevent reuse).
     let partition_recipes_json: Vec<String> = Vec::new();
 
     // Ship the serialized `PgSearchTableProvider` populated by `create_scan` (Phase 2b). If
@@ -850,7 +858,20 @@ fn decode_pgsearch_scan(
     let recon = ctx
         .session_config()
         .get_extension::<MppReconstructionContext>();
-    if let (false, Some(recon)) = (proto.table_provider_json.is_empty(), recon) {
+    let has_provider_json = !proto.table_provider_json.is_empty();
+    if has_provider_json && recon.is_none() {
+        // Loud surface for the asymmetric case: the leader shipped reconstruction-ready bytes
+        // but the worker's task ctx has no `MppReconstructionContext`. Today this only happens
+        // when `decode_pgsearch_scan` is invoked outside `ProducerTaskRegistry::on_subplan`
+        // (round-trip lib tests etc.). Falling through to the placeholder is correct there;
+        // surface a `warning!` so the asymmetry shows up in regression test output and helps
+        // future debugging if a new caller forgets to layer the extension.
+        pgrx::warning!(
+            "decode_pgsearch_scan: shipped table_provider_json present but no \
+             MppReconstructionContext on TaskContext; falling back to empty-states placeholder"
+        );
+    }
+    if let (true, Some(recon)) = (has_provider_json, recon) {
         let mut provider: PgSearchTableProvider =
             serde_json::from_slice(&proto.table_provider_json).map_err(|e| {
                 DataFusionError::Internal(format!(
@@ -869,7 +890,15 @@ fn decode_pgsearch_scan(
         if provider.non_partitioning_index().is_some() {
             if let Some(plan_pos) = provider.plan_position() {
                 if let Some(ids) = recon.index_segment_ids.get(plan_pos) {
-                    provider.set_canonical_segment_ids(ids.clone());
+                    // Empty slot means the registry never populated this position (e.g. no
+                    // parallel_state available at registry-build time). Setting an empty
+                    // canonical set would route `scan_inner` through
+                    // `MvccSatisfies::ParallelWorker(empty)` and silently emit zero rows;
+                    // skip injection and let scan_inner fall back to whatever path the
+                    // provider's other fields dictate.
+                    if !ids.is_empty() {
+                        provider.set_canonical_segment_ids(ids.clone());
+                    }
                 }
             }
         }
@@ -939,7 +968,7 @@ fn decode_pgsearch_scan(
     let _ = proto.partition_recipes_json; // superseded by `table_provider_json` (Phase 2c).
     let _ = proto.dynamic_filters; // dynamic filters are re-pushed via FilterPushdown after construction; nothing to do here yet.
 
-    let plan = PgSearchScanPlan::new(
+    let mut plan = PgSearchScanPlan::new(
         states,
         arrow_schema,
         query_for_display,
@@ -949,6 +978,14 @@ fn decode_pgsearch_scan(
         proto.indexrelid,
         deferred_ctid_plan_position,
     );
+
+    // Preserve the shipped table-provider bytes through the fallback so any subsequent
+    // re-encode (e.g. a future optimizer pass that rewrites this scan into a new variant)
+    // doesn't lose the codec metadata. The leader-side scan always carries them; the worker
+    // fallback should too.
+    if !proto.table_provider_json.is_empty() {
+        plan = plan.with_serialized_table_provider(proto.table_provider_json);
+    }
 
     Ok(Arc::new(plan))
 }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -18,16 +18,13 @@
 //! Real physical codec for our custom `ExecutionPlan` nodes.
 //!
 //! Companion to [`crate::scan::codec::PgSearchExtensionCodec`] (the logical-plan codec). The
-//! logical codec is used today on the DSM path: leader ships a serialized logical plan, workers
-//! deserialize and re-run physical planning. This module exists to support the planned move to
-//! shipping fully-built physical subplans on workers' Request response cycle — see PR description
-//! for the dispatch-flip follow-up.
-//!
-//! Today the codec is registered as a *parallel* codec to the existing
-//! [`crate::scan::codec::PgSearchPhysicalCodecStub`]: the stub stays the one used by
-//! `with_distributed_user_codec` until the dispatch-flip PR lands. That keeps every commit in
-//! this PR safe even while individual exec encoders/decoders are being filled in: the new codec
-//! is exercised by round-trip tests but never produces bytes a worker reads.
+//! dispatch-flip ships per-(stage, task) physical subplans over shm_mq; this codec round-trips
+//! the four custom physical execs (`VisibilityFilterExec`, `TantivyLookupExec`,
+//! `SegmentedTopKExec`, `PgSearchScan`) plus the five built-in aggregate UDAFs
+//! (`min`/`max`/`count`/`sum`/`avg`) the shipped `AggregateExec` plans depend on. Registered on
+//! the worker's `SessionConfig` via `with_distributed_user_codec` in
+//! [`crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context`]; leader and
+//! worker both pick it up through `DistributedCodec::new_combined_with_user`.
 //!
 //! ## Wire format
 //!
@@ -40,16 +37,18 @@
 //! Several execs hold tantivy runtime state (`ScanState`, `FFHelper`, etc.) that can't ship over
 //! the wire. The encoded form carries only declarative inputs (`indexrelid`, segment IDs, query,
 //! schema). `try_decode` rebuilds runtime state on the worker side via the same constructors
-//! that the table provider uses today.
+//! that the table provider uses today — see `decode_pgsearch_scan` and
+//! `collect_ffhelpers_from_input`.
 //!
-//! ## On the `dead_code` allow
+//! ## Test-build dead-code allow
 //!
-//! Nothing in production registers this codec yet — `with_distributed_user_codec` still gets
-//! [`crate::scan::codec::PgSearchPhysicalCodecStub`]. The struct, the proto messages, and the
-//! per-exec encode/decode helpers are exercised only by this file's `#[cfg(test)]` round-trip
-//! tests. Once the dispatch-flip PR swaps the registration, the allow comes off naturally.
+//! Several decode paths (`PgSearchScan`, `VisibilityFilterExec`) and helper constants are
+//! `#[cfg(not(test))]`-gated because they transitively link `pg_sys` symbols the cargo-test
+//! binary can't resolve. The remaining `MppReconstructionContext` fields and the
+//! `DEFERRED_CTID_NONE` constant are only read from those gated paths, so cargo-test sees them
+//! as dead. Suppress the warning here rather than per-item to keep the codec file readable.
 
-#![allow(dead_code)]
+#![cfg_attr(test, allow(dead_code))]
 
 use std::sync::Arc;
 

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -495,7 +495,7 @@ impl PgSearchTableProvider {
             Some(ffhelper)
         };
 
-        Ok(Arc::new(PgSearchScanPlan::new(
+        let mut plan = PgSearchScanPlan::new(
             segments,
             schema,
             query_for_display,
@@ -504,7 +504,30 @@ impl PgSearchTableProvider {
             ffhelper_arg,
             self.scan_info.indexrelid.to_u32(),
             deferred_ctid_plan_position,
-        )))
+        );
+
+        // Serialize the provider so the physical codec can ship the leader's declarative
+        // half (heaprelid, score_needed, projected fields, partitioning-source marker,
+        // sort_order, plan_position) over the wire. Worker decoders deserialize this and
+        // call back into `scan_inner` to rebuild the per-partition `ScanState`s that
+        // contain tantivy `SegmentReader` handles + raw pgrx pointers — neither of which
+        // can ride over shm_mq.
+        //
+        // `to_vec` on a fully-serializable struct is infallible in practice; if the
+        // serialization shape ever changes such that it could fail, surface the error so
+        // the plan-build fails fast instead of producing a worker-side decode crash.
+        match serde_json::to_vec(self) {
+            Ok(bytes) => {
+                plan = plan.with_serialized_table_provider(bytes);
+            }
+            Err(e) => {
+                return Err(DataFusionError::Internal(format!(
+                    "PgSearchTableProvider serialization failed during scan build: {e}"
+                )));
+            }
+        }
+
+        Ok(Arc::new(plan))
     }
 
     /// Creates a multi-partition `PgSearchScanPlan` for throttled parallel scans.

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -513,17 +513,26 @@ impl PgSearchTableProvider {
         // contain tantivy `SegmentReader` handles + raw pgrx pointers — neither of which
         // can ride over shm_mq.
         //
-        // `to_vec` on a fully-serializable struct is infallible in practice; if the
-        // serialization shape ever changes such that it could fail, surface the error so
-        // the plan-build fails fast instead of producing a worker-side decode crash.
-        match serde_json::to_vec(self) {
-            Ok(bytes) => {
-                plan = plan.with_serialized_table_provider(bytes);
-            }
-            Err(e) => {
-                return Err(DataFusionError::Internal(format!(
-                    "PgSearchTableProvider serialization failed during scan build: {e}"
-                )));
+        // Skip the work on the worker. `create_scan` is reached on the worker too — through
+        // the codec's `decode_pgsearch_scan` → `scan_sync` → `scan_inner` → `create_*_scan` →
+        // `create_scan` chain — but the reconstructed scan is never re-encoded, so the bytes
+        // would just be dead weight. `ParallelWorkerNumber == -1` is the leader; anything
+        // else is a parallel worker. Confined to the `unsafe` access of the global to keep
+        // the check at its most direct.
+        let on_leader = unsafe { pg_sys::ParallelWorkerNumber == -1 };
+        if on_leader {
+            // `to_vec` on a fully-serializable struct is infallible in practice; if the
+            // serialization shape ever changes such that it could fail, surface the error so
+            // the plan-build fails fast instead of producing a worker-side decode crash.
+            match serde_json::to_vec(self) {
+                Ok(bytes) => {
+                    plan = plan.with_serialized_table_provider(bytes);
+                }
+                Err(e) => {
+                    return Err(DataFusionError::Internal(format!(
+                        "PgSearchTableProvider serialization failed during scan build: {e}"
+                    )));
+                }
             }
         }
 

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -761,6 +761,20 @@ impl TableProvider for PgSearchTableProvider {
 }
 
 impl PgSearchTableProvider {
+    /// Sync entrypoint for the physical codec's worker-side reconstruction. Same recipe the
+    /// async `scan()` method runs, but exposed without the `Session`/async ceremony — the
+    /// codec doesn't have a `Session` and the body never `.await`s.
+    ///
+    /// Only called from `decode_pgsearch_scan`, which is itself `#[cfg(not(test))]`-gated
+    /// (the codec links PG runtime symbols that the cargo-test binary can't resolve), so the
+    /// `dead_code` allow covers the test build.
+    #[allow(dead_code)]
+    pub(crate) fn scan_sync(&self) -> Result<Arc<dyn ExecutionPlan>> {
+        self.scan_inner(self.canonical_segment_ids.clone(), None, &[], None)
+    }
+}
+
+impl PgSearchTableProvider {
     /// Sync core of the scan path. Same recipe `scan()` runs, but exposed for the physical
     /// codec's worker-side reconstruction (PR #5122 follow-up): there's no `Session` to thread
     /// through and no async runtime to .await against — the body is CPU-bound PG/tantivy work

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -746,27 +746,28 @@ impl TableProvider for PgSearchTableProvider {
 
     async fn scan(
         &self,
-        state: &dyn Session,
+        _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         limit: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         self.scan_inner(
             self.canonical_segment_ids.clone(),
-            state,
             projection,
             filters,
             limit,
         )
-        .await
     }
 }
 
 impl PgSearchTableProvider {
-    async fn scan_inner(
+    /// Sync core of the scan path. Same recipe `scan()` runs, but exposed for the physical
+    /// codec's worker-side reconstruction (PR #5122 follow-up): there's no `Session` to thread
+    /// through and no async runtime to .await against — the body is CPU-bound PG/tantivy work
+    /// and never yields.
+    pub(crate) fn scan_inner(
         &self,
         canonical_override: Option<HashSet<SegmentId>>,
-        _state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         _limit: Option<usize>,

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -100,6 +100,16 @@ pub struct PgSearchTableProvider {
     /// This is serialized so the execution codec can inject the correct canonical
     /// segment IDs in both the leader and parallel workers.
     non_partitioning_index: Option<usize>,
+    /// Absolute position of this source in the full join source list (0-based DFS
+    /// enumeration), or `None` for serial scans / non-join paths.
+    ///
+    /// Used by the physical codec's worker-side reconstruction (PR #5122 follow-up): when
+    /// the leader ships a per-(stage, task) physical subplan, the worker looks up the
+    /// per-source canonical segment IDs in its registry's `Vec<HashSet<SegmentId>>`,
+    /// indexed by `plan_position`. The logical-codec path doesn't read this — there the
+    /// segment IDs are injected based on `non_partitioning_index` for non-partitioning
+    /// sources and a separate `parallel_state` pointer for the partitioning one.
+    plan_position: Option<usize>,
     /// Canonical segment IDs for replicated-parallel execution.
     ///
     /// When `Some`, `scan()` uses `MvccSatisfies::ParallelWorker(ids)` instead of
@@ -168,6 +178,7 @@ impl PgSearchTableProvider {
             expr_context: None,
             planstate: None,
             non_partitioning_index: None,
+            plan_position: None,
             canonical_segment_ids: None,
             visibility_mode: VisibilityMode::Eager,
             late_materialization_active: AtomicBool::new(false),
@@ -199,6 +210,19 @@ impl PgSearchTableProvider {
     /// Return the position of this provider in the non-partitioning source list, or `None`.
     pub(crate) fn non_partitioning_index(&self) -> Option<usize> {
         self.non_partitioning_index
+    }
+
+    /// Record the absolute plan position (full join source list index) for the physical
+    /// codec's worker-side reconstruction. See the `plan_position` field doc on
+    /// [`PgSearchTableProvider`].
+    pub(crate) fn set_plan_position(&mut self, plan_position: usize) {
+        self.plan_position = Some(plan_position);
+    }
+
+    /// Absolute plan position as set by [`Self::set_plan_position`], or `None`.
+    #[allow(dead_code)] // consumed by the physical-codec decode path in the next commit.
+    pub(crate) fn plan_position(&self) -> Option<usize> {
+        self.plan_position
     }
 
     /// Inject the canonical segment IDs for this replicated-parallel provider.


### PR DESCRIPTION
Stacked on #5122. Closes the silent-zero-rows / panic-on-deferred-fields gap that PR #5122 left open: shipped subplans decoded with empty `Vec<ScanState>` and stub `FFHelper::empty()`, so any production query going through the dispatch-flip path returned wrong answers or panicked.

## Phases

1. **Phase 1** (`fdee24f44`, `e14125db4`) — Plumb segment-state inputs (`index_segment_ids`, `parallel_state`) into `ProducerTaskRegistry`. Pure threading work; nothing consumes the new fields yet.
2. **Phase 2** (`3d5bfc362`..`46fcbb1ce`) — Ship the serialized `PgSearchTableProvider` alongside each `PgSearchScanProto`; worker decoder deserializes it, injects runtime context (segment IDs by `plan_position`, `parallel_state`), and replays a new sync `scan_sync()` → `scan_inner` recipe to rebuild real per-partition `ScanState`s. Same recipe the existing logical-codec re-plan path uses today.
3. **Phase 3** (`77e470bd0`, `b3d9270c0`) — Reconstruct `FFHelper`s for `TantivyLookupExec` and `SegmentedTopKExec` by walking their input plans for the now-real per-scan FFHelpers. Hard-errors in production on missing entries (instead of falling through to `FFHelper::empty()` which would panic at `segment_caches[seg_ord]` indexing).
4. **Phase 4** (`80c56d0ba`, `1b35c9c2a`) — Reorder `run_mpp_worker`: install request + subplan handlers first, drain pump once, then prewarm. Catches the common case where the leader has already shipped by the time the worker reaches the pump. For the residual leader-vs-worker process race (no PG-level barrier between leader's `ExecutorRun` and worker's `end_custom_scan`), `on_subplan` now invalidates any stale `prepared` cache entry when a late-arriving Subplan frame lands.

## What's deliberately out of scope

- `expr_context` / `planstate` injection on the worker. The existing logical-codec re-plan path at `exec_worker.rs:172-173` also passes `None, None` for these — queries with runtime PG expressions (prepared-statement params, runtime-resolved casts) error visibly on the MPP path regardless of dispatch-flip. Fix requires plumbing the worker's own expr_context/planstate through `MppWorkerInputs`; separate concern.
- Retiring `partition_recipes_json` (proto tag 4) — now an always-empty legacy field; can be retired in a follow-up once dispatch-flip is stable (mark tag 4 `reserved` to prevent reuse).
- Wire-cost benchmark for `serialized_table_provider` payload — measured for a 4-source join this adds 4× JSON entries per stage; should be benched against the logical re-plan path before claiming a perf win.
- Integration coverage under `cargo pgrx test` for the reconstruction path. The decoder's reconstruction branch is `#[cfg(not(test))]`-gated (PG-symbol linkage); cargo-test lib tests cover the wire-shape round-trip but not the runtime reconstruction.

## Review notes

Each phase was reviewed by an independent senior-engineer agent and fixes applied in a follow-up commit. The Phase 2 review caught a critical "Phase 2 is dormant" issue (the codec extension wasn't reachable from `on_subplan` because that call used the bare session task ctx); fix in `46fcbb1ce`. The Phase 3 review caught a "the panic just moved one decode layer down" issue (FFHelper fallbacks would still OOB on `segment_caches[seg_ord]`); fix in `b3d9270c0`. The Phase 4 review caught the leader-vs-worker process race that the reorder didn't address; fix in `1b35c9c2a`.

## Test plan

- [ ] Lib tests (`cargo test --lib --package pg_search --no-default-features --features pg18 -- mpp physical_codec`): 70/70 pass locally, no new tests added (`#[cfg(not(test))]`-gated decoder paths uncoverable in cargo-test)
- [ ] `cargo clippy -D warnings` clean for both default and `--tests`
- [ ] Integration tests via `cargo pgrx test` — needs CI run to confirm the reconstructed paths produce real rows
- [ ] Bench: `aggregate_join_groupby` at 10M / 25M to confirm dispatch-flip with state reconstruction matches or beats the logical-codec re-plan path