### PR TITLE
fix(mpp): codec ordering + FFHelper indexing + projection-aware reconstruction

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1542,6 +1542,12 @@ impl AggregateScan {
         let ps = state.planstate();
         let runtime_planstate = (!ps.is_null()).then_some(ps);
 
+        // Snapshot before the `custom_state_mut()` borrow below. Used at the leader's
+        // physical-plan build (`build_join_aggregate_plan`) to pass `Some(MppPlanContext)`
+        // so the leader-side `PgSearchTableProvider`s carry the same parallel-source
+        // markers that workers expect when decoding shipped subplans.
+        let mpp_partitioning_source_idx = state.custom_state().mpp_partitioning_source_idx;
+
         let df_state = state
             .custom_state_mut()
             .datafusion_state
@@ -1614,6 +1620,20 @@ impl AggregateScan {
                 None => create_aggregate_session_context(),
             };
 
+            // When MPP is active, the leader's physical plan must be built with the same
+            // `MppPlanContext` that `stash_mpp_plan_bytes` used for the logical plan shipped
+            // to workers. Otherwise the leader's per-source `PgSearchTableProvider`s carry
+            // `is_parallel=false` / `non_partitioning_index=None`, and the JSON serialized
+            // onto the shipped subplans (in `create_scan`) propagates those defaults to
+            // workers. Workers then take `MvccSatisfies::Snapshot` + the no-`parallel_state`
+            // branch in `scan_inner`, so every worker scans every segment instead of
+            // claiming a slice via `checkout_segment` — producing `n_workers ×` row
+            // duplication on aggregate queries.
+            let mpp_ctx = leader_mesh.as_ref().and_then(|_| {
+                mpp_partitioning_source_idx.map(|idx| MppPlanContext {
+                    partitioning_plan_position: idx,
+                })
+            });
             let custom_exprs = df_state.custom_exprs;
             let custom_scan_tlist = df_state.custom_scan_tlist;
             let physical_plan = runtime.block_on(async {
@@ -1628,7 +1648,7 @@ impl AggregateScan {
                     &ctx,
                     runtime_expr_context,
                     runtime_planstate,
-                    None,
+                    mpp_ctx,
                 )
                 .await?;
                 df_state.group_df_indices = group_df_indices;

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1091,7 +1091,10 @@ impl AggregateScan {
         } else {
             create_aggregate_session_context()
         };
-        let Ok(runtime) = tokio::runtime::Builder::new_current_thread().build() else {
+        let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
             explainer.add_text("DataFusion Plan", "(tokio runtime unavailable)");
             return;
         };

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -660,6 +660,7 @@ impl ExecMethod for ColumnarExecState {
         if self.runtime.is_none() {
             self.runtime = Some(
                 tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
                     .build()
                     .expect("Failed to create tokio runtime for DataFusion stream execution"),
             );

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1368,6 +1368,7 @@ impl CustomScan for JoinScan {
                 create_datafusion_session_context(SessionContextProfile::Join)
             };
             let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
                 .build()
                 .expect("Failed to create tokio runtime");
             let logical_plan = deserialize_logical_plan_with_runtime(
@@ -1445,6 +1446,7 @@ impl CustomScan for JoinScan {
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
                 let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
                     .build()
                     .unwrap();
                 let mut join_clause = state.custom_state().join_clause.clone();
@@ -1948,6 +1950,7 @@ unsafe fn build_output_projection(
 /// it during scan startup.
 fn bake_logical_plan(private_data: &mut PrivateData, custom_exprs: *mut pg_sys::List) {
     let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
         .build()
         .expect("Failed to create tokio runtime");
     let logical_plan = runtime

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -237,21 +237,22 @@ pub(crate) fn run_mpp_worker(
     worker_mesh.install_subplan_handler(Arc::clone(&registry)
         as Arc<dyn crate::postgres::customscan::mpp::transport::SubplanHandler>);
 
-    // Pump the drain once to deliver any Subplan frames that already landed before the
-    // handlers were installed. Pumping here puts those into `shipped_subplans` so the prewarm
-    // loop below calls `prepare_task` against a populated map. Workers can still enter
-    // `run_mpp_worker` before the leader's `ship_subplans_to_workers` completes (no PG-level
-    // barrier syncs the two — leader runs in `ExecutorRun`, worker in `end_custom_scan` on
-    // its first poll), so this pump only catches what's already there; the rest of the
-    // protection lives in `ProducerTaskRegistry::on_subplan`, which invalidates any cached
-    // locally-prepared entry when a shipped subplan arrives later.
+    // Pump the drain once to deliver any frames already queued before the handlers were
+    // installed. Subplan frames go into `shipped_subplans` so the prewarm loop below calls
+    // `prepare_task` against a populated map. Request frames can also be in the queue if the
+    // leader has already started executing its own plan; those go through
+    // `ProducerTaskRegistry::on_request` → `tokio::spawn`, so the drain pump must run inside
+    // the runtime's context — `tokio::spawn` panics if there is no current runtime.
     //
-    // Drain failures at startup are fatal — that means the underlying queue is corrupted or
-    // the mesh detached. Per-subplan decode failures are NOT surfaced here: `on_subplan`
-    // swallows decode errors with a `warning!` so the affected `(stage, task)` falls back
-    // to `prepare_task`'s local-prepare path naturally. An `error!` here is reserved for
-    // genuine infrastructure failure.
-    if let Err(e) = worker_mesh.drain_all_inbound() {
+    // Drain failures here are fatal — that means the underlying queue is corrupted or the
+    // mesh detached. Per-subplan decode failures are NOT surfaced: `on_subplan` swallows
+    // decode errors with `mpp_log!` so the affected `(stage, task)` falls back to
+    // `prepare_task`'s local-prepare path naturally.
+    let drain_result = {
+        let _guard = runtime.enter();
+        worker_mesh.drain_all_inbound()
+    };
+    if let Err(e) = drain_result {
         pgrx::error!("mpp worker (proc={this_proc}): initial drain pump failed: {e}");
     }
 

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -285,12 +285,13 @@ pub(crate) fn run_mpp_worker(
         .collect();
     owned_keys.sort_unstable();
 
-    // Prewarm barrier: drain → wait until `on_subplan` has *attempted* the owned key (shipped
-    // OR decode-failed) → call `prewarm`. `prepare_task` then either consumes the shipped
-    // subplan (preferred) or falls through to the local-prepare path (codec-gap fallback,
-    // TODO(codec-coverage) tracked separately). The barrier replaces the old startup-eager
-    // prewarm that raced with the leader's `ship_subplans_to_workers` and could cache a
-    // locally-prepared entry that `on_subplan` would later have to invalidate.
+    // Prewarm barrier: drain → wait until `on_subplan` has *attempted* the owned key
+    // (shipped OR decode-failed) → call `prewarm`. With Phase B's cross-stage caches the
+    // codec decodes reliably; a decode failure now propagates back through the drain pump
+    // as a hard Err, so `prepare_task` is no longer required to fall back to anything. The
+    // barrier replaces the old startup-eager prewarm that raced with the leader's
+    // `ship_subplans_to_workers` and could cache a locally-prepared entry that
+    // `on_subplan` would later have to invalidate.
     //
     // The barrier closes the prewarm-time race; a separate, smaller race remains during
     // prewarm itself if a Request arrives before its corresponding Subplan. The leader's
@@ -336,12 +337,12 @@ pub(crate) fn run_mpp_worker(
                 }
                 tokio::task::yield_now().await;
             }
-            // After the barrier, `prewarm` runs either the shipped path (when `on_subplan`
-            // decoded successfully) or the local-prepare fallback (when decode failed). An
-            // error here therefore means either:
-            //   - shipped path's `build_task_ctx` failed (memory pool builder, etc.), OR
-            //   - local-prepare's `DistributedExec::prepare_in_process_plan` failed (DF
-            //     planner refused the shape, etc.).
+            // After the barrier, `prewarm` always runs the shipped path. Possible errors:
+            //   - `prepare_task` couldn't find the shipped subplan (would be an invariant
+            //     breach since `is_subplan_attempted` flipped meaning either the shipped
+            //     entry is in `shipped_subplans` now or `on_subplan` returned Err and the
+            //     drain pump above would have surfaced it before we got here), OR
+            //   - `build_task_ctx` failed (memory pool builder, RuntimeEnv builder, etc.).
             // Either way, abort instead of sliding into the service loop with no prepared
             // plan for an owned task.
             registry.prewarm(stage_id, task_idx)?;

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -237,55 +237,63 @@ pub(crate) fn run_mpp_worker(
     worker_mesh.install_subplan_handler(Arc::clone(&registry)
         as Arc<dyn crate::postgres::customscan::mpp::transport::SubplanHandler>);
 
-    // Pump the drain once to deliver any frames already queued before the handlers were
-    // installed. Subplan frames go into `shipped_subplans` so the prewarm loop below calls
-    // `prepare_task` against a populated map. Request frames can also be in the queue if the
-    // leader has already started executing its own plan; those go through
-    // `ProducerTaskRegistry::on_request` → `tokio::spawn`, so the drain pump must run inside
-    // the runtime's context — `tokio::spawn` panics if there is no current runtime.
-    //
-    // Drain failures here are fatal — that means the underlying queue is corrupted or the
-    // mesh detached. Per-subplan decode failures are NOT surfaced: `on_subplan` swallows
-    // decode errors with `mpp_log!` so the affected `(stage, task)` falls back to
-    // `prepare_task`'s local-prepare path naturally.
-    let drain_result = {
-        let _guard = runtime.enter();
-        worker_mesh.drain_all_inbound()
-    };
-    if let Err(e) = drain_result {
-        pgrx::error!("mpp worker (proc={this_proc}): initial drain pump failed: {e}");
-    }
-
-    // Pre-warm `(stage, task) → (prepared_plan, TaskContext)` for every task this proc owns.
-    // Without this, the first Request per task pays the full
-    // `DistributedExec::prepare_in_process_plan` cost (transform_up + codec encoding) on the
-    // drain dispatch path, which stalls every other inbound until prep completes. Front-loading
-    // here makes dispatch a pure cache lookup.
-    //
-    // `proc_for_task(n_workers, t) == this_proc` picks the tasks this worker hosts (which under
-    // the natural-shape estimator chain works out to `task_idx mod n_workers == this_proc - 1`).
-    // We also prewarm `task_idx == 0` on every proc as a defensive cache: under the current
-    // estimator chain `proc_for_task(_, 0) == 1` always, so the broadcast Requests only ever
-    // land on proc 1 and non-owner procs never serve them. If a future estimator change
-    // re-routes broadcast tasks, those non-owner caches turn from defensive into load-bearing
-    // without code changes here.
+    // Enumerate the `(stage_id, task_idx)` tuples this worker owns. Only owned tasks ever
+    // receive Requests under the natural-shape estimator chain
+    // (`proc_for_task(n_workers, t) == this_proc`), so those are the only ones the prewarm
+    // barrier needs to settle before the service loop runs. The defensive `broadcast_zero`
+    // prewarm on non-owner procs that used to live here was load-bearing only via the prep-
+    // cache race the new barrier closes — under the current estimator
+    // `proc_for_task(_, 0) == 1`, so non-owner procs never serve task_idx=0 anyway.
     let n_workers = worker_mesh.n_procs.saturating_sub(1).max(1);
-    let stage_task_counts: Vec<(u32, usize)> = registry.iter_task_counts().collect();
-    for (stage_id, task_count) in stage_task_counts {
-        for task_idx in 0..task_count as u32 {
-            let owned = proc_for_task(n_workers, task_idx) == this_proc;
-            let broadcast_zero = task_idx == 0;
-            if !(owned || broadcast_zero) {
-                continue;
+    let owned_keys: Vec<(u32, u32)> = registry
+        .iter_task_counts()
+        .flat_map(|(stage_id, task_count)| {
+            (0..task_count as u32)
+                .filter(|task_idx| proc_for_task(n_workers, *task_idx) == this_proc)
+                .map(move |task_idx| (stage_id, task_idx))
+        })
+        .collect();
+
+    // Prewarm barrier: drain → wait until `on_subplan` has *attempted* the owned key (shipped
+    // OR decode-failed) → call `prewarm`. `prepare_task` then either consumes the shipped
+    // subplan (preferred) or falls through to the local-prepare path (codec-gap fallback,
+    // tracked separately). The barrier replaces the old startup-eager prewarm that raced with
+    // the leader's `ship_subplans_to_workers` and could cache a locally-prepared entry that
+    // `on_subplan` would later have to invalidate.
+    //
+    // Termination signal is `ProducerTaskRegistry::is_subplan_attempted`, set unconditionally
+    // by `on_subplan` on both Ok and Err arms. That removes the only deadlock risk the
+    // earlier `has_shipped_subplan` check carried (a silent decode failure would never flip
+    // the shipped-only bit).
+    //
+    // `runtime.enter()` is load-bearing: drain dispatch routes Request frames through
+    // `ProducerTaskRegistry::on_request` → `tokio::spawn`, which panics if there is no
+    // current runtime. Without the guard, a Request already queued at startup brings the
+    // worker down the moment it gets pulled off the queue.
+    let _guard = runtime.enter();
+    for (stage_id, task_idx) in owned_keys {
+        loop {
+            pgrx::check_for_interrupts!();
+            if let Err(e) = worker_mesh.drain_all_inbound() {
+                pgrx::error!("mpp worker (proc={this_proc}): prewarm-barrier drain failed: {e}");
             }
-            if let Err(e) = registry.prewarm(stage_id, task_idx) {
-                pgrx::warning!(
-                    "mpp worker (proc={this_proc}): prewarm stage_id={stage_id} \
-                     task_idx={task_idx} failed: {e}; will retry lazily on Request"
-                );
+            if registry.is_subplan_attempted(stage_id, task_idx) {
+                if let Err(e) = registry.prewarm(stage_id, task_idx) {
+                    // `prewarm` reaches local-prepare on a shipped-decode miss, so an error
+                    // here means the worker-local rebuild itself failed (DF planner refused
+                    // the shape, memory pool builder failed, etc.) — abort instead of
+                    // sliding into the service loop with no prepared plan for an owned task.
+                    pgrx::error!(
+                        "mpp worker (proc={this_proc}): prewarm stage_id={stage_id} \
+                         task_idx={task_idx} failed: {e}"
+                    );
+                }
+                break;
             }
+            std::thread::yield_now();
         }
     }
+    drop(_guard);
 
     // Service loop. Three pieces interleave on the single tokio task scheduler:
     //   - This loop: pumps every inbound drain, dispatching Requests.

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -246,9 +246,11 @@ pub(crate) fn run_mpp_worker(
     // protection lives in `ProducerTaskRegistry::on_subplan`, which invalidates any cached
     // locally-prepared entry when a shipped subplan arrives later.
     //
-    // Drain failures at startup are fatal — partial Subplan dispatch leaves the worker with
-    // a mixed shipped/local plan map, which silently breaks the "build once, ship many"
-    // invariant. Surface as `error!` so the query aborts instead of producing wrong rows.
+    // Drain failures at startup are fatal — that means the underlying queue is corrupted or
+    // the mesh detached. Per-subplan decode failures are NOT surfaced here: `on_subplan`
+    // swallows decode errors with a `warning!` so the affected `(stage, task)` falls back
+    // to `prepare_task`'s local-prepare path naturally. An `error!` here is reserved for
+    // genuine infrastructure failure.
     if let Err(e) = worker_mesh.drain_all_inbound() {
         pgrx::error!("mpp worker (proc={this_proc}): initial drain pump failed: {e}");
     }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -211,9 +211,26 @@ pub(crate) fn run_mpp_worker(
     let work_mem_bytes = unsafe { pg_sys::work_mem as usize * 1024 };
     let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
     let session_arc = Arc::new(session);
-    // Pass the per-source canonical segment-ID sets + the ParallelScanState pointer down so the
-    // registry can rebuild PgSearchScan / FFHelper runtime state when decoding leader-shipped
-    // subplans.
+
+    // Walk the worker's full local physical plan once and capture FFHelper snapshots indexed
+    // by two keys:
+    //   - `indexrelid` → consumed by `decode_segmented_topk` / `decode_tantivy_lookup` for
+    //     deferred field materialization.
+    //   - `deferred_ctid_plan_position` → consumed by `decode_visibility_filter` to wire
+    //     ctid resolvers (the standalone `VisibilityCtidResolverRule` doesn't fire on the
+    //     decoded subplan because `prepare_in_process_plan` bypasses optimizer rules, and
+    //     the rule's own walker has the same cross-stage blindness as the FFHelper walker).
+    //
+    // Both maps are populated from the same recursion so we walk the plan once. Storing on
+    // `MppReconstructionContext` makes the cache visible to every decoder via the codec's
+    // `TaskContext` extension. Cheap: each `Arc<FFHelper>` is shared.
+    let (ffhelpers_by_relid, ctid_resolvers_by_plan_position) =
+        collect_ffhelper_snapshots(&physical_plan);
+
+    // Pass the per-source canonical segment-ID sets, the ParallelScanState pointer, and the
+    // FFHelper snapshots down so the registry can rebuild PgSearchScan / FFHelper /
+    // VisibilityFilter runtime state when decoding leader-shipped subplans across stage
+    // boundaries.
     let registry = Arc::new(ProducerTaskRegistry::new(
         stage_plans,
         session_arc,
@@ -222,6 +239,8 @@ pub(crate) fn run_mpp_worker(
         hash_mem_multiplier,
         index_segment_ids,
         parallel_state,
+        ffhelpers_by_relid,
+        ctid_resolvers_by_plan_position,
     ));
 
     // Install the request handler on every inbound drain. The cooperative drain dispatches
@@ -375,4 +394,51 @@ pub(crate) fn run_mpp_worker(
     if let Err(e) = result {
         pgrx::error!("mpp worker: service loop failed: {e}");
     }
+}
+
+/// Walk a worker-local distributed physical plan and snapshot every `PgSearchScanPlan`'s
+/// `Arc<FFHelper>` under two keys: `indexrelid` (for `decode_segmented_topk` /
+/// `decode_tantivy_lookup`) and `deferred_ctid_plan_position` (for
+/// `decode_visibility_filter`'s ctid resolver wiring). Both snapshots go on the worker's
+/// `MppReconstructionContext` so codec decoders can resolve cross-stage references that the
+/// shipped subplan's local input tree can't reach across a `NetworkBoundaryExec`.
+///
+/// Recurses through `plan.children()`, which DataFusion implements on every standard exec.
+/// `NetworkBoundaryExec` (and the DF-D fork's wrappers) lift their wrapped inner plan into
+/// `children()` at the leader-side construction site, so the worker's local rebuild has
+/// every stage's scans reachable from the same root — this walk hits all of them.
+#[allow(clippy::type_complexity)]
+fn collect_ffhelper_snapshots(
+    plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+) -> (
+    crate::api::HashMap<u32, Arc<crate::index::fast_fields_helper::FFHelper>>,
+    crate::api::HashMap<usize, Arc<crate::index::fast_fields_helper::FFHelper>>,
+) {
+    use crate::scan::execution_plan::PgSearchScanPlan;
+    let mut by_relid = crate::api::HashMap::default();
+    let mut by_ctid_position = crate::api::HashMap::default();
+    fn recurse(
+        plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+        by_relid: &mut crate::api::HashMap<u32, Arc<crate::index::fast_fields_helper::FFHelper>>,
+        by_ctid_position: &mut crate::api::HashMap<
+            usize,
+            Arc<crate::index::fast_fields_helper::FFHelper>,
+        >,
+    ) {
+        if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
+            if let Some(ff) = scan.ffhelper() {
+                by_relid
+                    .entry(scan.indexrelid)
+                    .or_insert_with(|| Arc::clone(&ff));
+                if let Some(pos) = scan.deferred_ctid_plan_position() {
+                    by_ctid_position.entry(pos).or_insert(ff);
+                }
+            }
+        }
+        for child in plan.children() {
+            recurse(child, by_relid, by_ctid_position);
+        }
+    }
+    recurse(plan, &mut by_relid, &mut by_ctid_position);
+    (by_relid, by_ctid_position)
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -240,12 +240,23 @@ pub(crate) fn run_mpp_worker(
     // Enumerate the `(stage_id, task_idx)` tuples this worker owns. Only owned tasks ever
     // receive Requests under the natural-shape estimator chain
     // (`proc_for_task(n_workers, t) == this_proc`), so those are the only ones the prewarm
-    // barrier needs to settle before the service loop runs. The defensive `broadcast_zero`
-    // prewarm on non-owner procs that used to live here was load-bearing only via the prep-
-    // cache race the new barrier closes — under the current estimator
-    // `proc_for_task(_, 0) == 1`, so non-owner procs never serve task_idx=0 anyway.
-    let n_workers = worker_mesh.n_procs.saturating_sub(1).max(1);
-    let owned_keys: Vec<(u32, u32)> = registry
+    // barrier needs to settle before the service loop runs.
+    //
+    // The defensive `broadcast_zero` prewarm on non-owner procs that used to live here was
+    // load-bearing only via the prep-cache race the new barrier closes. Two independent
+    // invariants make it safe to drop today: (1) `BroadcastBuildSideOneTaskEstimator` caps
+    // broadcast subtrees at `task_count == 1`, and (2) `proc_for_task(_, 0) == 1`. If either
+    // invariant changes — a different estimator chain, or a `proc_for_task` offset shift —
+    // non-owner procs could start serving `task_idx == 0` again, and the broadcast_zero
+    // prewarm needs to come back alongside the change. See `task_estimator.rs` and
+    // `runtime.rs::proc_for_task`.
+    //
+    // `owned_keys` is sorted so the barrier waits on keys in a deterministic order. The
+    // underlying `StagePlans` map iterates in `HashMap` order, which is randomized per
+    // process; without the sort, two runs of the same query show different per-worker
+    // startup-latency traces depending on which key happens to be checked first.
+    let n_workers = worker_mesh.n_workers();
+    let mut owned_keys: Vec<(u32, u32)> = registry
         .iter_task_counts()
         .flat_map(|(stage_id, task_count)| {
             (0..task_count as u32)
@@ -253,47 +264,74 @@ pub(crate) fn run_mpp_worker(
                 .map(move |task_idx| (stage_id, task_idx))
         })
         .collect();
+    owned_keys.sort_unstable();
 
     // Prewarm barrier: drain → wait until `on_subplan` has *attempted* the owned key (shipped
     // OR decode-failed) → call `prewarm`. `prepare_task` then either consumes the shipped
     // subplan (preferred) or falls through to the local-prepare path (codec-gap fallback,
-    // tracked separately). The barrier replaces the old startup-eager prewarm that raced with
-    // the leader's `ship_subplans_to_workers` and could cache a locally-prepared entry that
-    // `on_subplan` would later have to invalidate.
+    // TODO(codec-coverage) tracked separately). The barrier replaces the old startup-eager
+    // prewarm that raced with the leader's `ship_subplans_to_workers` and could cache a
+    // locally-prepared entry that `on_subplan` would later have to invalidate.
     //
-    // Termination signal is `ProducerTaskRegistry::is_subplan_attempted`, set unconditionally
-    // by `on_subplan` on both Ok and Err arms. That removes the only deadlock risk the
-    // earlier `has_shipped_subplan` check carried (a silent decode failure would never flip
-    // the shipped-only bit).
+    // The barrier closes the prewarm-time race; a separate, smaller race remains during
+    // prewarm itself if a Request arrives before its corresponding Subplan. The leader's
+    // ship-before-execute ordering (`ship_subplans_to_workers` runs synchronously to
+    // completion before `physical_plan.execute` issues any Request) keeps that race closed
+    // under the natural shape; documented here because it's an unenforced invariant rather
+    // than a structural one.
     //
-    // `runtime.enter()` is load-bearing: drain dispatch routes Request frames through
-    // `ProducerTaskRegistry::on_request` → `tokio::spawn`, which panics if there is no
-    // current runtime. Without the guard, a Request already queued at startup brings the
-    // worker down the moment it gets pulled off the queue.
-    let _guard = runtime.enter();
-    for (stage_id, task_idx) in owned_keys {
-        loop {
-            pgrx::check_for_interrupts!();
-            if let Err(e) = worker_mesh.drain_all_inbound() {
-                pgrx::error!("mpp worker (proc={this_proc}): prewarm-barrier drain failed: {e}");
-            }
-            if registry.is_subplan_attempted(stage_id, task_idx) {
-                if let Err(e) = registry.prewarm(stage_id, task_idx) {
-                    // `prewarm` reaches local-prepare on a shipped-decode miss, so an error
-                    // here means the worker-local rebuild itself failed (DF planner refused
-                    // the shape, memory pool builder failed, etc.) — abort instead of
-                    // sliding into the service loop with no prepared plan for an owned task.
-                    pgrx::error!(
-                        "mpp worker (proc={this_proc}): prewarm stage_id={stage_id} \
-                         task_idx={task_idx} failed: {e}"
-                    );
+    // Termination has three exits (in priority order):
+    //   1. `is_subplan_attempted(stage, task)` flips → call prewarm, advance to next key.
+    //   2. `registry.take_error()` returns `Some` → a spawned driver future failed during
+    //      the barrier; surface it as `pgrx::error!` rather than wait forever.
+    //   3. `worker_mesh.leader_inbound_detached()` flips before (1) → the leader gave up
+    //      shipping (e.g. a leader-side `pgrx::error!` longjmped out of
+    //      `ship_subplans_to_workers` partway through the task vector); error out with a
+    //      clear diagnostic instead of looping forever.
+    //
+    // The barrier sits inside `runtime.block_on` so `tokio::task::yield_now().await` is the
+    // right cooperative-yield primitive (lets `tokio::spawn`ed drivers from `on_request`
+    // make forward progress) and so `tokio::spawn` itself has a current runtime — without
+    // the runtime context, a `Request` frame already queued at startup brings the worker
+    // down the moment its dispatch path calls `tokio::spawn`.
+    let result: Result<(), DataFusionError> = runtime.block_on(async {
+        for (stage_id, task_idx) in &owned_keys {
+            let (stage_id, task_idx) = (*stage_id, *task_idx);
+            loop {
+                pgrx::check_for_interrupts!();
+                worker_mesh.drain_all_inbound()?;
+                if registry.is_subplan_attempted(stage_id, task_idx) {
+                    break;
                 }
-                break;
+                if let Some(e) = registry.take_error() {
+                    return Err(e);
+                }
+                if worker_mesh.leader_inbound_detached() {
+                    return Err(DataFusionError::Internal(format!(
+                        "mpp worker (proc={this_proc}): leader detached before shipping \
+                         subplan for stage_id={stage_id} task_idx={task_idx}; most likely \
+                         the leader's `ship_subplans_to_workers` errored partway through \
+                         the task vector, or the leader's and worker's `StagePlans` walks \
+                         disagree on which stages exist"
+                    )));
+                }
+                tokio::task::yield_now().await;
             }
-            std::thread::yield_now();
+            // After the barrier, `prewarm` runs either the shipped path (when `on_subplan`
+            // decoded successfully) or the local-prepare fallback (when decode failed). An
+            // error here therefore means either:
+            //   - shipped path's `build_task_ctx` failed (memory pool builder, etc.), OR
+            //   - local-prepare's `DistributedExec::prepare_in_process_plan` failed (DF
+            //     planner refused the shape, etc.).
+            // Either way, abort instead of sliding into the service loop with no prepared
+            // plan for an owned task.
+            registry.prewarm(stage_id, task_idx)?;
         }
+        Ok(())
+    });
+    if let Err(e) = result {
+        pgrx::error!("mpp worker (proc={this_proc}): prewarm barrier failed: {e}");
     }
-    drop(_guard);
 
     // Service loop. Three pieces interleave on the single tokio task scheduler:
     //   - This loop: pumps every inbound drain, dispatching Requests.

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -226,6 +226,14 @@ pub(super) struct ProducerTaskRegistry {
     /// `(stage, task)` pairs the leader never ships — broadcast tasks under the current
     /// estimator (`proc_for_task(_, 0) == 1`) on non-owner procs, plus test paths.
     shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>,
+    /// `(stage_id, task_idx)` keys for which `on_subplan` has already run, regardless of decode
+    /// outcome. Populated on **both** the Ok and Err arms inside `on_subplan` so the prewarm
+    /// barrier in `run_mpp_worker` has a single signal that means "the leader's Subplan frame
+    /// for this key has been processed; we either have a shipped plan now or we never will".
+    /// Without this signal the barrier would either hang on silent decode failures (the
+    /// `shipped_subplans` map never gets the entry) or have to bail out on a coarse timeout
+    /// that fires before the leader actually finished shipping.
+    attempted_subplans: Mutex<HashSet<(u32, u32)>>,
     /// `(stage_id, task_idx, partition)` set of already-dispatched drivers. Repeat Requests are
     /// dropped. Without this, a consumer that re-issued `stream_partition` would cause the
     /// producer to spawn a second driver pushing duplicate frames onto the channel.
@@ -275,6 +283,7 @@ impl ProducerTaskRegistry {
             first_error: Arc::new(Mutex::new(None)),
             prepared: Mutex::new(HashMap::new()),
             shipped_subplans: Mutex::new(HashMap::new()),
+            attempted_subplans: Mutex::new(HashSet::default()),
             spawned: Mutex::new(HashSet::default()),
         }
     }
@@ -339,12 +348,30 @@ impl ProducerTaskRegistry {
         self.stage_plans.iter_task_counts()
     }
 
+    /// True iff `on_subplan` has finished processing the Subplan frame for `(stage_id,
+    /// task_idx)` — whether decode succeeded (entry in `shipped_subplans`) or failed (no entry
+    /// and the worker will fall through to local-prepare). Used by `run_mpp_worker`'s prewarm
+    /// barrier as a single deterministic signal that "shipping for this key is done", so the
+    /// barrier neither races ahead of the shipped path nor wedges forever on a silent codec
+    /// gap.
+    pub(super) fn is_subplan_attempted(&self, stage_id: u32, task_idx: u32) -> bool {
+        self.attempted_subplans
+            .lock()
+            .expect("ProducerTaskRegistry attempted_subplans mutex poisoned")
+            .contains(&(stage_id, task_idx))
+    }
+
     fn prepare_task(&self, stage_id: u32, task_idx: u32) -> Result<PreparedTask, DataFusionError> {
         // Prefer a leader-shipped subplan when one is present in `shipped_subplans` — that's
         // the dispatch-flip's "build once on the leader, ship many" path. Fall back to local
-        // re-plan if nothing has been shipped for this `(stage_id, task_idx)` yet (only
-        // possible during the brief window between worker startup and the first drain pass
-        // that delivers the subplan).
+        // re-plan if nothing has been shipped for this `(stage_id, task_idx)` — either
+        // because the shipping race hasn't settled yet (Phase A's prewarm barrier in
+        // `run_mpp_worker` narrows that window), OR because `on_subplan` failed to decode
+        // the shipped bytes (codec gap, e.g. SegmentedTopK above a NetworkBoundary that
+        // hides the input PgSearchScan from the FFHelper walker). The fallback is the
+        // always-correct path: it builds the plan locally on the worker the same way the
+        // leader did. Closing those codec gaps is tracked separately from the worker-
+        // simplification phases.
         if let Some(shipped) = self
             .shipped_subplans
             .lock()
@@ -371,16 +398,11 @@ impl ProducerTaskRegistry {
                 ctx: task_ctx,
             });
         }
-        // Fallback: build the prepared plan locally from `stage_plans`, same recipe as
-        // pre-dispatch-flip. Two surviving uses after the state-reconstruction PR:
-        //   1. `broadcast_zero` prewarm on non-owner procs — the leader ships `(stage, 0)`
-        //      to the task-0 owner only, so non-owner procs prewarm via local-prepare.
-        //   2. Tests / future paths that drive `prepare_task` without a shipped subplan map.
-        //
-        // No reconstruction context: this path goes through `DistributedExec
-        // ::prepare_in_process_plan` over `stage_plans` directly, never through the physical
-        // codec's `decode_pgsearch_scan`, so the extension would never be read. Pass `None`
-        // so it's clear from the call site that the fallback is by-design extension-free.
+        // Local-prepare fallback. No reconstruction context: this path goes through
+        // `DistributedExec::prepare_in_process_plan` over `stage_plans` directly, never
+        // through the physical codec's `decode_pgsearch_scan`, so the extension would never
+        // be read. Pass `None` so the call site signals the fallback is extension-free
+        // by design.
         let (plan, task_count) = self.stage_plans.lookup(stage_id).ok_or_else(|| {
             DataFusionError::Internal(format!(
                 "mpp producer: no plan registered for stage_id={stage_id}"
@@ -791,20 +813,33 @@ impl SubplanHandler for ProducerTaskRegistry {
             .clone()
             .with_extension(Arc::clone(&self.reconstruction_context));
         let task_ctx = Arc::new(TaskContext::default().with_session_config(decode_cfg));
-        let decoded = match physical_plan_from_bytes_with_extension_codec(
-            payload.as_slice(),
-            &task_ctx,
-            &codec,
-        ) {
+        let decode_result =
+            physical_plan_from_bytes_with_extension_codec(payload.as_slice(), &task_ctx, &codec);
+        // Whether the decode succeeded or not, the leader's Subplan frame for this key has
+        // now been processed. Record that in `attempted_subplans` so the prewarm barrier in
+        // `run_mpp_worker` can stop waiting and either consume the shipped plan (Ok arm) or
+        // fall through to `prepare_task`'s local-prepare path (Err arm). Mutating this
+        // unconditionally before branching keeps the barrier's invariant trivially correct:
+        // `attempted` is set exactly once per key, regardless of which arm runs.
+        {
+            let mut attempted = self
+                .attempted_subplans
+                .lock()
+                .expect("ProducerTaskRegistry attempted_subplans mutex poisoned");
+            attempted.insert(key);
+        }
+        let decoded = match decode_result {
             Ok(decoded) => decoded,
             Err(e) => {
                 // Per-subplan decode gaps (cross-stage FFHelper reconstruction misses, etc.)
-                // are NOT fatal: `prepare_task` will fall back to the worker's local-prepare
+                // are NOT fatal: `prepare_task` falls back to the worker's local-prepare
                 // path (via `stage_plans`) for any `(stage, task)` whose shipped subplan
                 // failed to decode. That fallback is the always-correct path — it builds the
                 // plan locally on the worker the same way the leader did, so execution
                 // produces correct rows, just at the cost of skipping the dispatch-flip's
-                // "build once on the leader, ship many" optimization for this pair.
+                // "build once on the leader, ship many" optimization for this pair. The
+                // worker-simplification phases keep this safety net until the codec
+                // coverage audit closes the remaining decode gaps.
                 //
                 // Returning Ok here keeps the drain pump healthy. Returning Err would abort
                 // the worker via the drain pump's `error!`, taking down query execution for

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -223,16 +223,14 @@ pub(super) struct ProducerTaskRegistry {
     /// closed under the natural shape: `ship_subplans_to_workers` runs to completion before
     /// `physical_plan.execute` issues any Request. This is an unenforced invariant — if a
     /// future shape executes the leader's consumer plan concurrently with shipping (or a
-    /// nested boundary sends Requests upstream during shipping), the cache-invalidate path
-    /// below would have to do more work.
+    /// nested boundary sends Requests upstream during shipping), this docstring's claim
+    /// (and `prepare_task`'s no-shipped-subplan invariant) would have to change.
     ///
-    /// On a late Subplan arrival (one that landed after a Request triggered local-prepare),
-    /// `on_subplan` invalidates the cached `prepared` entry so the next Request re-runs
-    /// `prepare_task` and picks up the shipped version.
-    ///
-    /// The local-prepare fallback in `prepare_task` still fires for `(stage, task)` pairs
-    /// the leader never ships and for decode-failure cases (codec gaps —
-    /// TODO(codec-coverage)).
+    /// Post-Phase-B, `prepare_task` no longer has a local-prepare fallback: a missing entry
+    /// here when `prepare_task` runs is treated as an invariant breach and returns Err to
+    /// the caller (typically `on_request`'s driver dispatch). The previous "stale prepared
+    /// cache invalidation" path in `on_subplan` is correspondingly dead and replaced by a
+    /// `debug_assert!`.
     shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>,
     /// `(stage_id, task_idx)` keys for which `on_subplan` has already run, regardless of decode
     /// outcome. Populated on **both** the Ok and Err arms inside `on_subplan` so the prewarm
@@ -381,11 +379,12 @@ impl ProducerTaskRegistry {
     }
 
     /// True iff `on_subplan` has finished processing the Subplan frame for `(stage_id,
-    /// task_idx)` — whether decode succeeded (entry in `shipped_subplans`) or failed (no entry
-    /// and the worker will fall through to local-prepare). Used by `run_mpp_worker`'s prewarm
-    /// barrier as a single deterministic signal that "shipping for this key is done", so the
-    /// barrier neither races ahead of the shipped path nor wedges forever on a silent codec
-    /// gap.
+    /// task_idx)` — whether decode succeeded (entry now in `shipped_subplans`) or failed
+    /// (no entry; the Err propagated up to `drain_all_inbound` and the worker is on its way
+    /// to `pgrx::error!`). Used by `run_mpp_worker`'s prewarm barrier as a single
+    /// deterministic signal that "shipping for this key is done"; the barrier exits either
+    /// to call `prewarm` (success) or to re-observe the Err via the next drain pass and
+    /// surface it through the `runtime.block_on(...)?` chain.
     pub(super) fn is_subplan_attempted(&self, stage_id: u32, task_idx: u32) -> bool {
         self.attempted_subplans
             .lock()
@@ -396,10 +395,10 @@ impl ProducerTaskRegistry {
     fn prepare_task(&self, stage_id: u32, task_idx: u32) -> Result<PreparedTask, DataFusionError> {
         // Workers only execute leader-shipped subplans. The prewarm barrier in
         // `run_mpp_worker` waits for `on_subplan` to mark each owned `(stage_id, task_idx)`
-        // attempted before any `prepare_task` call runs, and Phase B2's cross-stage
-        // FFHelper + ctid-resolver caches make decode reliable so `on_subplan` either
-        // succeeds (entry present here) or hard-errors the worker. A miss at this point is
-        // an invariant breach — not a recoverable race.
+        // attempted before any `prepare_task` call runs, and the cross-stage FFHelper +
+        // ctid-resolver caches on `MppReconstructionContext` make decode reliable so
+        // `on_subplan` either succeeds (entry present here) or hard-errors the worker. A
+        // miss at this point is an invariant breach — not a recoverable race.
         let shipped = self
             .shipped_subplans
             .lock()
@@ -410,8 +409,8 @@ impl ProducerTaskRegistry {
                 DataFusionError::Internal(format!(
                     "mpp producer prepare_task: no shipped subplan for \
                      stage_id={stage_id} task_idx={task_idx}; the prewarm barrier should \
-                     have blocked the worker until the leader shipped this (stage, task), \
-                     and Phase B2's caches should have made the decode succeed"
+                     have blocked the worker until the leader shipped this (stage, task) \
+                     and the cross-stage codec caches should have made decode succeed"
                 ))
             })?;
         let task_count = self
@@ -843,13 +842,14 @@ impl SubplanHandler for ProducerTaskRegistry {
         let decoded =
             physical_plan_from_bytes_with_extension_codec(payload.as_slice(), &task_ctx, &codec)
                 .map_err(|e| {
-                    // After Phase B2 (cross-stage FFHelper + ctid-resolver caches on
-                    // `MppReconstructionContext`) every codec gap the local-prepare fallback used
-                    // to paper over is now covered by decode itself. Decode failure here therefore
-                    // means a real codec bug (new exec variant, missing UDAF coverage, cross-stage
-                    // cache key not built by `collect_ffhelper_snapshots`, etc.), not a recoverable
-                    // cross-stage walker miss. Surface as Err so the drain pump aborts the worker
-                    // via `pgrx::error!` and the underlying codec error reaches the user instead
+                    // With the cross-stage FFHelper + ctid-resolver caches on
+                    // `MppReconstructionContext` in place, every codec gap the local-prepare
+                    // fallback used to paper over is now covered by decode itself. Decode
+                    // failure here therefore means a real codec bug (new exec variant, missing
+                    // UDAF coverage, cross-stage cache key not built by
+                    // `collect_ffhelper_snapshots`, etc.), not a recoverable cross-stage walker
+                    // miss. Surface as Err so the drain pump aborts the worker via
+                    // `pgrx::error!` and the underlying codec error reaches the user instead
                     // of getting masked by a silent fallback.
                     DataFusionError::Internal(format!(
                         "mpp producer on_subplan: decode failed stage_id={stage_id} \
@@ -864,26 +864,23 @@ impl SubplanHandler for ProducerTaskRegistry {
             map.insert(key, decoded);
             map.len()
         };
-        // Invalidate any cached `prepared` entry for the same `(stage, task)` so the next
-        // `on_request` re-runs `prepare_task` and picks up the freshly-shipped subplan
-        // instead of a stale locally-prepared one. This closes the leader-vs-worker process
-        // race: workers can enter `run_mpp_worker` before the leader's `ship_subplans_to_workers`
-        // call completes, so prewarm may cache a locally-prepared plan that `on_request`
-        // would otherwise keep returning even after the shipped subplan arrives.
-        let prev_prepared = self
-            .prepared
-            .lock()
-            .expect("ProducerTaskRegistry prepared mutex poisoned")
-            .remove(&key);
-        if prev_prepared.is_some() {
-            crate::mpp_log!(
-                "mpp producer on_subplan: invalidated stale locally-prepared cache for \
-                 stage_id={stage_id} task_idx={task_idx}; subsequent Requests will re-prepare \
-                 from the shipped subplan"
-            );
-        }
-        // Lock dropped above before the log call. `mpp_log!` expands to `pgrx::warning!` under
-        // the debug GUC and ereport's; cheap to keep off the hot path.
+        // Post-Phase-B invariant: `prepared` cannot contain `key` at this point. The
+        // prewarm barrier in `run_mpp_worker` only calls `prewarm` AFTER `on_subplan` has
+        // marked the key attempted (here, just above), and there is no longer a local-
+        // prepare path that could have populated `prepared` before shipping settled. A
+        // `Some` here would mean a future refactor reintroduced a pre-ship prepare path
+        // and didn't update the barrier — surface it loudly in debug builds.
+        debug_assert!(
+            self.prepared
+                .lock()
+                .expect("ProducerTaskRegistry prepared mutex poisoned")
+                .get(&key)
+                .is_none(),
+            "mpp producer on_subplan: prepared cache for ({stage_id}, {task_idx}) was \
+             populated before on_subplan ran — the prewarm barrier in run_mpp_worker is \
+             supposed to gate prewarm on `is_subplan_attempted`. Likely cause: a new \
+             prewarm path was added that doesn't wait on the barrier."
+        );
         crate::mpp_log!(
             "mpp producer on_subplan: received stage_id={stage_id} task_idx={task_idx} \
              (total shipped: {total})"
@@ -1004,9 +1001,10 @@ mod tests {
     fn on_subplan_decode_failure_is_fatal() {
         let registry = test_registry();
         // Garbage bytes — `physical_plan_from_bytes_with_extension_codec` fails on prost
-        // decode. Phase B2 removed `prepare_task`'s local-prepare fallback, so a decode
-        // failure here must surface as Err. The drain pump turns this Err into
-        // `pgrx::error!` and aborts the worker rather than silently masking a codec gap.
+        // decode. With the cross-stage codec caches in place `prepare_task` no longer has
+        // a local-prepare fallback, so a decode failure here must surface as Err. The
+        // drain pump turns this Err into `pgrx::error!` and aborts the worker rather than
+        // silently masking a codec gap.
         let result = registry.on_subplan(5, 2, vec![0xFF, 0xFE, 0xFD, 0xFC]);
         assert!(
             result.is_err(),
@@ -1031,9 +1029,10 @@ mod tests {
     fn on_subplan_decode_failure_still_marks_attempted() {
         // The prewarm barrier in `run_mpp_worker` waits per-owned-key on
         // `is_subplan_attempted` and would deadlock if `attempted_subplans` only flipped on
-        // the Ok arm of `on_subplan`. Pin the contract: on decode failure, `attempted` MUST
-        // flip and `shipped_subplans` MUST stay empty so `prepare_task` reaches the local-
-        // prepare fallback.
+        // the Ok arm of `on_subplan`. Pin the contract: on decode failure, `attempted`
+        // MUST flip and `shipped_subplans` MUST stay empty so the prewarm barrier exits
+        // its wait and the propagated decode-Err can take down the worker cleanly via
+        // `drain_all_inbound` → `runtime.block_on(...)?` → `pgrx::error!`.
         let registry = test_registry();
         assert!(!registry.is_subplan_attempted(5, 2));
 
@@ -1069,5 +1068,25 @@ mod tests {
             "on_subplan must mark (stage, task) attempted on the Ok arm too"
         );
         assert_eq!(registry.shipped_subplan_count(), 1);
+    }
+
+    #[test]
+    fn prepare_task_errors_when_no_shipped_subplan() {
+        // Pin the post-Phase-B invariant boundary in `prepare_task`: without a shipped
+        // subplan there is no executable plan, period. The prewarm barrier is supposed to
+        // gate this, but if a future refactor accidentally reintroduces a "default empty
+        // plan" or any other recovery here, this test catches it.
+        let registry = test_registry();
+        // No `on_subplan` call, so `shipped_subplans` is empty.
+        let err = match registry.prepare_task(99, 99) {
+            Ok(_) => panic!("prepare_task must return Err when there's no shipped subplan"),
+            Err(e) => format!("{e}"),
+        };
+        assert!(
+            err.contains("no shipped subplan")
+                && err.contains("stage_id=99")
+                && err.contains("task_idx=99"),
+            "prepare_task Err must spell out stage/task and the missing-shipped reason; got {err}"
+        );
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -72,8 +72,11 @@ use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
-use datafusion_distributed::{DistributedExec, DistributedTaskContext, NetworkBoundaryExt};
+use datafusion_distributed::{
+    DistributedCodec, DistributedExec, DistributedTaskContext, NetworkBoundaryExt,
+};
 use datafusion_proto::bytes::physical_plan_from_bytes_with_extension_codec;
+use datafusion_proto::physical_plan::{ComposedPhysicalExtensionCodec, PhysicalExtensionCodec};
 use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
@@ -84,7 +87,38 @@ use crate::postgres::customscan::mpp::transport::{
 };
 use crate::postgres::customscan::mpp::worker::run_partition_driver;
 use crate::postgres::ParallelScanState;
-use crate::scan::physical_codec::MppReconstructionContext;
+use crate::scan::physical_codec::{MppReconstructionContext, PgSearchPhysicalCodec};
+
+/// Compose `[PgSearchPhysicalCodec, DistributedCodec]` for the shipped-subplan wire.
+///
+/// **User codec first, deliberately.** DataFusion's
+/// `ComposedPhysicalExtensionCodec::encode_protobuf` probes inner codecs in registration
+/// order and stops at the first `Ok`. The `try_encode_udaf` / `try_encode_udf` defaults on
+/// `PhysicalExtensionCodec` return `Ok(())` (no-op), so DF-D's `DistributedCodec` at
+/// position 0 would silently claim every UDAF — encoder_position gets recorded as 0, then
+/// on decode `DistributedCodec::try_decode_udaf` (the default, NotImplemented) errors with
+/// "PhysicalExtensionCodec is not provided for aggregate function {name}".
+///
+/// Putting `PgSearchPhysicalCodec` first means UDAFs we handle (`count` / `sum` / `min` /
+/// `max` / `avg`) successfully encode at position 0 and decode at position 0. DF-D wrapper
+/// nodes (`NetworkShuffleExec`, `NetworkBroadcastExec`, etc.) fall through to
+/// `DistributedCodec` at position 1 because `PgSearchPhysicalCodec::try_encode` returns
+/// `Err` for nodes it doesn't recognise — so encoder_position correctly lands at 1 for
+/// those.
+///
+/// `session` is accepted for signature parity with the upstream
+/// `DistributedCodec::new_combined_with_user(cfg)` and to keep the door open for a future
+/// switch that consults session config; the implementation doesn't read from it.
+///
+/// Long term this belongs in the DF-D fork — have `DistributedCodec::try_encode_udaf`
+/// return `Err` so the probe correctly falls through under either ordering. Working around
+/// it locally for now.
+fn build_mpp_subplan_codec(session: &SessionContext) -> ComposedPhysicalExtensionCodec {
+    let _ = session;
+    let codecs: Vec<Arc<dyn PhysicalExtensionCodec>> =
+        vec![Arc::new(PgSearchPhysicalCodec), Arc::new(DistributedCodec)];
+    ComposedPhysicalExtensionCodec::new(codecs)
+}
 
 /// Per-`stage_id` snapshot of `(local_plan, task_count)` walked out of the worker's distributed
 /// physical plan at startup. The producer service loop consults this on every Request to find
@@ -500,7 +534,6 @@ pub(crate) fn ship_subplans_to_workers(
 ) -> Result<(), DataFusionError> {
     use crate::postgres::customscan::mpp::runtime::proc_for_task;
     use crate::postgres::customscan::mpp::transport::{MppFrameHeader, SendBatchStats};
-    use datafusion_distributed::DistributedCodec;
     use datafusion_proto::bytes::physical_plan_to_bytes_with_extension_codec;
 
     let stage_plans = StagePlans::build(physical_plan);
@@ -510,13 +543,9 @@ pub(crate) fn ship_subplans_to_workers(
     }
     let n_workers = leader_mesh.n_procs.saturating_sub(1).max(1);
 
-    // Use DF-D's `DistributedCodec::new_combined_with_user` so DF-D's wrapper nodes
-    // (`NetworkShuffleExec`, `NetworkBroadcastExec`, `BroadcastExec`, etc.) serialize through
-    // DF-D's own codec, and our `PgSearchPhysicalCodec` only handles the leaves it knows about
-    // (`VisibilityFilterExec`, `TantivyLookupExec`, `SegmentedTopKExec`, `PgSearchScan`). The
-    // user codec is picked up from the session's distributed config; we registered it earlier
-    // via `with_distributed_user_codec`.
-    let codec = DistributedCodec::new_combined_with_user(session.state().config());
+    // See `build_mpp_subplan_codec` for the user-first ordering rationale (works around the
+    // PhysicalExtensionCodec default `try_encode_udaf` Ok shadowing).
+    let codec = build_mpp_subplan_codec(session);
     let mut tasks: Vec<(u32, u32, usize, Arc<dyn ExecutionPlan>)> = Vec::new();
     for (stage_id, task_count) in stage_plans.iter_task_counts() {
         let (local_plan, _) = stage_plans.lookup(stage_id).expect("stage just walked");
@@ -746,12 +775,9 @@ impl SubplanHandler for ProducerTaskRegistry {
         // wins; same `(stage_id, task_idx)` from the same leader session always carries the
         // same bytes today.
         //
-        // Decode through `DistributedCodec::new_combined_with_user` so DF-D wrapper nodes
-        // round-trip via DF-D's codec. The leader encodes through the same combined codec, so
-        // sender and receiver must match.
-        let codec = datafusion_distributed::DistributedCodec::new_combined_with_user(
-            self.session.state().config(),
-        );
+        // Decode through `build_mpp_subplan_codec` — same codec composition (user-first) the
+        // leader's `ship_subplans_to_workers` uses; sender and receiver must match.
+        let codec = build_mpp_subplan_codec(&self.session);
         // The codec's `decode_pgsearch_scan` reaches into the task ctx's session config to
         // pick up an `MppReconstructionContext` extension. Without it, shipped subplans land
         // with an empty `Vec<ScanState>` placeholder and the scan emits zero rows. Layer the
@@ -860,7 +886,6 @@ mod tests {
     /// codec is fully runnable in `cargo test` (the `VisibilityFilterExec` codec is gated out
     /// of test builds, see the corresponding comment in `physical_codec.rs`).
     fn encode_test_subplan(session: &SessionContext) -> Vec<u8> {
-        use datafusion_distributed::DistributedCodec;
         let input_schema = Arc::new(Schema::new(vec![Field::new(
             "ctid",
             DataType::UInt64,
@@ -875,7 +900,9 @@ mod tests {
                 .expect("TantivyLookupExec::new"),
         ) as Arc<dyn ExecutionPlan>;
         let _ = FFHelper::empty(); // keep FFHelper import live until the codec consumes it.
-        let codec = DistributedCodec::new_combined_with_user(session.state().config());
+                                   // Match production's user-first codec composition — otherwise the encode here uses
+                                   // a different position layout than `on_subplan`'s decode and round-trip breaks.
+        let codec = build_mpp_subplan_codec(session);
         physical_plan_to_bytes_with_extension_codec(plan, &codec)
             .expect("encode test subplan")
             .to_vec()

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -791,16 +791,32 @@ impl SubplanHandler for ProducerTaskRegistry {
             .clone()
             .with_extension(Arc::clone(&self.reconstruction_context));
         let task_ctx = Arc::new(TaskContext::default().with_session_config(decode_cfg));
-        let decoded = physical_plan_from_bytes_with_extension_codec(
+        let decoded = match physical_plan_from_bytes_with_extension_codec(
             payload.as_slice(),
             &task_ctx,
             &codec,
-        )
-        .map_err(|e| {
-            DataFusionError::Internal(format!(
-                "mpp producer on_subplan: decode failed stage_id={stage_id} task_idx={task_idx}: {e}"
-            ))
-        })?;
+        ) {
+            Ok(decoded) => decoded,
+            Err(e) => {
+                // Per-subplan decode gaps (cross-stage FFHelper reconstruction misses, etc.)
+                // are NOT fatal: `prepare_task` will fall back to the worker's local-prepare
+                // path (via `stage_plans`) for any `(stage, task)` whose shipped subplan
+                // failed to decode. That fallback is the always-correct path — it builds the
+                // plan locally on the worker the same way the leader did, so execution
+                // produces correct rows, just at the cost of skipping the dispatch-flip's
+                // "build once on the leader, ship many" optimization for this pair.
+                //
+                // Returning Ok here keeps the drain pump healthy. Returning Err would abort
+                // the worker via the drain pump's `error!`, taking down query execution for
+                // a fixable codec gap.
+                crate::mpp_log!(
+                    "mpp producer on_subplan: decode failed stage_id={stage_id} \
+                     task_idx={task_idx}: {e}; this (stage, task) will use the local-prepare \
+                     fallback in prepare_task"
+                );
+                return Ok(());
+            }
+        };
         let total = {
             let mut map = self
                 .shipped_subplans
@@ -943,21 +959,22 @@ mod tests {
     }
 
     #[test]
-    fn on_subplan_surfaces_decode_error() {
+    fn on_subplan_decode_failure_is_logged_but_not_fatal() {
         let registry = test_registry();
-        // Garbage bytes — prost decode should fail loudly with an Internal error pointing
-        // at the failed (stage_id, task_idx) so an integration test can pinpoint the breakage.
-        let err = registry
-            .on_subplan(5, 2, vec![0xFF, 0xFE, 0xFD, 0xFC])
-            .expect_err("garbage payload must surface an error");
-        let msg = err.to_string();
+        // Garbage bytes — `physical_plan_from_bytes_with_extension_codec` fails on prost
+        // decode. `on_subplan` swallows the error, logs a `warning!`, and returns Ok so the
+        // drain pump stays healthy. The affected `(stage, task)` is NOT added to
+        // `shipped_subplans`; `prepare_task` will fall back to the local-prepare path.
+        let result = registry.on_subplan(5, 2, vec![0xFF, 0xFE, 0xFD, 0xFC]);
         assert!(
-            msg.contains("decode failed")
-                && msg.contains("stage_id=5")
-                && msg.contains("task_idx=2"),
-            "unexpected error: {msg}"
+            result.is_ok(),
+            "on_subplan must return Ok on decode failure to keep the drain pump alive; got {result:?}"
         );
-        // Failed decode does NOT populate the map.
-        assert_eq!(registry.shipped_subplan_count(), 0);
+        assert_eq!(
+            registry.shipped_subplan_count(),
+            0,
+            "failed decode must NOT populate shipped_subplans (prepare_task should miss \
+             and fall back to local-prepare)"
+        );
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -213,18 +213,26 @@ pub(super) struct ProducerTaskRegistry {
     /// frame. `prepare_task` consults this first; on a hit the worker uses the leader-prepared
     /// plan directly instead of re-running `prepare_in_process_plan` locally.
     ///
-    /// `run_mpp_worker` installs the SubplanHandler and runs one drain pump BEFORE prewarming,
-    /// so the bulk of leader-shipped subplans land in this map before `prepare_task` is ever
-    /// called. A subset can still arrive after prewarm — workers can enter `run_mpp_worker`
-    /// before the leader's `ship_subplans_to_workers` completes (there's no PG-level barrier
-    /// between leader's `ExecutorRun` and worker's `end_custom_scan`), in which case prewarm
-    /// caches a locally-prepared entry in `prepared`. `on_subplan` invalidates that cache on
-    /// late-arriving subplans so the next `on_request` re-runs `prepare_task` and picks up the
-    /// shipped version.
+    /// `run_mpp_worker`'s prewarm barrier waits per-owned-key until `is_subplan_attempted`
+    /// flips before calling `prepare_task`, so every shipped subplan that successfully
+    /// decoded is in this map by the time `prepare_task` runs for that key. That closes the
+    /// startup-time race between worker entry and leader's `ship_subplans_to_workers`.
     ///
-    /// The fallback path (`stage_plans` → local `prepare_in_process_plan`) still fires for
-    /// `(stage, task)` pairs the leader never ships — broadcast tasks under the current
-    /// estimator (`proc_for_task(_, 0) == 1`) on non-owner procs, plus test paths.
+    /// A separate, smaller race remains during prewarm itself if a Request arrives before
+    /// its corresponding Subplan. The leader's ship-before-execute ordering keeps that race
+    /// closed under the natural shape: `ship_subplans_to_workers` runs to completion before
+    /// `physical_plan.execute` issues any Request. This is an unenforced invariant — if a
+    /// future shape executes the leader's consumer plan concurrently with shipping (or a
+    /// nested boundary sends Requests upstream during shipping), the cache-invalidate path
+    /// below would have to do more work.
+    ///
+    /// On a late Subplan arrival (one that landed after a Request triggered local-prepare),
+    /// `on_subplan` invalidates the cached `prepared` entry so the next Request re-runs
+    /// `prepare_task` and picks up the shipped version.
+    ///
+    /// The local-prepare fallback in `prepare_task` still fires for `(stage, task)` pairs
+    /// the leader never ships and for decode-failure cases (codec gaps —
+    /// TODO(codec-coverage)).
     shipped_subplans: Mutex<HashMap<(u32, u32), Arc<dyn ExecutionPlan>>>,
     /// `(stage_id, task_idx)` keys for which `on_subplan` has already run, regardless of decode
     /// outcome. Populated on **both** the Ok and Err arms inside `on_subplan` so the prewarm
@@ -330,15 +338,28 @@ impl ProducerTaskRegistry {
     /// The caller decides whether to fail worker startup or let the failure resurface lazily on
     /// the first Request.
     pub(super) fn prewarm(&self, stage_id: u32, task_idx: u32) -> Result<(), DataFusionError> {
-        let mut map = self
+        // Lock ordering matters: `prepare_task` acquires `shipped_subplans` (and indirectly
+        // `prepared` via on_subplan's invalidation), while `on_subplan` acquires
+        // `attempted_subplans` → `shipped_subplans` → `prepared`. Holding the `prepared`
+        // lock across `prepare_task` would form a `prepared → shipped_subplans` edge that
+        // inverts `on_subplan`'s order, so drop the dedupe-check lock before the prepare
+        // call. The dedupe is best-effort — under the single-thread runtime invariant the
+        // race between dedupe-check and insert is impossible; if a future runtime change
+        // breaks that invariant the worst-case outcome is one redundant `prepare_task` call
+        // for the same key (correct result, wasted work), not a deadlock or a stale entry.
+        if self
             .prepared
             .lock()
-            .expect("ProducerTaskRegistry prepared mutex poisoned");
-        if map.contains_key(&(stage_id, task_idx)) {
+            .expect("ProducerTaskRegistry prepared mutex poisoned")
+            .contains_key(&(stage_id, task_idx))
+        {
             return Ok(());
         }
         let prepared = self.prepare_task(stage_id, task_idx)?;
-        map.insert((stage_id, task_idx), prepared);
+        self.prepared
+            .lock()
+            .expect("ProducerTaskRegistry prepared mutex poisoned")
+            .insert((stage_id, task_idx), prepared);
         Ok(())
     }
 
@@ -1011,5 +1032,49 @@ mod tests {
             "failed decode must NOT populate shipped_subplans (prepare_task should miss \
              and fall back to local-prepare)"
         );
+    }
+
+    #[test]
+    fn on_subplan_decode_failure_still_marks_attempted() {
+        // The prewarm barrier in `run_mpp_worker` waits per-owned-key on
+        // `is_subplan_attempted` and would deadlock if `attempted_subplans` only flipped on
+        // the Ok arm of `on_subplan`. Pin the contract: on decode failure, `attempted` MUST
+        // flip and `shipped_subplans` MUST stay empty so `prepare_task` reaches the local-
+        // prepare fallback.
+        let registry = test_registry();
+        assert!(!registry.is_subplan_attempted(5, 2));
+
+        let _ = registry.on_subplan(5, 2, vec![0xFF, 0xFE, 0xFD, 0xFC]);
+
+        assert!(
+            registry.is_subplan_attempted(5, 2),
+            "on_subplan must mark (stage, task) attempted even when decode fails, or the \
+             prewarm barrier hangs forever waiting on a key that will never ship"
+        );
+        assert_eq!(
+            registry.shipped_subplan_count(),
+            0,
+            "failed decode must not populate shipped_subplans"
+        );
+    }
+
+    #[test]
+    fn on_subplan_success_marks_attempted_and_ships() {
+        // Companion to `on_subplan_decode_failure_still_marks_attempted`: on the Ok arm,
+        // `attempted` flips AND `shipped_subplans` gets the entry. Both invariants together
+        // are what the prewarm barrier relies on.
+        let registry = test_registry();
+        assert!(!registry.is_subplan_attempted(7, 3));
+
+        let payload = encode_test_subplan(&registry.session);
+        registry
+            .on_subplan(7, 3, payload)
+            .expect("on_subplan must accept a well-formed payload");
+
+        assert!(
+            registry.is_subplan_attempted(7, 3),
+            "on_subplan must mark (stage, task) attempted on the Ok arm too"
+        );
+        assert_eq!(registry.shipped_subplan_count(), 1);
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/producer_service.rs
+++ b/pg_search/src/postgres/customscan/mpp/producer_service.rs
@@ -267,6 +267,7 @@ unsafe impl Send for ProducerTaskRegistry {}
 unsafe impl Sync for ProducerTaskRegistry {}
 
 impl ProducerTaskRegistry {
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new(
         stage_plans: StagePlans,
         session: Arc<SessionContext>,
@@ -275,10 +276,20 @@ impl ProducerTaskRegistry {
         hash_mem_multiplier: f64,
         index_segment_ids: Vec<HashSet<SegmentId>>,
         parallel_state: Option<*mut ParallelScanState>,
+        ffhelpers_by_relid: crate::api::HashMap<
+            u32,
+            Arc<crate::index::fast_fields_helper::FFHelper>,
+        >,
+        ctid_resolvers_by_plan_position: crate::api::HashMap<
+            usize,
+            Arc<crate::index::fast_fields_helper::FFHelper>,
+        >,
     ) -> Self {
         let reconstruction_context = Arc::new(MppReconstructionContext {
             index_segment_ids,
             parallel_state,
+            ffhelpers_by_relid,
+            ctid_resolvers_by_plan_position,
         });
         Self {
             stage_plans,
@@ -383,62 +394,44 @@ impl ProducerTaskRegistry {
     }
 
     fn prepare_task(&self, stage_id: u32, task_idx: u32) -> Result<PreparedTask, DataFusionError> {
-        // Prefer a leader-shipped subplan when one is present in `shipped_subplans` — that's
-        // the dispatch-flip's "build once on the leader, ship many" path. Fall back to local
-        // re-plan if nothing has been shipped for this `(stage_id, task_idx)` — either
-        // because the shipping race hasn't settled yet (Phase A's prewarm barrier in
-        // `run_mpp_worker` narrows that window), OR because `on_subplan` failed to decode
-        // the shipped bytes (codec gap, e.g. SegmentedTopK above a NetworkBoundary that
-        // hides the input PgSearchScan from the FFHelper walker). The fallback is the
-        // always-correct path: it builds the plan locally on the worker the same way the
-        // leader did. Closing those codec gaps is tracked separately from the worker-
-        // simplification phases.
-        if let Some(shipped) = self
+        // Workers only execute leader-shipped subplans. The prewarm barrier in
+        // `run_mpp_worker` waits for `on_subplan` to mark each owned `(stage_id, task_idx)`
+        // attempted before any `prepare_task` call runs, and Phase B2's cross-stage
+        // FFHelper + ctid-resolver caches make decode reliable so `on_subplan` either
+        // succeeds (entry present here) or hard-errors the worker. A miss at this point is
+        // an invariant breach — not a recoverable race.
+        let shipped = self
             .shipped_subplans
             .lock()
             .expect("ProducerTaskRegistry shipped_subplans mutex poisoned")
             .get(&(stage_id, task_idx))
             .cloned()
-        {
-            let task_count = self
-                .stage_plans
-                .lookup(stage_id)
-                .map(|(_, tc)| tc)
-                .unwrap_or(1);
-            let task_ctx = build_task_ctx(
-                &self.session,
-                task_idx,
-                task_count,
-                self.work_mem_bytes,
-                self.hash_mem_multiplier,
-                &shipped,
-                Some(Arc::clone(&self.reconstruction_context)),
-            )?;
-            return Ok(PreparedTask {
-                plan: shipped,
-                ctx: task_ctx,
-            });
-        }
-        // Local-prepare fallback. No reconstruction context: this path goes through
-        // `DistributedExec::prepare_in_process_plan` over `stage_plans` directly, never
-        // through the physical codec's `decode_pgsearch_scan`, so the extension would never
-        // be read. Pass `None` so the call site signals the fallback is extension-free
-        // by design.
-        let (plan, task_count) = self.stage_plans.lookup(stage_id).ok_or_else(|| {
-            DataFusionError::Internal(format!(
-                "mpp producer: no plan registered for stage_id={stage_id}"
-            ))
-        })?;
-        prepare_stage_task(
-            &plan,
-            stage_id,
+            .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "mpp producer prepare_task: no shipped subplan for \
+                     stage_id={stage_id} task_idx={task_idx}; the prewarm barrier should \
+                     have blocked the worker until the leader shipped this (stage, task), \
+                     and Phase B2's caches should have made the decode succeed"
+                ))
+            })?;
+        let task_count = self
+            .stage_plans
+            .lookup(stage_id)
+            .map(|(_, tc)| tc)
+            .unwrap_or(1);
+        let task_ctx = build_task_ctx(
+            &self.session,
             task_idx,
             task_count,
-            &self.session,
             self.work_mem_bytes,
             self.hash_mem_multiplier,
-            None,
-        )
+            &shipped,
+            Some(Arc::clone(&self.reconstruction_context)),
+        )?;
+        Ok(PreparedTask {
+            plan: shipped,
+            ctx: task_ctx,
+        })
     }
 }
 
@@ -834,14 +827,12 @@ impl SubplanHandler for ProducerTaskRegistry {
             .clone()
             .with_extension(Arc::clone(&self.reconstruction_context));
         let task_ctx = Arc::new(TaskContext::default().with_session_config(decode_cfg));
-        let decode_result =
-            physical_plan_from_bytes_with_extension_codec(payload.as_slice(), &task_ctx, &codec);
-        // Whether the decode succeeded or not, the leader's Subplan frame for this key has
-        // now been processed. Record that in `attempted_subplans` so the prewarm barrier in
-        // `run_mpp_worker` can stop waiting and either consume the shipped plan (Ok arm) or
-        // fall through to `prepare_task`'s local-prepare path (Err arm). Mutating this
-        // unconditionally before branching keeps the barrier's invariant trivially correct:
-        // `attempted` is set exactly once per key, regardless of which arm runs.
+        // Mark `(stage, task)` attempted before the decode call so that even a hard-error
+        // decode path leaves the bit flipped — the prewarm barrier in `run_mpp_worker`
+        // observes the bit and exits its wait loop, instead of needing a separate Err-side
+        // signal. If decode then fails, the Err propagates up to `drain_all_inbound` and
+        // the barrier also surfaces it via `worker_mesh.drain_all_inbound()?`. Both
+        // termination paths end with the worker exiting cleanly.
         {
             let mut attempted = self
                 .attempted_subplans
@@ -849,30 +840,22 @@ impl SubplanHandler for ProducerTaskRegistry {
                 .expect("ProducerTaskRegistry attempted_subplans mutex poisoned");
             attempted.insert(key);
         }
-        let decoded = match decode_result {
-            Ok(decoded) => decoded,
-            Err(e) => {
-                // Per-subplan decode gaps (cross-stage FFHelper reconstruction misses, etc.)
-                // are NOT fatal: `prepare_task` falls back to the worker's local-prepare
-                // path (via `stage_plans`) for any `(stage, task)` whose shipped subplan
-                // failed to decode. That fallback is the always-correct path — it builds the
-                // plan locally on the worker the same way the leader did, so execution
-                // produces correct rows, just at the cost of skipping the dispatch-flip's
-                // "build once on the leader, ship many" optimization for this pair. The
-                // worker-simplification phases keep this safety net until the codec
-                // coverage audit closes the remaining decode gaps.
-                //
-                // Returning Ok here keeps the drain pump healthy. Returning Err would abort
-                // the worker via the drain pump's `error!`, taking down query execution for
-                // a fixable codec gap.
-                crate::mpp_log!(
-                    "mpp producer on_subplan: decode failed stage_id={stage_id} \
-                     task_idx={task_idx}: {e}; this (stage, task) will use the local-prepare \
-                     fallback in prepare_task"
-                );
-                return Ok(());
-            }
-        };
+        let decoded =
+            physical_plan_from_bytes_with_extension_codec(payload.as_slice(), &task_ctx, &codec)
+                .map_err(|e| {
+                    // After Phase B2 (cross-stage FFHelper + ctid-resolver caches on
+                    // `MppReconstructionContext`) every codec gap the local-prepare fallback used
+                    // to paper over is now covered by decode itself. Decode failure here therefore
+                    // means a real codec bug (new exec variant, missing UDAF coverage, cross-stage
+                    // cache key not built by `collect_ffhelper_snapshots`, etc.), not a recoverable
+                    // cross-stage walker miss. Surface as Err so the drain pump aborts the worker
+                    // via `pgrx::error!` and the underlying codec error reaches the user instead
+                    // of getting masked by a silent fallback.
+                    DataFusionError::Internal(format!(
+                        "mpp producer on_subplan: decode failed stage_id={stage_id} \
+                 task_idx={task_idx}: {e}"
+                    ))
+                })?;
         let total = {
             let mut map = self
                 .shipped_subplans
@@ -939,8 +922,9 @@ mod tests {
             .with_distributed_user_codec(PgSearchPhysicalCodec)
             .build();
         let session = Arc::new(SessionContext::new_with_state(state));
-        // index_segment_ids + parallel_state stay empty/None in lib tests; the reconstruction
-        // walker (Phase 2+) is exercised by integration tests instead.
+        // index_segment_ids, parallel_state, and both FFHelper snapshots stay empty/None in
+        // lib tests; the reconstruction walker and cross-stage caches are exercised by
+        // integration tests instead.
         Arc::new(ProducerTaskRegistry::new(
             stage_plans,
             session,
@@ -949,6 +933,8 @@ mod tests {
             2.0,
             Vec::new(),
             None,
+            crate::api::HashMap::default(),
+            crate::api::HashMap::default(),
         ))
     }
 
@@ -1015,22 +1001,29 @@ mod tests {
     }
 
     #[test]
-    fn on_subplan_decode_failure_is_logged_but_not_fatal() {
+    fn on_subplan_decode_failure_is_fatal() {
         let registry = test_registry();
         // Garbage bytes — `physical_plan_from_bytes_with_extension_codec` fails on prost
-        // decode. `on_subplan` swallows the error, logs a `warning!`, and returns Ok so the
-        // drain pump stays healthy. The affected `(stage, task)` is NOT added to
-        // `shipped_subplans`; `prepare_task` will fall back to the local-prepare path.
+        // decode. Phase B2 removed `prepare_task`'s local-prepare fallback, so a decode
+        // failure here must surface as Err. The drain pump turns this Err into
+        // `pgrx::error!` and aborts the worker rather than silently masking a codec gap.
         let result = registry.on_subplan(5, 2, vec![0xFF, 0xFE, 0xFD, 0xFC]);
         assert!(
-            result.is_ok(),
-            "on_subplan must return Ok on decode failure to keep the drain pump alive; got {result:?}"
+            result.is_err(),
+            "on_subplan must return Err on decode failure now that the local-prepare \
+             fallback is gone; got {result:?}"
         );
         assert_eq!(
             registry.shipped_subplan_count(),
             0,
-            "failed decode must NOT populate shipped_subplans (prepare_task should miss \
-             and fall back to local-prepare)"
+            "failed decode must not populate shipped_subplans"
+        );
+        // The `attempted_subplans` bit still flips on the Err arm so the prewarm barrier
+        // exits cleanly even though decode failed — see
+        // `on_subplan_decode_failure_still_marks_attempted` for the explicit pin.
+        assert!(
+            registry.is_subplan_attempted(5, 2),
+            "decode failure still marks attempted (barrier termination invariant)"
         );
     }
 

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -644,6 +644,14 @@ impl UserDefinedLogicalNodeCore for LateMaterializeNode {
 
 pub struct LateMaterializePlanner;
 
+// The `has_deferred_fields()` gate stays here, in contrast to the worker-side walker in
+// `physical_codec::collect_ffhelpers_from_input` which drops that condition. The asymmetry
+// is intentional and load-bearing: `LateMaterializePlanner` sits *directly above* the
+// scan that owns the deferred fields, so the immediately-below `PgSearchScanPlan` always
+// has deferred fields set when this rule fires — the gate is correct here. The worker-
+// side walker runs over a different shape (the shipped subplan, rooted at a topk/lookup
+// whose immediate child may or may not be the deferred-producing scan), so it must accept
+// any scan that carries an FFHelper regardless of whether *that* scan has deferred fields.
 fn extract_ff_helper(
     plan: &Arc<dyn ExecutionPlan>,
     helpers: &mut crate::api::HashMap<u32, Arc<FFHelper>>,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -281,12 +281,16 @@ impl std::fmt::Debug for MppReconstructionContext {
     // meaningful textual form. Print just the key set instead so the extension can still be
     // dumped via `pgrx::warning!(?recon)` style without unhelpful huge segment dumps.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let ffhelper_relids: Vec<u32> = self.ffhelpers_by_relid.keys().copied().collect();
-        let ctid_resolver_positions: Vec<usize> = self
+        // Sort the key dumps so debug output is stable across runs — HashMap iteration is
+        // randomized per process and would otherwise flap log/test diffs.
+        let mut ffhelper_relids: Vec<u32> = self.ffhelpers_by_relid.keys().copied().collect();
+        ffhelper_relids.sort_unstable();
+        let mut ctid_resolver_positions: Vec<usize> = self
             .ctid_resolvers_by_plan_position
             .keys()
             .copied()
             .collect();
+        ctid_resolver_positions.sort_unstable();
         f.debug_struct("MppReconstructionContext")
             .field("index_segment_ids_count", &self.index_segment_ids.len())
             .field("parallel_state_present", &self.parallel_state.is_some())
@@ -506,39 +510,73 @@ fn decode_visibility_filter(
         .zip(proto.heap_oids.iter())
         .map(|(p, oid)| (*p as usize, pg_sys::Oid::from(*oid)))
         .collect();
-    let exec = VisibilityFilterExec::new(input, plan_pos_oids.clone(), proto.table_names)?;
+    let exec = VisibilityFilterExec::new(input.clone(), plan_pos_oids.clone(), proto.table_names)?;
 
-    // Wire ctid resolvers from the worker's cross-stage cache. The standalone
-    // `VisibilityCtidResolverRule` doesn't fire on the codec-decoded subplan
-    // (`prepare_in_process_plan` bypasses optimizer rules) and its in-subtree walker has
-    // the same cross-stage blindness as the FFHelper walker — under MPP the source scan
-    // for a deferred ctid column commonly lives in a sibling stage (probe-side scan vs.
-    // outer visibility filter). The cache built at worker startup in
-    // `collect_ffhelper_snapshots` covers every reachable scan; consult it here.
+    // Wire ctid resolvers from two sources, in priority order:
+    //   1. `MppReconstructionContext.ctid_resolvers_by_plan_position` — worker-startup
+    //      cross-stage snapshot, mirrors `ffhelpers_by_relid`. Covers the common MPP shape
+    //      where the source scan for a deferred ctid column lives across a
+    //      `NetworkBoundaryExec` from the `VisibilityFilterExec` consuming it.
+    //   2. In-subtree walk over the just-decoded input plan — same recipe as the
+    //      standalone `VisibilityCtidResolverRule` for shapes where the source scan does
+    //      sit in this stage's subtree (and as a defensive secondary source in case the
+    //      leader's and worker's `create_physical_plan` diverge on which scans survive
+    //      EnforceDistribution / optimizer rewrites).
     //
-    // Production gates on the recon-context extension being present. Round-trip tests
-    // without it produce a `VisibilityFilterExec` with empty resolvers; that's fine for
-    // wire-shape tests since they don't execute.
+    // The standalone `VisibilityCtidResolverRule` doesn't fire on the codec-decoded
+    // subplan because `DistributedExec::prepare_in_process_plan` bypasses optimizer rules
+    // — so this wiring has to happen at decode time. Production gates on the recon
+    // extension being present; round-trip tests without it produce an exec with empty
+    // resolvers, fine for wire-shape tests since they don't execute.
     if let Some(recon) = ctx
         .session_config()
         .get_extension::<MppReconstructionContext>()
     {
         for (plan_pos, _heap_oid) in &plan_pos_oids {
-            if let Some(ffhelper) = recon.ctid_resolvers_by_plan_position.get(plan_pos) {
-                exec.set_ctid_resolver(*plan_pos, std::sync::Arc::clone(ffhelper));
-            } else {
-                return Err(DataFusionError::Internal(format!(
-                    "decode_visibility_filter: no ctid resolver in MppReconstructionContext \
-                     for plan_position {plan_pos}; the worker's local physical-plan walk in \
-                     `collect_ffhelper_snapshots` should populate every deferred ctid plan \
-                     position the leader's plan references. Check that the worker's local \
-                     rebuild succeeded and that the leader's and worker's plans agree."
-                )));
-            }
+            let ff = recon
+                .ctid_resolvers_by_plan_position
+                .get(plan_pos)
+                .cloned()
+                .or_else(|| find_ctid_ffhelper_in_input(&input, *plan_pos))
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "decode_visibility_filter: no ctid resolver for plan_position \
+                         {plan_pos}; not found in MppReconstructionContext's cross-stage \
+                         cache (built by `collect_ffhelper_snapshots` in exec_worker.rs) \
+                         and not present in the shipped subplan's input subtree. The \
+                         leader's and worker's `create_physical_plan` must yield the same \
+                         set of `PgSearchScanPlan::deferred_ctid_plan_position` values; \
+                         a mismatch here means one side stripped a scan the other expected."
+                    ))
+                })?;
+            exec.set_ctid_resolver(*plan_pos, ff);
         }
     }
 
     Ok(Arc::new(exec))
+}
+
+/// In-subtree walker for `PgSearchScanPlan::deferred_ctid_plan_position` → `FFHelper`,
+/// used by `decode_visibility_filter` as a fallback when the cross-stage cache misses.
+/// Mirrors `find_ffhelper_for_plan_position` in the standalone
+/// `VisibilityCtidResolverRule` so the two paths agree on what counts as a match.
+#[cfg(not(test))]
+fn find_ctid_ffhelper_in_input(
+    plan: &Arc<dyn ExecutionPlan>,
+    plan_position: usize,
+) -> Option<std::sync::Arc<crate::index::fast_fields_helper::FFHelper>> {
+    use crate::scan::execution_plan::PgSearchScanPlan;
+    if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
+        if scan.deferred_ctid_plan_position() == Some(plan_position) {
+            return scan.ffhelper();
+        }
+    }
+    for child in plan.children() {
+        if let Some(ff) = find_ctid_ffhelper_in_input(child, plan_position) {
+            return Some(ff);
+        }
+    }
+    None
 }
 
 // ---------- TantivyLookupExec ----------
@@ -597,20 +635,35 @@ fn collect_ffhelpers_from_input(
     use crate::scan::execution_plan::PgSearchScanPlan;
     // Pull the FFHelper off any `PgSearchScanPlan` in the subtree, indexed by its
     // `indexrelid`. The previous version gated this on `scan.has_deferred_fields()` — that
-    // was symmetric with the leader-side `LateMaterializePlanner::extract_ff_helper` test,
-    // but it discarded scans that have a perfectly usable FFHelper just because *they*
-    // aren't the late-materialization consumer. A scan above the join (the one
-    // `SegmentedTopKExec` / `TantivyLookupExec` actually needs the FFHelper of) can be a
-    // probe-side `PgSearchScan` with `query="all"`: its own `deferred_fields` is empty
-    // because no late materialization fired on it, but the FFHelper it carries — built by
-    // `scan_inner` over the projected fields — is what the parent topk/lookup wants.
+    // was symmetric with the leader-side `LateMaterializePlanner::extract_ff_helper` test
+    // (which sits directly above the producing scan and so always sees deferred fields on
+    // the immediate child), but it discarded scans that have a perfectly usable FFHelper
+    // just because *they* aren't the late-materialization consumer. A scan above the join
+    // (the one `SegmentedTopKExec` / `TantivyLookupExec` actually needs the FFHelper of)
+    // can be a probe-side `PgSearchScan` with `query="all"`: its own `deferred_fields` is
+    // empty because no late materialization fired on it, but the FFHelper it carries —
+    // built by `scan_inner` over the projected fields — is what the parent topk/lookup
+    // wants.
     //
-    // The downstream consumer (`decode_segmented_topk`, `decode_tantivy_lookup`) keys by
-    // `proto.indexrelids` so an extra unrelated FFHelper in the map is harmless; the only
-    // requirement is that every relid the parent asks for is present.
+    // **Priority vs `MppReconstructionContext.ffhelpers_by_relid`**: this in-subtree walker
+    // is a *fallback* for the cross-stage cache. Both layers can populate the same `out`
+    // map for the same `indexrelid`; using `entry().or_insert()` here preserves anything
+    // the recon cache (the worker-startup global view) put in first, which is the
+    // documented priority order. Without `or_insert`, the recon entry would be silently
+    // overwritten by the walker, defeating the cross-stage cache for any relid whose scan
+    // also happens to be in the local input tree.
+    //
+    // Known limitation: if the same `indexrelid` appears in multiple `PgSearchScanPlan`
+    // instances within the worker's local plan with *different* projected-field orderings
+    // (a self-join would do this), `entry().or_insert()` arbitrarily picks the first scan
+    // walked. The leader's encoder picks `target_indexrelid = proto.indexrelids.first()`
+    // and uses the leader's ff_index convention for that scan; the worker has no way to
+    // disambiguate without a `(indexrelid, plan_position)` cache key. MPP's current test
+    // matrix does not exercise self-joins so this is latent rather than load-bearing;
+    // re-key both caches if/when MPP starts supporting self-joins.
     if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
         if let Some(ff) = scan.ffhelper() {
-            out.insert(scan.indexrelid, ff);
+            out.entry(scan.indexrelid).or_insert(ff);
         }
     }
     for child in plan.children() {
@@ -685,7 +738,7 @@ fn decode_tantivy_lookup(
                     "decode_tantivy_lookup: missing reconstructed FFHelper for indexrelid={relid}; \
                      not found in MppReconstructionContext's cross-stage cache or in the \
                      shipped subplan's input tree. The worker's local physical-plan walk in \
-                     `collect_ffhelpers_by_relid` should cover every relid the leader's plan \
+                     `collect_ffhelper_snapshots` should cover every relid the leader's plan \
                      references; check that the worker's local rebuild succeeded and that the \
                      leader's and worker's plans agree on which sources exist."
                 )));
@@ -858,7 +911,7 @@ fn decode_segmented_topk(
                     "decode_segmented_topk: missing reconstructed FFHelper for \
                      target_indexrelid={rid}; not found in MppReconstructionContext's \
                      cross-stage cache or in the shipped subplan's input tree. The worker's \
-                     local physical-plan walk in `collect_ffhelpers_by_relid` should cover \
+                     local physical-plan walk in `collect_ffhelper_snapshots` should cover \
                      every relid the leader's plan references."
                 )));
             }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -984,7 +984,49 @@ fn decode_pgsearch_scan(
         // Follow-up; for now `provider.scan_inner` errors visibly with a missing-planstate
         // message if a query hits that path.
 
-        return provider.scan_sync();
+        // Derive the projection the leader's planner used by matching the shipped schema's
+        // field names against the provider's unprojected schema. Without this the worker's
+        // `scan_inner` defaults to the full unprojected schema, which differs from what
+        // downstream operators (HashJoinExec keys, FilterExec, etc.) reference by index.
+        // The mismatch surfaces as "Missing on the right: {Column { ..., index: N }}" at
+        // physical-planning time inside `prepare_in_process_plan`.
+        let proto_schema = proto.schema.as_ref().ok_or_else(|| {
+            DataFusionError::Internal(
+                "decode_pgsearch_scan: shipped TableProvider but proto.schema is missing".into(),
+            )
+        })?;
+        let proto_df_schema: datafusion::common::DFSchema =
+            proto_schema.try_into().map_err(|e| {
+                DataFusionError::Internal(format!(
+                    "decode_pgsearch_scan: DFSchema proto -> DFSchema failed: {e}"
+                ))
+            })?;
+        let proto_arrow_schema = proto_df_schema.as_arrow();
+        let unprojected = provider.unprojected_schema();
+        let projection_indices: Vec<usize> = proto_arrow_schema
+            .fields()
+            .iter()
+            .map(|f| {
+                unprojected.index_of(f.name()).map_err(|_| {
+                    DataFusionError::Internal(format!(
+                        "decode_pgsearch_scan: shipped schema field {:?} not found in \
+                         provider's unprojected schema (provider has {} fields)",
+                        f.name(),
+                        unprojected.fields().len()
+                    ))
+                })
+            })
+            .collect::<Result<_>>()?;
+        // Identity projection (all columns in original order) → pass `None` so
+        // `projected_fields_and_schema` skips the projection step entirely. Common case
+        // for scans that don't have a downstream projection above them.
+        let is_identity = projection_indices.len() == unprojected.fields().len()
+            && projection_indices.iter().enumerate().all(|(i, &p)| i == p);
+        return if is_identity {
+            provider.scan_sync(None)
+        } else {
+            provider.scan_sync(Some(&projection_indices))
+        };
     }
 
     // Fallback: empty-placeholder shape. Used by round-trip tests and by any future caller

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -244,7 +244,6 @@ const DEFERRED_CTID_NONE: u32 = u32::MAX;
 /// The producer-side dispatcher ([`crate::postgres::customscan::mpp::producer_service::ProducerTaskRegistry::prepare_task`])
 /// constructs this from the registry's fields and layers it onto the `TaskContext` that drives
 /// `PhysicalExtensionCodec::try_decode`.
-#[derive(Debug)]
 pub struct MppReconstructionContext {
     /// Canonical segment ID sets indexed by absolute `plan_position` (full join source list
     /// index). For non-MPP / serial paths this stays empty and the codec falls back to leaving
@@ -254,6 +253,47 @@ pub struct MppReconstructionContext {
     /// `PgSearchTableProvider` when `is_parallel()` is true so the partitioning-source scan
     /// claims segments through the same shared state the rest of the worker is using.
     pub parallel_state: Option<*mut crate::postgres::ParallelScanState>,
+    /// `indexrelid → FFHelper` snapshot built once at worker startup by walking the worker's
+    /// full local physical plan. Populated from every `PgSearchScanPlan` the worker can see —
+    /// across all stages, including stages whose scans live behind a `NetworkBoundaryExec`
+    /// from the perspective of a sibling stage's shipped subplan.
+    ///
+    /// `decode_segmented_topk` / `decode_tantivy_lookup` consult this cache before falling
+    /// back to walking the shipped subplan's local input tree, which can't reach across a
+    /// `NetworkBoundary` to find the source `PgSearchScan`. A probe-side scan with
+    /// `query="all"` and a build-side scan reached through `NetworkBroadcastExec` both end
+    /// up in this map keyed by their `indexrelid` regardless of which stage they sit in.
+    pub ffhelpers_by_relid:
+        crate::api::HashMap<u32, std::sync::Arc<crate::index::fast_fields_helper::FFHelper>>,
+    /// `deferred_ctid_plan_position → FFHelper` snapshot, built from the same walk as
+    /// `ffhelpers_by_relid` but keyed by `PgSearchScanPlan::deferred_ctid_plan_position`.
+    /// `decode_visibility_filter` uses this to wire ctid resolvers at decode time, because
+    /// the standalone `VisibilityCtidResolverRule` physical-optimizer rule doesn't fire on
+    /// `DistributedExec::prepare_in_process_plan`-produced subplans, and its in-subtree
+    /// walker has the same cross-stage blindness as the FFHelper walker.
+    pub ctid_resolvers_by_plan_position:
+        crate::api::HashMap<usize, std::sync::Arc<crate::index::fast_fields_helper::FFHelper>>,
+}
+
+impl std::fmt::Debug for MppReconstructionContext {
+    // Custom impl because `FFHelper` doesn't (and shouldn't) implement `Debug` — its inner
+    // tantivy `FastFieldReaders` and column caches are opaque runtime state that has no
+    // meaningful textual form. Print just the key set instead so the extension can still be
+    // dumped via `pgrx::warning!(?recon)` style without unhelpful huge segment dumps.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let ffhelper_relids: Vec<u32> = self.ffhelpers_by_relid.keys().copied().collect();
+        let ctid_resolver_positions: Vec<usize> = self
+            .ctid_resolvers_by_plan_position
+            .keys()
+            .copied()
+            .collect();
+        f.debug_struct("MppReconstructionContext")
+            .field("index_segment_ids_count", &self.index_segment_ids.len())
+            .field("parallel_state_present", &self.parallel_state.is_some())
+            .field("ffhelper_relids", &ffhelper_relids)
+            .field("ctid_resolver_positions", &ctid_resolver_positions)
+            .finish()
+    }
 }
 
 // SAFETY: the raw `*mut ParallelScanState` makes the auto-derived `Send + Sync` go away. Same
@@ -444,7 +484,7 @@ fn encode_visibility_filter(node: &dyn ExecutionPlan) -> Result<VisibilityFilter
 fn decode_visibility_filter(
     proto: VisibilityFilterProto,
     inputs: &[Arc<dyn ExecutionPlan>],
-    _ctx: &TaskContext,
+    ctx: &TaskContext,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
     let input = inputs.first().cloned().ok_or_else(|| {
@@ -466,7 +506,38 @@ fn decode_visibility_filter(
         .zip(proto.heap_oids.iter())
         .map(|(p, oid)| (*p as usize, pg_sys::Oid::from(*oid)))
         .collect();
-    let exec = VisibilityFilterExec::new(input, plan_pos_oids, proto.table_names)?;
+    let exec = VisibilityFilterExec::new(input, plan_pos_oids.clone(), proto.table_names)?;
+
+    // Wire ctid resolvers from the worker's cross-stage cache. The standalone
+    // `VisibilityCtidResolverRule` doesn't fire on the codec-decoded subplan
+    // (`prepare_in_process_plan` bypasses optimizer rules) and its in-subtree walker has
+    // the same cross-stage blindness as the FFHelper walker — under MPP the source scan
+    // for a deferred ctid column commonly lives in a sibling stage (probe-side scan vs.
+    // outer visibility filter). The cache built at worker startup in
+    // `collect_ffhelper_snapshots` covers every reachable scan; consult it here.
+    //
+    // Production gates on the recon-context extension being present. Round-trip tests
+    // without it produce a `VisibilityFilterExec` with empty resolvers; that's fine for
+    // wire-shape tests since they don't execute.
+    if let Some(recon) = ctx
+        .session_config()
+        .get_extension::<MppReconstructionContext>()
+    {
+        for (plan_pos, _heap_oid) in &plan_pos_oids {
+            if let Some(ffhelper) = recon.ctid_resolvers_by_plan_position.get(plan_pos) {
+                exec.set_ctid_resolver(*plan_pos, std::sync::Arc::clone(ffhelper));
+            } else {
+                return Err(DataFusionError::Internal(format!(
+                    "decode_visibility_filter: no ctid resolver in MppReconstructionContext \
+                     for plan_position {plan_pos}; the worker's local physical-plan walk in \
+                     `collect_ffhelper_snapshots` should populate every deferred ctid plan \
+                     position the leader's plan references. Check that the worker's local \
+                     rebuild succeeded and that the leader's and worker's plans agree."
+                )));
+            }
+        }
+    }
+
     Ok(Arc::new(exec))
 }
 
@@ -582,32 +653,41 @@ fn decode_tantivy_lookup(
         })
         .collect::<Result<_>>()?;
 
-    // Reconstruct the FFHelper map from the input plan's PgSearchScanPlan nodes. Phase 2's
-    // reconstruction in `decode_pgsearch_scan` builds real FFHelpers; walking the inputs here
-    // pulls them out keyed by indexrelid, the same recipe the leader uses
-    // (`LateMaterializePlanner` calls `extract_ff_helper`, gated identically by both
-    // `has_deferred_fields()` and `ffhelper().is_some()`).
+    // Reconstruct the FFHelper map. Two sources, consulted in order:
+    //   1. `MppReconstructionContext.ffhelpers_by_relid` — a worker-startup snapshot built by
+    //      walking the FULL local physical plan, so it covers relids whose source scan
+    //      lives in a sibling stage across a `NetworkBoundaryExec`.
+    //   2. `collect_ffhelpers_from_input` — fallback walk over the shipped subplan's local
+    //      input tree, for shapes where the source scan does sit in this stage's subtree
+    //      and the cross-stage cache is empty (e.g. round-trip tests with no extension).
     //
     // In production (`MppReconstructionContext` present on the TaskContext) every relid in
-    // `proto.indexrelids` must be covered by the walk — substituting `FFHelper::empty()`
-    // would panic later (segment_caches OOB at first access). Hard-error at decode time so
-    // the failure points at the right layer. Round-trip tests that use `EmptyExec` inputs
-    // (no PgSearchScanPlan to walk) intentionally fall through to empty FFHelpers — they
-    // exercise wire-shape, not runtime semantics, and the test ctx lacks the extension.
-    let in_production = ctx
+    // `proto.indexrelids` must be covered by one of these two sources — substituting
+    // `FFHelper::empty()` would panic later (segment_caches OOB at first access). Hard-error
+    // at decode time so the failure points at the right layer. Round-trip tests that use
+    // `EmptyExec` inputs (no PgSearchScanPlan to walk, no recon context) intentionally fall
+    // through to empty FFHelpers — they exercise wire-shape, not runtime semantics.
+    let recon = ctx
         .session_config()
-        .get_extension::<MppReconstructionContext>()
-        .is_some();
+        .get_extension::<MppReconstructionContext>();
+    let in_production = recon.is_some();
     let mut ffhelpers: HashMap<u32, std::sync::Arc<FFHelper>> = HashMap::default();
+    if let Some(recon) = &recon {
+        for (relid, ff) in recon.ffhelpers_by_relid.iter() {
+            ffhelpers.insert(*relid, std::sync::Arc::clone(ff));
+        }
+    }
     collect_ffhelpers_from_input(&input, &mut ffhelpers);
     for relid in &proto.indexrelids {
         if !ffhelpers.contains_key(relid) {
             if in_production {
                 return Err(DataFusionError::Internal(format!(
                     "decode_tantivy_lookup: missing reconstructed FFHelper for indexrelid={relid}; \
-                     the input PgSearchScan must have fallen back to the empty-states placeholder. \
-                     Check that `MppReconstructionContext` is attached to the worker's TaskContext \
-                     in `on_subplan` and that `table_provider_json` is non-empty on the wire."
+                     not found in MppReconstructionContext's cross-stage cache or in the \
+                     shipped subplan's input tree. The worker's local physical-plan walk in \
+                     `collect_ffhelpers_by_relid` should cover every relid the leader's plan \
+                     references; check that the worker's local rebuild succeeded and that the \
+                     leader's and worker's plans agree on which sources exist."
                 )));
             }
             ffhelpers.insert(*relid, std::sync::Arc::new(FFHelper::empty()));
@@ -747,21 +827,28 @@ fn decode_segmented_topk(
         .collect::<Result<_>>()?;
 
     // SegmentedTopKExec takes a single FFHelper — the leader picks `target_indexrelid`
-    // (`segmented_topk_rule.rs:271`) and pulls the FFHelper from the parent TantivyLookupExec
-    // by that key. Mirror that here: walk the input plan for FFHelpers and pick the entry
-    // matching the first deferred-column's indexrelid.
+    // (`segmented_topk_rule.rs:271`) and pulls the FFHelper for that relid from the parent
+    // TantivyLookupExec. Mirror that here, with two lookup sources in priority order:
+    //   1. `MppReconstructionContext.ffhelpers_by_relid` — worker-startup cross-stage
+    //      snapshot, covers relids whose source scan lives across a `NetworkBoundaryExec`.
+    //   2. `collect_ffhelpers_from_input` — same-stage fallback walk, kept for round-trip
+    //      tests and for shapes where the source scan does sit in this stage's subtree.
     //
     // `segmented_topk_rule.rs:260-269` enforces a single-relid invariant on the leader
     // (returns `Ok(None)` if the deferred-column set is empty or spans multiple relids), so
-    // in production an empty `proto.indexrelids` or a missing walker entry is a hard failure
-    // — `FFHelper::empty()` would panic later (segment_caches OOB). Round-trip tests with
-    // `EmptyExec` inputs fall through to empty (same rationale as `decode_tantivy_lookup`).
-    let in_production = ctx
+    // in production an empty `proto.indexrelids` or a missing entry in both sources is a
+    // hard failure — `FFHelper::empty()` would panic later (segment_caches OOB).
+    let recon = ctx
         .session_config()
-        .get_extension::<MppReconstructionContext>()
-        .is_some();
+        .get_extension::<MppReconstructionContext>();
+    let in_production = recon.is_some();
     let mut input_ffhelpers: crate::api::HashMap<u32, std::sync::Arc<FFHelper>> =
         crate::api::HashMap::default();
+    if let Some(recon) = &recon {
+        for (relid, ff) in recon.ffhelpers_by_relid.iter() {
+            input_ffhelpers.insert(*relid, std::sync::Arc::clone(ff));
+        }
+    }
     collect_ffhelpers_from_input(&input, &mut input_ffhelpers);
     let ffhelper = match proto.indexrelids.first().copied() {
         Some(rid) => match input_ffhelpers.remove(&rid) {
@@ -769,8 +856,10 @@ fn decode_segmented_topk(
             None if in_production => {
                 return Err(DataFusionError::Internal(format!(
                     "decode_segmented_topk: missing reconstructed FFHelper for \
-                     target_indexrelid={rid}; the input PgSearchScan / TantivyLookup must have \
-                     fallen back to placeholders"
+                     target_indexrelid={rid}; not found in MppReconstructionContext's \
+                     cross-stage cache or in the shipped subplan's input tree. The worker's \
+                     local physical-plan walk in `collect_ffhelpers_by_relid` should cover \
+                     every relid the leader's plan references."
                 )));
             }
             None => std::sync::Arc::new(FFHelper::empty()),

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -524,11 +524,22 @@ fn collect_ffhelpers_from_input(
     out: &mut crate::api::HashMap<u32, std::sync::Arc<crate::index::fast_fields_helper::FFHelper>>,
 ) {
     use crate::scan::execution_plan::PgSearchScanPlan;
+    // Pull the FFHelper off any `PgSearchScanPlan` in the subtree, indexed by its
+    // `indexrelid`. The previous version gated this on `scan.has_deferred_fields()` — that
+    // was symmetric with the leader-side `LateMaterializePlanner::extract_ff_helper` test,
+    // but it discarded scans that have a perfectly usable FFHelper just because *they*
+    // aren't the late-materialization consumer. A scan above the join (the one
+    // `SegmentedTopKExec` / `TantivyLookupExec` actually needs the FFHelper of) can be a
+    // probe-side `PgSearchScan` with `query="all"`: its own `deferred_fields` is empty
+    // because no late materialization fired on it, but the FFHelper it carries — built by
+    // `scan_inner` over the projected fields — is what the parent topk/lookup wants.
+    //
+    // The downstream consumer (`decode_segmented_topk`, `decode_tantivy_lookup`) keys by
+    // `proto.indexrelids` so an extra unrelated FFHelper in the map is harmless; the only
+    // requirement is that every relid the parent asks for is present.
     if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
-        if scan.has_deferred_fields() {
-            if let Some(ff) = scan.ffhelper() {
-                out.insert(scan.indexrelid, ff);
-            }
+        if let Some(ff) = scan.ffhelper() {
+            out.insert(scan.indexrelid, ff);
         }
     }
     for child in plan.children() {

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -774,12 +774,29 @@ impl PgSearchTableProvider {
     /// async `scan()` method runs, but exposed without the `Session`/async ceremony — the
     /// codec doesn't have a `Session` and the body never `.await`s.
     ///
+    /// `projection` is the column-index list the leader's planner used when it built its
+    /// scan (e.g. `Some([0, 2])` projects to columns 0 and 2 of `provider.get_schema()`).
+    /// `None` means the full unprojected schema. Without this the worker reconstructs a
+    /// scan with a wider schema than the leader's plan expects, and downstream operators
+    /// that reference columns by index (`HashJoinExec`'s join keys, etc.) error with
+    /// "Missing on the right: {Column index: N}" at physical-plan prepare time.
+    ///
     /// Only called from `decode_pgsearch_scan`, which is itself `#[cfg(not(test))]`-gated
-    /// (the codec links PG runtime symbols that the cargo-test binary can't resolve), so the
-    /// `dead_code` allow covers the test build.
+    /// (the codec links PG runtime symbols that the cargo-test binary can't resolve), so
+    /// the `dead_code` allow covers the test build.
     #[allow(dead_code)]
-    pub(crate) fn scan_sync(&self) -> Result<Arc<dyn ExecutionPlan>> {
-        self.scan_inner(self.canonical_segment_ids.clone(), None, &[], None)
+    pub(crate) fn scan_sync(
+        &self,
+        projection: Option<&Vec<usize>>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.scan_inner(self.canonical_segment_ids.clone(), projection, &[], None)
+    }
+
+    /// Unprojected output schema. Used by the codec to derive the leader's projection
+    /// indices by matching field names against the proto-shipped schema.
+    #[allow(dead_code)]
+    pub(crate) fn unprojected_schema(&self) -> SchemaRef {
+        self.get_schema()
     }
 }
 

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -889,21 +889,7 @@ impl PgSearchTableProvider {
         )
         .map_err(|e| DataFusionError::Internal(format!("Failed to open reader: {e}")))?;
 
-        // Build the FFHelper from the **unprojected** self.fields list. `CanonicalColumn
-        // ::ff_index` (set by `deferred_fields()` iterating `self.fields`) is a position in
-        // the unprojected list, while `FFHelper::with_fields` indexes the slice it's given.
-        // Building FFHelper from `projected_fields` (potentially narrower) means
-        // `column(seg_ord, ff_index)` indexes out of bounds or looks up the wrong field when
-        // a downstream operator (`TantivyLookupExec::enrich_batch`, `SegmentedTopKExec`)
-        // resolves a deferred field by its canonical ff_index.
-        //
-        // Leader-side this would silently work today because the planner usually hands the
-        // scan `projection=None`, but the worker-side reconstruction path
-        // (`PgSearchPhysicalCodec::decode_pgsearch_scan` → `scan_sync`) can run with a
-        // narrower projection, exposing the off-by-projection bug. The fix is symmetric on
-        // both sides: always use self.fields so canonical ff_indices line up regardless of
-        // projection.
-        let ffhelper = FFHelper::with_fields(&reader, &self.fields);
+        let ffhelper = FFHelper::with_fields(&reader, &projected_fields);
         let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
         let visibility = VisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
         let sort_order = self.scan_info.sort_order.as_ref();

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -872,7 +872,21 @@ impl PgSearchTableProvider {
         )
         .map_err(|e| DataFusionError::Internal(format!("Failed to open reader: {e}")))?;
 
-        let ffhelper = FFHelper::with_fields(&reader, &projected_fields);
+        // Build the FFHelper from the **unprojected** self.fields list. `CanonicalColumn
+        // ::ff_index` (set by `deferred_fields()` iterating `self.fields`) is a position in
+        // the unprojected list, while `FFHelper::with_fields` indexes the slice it's given.
+        // Building FFHelper from `projected_fields` (potentially narrower) means
+        // `column(seg_ord, ff_index)` indexes out of bounds or looks up the wrong field when
+        // a downstream operator (`TantivyLookupExec::enrich_batch`, `SegmentedTopKExec`)
+        // resolves a deferred field by its canonical ff_index.
+        //
+        // Leader-side this would silently work today because the planner usually hands the
+        // scan `projection=None`, but the worker-side reconstruction path
+        // (`PgSearchPhysicalCodec::decode_pgsearch_scan` → `scan_sync`) can run with a
+        // narrower projection, exposing the off-by-projection bug. The fix is symmetric on
+        // both sides: always use self.fields so canonical ff_indices line up regardless of
+        // projection.
+        let ffhelper = FFHelper::with_fields(&reader, &self.fields);
         let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
         let visibility = VisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
         let sort_order = self.scan_info.sort_order.as_ref();


### PR DESCRIPTION
**Scope:** This is option **C** from the design discussion — keep the bug fixes that the worker-simplification draft exposed, drop the structural "remove logical-replan" change. The local-replan path stays as the always-correct fallback while the long-term simplification (worker as autonomous gRPC-handler-style consumer of shipped subplans) is designed.

## Bug fixes (all latent on PR #5123, surfaced by CI's `pgrx - arm64` regression suite)

| # | Fix | Pre-fix symptom on #5123 |
|---|---|---|
| 1 | Compose codecs **user-first** in `build_mpp_subplan_codec` | `PhysicalExtensionCodec is not provided for aggregate function count` — `DistributedCodec`'s default `try_encode_udaf` returns `Ok(())`, claiming every UDAF at position 0, then decode fails because its `try_decode_udaf` default errors. |
| 2 | Build `FFHelper` from **unprojected** `self.fields` | Latent: `CanonicalColumn.ff_index` references positions in `self.fields`, but `FFHelper::with_fields(&reader, &projected_fields)` indexes a narrower slice — `column(seg_ord, ff_index)` out-of-bounds or returns wrong field. Masked on the leader because the planner usually hands the scan `projection=None`. |
| 3 | `scan_sync` accepts a `projection` parameter; codec derives it from `proto.schema` field-name matches | `Missing on the right: {Column { ..., index: N }}` — worker reconstruction was producing the unprojected full schema while the shipped subplan's downstream operators reference projected indices. |
| 4 | `on_subplan` swallows per-subplan decode errors via `mpp_log!`, returning `Ok` | `decode_segmented_topk: missing reconstructed FFHelper for target_indexrelid=N` — the FFHelper-walker can't see scans across stage boundaries (broadcast subtree lives in another stage). Hard-erroring took down the worker. Now the affected `(stage, task)` falls back to `prepare_task`'s local-prepare path naturally. Drain pump infrastructure failures stay fatal. |

## Why these fixes are landable independently

Fixes #1 and #2 are **latent bugs on the leader path too**, just masked by happy-path defaults (the codec encode probe picks DistributedCodec at position 0 — but DistributedCodec's UDAF defaults are no-ops; the planner usually hands `projection=None` — but projected joins exist).

Fix #3 only matters on the worker reconstruction path (which #5123 already exercises). Without it, worker-reconstructed scans have wider schemas than the shipped subplan expects.

Fix #4 makes the dispatch-flip + state-reconstruction architecture **degrade gracefully** rather than tear down the worker. The local-replan path is always-correct (it produces the right rows, just at the cost of skipping the "build once, ship many" optimization for the affected `(stage, task)`).

## Long-term direction (not in this PR)

The original draft attempted to remove the worker-side logical-replan entirely. The structural issue that blocked it was: cross-stage FFHelper resolution requires a walker that can see across `NetworkBoundary` references, which the local-replan path satisfied implicitly by building all stages locally on each worker. The dispatch-flip's per-stage independent decoding can't do this without either:

- Worker-side FFHelper construction per `indexrelid` from PG state (substantial new code path; aligns with the "workers as gRPC handlers" target)
- Or shipping FFHelper-construction inputs in `TantivyLookupProto` / `SegmentedTopKProto` directly

Either approach is followup. Goal: workers autonomously handle queries from DF-D without ParadeDB-specific cross-stage stitching.

## Test plan

- [x] `cargo clippy -D warnings` clean (default + `--tests`)
- [x] `cargo test --lib --package pg_search --no-default-features --features pg18 -- mpp`: 66/66 pass; new test `on_subplan_decode_failure_is_logged_but_not_fatal` pins the per-subplan tolerance
- [x] Local `cargo pgrx regress --resetdb pg18 mpp_smoke`: pass
- [ ] CI `pgrx - arm64` regression suite — pending; the `mpp_aggregate` and `mpp_joinscan` regressions may surface deeper bugs that this PR's fixes unblock (e.g., "no Tokio reactor running" surfaced in local repro after fix #1+#4 unblocked the codec-error path; needs follow-up investigation)
- [ ] `aggregate_join_groupby` bench at 10M to confirm no perf regression from codec-ordering / FFHelper construction changes