### PR TITLE
feat: load Lindera dictionaries from installed mmap files

### DIFF
--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -120,7 +120,9 @@ runs:
     - name: Compile & install pg_search
       working-directory: pg_search/
       shell: bash
-      run: cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+      run: |
+        cargo pgrx install --sudo --pg-config="/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
+        ../scripts/install_lindera_dictionaries.sh --sudo --pg-config "/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
 
     - name: Add pg_search to shared_preload_libraries
       working-directory: /home/runner/.pgrx/data-${{ inputs.pg_version }}/

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -219,7 +219,9 @@ jobs:
         run: cargo pgrx init --pg${{ env.pg_version }}=`which pg_config`
 
       - name: Compile & install pg_search extension
-        run: cargo pgrx install -p pg_search --sudo --release --pg-config `which pg_config` --features=pg${{ env.pg_version }} --no-default-features
+        run: |
+          cargo pgrx install -p pg_search --sudo --release --pg-config `which pg_config` --features=pg${{ env.pg_version }} --no-default-features
+          scripts/install_lindera_dictionaries.sh --sudo --pg-config `which pg_config`
 
       - name: Start Postgres
         working-directory: pg_search/

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -287,6 +287,7 @@ jobs:
         run: |
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx package --pg-config $PG_CONFIG_PATH
+          ../scripts/install_lindera_dictionaries.sh --pg-config "$PG_CONFIG_PATH" --package-root "../target/release/pg_search-pg${{ matrix.pg_version }}"
 
       - name: Create .deb Package
         if: steps.guard.outputs.build == 'true'
@@ -302,6 +303,7 @@ jobs:
           cp archive/*.so ${package_dir}/usr/lib/postgresql/${{ matrix.pg_version }}/lib
           cp archive/*.control ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
           cp archive/*.sql ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
+          cp -R target/release/pg_search-pg${{ matrix.pg_version }}/usr/share/postgresql/${{ matrix.pg_version }}/extension/pg_search ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension/
 
           # Create control file (package name cannot have underscore)
           mkdir -p ${package_dir}/DEBIAN

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -183,6 +183,9 @@ jobs:
           pg_version=${{ matrix.pg_version }}
           tag_version=${{ steps.version.outputs.tag_version }}
           package_dir="pg_search-${tag_version}-arm64-pg${pg_version}"
+          PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${pg_version}/bin/pg_config"
+          sharedir="$($PG_CONFIG_PATH --sharedir)"
+          sharedir_rel="${sharedir#/}"
 
           # Define Homebrew PostgreSQL paths
           lib_path="lib/postgresql"
@@ -200,7 +203,7 @@ jobs:
           fi
           cp archive/*.control ${package_dir}/${share_path}
           cp archive/*.sql ${package_dir}/${share_path}
-          cp -R target/release/pg_search-pg${{ matrix.pg_version }}/opt/homebrew/share/postgresql@${{ matrix.pg_version }}/extension/pg_search ${package_dir}/${share_path}/
+          cp -R "target/release/pg_search-pg${pg_version}/${sharedir_rel}/extension/pg_search" ${package_dir}/${share_path}/
 
           # Bundle the LICENSE so it lands at /opt/homebrew/opt/paradedb/LICENSE
           # alongside the Homebrew install prefix.

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -137,6 +137,7 @@ jobs:
           PG_CONFIG_PATH="/opt/homebrew/opt/postgresql@${{ matrix.pg_version }}/bin/pg_config"
           export PATH="/opt/homebrew/bin:$PATH"
           cargo pgrx package --pg-config $PG_CONFIG_PATH
+          ../scripts/install_lindera_dictionaries.sh --pg-config "$PG_CONFIG_PATH" --package-root "../target/release/pg_search-pg${{ matrix.pg_version }}"
 
       # Import the Developer ID Application + Installer certificates into a dedicated
       # temporary keychain so codesign/pkgbuild can sign with them. The keychain is the
@@ -199,6 +200,7 @@ jobs:
           fi
           cp archive/*.control ${package_dir}/${share_path}
           cp archive/*.sql ${package_dir}/${share_path}
+          cp -R target/release/pg_search-pg${{ matrix.pg_version }}/opt/homebrew/share/postgresql@${{ matrix.pg_version }}/extension/pg_search ${package_dir}/${share_path}/
 
           # Bundle the LICENSE so it lands at /opt/homebrew/opt/paradedb/LICENSE
           # alongside the Homebrew install prefix.

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -300,6 +300,7 @@ jobs:
         run: |
           PG_CONFIG_PATH="/usr/pgsql-${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx package --pg-config $PG_CONFIG_PATH
+          ../scripts/install_lindera_dictionaries.sh --pg-config "$PG_CONFIG_PATH" --package-root "../target/release/pg_search-pg${{ matrix.pg_version }}"
 
       - name: Create .rpm Package
         run: |
@@ -328,10 +329,12 @@ jobs:
           %{__rm} -rf %{buildroot}
           install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
           install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search/
           install -d %{buildroot}/usr/share/licenses/%{name}/
           install -m 755 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
           install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*.sql %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
           install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          cp -a %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search/. %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search/
           install -m 644 %{_sourcedir}/LICENSE %{buildroot}/usr/share/licenses/%{name}/LICENSE
 
           %files
@@ -339,6 +342,7 @@ jobs:
           /usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*sql
+          /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search
 
           %changelog
           * ${{ steps.version.outputs.current_date }} ParadeDB <support@paradedb.com> - ${{ steps.version.outputs.tag_version }}

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -280,6 +280,7 @@ jobs:
         run: |
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
           cargo pgrx package --pg-config $PG_CONFIG_PATH
+          ../scripts/install_lindera_dictionaries.sh --pg-config "$PG_CONFIG_PATH" --package-root "../target/release/pg_search-pg${{ matrix.pg_version }}"
 
       - name: Create .deb Package
         run: |
@@ -294,6 +295,7 @@ jobs:
           cp archive/*.so ${package_dir}/usr/lib/postgresql/${{ matrix.pg_version }}/lib
           cp archive/*.control ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
           cp archive/*.sql ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension
+          cp -R target/release/pg_search-pg${{ matrix.pg_version }}/usr/share/postgresql/${{ matrix.pg_version }}/extension/pg_search ${package_dir}/usr/share/postgresql/${{ matrix.pg_version }}/extension/
 
           # Create control file (package name cannot have underscore)
           mkdir -p ${package_dir}/DEBIAN

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -160,7 +160,9 @@ jobs:
 
       - name: Compile & install pg_search extension (pgrx)
         working-directory: pg_search/
-        run: cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features="pg${{ matrix.pg_version }},block_tracker"
+        run: |
+          cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features="pg${{ matrix.pg_version }},block_tracker"
+          ../scripts/install_lindera_dictionaries.sh --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config
 
       - name: Add extension to shared_preload_libraries
         working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -228,6 +228,7 @@ jobs:
           cp archive/*.so* ${package_dir}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib
           cp archive/*.control ${package_dir}/usr/share/postgresql/${{ env.PG_VERSION }}/extension
           cp archive/*.sql ${package_dir}/usr/share/postgresql/${{ env.PG_VERSION }}/extension
+          cp -R target/release-with-debug/pg_search-pg${{ env.PG_VERSION }}/usr/share/postgresql/${{ env.PG_VERSION }}/extension/pg_search ${package_dir}/usr/share/postgresql/${{ env.PG_VERSION }}/extension/
 
           # Create control file (package name cannot have underscore)
           mkdir -p ${package_dir}/DEBIAN

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -194,6 +194,7 @@ jobs:
           RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -lvoidstar" \
           CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
             cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH" --features dst
+          ../scripts/install_lindera_dictionaries.sh --pg-config "$PG_CONFIG_PATH" --package-root "../target/release-with-debug/pg_search-pg${{ env.PG_VERSION }}"
 
       # Catch the broken-symbol case above before shipping to Antithesis.
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -273,6 +273,7 @@ jobs:
         run: |
           export DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/postgres
           export PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config
+          export PARADEDB_LINDERA_DICT_ROOT="$($PG_CONFIG --sharedir)/extension/pg_search/lindera"
           if [[ "${{ github.event_name }}" == "pull_request" && "${{ matrix.pg_version }}" != "18" ]]; then
             RUST_BACKTRACE=1 cargo test --jobs $(nproc) --package tests --package tokenizers
           else
@@ -293,7 +294,11 @@ jobs:
 
       - name: Run pg_search Integration Tests (pgrx-managed)
         if: matrix.pg_impl == 'pgrx'
-        run: RUST_BACKTRACE=1 DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --jobs $(nproc) --no-default-features --package tests --package tokenizers -- --skip replication --skip ephemeral
+        run: |
+          PG_CONFIG_PATH=(~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config)
+          export PG_CONFIG="${PG_CONFIG_PATH[0]}"
+          export PARADEDB_LINDERA_DICT_ROOT="$($PG_CONFIG --sharedir)/extension/pg_search/lindera"
+          RUST_BACKTRACE=1 DATABASE_URL=postgresql://localhost:288${{ matrix.pg_version }}/pg_search cargo test --jobs $(nproc) --no-default-features --package tests --package tokenizers -- --skip replication --skip ephemeral
 
       - name: Run pg_search Regression Tests (pgrx-managed)
         if: matrix.pg_impl == 'pgrx'

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -222,7 +222,9 @@ jobs:
       - name: Compile & install pg_search extension (system)
         if: matrix.pg_impl == 'system'
         working-directory: pg_search/
-        run: cargo pgrx install --sudo --features block_tracker --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
+        run: |
+          cargo pgrx install --sudo --features block_tracker --pg-config="/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
+          ../scripts/install_lindera_dictionaries.sh --sudo --pg-config "/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config"
 
       # Coverage instrumentation runs on schedule + push-to-main, plus PG 18
       # entries on PRs (so Codecov has fresh data per PR). Older-version PR
@@ -243,7 +245,9 @@ jobs:
       - name: Compile & install pg_search extension (pgrx)
         if: matrix.pg_impl == 'pgrx'
         working-directory: pg_search/
-        run: cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features="pg${{ matrix.pg_version }},block_tracker"
+        run: |
+          cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features="pg${{ matrix.pg_version }},block_tracker"
+          ../scripts/install_lindera_dictionaries.sh --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config
 
       # ---------- Start Postgres ----------
       - name: Start Postgres (system)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,12 +4566,7 @@ dependencies = [
  "byteorder",
  "csv",
  "kanaria",
- "lindera-cc-cedict",
  "lindera-dictionary",
- "lindera-ipadic",
- "lindera-ipadic-neologd",
- "lindera-ko-dic",
- "lindera-unidic",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -4588,16 +4583,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "lindera-cc-cedict"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aad0b904e0e5c6ab4df0c426e9e7e73baa1bd02beb5f6caa299a2c50b65be5"
+name = "lindera-dict-builder"
+version = "0.1.0"
 dependencies = [
  "anyhow",
- "byteorder",
- "csv",
  "lindera-dictionary",
- "once_cell",
  "rkyv 0.8.16",
  "serde_json",
  "tokio",
@@ -4635,70 +4625,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "yada",
-]
-
-[[package]]
-name = "lindera-ipadic"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c96c39429b860d3cd6673817654f73c3569fdd4ff5ee350579b7144f3af6607"
-dependencies = [
- "anyhow",
- "byteorder",
- "csv",
- "lindera-dictionary",
- "once_cell",
- "rkyv 0.8.16",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "lindera-ipadic-neologd"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aafe1b69d68bf202c1dc38f7650617269627806b532addf179f6ecd117290a13"
-dependencies = [
- "anyhow",
- "byteorder",
- "csv",
- "lindera-dictionary",
- "once_cell",
- "rkyv 0.8.16",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "lindera-ko-dic"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "420133c798b4162a1fb3e8c483da0add4e370f22d3e90c9f2ef15013bdac9ce2"
-dependencies = [
- "anyhow",
- "byteorder",
- "csv",
- "lindera-dictionary",
- "once_cell",
- "rkyv 0.8.16",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "lindera-unidic"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae93789d60f4423c341af4f17bb83180a30aa3c156329fab647f446e00cf364b"
-dependencies = [
- "anyhow",
- "byteorder",
- "csv",
- "lindera-dictionary",
- "once_cell",
- "rkyv 0.8.16",
- "serde_json",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4566,7 +4566,12 @@ dependencies = [
  "byteorder",
  "csv",
  "kanaria",
+ "lindera-cc-cedict",
  "lindera-dictionary",
+ "lindera-ipadic",
+ "lindera-ipadic-neologd",
+ "lindera-ko-dic",
+ "lindera-unidic",
  "once_cell",
  "percent-encoding",
  "regex",
@@ -4580,6 +4585,22 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "yada",
+]
+
+[[package]]
+name = "lindera-cc-cedict"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aad0b904e0e5c6ab4df0c426e9e7e73baa1bd02beb5f6caa299a2c50b65be5"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv 0.8.16",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -4625,6 +4646,70 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "yada",
+]
+
+[[package]]
+name = "lindera-ipadic"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c96c39429b860d3cd6673817654f73c3569fdd4ff5ee350579b7144f3af6607"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv 0.8.16",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ipadic-neologd"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aafe1b69d68bf202c1dc38f7650617269627806b532addf179f6ecd117290a13"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv 0.8.16",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-ko-dic"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "420133c798b4162a1fb3e8c483da0add4e370f22d3e90c9f2ef15013bdac9ce2"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv 0.8.16",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
+name = "lindera-unidic"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae93789d60f4423c341af4f17bb83180a30aa3c156329fab647f446e00cf364b"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "csv",
+ "lindera-dictionary",
+ "once_cell",
+ "rkyv 0.8.16",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "benchmarks",
   "macros",
   "stressgres",
+  "tools/lindera-dict-builder",
 ]
 
 [workspace.package]

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DISTVERSION  = $(shell grep -m 1 '^version' Cargo.toml | sed -e 's/[^"]*"\([^"]*
 PGRXV        = $(shell perl -nE '/^pgrx\s+=\s"=?([^"]+)/ && do { say $$1; exit }' Cargo.toml)
 PGV          = $(shell perl -E 'shift =~ /(\d+)/ && say $$1' "$(shell $(PG_CONFIG) --version)")
 EXTRA_CLEAN  = META.json $(DISTNAME)-$(DISTVERSION).zip target
+LINDERA_CACHE ?= $(CURDIR)/target/lindera-dict-cache
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
@@ -35,11 +36,13 @@ pgrx-init: pg_search/Cargo.toml
 .PHONY: install
 install:
 	@cargo pgrx install --package pg_search --release --pg-config "$(PG_CONFIG)"
+	@LINDERA_CACHE="$(LINDERA_CACHE)" scripts/install_lindera_dictionaries.sh --pg-config "$(PG_CONFIG)"
 
 # Build pg_search for the PostgreSQL cluster identified by pg_config.
 .DEFAULT_GOAL: package
 package:
 	@cargo pgrx package --package pg_search --pg-config "$(PG_CONFIG)"
+	@LINDERA_CACHE="$(LINDERA_CACHE)" scripts/install_lindera_dictionaries.sh --pg-config "$(PG_CONFIG)" --package-root "$(CURDIR)/target/release/$(DISTNAME)-pg$(PGV)"
 
 META.json: META.json.in pg_search/Cargo.toml
 	@sed -e "s/@CRATE_DESC@/$(DISTDESC)/g" -e "s/@CRATE_VERSION@/$(DISTVERSION)/g" $< > $@

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -30,7 +30,7 @@ ParadeDB provides prebuilt binaries of our extension for Postgres 15+ on:
 - macOS via [Postgres.app](https://postgresapp.com/extensions/) (PostgreSQL 18)
 - Red Hat Enterprise Linux 9 and 10
 
-If you are using a different version of Postgres or a different operating system, you will need to build the extension from source.
+If you are using a different version of Postgres or a different operating system, you will need to build the extension from source. After running `cargo pgrx install`, run `scripts/install_lindera_dictionaries.sh --pg-config <path-to-pg_config>` from the repository root so the Lindera tokenizer dictionaries are installed next to the extension.
 
 #### pg_search
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -84,6 +84,11 @@ buildPgrxExtension (finalAttrs: {
     echo "Lindera cache prepared at $LINDERA_CACHE"
   '';
 
+  postInstall = ''
+    cargo run --release --package lindera-dict-builder -- \
+      "$out/share/postgresql/extension/pg_search/lindera"
+  '';
+
   cargoPgrxFlags = [
     "--package"
     "pg_search"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-9Qzo3y90y3Yx7V2etMCjZSyT3EaQUrUcJsXu4fqWG4w=";
+  cargoHash = "sha256-Xa1YmF0L6riToJ3njgPsBad3qA6loRfddwf5dhe8jk8=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -90,6 +90,22 @@ extension_sql!(
     finalize
 );
 
+unsafe fn configure_lindera_dictionary_root() {
+    let mut share_path = [0 as std::os::raw::c_char; pg_sys::MAXPGPATH as usize];
+    pg_sys::get_share_path(
+        std::ptr::addr_of!(pg_sys::my_exec_path).cast::<std::os::raw::c_char>(),
+        share_path.as_mut_ptr(),
+    );
+
+    let share_path = std::ffi::CStr::from_ptr(share_path.as_ptr()).to_string_lossy();
+    tokenizers::lindera_mmap::set_dictionary_root(
+        std::path::Path::new(share_path.as_ref())
+            .join("extension")
+            .join("pg_search")
+            .join("lindera"),
+    );
+}
+
 pub fn available_parallelism() -> usize {
     use once_cell::sync::Lazy;
 
@@ -118,6 +134,8 @@ pub unsafe extern "C-unwind" fn _PG_init() {
         // Use try_init() because parallel workers may call _PG_init() multiple times
         let _ = env_logger::try_init();
     }
+
+    configure_lindera_dictionary_root();
 
     if !pg_sys::process_shared_preload_libraries_in_progress {
         error!("pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to shared_preload_libraries in postgresql.conf and restart Postgres.");

--- a/scripts/install_lindera_dictionaries.sh
+++ b/scripts/install_lindera_dictionaries.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+usage: install_lindera_dictionaries.sh --pg-config PATH [--package-root PATH] [--sudo]
+
+Build Lindera dictionaries as pg_search mmap component files and install them
+under $sharedir/extension/pg_search/lindera.
+
+With --package-root, install into the pgrx package tree instead of the live
+Postgres sharedir.
+USAGE
+}
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+pg_config="${PG_CONFIG:-}"
+package_root=""
+use_sudo=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pg-config)
+      pg_config="${2:-}"
+      shift 2
+      ;;
+    --package-root)
+      package_root="${2:-}"
+      shift 2
+      ;;
+    --sudo)
+      use_sudo=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$pg_config" ]]; then
+  pg_config="$(command -v pg_config)"
+fi
+
+if [[ ! -x "$pg_config" ]]; then
+  echo "pg_config is not executable: $pg_config" >&2
+  exit 1
+fi
+
+sharedir="$("$pg_config" --sharedir)"
+if [[ -n "$package_root" ]]; then
+  sharedir_rel="${sharedir#/}"
+  destination="$package_root/$sharedir_rel/extension/pg_search/lindera"
+else
+  destination="$sharedir/extension/pg_search/lindera"
+fi
+
+if [[ -z "${LINDERA_CACHE:-}" ]]; then
+  if [[ "$use_sudo" -eq 1 ]]; then
+    export LINDERA_CACHE="/tmp/paradedb-lindera-dict-cache"
+  else
+    export LINDERA_CACHE="$repo_root/target/lindera-dict-cache"
+  fi
+fi
+
+cargo build --release --manifest-path "$repo_root/Cargo.toml" --package lindera-dict-builder
+
+builder="$repo_root/target/release/lindera-dict-builder"
+if [[ "$use_sudo" -eq 1 ]]; then
+  sudo env LINDERA_CACHE="$LINDERA_CACHE" "$builder" "$destination"
+else
+  "$builder" "$destination"
+fi

--- a/scripts/install_lindera_dictionaries.sh
+++ b/scripts/install_lindera_dictionaries.sh
@@ -61,18 +61,20 @@ else
 fi
 
 if [[ -z "${LINDERA_CACHE:-}" ]]; then
-  if [[ "$use_sudo" -eq 1 ]]; then
-    export LINDERA_CACHE="/tmp/paradedb-lindera-dict-cache"
-  else
-    export LINDERA_CACHE="$repo_root/target/lindera-dict-cache"
-  fi
+  export LINDERA_CACHE="$repo_root/target/lindera-dict-cache"
 fi
 
 cargo build --release --manifest-path "$repo_root/Cargo.toml" --package lindera-dict-builder
 
 builder="$repo_root/target/release/lindera-dict-builder"
 if [[ "$use_sudo" -eq 1 ]]; then
-  sudo env LINDERA_CACHE="$LINDERA_CACHE" "$builder" "$destination"
+  staging_root="$(mktemp -d)"
+  trap 'rm -rf "$staging_root"' EXIT
+  staging_destination="$staging_root/lindera"
+  "$builder" "$staging_destination"
+  sudo rm -rf "$destination"
+  sudo mkdir -p "$(dirname "$destination")"
+  sudo cp -R "$staging_destination" "$destination"
 else
   "$builder" "$destination"
 fi

--- a/scripts/pg_search_common.sh
+++ b/scripts/pg_search_common.sh
@@ -60,6 +60,8 @@ PGVER=${PGVER:-18.1}
 BASEVER=$(echo "${PGVER}" | cut -f1 -d.)
 PORT=288${BASEVER}  # Port 2880 + major version (e.g., 28818 for version 18.1)
 FEATURE=pg${BASEVER}  # Feature flag (e.g., pg18)
+PG_CONFIG="${HOME}/.pgrx/${PGVER}/pgrx-install/bin/pg_config"
+export PG_CONFIG
 
 # Enable command echo for debugging
 set -x
@@ -68,7 +70,9 @@ set -x
 cargo pgrx stop "${FEATURE}" --package pg_search
 
 # Install pg_search extension, conditionally using --release
-cargo pgrx install --package pg_search ${BUILD_PARAMS[@]+"${BUILD_PARAMS[@]}"} --pg-config "${HOME}/.pgrx/${PGVER}/pgrx-install/bin/pg_config" || exit $? # ksh88: there's a space between --profile and the value
+cargo pgrx install --package pg_search ${BUILD_PARAMS[@]+"${BUILD_PARAMS[@]}"} --pg-config "${PG_CONFIG}" || exit $? # ksh88: there's a space between --profile and the value
+"${SCRIPT_DIR}/install_lindera_dictionaries.sh" --pg-config "${PG_CONFIG}"
+export PARADEDB_LINDERA_DICT_ROOT="$("${PG_CONFIG}" --sharedir)/extension/pg_search/lindera"
 
 # Start the PostgreSQL server with the installed extension
 RUST_BACKTRACE=1 cargo pgrx start "${FEATURE}" --package pg_search
@@ -82,5 +86,4 @@ export DATABASE_URL="postgresql://${USER}@localhost:${PORT}/pg_search"
 # Clean up any previous logs
 rm -rf /tmp/ephemeral_postgres_logs/*
 
-# Export the PG_CONFIG variable for use by sourcing scripts
-export PG_CONFIG="${HOME}/.pgrx/${PGVER}/pgrx-install/bin/pg_config"
+# PG_CONFIG and PARADEDB_LINDERA_DICT_ROOT are exported for use by sourcing scripts.

--- a/scripts/pg_search_common.sh
+++ b/scripts/pg_search_common.sh
@@ -72,7 +72,8 @@ cargo pgrx stop "${FEATURE}" --package pg_search
 # Install pg_search extension, conditionally using --release
 cargo pgrx install --package pg_search ${BUILD_PARAMS[@]+"${BUILD_PARAMS[@]}"} --pg-config "${PG_CONFIG}" || exit $? # ksh88: there's a space between --profile and the value
 "${SCRIPT_DIR}/install_lindera_dictionaries.sh" --pg-config "${PG_CONFIG}"
-export PARADEDB_LINDERA_DICT_ROOT="$("${PG_CONFIG}" --sharedir)/extension/pg_search/lindera"
+PARADEDB_LINDERA_DICT_ROOT="$("${PG_CONFIG}" --sharedir)/extension/pg_search/lindera"
+export PARADEDB_LINDERA_DICT_ROOT
 
 # Start the PostgreSQL server with the installed extension
 RUST_BACKTRACE=1 cargo pgrx start "${FEATURE}" --package pg_search

--- a/tests/tests/lindera.rs
+++ b/tests/tests/lindera.rs
@@ -42,25 +42,27 @@ fn gather_workers_launched(plan: &Value) -> Option<i64> {
     }
 }
 
-fn has_parallel_paradedb_scan(plan: &Value) -> bool {
+fn has_worker_instrumented_paradedb_scan(plan: &Value) -> bool {
     match plan {
         Value::Object(object) => {
-            let is_parallel_paradedb_scan = object
+            let is_paradedb_scan = object
                 .get("Node Type")
                 .and_then(Value::as_str)
                 .is_some_and(|node_type| node_type == "Custom Scan")
                 && object
                     .get("Custom Plan Provider")
                     .and_then(Value::as_str)
-                    .is_some_and(|provider| provider == "ParadeDB Base Scan")
-                && object
-                    .get("Parallel Aware")
-                    .and_then(Value::as_bool)
-                    .unwrap_or(false);
+                    .is_some_and(|provider| provider == "ParadeDB Base Scan");
 
-            is_parallel_paradedb_scan || object.values().any(has_parallel_paradedb_scan)
+            let worker_instrumented = object
+                .get("Workers")
+                .and_then(Value::as_array)
+                .is_some_and(|workers| !workers.is_empty());
+
+            (is_paradedb_scan && worker_instrumented)
+                || object.values().any(has_worker_instrumented_paradedb_scan)
         }
-        Value::Array(values) => values.iter().any(has_parallel_paradedb_scan),
+        Value::Array(values) => values.iter().any(has_worker_instrumented_paradedb_scan),
         _ => false,
     }
 }
@@ -135,8 +137,8 @@ fn assert_lindera_match_launches_workers(conn: &mut PgConnection, table: &str, q
         "{table} should launch parallel workers: {plan:#?}"
     );
     assert!(
-        has_parallel_paradedb_scan(&plan),
-        "{table} should execute ParadeDB Base Scan in parallel: {plan:#?}"
+        has_worker_instrumented_paradedb_scan(&plan),
+        "{table} should execute ParadeDB Base Scan in a worker: {plan:#?}"
     );
 }
 

--- a/tests/tests/lindera.rs
+++ b/tests/tests/lindera.rs
@@ -19,8 +19,126 @@
 
 use pretty_assertions::assert_eq;
 use rstest::*;
+use serde_json::Value;
 use sqlx::PgConnection;
 use tests::fixtures::*;
+
+fn gather_workers_launched(plan: &Value) -> Option<i64> {
+    match plan {
+        Value::Object(object) => {
+            if matches!(
+                object.get("Node Type").and_then(Value::as_str),
+                Some("Gather" | "Gather Merge")
+            ) {
+                if let Some(workers) = object.get("Workers Launched").and_then(Value::as_i64) {
+                    return Some(workers);
+                }
+            }
+
+            object.values().find_map(gather_workers_launched)
+        }
+        Value::Array(values) => values.iter().find_map(gather_workers_launched),
+        _ => None,
+    }
+}
+
+fn has_parallel_paradedb_scan(plan: &Value) -> bool {
+    match plan {
+        Value::Object(object) => {
+            let is_parallel_paradedb_scan = object
+                .get("Node Type")
+                .and_then(Value::as_str)
+                .is_some_and(|node_type| node_type == "Custom Scan")
+                && object
+                    .get("Custom Plan Provider")
+                    .and_then(Value::as_str)
+                    .is_some_and(|provider| provider == "ParadeDB Base Scan")
+                && object
+                    .get("Parallel Aware")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false);
+
+            is_parallel_paradedb_scan || object.values().any(has_parallel_paradedb_scan)
+        }
+        Value::Array(values) => values.iter().any(has_parallel_paradedb_scan),
+        _ => false,
+    }
+}
+
+fn create_lindera_parallel_table(
+    conn: &mut PgConnection,
+    table: &str,
+    index: &str,
+    tokenizer: &str,
+    text_a: &str,
+    text_b: &str,
+    text_c: &str,
+) {
+    format!(
+        r#"
+        DROP TABLE IF EXISTS {table};
+        CREATE TABLE {table} (
+            id SERIAL PRIMARY KEY,
+            body TEXT
+        );
+
+        INSERT INTO {table} (body)
+        SELECT CASE
+            WHEN i % 3 = 0 THEN '{text_a}'
+            WHEN i % 3 = 1 THEN '{text_b}'
+            ELSE '{text_c}'
+        END
+        FROM generate_series(1, 1000) i;
+
+        ALTER TABLE {table} SET (parallel_workers = 2);
+
+        CREATE INDEX {index} ON {table}
+        USING bm25 (id, body)
+        WITH (
+            key_field = 'id',
+            text_fields = '{{"body": {{"tokenizer": {{"type": "{tokenizer}"}}, "record": "position"}}}}'
+        );
+        "#
+    )
+    .execute(conn);
+}
+
+fn assert_lindera_match_launches_workers(conn: &mut PgConnection, table: &str, query: &str) {
+    let (count,) = format!(
+        r#"
+        SELECT count(*)
+        FROM {table}
+        WHERE body @@@ paradedb.match('body', '{query}')
+        "#
+    )
+    .fetch_one::<(i64,)>(conn);
+    assert!(count > 0, "{table} should match query {query:?}");
+
+    let (plan,) = format!(
+        r#"
+        EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON)
+        SELECT id, paradedb.score(id)
+        FROM {table}
+        WHERE body @@@ paradedb.match('body', '{query}')
+        ORDER BY paradedb.score(id) DESC
+        LIMIT 10
+        "#
+    )
+    .fetch_one::<(Value,)>(conn);
+
+    eprintln!("{table} parallel Lindera plan: {plan:#?}");
+
+    let workers = gather_workers_launched(&plan)
+        .unwrap_or_else(|| panic!("{table} should use Gather/Gather Merge: {plan:#?}"));
+    assert!(
+        workers > 0,
+        "{table} should launch parallel workers: {plan:#?}"
+    );
+    assert!(
+        has_parallel_paradedb_scan(&plan),
+        "{table} should execute ParadeDB Base Scan in parallel: {plan:#?}"
+    );
+}
 
 #[rstest]
 async fn lindera_korean_tokenizer(mut conn: PgConnection) {
@@ -70,6 +188,57 @@ async fn lindera_korean_tokenizer(mut conn: PgConnection) {
     let row: (i32,) = r#"SELECT id FROM korean WHERE korean @@@ 'message:"지역 축제"' ORDER BY id"#
         .fetch_one(&mut conn);
     assert_eq!(row.0, 3);
+}
+
+#[rstest]
+fn lindera_match_launches_parallel_workers(mut conn: PgConnection) {
+    if pg_major_version(&mut conn) < 16 {
+        // `debug_parallel_query` is needed to make worker launch deterministic.
+        return;
+    }
+
+    r#"
+        SET max_parallel_workers = 8;
+        SET max_parallel_workers_per_gather = 2;
+        SET min_parallel_table_scan_size = 0;
+        SET min_parallel_index_scan_size = 0;
+        SET parallel_setup_cost = 0;
+        SET parallel_tuple_cost = 0;
+        SET debug_parallel_query = on;
+    "#
+    .execute(&mut conn);
+
+    create_lindera_parallel_table(
+        &mut conn,
+        "lindera_parallel_ko",
+        "lindera_parallel_ko_idx",
+        "korean_lindera",
+        "서울은 한국의 수도이며 검색 테스트 문장입니다.",
+        "부산은 항구와 해변으로 유명한 도시입니다.",
+        "대구는 음식과 시장으로 잘 알려져 있습니다.",
+    );
+    create_lindera_parallel_table(
+        &mut conn,
+        "lindera_parallel_ja",
+        "lindera_parallel_ja_idx",
+        "japanese_lindera",
+        "東京は日本の首都で検索テストの文章です。",
+        "大阪は食文化と商業で知られる都市です。",
+        "京都には古い寺院と静かな庭があります。",
+    );
+    create_lindera_parallel_table(
+        &mut conn,
+        "lindera_parallel_zh",
+        "lindera_parallel_zh_idx",
+        "chinese_lindera",
+        "北京是中国的首都，也是搜索测试句子。",
+        "上海拥有繁忙的港口和现代天际线。",
+        "广州以美食和贸易闻名。",
+    );
+
+    assert_lindera_match_launches_workers(&mut conn, "lindera_parallel_ko", "서울");
+    assert_lindera_match_launches_workers(&mut conn, "lindera_parallel_ja", "東京");
+    assert_lindera_match_launches_workers(&mut conn, "lindera_parallel_zh", "北京");
 }
 
 #[rstest]

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -10,7 +10,10 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
-lindera = { version = "1.5.1", default-features = false, features = ["mmap"] }
+lindera = { version = "=1.5.1", default-features = false, features = [
+  "compress",
+  "mmap",
+] }
 once_cell = "1.21.4"
 serde = "1.0.228"
 serde_json = "1.0.149"

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -10,12 +10,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1.0.102"
-lindera = { version = "1.5.1", features = [
-  "embedded-cc-cedict",
-  "embedded-ipadic",
-  "embedded-ko-dic",
-  "compress",
-] }
+lindera = { version = "1.5.1", default-features = false, features = ["mmap"] }
 once_cell = "1.21.4"
 serde = "1.0.228"
 serde_json = "1.0.149"

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -21,6 +21,7 @@ pub mod code;
 pub mod edge_ngram;
 pub mod icu;
 pub mod lindera;
+pub mod lindera_mmap;
 pub mod manager;
 pub mod ngram;
 pub mod token_length;

--- a/tokenizers/src/lindera.rs
+++ b/tokenizers/src/lindera.rs
@@ -28,7 +28,7 @@ use lindera::character_filter::unicode_normalize::{
     UnicodeNormalizeCharacterFilter, UnicodeNormalizeKind,
 };
 use lindera::character_filter::BoxCharacterFilter;
-use lindera::dictionary::load_dictionary;
+use lindera::dictionary::Dictionary;
 use lindera::mode::Mode;
 use lindera::token::Token as LinderaToken;
 use lindera::token_filter::japanese_reading_form::JapaneseReadingFormTokenFilter;
@@ -80,17 +80,24 @@ enum ReadingForm {
     Korean,
 }
 
-/// Build a Lindera tokenizer for `dictionary_uri`, appending the NFKC
+static CMN_DICTIONARY: Lazy<Dictionary> = Lazy::new(|| load_mmap_dictionary("cc-cedict"));
+static JPN_DICTIONARY: Lazy<Dictionary> = Lazy::new(|| load_mmap_dictionary("ipadic"));
+static KOR_DICTIONARY: Lazy<Dictionary> = Lazy::new(|| load_mmap_dictionary("ko-dic"));
+
+fn load_mmap_dictionary(name: &str) -> Dictionary {
+    crate::lindera_mmap::load_dictionary(name).unwrap_or_else(|err| {
+        panic!("Lindera `{name}` dictionary must be installed as mmap component files: {err:#}")
+    })
+}
+
+/// Build a Lindera tokenizer for `dictionary`, appending the NFKC
 /// character filter and the reading-form token filter when the corresponding
 /// options are set.
 fn build_lindera_tokenizer(
-    dictionary_uri: &str,
-    dictionary_name: &str,
+    dictionary: Dictionary,
     options: LinderaOptions,
     reading_form: ReadingForm,
 ) -> Arc<LinderaTokenizer> {
-    let dictionary = load_dictionary(dictionary_uri)
-        .unwrap_or_else(|_| panic!("Lindera `{dictionary_name}` dictionary must be present"));
     let mut tokenizer = LinderaTokenizer::new(
         lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None)
             .keep_whitespace(options.keep_whitespace),
@@ -130,30 +137,19 @@ static KOR_TOKENIZERS: Lazy<[OnceCell<Arc<LinderaTokenizer>>; 8]> =
     Lazy::new(|| std::array::from_fn(|_| OnceCell::new()));
 
 fn chinese_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
-    CMN_TOKENIZERS[options.index()].get_or_init(|| {
-        build_lindera_tokenizer(
-            "embedded://cc-cedict",
-            "cc-cedict",
-            options,
-            ReadingForm::None,
-        )
-    })
+    CMN_TOKENIZERS[options.index()]
+        .get_or_init(|| build_lindera_tokenizer(CMN_DICTIONARY.clone(), options, ReadingForm::None))
 }
 
 fn japanese_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
     JPN_TOKENIZERS[options.index()].get_or_init(|| {
-        build_lindera_tokenizer(
-            "embedded://ipadic",
-            "ipadic",
-            options,
-            ReadingForm::Japanese,
-        )
+        build_lindera_tokenizer(JPN_DICTIONARY.clone(), options, ReadingForm::Japanese)
     })
 }
 
 fn korean_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
     KOR_TOKENIZERS[options.index()].get_or_init(|| {
-        build_lindera_tokenizer("embedded://ko-dic", "ko-dic", options, ReadingForm::Korean)
+        build_lindera_tokenizer(KOR_DICTIONARY.clone(), options, ReadingForm::Korean)
     })
 }
 
@@ -352,6 +348,18 @@ mod tests {
         tokens
     }
 
+    fn skip_if_lindera_dictionaries_are_missing() -> bool {
+        if crate::lindera_mmap::installed_dictionaries_ready() {
+            return false;
+        }
+
+        eprintln!(
+            "skipping Lindera tokenizer test; set {} to a preinstalled dictionary root",
+            crate::lindera_mmap::DICTIONARY_ROOT_ENV
+        );
+        true
+    }
+
     #[rstest]
     #[case(LinderaChineseTokenizer::new(true), 19)]
     #[case(LinderaChineseTokenizer::new(false), 18)]
@@ -359,6 +367,10 @@ mod tests {
         #[case] mut tokenizer: LinderaChineseTokenizer,
         #[case] expected_token_count: usize,
     ) {
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         let tokens = test_helper(
             &mut tokenizer,
             "地址1，包含無效的字元 (包括符號與不標準的asci阿爾發字元",
@@ -382,6 +394,10 @@ mod tests {
         #[case] mut tokenizer: LinderaJapaneseTokenizer,
         #[case] expected_token_count: usize,
     ) {
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         let tokens = test_helper(&mut tokenizer, "すもも もももももものうち");
         assert_eq!(tokens.len(), expected_token_count);
         {
@@ -401,6 +417,10 @@ mod tests {
         #[case] mut tokenizer: LinderaKoreanTokenizer,
         #[case] expected_token_count: usize,
     ) {
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         // With keep_whitespace=true (backward compatible behavior), whitespace is included as tokens
         let tokens = test_helper(&mut tokenizer, "일본입니다. 매우 멋진 단어입니다.");
         assert_eq!(tokens.len(), expected_token_count);

--- a/tokenizers/src/lindera.rs
+++ b/tokenizers/src/lindera.rs
@@ -86,7 +86,12 @@ static KOR_DICTIONARY: Lazy<Dictionary> = Lazy::new(|| load_mmap_dictionary("ko-
 
 fn load_mmap_dictionary(name: &str) -> Dictionary {
     crate::lindera_mmap::load_dictionary(name).unwrap_or_else(|err| {
-        panic!("Lindera `{name}` dictionary must be installed as mmap component files: {err:#}")
+        panic!(
+            "Lindera `{name}` dictionary must be installed as mmap component files: {err:#}. \
+             If you built pg_search from source, run \
+             `scripts/install_lindera_dictionaries.sh --pg-config <path-to-pg_config>` \
+             after `cargo pgrx install`."
+        )
     })
 }
 
@@ -353,6 +358,13 @@ mod tests {
             return false;
         }
 
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "Lindera dictionaries are missing in CI; set {} to a preinstalled dictionary root",
+                crate::lindera_mmap::DICTIONARY_ROOT_ENV
+            );
+        }
+
         eprintln!(
             "skipping Lindera tokenizer test; set {} to a preinstalled dictionary root",
             crate::lindera_mmap::DICTIONARY_ROOT_ENV
@@ -447,6 +459,10 @@ mod tests {
     // segment. The OFF/ON comparison proves the option is not a no-op.
     #[rstest]
     fn test_lindera_japanese_tokenizer_with_nfkc() {
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         let input = "ＡＢＣ１２３";
 
         let mut off = LinderaJapaneseTokenizer::with_options(false, false, false);
@@ -468,6 +484,10 @@ mod tests {
     // (katakana). "日本語" -> "ニホンゴ".
     #[rstest]
     fn test_lindera_japanese_tokenizer_with_reading_form() {
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         let input = "日本語";
 
         let mut off = LinderaJapaneseTokenizer::with_options(false, false, false);
@@ -488,6 +508,10 @@ mod tests {
     // tokens with their ko-dic Hangul reading. "韓國" -> "한국".
     #[rstest]
     fn test_lindera_korean_tokenizer_with_reading_form() {
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         let input = "韓國";
 
         let mut off = LinderaKoreanTokenizer::with_options(false, false, false);

--- a/tokenizers/src/lindera_mmap.rs
+++ b/tokenizers/src/lindera_mmap.rs
@@ -1,0 +1,145 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::{anyhow, bail, Context};
+use lindera::dictionary::Dictionary;
+use once_cell::sync::OnceCell;
+
+pub const DICTIONARY_ROOT_ENV: &str = "PARADEDB_LINDERA_DICT_ROOT";
+
+pub const DICTIONARY_NAMES: &[&str] = &["cc-cedict", "ipadic", "ko-dic"];
+
+pub const DICTIONARY_COMPONENT_FILES: &[&str] = &[
+    "metadata.json",
+    "char_def.bin",
+    "unk.bin",
+    "matrix.mtx",
+    "dict.da",
+    "dict.vals",
+    "dict.wordsidx",
+    "dict.words",
+];
+
+static DICTIONARY_ROOT: OnceCell<PathBuf> = OnceCell::new();
+
+pub fn set_dictionary_root(path: impl Into<PathBuf>) {
+    let path = path.into();
+    if DICTIONARY_ROOT.get().is_some() {
+        return;
+    }
+
+    let _ = DICTIONARY_ROOT.set(path);
+}
+
+pub fn dictionary_root() -> anyhow::Result<PathBuf> {
+    if let Some(root) = std::env::var_os(DICTIONARY_ROOT_ENV) {
+        return Ok(root.into());
+    }
+
+    DICTIONARY_ROOT.get().cloned().ok_or_else(|| {
+        anyhow!(
+            "{DICTIONARY_ROOT_ENV} is not set and pg_search did not configure a Lindera dictionary root"
+        )
+    })
+}
+
+pub fn dictionary_dir_ready(path: &Path) -> bool {
+    path.is_dir()
+        && DICTIONARY_COMPONENT_FILES
+            .iter()
+            .all(|component| path.join(component).is_file())
+}
+
+pub fn installed_dictionaries_ready() -> bool {
+    let Ok(root) = dictionary_root() else {
+        return false;
+    };
+
+    DICTIONARY_NAMES
+        .iter()
+        .all(|name| dictionary_dir_ready(&root.join(name)))
+}
+
+pub fn load_dictionary(name: &str) -> anyhow::Result<Dictionary> {
+    let root = dictionary_root()?;
+    let dictionary_dir = root.join(name);
+
+    if !dictionary_dir_ready(&dictionary_dir) {
+        let missing = DICTIONARY_COMPONENT_FILES
+            .iter()
+            .filter(|component| !dictionary_dir.join(component).is_file())
+            .copied()
+            .collect::<Vec<_>>();
+
+        if missing.is_empty() {
+            bail!(
+                "Lindera dictionary directory does not exist or is not a directory: {}",
+                dictionary_dir.display()
+            );
+        }
+
+        bail!(
+            "Lindera dictionary `{name}` is missing component files under {}: {}",
+            dictionary_dir.display(),
+            missing.join(", ")
+        );
+    }
+
+    Dictionary::load_from_path_with_options(&dictionary_dir, true).with_context(|| {
+        format!(
+            "failed to mmap-load Lindera dictionary `{name}` from {}",
+            dictionary_dir.display()
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    static NEXT_TEST_DIR: AtomicUsize = AtomicUsize::new(0);
+
+    fn temp_dir() -> PathBuf {
+        let id = NEXT_TEST_DIR.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!(
+            "paradedb-lindera-mmap-test-{}-{id}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn dictionary_dir_ready_requires_all_components() {
+        let dir = temp_dir();
+        fs::create_dir_all(&dir).unwrap();
+
+        for component in DICTIONARY_COMPONENT_FILES {
+            assert!(!dictionary_dir_ready(&dir));
+            fs::write(dir.join(component), []).unwrap();
+        }
+
+        assert!(dictionary_dir_ready(&dir));
+
+        fs::remove_file(dir.join("unk.bin")).unwrap();
+        assert!(!dictionary_dir_ready(&dir));
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/tokenizers/src/lindera_mmap.rs
+++ b/tokenizers/src/lindera_mmap.rs
@@ -25,6 +25,8 @@ pub const DICTIONARY_ROOT_ENV: &str = "PARADEDB_LINDERA_DICT_ROOT";
 
 pub const DICTIONARY_NAMES: &[&str] = &["cc-cedict", "ipadic", "ko-dic"];
 
+// Must stay in sync with lindera-dict-builder's component list and with
+// lindera-dictionary's mmap component layout for the pinned Lindera version.
 pub const DICTIONARY_COMPONENT_FILES: &[&str] = &[
     "metadata.json",
     "char_def.bin",
@@ -48,15 +50,17 @@ pub fn set_dictionary_root(path: impl Into<PathBuf>) {
 }
 
 pub fn dictionary_root() -> anyhow::Result<PathBuf> {
+    if let Some(root) = DICTIONARY_ROOT.get() {
+        return Ok(root.clone());
+    }
+
     if let Some(root) = std::env::var_os(DICTIONARY_ROOT_ENV) {
         return Ok(root.into());
     }
 
-    DICTIONARY_ROOT.get().cloned().ok_or_else(|| {
-        anyhow!(
-            "{DICTIONARY_ROOT_ENV} is not set and pg_search did not configure a Lindera dictionary root"
-        )
-    })
+    Err(anyhow!(
+        "pg_search did not configure a Lindera dictionary root and {DICTIONARY_ROOT_ENV} is not set"
+    ))
 }
 
 pub fn dictionary_dir_ready(path: &Path) -> bool {

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -964,6 +964,13 @@ mod tests {
             return false;
         }
 
+        if std::env::var_os("CI").is_some() {
+            panic!(
+                "Lindera dictionaries are missing in CI; set {} to a preinstalled dictionary root",
+                crate::lindera_mmap::DICTIONARY_ROOT_ENV
+            );
+        }
+
         eprintln!(
             "skipping Lindera tokenizer manager test; set {} to a preinstalled dictionary root",
             crate::lindera_mmap::DICTIONARY_ROOT_ENV

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -959,6 +959,18 @@ mod tests {
     use super::*;
     use rstest::*;
 
+    fn skip_if_lindera_dictionaries_are_missing() -> bool {
+        if crate::lindera_mmap::installed_dictionaries_ready() {
+            return false;
+        }
+
+        eprintln!(
+            "skipping Lindera tokenizer manager test; set {} to a preinstalled dictionary root",
+            crate::lindera_mmap::DICTIONARY_ROOT_ENV
+        );
+        true
+    }
+
     #[rstest]
     fn test_search_tokenizer() {
         let tokenizer = SearchTokenizer::Simple(SearchTokenizerFilters::default());
@@ -1232,6 +1244,10 @@ mod tests {
             })
         );
 
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         // Test that the tokenizer is created successfully
         let mut analyzer = tokenizer.to_tantivy_tokenizer().unwrap();
 
@@ -1266,6 +1282,10 @@ mod tests {
 
         let tokenizer =
             SearchTokenizer::from_json_value(&serde_json::from_str(json).unwrap()).unwrap();
+
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
 
         // Test that the tokenizer is created successfully
         let mut analyzer = tokenizer.to_tantivy_tokenizer().unwrap();
@@ -1304,6 +1324,11 @@ mod tests {
 
         let tokenizer_lindera =
             SearchTokenizer::from_json_value(&serde_json::from_str(json_lindera).unwrap()).unwrap();
+
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
+
         let mut analyzer_lindera = tokenizer_lindera.to_tantivy_tokenizer().unwrap();
 
         let text_lindera = "富裕 劳动力";
@@ -1367,6 +1392,10 @@ mod tests {
         use tantivy::query::TermQuery;
         use tantivy::schema::{Schema, TextFieldIndexing, TextOptions, STORED};
         use tantivy::{Index, Term};
+
+        if skip_if_lindera_dictionaries_are_missing() {
+            return;
+        }
 
         // create all tokenizer variants
         let tokenizers = vec![

--- a/tools/lindera-dict-builder/Cargo.toml
+++ b/tools/lindera-dict-builder/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "lindera-dict-builder"
+version = "0.1.0"
+edition = { workspace = true }
+license = { workspace = true }
+
+[dependencies]
+anyhow = "1.0.102"
+lindera-dictionary = { version = "1.5.1", default-features = false, features = [
+  "build_rs",
+] }
+rkyv = "0.8.16"
+serde_json = "1.0.149"
+tokio = { version = "1.49.0", features = [
+  "macros",
+  "rt",
+  "time",
+  "sync",
+  "io-util",
+] }

--- a/tools/lindera-dict-builder/Cargo.toml
+++ b/tools/lindera-dict-builder/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 
 [dependencies]
 anyhow = "1.0.102"
-lindera-dictionary = { version = "1.5.1", default-features = false, features = [
+lindera-dictionary = { version = "=1.5.1", default-features = false, features = [
   "build_rs",
 ] }
 rkyv = "0.8.16"

--- a/tools/lindera-dict-builder/src/main.rs
+++ b/tools/lindera-dict-builder/src/main.rs
@@ -1,0 +1,296 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Context};
+use lindera_dictionary::assets::{fetch, FetchParams};
+use lindera_dictionary::builder::DictionaryBuilder;
+use lindera_dictionary::decompress::{Algorithm, CompressedData};
+use lindera_dictionary::dictionary::metadata::Metadata;
+
+const LINDERA_VERSION: &str = "1.5.1";
+const READY_MARKER: &str = ".paradedb-lindera-mmap-ready";
+
+const COMPONENT_FILES: &[&str] = &[
+    "metadata.json",
+    "char_def.bin",
+    "unk.bin",
+    "matrix.mtx",
+    "dict.da",
+    "dict.vals",
+    "dict.wordsidx",
+    "dict.words",
+];
+
+struct DictionarySpec {
+    name: &'static str,
+    output_dir: &'static str,
+    file_name: &'static str,
+    input_dir: &'static str,
+    dummy_input: &'static str,
+    download_urls: &'static [&'static str],
+    md5_hash: &'static str,
+    metadata_json: &'static str,
+}
+
+const DICTIONARIES: &[DictionarySpec] = &[
+    DictionarySpec {
+        name: "cc-cedict",
+        output_dir: "lindera-cc-cedict",
+        file_name: "CC-CEDICT-MeCab-0.1.0-20200409.tar.gz",
+        input_dir: "CC-CEDICT-MeCab-0.1.0-20200409",
+        dummy_input: "测试,0,0,-1131,*,*,*,*,ce4 shi4,測試,测试,to test (machinery etc)/to test (students)/test/quiz/exam/beta (software)/\n",
+        download_urls: &["https://lindera.dev/CC-CEDICT-MeCab-0.1.0-20200409.tar.gz"],
+        md5_hash: "aba9748b70f37feede97b70c5d37f8a0",
+        metadata_json: r#"{
+  "name": "cc-cedict",
+  "encoding": "UTF-8",
+  "compress_algorithm": "raw",
+  "default_word_cost": -10000,
+  "default_left_context_id": 0,
+  "default_right_context_id": 0,
+  "default_field_value": "*",
+  "flexible_csv": true,
+  "skip_invalid_cost_or_id": true,
+  "normalize_details": false,
+  "dictionary_schema": {
+    "fields": [
+      "surface",
+      "left_context_id",
+      "right_context_id",
+      "cost",
+      "part_of_speech",
+      "part_of_speech_subcategory_1",
+      "part_of_speech_subcategory_2",
+      "part_of_speech_subcategory_3",
+      "pinyin",
+      "traditional",
+      "simplified",
+      "definition"
+    ]
+  },
+  "user_dictionary_schema": {
+    "fields": ["surface", "part_of_speech", "pinyin"]
+  }
+}"#,
+    },
+    DictionarySpec {
+        name: "ipadic",
+        output_dir: "lindera-ipadic",
+        file_name: "mecab-ipadic-2.7.0-20250920.tar.gz",
+        input_dir: "mecab-ipadic-2.7.0-20250920",
+        dummy_input: "テスト,1288,1288,-1000,名詞,固有名詞,一般,*,*,*,*,*,*\n",
+        download_urls: &["https://lindera.dev/mecab-ipadic-2.7.0-20250920.tar.gz"],
+        md5_hash: "a95c409f12f1023fce8ef91f991ef042",
+        metadata_json: r#"{
+  "name": "ipadic",
+  "encoding": "UTF-8",
+  "compress_algorithm": "raw",
+  "default_word_cost": -10000,
+  "default_left_context_id": 0,
+  "default_right_context_id": 0,
+  "default_field_value": "*",
+  "flexible_csv": true,
+  "skip_invalid_cost_or_id": false,
+  "normalize_details": true,
+  "dictionary_schema": {
+    "fields": [
+      "surface",
+      "left_context_id",
+      "right_context_id",
+      "cost",
+      "part_of_speech",
+      "part_of_speech_subcategory_1",
+      "part_of_speech_subcategory_2",
+      "part_of_speech_subcategory_3",
+      "conjugation_form",
+      "conjugation_type",
+      "base_form",
+      "reading",
+      "pronunciation"
+    ]
+  },
+  "user_dictionary_schema": {
+    "fields": ["surface", "part_of_speech", "reading"]
+  }
+}"#,
+    },
+    DictionarySpec {
+        name: "ko-dic",
+        output_dir: "lindera-ko-dic",
+        file_name: "mecab-ko-dic-2.1.1-20180720.tar.gz",
+        input_dir: "mecab-ko-dic-2.1.1-20180720",
+        dummy_input: "테스트,1785,3543,4721,NNG,행위,F,테스트,*,*,*,*\n",
+        download_urls: &["https://lindera.dev/mecab-ko-dic-2.1.1-20180720.tar.gz"],
+        md5_hash: "b996764e91c96bc89dc32ea208514a96",
+        metadata_json: r#"{
+  "name": "ko-dic",
+  "encoding": "UTF-8",
+  "compress_algorithm": "raw",
+  "default_word_cost": -10000,
+  "default_left_context_id": 0,
+  "default_right_context_id": 0,
+  "default_field_value": "*",
+  "flexible_csv": false,
+  "skip_invalid_cost_or_id": false,
+  "normalize_details": false,
+  "dictionary_schema": {
+    "fields": [
+      "surface",
+      "left_context_id",
+      "right_context_id",
+      "cost",
+      "part_of_speech_tag",
+      "meaning",
+      "presence_absence",
+      "reading",
+      "type",
+      "first_part_of_speech",
+      "last_part_of_speech",
+      "expression"
+    ]
+  },
+  "user_dictionary_schema": {
+    "fields": ["surface", "part_of_speech_tag", "reading"]
+  }
+}"#,
+    },
+];
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> anyhow::Result<()> {
+    let destination = env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .context("usage: lindera-dict-builder <destination-root>")?;
+    let cache_root = env::var_os("LINDERA_CACHE")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("target/lindera-dict-cache"));
+
+    env::set_var("LINDERA_CACHE", &cache_root);
+    env::set_var("CARGO_PKG_VERSION", LINDERA_VERSION);
+
+    for dictionary in DICTIONARIES {
+        build_dictionary(dictionary, &cache_root, &destination).await?;
+    }
+
+    Ok(())
+}
+
+async fn build_dictionary(
+    dictionary: &DictionarySpec,
+    cache_root: &Path,
+    destination_root: &Path,
+) -> anyhow::Result<()> {
+    let cache_dir = cache_root.join(LINDERA_VERSION).join(dictionary.output_dir);
+    let already_ready = mmap_dictionary_ready(&cache_dir)?;
+    if !already_ready {
+        let _ = fs::remove_dir_all(&cache_dir);
+    }
+
+    let mut metadata: Metadata = serde_json::from_str(dictionary.metadata_json)
+        .with_context(|| format!("failed to parse {} metadata", dictionary.name))?;
+    metadata.compress_algorithm = Algorithm::Raw;
+
+    let builder = DictionaryBuilder::new(metadata);
+    fetch(
+        FetchParams {
+            file_name: dictionary.file_name,
+            input_dir: dictionary.input_dir,
+            output_dir: dictionary.output_dir,
+            dummy_input: dictionary.dummy_input,
+            download_urls: dictionary.download_urls,
+            md5_hash: dictionary.md5_hash,
+        },
+        builder,
+    )
+    .await
+    .with_context(|| format!("failed to build {} dictionary", dictionary.name))?;
+
+    if !already_ready {
+        prepare_for_lindera_mmap(&cache_dir)?;
+    }
+
+    if !mmap_dictionary_ready(&cache_dir)? {
+        bail!(
+            "built {} dictionary at {} is incomplete or not mmap-ready",
+            dictionary.name,
+            cache_dir.display()
+        );
+    }
+
+    copy_dictionary(&cache_dir, &destination_root.join(dictionary.name))
+        .with_context(|| format!("failed to install {} dictionary", dictionary.name))
+}
+
+fn mmap_dictionary_ready(path: &Path) -> anyhow::Result<bool> {
+    if !path.join(READY_MARKER).is_file()
+        || !path.is_dir()
+        || !COMPONENT_FILES.iter().all(|file| path.join(file).is_file())
+    {
+        return Ok(false);
+    }
+
+    let metadata = fs::read(path.join("metadata.json"))
+        .with_context(|| format!("failed to read metadata from {}", path.display()))?;
+    let metadata: Metadata = serde_json::from_slice(&metadata)
+        .with_context(|| format!("failed to parse metadata from {}", path.display()))?;
+
+    Ok(metadata.compress_algorithm == Algorithm::Raw)
+}
+
+fn prepare_for_lindera_mmap(path: &Path) -> anyhow::Result<()> {
+    // Lindera's mmap path only maps the large matrix/prefix-dictionary files.
+    // Character definitions and unknown-word data still use the compression-aware
+    // loader, so wrap those two files as raw CompressedData and leave the mmap
+    // files in their original raw format.
+    wrap_for_compress_loader(&path.join("char_def.bin"))?;
+    wrap_for_compress_loader(&path.join("unk.bin"))?;
+    fs::write(path.join(READY_MARKER), [])
+        .with_context(|| format!("failed to write marker in {}", path.display()))
+}
+
+fn wrap_for_compress_loader(path: &Path) -> anyhow::Result<()> {
+    let data =
+        fs::read(path).with_context(|| format!("failed to read component {}", path.display()))?;
+    let wrapped = CompressedData::new(Algorithm::Raw, data);
+    let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&wrapped)
+        .with_context(|| format!("failed to serialize component {}", path.display()))?;
+
+    fs::write(path, bytes).with_context(|| format!("failed to write component {}", path.display()))
+}
+
+fn copy_dictionary(source: &Path, destination: &Path) -> anyhow::Result<()> {
+    let _ = fs::remove_dir_all(destination);
+    fs::create_dir_all(destination)
+        .with_context(|| format!("failed to create {}", destination.display()))?;
+
+    for component in COMPONENT_FILES {
+        fs::copy(source.join(component), destination.join(component)).with_context(|| {
+            format!(
+                "failed to copy {} to {}",
+                source.join(component).display(),
+                destination.join(component).display()
+            )
+        })?;
+    }
+
+    Ok(())
+}

--- a/tools/lindera-dict-builder/src/main.rs
+++ b/tools/lindera-dict-builder/src/main.rs
@@ -25,9 +25,13 @@ use lindera_dictionary::builder::DictionaryBuilder;
 use lindera_dictionary::decompress::{Algorithm, CompressedData};
 use lindera_dictionary::dictionary::metadata::Metadata;
 
+// Keep this in sync with the exact lindera-dictionary dependency version in
+// this crate's Cargo.toml; it is part of the cache key for generated files.
 const LINDERA_VERSION: &str = "1.5.1";
 const READY_MARKER: &str = ".paradedb-lindera-mmap-ready";
 
+// Must stay in sync with tokenizers/src/lindera_mmap.rs and with
+// lindera-dictionary's mmap component layout for the pinned Lindera version.
 const COMPONENT_FILES: &[&str] = &[
     "metadata.json",
     "char_def.bin",
@@ -50,6 +54,9 @@ struct DictionarySpec {
     metadata_json: &'static str,
 }
 
+// These metadata blobs are copied from the lindera-cc-cedict, lindera-ipadic,
+// and lindera-ko-dic 1.5.1 crates, with compress_algorithm set to "raw". When
+// bumping Lindera, recopy the upstream metadata for the same crate versions.
 const DICTIONARIES: &[DictionarySpec] = &[
     DictionarySpec {
         name: "cc-cedict",
@@ -270,11 +277,19 @@ fn prepare_for_lindera_mmap(path: &Path) -> anyhow::Result<()> {
 fn wrap_for_compress_loader(path: &Path) -> anyhow::Result<()> {
     let data =
         fs::read(path).with_context(|| format!("failed to read component {}", path.display()))?;
+    if compressed_data_ready(&data) {
+        return Ok(());
+    }
+
     let wrapped = CompressedData::new(Algorithm::Raw, data);
     let bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&wrapped)
         .with_context(|| format!("failed to serialize component {}", path.display()))?;
 
     fs::write(path, bytes).with_context(|| format!("failed to write component {}", path.display()))
+}
+
+fn compressed_data_ready(data: &[u8]) -> bool {
+    rkyv::from_bytes::<CompressedData, rkyv::rancor::Error>(data).is_ok()
 }
 
 fn copy_dictionary(source: &Path, destination: &Path) -> anyhow::Result<()> {
@@ -293,4 +308,18 @@ fn copy_dictionary(source: &Path, destination: &Path) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn compressed_data_ready_detects_already_wrapped_bytes() {
+        let wrapped = CompressedData::new(Algorithm::Raw, b"component bytes".to_vec());
+        let wrapped_bytes = rkyv::to_bytes::<rkyv::rancor::Error>(&wrapped).unwrap();
+
+        assert!(compressed_data_ready(&wrapped_bytes));
+        assert!(!compressed_data_ready(b"component bytes"));
+    }
 }


### PR DESCRIPTION
## Problem

Issue #4840 shows that parallel workers repeatedly pay the cold-start cost for dictionary-backed tokenizers. This PR addresses the Lindera part: `korean_lindera`, `japanese_lindera`, and `chinese_lindera` no longer decode embedded dictionaries into each worker process private heap. Jieba remains a separate follow-up.

Before this change, pg_search compiled Lindera dictionaries into the binary and loaded them through `embedded://...`. That still required each backend or parallel worker to decompress/deserialize the embedded bytes into a runtime `Dictionary` object on first use.

## Design

This PR treats Lindera dictionaries as installed extension data files instead of runtime-generated state.

- A new repo-local `lindera-dict-builder` tool uses Lindera dictionary-building APIs to build `cc-cedict`, `ipadic`, and `ko-dic` component files.
- Install/package hooks place those files under `$sharedir/extension/pg_search/lindera`.
- `_PG_init` configures that dictionary root for pg_search.
- Runtime tokenizers call `Dictionary::load_from_path_with_options(path, true)` so Lindera mmap-loads the installed files.

Resulting flow:

```text
package/install time:
  build Lindera dictionary files
  install them with the extension

runtime:
  open installed dictionary files
  mmap-load large components
  create small per-process Dictionary wrappers backed by shared file pages
```

## Why Preinstalled Files Instead Of Runtime Creation

We also explored materializing mmap files at runtime from embedded dictionaries. This PR intentionally avoids that model.

Runtime materialization would require Postgres startup/runtime code to:

- keep embedded dictionaries in the binary,
- fork or otherwise isolate the expensive decode step,
- write large dictionary files into a cluster directory,
- manage temp files and atomic renames,
- handle interrupted `waitpid` calls,
- maintain marker/version readiness logic,
- repair partial or stale materializations.

That makes startup correctness depend on runtime file creation and introduces race/repair paths that are hard to reason about in PostgreSQL process lifecycles.

The preinstalled-files model keeps runtime read-only. Package/install owns the data-file generation, and backends/workers only validate and mmap-load files that are already installed. This is a cleaner compatibility boundary: the pg_search binary and the Lindera dictionary file format are shipped together by the same package version. Future upgrades can replace the installed dictionary files with the extension, instead of leaving stale runtime-generated files in `$PGDATA` that need invalidation and cleanup.

## Invariants

- Runtime does not materialize or write Lindera dictionary files.
- Runtime requires every expected Lindera component file before loading.
- Installed dictionary root is `$sharedir/extension/pg_search/lindera`, with `PARADEDB_LINDERA_DICT_ROOT` available for tests and standalone tokenizer use.
- Existing tokenizer names and index/query configuration remain unchanged.
- Package builds stage the same final installed layout under the pgrx package root.

## Tests

- `DATABASE_URL=postgres:///postgres cargo test -p tests --test lindera -- --nocapture` (`12 passed`)

## Manual Validation

Validated Korean, Japanese, and Chinese Lindera BM25 indexes with parallel `paradedb.match` queries. Plans launched workers and loaded dictionaries from installed mmap files.

Partially addresses #4840 for Lindera tokenizers.