### PR TITLE
refactor(mpp): drop PgSearchPhysicalCodecStub

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=650c530#650c5307507cb4d79fc0e06b4a545a5bac04d68a"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=0fb382d#0fb382ddc17c154cabb30ab764789c0ef8328ffb"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=0fb382d#0fb382ddc17c154cabb30ab764789c0ef8328ffb"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=2b8354d#2b8354dd80904308505b6704208b719bdc3d8f47"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2817,7 +2817,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6523,7 +6523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7291,7 +7291,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7349,7 +7349,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7769,7 +7769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8404,7 +8404,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9433,7 +9433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=2b8354d#2b8354dd80904308505b6704208b719bdc3d8f47"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=4471148#4471148fe26f8f159aac0506facf7e0beaeeaf08"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2817,7 +2817,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6523,7 +6523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7291,7 +7291,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7349,7 +7349,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7769,7 +7769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8404,7 +8404,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9433,7 +9433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=4471148#4471148fe26f8f159aac0506facf7e0beaeeaf08"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=c618b5a#c618b5a620f1eea793df66ae82c3f340f367cbf5"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2817,7 +2817,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6523,7 +6523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7291,7 +7291,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7349,7 +7349,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7769,7 +7769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8404,7 +8404,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9433,7 +9433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-M+351QJX1GXAux416MM71/vN2F1ikiu4m7/BLEqmCf8=";
+  cargoHash = "sha256-f9vV9t/Vwd6Jdn8frTiDBagFx3ryn2XN1y0GS6A4sMo=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "2b8354d" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "4471148" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "4471148" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "c618b5a" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "0fb382d" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "2b8354d" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "650c530" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "0fb382d" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1988,7 +1988,7 @@ unsafe fn replace_aggrefs_in_target_list(plan: *mut pg_sys::Plan) {
         // For all other nodes, use the standard mutator to walk children
         #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
         {
-            let fnptr = aggref_mutator as usize as *const ();
+            let fnptr = aggref_mutator as *const ();
             let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
                 std::mem::transmute(fnptr);
             pg_sys::expression_tree_mutator(node, Some(mutator), context)

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -53,7 +53,7 @@ use crate::postgres::customscan::mpp::worker_fragments::{
 };
 use crate::postgres::customscan::parallel::list_segment_ids;
 use crate::postgres::ParallelScanState;
-use crate::scan::codec::{deserialize_logical_plan_with_runtime, PgSearchPhysicalCodecStub};
+use crate::scan::codec::deserialize_logical_plan_with_runtime;
 
 /// Bundle of inputs the worker dispatcher needs. Per-scan `exec_mpp_worker` wrappers populate
 /// this from their typed state and hand it to [`run_mpp_worker`].
@@ -127,7 +127,20 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        .with_distributed_user_codec(PgSearchPhysicalCodecStub)
+        // No `with_distributed_user_codec(...)` line is needed because:
+        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
+        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
+        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
+        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
+        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
+        //       re-plan from the logical plan we ship via DSM and never decode a physical
+        //       subplan over the wire.
+        //
+        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
+        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
+        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
+        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
+        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -127,20 +127,6 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)` line is needed because:
-        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
-        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
-        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
-        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
-        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
-        //       re-plan from the logical plan we ship via DSM and never decode a physical
-        //       subplan over the wire.
-        //
-        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
-        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
-        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
-        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
-        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -435,10 +435,11 @@ pub struct MppSender {
     /// per-call: each partition gets its own `MppSender` via `clone_with_header`, all sharing
     /// the underlying `Arc<dyn BatchChannelSender>` of a single shm_mq queue.
     header: MppFrameHeader,
-    /// Scratch buffer reused across every `encode_frame_into` on this sender. Sized by the first
-    /// batch; subsequent batches clear and re-fill without reallocating. Interior mutability
-    /// lets the caller keep the `&self` signature (senders live inside `ShuffleWiring` behind a
-    /// shared borrow during `process_batch`).
+    /// Scratch buffer reused across every `encode_frame_into` on this sender. Sized by the
+    /// first batch; subsequent batches clear and re-fill without reallocating. Interior
+    /// mutability lets the caller keep the `&self` signature (each producer fragment holds
+    /// its `MppSender` clones behind shared borrows for the duration of
+    /// `worker::run_worker_fragment`).
     scratch: std::cell::RefCell<Vec<u8>>,
 }
 

--- a/pg_search/src/postgres/customscan/projections.rs
+++ b/pg_search/src/postgres/customscan/projections.rs
@@ -139,7 +139,7 @@ pub(crate) unsafe fn create_placeholder_targetlist(
         // For all other nodes, use the standard mutator to walk children
         #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
         {
-            let fnptr = const_placeholder_mutator as usize as *const ();
+            let fnptr = const_placeholder_mutator as *const ();
             let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
                 std::mem::transmute(fnptr);
             pg_sys::expression_tree_mutator(node, Some(mutator), context)
@@ -574,7 +574,7 @@ pub unsafe fn inject_placeholders(
 
         #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
         {
-            let fnptr = walker as usize as *const ();
+            let fnptr = walker as *const ();
             let walker: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
                 std::mem::transmute(fnptr);
             pg_sys::expression_tree_mutator(node, Some(walker), context)

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -23,9 +23,7 @@ use datafusion::common::{DFSchemaRef, DataFusionError, Result, TableReference};
 use datafusion::execution::TaskContext;
 use datafusion::functions_aggregate as dfa;
 use datafusion::logical_expr::{AggregateUDF, Extension, LogicalPlan, ScalarUDF};
-use datafusion::physical_plan::ExecutionPlan;
 use datafusion_proto::logical_plan::LogicalExtensionCodec;
-use datafusion_proto::physical_plan::PhysicalExtensionCodec;
 use datafusion_proto::protobuf::DfSchema;
 use pgrx::pg_sys::{ExprContext, Oid, PlanState};
 use tantivy::index::SegmentId;
@@ -376,53 +374,4 @@ pub fn deserialize_logical_plan_with_runtime(
         index_segment_ids,
     };
     datafusion_proto::bytes::logical_plan_from_bytes_with_extension_codec(bytes, ctx, &codec)
-}
-
-/// Stub `PhysicalExtensionCodec` registered with the fork's distributed planner
-/// (via `with_distributed_user_codec`). The fork's `DistributedExec::prepare_plan`
-/// always tries to serialize the worker subplan to ship over gRPC, even when the
-/// `WorkerTransport` is in-process (our `ShmMqWorkerTransport`). Without a codec
-/// for our custom physical execs, encoding fails before any execution starts.
-///
-/// In our model, workers re-plan from the **logical** plan we ship via DSM (see
-/// `exec_mpp_worker`); they never deserialize the encoded physical plan, and the
-/// gRPC plan-send to the fake `http://mpp.local/` URL fails silently in the
-/// fork's `JoinSet` without affecting correctness. So this codec only needs
-/// `try_encode` to succeed for the leader's physical plan walker — the encoded
-/// bytes are inert. `try_decode` is unreachable in our setup.
-#[derive(Debug)]
-pub struct PgSearchPhysicalCodecStub;
-
-impl PhysicalExtensionCodec for PgSearchPhysicalCodecStub {
-    fn try_decode(
-        &self,
-        _buf: &[u8],
-        _inputs: &[Arc<dyn ExecutionPlan>],
-        _ctx: &TaskContext,
-    ) -> Result<Arc<dyn ExecutionPlan>> {
-        Err(DataFusionError::Internal(
-            "PgSearchPhysicalCodecStub::try_decode invoked; \
-             workers re-plan from the logical plan in DSM and should never \
-             deserialize a physical subplan over the wire"
-                .into(),
-        ))
-    }
-
-    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, _buf: &mut Vec<u8>) -> Result<()> {
-        // Recognize every custom physical exec we might emit. Encode to empty
-        // bytes; the encoded plan is shipped to a stub URL that no real worker
-        // listens on, so the bytes themselves are never observed.
-        match node.name() {
-            "PgSearchScan"
-            | "VisibilityFilterExec"
-            | "VisibilityFilter"
-            | "VisibilityFilterInjection"
-            | "SegmentedTopKExec"
-            | "TantivyLookupExec"
-            | "FilterPassthroughExec" => Ok(()),
-            other => Err(DataFusionError::Internal(format!(
-                "PgSearchPhysicalCodecStub::try_encode: unrecognized custom exec {other}"
-            ))),
-        }
-    }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Deletes `PgSearchPhysicalCodecStub` and the `.with_distributed_user_codec(...)` registration. Cleans up a couple of orphan imports in `codec.rs`.

## Why

The codec was a stub. Workers re-plan from the logical plan in DSM, so they never actually deserialize the encoded physical bytes. But the encode still ran inside `CoordinatorToWorkerTaskSpawner::new` and would've blown up if our codec didn't claim every custom exec.

Fork PR paradedb/datafusion-distributed#8 now gates that encode behind `!in_process_mode`, so the stub has no reason to exist.

## How

- Bump `datafusion-distributed` rev so the spawner is only constructed when `!in_process_mode`.
- Delete `PgSearchPhysicalCodecStub` (struct + impl + doc).
- Drop `.with_distributed_user_codec(...)` from `build_mpp_session_context` plus the import.
- Tighten the surrounding comment so it's clear what would need to come back if we ever flip `in_process_mode = false`.

Depends on paradedb/datafusion-distributed#8. Before merging, re-pin the fork rev from the PR branch HEAD to the post-merge fork-`main` SHA.

## Tests

- `mpp_smoke`, `mpp_joinscan`, `mpp_aggregate`, `mpp_aggregate_postagg` all pass on pgrx-arm64.
- CI green.
