### PR TITLE
refactor(mpp): switch worker_fragments to NetworkBoundaryKind enum match

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=593e8f4#593e8f46429449e3c3d42c643e9d0712d8e8f937"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=340ceb5#340ceb52a10415ea5c81ba0de2541326faccedca"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2817,7 +2817,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6523,7 +6523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7291,7 +7291,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7349,7 +7349,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7769,7 +7769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8404,7 +8404,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9433,7 +9433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=c618b5a#c618b5a620f1eea793df66ae82c3f340f367cbf5"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=593e8f4#593e8f46429449e3c3d42c643e9d0712d8e8f937"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2817,7 +2817,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3130,7 +3130,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4368,7 +4368,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5518,7 +5518,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6523,7 +6523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7291,7 +7291,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7349,7 +7349,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7769,7 +7769,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8404,7 +8404,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9433,7 +9433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-f9vV9t/Vwd6Jdn8frTiDBagFx3ryn2XN1y0GS6A4sMo=";
+  cargoHash = "sha256-Huc2l4akIToBdlEwdwpy2yoftKfwonJX02GctUgVaug=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "593e8f4" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "340ceb5" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "c618b5a" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "593e8f4" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -183,26 +183,22 @@ fn collect(
         // receive-side formula `off = P_c * task_index`.
         let p_c = plan.properties().partitioning.partition_count();
 
-        // Classify by `(boundary_kind, top_level)`. Upstream DF-D dispatches producers via gRPC
-        // keyed on the resolver's URLs, so worker code never has to decide where a producer's
-        // output partitions land. We don't have URLs: each shm_mq peer is push-driven, and the
-        // dispatcher here picks the destination proc for every output partition. The routing
-        // math differs by boundary kind (Shuffle / Broadcast share receive-side math but
-        // Broadcast caps to task 0; Coalesce collapses to one consumer task), and the
-        // top-level case (`nested == false`) routes to the leader.
+        // Classify by `(boundary_kind, top_level)` and pick a destination proc for every
+        // output partition. The fork's gRPC path keys dispatch on resolver URLs and never
+        // has to decide this; our shm_mq peers are push-driven without URLs, so the
+        // dispatcher has to. Shuffle and Broadcast share the receive-side math but Broadcast
+        // caps to task 0; Coalesce collapses to one consumer task; top-level (`nested ==
+        // false`) routes to the leader.
         //
-        // `nb.kind()` returns a typed enum from the DF-D fork
-        // (paradedb/datafusion-distributed#9), replacing the older `plan.name()` string match.
-        // A future fork rename of any of the three exec types is now a compile error here.
-        // `NetworkBoundaryKind` is `#[non_exhaustive]`, so the `_ =>` arm at the end is
-        // required and serves as the drift detector for a future fork-side variant addition.
+        // `NetworkBoundaryKind` is `#[non_exhaustive]`, so the catch-all `_ =>` arm is
+        // required. It also surfaces any future fork variant we haven't reasoned about.
         let routing = match (kind, nested) {
-            // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan plan
-            // produces (broadcast is always nested inside the HashJoin build subtree). Falling
-            // through to `Coalesce { dest_proc: 0 }` would silently send every input task's
+            // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan
+            // plan produces; broadcast always sits nested inside the HashJoin build subtree.
+            // Falling through to `Coalesce { dest_proc: 0 }` would send every input task's
             // full canonical replica to the leader and `select_all` would over-count by
-            // `input_task_count`. Surface it as an error so a future planner change that hits
-            // this shape doesn't silently produce wrong answers.
+            // `input_task_count`. Fail loudly so a future planner change that hits this
+            // shape can't silently produce wrong answers.
             (NetworkBoundaryKind::Broadcast, false) => {
                 crate::postgres::customscan::mpp::fail_loud(format!(
                     "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
@@ -210,13 +206,12 @@ fn collect(
                      produce this shape; route via a NetworkCoalesceExec gather instead."
                 ))
             }
-            // Top-level NetworkShuffleExec is also not a shape any of our customscan plans
-            // produce — shuffles emit hash-partitioned output into a parent consumer stage,
-            // not directly into the leader. Routing the partitions through
-            // `Coalesce { dest_proc: 0 }` would technically work (`select_all` would receive
-            // every batch exactly once) but it would be silently treating a hash-partitioned
-            // output as one logical stream, masking a planner anomaly. Mirror the top-level
-            // Broadcast stance: fail loudly so a future planner change is visible.
+            // Top-level NetworkShuffleExec isn't a shape our customscan plans produce
+            // either. Shuffles emit hash-partitioned output into a parent consumer stage,
+            // not directly into the leader. Coalescing the partitions to proc 0 would
+            // technically work (each batch reaches `select_all` exactly once) but it would
+            // mask a planner anomaly by silently treating hash-partitioned output as one
+            // logical stream. Same stance as the Broadcast case above.
             (NetworkBoundaryKind::Shuffle, false) => {
                 crate::postgres::customscan::mpp::fail_loud(format!(
                     "mpp worker_fragments: top-level NetworkShuffleExec is unsupported \
@@ -243,14 +238,12 @@ fn collect(
             (NetworkBoundaryKind::Coalesce, true) => FragmentRouting::Coalesce {
                 dest_proc: proc_for_task(n_workers, 0),
             },
-            // `NetworkBoundaryKind` is `#[non_exhaustive]`. This arm catches any variant the
-            // fork adds in a future release that we haven't reasoned about yet. Fail loudly
-            // rather than guess at routing — the alternative (a default destination) would
-            // silently produce wrong answers under a shape we haven't seen.
+            // Catch-all for `#[non_exhaustive]` future variants. Fail loudly rather than
+            // guess routing; a default destination would silently produce wrong answers
+            // under a shape we haven't seen.
             _ => crate::postgres::customscan::mpp::fail_loud(format!(
                 "mpp worker_fragments: unrecognized NetworkBoundaryKind {kind:?} \
-                 (stage_id={stage_id}). The DF-D fork has added a variant the embedder \
-                 hasn't been updated for; add a routing arm before bumping the rev."
+                 (stage_id={stage_id}). Add a routing arm before bumping the fork rev."
             )),
         };
         #[cfg(not(test))]

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -43,7 +43,7 @@ use std::sync::Arc;
 use datafusion::physical_plan::ExecutionPlan;
 #[cfg(not(test))]
 use datafusion::physical_plan::ExecutionPlanProperties;
-use datafusion_distributed::NetworkBoundaryExt;
+use datafusion_distributed::{NetworkBoundaryExt, NetworkBoundaryKind};
 
 use crate::postgres::customscan::mpp::runtime::proc_for_task;
 
@@ -178,66 +178,85 @@ fn collect(
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
         let stage_id = stage.num() as u32;
-        let name = plan.name();
+        let kind = nb.kind();
         // Per-consumer-task partition count from upstream's `NetworkShuffleExec::execute`
         // receive-side formula `off = P_c * task_index`.
         let p_c = plan.properties().partitioning.partition_count();
 
-        // Why we classify by `(boundary_kind, top_level)`. Upstream DF-D dispatches producers via
-        // gRPC keyed on the resolver's URLs, so worker code never has to decide where a producer's
+        // Classify by `(boundary_kind, top_level)`. Upstream DF-D dispatches producers via gRPC
+        // keyed on the resolver's URLs, so worker code never has to decide where a producer's
         // output partitions land. We don't have URLs: each shm_mq peer is push-driven, and the
-        // dispatcher here picks the destination proc for every output partition. The routing math
-        // differs by boundary kind (Shuffle / Broadcast share receive-side math but Broadcast caps
-        // to task 0; Coalesce collapses to one consumer task), and the top-level case routes to
-        // the leader.
-        let routing = match (name, nested) {
+        // dispatcher here picks the destination proc for every output partition. The routing
+        // math differs by boundary kind (Shuffle / Broadcast share receive-side math but
+        // Broadcast caps to task 0; Coalesce collapses to one consumer task), and the
+        // top-level case (`nested == false`) routes to the leader.
+        //
+        // `nb.kind()` returns a typed enum from the DF-D fork
+        // (paradedb/datafusion-distributed#9), replacing the older `plan.name()` string match.
+        // A future fork rename of any of the three exec types is now a compile error here.
+        // `NetworkBoundaryKind` is `#[non_exhaustive]`, so the `_ =>` arm at the end is
+        // required and serves as the drift detector for a future fork-side variant addition.
+        let routing = match (kind, nested) {
             // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan plan
             // produces (broadcast is always nested inside the HashJoin build subtree). Falling
-            // through to `Coalesce { dest_proc: 0 }` would silently send every input task's full
-            // canonical replica to the leader and `select_all` would over-count by
+            // through to `Coalesce { dest_proc: 0 }` would silently send every input task's
+            // full canonical replica to the leader and `select_all` would over-count by
             // `input_task_count`. Surface it as an error so a future planner change that hits
             // this shape doesn't silently produce wrong answers.
-            ("NetworkBroadcastExec", false) => {
+            (NetworkBoundaryKind::Broadcast, false) => {
                 crate::postgres::customscan::mpp::fail_loud(format!(
                     "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
                      (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
                      produce this shape; route via a NetworkCoalesceExec gather instead."
                 ))
             }
-            // Top-level boundary (gather to leader): consumer is leader proc 0.
-            (_, false) => FragmentRouting::Coalesce { dest_proc: 0 },
-            // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps to
-            // consumer task q / p_c.
-            ("NetworkShuffleExec", true) => FragmentRouting::Shuffle {
+            // Top-level NetworkShuffleExec is also not a shape any of our customscan plans
+            // produce — shuffles emit hash-partitioned output into a parent consumer stage,
+            // not directly into the leader. Routing the partitions through
+            // `Coalesce { dest_proc: 0 }` would technically work (`select_all` would receive
+            // every batch exactly once) but it would be silently treating a hash-partitioned
+            // output as one logical stream, masking a planner anomaly. Mirror the top-level
+            // Broadcast stance: fail loudly so a future planner change is visible.
+            (NetworkBoundaryKind::Shuffle, false) => {
+                crate::postgres::customscan::mpp::fail_loud(format!(
+                    "mpp worker_fragments: top-level NetworkShuffleExec is unsupported \
+                     (stage_id={stage_id}). Shuffles emit hash-partitioned output into a \
+                     parent consumer stage; a top-level shuffle is a planner anomaly."
+                ))
+            }
+            // Top-level NetworkCoalesceExec (gather to leader): consumer is leader proc 0.
+            (NetworkBoundaryKind::Coalesce, false) => FragmentRouting::Coalesce { dest_proc: 0 },
+            // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps
+            // to consumer task q / p_c.
+            (NetworkBoundaryKind::Shuffle, true) => FragmentRouting::Shuffle {
                 partitions_per_consumer_task: p_c,
             },
-            // Nested NetworkBroadcastExec: same wire-level math as Shuffle, but the dispatcher
-            // only runs the producer plan on task 0 to avoid the canonical-replica duplication
-            // described on `FragmentRouting::Broadcast`.
-            ("NetworkBroadcastExec", true) => FragmentRouting::Broadcast {
+            // Nested NetworkBroadcastExec: same wire-level math as Shuffle, but the
+            // dispatcher only runs the producer plan on task 0 to avoid the canonical-replica
+            // duplication described on `FragmentRouting::Broadcast`.
+            (NetworkBoundaryKind::Broadcast, true) => FragmentRouting::Broadcast {
                 partitions_per_consumer_task: p_c,
             },
             // Nested NetworkCoalesceExec: consumer is a single task in the parent stage. The
             // receive math collapses to task 0 of the parent group, so the destination proc is
             // `proc_for_task(n_workers, 0)`.
-            ("NetworkCoalesceExec", true) => FragmentRouting::Coalesce {
+            (NetworkBoundaryKind::Coalesce, true) => FragmentRouting::Coalesce {
                 dest_proc: proc_for_task(n_workers, 0),
             },
-            // Any other nested boundary kind is unknown territory. Fall through to a hard error
-            // rather than silently routing to task 0 of `proc_for_task`, which would over-count
-            // or drop batches for a shape we haven't reasoned about. Surface as error so
-            // plan-walk drift is visible.
-            (other, true) => crate::postgres::customscan::mpp::fail_loud(format!(
-                "mpp worker_fragments: unsupported nested boundary kind {other} \
-                 (stage_id={stage_id}). Only NetworkShuffleExec, NetworkBroadcastExec, \
-                 and NetworkCoalesceExec are recognised; routing this shape would silently \
-                 mis-route batches."
+            // `NetworkBoundaryKind` is `#[non_exhaustive]`. This arm catches any variant the
+            // fork adds in a future release that we haven't reasoned about yet. Fail loudly
+            // rather than guess at routing — the alternative (a default destination) would
+            // silently produce wrong answers under a shape we haven't seen.
+            _ => crate::postgres::customscan::mpp::fail_loud(format!(
+                "mpp worker_fragments: unrecognized NetworkBoundaryKind {kind:?} \
+                 (stage_id={stage_id}). The DF-D fork has added a variant the embedder \
+                 hasn't been updated for; add a routing arm before bumping the rev."
             )),
         };
         #[cfg(not(test))]
         {
             crate::mpp_log!(
-                "mpp worker_fragments::collect boundary name={name} stage_id={stage_id} \
+                "mpp worker_fragments::collect boundary kind={kind:?} stage_id={stage_id} \
                  p_c={p_c} nested={nested}"
             );
         }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Switches `worker_fragments::collect` from a `plan.name()` string match to a typed `NetworkBoundaryKind` enum match.

## Why

String-matching against fork-internal type names was fragile. If the fork ever renamed `NetworkShuffleExec` (or either of the other two), our walker would silently fall through to the "unsupported nested boundary kind" arm and refuse to classify the boundary at runtime. Fork PR paradedb/datafusion-distributed#9 exposes `kind()`, so a rename surfaces as a compile error here instead.

## How

- Replace the string match with `nb.kind()` enum match.
- Split the wildcard top-level arm into explicit `(Coalesce, false)` and `(Shuffle, false) => fail_loud(...)`. Mirrors the existing top-level Broadcast guard. A top-level shuffle is a planner anomaly worth surfacing.
- Add a `_ => fail_loud(...)` catch-all for the fork's `#[non_exhaustive]` enum. Doubles as a drift detector if the fork adds a new variant.

## Tests

- `mpp_smoke`, `mpp_joinscan`, `mpp_aggregate`, `mpp_aggregate_postagg` all pass on pgrx-arm64.
- CI green.
