### PR TITLE
docs: Inject ParadeDB Organization JSON-LD on docs site

### DIFF
--- a/docs/override.js
+++ b/docs/override.js
@@ -3,3 +3,50 @@ if (input) {
   input.placeholder =
     "Powered by Mintlify, the documentation platform of tomorrow";
 }
+
+// Inject ParadeDB Organization structured data. Mintlify auto-emits only a
+// generic WebSite node (whose creator is Mintlify), so the docs otherwise have
+// no ParadeDB identity markup. Reusing the same @id as paradedb.com lets search
+// engines and agents treat both sites as one Organization entity.
+(function () {
+  if (document.querySelector("script[data-paradedb-org]")) return;
+
+  const organization = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": "https://www.paradedb.com/#organization",
+    name: "ParadeDB",
+    legalName: "ParadeDB, Inc.",
+    url: "https://www.paradedb.com",
+    logo: {
+      "@type": "ImageObject",
+      url: "https://www.paradedb.com/brand/paradedb-logo-light.svg",
+    },
+    description:
+      "You want better search, not the burden of Elasticsearch. ParadeDB is the modern Elastic alternative built as a Postgres extension.",
+    email: "hello@paradedb.com",
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        contactType: "customer support",
+        email: "support@paradedb.com",
+      },
+      {
+        "@type": "ContactPoint",
+        contactType: "sales",
+        email: "sales@paradedb.com",
+      },
+    ],
+    sameAs: [
+      "https://github.com/paradedb",
+      "https://x.com/paradedb",
+      "https://www.linkedin.com/company/paradedb",
+    ],
+  };
+
+  const script = document.createElement("script");
+  script.type = "application/ld+json";
+  script.setAttribute("data-paradedb-org", "");
+  script.textContent = JSON.stringify(organization);
+  document.head.appendChild(script);
+})();


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Inject a ParadeDB `Organization` JSON-LD node into the docs site via `docs/override.js`.

## Why

Part of an agent-readiness / SEO effort (see paradedb/website #305–#308). Mintlify auto-emits only a generic `WebSite` JSON-LD node whose `creator` is **Mintlify** — the docs site has **no ParadeDB identity markup**. `docs.json`'s `seo.metatags` can't express JSON-LD, so `override.js` (already loaded by Mintlify) is the supported injection point.

The node reuses the same `@id` (`https://www.paradedb.com/#organization`) as the marketing site's Organization schema, so search engines and agents treat both domains as one entity.

## How

**`docs/override.js`**

- Keep the existing search-input placeholder tweak.
- Append a `<script type="application/ld+json">` with a ParadeDB `Organization` (name, legalName, url, logo, description, `email`, `contactPoint` for support/sales, and `sameAs` → GitHub org / X / LinkedIn).
- Guarded by a `data-paradedb-org` marker so it's injected at most once.

## Tests

- `prettier --check docs/override.js` passes.
- Verified the live docs currently emit only the generic Mintlify `WebSite` node; this adds the missing ParadeDB `Organization`. (Client-side injection — note non-JS crawlers won't see it, but Google and modern agent crawlers execute JS.)
