### PR TITLE
refactor(mpp): drop MppWorkerResolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5775,7 +5775,6 @@ dependencies = [
  "tokenizers",
  "tokio",
  "typetag",
- "url",
  "uuid",
 ]
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-Huc2l4akIToBdlEwdwpy2yoftKfwonJX02GctUgVaug=";
+  cargoHash = "sha256-L7PUqoiSmXwcF9p51QlIuPZ4h+Hry7Gq+T6xFGzRJhQ=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -79,7 +79,6 @@ bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
 datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "340ceb5" }
-url = "2"
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -42,9 +42,7 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
-use crate::postgres::customscan::mpp::runtime::{
-    proc_for_task, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
-};
+use crate::postgres::customscan::mpp::runtime::{proc_for_task, MppMesh, ShmMqWorkerTransport};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
 use crate::postgres::customscan::mpp::worker::run_worker_fragment;
@@ -113,7 +111,12 @@ pub(crate) fn build_mpp_session_context(
     // distributed-planner knobs on top.
     let state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
-        .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers))
+        // No `with_distributed_worker_resolver(...)` line is needed: fork PR
+        // paradedb/datafusion-distributed#10 made the `WorkerResolver` lookup conditional
+        // on `!in_process_mode`. Workers in our embedding are PG parallel workers in the
+        // same backend tree, not URL-addressed nodes; the fork substitutes a single
+        // placeholder URL internally so its planner's URL plumbing stays satisfied while
+        // we ship no resolver of our own.
         .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
         .with_distributed_in_process_mode(true)
         .expect("with_distributed_in_process_mode")
@@ -127,6 +130,20 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
+        // No `with_distributed_user_codec(...)` line is needed because:
+        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
+        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
+        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
+        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
+        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
+        //       re-plan from the logical plan we ship via DSM and never decode a physical
+        //       subplan over the wire.
+        //
+        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
+        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
+        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
+        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
+        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -111,12 +111,10 @@ pub(crate) fn build_mpp_session_context(
     // distributed-planner knobs on top.
     let state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
-        // No `with_distributed_worker_resolver(...)` line is needed: fork PR
-        // paradedb/datafusion-distributed#10 made the `WorkerResolver` lookup conditional
-        // on `!in_process_mode`. Workers in our embedding are PG parallel workers in the
-        // same backend tree, not URL-addressed nodes; the fork substitutes a single
-        // placeholder URL internally so its planner's URL plumbing stays satisfied while
-        // we ship no resolver of our own.
+        // No `with_distributed_worker_resolver(...)`: under `in_process_mode = true`, the
+        // fork gates the resolver lookup and substitutes a single placeholder URL. Our
+        // "workers" are PG parallel workers in the same backend tree, not URL-addressed
+        // nodes, so we have nothing meaningful to resolve.
         .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
         .with_distributed_in_process_mode(true)
         .expect("with_distributed_in_process_mode")
@@ -130,20 +128,12 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)` line is needed because:
-        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
-        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
-        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
-        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
-        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
-        //       re-plan from the logical plan we ship via DSM and never decode a physical
-        //       subplan over the wire.
-        //
-        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
-        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
-        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
-        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
-        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
+        // No `with_distributed_user_codec(...)`: under `in_process_mode = true`, the fork
+        // skips constructing `CoordinatorToWorkerTaskSpawner`, so its eager codec encode
+        // never runs. Workers re-plan from the logical plan we ship via DSM and never
+        // decode a physical subplan over the wire. If `in_process_mode = false` ever gets
+        // exercised, restore a codec here for our custom execs or `try_encode` will reject
+        // the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -15,22 +15,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Runtime glue between the leader's DataFusion execution and the
-//! shm_mq mesh.
+//! Runtime glue between the leader's DataFusion execution and the shm_mq mesh.
 //!
-//! - [`MppMesh`] — runtime handle the leader builds at DSM-init time,
-//!   carrying one [`crate::postgres::customscan::mpp::transport::DrainHandle`]
-//!   per producer worker for each consumer partition. Installed on the
-//!   leader's `SessionConfig` extensions before plan execution.
-//! - [`ShmMqWorkerTransport`] — implements the DF-D fork's [`WorkerTransport`]
-//!   trait, consulted by `NetworkShuffleExec`/`NetworkCoalesceExec`/
-//!   `NetworkBroadcastExec` at execute time. `open(target_task=worker)`
-//!   returns a [`ShmMqWorkerConnection`] that yields one stream per
-//!   consumer partition from the corresponding [`DrainHandle`].
+//! [`MppMesh`] is the runtime handle the leader builds at DSM-init time. It carries one
+//! [`crate::postgres::customscan::mpp::transport::DrainHandle`] per producer worker for
+//! each consumer partition and gets installed on the leader's `SessionConfig` extensions
+//! before plan execution.
 //!
-//! Fork PR paradedb/datafusion-distributed#10 made the `WorkerResolver` optional under
-//! `in_process_mode = true` (the fork substitutes a single placeholder URL internally), so
-//! we no longer register one here.
+//! [`ShmMqWorkerTransport`] implements the fork's [`WorkerTransport`] trait, consulted by
+//! `NetworkShuffleExec`/`NetworkCoalesceExec`/`NetworkBroadcastExec` at execute time.
+//! `open(target_task=worker)` returns a [`ShmMqWorkerConnection`] that yields one stream
+//! per consumer partition from the matching [`DrainHandle`].
+//!
+//! No `WorkerResolver` impl. Under `in_process_mode = true` the fork makes the resolver
+//! optional and substitutes a placeholder URL internally; our embedding never resolves
+//! anything by URL.
 
 use std::ops::Range;
 use std::sync::Arc;

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -27,22 +27,20 @@
 //!   `NetworkBroadcastExec` at execute time. `open(target_task=worker)`
 //!   returns a [`ShmMqWorkerConnection`] that yields one stream per
 //!   consumer partition from the corresponding [`DrainHandle`].
-//! - [`MppWorkerResolver`] — stub [`WorkerResolver`] returning N dummy
-//!   URLs. The DF-D fork's planner reads `get_urls().len()` to decide cluster
-//!   capacity; we don't have URLs (everything is in-process), so any
-//!   address satisfies the API.
+//!
+//! Fork PR paradedb/datafusion-distributed#10 made the `WorkerResolver` optional under
+//! `in_process_mode = true` (the fork substitutes a single placeholder URL internally), so
+//! we no longer register one here.
 
 use std::ops::Range;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
 use datafusion_distributed::{
-    RemoteStage, WorkerConnection, WorkerPartitionStream, WorkerResolver, WorkerTransport,
+    RemoteStage, WorkerConnection, WorkerPartitionStream, WorkerTransport,
 };
-use url::Url;
 
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, DrainHandle, DrainItem};
 
@@ -252,28 +250,5 @@ impl WorkerConnection for ShmMqWorkerConnection {
             }
         };
         Ok(Box::pin(stream))
-    }
-}
-
-/// Stub [`WorkerResolver`] for the DF-D fork's distributed planner. Workers in
-/// our embedded model are PG parallel workers in the same backend tree, not
-/// URL-addressed nodes; the planner only consults `get_urls().len()` for
-/// task-count sizing, so any URL satisfies it.
-#[derive(Clone)]
-pub struct MppWorkerResolver {
-    n_workers: usize,
-}
-
-impl MppWorkerResolver {
-    pub fn new(n_workers: usize) -> Self {
-        Self { n_workers }
-    }
-}
-
-#[async_trait]
-impl WorkerResolver for MppWorkerResolver {
-    fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
-        let url = Url::parse("http://mpp.local/").expect("static URL parses");
-        Ok(vec![url; self.n_workers])
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Deletes `MppWorkerResolver` and the `.with_distributed_worker_resolver(...)` registration. Drops the now-unused `url` dependency.

## Why

Our resolver was pure paper-weight. The URLs it returned were never read. The `ShmMqWorkerTransport` keys off `target_task`, not URL. The fork only forced us to ship one because `prepare_plan` and `plan_annotator::_annotate_plan` unconditionally called `worker_resolver.get_urls()?`.

Fork PR paradedb/datafusion-distributed#10 gates those calls behind `!in_process_mode` and substitutes a 1-element placeholder vec internally, so embedders running in-process no longer need a resolver at all.

## How

- Delete `MppWorkerResolver` from `runtime.rs`.
- Drop `.with_distributed_worker_resolver(...)` from `build_mpp_session_context` plus the import.
- Drop the orphan `async_trait`, `WorkerResolver`, and `url::Url` imports.
- Drop `url` from `pg_search/Cargo.toml`.

## Tests

- `mpp_smoke`, `mpp_joinscan`, `mpp_aggregate`, `mpp_aggregate_postagg` all pass on pgrx-arm64.
- CI green.
