### PR TITLE
refactor(mpp): centralize the mpp_worker_count >= 3 invariant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5775,7 +5775,6 @@ dependencies = [
  "tokenizers",
  "tokio",
  "typetag",
- "url",
  "uuid",
 ]
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-Huc2l4akIToBdlEwdwpy2yoftKfwonJX02GctUgVaug=";
+  cargoHash = "sha256-L7PUqoiSmXwcF9p51QlIuPZ4h+Hry7Gq+T6xFGzRJhQ=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -79,7 +79,6 @@ bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
 datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "340ceb5" }
-url = "2"
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1266,9 +1266,7 @@ impl AggregateScan {
         // `Single Copy: true` Gather where the customscan never actually
         // runs in multiple workers.
         let builder = if mpp_is_active() {
-            let n_workers = mpp_worker_count();
-            let workers_to_launch = (n_workers.saturating_sub(1) as usize).max(1);
-            builder.set_parallel(workers_to_launch)
+            builder.set_parallel(producer_worker_count() as usize)
         } else {
             builder
         };

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -42,9 +42,7 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
-use crate::postgres::customscan::mpp::runtime::{
-    proc_for_task, MppMesh, MppWorkerResolver, ShmMqWorkerTransport,
-};
+use crate::postgres::customscan::mpp::runtime::{proc_for_task, MppMesh, ShmMqWorkerTransport};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
 use crate::postgres::customscan::mpp::worker::run_worker_fragment;
@@ -113,7 +111,12 @@ pub(crate) fn build_mpp_session_context(
     // distributed-planner knobs on top.
     let state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
-        .with_distributed_worker_resolver(MppWorkerResolver::new(n_workers))
+        // No `with_distributed_worker_resolver(...)` line is needed: fork PR
+        // paradedb/datafusion-distributed#10 made the `WorkerResolver` lookup conditional
+        // on `!in_process_mode`. Workers in our embedding are PG parallel workers in the
+        // same backend tree, not URL-addressed nodes; the fork substitutes a single
+        // placeholder URL internally so its planner's URL plumbing stays satisfied while
+        // we ship no resolver of our own.
         .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
         .with_distributed_in_process_mode(true)
         .expect("with_distributed_in_process_mode")
@@ -127,6 +130,20 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
+        // No `with_distributed_user_codec(...)` line is needed because:
+        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
+        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
+        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
+        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
+        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
+        //       re-plan from the logical plan we ship via DSM and never decode a physical
+        //       subplan over the wire.
+        //
+        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
+        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
+        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
+        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
+        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -111,12 +111,10 @@ pub(crate) fn build_mpp_session_context(
     // distributed-planner knobs on top.
     let state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
-        // No `with_distributed_worker_resolver(...)` line is needed: fork PR
-        // paradedb/datafusion-distributed#10 made the `WorkerResolver` lookup conditional
-        // on `!in_process_mode`. Workers in our embedding are PG parallel workers in the
-        // same backend tree, not URL-addressed nodes; the fork substitutes a single
-        // placeholder URL internally so its planner's URL plumbing stays satisfied while
-        // we ship no resolver of our own.
+        // No `with_distributed_worker_resolver(...)`: under `in_process_mode = true`, the
+        // fork gates the resolver lookup and substitutes a single placeholder URL. Our
+        // "workers" are PG parallel workers in the same backend tree, not URL-addressed
+        // nodes, so we have nothing meaningful to resolve.
         .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
         .with_distributed_in_process_mode(true)
         .expect("with_distributed_in_process_mode")
@@ -130,20 +128,12 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)` line is needed because:
-        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
-        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
-        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
-        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
-        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
-        //       re-plan from the logical plan we ship via DSM and never decode a physical
-        //       subplan over the wire.
-        //
-        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
-        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
-        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
-        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
-        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
+        // No `with_distributed_user_codec(...)`: under `in_process_mode = true`, the fork
+        // skips constructing `CoordinatorToWorkerTaskSpawner`, so its eager codec encode
+        // never runs. Workers re-plan from the logical plan we ship via DSM and never
+        // decode a physical subplan over the wire. If `in_process_mode = false` ever gets
+        // exercised, restore a codec here for our custom execs or `try_encode` will reject
+        // the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -59,23 +59,31 @@ const NATURAL_GATHER_STAGE_ID: u32 = 0;
 /// partition on the leader.
 const NATURAL_GATHER_PARTITION: u32 = 0;
 
-/// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >= 3`. Customscan
-/// path-builders gate `parallel_workers` on this.
-///
-/// `>= 3` (not `>= 2`) because the leader is consumer-only: with `mpp_worker_count = 2`,
-/// [`producer_worker_count`] returns 1 and the DSM mesh has one producer row, while
-/// `with_target_partitions(2)` (clamped by `n_workers.max(2)` in `build_mpp_session_context`)
-/// makes the planner build a 2-partition shuffle. The mesh wouldn't have a queue for the
-/// second partition. Gating at `>= 3` keeps `producer_worker_count >= 2` so mesh shape and
-/// shuffle width line up.
+/// Minimum total proc count for MPP to be active: leader (consumer-only) + at least 2
+/// producers. Below this, [`producer_worker_count`] would drop to 1 while
+/// `build_mpp_session_context` would still call `with_target_partitions(n_workers.max(2))`
+/// (where `n_workers = mesh.n_procs - 1`), clamping the shuffle width up to 2 — the mesh
+/// wouldn't have a queue for the second partition. Stays as a single source of truth so
+/// [`mpp_is_active`] and [`mpp_worker_count`] don't drift on the threshold.
+const MIN_TOTAL_WORKER_COUNT: i32 = 3;
+
+/// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >=
+/// MIN_TOTAL_WORKER_COUNT`. Customscan path-builders gate `parallel_workers` on this.
 pub fn mpp_is_active() -> bool {
-    enable_mpp() && gucs_mpp_worker_count() >= 3
+    enable_mpp() && gucs_mpp_worker_count() >= MIN_TOTAL_WORKER_COUNT
 }
 
-/// Total proc count: leader + producers. Clamped at 3 so the mesh
-/// shape matches the planner's `target_partitions` (see [`mpp_is_active`]).
+/// Total proc count: leader + producers. Equal to the GUC value when [`mpp_is_active`] is
+/// true. **Callers must gate on [`mpp_is_active`] first.** In debug builds the
+/// `debug_assert!` aborts on misuse; in release builds the function silently returns the
+/// raw GUC value, and downstream [`producer_worker_count`] may underflow or fall below 2,
+/// breaking the planner's `target_partitions` / mesh-width invariant.
 pub fn mpp_worker_count() -> u32 {
-    gucs_mpp_worker_count().max(3) as u32
+    debug_assert!(
+        mpp_is_active(),
+        "mpp_worker_count() called when mpp_is_active() is false — callers must gate first"
+    );
+    gucs_mpp_worker_count() as u32
 }
 
 /// Customscan-side header at offset 0 of the DSM coordinate that the leader hands to
@@ -155,9 +163,11 @@ pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
 }
 
 /// Number of producer workers PG should launch as `parallel_workers`.
-/// `mpp_worker_count - 1` because proc 0 is the leader.
+/// `mpp_worker_count - 1` because proc 0 is the leader (consumer-only). Callers must gate
+/// on [`mpp_is_active`] first; when active, [`MIN_TOTAL_WORKER_COUNT`] guarantees this is
+/// `>= 2` without further clamping.
 pub fn producer_worker_count() -> u32 {
-    mpp_worker_count().saturating_sub(1).max(1)
+    mpp_worker_count() - 1
 }
 
 /// Total proc count: 1 leader + N producer workers. This is the

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -59,12 +59,11 @@ const NATURAL_GATHER_STAGE_ID: u32 = 0;
 /// partition on the leader.
 const NATURAL_GATHER_PARTITION: u32 = 0;
 
-/// Minimum total proc count for MPP to be active: leader (consumer-only) + at least 2
-/// producers. Below this, [`producer_worker_count`] would drop to 1 while
-/// `build_mpp_session_context` would still call `with_target_partitions(n_workers.max(2))`
-/// (where `n_workers = mesh.n_procs - 1`), clamping the shuffle width up to 2 — the mesh
-/// wouldn't have a queue for the second partition. Stays as a single source of truth so
-/// [`mpp_is_active`] and [`mpp_worker_count`] don't drift on the threshold.
+/// Minimum total procs for MPP: leader (consumer-only) plus at least 2 producers. Single
+/// source of truth so [`mpp_is_active`] and [`mpp_worker_count`] don't drift on the
+/// threshold. Below 3, [`producer_worker_count`] would be 1 while
+/// `build_mpp_session_context` still clamps `target_partitions` to 2; the mesh wouldn't
+/// have a queue for the second partition.
 const MIN_TOTAL_WORKER_COUNT: i32 = 3;
 
 /// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >=
@@ -73,11 +72,10 @@ pub fn mpp_is_active() -> bool {
     enable_mpp() && gucs_mpp_worker_count() >= MIN_TOTAL_WORKER_COUNT
 }
 
-/// Total proc count: leader + producers. Equal to the GUC value when [`mpp_is_active`] is
-/// true. **Callers must gate on [`mpp_is_active`] first.** In debug builds the
-/// `debug_assert!` aborts on misuse; in release builds the function silently returns the
-/// raw GUC value, and downstream [`producer_worker_count`] may underflow or fall below 2,
-/// breaking the planner's `target_partitions` / mesh-width invariant.
+/// Total proc count: leader + producers. Equals the GUC value when [`mpp_is_active`] is
+/// true. Callers must gate on [`mpp_is_active`] first. Debug builds assert; release builds
+/// return the raw GUC, which can leave [`producer_worker_count`] below 2 and break the
+/// planner's `target_partitions` / mesh-width invariant.
 pub fn mpp_worker_count() -> u32 {
     debug_assert!(
         mpp_is_active(),

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -15,22 +15,21 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Runtime glue between the leader's DataFusion execution and the
-//! shm_mq mesh.
+//! Runtime glue between the leader's DataFusion execution and the shm_mq mesh.
 //!
-//! - [`MppMesh`] — runtime handle the leader builds at DSM-init time,
-//!   carrying one [`crate::postgres::customscan::mpp::transport::DrainHandle`]
-//!   per producer worker for each consumer partition. Installed on the
-//!   leader's `SessionConfig` extensions before plan execution.
-//! - [`ShmMqWorkerTransport`] — implements the DF-D fork's [`WorkerTransport`]
-//!   trait, consulted by `NetworkShuffleExec`/`NetworkCoalesceExec`/
-//!   `NetworkBroadcastExec` at execute time. `open(target_task=worker)`
-//!   returns a [`ShmMqWorkerConnection`] that yields one stream per
-//!   consumer partition from the corresponding [`DrainHandle`].
+//! [`MppMesh`] is the runtime handle the leader builds at DSM-init time. It carries one
+//! [`crate::postgres::customscan::mpp::transport::DrainHandle`] per producer worker for
+//! each consumer partition and gets installed on the leader's `SessionConfig` extensions
+//! before plan execution.
 //!
-//! Fork PR paradedb/datafusion-distributed#10 made the `WorkerResolver` optional under
-//! `in_process_mode = true` (the fork substitutes a single placeholder URL internally), so
-//! we no longer register one here.
+//! [`ShmMqWorkerTransport`] implements the fork's [`WorkerTransport`] trait, consulted by
+//! `NetworkShuffleExec`/`NetworkCoalesceExec`/`NetworkBroadcastExec` at execute time.
+//! `open(target_task=worker)` returns a [`ShmMqWorkerConnection`] that yields one stream
+//! per consumer partition from the matching [`DrainHandle`].
+//!
+//! No `WorkerResolver` impl. Under `in_process_mode = true` the fork makes the resolver
+//! optional and substitutes a placeholder URL internally; our embedding never resolves
+//! anything by URL.
 
 use std::ops::Range;
 use std::sync::Arc;

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -27,22 +27,20 @@
 //!   `NetworkBroadcastExec` at execute time. `open(target_task=worker)`
 //!   returns a [`ShmMqWorkerConnection`] that yields one stream per
 //!   consumer partition from the corresponding [`DrainHandle`].
-//! - [`MppWorkerResolver`] — stub [`WorkerResolver`] returning N dummy
-//!   URLs. The DF-D fork's planner reads `get_urls().len()` to decide cluster
-//!   capacity; we don't have URLs (everything is in-process), so any
-//!   address satisfies the API.
+//!
+//! Fork PR paradedb/datafusion-distributed#10 made the `WorkerResolver` optional under
+//! `in_process_mode = true` (the fork substitutes a single placeholder URL internally), so
+//! we no longer register one here.
 
 use std::ops::Range;
 use std::sync::Arc;
 
-use async_trait::async_trait;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
 use datafusion_distributed::{
-    RemoteStage, WorkerConnection, WorkerPartitionStream, WorkerResolver, WorkerTransport,
+    RemoteStage, WorkerConnection, WorkerPartitionStream, WorkerTransport,
 };
-use url::Url;
 
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, DrainHandle, DrainItem};
 
@@ -252,28 +250,5 @@ impl WorkerConnection for ShmMqWorkerConnection {
             }
         };
         Ok(Box::pin(stream))
-    }
-}
-
-/// Stub [`WorkerResolver`] for the DF-D fork's distributed planner. Workers in
-/// our embedded model are PG parallel workers in the same backend tree, not
-/// URL-addressed nodes; the planner only consults `get_urls().len()` for
-/// task-count sizing, so any URL satisfies it.
-#[derive(Clone)]
-pub struct MppWorkerResolver {
-    n_workers: usize,
-}
-
-impl MppWorkerResolver {
-    pub fn new(n_workers: usize) -> Self {
-        Self { n_workers }
-    }
-}
-
-#[async_trait]
-impl WorkerResolver for MppWorkerResolver {
-    fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
-        let url = Url::parse("http://mpp.local/").expect("static URL parses");
-        Ok(vec![url; self.n_workers])
     }
 }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Centralizes the "MPP needs at least 3 procs" invariant on a single constant, drops the soft `.max(3)` clamp, and tightens `producer_worker_count()`.

## Why

The invariant was encoded in two places: the `>= 3` gate in `mpp_is_active` and the `.max(3)` clamp in `mpp_worker_count`. The clamp was a soft GUC-level bandage on a planner contract that's already checked at the gate, so the two sites could drift on the threshold.

## How

- Introduce `MIN_TOTAL_WORKER_COUNT: i32 = 3` as the single source of truth. Doc comment explains why 3 (below that, `producer_worker_count()` drops to 1, while `with_target_partitions(n.max(2))` in `build_mpp_session_context` would still build a 2-partition shuffle and the mesh wouldn't have a queue for the second partition).
- `mpp_is_active()` checks `>= MIN_TOTAL_WORKER_COUNT`.
- `mpp_worker_count()` returns the raw GUC value with a `debug_assert!(mpp_is_active())`. Callers must gate on `mpp_is_active()` first. Audit confirmed every caller already does, so this catches a future misuse loudly.
- `producer_worker_count()` becomes plain `mpp_worker_count() - 1`. The previous `.saturating_sub(1).max(1)` was redundant.

## Tests

- `mpp_smoke`, `mpp_joinscan`, `mpp_aggregate`, `mpp_aggregate_postagg` all pass on pgrx-arm64.
- CI green.
