### PR TITLE
refactor(mpp): drop dead clamps + MppHostState trait

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1496,7 +1496,7 @@ impl AggregateScan {
         // call, then return null forever. Workers emit zero rows back to
         // PG; the leader assembles the result via the consumer plan.
         if let Some(scan_state::MppExecState::Worker(_)) = &df_state.mpp {
-            return mpp::exec_mpp_worker(state);
+            return crate::postgres::customscan::mpp::host::exec_mpp_worker(state);
         }
 
         // First call: build and execute the DataFusion plan

--- a/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
@@ -50,12 +50,11 @@ impl MppHostState for CustomScanStateWrapper<AggregateScan> {
     }
 
     fn take_worker_inputs(&mut self) -> MppWorkerInputs {
-        // Pull state-level inputs out before borrowing df_state mutably. parallel_state
-        // and non_partitioning_segments pin each worker's PgSearchTableProvider to the
-        // right segment slice (the partitioning source) and the leader's canonical
-        // replica (the non-partitioning sources). Without them, every worker re-scans
-        // the full data and the leader-side hash partitions get the same rows from
-        // every worker.
+        // Read these out before we borrow df_state mutably. `parallel_state` and
+        // `non_partitioning_segments` pin the worker's PgSearchTableProvider to the right
+        // segment slice (partitioning source) and the leader's canonical replica
+        // (non-partitioning sources). Without them every worker re-scans the full data
+        // and the leader-side hash partitions see the same rows from every worker.
         let parallel_state = self.custom_state().parallel_state;
         let non_partitioning_segments = self.custom_state().non_partitioning_segments.clone();
         let partitioning_source_idx = self.custom_state().mpp_partitioning_source_idx.unwrap_or(0);

--- a/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
@@ -15,32 +15,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! AggregateScan MPP worker exec path.
-//!
-//! Thin [`MppHostState`] impl that exposes AggregateScan's typed state to the shared
-//! dispatcher in [`mpp::host`]: the runtime lives nested under `datafusion_state`,
-//! and the seed `SessionContext` is built from the aggregate profile.
+//! AggregateScan [`MppWorkerHost`] impl: exposes AggregateScan's typed state to the shared
+//! dispatcher in [`mpp::host`]. The runtime lives nested under `datafusion_state`, and the
+//! seed `SessionContext` is built from the aggregate profile.
 
 use std::sync::Arc;
 
 use datafusion::execution::context::SessionContext;
-use pgrx::pg_sys;
 
 use crate::postgres::customscan::aggregatescan::datafusion_exec::create_aggregate_session_context;
 use crate::postgres::customscan::aggregatescan::scan_state::MppExecState;
 use crate::postgres::customscan::aggregatescan::AggregateScan;
 use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
 use crate::postgres::customscan::mpp::exec_worker::MppWorkerInputs;
-use crate::postgres::customscan::mpp::host::{exec_mpp_worker_impl, MppHostState};
+use crate::postgres::customscan::mpp::host::MppWorkerHost;
 use crate::postgres::customscan::mpp::transport::MppSender;
 
-pub(super) fn exec_mpp_worker(
-    state: &mut CustomScanStateWrapper<AggregateScan>,
-) -> *mut pg_sys::TupleTableSlot {
-    exec_mpp_worker_impl(state)
-}
-
-impl MppHostState for CustomScanStateWrapper<AggregateScan> {
+impl MppWorkerHost for CustomScanStateWrapper<AggregateScan> {
     fn already_drained(&self) -> bool {
         self.custom_state()
             .datafusion_state

--- a/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mpp.rs
@@ -17,83 +17,70 @@
 
 //! AggregateScan MPP worker exec path.
 //!
-//! Thin wrapper over [`mpp::exec_worker::run_mpp_worker`]: pulls AggregateScan-specific inputs
-//! (parallel_state, source_manifests, partitioning source index, the worker's plan bytes and
-//! mesh) out of the typed state, builds the aggregate-profile seed `SessionContext`, hands the
-//! whole thing to the shape-agnostic dispatcher.
+//! Thin [`MppHostState`] impl that exposes AggregateScan's typed state to the shared
+//! dispatcher in [`mpp::host`]: the runtime lives nested under `datafusion_state`,
+//! and the seed `SessionContext` is built from the aggregate profile.
 
 use std::sync::Arc;
 
+use datafusion::execution::context::SessionContext;
 use pgrx::pg_sys;
 
 use crate::postgres::customscan::aggregatescan::datafusion_exec::create_aggregate_session_context;
-use crate::postgres::customscan::aggregatescan::scan_state;
+use crate::postgres::customscan::aggregatescan::scan_state::MppExecState;
 use crate::postgres::customscan::aggregatescan::AggregateScan;
 use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
-use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
+use crate::postgres::customscan::mpp::exec_worker::MppWorkerInputs;
+use crate::postgres::customscan::mpp::host::{exec_mpp_worker_impl, MppHostState};
 use crate::postgres::customscan::mpp::transport::MppSender;
 
-/// MPP worker exec: extract inputs from AggregateScan's state, build the aggregate-profile seed
-/// context, hand off to the shape-agnostic dispatcher. Workers emit zero rows back to PG;
-/// returning `null_mut()` signals end-of-stream.
 pub(super) fn exec_mpp_worker(
     state: &mut CustomScanStateWrapper<AggregateScan>,
 ) -> *mut pg_sys::TupleTableSlot {
-    // Pull worker-thread inputs from the outer state before we borrow df_state mutably.
-    // parallel_state and non_partitioning_segments are required to pin each worker's
-    // PgSearchTableProvider to the right segment slice (the partitioning source) and the
-    // leader's canonical replica (the non-partitioning sources). Without them, every worker
-    // re-scans the full data and the leader-side hash partitions get the same rows from
-    // every worker.
-    let parallel_state = state.custom_state().parallel_state;
-    let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
-    let partitioning_source_idx = state
-        .custom_state()
-        .mpp_partitioning_source_idx
-        .unwrap_or(0);
-    let plan_sources_count = state
-        .custom_state()
-        .source_manifests
-        .len()
-        .max(non_partitioning_segments.len() + 1);
+    exec_mpp_worker_impl(state)
+}
 
-    let df_state = state
-        .custom_state_mut()
-        .datafusion_state
-        .as_mut()
-        .expect("DataFusion state must be initialized");
-
-    if df_state.runtime.is_some() {
-        // Already drained on a prior call; just signal EOF.
-        return std::ptr::null_mut();
+impl MppHostState for CustomScanStateWrapper<AggregateScan> {
+    fn already_drained(&self) -> bool {
+        self.custom_state()
+            .datafusion_state
+            .as_ref()
+            .and_then(|df| df.runtime.as_ref())
+            .is_some()
     }
-    let scan_state::MppExecState::Worker(worker) = df_state.mpp.as_ref().expect("checked") else {
-        unreachable!("exec_mpp_worker called outside Worker state");
-    };
-    let plan_bytes = worker.plan_bytes.clone();
-    let worker_mesh = Arc::clone(&worker.mesh);
-    let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
-        Some(scan_state::MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
-        _ => unreachable!(),
-    };
 
-    let runtime = match tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-    {
-        Ok(rt) => rt,
-        Err(e) => pgrx::error!("mpp worker: tokio runtime build failed: {e}"),
-    };
-    df_state.runtime = Some(runtime);
-    let runtime = df_state.runtime.as_ref().unwrap();
+    fn take_worker_inputs(&mut self) -> MppWorkerInputs {
+        // Pull state-level inputs out before borrowing df_state mutably. parallel_state
+        // and non_partitioning_segments pin each worker's PgSearchTableProvider to the
+        // right segment slice (the partitioning source) and the leader's canonical
+        // replica (the non-partitioning sources). Without them, every worker re-scans
+        // the full data and the leader-side hash partitions get the same rows from
+        // every worker.
+        let parallel_state = self.custom_state().parallel_state;
+        let non_partitioning_segments = self.custom_state().non_partitioning_segments.clone();
+        let partitioning_source_idx = self.custom_state().mpp_partitioning_source_idx.unwrap_or(0);
+        let plan_sources_count = self
+            .custom_state()
+            .source_manifests
+            .len()
+            .max(non_partitioning_segments.len() + 1);
 
-    // Use a bare aggregate-profile context for plan deserialization. The distributed planner
-    // config (worker resolver, transport, estimators, codec) is layered on top inside
-    // `run_mpp_worker` via `build_mpp_session_context`. Both procs have to agree on stage shape;
-    // this is how.
-    let seed_ctx = create_aggregate_session_context();
+        let df_state = self
+            .custom_state_mut()
+            .datafusion_state
+            .as_mut()
+            .expect("DataFusion state must be initialized");
 
-    run_mpp_worker(
+        let MppExecState::Worker(worker) = df_state.mpp.as_ref().expect("checked") else {
+            unreachable!("exec_mpp_worker called outside Worker state");
+        };
+        let plan_bytes = worker.plan_bytes.clone();
+        let worker_mesh = Arc::clone(&worker.mesh);
+        let outbound_senders: Vec<Option<MppSender>> = match df_state.mpp.as_mut() {
+            Some(MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
+            _ => unreachable!(),
+        };
+
         MppWorkerInputs {
             parallel_state,
             non_partitioning_segments,
@@ -102,9 +89,20 @@ pub(super) fn exec_mpp_worker(
             plan_bytes,
             worker_mesh,
             outbound_senders,
-        },
-        seed_ctx,
-        runtime,
-    );
-    std::ptr::null_mut()
+        }
+    }
+
+    fn build_seed_ctx(&self) -> SessionContext {
+        create_aggregate_session_context()
+    }
+
+    fn install_runtime(&mut self, runtime: tokio::runtime::Runtime) -> &tokio::runtime::Runtime {
+        let df_state = self
+            .custom_state_mut()
+            .datafusion_state
+            .as_mut()
+            .expect("DataFusion state must be initialized");
+        df_state.runtime = Some(runtime);
+        df_state.runtime.as_ref().unwrap()
+    }
 }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1437,7 +1437,7 @@ impl CustomScan for JoinScan {
         // MPP worker dispatch: producer-side fragments emit nothing back to PG. Route to the
         // MPP exec helper and return null_mut() to signal end-of-stream.
         if matches!(state.custom_state().mpp, Some(MppExecState::Worker(_))) {
-            return mpp::exec_mpp_worker(state);
+            return crate::postgres::customscan::mpp::host::exec_mpp_worker(state);
         }
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1437,7 +1437,7 @@ impl CustomScan for JoinScan {
         // MPP worker dispatch: producer-side fragments emit nothing back to PG. Route to the
         // MPP exec helper and return null_mut() to signal end-of-stream.
         if matches!(state.custom_state().mpp, Some(MppExecState::Worker(_))) {
-            return JoinScan::exec_mpp_worker(state);
+            return mpp::exec_mpp_worker(state);
         }
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {

--- a/pg_search/src/postgres/customscan/joinscan/mpp.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mpp.rs
@@ -17,85 +17,73 @@
 
 //! JoinScan MPP worker exec path.
 //!
-//! Thin wrapper over [`mpp::exec_worker::run_mpp_worker`]: pulls JoinScan-specific inputs out
-//! of the typed state, builds the join-profile seed `SessionContext`, hands the whole thing
-//! to the shape-agnostic dispatcher.
+//! Thin [`MppHostState`] impl that exposes JoinScan's typed state to the shared
+//! dispatcher in [`mpp::host`]: the runtime lives directly on `custom_state`, and
+//! the seed `SessionContext` is built from the join profile.
 
 use std::sync::Arc;
 
+use datafusion::execution::context::SessionContext;
 use pgrx::pg_sys;
 
 use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
-use crate::postgres::customscan::joinscan::scan_state as join_scan_state;
-use crate::postgres::customscan::joinscan::scan_state::{MppExecState, SessionContextProfile};
+use crate::postgres::customscan::joinscan::scan_state::{
+    create_datafusion_session_context, MppExecState, SessionContextProfile,
+};
 use crate::postgres::customscan::joinscan::JoinScan;
-use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
+use crate::postgres::customscan::mpp::exec_worker::MppWorkerInputs;
+use crate::postgres::customscan::mpp::host::{exec_mpp_worker_impl, MppHostState};
 use crate::postgres::customscan::mpp::transport::MppSender;
-// `create_datafusion_session_context` lives in joinscan::scan_state and isn't pub from
-// crate root, so import via the joinscan module path.
-use crate::postgres::customscan::joinscan::scan_state::create_datafusion_session_context;
 
-impl JoinScan {
-    /// MPP worker exec: extract inputs from JoinScan's state, build the join-profile seed
-    /// context, hand off to the shape-agnostic dispatcher. Workers emit zero rows back to PG;
-    /// returning `null_mut()` signals end-of-stream.
-    pub(super) fn exec_mpp_worker(
-        state: &mut CustomScanStateWrapper<Self>,
-    ) -> *mut pg_sys::TupleTableSlot {
-        let parallel_state = state.custom_state().parallel_state;
-        let non_partitioning_segments = state.custom_state().non_partitioning_segments.clone();
-        let partitioning_source_idx = state
-            .custom_state()
-            .mpp_partitioning_source_idx
-            .unwrap_or(0);
-        let plan_sources_count = state
+pub(super) fn exec_mpp_worker(
+    state: &mut CustomScanStateWrapper<JoinScan>,
+) -> *mut pg_sys::TupleTableSlot {
+    exec_mpp_worker_impl(state)
+}
+
+impl MppHostState for CustomScanStateWrapper<JoinScan> {
+    fn already_drained(&self) -> bool {
+        self.custom_state().runtime.is_some()
+    }
+
+    fn take_worker_inputs(&mut self) -> MppWorkerInputs {
+        let parallel_state = self.custom_state().parallel_state;
+        let non_partitioning_segments = self.custom_state().non_partitioning_segments.clone();
+        let partitioning_source_idx = self.custom_state().mpp_partitioning_source_idx.unwrap_or(0);
+        let plan_sources_count = self
             .custom_state()
             .source_manifests
             .len()
             .max(non_partitioning_segments.len() + 1);
 
-        // Already drained on a prior call; just signal EOF.
-        if state.custom_state().runtime.is_some() {
-            return std::ptr::null_mut();
-        }
-
-        let join_scan_state::MppExecState::Worker(worker) =
-            state.custom_state().mpp.as_ref().expect("checked")
+        let MppExecState::Worker(worker) = self.custom_state().mpp.as_ref().expect("checked")
         else {
             unreachable!("exec_mpp_worker called outside Worker state");
         };
         let plan_bytes = worker.plan_bytes.clone();
         let worker_mesh = Arc::clone(&worker.mesh);
-        let outbound_senders: Vec<Option<MppSender>> = match state.custom_state_mut().mpp.as_mut() {
+        let outbound_senders: Vec<Option<MppSender>> = match self.custom_state_mut().mpp.as_mut() {
             Some(MppExecState::Worker(w)) => std::mem::take(&mut w.outbound_senders),
             _ => unreachable!(),
         };
 
-        let runtime = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => pgrx::error!("mpp join worker: tokio runtime build failed: {e}"),
-        };
-        state.custom_state_mut().runtime = Some(runtime);
-        let runtime = state.custom_state().runtime.as_ref().unwrap();
+        MppWorkerInputs {
+            parallel_state,
+            non_partitioning_segments,
+            partitioning_source_idx,
+            plan_sources_count,
+            plan_bytes,
+            worker_mesh,
+            outbound_senders,
+        }
+    }
 
-        let seed_ctx = create_datafusion_session_context(SessionContextProfile::Join);
+    fn build_seed_ctx(&self) -> SessionContext {
+        create_datafusion_session_context(SessionContextProfile::Join)
+    }
 
-        run_mpp_worker(
-            MppWorkerInputs {
-                parallel_state,
-                non_partitioning_segments,
-                partitioning_source_idx,
-                plan_sources_count,
-                plan_bytes,
-                worker_mesh,
-                outbound_senders,
-            },
-            seed_ctx,
-            runtime,
-        );
-        std::ptr::null_mut()
+    fn install_runtime(&mut self, runtime: tokio::runtime::Runtime) -> &tokio::runtime::Runtime {
+        self.custom_state_mut().runtime = Some(runtime);
+        self.custom_state().runtime.as_ref().unwrap()
     }
 }

--- a/pg_search/src/postgres/customscan/joinscan/mpp.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mpp.rs
@@ -15,16 +15,13 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! JoinScan MPP worker exec path.
-//!
-//! Thin [`MppHostState`] impl that exposes JoinScan's typed state to the shared
-//! dispatcher in [`mpp::host`]: the runtime lives directly on `custom_state`, and
-//! the seed `SessionContext` is built from the join profile.
+//! JoinScan [`MppWorkerHost`] impl: exposes JoinScan's typed state to the shared dispatcher
+//! in [`mpp::host`]. The runtime lives directly on `custom_state`, and the seed
+//! `SessionContext` is built from the join profile.
 
 use std::sync::Arc;
 
 use datafusion::execution::context::SessionContext;
-use pgrx::pg_sys;
 
 use crate::postgres::customscan::builders::custom_state::CustomScanStateWrapper;
 use crate::postgres::customscan::joinscan::scan_state::{
@@ -32,16 +29,10 @@ use crate::postgres::customscan::joinscan::scan_state::{
 };
 use crate::postgres::customscan::joinscan::JoinScan;
 use crate::postgres::customscan::mpp::exec_worker::MppWorkerInputs;
-use crate::postgres::customscan::mpp::host::{exec_mpp_worker_impl, MppHostState};
+use crate::postgres::customscan::mpp::host::MppWorkerHost;
 use crate::postgres::customscan::mpp::transport::MppSender;
 
-pub(super) fn exec_mpp_worker(
-    state: &mut CustomScanStateWrapper<JoinScan>,
-) -> *mut pg_sys::TupleTableSlot {
-    exec_mpp_worker_impl(state)
-}
-
-impl MppHostState for CustomScanStateWrapper<JoinScan> {
+impl MppWorkerHost for CustomScanStateWrapper<JoinScan> {
     fn already_drained(&self) -> bool {
         self.custom_state().runtime.is_some()
     }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -203,11 +203,10 @@ pub(crate) fn run_mpp_worker(
         Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
     };
 
-    // Walk the plan and collect every `(stage_id, task_idx)` slot owned by this proc under
-    // the `proc_for_task` round-robin policy. The dispatcher spawns one async task per
-    // fragment; together they form the worker's complete contribution to the distributed
-    // plan. `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate
-    // before reaching this), so `n_workers() = n_procs - 1` is safe.
+    // Collect every `(stage_id, task_idx)` slot this proc owns under the `proc_for_task`
+    // round-robin. The dispatcher spawns one async task per fragment; together they form
+    // the worker's full contribution to the distributed plan. `mpp_is_active()` already
+    // guarantees `n_procs >= 3`, so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();
     let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
     if fragments.is_empty() {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -24,9 +24,12 @@
 //! `SessionContext` (different `SessionContextProfile`) and where the inputs come from in
 //! per-scan state.
 //!
-//! This module isolates the shape-agnostic logic. Per-scan wrappers (`AggregateScan::exec_mpp_worker`,
-//! `JoinScan::exec_mpp_worker`) extract their inputs into [`MppWorkerInputs`], build their seed
-//! `SessionContext`, and call [`run_mpp_worker`].
+//! This module isolates the shape-agnostic logic. Per-scan
+//! [`crate::postgres::customscan::mpp::host::MppWorkerHost`] impls (in
+//! `aggregatescan::mpp` and `joinscan::mpp`) extract their inputs into [`MppWorkerInputs`],
+//! build their seed `SessionContext`, and are driven by
+//! [`crate::postgres::customscan::mpp::host::exec_mpp_worker`], which calls
+//! [`run_mpp_worker`].
 
 use std::sync::Arc;
 
@@ -53,8 +56,9 @@ use crate::postgres::customscan::parallel::list_segment_ids;
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::deserialize_logical_plan_with_runtime;
 
-/// Bundle of inputs the worker dispatcher needs. Per-scan `exec_mpp_worker` wrappers populate
-/// this from their typed state and hand it to [`run_mpp_worker`].
+/// Bundle of inputs the worker dispatcher needs. Per-scan
+/// [`crate::postgres::customscan::mpp::host::MppWorkerHost`] impls populate this from their
+/// typed state and hand it to [`run_mpp_worker`].
 pub(crate) struct MppWorkerInputs {
     /// The leader's `ParallelScanState`, used to claim the partitioning source's segment slice.
     pub parallel_state: Option<*mut ParallelScanState>,

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -86,7 +86,8 @@ pub(crate) fn build_mpp_session_context(
     mesh: Arc<MppMesh>,
 ) -> SessionContext {
     // Workers are procs 1..n_procs; leader is proc 0. The producer count is `n_procs - 1`.
-    let n_workers = mesh.n_procs.saturating_sub(1).max(1) as usize;
+    // `n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before reaching this).
+    let n_workers = mesh.n_workers() as usize;
     // Four-knob unlock for actually inserting NetworkShuffleExec/etc.:
     //   1. target_partitions(N) — without this, EnforceDistribution skips every
     //      RepartitionExec, so the annotator never sees a Shuffle.
@@ -161,7 +162,6 @@ pub(crate) fn run_mpp_worker(
     } = inputs;
 
     let this_proc = worker_mesh.this_proc;
-    let total_procs = worker_mesh.n_procs;
 
     // Build per-source canonical segment ID sets. For the partitioning source, pull the full
     // list out of the populated ParallelScanState (workers will then claim individual segments
@@ -203,10 +203,12 @@ pub(crate) fn run_mpp_worker(
         Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
     };
 
-    // Walk the plan and collect every `(stage_id, task_idx)` slot owned by this proc under the
-    // `proc_for_task` round-robin policy. The dispatcher spawns one async task per fragment;
-    // together they form the worker's complete contribution to the distributed plan.
-    let n_workers = total_procs.saturating_sub(1).max(1);
+    // Walk the plan and collect every `(stage_id, task_idx)` slot owned by this proc under
+    // the `proc_for_task` round-robin policy. The dispatcher spawns one async task per
+    // fragment; together they form the worker's complete contribution to the distributed
+    // plan. `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate
+    // before reaching this), so `n_workers() = n_procs - 1` is safe.
+    let n_workers = worker_mesh.n_workers();
     let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
     if fragments.is_empty() {
         pgrx::warning!(

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -155,7 +155,7 @@ pub(super) fn mpp_queue_size() -> usize {
 /// plan, the multiplexed `n_procs × n_procs` queue mesh, and the worker plan. `n_procs` is the
 /// total proc count (leader + `producer_worker_count()` parallel workers).
 pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
-    let layout = compute_dsm_layout(n_procs(), mpp_queue_size(), plan_bytes_len)
+    let layout = compute_dsm_layout(mpp_worker_count(), mpp_queue_size(), plan_bytes_len)
         .map_err(|e| format!("mpp: estimate_dsm_size: {e}"))?;
     Ok(layout.region_total)
 }
@@ -166,12 +166,6 @@ pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
 /// `>= 2` without further clamping.
 pub fn producer_worker_count() -> u32 {
     mpp_worker_count() - 1
-}
-
-/// Total proc count: 1 leader + N producer workers. This is the
-/// dimension of the multiplexed `n_procs × n_procs` shm_mq grid.
-pub(super) fn n_procs() -> u32 {
-    mpp_worker_count()
 }
 
 /// Returned to the leader from [`leader_setup`]. The customscan stashes this on its execution
@@ -252,7 +246,7 @@ pub unsafe fn leader_setup(
     pcxt: *mut pg_sys::ParallelContext,
     plan_bytes: Vec<u8>,
 ) -> Result<MppLeaderState, String> {
-    let total_procs = n_procs();
+    let total_procs = mpp_worker_count();
     let layout = compute_dsm_layout(total_procs, mpp_queue_size(), plan_bytes.len())
         .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
 

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -208,7 +208,8 @@ fn build_inbound_receivers(
 }
 
 /// Wrap each peer-indexed `ShmMqSender` into an outbound `MppSender` keyed by `target_proc`. The
-/// per-fragment dispatcher in `aggregatescan::exec_mpp_worker` immediately `clone_with_header`s
+/// per-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`] immediately
+/// `clone_with_header`s
 /// these to the right `(stage_id, partition)`, so the default placeholder header is never
 /// observed on the wire. Slot at index `this_proc` is `None`; the worker's self-loop install
 /// fills it in afterward.
@@ -284,7 +285,7 @@ pub struct MppWorkerState {
     /// Worker's MppMesh, same shape as the leader's. `inbound_receivers[sender_proc]` pulls frames
     /// from `slot(sender_proc, this_proc)`. Workers consume from peers when running consumer
     /// fragments (e.g. a `FinalPartitioned` aggregate above a `NetworkShuffleExec` peer-mesh).
-    /// Read by the multi-fragment dispatcher in `aggregatescan::exec_mpp_worker`.
+    /// Read by the multi-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`].
     pub mesh: Arc<MppMesh>,
 }
 

--- a/pg_search/src/postgres/customscan/mpp/host.rs
+++ b/pg_search/src/postgres/customscan/mpp/host.rs
@@ -1,0 +1,93 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Shape-agnostic MPP worker exec dispatcher.
+//!
+//! Each CustomScan provider that hosts an MPP plan implements [`MppHostState`] on its
+//! `CustomScanStateWrapper<T>` to expose its provider-specific state to the shared
+//! [`exec_mpp_worker_impl`]. AggregateScan and JoinScan used to keep two ~100-LOC
+//! near-duplicate `exec_mpp_worker` functions; the only real differences are where the
+//! tokio runtime lives in the typed state and which `SessionContext` profile is used
+//! to deserialize the plan. The trait isolates those two concerns; the rest of the
+//! body is shared.
+
+use datafusion::execution::context::SessionContext;
+use pgrx::pg_sys;
+
+use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
+
+/// Per-scan glue the shared dispatcher needs to host an MPP worker.
+///
+/// Implementations live alongside their CustomScan provider (see
+/// `aggregatescan::mpp` and `joinscan::mpp`). They own the typed state and know
+/// where the runtime slot and `MppExecState::Worker` variant are kept; the trait
+/// is the smallest interface that lets [`exec_mpp_worker_impl`] drive the worker
+/// without knowing which scan provider it's hosted under.
+pub(crate) trait MppHostState {
+    /// `true` if a tokio runtime is already installed in this state.
+    ///
+    /// **Contract:** must return `true` after a prior call to [`Self::install_runtime`]
+    /// on the same state. Implementations must check the same slot they wrote in
+    /// `install_runtime` — a slot-incoherent impl (write to slot A, check slot B)
+    /// would rebuild the runtime on every PG re-entry and crash on the second pass.
+    ///
+    /// Workers can call `exec_mpp_worker` more than once (PG re-enters scan exec after
+    /// EOS); only the first call should build the runtime and drive the plan, so
+    /// subsequent calls short-circuit to EOF.
+    fn already_drained(&self) -> bool;
+
+    /// Pulls worker-thread inputs out of the typed state. Called exactly once per
+    /// worker exec — implementations are expected to `mem::take` `outbound_senders`
+    /// out of the `MppExecState::Worker` variant rather than cloning it.
+    fn take_worker_inputs(&mut self) -> MppWorkerInputs;
+
+    /// Builds the seed `SessionContext` used only for plan deserialization
+    /// (`ctx.task_ctx()`). The distributed planner config (worker resolver, transport,
+    /// estimators, codec) is layered on top inside `run_mpp_worker` via
+    /// `build_mpp_session_context`. Both procs have to agree on stage shape; this is how.
+    fn build_seed_ctx(&self) -> SessionContext;
+
+    /// Installs the tokio runtime in the provider-specific slot and returns a borrowed
+    /// reference to it. The runtime must live for the entire body of `run_mpp_worker`,
+    /// which is why we return the reference rather than dropping the value back in
+    /// after install.
+    fn install_runtime(&mut self, runtime: tokio::runtime::Runtime) -> &tokio::runtime::Runtime;
+}
+
+/// Shape-agnostic body of `exec_mpp_worker`. Workers emit zero rows back to PG;
+/// `null_mut()` signals end-of-stream. Per-scan wrappers should simply call this with
+/// `self` after their wrapper-side state checks.
+pub(crate) fn exec_mpp_worker_impl<S: MppHostState>(state: &mut S) -> *mut pg_sys::TupleTableSlot {
+    if state.already_drained() {
+        return std::ptr::null_mut();
+    }
+    let inputs = state.take_worker_inputs();
+    let seed_ctx = state.build_seed_ctx();
+    let runtime = match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt,
+        Err(e) => pgrx::error!("mpp worker: tokio runtime build failed: {e}"),
+    };
+    // Extending the runtime borrow through `run_mpp_worker` is sound because `inputs`
+    // and `seed_ctx` are owned values (no `state` borrow held) and `run_mpp_worker`
+    // never reaches back into `state`.
+    let runtime = state.install_runtime(runtime);
+    run_mpp_worker(inputs, seed_ctx, runtime);
+    std::ptr::null_mut()
+}

--- a/pg_search/src/postgres/customscan/mpp/host.rs
+++ b/pg_search/src/postgres/customscan/mpp/host.rs
@@ -17,11 +17,15 @@
 
 //! Shape-agnostic MPP worker exec dispatcher.
 //!
-//! Each CustomScan provider that hosts an MPP plan implements [`MppHostState`] on its
-//! `CustomScanStateWrapper<T>` so the shared [`exec_mpp_worker_impl`] can drive it
+//! Each CustomScan provider that hosts an MPP plan implements [`MppWorkerHost`] on its
+//! `CustomScanStateWrapper<T>` so the shared [`exec_mpp_worker`] can drive it
 //! without knowing which provider it's hosted under. The trait isolates the two
 //! provider-specific concerns (runtime-slot location and seed `SessionContext` profile);
 //! everything else is shared.
+//!
+//! "Host" here means *the CustomScan provider that hosts the worker exec path*, not a
+//! physical machine. The MPP execution path lives on a single Postgres backend; there is
+//! no remote host.
 
 use datafusion::execution::context::SessionContext;
 use pgrx::pg_sys;
@@ -33,9 +37,9 @@ use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInp
 /// Implementations live alongside their CustomScan provider (see
 /// `aggregatescan::mpp` and `joinscan::mpp`). They own the typed state and know
 /// where the runtime slot and `MppExecState::Worker` variant are kept; the trait
-/// is the smallest interface that lets [`exec_mpp_worker_impl`] drive the worker
+/// is the smallest interface that lets [`exec_mpp_worker`] drive the worker
 /// without knowing which scan provider it's hosted under.
-pub(crate) trait MppHostState {
+pub(crate) trait MppWorkerHost {
     /// `true` if a tokio runtime is already installed.
     ///
     /// Workers can call `exec_mpp_worker` more than once: PG re-enters scan exec after
@@ -65,10 +69,10 @@ pub(crate) trait MppHostState {
     fn install_runtime(&mut self, runtime: tokio::runtime::Runtime) -> &tokio::runtime::Runtime;
 }
 
-/// Shape-agnostic body of `exec_mpp_worker`. Workers emit zero rows back to PG;
-/// `null_mut()` signals end-of-stream. Per-scan wrappers call this with `self` after
-/// their wrapper-side state checks.
-pub(crate) fn exec_mpp_worker_impl<S: MppHostState>(state: &mut S) -> *mut pg_sys::TupleTableSlot {
+/// Drives an MPP worker exec on the [`MppWorkerHost`]. Workers emit zero rows back to PG;
+/// `null_mut()` signals end-of-stream. Per-scan call sites pass `&mut state` directly; the
+/// trait bound supplies the provider-specific glue.
+pub(crate) fn exec_mpp_worker<S: MppWorkerHost>(state: &mut S) -> *mut pg_sys::TupleTableSlot {
     if state.already_drained() {
         return std::ptr::null_mut();
     }

--- a/pg_search/src/postgres/customscan/mpp/host.rs
+++ b/pg_search/src/postgres/customscan/mpp/host.rs
@@ -18,12 +18,10 @@
 //! Shape-agnostic MPP worker exec dispatcher.
 //!
 //! Each CustomScan provider that hosts an MPP plan implements [`MppHostState`] on its
-//! `CustomScanStateWrapper<T>` to expose its provider-specific state to the shared
-//! [`exec_mpp_worker_impl`]. AggregateScan and JoinScan used to keep two ~100-LOC
-//! near-duplicate `exec_mpp_worker` functions; the only real differences are where the
-//! tokio runtime lives in the typed state and which `SessionContext` profile is used
-//! to deserialize the plan. The trait isolates those two concerns; the rest of the
-//! body is shared.
+//! `CustomScanStateWrapper<T>` so the shared [`exec_mpp_worker_impl`] can drive it
+//! without knowing which provider it's hosted under. The trait isolates the two
+//! provider-specific concerns (runtime-slot location and seed `SessionContext` profile);
+//! everything else is shared.
 
 use datafusion::execution::context::SessionContext;
 use pgrx::pg_sys;
@@ -38,39 +36,38 @@ use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInp
 /// is the smallest interface that lets [`exec_mpp_worker_impl`] drive the worker
 /// without knowing which scan provider it's hosted under.
 pub(crate) trait MppHostState {
-    /// `true` if a tokio runtime is already installed in this state.
+    /// `true` if a tokio runtime is already installed.
     ///
-    /// **Contract:** must return `true` after a prior call to [`Self::install_runtime`]
-    /// on the same state. Implementations must check the same slot they wrote in
-    /// `install_runtime` — a slot-incoherent impl (write to slot A, check slot B)
-    /// would rebuild the runtime on every PG re-entry and crash on the second pass.
+    /// Workers can call `exec_mpp_worker` more than once: PG re-enters scan exec after
+    /// EOS, so only the first call should build the runtime and drive the plan.
+    /// Subsequent calls short-circuit to EOF.
     ///
-    /// Workers can call `exec_mpp_worker` more than once (PG re-enters scan exec after
-    /// EOS); only the first call should build the runtime and drive the plan, so
-    /// subsequent calls short-circuit to EOF.
+    /// Contract: must return `true` after a prior [`Self::install_runtime`] on the same
+    /// state. Implementations must check the same slot they wrote in `install_runtime`;
+    /// a slot-incoherent impl (write A, check B) would rebuild the runtime on every PG
+    /// re-entry and crash on the second pass.
     fn already_drained(&self) -> bool;
 
-    /// Pulls worker-thread inputs out of the typed state. Called exactly once per
-    /// worker exec — implementations are expected to `mem::take` `outbound_senders`
-    /// out of the `MppExecState::Worker` variant rather than cloning it.
+    /// Pull worker inputs out of the typed state. Called exactly once per worker exec;
+    /// implementations should `mem::take` `outbound_senders` out of `MppExecState::Worker`
+    /// rather than cloning.
     fn take_worker_inputs(&mut self) -> MppWorkerInputs;
 
-    /// Builds the seed `SessionContext` used only for plan deserialization
+    /// Build the seed `SessionContext` used only for plan deserialization
     /// (`ctx.task_ctx()`). The distributed planner config (worker resolver, transport,
-    /// estimators, codec) is layered on top inside `run_mpp_worker` via
+    /// estimators, codec) gets layered on top inside `run_mpp_worker` via
     /// `build_mpp_session_context`. Both procs have to agree on stage shape; this is how.
     fn build_seed_ctx(&self) -> SessionContext;
 
-    /// Installs the tokio runtime in the provider-specific slot and returns a borrowed
-    /// reference to it. The runtime must live for the entire body of `run_mpp_worker`,
-    /// which is why we return the reference rather than dropping the value back in
-    /// after install.
+    /// Install the tokio runtime in the provider-specific slot and return a borrowed
+    /// reference. The runtime needs to live for the entire body of `run_mpp_worker`, so
+    /// we hand back the reference rather than dropping the value back in after install.
     fn install_runtime(&mut self, runtime: tokio::runtime::Runtime) -> &tokio::runtime::Runtime;
 }
 
 /// Shape-agnostic body of `exec_mpp_worker`. Workers emit zero rows back to PG;
-/// `null_mut()` signals end-of-stream. Per-scan wrappers should simply call this with
-/// `self` after their wrapper-side state checks.
+/// `null_mut()` signals end-of-stream. Per-scan wrappers call this with `self` after
+/// their wrapper-side state checks.
 pub(crate) fn exec_mpp_worker_impl<S: MppHostState>(state: &mut S) -> *mut pg_sys::TupleTableSlot {
     if state.already_drained() {
         return std::ptr::null_mut();

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -28,6 +28,7 @@
 pub mod dsm;
 pub mod exec_worker;
 pub mod glue;
+pub mod host;
 pub mod mesh;
 pub mod runtime;
 pub mod task_estimator;

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -101,10 +101,23 @@ impl MppMesh {
             .and_then(|slot| slot.as_ref())
     }
 
-    /// Number of worker procs (= `n_procs - 1`, since the leader is proc 0).
-    /// Used as the modulus in [`proc_for_task`].
+    /// Number of worker procs (= `n_procs - 1`, since the leader is proc 0). Used as the
+    /// modulus in [`proc_for_task`].
+    ///
+    /// The `n_procs >= 3` invariant is enforced by
+    /// [`crate::postgres::customscan::mpp::glue::mpp_is_active`] via
+    /// `MIN_TOTAL_WORKER_COUNT`, so the subtraction is safe without a `saturating_sub` /
+    /// `max(1)` belt-and-braces: every code path that constructs an `MppMesh` (or reaches
+    /// this method) is gated on `mpp_is_active()` first. Asserted in debug builds so a
+    /// future misuse fails loudly.
     pub(super) fn n_workers(&self) -> u32 {
-        self.n_procs.saturating_sub(1).max(1)
+        debug_assert!(
+            self.n_procs >= 3,
+            "MppMesh::n_workers() called with n_procs={} (< 3); callers must gate on \
+             mpp_is_active()",
+            self.n_procs
+        );
+        self.n_procs - 1
     }
 
     /// Pull from every installed inbound drain. Called from

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -20,7 +20,7 @@
 //! [`find_worker_assignments`] walks a worker's physical plan, visits every
 //! [`datafusion_distributed::NetworkBoundary`], and collects the
 //! `(input_stage.num, task_idx, plan, routing)` tuples assigned to a given
-//! `this_proc`. The dispatcher in `aggregatescan::exec_mpp_worker` runs one
+//! `this_proc`. The dispatcher driven by [`mpp::host::exec_mpp_worker`] runs one
 //! fragment per returned [`FragmentAssignment`].
 //!
 //! The walker tracks a `ParentContext` per recursion level so nested


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Two cleanups:

1. drop the dead `saturating_sub(1).max(1)` clamps and the `glue::n_procs()` trampoline that the centralized invariant in PR #5132 made redundant.
2. factor the aggregatescan / joinscan `exec_mpp_worker` wrappers behind an `MppHostState` trait so they share a single dispatcher.

## Why

(1) is straightforward dead code. With PR #5132's `>= MIN_TOTAL_WORKER_COUNT` invariant centralized, the belt-and-braces clamps at three sites become noise.

(2)is structural. The aggregatescan and joinscan wrappers had the same skeleton but differed in four real ways: runtime slot location, the `MppExecState::Worker` enum, the seed `SessionContext` profile, and the path to the `outbound_senders` slot for `mem::take`. A trait isolates those four concerns and the shared body fits on one screen.

## How

- `MppMesh::n_workers()` → `self.n_procs - 1` with a debug_assert.
- `exec_worker.rs` calls `n_workers()` directly. Drop the unused `total_procs` local.
- Delete `glue::n_procs()`. Call sites use `mpp_worker_count()` directly.
- New `mpp/host.rs` with the `MppHostState` trait and a `exec_mpp_worker_impl<S>` dispatcher.
- Both providers `impl MppHostState for CustomScanStateWrapper<T>`.

## Tests

- `cargo check --package pg_search --features pg18 --no-default-features` clean.
- `mpp_smoke`, `mpp_joinscan`, `mpp_aggregate`, `mpp_aggregate_postagg` all pass.
- CI green.
