### PR TITLE
refactor(mpp): drop EXPLAIN-time stub mesh

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -45,9 +45,8 @@ use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTas
 
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, mpp_worker_count,
-    producer_worker_count, pscan_offset, read_custom_scan_header, worker_setup,
-    write_custom_scan_header, CustomScanMppHeader,
+    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
+    read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 
@@ -1001,7 +1000,10 @@ impl AggregateScan {
     /// Build the leader's distributed session context for this AggregateScan query. Thin
     /// wrapper over the shape-agnostic [`crate::postgres::customscan::mpp::exec_worker::
     /// build_mpp_session_context`] that seeds with `create_aggregate_session_context()`.
-    fn build_mpp_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
+    /// `mesh = None` is the EXPLAIN-time variant — see the shared helper's doc.
+    fn build_mpp_session_context(
+        mesh: Option<Arc<MppMesh>>,
+    ) -> datafusion::prelude::SessionContext {
         crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context(
             create_aggregate_session_context(),
             mesh,
@@ -1030,12 +1032,11 @@ impl AggregateScan {
         let custom_exprs = df_state.custom_exprs;
         let custom_scan_tlist = df_state.custom_scan_tlist;
         let ctx = if mpp_is_active() {
-            // Drain-less stub mesh. `with_distributed_planner` only needs `n_procs` for stage
-            // sizing, and `ShmMqWorkerTransport::open()` doesn't run during EXPLAIN. Going
-            // through the constructor is the only safe way to build an `MppMesh` outside
-            // `glue::leader_setup`.
-            let stub_mesh = Arc::new(MppMesh::new(0, mpp_worker_count(), Vec::new()));
-            Self::build_mpp_session_context(stub_mesh)
+            // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
+            // The shared session-context builder takes `mesh = None` and derives `n_workers`
+            // from `producer_worker_count()`, so the planner still emits a `DistributedExec`
+            // root with the right stage sizing for display.
+            Self::build_mpp_session_context(None)
         } else {
             create_aggregate_session_context()
         };
@@ -1536,7 +1537,7 @@ impl AggregateScan {
                             );
                         }
                     }
-                    Self::build_mpp_session_context(Arc::clone(&leader.mesh))
+                    Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
                 }
                 _ => create_aggregate_session_context(),
             };

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1000,7 +1000,7 @@ impl AggregateScan {
     /// Build the leader's distributed session context for this AggregateScan query. Thin
     /// wrapper over the shape-agnostic [`crate::postgres::customscan::mpp::exec_worker::
     /// build_mpp_session_context`] that seeds with `create_aggregate_session_context()`.
-    /// `mesh = None` is the EXPLAIN-time variant — see the shared helper's doc.
+    /// `mesh = None` is the EXPLAIN-time path. See the shared helper's doc.
     fn build_mpp_session_context(
         mesh: Option<Arc<MppMesh>>,
     ) -> datafusion::prelude::SessionContext {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1060,7 +1060,7 @@ impl JoinScan {
     /// Build the leader's distributed session context for this JoinScan query. Thin wrapper
     /// over the shared [`crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context`]
     /// that seeds with `create_datafusion_session_context(SessionContextProfile::Join)`.
-    /// `mesh = None` is the EXPLAIN-time variant — see the shared helper's doc.
+    /// `mesh = None` is the EXPLAIN-time path. See the shared helper's doc.
     fn build_mpp_session_context(
         mesh: Option<Arc<MppMesh>>,
     ) -> datafusion::prelude::SessionContext {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -180,9 +180,8 @@ use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_f
 use crate::postgres::customscan::joinscan::scan_state::MppExecState;
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, mpp_worker_count,
-    producer_worker_count, pscan_offset, read_custom_scan_header, worker_setup,
-    write_custom_scan_header, CustomScanMppHeader,
+    estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
+    read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::parallel::compute_nworkers;
@@ -1061,7 +1060,10 @@ impl JoinScan {
     /// Build the leader's distributed session context for this JoinScan query. Thin wrapper
     /// over the shared [`crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context`]
     /// that seeds with `create_datafusion_session_context(SessionContextProfile::Join)`.
-    fn build_mpp_session_context(mesh: Arc<MppMesh>) -> datafusion::prelude::SessionContext {
+    /// `mesh = None` is the EXPLAIN-time variant — see the shared helper's doc.
+    fn build_mpp_session_context(
+        mesh: Option<Arc<MppMesh>>,
+    ) -> datafusion::prelude::SessionContext {
         crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context(
             create_datafusion_session_context(SessionContextProfile::Join),
             mesh,
@@ -1356,13 +1358,12 @@ impl CustomScan for JoinScan {
             }
             // For plain EXPLAIN, reconstruct the plan using the same session configuration
             // that execution uses so `VisibilityFilterExec` appears in the displayed plan,
-            // matching EXPLAIN ANALYZE. When MPP is active, use a drain-less stub mesh so the
-            // distributed planner runs and the displayed plan shows `DistributedExec` + stages.
-            // `ShmMqWorkerTransport::open()` doesn't run during EXPLAIN, so the stub is safe.
+            // matching EXPLAIN ANALYZE. When MPP is active, pass `mesh = None`; the shared
+            // session-context builder derives `n_workers` from `producer_worker_count()` and
+            // skips the shm_mq transport install (EXPLAIN doesn't execute).
             let expr_context = crate::postgres::utils::ExprContextGuard::new();
             let ctx = if mpp_is_active() {
-                let stub_mesh = Arc::new(MppMesh::new(0, mpp_worker_count(), Vec::new()));
-                Self::build_mpp_session_context(stub_mesh)
+                Self::build_mpp_session_context(None)
             } else {
                 create_datafusion_session_context(SessionContextProfile::Join)
             };
@@ -1498,7 +1499,7 @@ impl CustomScan for JoinScan {
                                 );
                             }
                         }
-                        Self::build_mpp_session_context(Arc::clone(&leader.mesh))
+                        Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
                     }
                     _ => create_datafusion_session_context(SessionContextProfile::Join),
                 };

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -91,51 +91,43 @@ pub(crate) fn build_mpp_session_context(
     seed: SessionContext,
     mesh: Option<Arc<MppMesh>>,
 ) -> SessionContext {
-    // Workers are procs 1..n_procs; leader is proc 0. The producer count is `n_procs - 1`.
-    // `n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before reaching this).
+    // Workers are procs 1..n_procs; leader is proc 0. Producer count = n_procs - 1.
+    // `mpp_is_active()` already guarantees n_procs >= 3 (callers gate first).
     //
-    // `mesh = None` is the EXPLAIN-time variant: the planner only needs `n_workers` for stage
-    // sizing and target_partitions; the WorkerTransport is never consulted because EXPLAIN
-    // doesn't execute. Skip the transport install in that case and the fork's default
-    // (FlightWorkerTransport) sits unused. `mesh = Some(_)` is required for actual execution.
-    //
-    // Both branches resolve to `mpp_worker_count() - 1` at call time — the leader's `MppMesh`
-    // is itself constructed from `mpp_worker_count()` in `leader_setup`. EXPLAIN reflects the
-    // GUC at EXPLAIN time; a subsequent `SET paradedb.mpp_worker_count` shifts the next
-    // execute path's stage shape away from what EXPLAIN rendered (same behavior as pre-R13,
-    // since the stub-mesh also read the GUC at EXPLAIN time).
+    // `mesh = None` is the EXPLAIN-time path: the planner only needs `n_workers` for stage
+    // sizing and target_partitions. EXPLAIN never opens a `WorkerConnection`, so we skip
+    // the transport install and the fork's default sits unused. Both branches resolve to
+    // `mpp_worker_count() - 1` at call time, so EXPLAIN reflects the GUC at the time it
+    // ran; a later `SET paradedb.mpp_worker_count` shifts the next execute path.
     let n_workers = match mesh.as_ref() {
         Some(m) => m.n_workers() as usize,
         None => producer_worker_count() as usize,
     };
-    // Four-knob unlock for actually inserting NetworkShuffleExec/etc.:
-    //   1. target_partitions(N) — without this, EnforceDistribution skips every
-    //      RepartitionExec, so the annotator never sees a Shuffle.
-    //   2. distributed_task_estimator(N) — without this, leaves default to Maximum(1) and
+    // Four knobs that have to be set for the planner to actually emit `NetworkShuffleExec`:
+    //   1. target_partitions(N): without it, EnforceDistribution skips every
+    //      RepartitionExec so the annotator never sees a Shuffle.
+    //   2. distributed_task_estimator(N): without it, leaves default to Maximum(1) and
     //      `_distribute_plan` elides every shuffle.
-    //   3. distributed_broadcast_joins(true) — CollectLeft HashJoins otherwise cap their
-    //      stage's task_count to Maximum(1) and propagate that cap upward, eliding shuffles
-    //      above the join.
-    //   4. distributed_user_codec — the DF-D fork's prepare_plan unconditionally encodes
-    //      worker subplans for gRPC shipment; without a codec for our custom physical execs,
-    //      encoding errors before execution. In our model the encoded bytes are never observed
-    //      (workers re-plan from the logical plan in DSM), so the codec is a stub.
+    //   3. distributed_broadcast_joins(true): otherwise CollectLeft HashJoins cap their
+    //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
+    //   4. distributed_in_process_mode(true): skips the gRPC plan-send / metrics /
+    //      work-unit-feed tasks. Workers re-plan from the logical plan in DSM.
     let cfg = seed
         .copied_config()
         .with_target_partitions(n_workers.max(2));
 
-    // Start from the seed's existing state so the customscan's query planner (`PgSearchQueryPlanner`),
-    // optimizer rules, and registered extensions all carry over. JoinScan relies on this for
-    // `VisibilityFilterNode` -> `VisibilityFilterExec` translation; AggregateScan's plan happens
-    // not to use any custom logical nodes but inheriting the planner is still the correct
-    // default. We then override `with_config` (bumps `target_partitions`) and layer the
-    // distributed-planner knobs on top.
-    // Both seeds (`create_aggregate_session_context`, `create_datafusion_session_context`) ship
-    // without a `DistributedConfig` extension installed. The bootstrap below would clobber one
-    // if a future change started adding `with_distributed_*` calls on the seed, so guard
-    // explicitly. Debug-only — release builds silently take the latter precedence (an honest
-    // mistake here would surface as missing `in_process_mode` / `broadcast_joins` knobs at
-    // execute time, which the existing regress suite catches).
+    // Start from the seed's existing state so the customscan's query planner
+    // (`PgSearchQueryPlanner`), optimizer rules, and registered extensions all carry over.
+    // JoinScan needs this for `VisibilityFilterNode` -> `VisibilityFilterExec` translation;
+    // AggregateScan's plan doesn't use custom logical nodes but inheriting the planner is
+    // still the right default. We then override `with_config` (bumps target_partitions)
+    // and layer the distributed-planner knobs on top.
+    //
+    // Both seeds ship without a `DistributedConfig` extension. The bootstrap below would
+    // clobber one if a future change started adding `with_distributed_*` calls on the
+    // seed, so guard explicitly. Debug-only; release builds silently let the bootstrap
+    // win, which would surface as missing `in_process_mode` / `broadcast_joins` knobs at
+    // execute time and trip the regress suite.
     debug_assert!(
         seed.state()
             .config()
@@ -148,18 +140,16 @@ pub(crate) fn build_mpp_session_context(
     );
     let mut state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
-        // Explicit bootstrap: install a default `DistributedConfig` so the downstream
-        // `with_distributed_*` setters have an extension to mutate. Previously
-        // `with_distributed_worker_transport` did this implicitly as a side effect of being
-        // first in the chain; with the transport now optional (EXPLAIN passes mesh = None),
-        // bootstrap explicitly so the order of setters doesn't matter.
+        // Explicit `DistributedConfig` bootstrap so the downstream `with_distributed_*`
+        // setters have something to mutate. `with_distributed_worker_transport` used to
+        // bootstrap this implicitly when it was first in the chain; with the transport
+        // now optional (EXPLAIN passes mesh = None) we install the extension explicitly
+        // so order doesn't matter.
         .with_distributed_option_extension(DistributedConfig::default())
-        // No `with_distributed_worker_resolver(...)` line is needed: fork PR
-        // paradedb/datafusion-distributed#10 made the `WorkerResolver` lookup conditional
-        // on `!in_process_mode`. Workers in our embedding are PG parallel workers in the
-        // same backend tree, not URL-addressed nodes; the fork substitutes a single
-        // placeholder URL internally so its planner's URL plumbing stays satisfied while
-        // we ship no resolver of our own.
+        // No `with_distributed_worker_resolver(...)`: under `in_process_mode = true`, the
+        // fork gates the resolver lookup and substitutes a single placeholder URL. Our
+        // "workers" are PG parallel workers in the same backend tree, not URL-addressed
+        // nodes, so we have nothing meaningful to resolve.
         .with_distributed_in_process_mode(true)
         .expect("with_distributed_in_process_mode");
     // Install the shm_mq transport only when running for actual execution (mesh = Some).
@@ -178,20 +168,12 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)` line is needed because:
-        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
-        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
-        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
-        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
-        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
-        //       re-plan from the logical plan we ship via DSM and never decode a physical
-        //       subplan over the wire.
-        //
-        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
-        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
-        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
-        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
-        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
+        // No `with_distributed_user_codec(...)`: under `in_process_mode = true`, the fork
+        // skips constructing `CoordinatorToWorkerTaskSpawner`, so its eager codec encode
+        // never runs. Workers re-plan from the logical plan we ship via DSM and never
+        // decode a physical subplan over the wire. If `in_process_mode = false` ever gets
+        // exercised, restore a codec here for our custom execs or `try_encode` will reject
+        // the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -38,13 +38,15 @@ use datafusion::execution::{SessionStateBuilder, TaskContext};
 use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
-    DistributedExec, DistributedExt, DistributedTaskContext, SessionStateBuilderExt,
+    DistributedConfig, DistributedExec, DistributedExt, DistributedTaskContext,
+    SessionStateBuilderExt,
 };
 use pgrx::pg_sys;
 use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use crate::postgres::customscan::mpp::glue::producer_worker_count;
 use crate::postgres::customscan::mpp::runtime::{proc_for_task, MppMesh, ShmMqWorkerTransport};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
@@ -87,11 +89,25 @@ pub(crate) struct MppWorkerInputs {
 /// The function copies its config and layers the distributed-planner knobs on top.
 pub(crate) fn build_mpp_session_context(
     seed: SessionContext,
-    mesh: Arc<MppMesh>,
+    mesh: Option<Arc<MppMesh>>,
 ) -> SessionContext {
     // Workers are procs 1..n_procs; leader is proc 0. The producer count is `n_procs - 1`.
     // `n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before reaching this).
-    let n_workers = mesh.n_workers() as usize;
+    //
+    // `mesh = None` is the EXPLAIN-time variant: the planner only needs `n_workers` for stage
+    // sizing and target_partitions; the WorkerTransport is never consulted because EXPLAIN
+    // doesn't execute. Skip the transport install in that case and the fork's default
+    // (FlightWorkerTransport) sits unused. `mesh = Some(_)` is required for actual execution.
+    //
+    // Both branches resolve to `mpp_worker_count() - 1` at call time — the leader's `MppMesh`
+    // is itself constructed from `mpp_worker_count()` in `leader_setup`. EXPLAIN reflects the
+    // GUC at EXPLAIN time; a subsequent `SET paradedb.mpp_worker_count` shifts the next
+    // execute path's stage shape away from what EXPLAIN rendered (same behavior as pre-R13,
+    // since the stub-mesh also read the GUC at EXPLAIN time).
+    let n_workers = match mesh.as_ref() {
+        Some(m) => m.n_workers() as usize,
+        None => producer_worker_count() as usize,
+    };
     // Four-knob unlock for actually inserting NetworkShuffleExec/etc.:
     //   1. target_partitions(N) — without this, EnforceDistribution skips every
     //      RepartitionExec, so the annotator never sees a Shuffle.
@@ -114,31 +130,68 @@ pub(crate) fn build_mpp_session_context(
     // not to use any custom logical nodes but inheriting the planner is still the correct
     // default. We then override `with_config` (bumps `target_partitions`) and layer the
     // distributed-planner knobs on top.
-    let state_builder = SessionStateBuilder::new_from_existing(seed.state())
+    // Both seeds (`create_aggregate_session_context`, `create_datafusion_session_context`) ship
+    // without a `DistributedConfig` extension installed. The bootstrap below would clobber one
+    // if a future change started adding `with_distributed_*` calls on the seed, so guard
+    // explicitly. Debug-only — release builds silently take the latter precedence (an honest
+    // mistake here would surface as missing `in_process_mode` / `broadcast_joins` knobs at
+    // execute time, which the existing regress suite catches).
+    debug_assert!(
+        seed.state()
+            .config()
+            .options()
+            .extensions
+            .get::<DistributedConfig>()
+            .is_none(),
+        "build_mpp_session_context: seed already carries a DistributedConfig; the bootstrap \
+         below would overwrite it"
+    );
+    let mut state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
-        // No `with_distributed_worker_resolver(...)`: under `in_process_mode = true`, the
-        // fork gates the resolver lookup and substitutes a single placeholder URL. Our
-        // "workers" are PG parallel workers in the same backend tree, not URL-addressed
-        // nodes, so we have nothing meaningful to resolve.
-        .with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))
+        // Explicit bootstrap: install a default `DistributedConfig` so the downstream
+        // `with_distributed_*` setters have an extension to mutate. Previously
+        // `with_distributed_worker_transport` did this implicitly as a side effect of being
+        // first in the chain; with the transport now optional (EXPLAIN passes mesh = None),
+        // bootstrap explicitly so the order of setters doesn't matter.
+        .with_distributed_option_extension(DistributedConfig::default())
+        // No `with_distributed_worker_resolver(...)` line is needed: fork PR
+        // paradedb/datafusion-distributed#10 made the `WorkerResolver` lookup conditional
+        // on `!in_process_mode`. Workers in our embedding are PG parallel workers in the
+        // same backend tree, not URL-addressed nodes; the fork substitutes a single
+        // placeholder URL internally so its planner's URL plumbing stays satisfied while
+        // we ship no resolver of our own.
         .with_distributed_in_process_mode(true)
-        .expect("with_distributed_in_process_mode")
-        // Estimator chain order matters. The DF-D fork tries each estimator in registration
-        // order until one returns Some. The build-side one-task estimator has to come first.
-        // Otherwise the default `Desired(n_workers)` leaf estimator wins, the all-gather
-        // memory leaf gets task_count = n_workers, `_distribute_plan` builds
-        // `NetworkBroadcastExec` with `input_task_count = n_workers`, and the consumer's
-        // `select_all` over-counts by n_workers. See task_estimator.rs.
+        .expect("with_distributed_in_process_mode");
+    // Install the shm_mq transport only when running for actual execution (mesh = Some).
+    // EXPLAIN passes mesh = None and the fork's default (FlightWorkerTransport) sits
+    // unused. The planner never calls WorkerConnection::open() outside streaming, so the
+    // default is fine for read-only plan introspection.
+    if let Some(mesh) = mesh {
+        state_builder =
+            state_builder.with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh));
+    }
+    let state_builder = state_builder
+        // Broadcast-subtree cap. Chain order matters: this has to come before the leaf
+        // estimator, otherwise the leaf's `Desired(n_workers)` wins, every producer task
+        // re-emits the full build side, and the consumer's `select_all` over-counts.
         .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)`: under `in_process_mode = true`, the fork
-        // skips constructing `CoordinatorToWorkerTaskSpawner`, so its eager codec encode
-        // never runs. Workers re-plan from the logical plan we ship via DSM and never
-        // decode a physical subplan over the wire. If `in_process_mode = false` ever gets
-        // exercised, restore a codec here for our custom execs or `try_encode` will reject
-        // the first one it meets.
+        // No `with_distributed_user_codec(...)` line is needed because:
+        //   (a) we hard-wire `with_distributed_in_process_mode(true)` two lines above, and
+        //   (b) fork PR paradedb/datafusion-distributed#8 short-circuits the eager
+        //       `PhysicalPlanNode::try_from_physical_plan(stage.plan, codec).encode_to_vec()`
+        //       inside `CoordinatorToWorkerTaskSpawner::new` whenever in-process mode is
+        //       on. With (a) + (b), no physical codec is consulted at any point. Workers
+        //       re-plan from the logical plan we ship via DSM and never decode a physical
+        //       subplan over the wire.
+        //
+        // If `in_process_mode = false` is ever exercised (e.g. a remote-worker mode
+        // appears), restore `.with_distributed_user_codec(...)` here for our custom execs
+        // (`PgSearchScan`, `VisibilityFilterExec`, `SegmentedTopKExec`, `TantivyLookupExec`,
+        // `FilterPassthroughExec`); the default `DistributedCodec` will otherwise fail with
+        // `Unexpected plan {name}` from `try_encode` on the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }
@@ -198,7 +251,7 @@ pub(crate) fn run_mpp_worker(
         Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
     };
 
-    let session = build_mpp_session_context(seed_ctx, Arc::clone(&worker_mesh));
+    let session = build_mpp_session_context(seed_ctx, Some(Arc::clone(&worker_mesh)));
 
     let physical_plan =
         runtime.block_on(async { session.state().create_physical_plan(&logical).await });
@@ -207,10 +260,11 @@ pub(crate) fn run_mpp_worker(
         Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
     };
 
-    // Collect every `(stage_id, task_idx)` slot this proc owns under the `proc_for_task`
-    // round-robin. The dispatcher spawns one async task per fragment; together they form
-    // the worker's full contribution to the distributed plan. `mpp_is_active()` already
-    // guarantees `n_procs >= 3`, so `n_workers() = n_procs - 1` is safe.
+    // Walk the plan and collect every `(stage_id, task_idx)` slot owned by this proc under
+    // the `proc_for_task` round-robin policy. The dispatcher spawns one async task per
+    // fragment; together they form the worker's complete contribution to the distributed
+    // plan. `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate
+    // before reaching this), so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();
     let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
     if fragments.is_empty() {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Drops the drain-less stub `MppMesh` that EXPLAIN was building purely to satisfy `with_distributed_worker_transport`'s non-optional argument. `build_mpp_session_context` now takes `Option<Arc<MppMesh>>`.

## Why

The fork's `get_distributed_worker_transport` already falls back to a default `WorkerTransport` (`FlightWorkerTransport`) when none is registered. EXPLAIN never executes anything that consults the transport, so the stub was protecting against a phantom problem.

## How

- `build_mpp_session_context(seed, mesh: Option<Arc<MppMesh>>)`. When `Some`, install `ShmMqWorkerTransport`. When `None`, skip and let the fork's default sit unused.
- `n_workers` resolves from `mesh.n_workers()` when present and `producer_worker_count()` when not. Same value at runtime, but the latter doesn't need a mesh.
- Explicitly bootstrap `DistributedConfig::default()` via `with_distributed_option_extension` so the rest of the chain doesn't depend on `with_distributed_worker_transport` running first.
- `aggregatescan::render_df_physical_plan` and JoinScan's EXPLAIN-time `build_displayable_explain_string` both pass `None` instead of constructing a stub mesh. Drop the now-unused `mpp_worker_count` imports.

## Tests

- `cargo check --package pg_search --features pg18 --no-default-features` clean.
- All 4 MPP regress tests pass. EXPLAIN output unchanged — no expected-file drift.
- CI green.
