### PR TITLE
refactor(mpp): extract frame codec into fork_portable submodule (R14)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=df08003#df08003fa0666ed682bbf8b0d8b3402265ef2b5d"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=5c84235#5c8423566e3ace73bcf97129948152a8b7c1350d"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2204,7 +2204,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=5c84235#5c8423566e3ace73bcf97129948152a8b7c1350d"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=9f11f0c#9f11f0cb539e2a5a5ff83987c6452cc6a78cdb15"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-7chFNBcr99SyPJIoSRybum2Ka/k6zTBydBhr9ztR/Wk=";
+  cargoHash = "sha256-QjM3MftR5Wf40rPwQmMkVX+A42rLTz+EclflSHDm40c=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-PUkmkE6O+6idrOCSohBSnvUu8azYf43VtOenqzzfgA8=";
+  cargoHash = "sha256-7chFNBcr99SyPJIoSRybum2Ka/k6zTBydBhr9ztR/Wk=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "5c84235" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "9f11f0c" }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "df08003" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "5c84235" }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -43,9 +43,10 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use crate::postgres::customscan::mpp::fork_portable::frame::MppFrameHeader;
 use crate::postgres::customscan::mpp::glue::producer_worker_count;
 use crate::postgres::customscan::mpp::runtime::{proc_for_task, MppMesh, ShmMqWorkerTransport};
-use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
+use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppSender};
 use crate::postgres::customscan::mpp::worker::run_worker_fragment;
 use crate::postgres::customscan::mpp::worker_fragments::{
     find_worker_assignments, FragmentRouting,

--- a/pg_search/src/postgres/customscan/mpp/fork_portable/frame.rs
+++ b/pg_search/src/postgres/customscan/mpp/fork_portable/frame.rs
@@ -1,0 +1,365 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Multi-channel Arrow IPC frame codec.
+//!
+//! Every wire message carries a fixed 16-byte [`MppFrameHeader`] prefix
+//! `(magic, flags, stage_id, partition)` so a single underlying byte queue can
+//! interleave frames for many logical `(stage_id, partition)` channels.
+//! Receivers demultiplex by header before touching Arrow IPC.
+//!
+//! Wire format:
+//!
+//! ```text
+//! [ magic | flags | stage_id | partition ] [ Arrow IPC stream bytes ]
+//! |---------- 16 bytes --------|           |---- variable ----|
+//! ```
+//!
+//! No `pgrx::*` references — see this submodule's `mod.rs` for the
+//! fork-portability story.
+
+use datafusion::arrow::array::RecordBatch;
+use datafusion::arrow::ipc::reader::StreamReader;
+use datafusion::arrow::ipc::writer::StreamWriter;
+use datafusion::common::DataFusionError;
+
+/// Magic bytes "MPPF" (MPP Frame) at the start of every wire message.
+/// Lets receivers reject misrouted / corrupt frames before they hit Arrow IPC.
+const MPP_FRAME_MAGIC: u32 = 0x4D505046;
+
+/// Wire-format size of [`MppFrameHeader`] in bytes. Asserted at compile time
+/// below via `const _: ()`.
+pub(in crate::postgres::customscan::mpp) const MPP_FRAME_HEADER_SIZE: usize = 16;
+
+/// Kind of payload following [`MppFrameHeader`].
+///
+/// `Batch` is the common case. The header is followed by an Arrow IPC stream containing one
+/// `RecordBatch`. `Eof` carries no payload. It signals the receiver that the named
+/// `(stage_id, partition)` channel is done, even though the underlying byte queue may still
+/// carry frames for other channels.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::postgres::customscan::mpp) enum MppFrameKind {
+    Batch = 0,
+    Eof = 1,
+}
+
+/// 16-byte prefix on every transport frame.
+///
+/// The fixed layout `[magic, flags, stage_id, partition]` (4×u32) is what
+/// senders prepend before the Arrow IPC stream bytes and what receivers
+/// parse before deciding which channel buffer the payload belongs to.
+///
+/// The `flags` word currently encodes [`MppFrameKind`] in its low byte (mask
+/// `0x0000_00FF`); the upper 24 bits are reserved-must-be-zero and are
+/// validated at parse time so a future use can repurpose them without a
+/// wire-format break.
+#[repr(C)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MppFrameHeader {
+    pub magic: u32,
+    pub flags: u32,
+    pub stage_id: u32,
+    pub partition: u32,
+}
+
+/// Bit mask in [`MppFrameHeader::flags`] for the [`MppFrameKind`] discriminant.
+const FRAME_KIND_MASK: u32 = 0x0000_00FF;
+
+const _: () = {
+    // shm_mq slot layout calculations depend on this being exact.
+    assert!(std::mem::size_of::<MppFrameHeader>() == MPP_FRAME_HEADER_SIZE);
+};
+
+impl MppFrameHeader {
+    /// Build a `Batch` header for the given `(stage_id, partition)`.
+    pub fn batch(stage_id: u32, partition: u32) -> Self {
+        Self {
+            magic: MPP_FRAME_MAGIC,
+            flags: MppFrameKind::Batch as u32,
+            stage_id,
+            partition,
+        }
+    }
+
+    /// Build an `Eof` header for the given `(stage_id, partition)`. Carries no payload; receivers
+    /// route it to the channel buffer's source-done counter. Emitted after a producer fragment's
+    /// per-partition stream exhausts (or errors), and consumed by the matching channel buffer's
+    /// `notify_source_done`.
+    pub fn eof(stage_id: u32, partition: u32) -> Self {
+        Self {
+            magic: MPP_FRAME_MAGIC,
+            flags: MppFrameKind::Eof as u32,
+            stage_id,
+            partition,
+        }
+    }
+
+    /// Read the kind out of `flags`. Returns an error if the kind byte is
+    /// unknown or if any reserved upper bit is set, which catches wire-format
+    /// drift early.
+    pub(in crate::postgres::customscan::mpp) fn kind(
+        &self,
+    ) -> Result<MppFrameKind, DataFusionError> {
+        let reserved = self.flags & !FRAME_KIND_MASK;
+        if reserved != 0 {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: reserved frame flag bits set ({reserved:#x})"
+            )));
+        }
+        match self.flags & FRAME_KIND_MASK {
+            0 => Ok(MppFrameKind::Batch),
+            1 => Ok(MppFrameKind::Eof),
+            other => Err(DataFusionError::Internal(format!(
+                "mpp: unknown frame kind {other:#x}"
+            ))),
+        }
+    }
+
+    /// Serialize into the first `MPP_FRAME_HEADER_SIZE` bytes of `out`.
+    /// `out.len()` must be `>= MPP_FRAME_HEADER_SIZE`.
+    fn write_to(&self, out: &mut [u8]) {
+        debug_assert!(out.len() >= MPP_FRAME_HEADER_SIZE);
+        out[0..4].copy_from_slice(&self.magic.to_le_bytes());
+        out[4..8].copy_from_slice(&self.flags.to_le_bytes());
+        out[8..12].copy_from_slice(&self.stage_id.to_le_bytes());
+        out[12..16].copy_from_slice(&self.partition.to_le_bytes());
+    }
+
+    /// Parse from the first `MPP_FRAME_HEADER_SIZE` bytes of `bytes`. Returns
+    /// `Err` if the slice is too short or the magic doesn't match.
+    fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
+        if bytes.len() < MPP_FRAME_HEADER_SIZE {
+            // No encoder in this file emits sub-header output, so a short frame means the
+            // byte queue stitched together payloads from different senders. Hex-dump the bytes
+            // so the source is identifiable from log output without a debugger.
+            let hex = bytes
+                .iter()
+                .map(|b| format!("{b:02x}"))
+                .collect::<Vec<_>>()
+                .join(" ");
+            return Err(DataFusionError::Internal(format!(
+                "mpp: frame too short for header ({} < {}); bytes = [{hex}]",
+                bytes.len(),
+                MPP_FRAME_HEADER_SIZE
+            )));
+        }
+        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        if magic != MPP_FRAME_MAGIC {
+            return Err(DataFusionError::Internal(format!(
+                "mpp: bad frame magic {magic:#x} (expected {MPP_FRAME_MAGIC:#x})"
+            )));
+        }
+        Ok(Self {
+            magic,
+            flags: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
+            stage_id: u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
+            partition: u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
+        })
+    }
+}
+
+/// Serialize `batch` into `buf` with a 16-byte [`MppFrameHeader`] prefix
+/// addressing it to `(stage_id, partition)`. Wire format:
+///
+/// ```text
+/// [ magic | flags | stage_id | partition ] [ Arrow IPC stream bytes ]
+/// |---------- 16 bytes --------|           |---- variable ----|
+/// ```
+///
+/// Caller is expected to hold `buf` alive across many encodes so the peak-sized
+/// allocation amortizes (~500 KB/batch on the 25M GROUP BY bench).
+pub(in crate::postgres::customscan::mpp) fn encode_frame_into(
+    header: MppFrameHeader,
+    batch: &RecordBatch,
+    buf: &mut Vec<u8>,
+) -> Result<(), DataFusionError> {
+    buf.clear();
+    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
+    header.write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
+    let mut writer = StreamWriter::try_new(&mut *buf, batch.schema_ref())?;
+    writer.write(batch)?;
+    writer.finish()?;
+    Ok(())
+}
+
+/// Serialize a payload-less [`MppFrameKind::Eof`] frame for `(stage_id, partition)`
+/// into `buf`. Receivers read this as a 16-byte message and route it to the
+/// channel buffer's source-done counter without touching Arrow IPC.
+///
+/// Used when a producer fragment's per-partition stream exhausts, so the
+/// receiver's `(stage_id, partition)` channel buffer transitions to `Eof` even
+/// though the multiplexed underlying queue stays attached for other channels.
+pub(in crate::postgres::customscan::mpp) fn encode_eof_frame_into(
+    stage_id: u32,
+    partition: u32,
+    buf: &mut Vec<u8>,
+) -> Result<(), DataFusionError> {
+    buf.clear();
+    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
+    MppFrameHeader::eof(stage_id, partition).write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
+    Ok(())
+}
+
+/// Inverse of [`encode_frame_into`]. Parses the 16-byte header and, for `Batch` frames, decodes
+/// the trailing Arrow IPC stream. `Eof` frames return `(header, None)`. Receivers branch on
+/// `header.kind()` to decide routing.
+pub(in crate::postgres::customscan::mpp) fn decode_frame(
+    bytes: &[u8],
+) -> Result<(MppFrameHeader, Option<RecordBatch>), DataFusionError> {
+    let header = MppFrameHeader::parse(bytes)?;
+    match header.kind()? {
+        MppFrameKind::Eof => {
+            if bytes.len() != MPP_FRAME_HEADER_SIZE {
+                return Err(DataFusionError::Internal(format!(
+                    "mpp: Eof frame carries payload ({} > {})",
+                    bytes.len(),
+                    MPP_FRAME_HEADER_SIZE
+                )));
+            }
+            Ok((header, None))
+        }
+        MppFrameKind::Batch => {
+            let payload = &bytes[MPP_FRAME_HEADER_SIZE..];
+            let mut reader = StreamReader::try_new(payload, None)?;
+            let batch = reader.next().ok_or_else(|| {
+                DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_frame".into())
+            })??;
+            Ok((header, Some(batch)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::arrow::array::{Int32Array, StringArray};
+    use datafusion::arrow::datatypes::{DataType, Field, Schema};
+    use std::sync::Arc;
+
+    fn sample_batch(rows: i32) -> RecordBatch {
+        let schema = Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Int32, false),
+            Field::new("name", DataType::Utf8, false),
+        ]));
+        let ids = Int32Array::from_iter_values(0..rows);
+        let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
+        RecordBatch::try_new(schema, vec![Arc::new(ids), Arc::new(names)]).unwrap()
+    }
+
+    #[test]
+    fn frame_round_trips_a_batch_with_header() {
+        let orig = sample_batch(64);
+        let header = MppFrameHeader::batch(7, 3);
+        let mut buf = Vec::with_capacity(1024);
+        encode_frame_into(header, &orig, &mut buf).expect("encode_frame");
+
+        let (parsed, batch_opt) = decode_frame(&buf).expect("decode_frame");
+        assert_eq!(parsed, header);
+        assert_eq!(parsed.kind().unwrap(), MppFrameKind::Batch);
+        let decoded = batch_opt.expect("Batch frame must carry a payload");
+        assert_eq!(decoded.num_rows(), 64);
+        assert_eq!(decoded.schema(), orig.schema());
+        assert_eq!(decoded.num_columns(), orig.num_columns());
+        for col in 0..orig.num_columns() {
+            assert_eq!(orig.column(col).as_ref(), decoded.column(col).as_ref());
+        }
+    }
+
+    #[test]
+    fn frame_round_trips_eof() {
+        let mut buf = Vec::new();
+        encode_eof_frame_into(2, 5, &mut buf).expect("encode_eof");
+        assert_eq!(buf.len(), MPP_FRAME_HEADER_SIZE);
+
+        let (header, batch_opt) = decode_frame(&buf).expect("decode_frame");
+        assert_eq!(header, MppFrameHeader::eof(2, 5));
+        assert_eq!(header.kind().unwrap(), MppFrameKind::Eof);
+        assert!(batch_opt.is_none());
+    }
+
+    #[test]
+    fn frame_rejects_short_message() {
+        let too_short = vec![0u8; MPP_FRAME_HEADER_SIZE - 1];
+        let err = decode_frame(&too_short).expect_err("short frame must fail");
+        assert!(format!("{err}").contains("too short"));
+    }
+
+    #[test]
+    fn frame_rejects_bad_magic() {
+        // Explicit non-zero, non-magic prefix. Don't rely on the
+        // happenstance that 0u32 != MPP_FRAME_MAGIC.
+        let mut bad = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        bad[0..4].copy_from_slice(&0xCAFEBABE_u32.to_le_bytes());
+        let err = decode_frame(&bad).expect_err("bad magic must fail");
+        assert!(format!("{err}").contains("bad frame magic"));
+        bad[0..4].copy_from_slice(&0xDEADBEEF_u32.to_le_bytes());
+        let err = decode_frame(&bad).expect_err("bad magic must fail");
+        assert!(format!("{err}").contains("bad frame magic"));
+    }
+
+    #[test]
+    fn frame_rejects_unknown_kind() {
+        let header = MppFrameHeader {
+            magic: MPP_FRAME_MAGIC,
+            flags: 0x42, // unknown kind byte, no reserved bits set
+            stage_id: 0,
+            partition: 0,
+        };
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        let err = decode_frame(&buf).expect_err("unknown kind must fail");
+        assert!(format!("{err}").contains("unknown frame kind"));
+    }
+
+    #[test]
+    fn frame_rejects_reserved_flag_bits() {
+        // Any bit above the low byte of `flags` is reserved-must-be-zero;
+        // setting one should trip `kind()` before the kind byte is consulted.
+        let header = MppFrameHeader {
+            magic: MPP_FRAME_MAGIC,
+            flags: 0x0000_0100, // bit 8 set, kind byte 0 (would be Batch)
+            stage_id: 0,
+            partition: 0,
+        };
+        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+        header.write_to(&mut buf);
+        let err = decode_frame(&buf).expect_err("reserved bit must fail");
+        assert!(format!("{err}").contains("reserved frame flag bits"));
+    }
+
+    #[test]
+    fn frame_eof_with_payload_is_rejected() {
+        let mut buf = Vec::with_capacity(32);
+        encode_eof_frame_into(0, 0, &mut buf).expect("encode_eof");
+        buf.push(0xAB); // smuggle a payload byte after the Eof header
+        let err = decode_frame(&buf).expect_err("Eof+payload must fail");
+        assert!(format!("{err}").contains("Eof frame carries payload"));
+    }
+
+    #[test]
+    fn codec_round_trips_many_batch_sizes() {
+        let mut buf = Vec::with_capacity(1024);
+        for rows in [0, 1, 7, 64, 1024] {
+            let orig = sample_batch(rows);
+            encode_frame_into(MppFrameHeader::batch(0, 0), &orig, &mut buf).expect("encode");
+            let (_header, decoded) = decode_frame(&buf).expect("decode");
+            let decoded = decoded.expect("Batch frame must carry a payload");
+            assert_eq!(orig.num_rows(), decoded.num_rows());
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/fork_portable/frame.rs
+++ b/pg_search/src/postgres/customscan/mpp/fork_portable/frame.rs
@@ -81,7 +81,9 @@ pub struct MppFrameHeader {
 const FRAME_KIND_MASK: u32 = 0x0000_00FF;
 
 const _: () = {
-    // shm_mq slot layout calculations depend on this being exact.
+    // Downstream wire-layer slot-size math depends on this being exact (e.g. Postgres `shm_mq`
+    // grid sizing inside `super::super::dsm`). Asserted here so a future field reorder breaks
+    // the codec build before it can silently shift slot offsets.
     assert!(std::mem::size_of::<MppFrameHeader>() == MPP_FRAME_HEADER_SIZE);
 };
 

--- a/pg_search/src/postgres/customscan/mpp/fork_portable/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/fork_portable/mod.rs
@@ -1,0 +1,51 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Distributed-runtime primitives that could plausibly live in the
+//! [`datafusion-distributed`](https://github.com/paradedb/datafusion-distributed)
+//! fork.
+//!
+//! Everything in this submodule is structurally embedding-agnostic — no
+//! `pgrx::*`, no Postgres-specific concepts. Currently:
+//!
+//! - [`frame`] — multi-channel Arrow IPC frame codec ([`frame::MppFrameHeader`] +
+//!   `encode_frame_into` / `encode_eof_frame_into` / `decode_frame`). Generic
+//!   over any wire transport — Postgres `shm_mq`, in-proc `std::sync::mpsc`,
+//!   hypothetically gRPC.
+//!
+//! What's deliberately **not** here (lives in [`super::transport`]):
+//!
+//! - [`super::transport::MppSender`]: the cooperative-spin send loop calls
+//!   `pgrx::check_for_interrupts!()` and is therefore PG-backend-thread bound.
+//! - The channel-buffer / drain-handle infrastructure (`DrainBuffer`,
+//!   `DrainHandle`, `BatchChannelReceiver`/`Sender`, `CooperativeDrainSet`,
+//!   in-proc channel pair): structurally portable, but the existing test
+//!   module in `super::transport` reaches into private fields via `cfg(test)`
+//!   inherent impls. Moving the production code without restructuring the
+//!   ~850-LOC test module would require either a parallel test relocation or
+//!   exposing the private fields to a wider scope. Out of R14 scope; revisit
+//!   in a follow-up if the fork ever needs these primitives.
+//!
+//! See also [`super::mesh`] (shm_mq FFI, PG-bound) and [`super::dsm`]
+//! (DSM coordinate layout, PG-bound) for the genuinely PG-tied pieces.
+//!
+//! Promotion to a real fork PR would lift `fork_portable` upstream as-is and
+//! flip the import paths from `crate::postgres::customscan::mpp::fork_portable::*`
+//! to `datafusion_distributed::*` at the few call sites that consume these
+//! primitives.
+
+pub mod frame;

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -42,11 +42,11 @@ use crate::gucs::{
 use crate::postgres::customscan::mpp::dsm::{
     compute_dsm_layout, leader_init, peer_proc_for_index, worker_attach,
 };
+use crate::postgres::customscan::mpp::fork_portable::frame::MppFrameHeader;
 use crate::postgres::customscan::mpp::mesh::{ShmMqReceiver, ShmMqSender};
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
-    in_proc_channel, BatchChannelSender, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
-    SELF_LOOP_CAPACITY,
+    in_proc_channel, BatchChannelSender, DrainHandle, MppReceiver, MppSender, SELF_LOOP_CAPACITY,
 };
 
 /// Default stage id stamped on outbound sender headers before the per-fragment dispatcher

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -27,6 +27,7 @@
 
 pub mod dsm;
 pub mod exec_worker;
+pub mod fork_portable;
 pub mod glue;
 pub mod host;
 pub mod mesh;

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -63,7 +63,7 @@ pub fn proc_for_task(n_workers: u32, task_idx: u32) -> u32 {
 /// on one queue, tagged by [`MppFrameHeader`]. The channel buffer registry on each [`DrainHandle`]
 /// fans them out to the matching consumers keyed on `(stage_id, partition)`.
 ///
-/// [`MppFrameHeader`]: crate::postgres::customscan::mpp::transport::MppFrameHeader
+/// [`MppFrameHeader`]: crate::postgres::customscan::mpp::fork_portable::frame::MppFrameHeader
 pub struct MppMesh {
     /// This process's `proc_idx` (= 0 for the leader, `ParallelWorkerNumber + 1` for workers).
     /// Frames addressed to this proc arrive on `slot(*, this_proc)`.

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -18,18 +18,18 @@
 //! Transport layer for MPP shuffle.
 //!
 //! Layout:
-//! - [`MppFrameHeader`] is a fixed 16-byte prefix every wire message carries. It tags the
-//!   payload with `(stage_id, partition)`, so one underlying queue can carry frames for many
-//!   logical channels at once. That's what the multi-stage natural-shape path needs.
-//! - [`encode_frame_into`] / [`decode_frame`] serialize a `RecordBatch` with a header prefix via
-//!   Arrow IPC. They're the only codec entry points; tests round-trip through the same path so
-//!   the wire format under test always matches production.
+//! - The frame codec lives in [`super::fork_portable::frame`]
+//!   ([`MppFrameHeader`], `encode_frame_into`, `decode_frame`) — see that
+//!   submodule's doc for why it's separable from the rest of this file.
 //! - [`DrainBuffer`] is the local per-proc queue that the drain thread
 //!   writes into and the DataFusion consumer reads from. It decouples
 //!   consumer-side backpressure from producer-side backpressure: the drain thread
 //!   always makes forward progress on the inbound shm_mqs, so a stalled consumer
 //!   cannot propagate backpressure to remote producers and cause an N×N
 //!   peer-stall cycle.
+//! - [`MppSender`] is the producer-side wrapper that drives the cooperative
+//!   spin (the `pgrx::check_for_interrupts!()` call site keeps this file
+//!   PG-bound).
 //!
 //! The shm_mq-backed sender/receiver and drain thread spawn logic build on
 //! top of these primitives.
@@ -39,212 +39,11 @@ use std::sync::{Arc, Condvar, Mutex, MutexGuard};
 use std::time::{Duration, Instant};
 
 use datafusion::arrow::array::RecordBatch;
-use datafusion::arrow::ipc::reader::StreamReader;
-use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::common::DataFusionError;
 
-/// Magic bytes "MPPF" (MPP Frame) at the start of every wire message.
-/// Lets receivers reject misrouted / corrupt frames before they hit Arrow IPC.
-const MPP_FRAME_MAGIC: u32 = 0x4D505046;
-
-/// Wire-format size of [`MppFrameHeader`] in bytes. Asserted at compile time
-/// below via `const _: ()`.
-const MPP_FRAME_HEADER_SIZE: usize = 16;
-
-/// Kind of payload following [`MppFrameHeader`].
-///
-/// `Batch` is the common case. The header is followed by an Arrow IPC stream containing one
-/// `RecordBatch`. `Eof` carries no payload. It signals the receiver that the named
-/// `(stage_id, partition)` channel is done, even though the underlying shm_mq queue may still
-/// carry frames for other channels.
-#[repr(u32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum MppFrameKind {
-    Batch = 0,
-    Eof = 1,
-}
-
-/// 16-byte prefix on every transport frame.
-///
-/// The fixed layout `[magic, flags, stage_id, partition]` (4×u32) is what
-/// senders prepend before the Arrow IPC stream bytes and what receivers
-/// parse before deciding which channel buffer the payload belongs to.
-///
-/// The `flags` word currently encodes `MppFrameKind` in its low byte (mask
-/// `0x0000_00FF`); the upper 24 bits are reserved-must-be-zero and are
-/// validated at parse time so a future use can repurpose them without a
-/// wire-format break.
-#[repr(C)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct MppFrameHeader {
-    pub magic: u32,
-    pub flags: u32,
-    pub stage_id: u32,
-    pub partition: u32,
-}
-
-/// Bit mask in [`MppFrameHeader::flags`] for the [`MppFrameKind`] discriminant.
-const FRAME_KIND_MASK: u32 = 0x0000_00FF;
-
-const _: () = {
-    // shm_mq slot layout calculations depend on this being exact.
-    assert!(std::mem::size_of::<MppFrameHeader>() == MPP_FRAME_HEADER_SIZE);
+use super::fork_portable::frame::{
+    decode_frame, encode_eof_frame_into, encode_frame_into, MppFrameHeader,
 };
-
-impl MppFrameHeader {
-    /// Build a `Batch` header for the given `(stage_id, partition)`.
-    pub fn batch(stage_id: u32, partition: u32) -> Self {
-        Self {
-            magic: MPP_FRAME_MAGIC,
-            flags: MppFrameKind::Batch as u32,
-            stage_id,
-            partition,
-        }
-    }
-
-    /// Build an `Eof` header for the given `(stage_id, partition)`. Carries no payload; receivers
-    /// route it to the channel buffer's source-done counter. Emitted by
-    /// [`MppSender::send_eof_traced`] after a producer fragment's per-partition stream exhausts
-    /// (or errors), and consumed by the matching channel buffer's `notify_source_done`.
-    pub fn eof(stage_id: u32, partition: u32) -> Self {
-        Self {
-            magic: MPP_FRAME_MAGIC,
-            flags: MppFrameKind::Eof as u32,
-            stage_id,
-            partition,
-        }
-    }
-
-    /// Read the kind out of `flags`. Returns an error if the kind byte is
-    /// unknown or if any reserved upper bit is set, which catches wire-format
-    /// drift early.
-    pub(super) fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
-        let reserved = self.flags & !FRAME_KIND_MASK;
-        if reserved != 0 {
-            return Err(DataFusionError::Internal(format!(
-                "mpp: reserved frame flag bits set ({reserved:#x})"
-            )));
-        }
-        match self.flags & FRAME_KIND_MASK {
-            0 => Ok(MppFrameKind::Batch),
-            1 => Ok(MppFrameKind::Eof),
-            other => Err(DataFusionError::Internal(format!(
-                "mpp: unknown frame kind {other:#x}"
-            ))),
-        }
-    }
-
-    /// Serialize into the first `MPP_FRAME_HEADER_SIZE` bytes of `out`.
-    /// `out.len()` must be `>= MPP_FRAME_HEADER_SIZE`.
-    fn write_to(&self, out: &mut [u8]) {
-        debug_assert!(out.len() >= MPP_FRAME_HEADER_SIZE);
-        out[0..4].copy_from_slice(&self.magic.to_le_bytes());
-        out[4..8].copy_from_slice(&self.flags.to_le_bytes());
-        out[8..12].copy_from_slice(&self.stage_id.to_le_bytes());
-        out[12..16].copy_from_slice(&self.partition.to_le_bytes());
-    }
-
-    /// Parse from the first `MPP_FRAME_HEADER_SIZE` bytes of `bytes`. Returns
-    /// `Err` if the slice is too short or the magic doesn't match.
-    fn parse(bytes: &[u8]) -> Result<Self, DataFusionError> {
-        if bytes.len() < MPP_FRAME_HEADER_SIZE {
-            // No encoder in this file emits sub-header output, so a short frame means the
-            // shm_mq stitched together payloads from different senders. Hex-dump the bytes
-            // so the source is identifiable from log output without a debugger.
-            let hex = bytes
-                .iter()
-                .map(|b| format!("{b:02x}"))
-                .collect::<Vec<_>>()
-                .join(" ");
-            return Err(DataFusionError::Internal(format!(
-                "mpp: frame too short for header ({} < {}); bytes = [{hex}]",
-                bytes.len(),
-                MPP_FRAME_HEADER_SIZE
-            )));
-        }
-        let magic = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
-        if magic != MPP_FRAME_MAGIC {
-            return Err(DataFusionError::Internal(format!(
-                "mpp: bad frame magic {magic:#x} (expected {MPP_FRAME_MAGIC:#x})"
-            )));
-        }
-        Ok(Self {
-            magic,
-            flags: u32::from_le_bytes(bytes[4..8].try_into().unwrap()),
-            stage_id: u32::from_le_bytes(bytes[8..12].try_into().unwrap()),
-            partition: u32::from_le_bytes(bytes[12..16].try_into().unwrap()),
-        })
-    }
-}
-
-/// Serialize `batch` into `buf` with a 16-byte [`MppFrameHeader`] prefix
-/// addressing it to `(stage_id, partition)`. Wire format:
-///
-/// ```text
-/// [ magic | flags | stage_id | partition ] [ Arrow IPC stream bytes ]
-/// |---------- 16 bytes --------|           |---- variable ----|
-/// ```
-///
-/// Caller is expected to hold `buf` alive across many encodes so the peak-sized
-/// allocation amortizes (~500 KB/batch on the 25M GROUP BY bench).
-fn encode_frame_into(
-    header: MppFrameHeader,
-    batch: &RecordBatch,
-    buf: &mut Vec<u8>,
-) -> Result<(), DataFusionError> {
-    buf.clear();
-    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
-    header.write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
-    let mut writer = StreamWriter::try_new(&mut *buf, batch.schema_ref())?;
-    writer.write(batch)?;
-    writer.finish()?;
-    Ok(())
-}
-
-/// Serialize a payload-less [`MppFrameKind::Eof`] frame for `(stage_id, partition)`
-/// into `buf`. The shm_mq peer reads this as a 16-byte message and routes it to
-/// the channel buffer's source-done counter without touching Arrow IPC.
-/// Consumed by [`MppSender::send_eof_traced`] when a producer fragment's
-/// per-partition stream exhausts, so the receiver's `(stage_id, partition)`
-/// channel buffer transitions to `Eof` even though the multiplexed shm_mq queue
-/// stays attached for other channels.
-fn encode_eof_frame_into(
-    stage_id: u32,
-    partition: u32,
-    buf: &mut Vec<u8>,
-) -> Result<(), DataFusionError> {
-    buf.clear();
-    buf.resize(MPP_FRAME_HEADER_SIZE, 0);
-    MppFrameHeader::eof(stage_id, partition).write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
-    Ok(())
-}
-
-/// Inverse of [`encode_frame_into`]. Parses the 16-byte header and, for `Batch` frames, decodes
-/// the trailing Arrow IPC stream. `Eof` frames return `(header, None)`. Receivers branch on
-/// `header.kind()` to decide routing.
-fn decode_frame(bytes: &[u8]) -> Result<(MppFrameHeader, Option<RecordBatch>), DataFusionError> {
-    let header = MppFrameHeader::parse(bytes)?;
-    match header.kind()? {
-        MppFrameKind::Eof => {
-            if bytes.len() != MPP_FRAME_HEADER_SIZE {
-                return Err(DataFusionError::Internal(format!(
-                    "mpp: Eof frame carries payload ({} > {})",
-                    bytes.len(),
-                    MPP_FRAME_HEADER_SIZE
-                )));
-            }
-            Ok((header, None))
-        }
-        MppFrameKind::Batch => {
-            let payload = &bytes[MPP_FRAME_HEADER_SIZE..];
-            let mut reader = StreamReader::try_new(payload, None)?;
-            let batch = reader.next().ok_or_else(|| {
-                DataFusionError::Execution("mpp: empty arrow-ipc stream in decode_frame".into())
-            })??;
-            Ok((header, Some(batch)))
-        }
-    }
-}
 
 /// Local queue between a drain (either the cooperative `try_drain_pass` or the test-only thread
 /// variant) and the consumer that pops batches.
@@ -1171,108 +970,6 @@ mod tests {
         let ids = Int32Array::from_iter_values(0..rows);
         let names = StringArray::from_iter_values((0..rows).map(|i| format!("n{i}")));
         RecordBatch::try_new(schema, vec![StdArc::new(ids), StdArc::new(names)]).unwrap()
-    }
-
-    #[test]
-    fn frame_round_trips_a_batch_with_header() {
-        let orig = sample_batch(64);
-        let header = MppFrameHeader::batch(7, 3);
-        let mut buf = Vec::with_capacity(1024);
-        encode_frame_into(header, &orig, &mut buf).expect("encode_frame");
-
-        let (parsed, batch_opt) = decode_frame(&buf).expect("decode_frame");
-        assert_eq!(parsed, header);
-        assert_eq!(parsed.kind().unwrap(), MppFrameKind::Batch);
-        let decoded = batch_opt.expect("Batch frame must carry a payload");
-        assert_eq!(decoded.num_rows(), 64);
-        assert_eq!(decoded.schema(), orig.schema());
-        assert_eq!(decoded.num_columns(), orig.num_columns());
-        for col in 0..orig.num_columns() {
-            assert_eq!(orig.column(col).as_ref(), decoded.column(col).as_ref());
-        }
-    }
-
-    #[test]
-    fn frame_round_trips_eof() {
-        let mut buf = Vec::new();
-        encode_eof_frame_into(2, 5, &mut buf).expect("encode_eof");
-        assert_eq!(buf.len(), MPP_FRAME_HEADER_SIZE);
-
-        let (header, batch_opt) = decode_frame(&buf).expect("decode_frame");
-        assert_eq!(header, MppFrameHeader::eof(2, 5));
-        assert_eq!(header.kind().unwrap(), MppFrameKind::Eof);
-        assert!(batch_opt.is_none());
-    }
-
-    #[test]
-    fn frame_rejects_short_message() {
-        let too_short = vec![0u8; MPP_FRAME_HEADER_SIZE - 1];
-        let err = decode_frame(&too_short).expect_err("short frame must fail");
-        assert!(format!("{err}").contains("too short"));
-    }
-
-    #[test]
-    fn frame_rejects_bad_magic() {
-        // Explicit non-zero, non-magic prefix. Don't rely on the
-        // happenstance that 0u32 != MPP_FRAME_MAGIC.
-        let mut bad = vec![0u8; MPP_FRAME_HEADER_SIZE];
-        bad[0..4].copy_from_slice(&0xCAFEBABE_u32.to_le_bytes());
-        let err = decode_frame(&bad).expect_err("bad magic must fail");
-        assert!(format!("{err}").contains("bad frame magic"));
-        bad[0..4].copy_from_slice(&0xDEADBEEF_u32.to_le_bytes());
-        let err = decode_frame(&bad).expect_err("bad magic must fail");
-        assert!(format!("{err}").contains("bad frame magic"));
-    }
-
-    #[test]
-    fn frame_rejects_unknown_kind() {
-        let header = MppFrameHeader {
-            magic: MPP_FRAME_MAGIC,
-            flags: 0x42, // unknown kind byte, no reserved bits set
-            stage_id: 0,
-            partition: 0,
-        };
-        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
-        header.write_to(&mut buf);
-        let err = decode_frame(&buf).expect_err("unknown kind must fail");
-        assert!(format!("{err}").contains("unknown frame kind"));
-    }
-
-    #[test]
-    fn frame_rejects_reserved_flag_bits() {
-        // Any bit above the low byte of `flags` is reserved-must-be-zero;
-        // setting one should trip `kind()` before the kind byte is consulted.
-        let header = MppFrameHeader {
-            magic: MPP_FRAME_MAGIC,
-            flags: 0x0000_0100, // bit 8 set, kind byte 0 (would be Batch)
-            stage_id: 0,
-            partition: 0,
-        };
-        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
-        header.write_to(&mut buf);
-        let err = decode_frame(&buf).expect_err("reserved bit must fail");
-        assert!(format!("{err}").contains("reserved frame flag bits"));
-    }
-
-    #[test]
-    fn frame_eof_with_payload_is_rejected() {
-        let mut buf = Vec::with_capacity(32);
-        encode_eof_frame_into(0, 0, &mut buf).expect("encode_eof");
-        buf.push(0xAB); // smuggle a payload byte after the Eof header
-        let err = decode_frame(&buf).expect_err("Eof+payload must fail");
-        assert!(format!("{err}").contains("Eof frame carries payload"));
-    }
-
-    #[test]
-    fn codec_round_trips_many_batch_sizes() {
-        let mut buf = Vec::with_capacity(1024);
-        for rows in [0, 1, 7, 64, 1024] {
-            let orig = sample_batch(rows);
-            encode_frame_into(MppFrameHeader::batch(0, 0), &orig, &mut buf).expect("encode");
-            let (_header, decoded) = decode_frame(&buf).expect("decode");
-            let decoded = decoded.expect("Batch frame must carry a payload");
-            assert_eq!(orig.num_rows(), decoded.num_rows());
-        }
     }
 
     #[test]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

Splits the frame codec out of `transport.rs` into a new `mpp/fork_portable/frame.rs` submodule. Same code, new location, no `pgrx::*` references.

## Why

To make the "could-move-to-fork" boundary explicit at the file level. The codec is transport-agnostic: any in-process embedder mapping multiple logical channels onto one byte queue can use it. Promoting it to a real fork PR later (R18) becomes mechanical because the file is already PG-free.

## How

- Move `MppFrameHeader`, `MppFrameKind`, `encode_frame_into`, `encode_eof_frame_into`, `decode_frame`, plus constants and the size-assertion into `fork_portable/frame.rs`.
- Move the codec unit tests + `sample_batch` helper into the same module's `#[cfg(test)] mod tests`.
- New `fork_portable/mod.rs` documents the boundary and what's deliberately NOT moved (the cooperative-spin `MppSender` stays in `transport.rs` because of `pgrx::check_for_interrupts!()`).

Why not move more? The original gap-analysis flagged ~1300 LOC of structurally-portable infrastructure in `transport.rs` (frame codec + channel-buffer demux + drain registry + cooperative-drain trait). Most of that is in scope for "could move to fork", but the existing ~850-LOC test module reaches into `DrainBuffer`/`DrainHandle` private fields via `cfg(test)` inherent impls. Moving those production types without restructuring the test module would mean either a parallel relocation of all those tests or exposing private fields wider. Both are invasive. This ships the clearest-boundary piece first.

## Tests

- `cargo check --package pg_search --features pg18 --no-default-features` clean (lib + tests).
- Codec tests pass from their new home: `cargo test ... -- frame`.
- All 4 MPP regress tests pass.
- CI green.
