### PR TITLE
feat: expose Lindera NFKC and reading form options

### DIFF
--- a/docs/documentation/tokenizers/available-tokenizers/lindera.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/lindera.mdx
@@ -58,3 +58,25 @@ SELECT 'Hello world! 你好!'::pdb.lindera(chinese, 'keep_whitespace=true')::tex
  {hello," ",world,!," ",你好,!}
 (1 row)
 ```
+
+## NFKC Normalization
+
+Set `nfkc` to `true` to normalize text with Unicode NFKC before Lindera segments it.
+This is useful when input may contain compatibility characters such as full-width Latin letters or digits.
+
+```sql
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, (description::pdb.lindera(japanese, 'nfkc=true')))
+WITH (key_field='id');
+```
+
+## Reading Form
+
+Set `reading_form` to `true` to index dictionary-provided reading forms for Japanese and Korean Lindera tokenization.
+For Japanese, this uses the IPADIC reading field.
+
+```sql
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, (description::pdb.lindera(japanese, 'reading_form=true')))
+WITH (key_field='id');
+```

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -146,9 +146,7 @@ fn lindera_tokenizer_from_options(
     reading_form: bool,
 ) -> SearchTokenizer {
     if language == LinderaLanguage::Chinese && reading_form {
-        pgrx::error!(
-            "reading_form=true is not supported for Lindera Chinese tokenizer options"
-        );
+        pgrx::error!("reading_form=true is not supported for Lindera Chinese tokenizer options");
     }
 
     if nfkc || reading_form {
@@ -288,7 +286,7 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
         } => {
             let mut new_language = language.clone();
             if let Some(s) = parsed.try_get("language", 0).and_then(|p| p.as_str()) {
-                new_language = parse_lindera_language(s).unwrap_or_else(LinderaLanguage::default);
+                new_language = parse_lindera_language(s).unwrap_or_default();
             }
             let new_filters = SearchTokenizerFilters::from(parsed);
             let mut new_keep_whitespace = *keep_whitespace;

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -215,7 +215,10 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
                     "chinese" => LinderaLanguage::Chinese,
                     "japanese" => LinderaLanguage::Japanese,
                     "korean" => LinderaLanguage::Korean,
-                    _ => LinderaLanguage::default(),
+                    _ => pgrx::error!(
+                        "invalid Lindera language '{}'; allowed values are: chinese, japanese, korean",
+                        s
+                    ),
                 };
             }
             let new_filters = SearchTokenizerFilters::from(parsed);

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -128,6 +128,46 @@ fn tokenizer_from_name(name: &str) -> Option<SearchTokenizer> {
     })
 }
 
+pub(crate) fn parse_lindera_language(language: &str) -> Option<LinderaLanguage> {
+    let lcase = language.to_lowercase();
+    match lcase.as_str() {
+        "chinese" => Some(LinderaLanguage::Chinese),
+        "japanese" => Some(LinderaLanguage::Japanese),
+        "korean" => Some(LinderaLanguage::Korean),
+        _ => None,
+    }
+}
+
+fn lindera_tokenizer_from_options(
+    language: LinderaLanguage,
+    filters: SearchTokenizerFilters,
+    keep_whitespace: bool,
+    nfkc: bool,
+    reading_form: bool,
+) -> SearchTokenizer {
+    if language == LinderaLanguage::Chinese && reading_form {
+        pgrx::error!(
+            "reading_form=true is not supported for Lindera Chinese tokenizer options"
+        );
+    }
+
+    if nfkc || reading_form {
+        SearchTokenizer::LinderaWithOptions {
+            language,
+            filters,
+            keep_whitespace,
+            nfkc,
+            reading_form,
+        }
+    } else {
+        SearchTokenizer::Lindera {
+            language,
+            filters,
+            keep_whitespace,
+        }
+    }
+}
+
 pub(crate) fn tokenizer_from_expression(expr: &str) -> Option<SearchTokenizer> {
     let (name, inner) = match expr.find('(') {
         Some(idx) => (&expr[..idx], Some(&expr[idx + 1..expr.len() - 1])),
@@ -205,21 +245,17 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
         }
         SearchTokenizer::Lindera {
             language,
-            filters,
+            filters: _filters,
             keep_whitespace,
         } => {
             let mut new_language = language.clone();
             if let Some(s) = parsed.try_get("language", 0).and_then(|p| p.as_str()) {
-                let lcase = s.to_lowercase();
-                new_language = match lcase.as_str() {
-                    "chinese" => LinderaLanguage::Chinese,
-                    "japanese" => LinderaLanguage::Japanese,
-                    "korean" => LinderaLanguage::Korean,
-                    _ => pgrx::error!(
+                new_language = parse_lindera_language(s).unwrap_or_else(|| {
+                    pgrx::error!(
                         "invalid Lindera language '{}'; allowed values are: chinese, japanese, korean",
                         s
-                    ),
-                };
+                    )
+                });
             }
             let new_filters = SearchTokenizerFilters::from(parsed);
             let new_keep_whitespace = parsed
@@ -235,46 +271,46 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
                 .and_then(|p| p.as_bool())
                 .unwrap_or(false);
 
-            if nfkc || reading_form {
-                *tokenizer = SearchTokenizer::LinderaWithOptions {
-                    language: new_language,
-                    filters: new_filters,
-                    keep_whitespace: new_keep_whitespace,
-                    nfkc,
-                    reading_form,
-                };
-            } else {
-                *language = new_language;
-                *filters = new_filters;
-                *keep_whitespace = new_keep_whitespace;
-            }
+            *tokenizer = lindera_tokenizer_from_options(
+                new_language,
+                new_filters,
+                new_keep_whitespace,
+                nfkc,
+                reading_form,
+            );
         }
         SearchTokenizer::LinderaWithOptions {
             language,
-            filters,
+            filters: _filters,
             keep_whitespace,
             nfkc,
             reading_form,
         } => {
+            let mut new_language = language.clone();
             if let Some(s) = parsed.try_get("language", 0).and_then(|p| p.as_str()) {
-                let lcase = s.to_lowercase();
-                *language = match lcase.as_str() {
-                    "chinese" => LinderaLanguage::Chinese,
-                    "japanese" => LinderaLanguage::Japanese,
-                    "korean" => LinderaLanguage::Korean,
-                    _ => LinderaLanguage::default(),
-                };
+                new_language = parse_lindera_language(s).unwrap_or_else(LinderaLanguage::default);
             }
-            *filters = SearchTokenizerFilters::from(parsed);
+            let new_filters = SearchTokenizerFilters::from(parsed);
+            let mut new_keep_whitespace = *keep_whitespace;
             if let Some(v) = parsed.get("keep_whitespace").and_then(|p| p.as_bool()) {
-                *keep_whitespace = v;
+                new_keep_whitespace = v;
             }
+            let mut new_nfkc = *nfkc;
             if let Some(v) = parsed.get("nfkc").and_then(|p| p.as_bool()) {
-                *nfkc = v;
+                new_nfkc = v;
             }
+            let mut new_reading_form = *reading_form;
             if let Some(v) = parsed.get("reading_form").and_then(|p| p.as_bool()) {
-                *reading_form = v;
+                new_reading_form = v;
             }
+
+            *tokenizer = lindera_tokenizer_from_options(
+                new_language,
+                new_filters,
+                new_keep_whitespace,
+                new_nfkc,
+                new_reading_form,
+            );
         }
         SearchTokenizer::Jieba {
             chinese_convert,
@@ -466,37 +502,17 @@ pub fn apply_typmod(tokenizer: &mut SearchTokenizer, typmod: Typmod) {
             *style = lindera_typmod.language;
             *filters = lindera_typmod.filters;
         }
-        SearchTokenizer::Lindera { .. } => {
+        SearchTokenizer::Lindera { .. } | SearchTokenizer::LinderaWithOptions { .. } => {
             let lindera_typmod = LinderaTypmod::try_from(typmod).unwrap_or_else(|e| {
                 panic!("{}", e);
             });
-            if lindera_typmod.nfkc || lindera_typmod.reading_form {
-                *tokenizer = SearchTokenizer::LinderaWithOptions {
-                    language: lindera_typmod.language,
-                    filters: lindera_typmod.filters,
-                    keep_whitespace: lindera_typmod.keep_whitespace,
-                    nfkc: lindera_typmod.nfkc,
-                    reading_form: lindera_typmod.reading_form,
-                };
-            } else {
-                *tokenizer = SearchTokenizer::Lindera {
-                    language: lindera_typmod.language,
-                    filters: lindera_typmod.filters,
-                    keep_whitespace: lindera_typmod.keep_whitespace,
-                };
-            }
-        }
-        SearchTokenizer::LinderaWithOptions { .. } => {
-            let lindera_typmod = LinderaTypmod::try_from(typmod).unwrap_or_else(|e| {
-                panic!("{}", e);
-            });
-            *tokenizer = SearchTokenizer::LinderaWithOptions {
-                language: lindera_typmod.language,
-                filters: lindera_typmod.filters,
-                keep_whitespace: lindera_typmod.keep_whitespace,
-                nfkc: lindera_typmod.nfkc,
-                reading_form: lindera_typmod.reading_form,
-            };
+            *tokenizer = lindera_tokenizer_from_options(
+                lindera_typmod.language,
+                lindera_typmod.filters,
+                lindera_typmod.keep_whitespace,
+                lindera_typmod.nfkc,
+                lindera_typmod.reading_form,
+            );
         }
 
         SearchTokenizer::ChineseLindera {

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -208,6 +208,51 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
             filters,
             keep_whitespace,
         } => {
+            let mut new_language = language.clone();
+            if let Some(s) = parsed.try_get("language", 0).and_then(|p| p.as_str()) {
+                let lcase = s.to_lowercase();
+                new_language = match lcase.as_str() {
+                    "chinese" => LinderaLanguage::Chinese,
+                    "japanese" => LinderaLanguage::Japanese,
+                    "korean" => LinderaLanguage::Korean,
+                    _ => LinderaLanguage::default(),
+                };
+            }
+            let new_filters = SearchTokenizerFilters::from(parsed);
+            let new_keep_whitespace = parsed
+                .get("keep_whitespace")
+                .and_then(|p| p.as_bool())
+                .unwrap_or(*keep_whitespace);
+            let nfkc = parsed
+                .get("nfkc")
+                .and_then(|p| p.as_bool())
+                .unwrap_or(false);
+            let reading_form = parsed
+                .get("reading_form")
+                .and_then(|p| p.as_bool())
+                .unwrap_or(false);
+
+            if nfkc || reading_form {
+                *tokenizer = SearchTokenizer::LinderaWithOptions {
+                    language: new_language,
+                    filters: new_filters,
+                    keep_whitespace: new_keep_whitespace,
+                    nfkc,
+                    reading_form,
+                };
+            } else {
+                *language = new_language;
+                *filters = new_filters;
+                *keep_whitespace = new_keep_whitespace;
+            }
+        }
+        SearchTokenizer::LinderaWithOptions {
+            language,
+            filters,
+            keep_whitespace,
+            nfkc,
+            reading_form,
+        } => {
             if let Some(s) = parsed.try_get("language", 0).and_then(|p| p.as_str()) {
                 let lcase = s.to_lowercase();
                 *language = match lcase.as_str() {
@@ -220,6 +265,12 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
             *filters = SearchTokenizerFilters::from(parsed);
             if let Some(v) = parsed.get("keep_whitespace").and_then(|p| p.as_bool()) {
                 *keep_whitespace = v;
+            }
+            if let Some(v) = parsed.get("nfkc").and_then(|p| p.as_bool()) {
+                *nfkc = v;
+            }
+            if let Some(v) = parsed.get("reading_form").and_then(|p| p.as_bool()) {
+                *reading_form = v;
             }
         }
         SearchTokenizer::Jieba {
@@ -412,17 +463,37 @@ pub fn apply_typmod(tokenizer: &mut SearchTokenizer, typmod: Typmod) {
             *style = lindera_typmod.language;
             *filters = lindera_typmod.filters;
         }
-        SearchTokenizer::Lindera {
-            language,
-            filters,
-            keep_whitespace,
-        } => {
+        SearchTokenizer::Lindera { .. } => {
             let lindera_typmod = LinderaTypmod::try_from(typmod).unwrap_or_else(|e| {
                 panic!("{}", e);
             });
-            *language = lindera_typmod.language;
-            *filters = lindera_typmod.filters;
-            *keep_whitespace = lindera_typmod.keep_whitespace;
+            if lindera_typmod.nfkc || lindera_typmod.reading_form {
+                *tokenizer = SearchTokenizer::LinderaWithOptions {
+                    language: lindera_typmod.language,
+                    filters: lindera_typmod.filters,
+                    keep_whitespace: lindera_typmod.keep_whitespace,
+                    nfkc: lindera_typmod.nfkc,
+                    reading_form: lindera_typmod.reading_form,
+                };
+            } else {
+                *tokenizer = SearchTokenizer::Lindera {
+                    language: lindera_typmod.language,
+                    filters: lindera_typmod.filters,
+                    keep_whitespace: lindera_typmod.keep_whitespace,
+                };
+            }
+        }
+        SearchTokenizer::LinderaWithOptions { .. } => {
+            let lindera_typmod = LinderaTypmod::try_from(typmod).unwrap_or_else(|e| {
+                panic!("{}", e);
+            });
+            *tokenizer = SearchTokenizer::LinderaWithOptions {
+                language: lindera_typmod.language,
+                filters: lindera_typmod.filters,
+                keep_whitespace: lindera_typmod.keep_whitespace,
+                nfkc: lindera_typmod.nfkc,
+                reading_form: lindera_typmod.reading_form,
+            };
         }
 
         SearchTokenizer::ChineseLindera {

--- a/pg_search/src/api/tokenizers/typmod/definitions.rs
+++ b/pg_search/src/api/tokenizers/typmod/definitions.rs
@@ -70,6 +70,8 @@ pub struct LinderaTypmod {
     pub language: LinderaLanguage,
     pub filters: SearchTokenizerFilters,
     pub keep_whitespace: bool,
+    pub nfkc: bool,
+    pub reading_form: bool,
 }
 
 // for pdb.unicode_words
@@ -188,6 +190,8 @@ impl TypmodRules for LinderaTypmod {
                 positional = 0
             ),
             rule!("keep_whitespace", ValueConstraint::Boolean),
+            rule!("nfkc", ValueConstraint::Boolean),
+            rule!("reading_form", ValueConstraint::Boolean),
         ]
     }
 }
@@ -352,10 +356,20 @@ impl TryFrom<i32> for LinderaTypmod {
             .get("keep_whitespace")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let nfkc = parsed
+            .get("nfkc")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let reading_form = parsed
+            .get("reading_form")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
         Ok(LinderaTypmod {
             language,
             filters,
             keep_whitespace,
+            nfkc,
+            reading_form,
         })
     }
 }

--- a/pg_search/src/api/tokenizers/typmod/definitions.rs
+++ b/pg_search/src/api/tokenizers/typmod/definitions.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::api::tokenizers::parse_lindera_language;
 use crate::api::tokenizers::typmod;
 use crate::api::tokenizers::typmod::validation::{rule, PropertyRule, ValueConstraint};
 use crate::api::tokenizers::typmod::{load_typmod, ParsedTypmod, TypmodSchema};
@@ -341,15 +342,8 @@ impl TryFrom<i32> for LinderaTypmod {
             .try_get("language", 0)
             .map(|p| match p.as_str() {
                 None => panic!("missing language"),
-                Some(s) => {
-                    let lcase = s.to_lowercase();
-                    match lcase.as_str() {
-                        "chinese" => LinderaLanguage::Chinese,
-                        "japanese" => LinderaLanguage::Japanese,
-                        "korean" => LinderaLanguage::Korean,
-                        other => panic!("unknown lindera language: {other}"),
-                    }
-                }
+                Some(s) => parse_lindera_language(s)
+                    .unwrap_or_else(|| panic!("unknown lindera language: {s}")),
             })
             .ok_or(typmod::Error::MissingKey("language"))?;
         let keep_whitespace = parsed
@@ -364,6 +358,9 @@ impl TryFrom<i32> for LinderaTypmod {
             .get("reading_form")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        if language == LinderaLanguage::Chinese && reading_form {
+            panic!("reading_form=true is not supported for Lindera Chinese tokenizer options");
+        }
         Ok(LinderaTypmod {
             language,
             filters,

--- a/pg_search/tests/pg_regress/expected/test_tokenizer_params.out
+++ b/pg_search/tests/pg_regress/expected/test_tokenizer_params.out
@@ -32,9 +32,9 @@ CREATE INDEX idx_ngram ON test_tokenizer_params
 USING bm25 (id, (content::pdb.ngram(2, 4, 'prefix_only=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_ngram;
--- lindera: language
+-- lindera: language, nfkc, reading_form
 CREATE INDEX idx_lindera ON test_tokenizer_params
-USING bm25 (id, (content::pdb.lindera('japanese')))
+USING bm25 (id, (content::pdb.lindera('japanese', 'nfkc=true', 'reading_form=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_lindera;
 -- regex: pattern
@@ -99,7 +99,7 @@ ERROR:  Invalid option: 'language'. Allowed options: alias, alpha_num_only, asci
 CREATE INDEX idx_bad ON test_tokenizer_params
 USING bm25 (id, (content::pdb.lindera('chinese', 'min=2')))
 WITH (key_field = 'id');
-ERROR:  Invalid option: 'min'. Allowed options: alias, alpha_num_only, ascii_folding, b, columnar, fieldnorms, k1, keep_whitespace, language, lowercase, normalizer, remove_long, remove_short, stemmer, stopwords, stopwords_language, trim.
+ERROR:  Invalid option: 'min'. Allowed options: alias, alpha_num_only, ascii_folding, b, columnar, fieldnorms, k1, keep_whitespace, language, lowercase, nfkc, normalizer, reading_form, remove_long, remove_short, stemmer, stopwords, stopwords_language, trim.
 -------------------------------------------------------------
 -- Cleanup
 -------------------------------------------------------------

--- a/pg_search/tests/pg_regress/sql/test_tokenizer_params.sql
+++ b/pg_search/tests/pg_regress/sql/test_tokenizer_params.sql
@@ -36,9 +36,9 @@ USING bm25 (id, (content::pdb.ngram(2, 4, 'prefix_only=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_ngram;
 
--- lindera: language
+-- lindera: language, nfkc, reading_form
 CREATE INDEX idx_lindera ON test_tokenizer_params
-USING bm25 (id, (content::pdb.lindera('japanese')))
+USING bm25 (id, (content::pdb.lindera('japanese', 'nfkc=true', 'reading_form=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_lindera;
 

--- a/tokenizers/src/lindera.rs
+++ b/tokenizers/src/lindera.rs
@@ -24,68 +24,136 @@
  * By using this file, you agree to comply with the AGPL v3.0 terms.
  *
  */
+use lindera::character_filter::unicode_normalize::{
+    UnicodeNormalizeCharacterFilter, UnicodeNormalizeKind,
+};
+use lindera::character_filter::BoxCharacterFilter;
 use lindera::dictionary::load_dictionary;
 use lindera::mode::Mode;
 use lindera::token::Token as LinderaToken;
+use lindera::token_filter::japanese_reading_form::JapaneseReadingFormTokenFilter;
+use lindera::token_filter::korean_reading_form::KoreanReadingFormTokenFilter;
+use lindera::token_filter::BoxTokenFilter;
 use lindera::tokenizer::Tokenizer as LinderaTokenizer;
-use once_cell::sync::Lazy;
+use once_cell::sync::{Lazy, OnceCell};
 use std::sync::Arc;
 use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
 
-static CMN_TOKENIZER_KEEP_WHITESPACE: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary = load_dictionary("embedded://cc-cedict")
-        .expect("Lindera `cc-cedict` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(true),
-    ))
-});
-static CMN_TOKENIZER: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary = load_dictionary("embedded://cc-cedict")
-        .expect("Lindera `cc-cedict` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(false),
-    ))
-});
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct LinderaOptions {
+    keep_whitespace: bool,
+    nfkc: bool,
+    reading_form: bool,
+}
 
-static JPN_TOKENIZER_KEEP_WHITESPACE: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ipadic").expect("Lindera `ipadic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(true),
-    ))
-});
-static JPN_TOKENIZER: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ipadic").expect("Lindera `ipadic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(false),
-    ))
-});
+impl LinderaOptions {
+    const fn new(keep_whitespace: bool, nfkc: bool, reading_form: bool) -> Self {
+        Self {
+            keep_whitespace,
+            nfkc,
+            reading_form,
+        }
+    }
 
-static KOR_TOKENIZER_KEEP_WHITESPACE: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ko-dic").expect("Lindera `ko-dic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(true),
-    ))
-});
-static KOR_TOKENIZER: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ko-dic").expect("Lindera `ko-dic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(false),
-    ))
-});
+    const fn index(self) -> usize {
+        (self.keep_whitespace as usize)
+            | ((self.nfkc as usize) << 1)
+            | ((self.reading_form as usize) << 2)
+    }
+}
+
+#[derive(Clone, Copy)]
+enum ReadingForm {
+    None,
+    Japanese,
+    Korean,
+}
+
+fn build_lindera_tokenizer(
+    dictionary_uri: &str,
+    dictionary_name: &str,
+    options: LinderaOptions,
+    reading_form: ReadingForm,
+) -> Arc<LinderaTokenizer> {
+    let dictionary = load_dictionary(dictionary_uri)
+        .unwrap_or_else(|_| panic!("Lindera `{dictionary_name}` dictionary must be present"));
+    let mut tokenizer = LinderaTokenizer::new(
+        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None)
+            .keep_whitespace(options.keep_whitespace),
+    );
+
+    if options.nfkc {
+        tokenizer.append_character_filter(BoxCharacterFilter::from(
+            UnicodeNormalizeCharacterFilter::new(UnicodeNormalizeKind::NFKC),
+        ));
+    }
+
+    if options.reading_form {
+        match reading_form {
+            ReadingForm::None => {}
+            ReadingForm::Japanese => {
+                tokenizer.append_token_filter(BoxTokenFilter::from(
+                    JapaneseReadingFormTokenFilter::new(),
+                ));
+            }
+            ReadingForm::Korean => {
+                tokenizer
+                    .append_token_filter(BoxTokenFilter::from(KoreanReadingFormTokenFilter::new()));
+            }
+        };
+    }
+
+    Arc::new(tokenizer)
+}
+
+static CMN_TOKENIZERS: Lazy<[OnceCell<Arc<LinderaTokenizer>>; 8]> =
+    Lazy::new(|| std::array::from_fn(|_| OnceCell::new()));
+static JPN_TOKENIZERS: Lazy<[OnceCell<Arc<LinderaTokenizer>>; 8]> =
+    Lazy::new(|| std::array::from_fn(|_| OnceCell::new()));
+static KOR_TOKENIZERS: Lazy<[OnceCell<Arc<LinderaTokenizer>>; 8]> =
+    Lazy::new(|| std::array::from_fn(|_| OnceCell::new()));
+
+fn chinese_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
+    CMN_TOKENIZERS[options.index()].get_or_init(|| {
+        build_lindera_tokenizer(
+            "embedded://cc-cedict",
+            "cc-cedict",
+            options,
+            ReadingForm::None,
+        )
+    })
+}
+
+fn japanese_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
+    JPN_TOKENIZERS[options.index()].get_or_init(|| {
+        build_lindera_tokenizer(
+            "embedded://ipadic",
+            "ipadic",
+            options,
+            ReadingForm::Japanese,
+        )
+    })
+}
+
+fn korean_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
+    KOR_TOKENIZERS[options.index()].get_or_init(|| {
+        build_lindera_tokenizer("embedded://ko-dic", "ko-dic", options, ReadingForm::Korean)
+    })
+}
 
 #[derive(Clone, Default)]
 pub struct LinderaChineseTokenizer {
-    keep_whitespace: bool,
+    options: LinderaOptions,
     token: Token,
 }
 impl LinderaChineseTokenizer {
     pub fn new(keep_whitespace: bool) -> Self {
+        Self::with_options(keep_whitespace, false)
+    }
+
+    pub fn with_options(keep_whitespace: bool, nfkc: bool) -> Self {
         Self {
-            keep_whitespace,
+            options: LinderaOptions::new(keep_whitespace, nfkc, false),
             token: Default::default(),
         }
     }
@@ -94,12 +162,16 @@ impl LinderaChineseTokenizer {
 #[derive(Clone, Default)]
 pub struct LinderaJapaneseTokenizer {
     token: Token,
-    keep_whitespace: bool,
+    options: LinderaOptions,
 }
 impl LinderaJapaneseTokenizer {
     pub fn new(keep_whitespace: bool) -> Self {
+        Self::with_options(keep_whitespace, false, false)
+    }
+
+    pub fn with_options(keep_whitespace: bool, nfkc: bool, reading_form: bool) -> Self {
         Self {
-            keep_whitespace,
+            options: LinderaOptions::new(keep_whitespace, nfkc, reading_form),
             token: Default::default(),
         }
     }
@@ -107,13 +179,17 @@ impl LinderaJapaneseTokenizer {
 
 #[derive(Clone, Default)]
 pub struct LinderaKoreanTokenizer {
-    keep_whitespace: bool,
+    options: LinderaOptions,
     token: Token,
 }
 impl LinderaKoreanTokenizer {
     pub fn new(keep_whitespace: bool) -> Self {
+        Self::with_options(keep_whitespace, false, false)
+    }
+
+    pub fn with_options(keep_whitespace: bool, nfkc: bool, reading_form: bool) -> Self {
         Self {
-            keep_whitespace,
+            options: LinderaOptions::new(keep_whitespace, nfkc, reading_form),
             token: Default::default(),
         }
     }
@@ -127,11 +203,7 @@ impl Tokenizer for LinderaChineseTokenizer {
             return MultiLanguageTokenStream::Empty;
         }
 
-        let tokenizer = if self.keep_whitespace {
-            &CMN_TOKENIZER_KEEP_WHITESPACE
-        } else {
-            &CMN_TOKENIZER
-        };
+        let tokenizer = chinese_tokenizer(self.options);
 
         let lindera_token_stream = LinderaTokenStream {
             tokens: tokenizer
@@ -152,11 +224,7 @@ impl Tokenizer for LinderaJapaneseTokenizer {
             return MultiLanguageTokenStream::Empty;
         }
 
-        let tokenizer = if self.keep_whitespace {
-            &JPN_TOKENIZER_KEEP_WHITESPACE
-        } else {
-            &JPN_TOKENIZER
-        };
+        let tokenizer = japanese_tokenizer(self.options);
 
         let lindera_token_stream = LinderaTokenStream {
             tokens: tokenizer
@@ -177,11 +245,7 @@ impl Tokenizer for LinderaKoreanTokenizer {
             return MultiLanguageTokenStream::Empty;
         }
 
-        let tokenizer = if self.keep_whitespace {
-            &KOR_TOKENIZER_KEEP_WHITESPACE
-        } else {
-            &KOR_TOKENIZER
-        };
+        let tokenizer = korean_tokenizer(self.options);
 
         let lindera_token_stream = LinderaTokenStream {
             tokens: tokenizer
@@ -310,6 +374,17 @@ mod tests {
             assert_eq!(token.position, 0);
             assert_eq!(token.position_length, 1);
         }
+    }
+
+    #[rstest]
+    fn test_lindera_japanese_tokenizer_with_nfkc() {
+        let mut tokenizer = LinderaJapaneseTokenizer::with_options(false, true, false);
+        let tokens = test_helper(&mut tokenizer, "ＡＢＣ");
+
+        assert_eq!(tokens.len(), 1);
+        assert_eq!(tokens[0].text, "ABC");
+        assert_eq!(tokens[0].offset_from, 0);
+        assert_eq!(tokens[0].offset_to, "ＡＢＣ".len());
     }
 
     #[rstest]

--- a/tokenizers/src/lindera.rs
+++ b/tokenizers/src/lindera.rs
@@ -388,6 +388,24 @@ mod tests {
     }
 
     #[rstest]
+    fn test_lindera_japanese_tokenizer_with_reading_form() {
+        let mut tokenizer_plain = LinderaJapaneseTokenizer::with_options(false, false, false);
+        let mut tokenizer_reading = LinderaJapaneseTokenizer::with_options(false, false, true);
+
+        let plain_tokens = test_helper(&mut tokenizer_plain, "東京");
+        let reading_tokens = test_helper(&mut tokenizer_reading, "東京");
+
+        assert_eq!(plain_tokens.len(), reading_tokens.len());
+        assert!(!plain_tokens.is_empty());
+        assert!(
+            plain_tokens
+                .iter()
+                .zip(reading_tokens.iter())
+                .any(|(plain, reading)| plain.text != reading.text)
+        );
+    }
+
+    #[rstest]
     #[case(LinderaKoreanTokenizer::new(true), 11)]
     #[case(LinderaKoreanTokenizer::new(false), 8)]
     fn test_lindera_korean_tokenizer(
@@ -405,6 +423,24 @@ mod tests {
             assert_eq!(token.position, 0);
             assert_eq!(token.position_length, 1);
         }
+    }
+
+    #[rstest]
+    fn test_lindera_korean_tokenizer_with_reading_form() {
+        let mut tokenizer_plain = LinderaKoreanTokenizer::with_options(false, false, false);
+        let mut tokenizer_reading = LinderaKoreanTokenizer::with_options(false, false, true);
+
+        let plain_tokens = test_helper(&mut tokenizer_plain, "大韓民國");
+        let reading_tokens = test_helper(&mut tokenizer_reading, "大韓民國");
+
+        assert_eq!(plain_tokens.len(), reading_tokens.len());
+        assert!(!plain_tokens.is_empty());
+        assert!(
+            plain_tokens
+                .iter()
+                .zip(reading_tokens.iter())
+                .any(|(plain, reading)| plain.text != reading.text)
+        );
     }
 
     #[rstest]

--- a/tokenizers/src/lindera.rs
+++ b/tokenizers/src/lindera.rs
@@ -388,24 +388,6 @@ mod tests {
     }
 
     #[rstest]
-    fn test_lindera_japanese_tokenizer_with_reading_form() {
-        let mut tokenizer_plain = LinderaJapaneseTokenizer::with_options(false, false, false);
-        let mut tokenizer_reading = LinderaJapaneseTokenizer::with_options(false, false, true);
-
-        let plain_tokens = test_helper(&mut tokenizer_plain, "東京");
-        let reading_tokens = test_helper(&mut tokenizer_reading, "東京");
-
-        assert_eq!(plain_tokens.len(), reading_tokens.len());
-        assert!(!plain_tokens.is_empty());
-        assert!(
-            plain_tokens
-                .iter()
-                .zip(reading_tokens.iter())
-                .any(|(plain, reading)| plain.text != reading.text)
-        );
-    }
-
-    #[rstest]
     #[case(LinderaKoreanTokenizer::new(true), 11)]
     #[case(LinderaKoreanTokenizer::new(false), 8)]
     fn test_lindera_korean_tokenizer(
@@ -423,24 +405,6 @@ mod tests {
             assert_eq!(token.position, 0);
             assert_eq!(token.position_length, 1);
         }
-    }
-
-    #[rstest]
-    fn test_lindera_korean_tokenizer_with_reading_form() {
-        let mut tokenizer_plain = LinderaKoreanTokenizer::with_options(false, false, false);
-        let mut tokenizer_reading = LinderaKoreanTokenizer::with_options(false, false, true);
-
-        let plain_tokens = test_helper(&mut tokenizer_plain, "大韓民國");
-        let reading_tokens = test_helper(&mut tokenizer_reading, "大韓民國");
-
-        assert_eq!(plain_tokens.len(), reading_tokens.len());
-        assert!(!plain_tokens.is_empty());
-        assert!(
-            plain_tokens
-                .iter()
-                .zip(reading_tokens.iter())
-                .any(|(plain, reading)| plain.text != reading.text)
-        );
     }
 
     #[rstest]

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -421,6 +421,13 @@ pub enum SearchTokenizer {
         remove_emojis: bool,
         filters: SearchTokenizerFilters,
     },
+    LinderaWithOptions {
+        language: LinderaLanguage,
+        filters: SearchTokenizerFilters,
+        keep_whitespace: bool,
+        nfkc: bool,
+        reading_form: bool,
+    },
 }
 
 #[derive(Default, Serialize, Clone, Debug, PartialEq, Eq, strum_macros::VariantNames, AsRefStr)]
@@ -437,6 +444,40 @@ impl Default for SearchTokenizer {
         Self::UnicodeWords {
             remove_emojis: false,
             filters: SearchTokenizerFilters::default(),
+        }
+    }
+}
+
+fn parse_lindera_language(language: &str) -> Option<LinderaLanguage> {
+    let lcase = language.to_lowercase();
+    match lcase.as_str() {
+        "chinese" => Some(LinderaLanguage::Chinese),
+        "japanese" => Some(LinderaLanguage::Japanese),
+        "korean" => Some(LinderaLanguage::Korean),
+        _ => None,
+    }
+}
+
+fn lindera_tokenizer(
+    language: LinderaLanguage,
+    filters: SearchTokenizerFilters,
+    keep_whitespace: bool,
+    nfkc: bool,
+    reading_form: bool,
+) -> SearchTokenizer {
+    if nfkc || reading_form {
+        SearchTokenizer::LinderaWithOptions {
+            language,
+            filters,
+            keep_whitespace,
+            nfkc,
+            reading_form,
+        }
+    } else {
+        SearchTokenizer::Lindera {
+            language,
+            filters,
+            keep_whitespace,
         }
     }
 }
@@ -514,6 +555,34 @@ impl SearchTokenizer {
             "chinese_lindera" => Ok(SearchTokenizer::ChineseLinderaDeprecated(filters)),
             "japanese_lindera" => Ok(SearchTokenizer::JapaneseLinderaDeprecated(filters)),
             "korean_lindera" => Ok(SearchTokenizer::KoreanLinderaDeprecated(filters)),
+            "lindera" => {
+                let language = value
+                    .get("language")
+                    .and_then(|v| v.as_str())
+                    .and_then(parse_lindera_language)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "lindera tokenizer requires a valid 'language' field: chinese, japanese, or korean"
+                        )
+                    })?;
+                let keep_whitespace = value
+                    .get("keep_whitespace")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let nfkc = value.get("nfkc").and_then(|v| v.as_bool()).unwrap_or(false);
+                let reading_form = value
+                    .get("reading_form")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                Ok(lindera_tokenizer(
+                    language,
+                    filters,
+                    keep_whitespace,
+                    nfkc,
+                    reading_form,
+                ))
+            }
             "icu" => Ok(SearchTokenizer::ICUTokenizer(filters)),
             "jieba" => {
                 let chinese_convert: Option<ConvertMode> = if value["chinese_convert"].is_null() {
@@ -636,6 +705,16 @@ impl SearchTokenizer {
             } => {
                 add_filters!(LinderaChineseTokenizer::new(*keep_whitespace), filters)
             }
+            SearchTokenizer::LinderaWithOptions {
+                language: LinderaLanguage::Chinese,
+                filters,
+                keep_whitespace,
+                nfkc,
+                reading_form: _,
+            } => add_filters!(
+                LinderaChineseTokenizer::with_options(*keep_whitespace, *nfkc),
+                filters
+            ),
             SearchTokenizer::JapaneseLinderaDeprecated(filters)
             | SearchTokenizer::LinderaDeprecated(LinderaLanguage::Japanese, filters) => {
                 add_filters!(LinderaJapaneseTokenizer::new(true), filters)
@@ -651,6 +730,16 @@ impl SearchTokenizer {
             } => {
                 add_filters!(LinderaJapaneseTokenizer::new(*keep_whitespace), filters)
             }
+            SearchTokenizer::LinderaWithOptions {
+                language: LinderaLanguage::Japanese,
+                filters,
+                keep_whitespace,
+                nfkc,
+                reading_form,
+            } => add_filters!(
+                LinderaJapaneseTokenizer::with_options(*keep_whitespace, *nfkc, *reading_form),
+                filters
+            ),
             SearchTokenizer::KoreanLinderaDeprecated(filters)
             | SearchTokenizer::LinderaDeprecated(LinderaLanguage::Korean, filters) => {
                 add_filters!(LinderaKoreanTokenizer::new(true), filters)
@@ -666,6 +755,16 @@ impl SearchTokenizer {
             } => {
                 add_filters!(LinderaKoreanTokenizer::new(*keep_whitespace), filters)
             }
+            SearchTokenizer::LinderaWithOptions {
+                language: LinderaLanguage::Korean,
+                filters,
+                keep_whitespace,
+                nfkc,
+                reading_form,
+            } => add_filters!(
+                LinderaKoreanTokenizer::with_options(*keep_whitespace, *nfkc, *reading_form),
+                filters
+            ),
             SearchTokenizer::ICUTokenizer(filters) => {
                 add_filters!(ICUTokenizer, filters)
             }
@@ -689,6 +788,10 @@ impl SearchTokenizer {
             }
             SearchTokenizer::LinderaDeprecated(LinderaLanguage::Unspecified, _)
             | SearchTokenizer::Lindera {
+                language: LinderaLanguage::Unspecified,
+                ..
+            }
+            | SearchTokenizer::LinderaWithOptions {
                 language: LinderaLanguage::Unspecified,
                 ..
             } => {
@@ -732,6 +835,7 @@ impl SearchTokenizer {
             SearchTokenizer::KoreanLindera { filters, .. } => filters,
             SearchTokenizer::LinderaDeprecated(_, filters) => filters,
             SearchTokenizer::Lindera { filters, .. } => filters,
+            SearchTokenizer::LinderaWithOptions { filters, .. } => filters,
             SearchTokenizer::ICUTokenizer(filters) => filters,
             SearchTokenizer::Jieba { filters, .. } => filters,
             SearchTokenizer::UnicodeWordsDeprecated { filters, .. } => filters,
@@ -866,6 +970,26 @@ impl SearchTokenizer {
                     format!("korean_lindera_keepwhitespace:{keep_whitespace}{filters_suffix}")
                 }
             },
+            SearchTokenizer::LinderaWithOptions {
+                language,
+                filters: _,
+                keep_whitespace,
+                nfkc,
+                reading_form,
+            } => match language {
+                LinderaLanguage::Unspecified => {
+                    panic!("LinderaStyle::Unspecified is not supported")
+                }
+                LinderaLanguage::Chinese => {
+                    format!("chinese_lindera_keepwhitespace:{keep_whitespace}_nfkc:{nfkc}_readingform:{reading_form}{filters_suffix}")
+                }
+                LinderaLanguage::Japanese => {
+                    format!("japanese_lindera_keepwhitespace:{keep_whitespace}_nfkc:{nfkc}_readingform:{reading_form}{filters_suffix}")
+                }
+                LinderaLanguage::Korean => {
+                    format!("korean_lindera_keepwhitespace:{keep_whitespace}_nfkc:{nfkc}_readingform:{reading_form}{filters_suffix}")
+                }
+            },
             SearchTokenizer::ICUTokenizer(_filters) => format!("icu{filters_suffix}"),
             SearchTokenizer::Jieba {
                 chinese_convert,
@@ -989,6 +1113,35 @@ mod tests {
         assert_eq!(
             tokenizer,
             SearchTokenizer::from_json_value(&serde_json::from_str(json).unwrap()).unwrap()
+        );
+    }
+
+    #[rstest]
+    fn test_lindera_tokenizer_with_nfkc_and_reading_form() {
+        let json = r#"{
+            "type": "lindera",
+            "language": "japanese",
+            "keep_whitespace": true,
+            "nfkc": true,
+            "reading_form": true
+        }"#;
+
+        let tokenizer =
+            SearchTokenizer::from_json_value(&serde_json::from_str(json).unwrap()).unwrap();
+
+        assert_eq!(
+            tokenizer,
+            SearchTokenizer::LinderaWithOptions {
+                language: LinderaLanguage::Japanese,
+                filters: SearchTokenizerFilters::default(),
+                keep_whitespace: true,
+                nfkc: true,
+                reading_form: true,
+            }
+        );
+        assert_eq!(
+            tokenizer.name(),
+            "japanese_lindera_keepwhitespace:true_nfkc:true_readingform:true"
         );
     }
 

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -574,6 +574,11 @@ impl SearchTokenizer {
                     .get("reading_form")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
+                if language == LinderaLanguage::Chinese && reading_form {
+                    return Err(anyhow::anyhow!(
+                        "reading_form=true is not supported for Lindera Chinese tokenizer options"
+                    ));
+                }
 
                 Ok(lindera_tokenizer(
                     language,
@@ -710,11 +715,18 @@ impl SearchTokenizer {
                 filters,
                 keep_whitespace,
                 nfkc,
-                reading_form: _,
-            } => add_filters!(
-                LinderaChineseTokenizer::with_options(*keep_whitespace, *nfkc),
-                filters
-            ),
+                reading_form,
+            } => {
+                if *reading_form {
+                    panic!(
+                        "reading_form=true is not supported for Lindera Chinese tokenizer options"
+                    );
+                }
+                add_filters!(
+                    LinderaChineseTokenizer::with_options(*keep_whitespace, *nfkc),
+                    filters
+                )
+            }
             SearchTokenizer::JapaneseLinderaDeprecated(filters)
             | SearchTokenizer::LinderaDeprecated(LinderaLanguage::Japanese, filters) => {
                 add_filters!(LinderaJapaneseTokenizer::new(true), filters)
@@ -981,7 +993,7 @@ impl SearchTokenizer {
                     panic!("LinderaStyle::Unspecified is not supported")
                 }
                 LinderaLanguage::Chinese => {
-                    format!("chinese_lindera_keepwhitespace:{keep_whitespace}_nfkc:{nfkc}_readingform:{reading_form}{filters_suffix}")
+                    format!("chinese_lindera_keepwhitespace:{keep_whitespace}_nfkc:{nfkc}_readingform:false{filters_suffix}")
                 }
                 LinderaLanguage::Japanese => {
                     format!("japanese_lindera_keepwhitespace:{keep_whitespace}_nfkc:{nfkc}_readingform:{reading_form}{filters_suffix}")
@@ -1143,6 +1155,21 @@ mod tests {
             tokenizer.name(),
             "japanese_lindera_keepwhitespace:true_nfkc:true_readingform:true"
         );
+    }
+
+    #[rstest]
+    fn test_lindera_chinese_reading_form_rejected() {
+        let json = r#"{
+            "type": "lindera",
+            "language": "chinese",
+            "reading_form": true
+        }"#;
+
+        let err = SearchTokenizer::from_json_value(&serde_json::from_str(json).unwrap())
+            .unwrap_err()
+            .to_string();
+
+        assert!(err.contains("reading_form=true is not supported"));
     }
 
     #[rstest]


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4808

## What
Expose Lindera `nfkc` normalization and `reading_form` options for the Lindera tokenizer

## Why
A customer needs access to Lindera's IPADIC reading alignment and NFKC normalization for Japanese and Korean tokenizer workflows.

## How
Added Lindera tokenizer options for `nfkc` and `reading_form`, wired them through SQL typmods and tokenizer construction, updated docs, and added focused test/regression coverage.

## Tests
- `cargo test -p tokenizers lindera -- --nocapture`
- `cargo check -p pg_search --no-default-features --features pg17`
- `cargo pgrx regress -p pg_search --auto -- pg17 test_tokenizer_params`