### PR TITLE
feat: top k pushdown for JSON sub-path ORDER BY

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -271,6 +271,32 @@ pub struct TopKAuxiliaryCollector {
     pub vischeck: Option<VisibilityChecker>,
 }
 
+/// Probe a single segment for the fast-field leaf type at `path`.
+///
+/// Returns `Some(Type)` if the segment exposes a fast-field column for `path`, or `None`
+/// if the segment has no fast-field column for that path
+///
+/// The probe order is fixed so that segments which store the same
+/// underlying Tantivy column type always resolve to the same `Type`.
+fn probe_segment_leaf_type(reader: &SegmentReader, path: &str) -> Option<tantivy::schema::Type> {
+    let ffr = reader.fast_fields();
+    if ffr.i64(path).is_ok() {
+        Some(tantivy::schema::Type::I64)
+    } else if ffr.u64(path).is_ok() {
+        Some(tantivy::schema::Type::U64)
+    } else if ffr.f64(path).is_ok() {
+        Some(tantivy::schema::Type::F64)
+    } else if ffr.bool(path).is_ok() {
+        Some(tantivy::schema::Type::Bool)
+    } else if ffr.date(path).is_ok() {
+        Some(tantivy::schema::Type::Date)
+    } else if matches!(ffr.str(path), Ok(Some(_))) {
+        Some(tantivy::schema::Type::Str)
+    } else {
+        None
+    }
+}
+
 pub struct SearchIndexReader {
     index_rel: PgSearchRelation,
     searcher: Searcher,
@@ -457,6 +483,44 @@ impl SearchIndexReader {
             .iter()
             .map(|r| r.segment_id())
             .collect()
+    }
+
+    /// Probe ALL Tantivy segments for the leaf fast-field type of a JSON path.
+    ///
+    /// Returns `Some(Type)` only when every segment that exposes any fast-field column for
+    /// `path` resolves to the same leaf type. Returns `None` if no segment has a fast-field
+    /// column for `path`, or if segments disagree on the leaf type
+    pub fn probe_json_leaf_type(&self, path: &str) -> Option<tantivy::schema::Type> {
+        let mut resolved: Option<tantivy::schema::Type> = None;
+        for reader in self.searcher.segment_readers().iter() {
+            let Some(segment_type) = probe_segment_leaf_type(reader, path) else {
+                continue;
+            };
+            match resolved {
+                None => resolved = Some(segment_type),
+                Some(prev) if prev != segment_type => return None,
+                _ => {}
+            }
+        }
+        resolved
+    }
+
+    /// If `value_type` is `Type::Json`, resolve `path` to its concrete leaf fast-field type
+    /// via [`probe_json_leaf_type`]. Otherwise return `value_type` unchanged
+    pub(crate) fn normalize_json_value_type(
+        &self,
+        value_type: tantivy::schema::Type,
+        path: &str,
+    ) -> tantivy::schema::Type {
+        match value_type {
+            tantivy::schema::Type::Json => self.probe_json_leaf_type(path).unwrap_or_else(|| {
+                panic!(
+                    "JSON path `{path}` has no fast-field leaf type that is consistent across \
+                     segments; this should have been rejected by the planner before Top K dispatch."
+                )
+            }),
+            other => other,
+        }
     }
 
     pub fn need_scores(&self) -> bool {
@@ -771,7 +835,11 @@ impl SearchIndexReader {
                     .search_field(sort_field)
                     .expect("sort field should exist in index schema");
                 let order: ComparatorEnum = (*direction).into();
-                match field.field_entry().field_type().value_type() {
+                let value_type = self.normalize_json_value_type(
+                    field.field_entry().field_type().value_type(),
+                    sort_field.as_ref(),
+                );
+                match value_type {
                     tantivy::schema::Type::Str => {
                         TopKSearchResults::new_for_discarded_field(self.top_in_segments(
                             segment_ids,

--- a/pg_search/src/postgres/customscan/aggregatescan/orderby.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/orderby.rs
@@ -23,7 +23,7 @@ use crate::postgres::customscan::aggregatescan::{
 };
 use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_matching_fast_field;
 use crate::postgres::customscan::orderby::{
-    extract_pathkey_styles_with_sortability_check, PathKeyInfo,
+    extract_pathkey_styles_with_sortability_check, JsonSortGate, PathKeyInfo,
 };
 use crate::postgres::var::{find_one_var_and_fieldname, VarContext};
 use crate::postgres::PgSearchRelation;
@@ -102,6 +102,7 @@ impl CustomScanClause<AggregateScan> for OrderByClause {
                 .collect::<HashSet<String>>()
         };
 
+        let json_sort_gate = JsonSortGate::new(index);
         let pathkeys = unsafe {
             extract_pathkey_styles_with_sortability_check(
                 args.root,
@@ -110,6 +111,7 @@ impl CustomScanClause<AggregateScan> for OrderByClause {
                 |f| f.is_fast(),
                 |_| false,
                 Some(&index_expressions),
+                Some(&json_sort_gate),
             )
         };
 

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -689,8 +689,13 @@ impl CustomScan for BaseScan {
                 .schema()
                 .expect("custom_scan: should have a schema");
             let index_expressions = bm25_index.index_expressions();
-            let topk_pathkey_info =
-                pullup_topk_pathkeys(rti, &schema, root, Some(&index_expressions));
+            let topk_pathkey_info = pullup_topk_pathkeys(
+                rti,
+                &schema,
+                root,
+                Some(&index_expressions),
+                Some(&bm25_index),
+            );
 
             #[cfg(feature = "pg15")]
             let baserels = (*builder.args().root).all_baserels;
@@ -2246,7 +2251,10 @@ unsafe fn pullup_topk_pathkeys(
     schema: &SearchIndexSchema,
     root: *mut pg_sys::PlannerInfo,
     index_expressions: Option<&PgList<pg_sys::Expr>>,
+    index_relation: Option<&PgSearchRelation>,
 ) -> PathKeyInfo {
+    let json_sort_gate =
+        index_relation.map(crate::postgres::customscan::orderby::JsonSortGate::new);
     match extract_pathkey_styles_with_sortability_check(
         root,
         rti,
@@ -2254,6 +2262,7 @@ unsafe fn pullup_topk_pathkeys(
         |search_field| search_field.is_raw_sortable(),
         |search_field| search_field.is_lower_sortable(),
         index_expressions,
+        json_sort_gate.as_ref(),
     ) {
         PathKeyInfo::UsableAll(styles) if styles.len() <= MAX_TOPK_FEATURES => {
             // Top K is the base scan's only executor which supports sorting, and supports up to

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -232,20 +232,13 @@ fn pg_type_to_tantivy_type(pg_type: pg_sys::Oid) -> Option<tantivy::schema::Type
         || pg_type == pg_sys::NAMEOID
     {
         Some(Type::Str)
-    } else if pg_type == pg_sys::INT2OID || pg_type == pg_sys::INT4OID || pg_type == pg_sys::INT8OID
-    {
+    } else if pg_type == pg_sys::INT8OID {
         Some(Type::I64)
-    } else if pg_type == pg_sys::FLOAT4OID
-        || pg_type == pg_sys::FLOAT8OID
-        || pg_type == pg_sys::NUMERICOID
-    {
+    } else if pg_type == pg_sys::FLOAT8OID {
         Some(Type::F64)
     } else if pg_type == pg_sys::BOOLOID {
         Some(Type::Bool)
-    } else if pg_type == pg_sys::TIMESTAMPOID
-        || pg_type == pg_sys::TIMESTAMPTZOID
-        || pg_type == pg_sys::DATEOID
-    {
+    } else if pg_type == pg_sys::TIMESTAMPOID || pg_type == pg_sys::TIMESTAMPTZOID {
         Some(Type::Date)
     } else {
         None

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -25,7 +25,8 @@
 //! when we are certain that the query can be executed as a Top K query.
 
 use crate::api::FieldName;
-use crate::index::reader::index::MAX_TOPK_FEATURES;
+use crate::index::directory::mvcc::MvccSatisfies;
+use crate::index::reader::index::{SearchIndexReader, MAX_TOPK_FEATURES};
 use crate::nodecast;
 use crate::postgres::customscan::basescan::exec_methods::fast_fields::find_matching_fast_field;
 use crate::postgres::customscan::builders::custom_path::OrderByStyle;
@@ -38,6 +39,7 @@ use crate::postgres::var::{
 };
 use crate::schema::{SearchField, SearchIndexSchema};
 use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList};
+use std::cell::RefCell;
 
 /// The type of sort expression found in an ORDER BY clause.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -177,6 +179,104 @@ pub struct IndexExpressionInfo<'a> {
     pub heap_rti: pg_sys::Index,
 }
 
+/// Lazy probe of Tantivy segments used during planning to verify that a JSON sub-path's
+/// fast-field leaf type matches the type that Postgres would use to evaluate an ORDER BY
+/// expression
+///
+/// Opening a [`SearchIndexReader`] is not free, so the reader is created on first use and
+/// reused across every sort key in the same query. Probes per JSON path are cached so that
+/// repeated checks across multiple pathkeys do not re-walk every segment
+pub struct JsonSortGate<'a> {
+    index_relation: &'a PgSearchRelation,
+    reader: RefCell<Option<Option<SearchIndexReader>>>,
+    probed: RefCell<std::collections::HashMap<String, Option<tantivy::schema::Type>>>,
+}
+
+impl<'a> JsonSortGate<'a> {
+    pub fn new(index_relation: &'a PgSearchRelation) -> Self {
+        Self {
+            index_relation,
+            reader: RefCell::new(None),
+            probed: RefCell::new(std::collections::HashMap::new()),
+        }
+    }
+
+    pub fn probe(&self, path: &str) -> Option<tantivy::schema::Type> {
+        if let Some(cached) = self.probed.borrow().get(path).copied() {
+            return cached;
+        }
+        let result = {
+            let mut slot = self.reader.borrow_mut();
+            if slot.is_none() {
+                *slot = Some(
+                    SearchIndexReader::empty(self.index_relation, MvccSatisfies::Snapshot).ok(),
+                );
+            }
+            slot.as_ref()
+                .and_then(|inner| inner.as_ref())
+                .and_then(|r| r.probe_json_leaf_type(path))
+        };
+        self.probed.borrow_mut().insert(path.to_string(), result);
+        result
+    }
+}
+
+/// Map a Postgres type OID to the Tantivy schema [`Type`](tantivy::schema::Type) whose stored
+/// order matches Postgres' btree ordering for that type. Returns `None` for OIDs that have no
+/// safe Tantivy counterpart
+fn pg_type_to_tantivy_type(pg_type: pg_sys::Oid) -> Option<tantivy::schema::Type> {
+    use tantivy::schema::Type;
+    if pg_type == pg_sys::TEXTOID
+        || pg_type == pg_sys::VARCHAROID
+        || pg_type == pg_sys::BPCHAROID
+        || pg_type == pg_sys::NAMEOID
+    {
+        Some(Type::Str)
+    } else if pg_type == pg_sys::INT2OID || pg_type == pg_sys::INT4OID || pg_type == pg_sys::INT8OID
+    {
+        Some(Type::I64)
+    } else if pg_type == pg_sys::FLOAT4OID
+        || pg_type == pg_sys::FLOAT8OID
+        || pg_type == pg_sys::NUMERICOID
+    {
+        Some(Type::F64)
+    } else if pg_type == pg_sys::BOOLOID {
+        Some(Type::Bool)
+    } else if pg_type == pg_sys::TIMESTAMPOID
+        || pg_type == pg_sys::TIMESTAMPTZOID
+        || pg_type == pg_sys::DATEOID
+    {
+        Some(Type::Date)
+    } else {
+        None
+    }
+}
+
+/// Determine whether a Raw sort on a JSON field is safe to push down.
+///
+/// Returns `true` only when:
+/// the resolved [`FieldName`] addresses a JSON sub-path (e.g. `metadata.price`)
+/// the ORDER BY expression's result type maps to a known Tantivy leaf type
+/// the fast-field leaf type stored in Tantivy agrees across all visible segments
+/// the probed leaf type matches the expression's expected type
+///
+/// When any check fails we return `false` and the caller leaves the sort to Postgres, which
+/// preserves the user's expected ordering semantics.
+pub unsafe fn json_sub_path_sort_pushable(
+    gate: &JsonSortGate,
+    field_name: &FieldName,
+    original_expr: *mut pg_sys::Node,
+) -> bool {
+    if field_name.path().is_none() {
+        return false;
+    }
+    let expected_oid = pg_sys::exprType(original_expr);
+    let Some(expected_type) = pg_type_to_tantivy_type(expected_oid) else {
+        return false;
+    };
+    matches!(gate.probe(field_name.as_ref()), Some(t) if t == expected_type)
+}
+
 /// Analyzes an ORDER BY expression to determine its type and extract the underlying variable.
 ///
 /// This function unifies the logic for identifying sort keys across the planner hook (validation)
@@ -302,6 +402,7 @@ pub unsafe fn extract_pathkey_styles_with_sortability_check<F1, F2>(
     regular_sortability_check: F1,
     lower_sortability_check: F2,
     index_expressions: Option<&PgList<pg_sys::Expr>>,
+    json_sort_gate: Option<&JsonSortGate>,
 ) -> PathKeyInfo
 where
     F1: Fn(&SearchField) -> bool,
@@ -374,6 +475,20 @@ where
                         if let Some(field_name) = field_name_opt {
                             if let Some(search_field) = schema.search_field(field_name.root()) {
                                 if regular_sortability_check(&search_field) {
+                                    // For JSON sub-paths, gate pushdown on the probed leaf
+                                    // type matching the SQL expression's expected type
+                                    if search_field.is_json() {
+                                        let pushable = json_sort_gate.is_some_and(|gate| {
+                                            json_sub_path_sort_pushable(
+                                                gate,
+                                                &field_name,
+                                                expr_to_analyze.cast(),
+                                            )
+                                        });
+                                        if !pushable {
+                                            continue;
+                                        }
+                                    }
                                     pathkey_styles.push(OrderByStyle::Field {
                                         pathkey,
                                         name: field_name,
@@ -442,13 +557,15 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
     let target_list = PgList::<pg_sys::TargetEntry>::from_pg((*parse).targetList);
 
     // We need to identify the single relation that this Top K query targets
-    // Tuple: (varno, relid, schema, index_expressions)
+    // Tuple: (varno, relid, bm25_index, schema, index_expressions)
     let mut target_relation_info: Option<(
         pg_sys::Index,
         pg_sys::Oid,
+        PgSearchRelation,
         SearchIndexSchema,
         PgList<pg_sys::Expr>,
     )> = None;
+    let mut json_sort_gate: Option<JsonSortGate> = None;
 
     for sort_clause in sort_list.iter_ptr() {
         let tle_ref = (*sort_clause).tleSortGroupRef;
@@ -461,7 +578,7 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
         // Pass index expressions if we have them (after first sort clause identifies the relation)
         let index_info = target_relation_info
             .as_ref()
-            .map(|(_, _, schema, idx_exprs)| IndexExpressionInfo {
+            .map(|(_, _, _, schema, idx_exprs)| IndexExpressionInfo {
                 index_expressions: idx_exprs,
                 schema,
                 // TODO: heap_rti should use the actual varno from target_relation_info
@@ -482,7 +599,7 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
             return false;
         }
 
-        if let Some((expected_varno, _, _, _)) = &target_relation_info {
+        if let Some((expected_varno, _, _, _, _)) = &target_relation_info {
             if varno != *expected_varno {
                 // Sorting by different relations
                 return false;
@@ -507,11 +624,11 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
 
             let index_expressions = bm25_index.index_expressions();
 
-            target_relation_info = Some((varno, relid, schema, index_expressions));
+            target_relation_info = Some((varno, relid, bm25_index, schema, index_expressions));
         }
 
         // Validate sortability
-        let (_, _, schema, _) = target_relation_info.as_ref().unwrap();
+        let (_, _, bm25_index, schema, _) = target_relation_info.as_ref().unwrap();
 
         match sort_type {
             SortExpressionType::Score => {
@@ -538,6 +655,21 @@ pub unsafe fn validate_topk_compatibility(parse: *mut pg_sys::Query) -> bool {
                 };
                 if !search_field.is_raw_sortable() {
                     return false;
+                }
+                if search_field.is_json() {
+                    // Lazily build the gate the first time we hit a JSON sub-path sort
+                    // SAFETY: the gate borrows from `target_relation_info`, which lives for
+                    // the rest of this function
+                    let gate = json_sort_gate.get_or_insert_with(|| {
+                        JsonSortGate::new(
+                            // Re-borrow through a raw pointer to satisfy the borrow checker:
+                            // bm25_index lives in target_relation_info for the whole loop.
+                            &*(bm25_index as *const PgSearchRelation),
+                        )
+                    });
+                    if !json_sub_path_sort_pushable(gate, &field_name, expr) {
+                        return false;
+                    }
                 }
             }
             SortExpressionType::IndexedExpression => {

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -667,8 +667,13 @@ impl SearchField {
             FieldType::Bool(options) => options.is_fast(),
             FieldType::Date(options) => options.is_fast(),
             FieldType::Bytes(options) => options.is_fast(),
-            // TODO: JSON and range fields are not yet sortable by us
-            FieldType::JsonObject(_) => false,
+            // JSON sub-path sorts (e.g. `metadata->>'k'`) require an additional planner-side
+            // gate which verifies that the SQL expression's expected type matches the leaf
+            // fast-field type stored across all segments. Sorting the JSON object itself is
+            // not meaningful, so we only flag the column as raw-sortable here.
+            FieldType::JsonObject(options) => {
+                options.is_fast() && matches!(desired_normalizer, SearchNormalizer::Raw)
+            }
             _ => false,
         }
     }

--- a/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/json_groupby_aggregate.out
@@ -998,16 +998,19 @@ WHERE id @@@ paradedb.exists('config.api.endpoints.users')
   AND id @@@ paradedb.exists('config.database.port')
 GROUP BY config->'api'->'endpoints'->>'users', config->'database'->>'port'
 ORDER BY users_endpoint, db_port;
-                                                                                                                               QUERY PLAN                                                                                                                               
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
-   Output: (((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text), ((config -> 'database'::text) ->> 'port'::text), pdb.agg_fn('COUNT(*)'::text)
-   Index: idx_json_reconstruction
-   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.api.endpoints.users"}}}},{"with_index":{"query":{"exists":{"field":"config.database.port"}}}}]}}
-     Applies to Aggregates: COUNT(*)
-     Group By: config.api.endpoints.users, config.database.port
-     Aggregate Definition: {"grouped":{"aggs":{"grouped":{"terms":{"field":"config.database.port","order":{"_key":"asc"},"segment_size":65000,"size":65000}}},"terms":{"field":"config.api.endpoints.users","order":{"_key":"asc"},"segment_size":65000,"size":65000}}}
-(7 rows)
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Output: ((((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text)), (((config -> 'database'::text) ->> 'port'::text)), (pdb.agg_fn('COUNT(*)'::text))
+   Sort Key: ((((json_test_reconstruction.config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text)), (((json_test_reconstruction.config -> 'database'::text) ->> 'port'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan) on public.json_test_reconstruction
+         Output: (((config -> 'api'::text) -> 'endpoints'::text) ->> 'users'::text), ((config -> 'database'::text) ->> 'port'::text), pdb.agg_fn('COUNT(*)'::text)
+         Index: idx_json_reconstruction
+         Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"exists":{"field":"config.api.endpoints.users"}}}},{"with_index":{"query":{"exists":{"field":"config.database.port"}}}}]}}
+           Applies to Aggregates: COUNT(*)
+           Group By: config.api.endpoints.users, config.database.port
+           Aggregate Definition: {"grouped":{"aggs":{"grouped":{"terms":{"field":"config.database.port","segment_size":65000,"size":65000}}},"terms":{"field":"config.api.endpoints.users","segment_size":65000,"size":65000}}}
+(10 rows)
 
 -- Execute the query  
 SELECT 

--- a/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-fast-field.out
@@ -147,25 +147,24 @@ SELECT metadata->>'key', COUNT(*) FROM tokenizer_fast WHERE id @@@ pdb.all() GRO
  the big cat     |     1
 (3 rows)
 
--- Order by JSON not supported
+-- Order by JSON text sub-key is pushed down when the stored fast-field leaf type
+-- (Str) matches the expression's text type.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT * FROM tokenizer_fast WHERE id @@@ pdb.all() ORDER BY metadata->>'key', id LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: tokenizer_fast)
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: ((metadata ->> 'key'::text)), id
-         ->  Custom Scan (ParadeDB Base Scan) on tokenizer_fast
-               Table: tokenizer_fast
-               Index: idxtokenizer_fast
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+   ->  Custom Scan (ParadeDB Base Scan) on tokenizer_fast
+         Table: tokenizer_fast
+         Index: idxtokenizer_fast
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: metadata.key asc, id asc
+            TopK Limit: 5
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
 (9 rows)
 
 SELECT * FROM tokenizer_fast WHERE id @@@ pdb.all() ORDER BY metadata->>'key', id LIMIT 5;
-WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: tokenizer_fast)
  id |   t   |     t_long      |                metadata                
 ----+-------+-----------------+----------------------------------------
   3 | world | Quick brown fox | {"key": "Quick brown fox", "value": 2}

--- a/pg_search/tests/pg_regress/expected/topn-json-orderby-edges.out
+++ b/pg_search/tests/pg_regress/expected/topn-json-orderby-edges.out
@@ -1,0 +1,287 @@
+-- Additional coverage for JSON sub-path Top K pushdown (see topn-json-orderby.sql).
+--
+-- These cases exercise the JsonSortGate code paths that are not covered by the
+-- primary regression file:
+--   * JSON string value with a ::timestamp cast (probed leaf is Str, expected
+--     is Date) -> pushdown rejected
+--   * Float leaf type (Type::F64) with true decimal JSON numbers -> pushdown
+--   * Probe miss when the requested JSON key is absent from every document
+--   * Non-fast JSON field (fast: false) -> is_raw_sortable returns false
+--   * DESC sort direction on a Str leaf
+--   * JSON sub-path as a secondary sort key
+--   * Aggregate scan ORDER BY (metadata->>'k')::cast LIMIT (aggregatescan/orderby.rs)
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+SET paradedb.enable_aggregate_custom_scan = true;
+DROP TABLE IF EXISTS mock_items_jsonsort_edges;
+CREATE TABLE mock_items_jsonsort_edges (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    metadata JSONB,
+    raw_metadata JSONB
+);
+INSERT INTO mock_items_jsonsort_edges (description, metadata, raw_metadata) VALUES
+('Computer mouse', '{"price":100,   "color":"white","released":"2021-05-01","weight":1.5,  "tier":1}',
+                    '{"hidden":"a"}'),
+('Keyboard',       '{"price":150,   "color":"black","released":"2020-01-15","weight":2.25, "tier":2}',
+                    '{"hidden":"b"}'),
+('Monitor',        '{"price":200,   "color":"white","released":"2022-08-20","weight":7.0,  "tier":1}',
+                    '{"hidden":"c"}'),
+('Printer',        '{"price":120,   "color":"black","released":"2019-11-30","weight":4.4,  "tier":3}',
+                    '{"hidden":"d"}'),
+('Speaker',        '{"price":80,    "color":"white","released":"2023-03-10","weight":3.1,  "tier":2}',
+                    '{"hidden":"e"}');
+CREATE INDEX jsonsort_edges_idx ON mock_items_jsonsort_edges
+USING bm25 (id, description, metadata, raw_metadata)
+WITH (
+    key_field='id',
+    json_fields='{"metadata": {"fast": true}, "raw_metadata": {"fast": false}}'
+);
+-- 1. JSON string sorted via ::timestamp cast. Tantivy stores "released" as a
+--    Str leaf inside the JSON object (JSON strings are not auto-promoted to
+--    Date), but the SQL expression's expected leaf type is Date. The leaf
+--    types disagree, so JsonSortGate refuses pushdown and Postgres performs
+--    the sort itself. The final result is still in chronological order
+--    because Postgres compares as timestamp.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'released')::timestamp AS released
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY released ASC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort_edges)
+                                     QUERY PLAN                                     
+------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (((metadata ->> 'released'::text))::timestamp without time zone)
+         ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort_edges
+               Table: mock_items_jsonsort_edges
+               Index: jsonsort_edges_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Full Index Scan: true
+               Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, (metadata->>'released')::timestamp AS released
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY released ASC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort_edges)
+  description   |         released         
+----------------+--------------------------
+ Printer        | Sat Nov 30 00:00:00 2019
+ Keyboard       | Wed Jan 15 00:00:00 2020
+ Computer mouse | Sat May 01 00:00:00 2021
+ Monitor        | Sat Aug 20 00:00:00 2022
+ Speaker        | Fri Mar 10 00:00:00 2023
+(5 rows)
+
+-- 2. F64 leaf type. The "weight" key stores true decimals, so the column is an
+--    F64 fast field and a ::float8 cast pushes down to Top K.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'weight')::float8 AS weight
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY weight DESC
+LIMIT 5;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort_edges
+         Table: mock_items_jsonsort_edges
+         Index: jsonsort_edges_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: metadata.weight desc
+            TopK Limit: 5
+         Full Index Scan: true
+         Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, (metadata->>'weight')::float8 AS weight
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY weight DESC
+LIMIT 5;
+  description   | weight 
+----------------+--------
+ Monitor        |      7
+ Printer        |    4.4
+ Speaker        |    3.1
+ Keyboard       |   2.25
+ Computer mouse |    1.5
+(5 rows)
+
+-- 3. Probe miss: no document defines metadata->>'nonexistent', so probe_json_leaf_type
+--    returns None across every segment and the JsonSortGate rejects the pushdown.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'nonexistent' AS missing
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY missing ASC, id ASC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort_edges)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: ((metadata ->> 'nonexistent'::text)), id
+         ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort_edges
+               Table: mock_items_jsonsort_edges
+               Index: jsonsort_edges_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Full Index Scan: true
+               Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+-- 4. raw_metadata is declared with fast:false, so SearchField::is_raw_sortable
+--    must return false and the JSON sort cannot be pushed down regardless of the
+--    expression type.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, raw_metadata->>'hidden' AS h
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY h ASC, id ASC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort_edges)
+                                QUERY PLAN                                 
+---------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: ((raw_metadata ->> 'hidden'::text)), id
+         ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort_edges
+               Table: mock_items_jsonsort_edges
+               Index: jsonsort_edges_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Full Index Scan: true
+               Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+-- 5. DESC sort direction on a Str leaf -- confirms ORDER BY direction flows
+--    through the new JSON pushdown branch.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'color' AS color
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY color DESC, id ASC
+LIMIT 5;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort_edges
+         Table: mock_items_jsonsort_edges
+         Index: jsonsort_edges_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: metadata.color desc, id asc
+            TopK Limit: 5
+         Full Index Scan: true
+         Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, metadata->>'color' AS color
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY color DESC, id ASC
+LIMIT 5;
+  description   | color 
+----------------+-------
+ Computer mouse | white
+ Monitor        | white
+ Speaker        | white
+ Keyboard       | black
+ Printer        | black
+(5 rows)
+
+-- 6. JSON sub-path as a secondary sort key together with a primary fast field
+--    (id). The full pathkey list must remain Top K compatible.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id, description, (metadata->>'tier')::int AS tier
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY (metadata->>'tier')::int ASC, id ASC
+LIMIT 5;
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort_edges
+         Table: mock_items_jsonsort_edges
+         Index: jsonsort_edges_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: metadata.tier asc, id asc
+            TopK Limit: 5
+         Full Index Scan: true
+         Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT id, description, (metadata->>'tier')::int AS tier
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY (metadata->>'tier')::int ASC, id ASC
+LIMIT 5;
+ id |  description   | tier 
+----+----------------+------
+  1 | Computer mouse |    1
+  3 | Monitor        |    1
+  2 | Keyboard       |    2
+  5 | Speaker        |    2
+  4 | Printer        |    3
+(5 rows)
+
+-- 7. Aggregate scan path: GROUP BY ... ORDER BY (metadata->>'k')::cast LIMIT.
+--    Confirms that aggregatescan/orderby.rs threads the JsonSortGate through
+--    when the sort key is a cast over a JSON sub-path.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT (metadata->>'tier')::int AS tier, COUNT(*)
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+GROUP BY (metadata->>'tier')::int
+ORDER BY (metadata->>'tier')::int ASC
+LIMIT 5;
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Aggregate Scan) on mock_items_jsonsort_edges
+         Index: jsonsort_edges_idx
+         Tantivy Query: {"with_index":{"query":"all"}}
+           Applies to Aggregates: COUNT(*)
+           Group By: metadata.tier
+           Limit: 5
+           Aggregate Definition: {"grouped":{"terms":{"field":"metadata.tier","order":{"_key":"asc"},"segment_size":65000,"size":65000}}}
+(8 rows)
+
+SELECT (metadata->>'tier')::int AS tier, COUNT(*)
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+GROUP BY (metadata->>'tier')::int
+ORDER BY (metadata->>'tier')::int ASC
+LIMIT 5;
+ tier | count 
+------+-------
+    1 |     2
+    2 |     2
+    3 |     1
+(3 rows)
+
+DROP TABLE mock_items_jsonsort_edges;
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_columnar_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/expected/topn-json-orderby.out
+++ b/pg_search/tests/pg_regress/expected/topn-json-orderby.out
@@ -1,0 +1,209 @@
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+DROP TABLE IF EXISTS mock_items_jsonsort;
+CREATE TABLE mock_items_jsonsort (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    metadata JSONB
+);
+INSERT INTO mock_items_jsonsort (description, metadata) VALUES
+('Computer mouse', '{"price": 100, "color": "white", "in_stock": true,  "released": "2021-05-01"}'),
+('Keyboard',       '{"price": 150, "color": "black", "in_stock": false, "released": "2020-01-15"}'),
+('Monitor',        '{"price": 200, "color": "white", "in_stock": true,  "released": "2022-08-20"}'),
+('Printer',        '{"price": 120, "color": "black", "in_stock": false, "released": "2019-11-30"}'),
+('Speaker',        '{"price":  80, "color": "white", "in_stock": true,  "released": "2023-03-10"}');
+CREATE INDEX jsonsort_idx ON mock_items_jsonsort
+USING bm25 (id, description, metadata)
+WITH (key_field='id', json_fields='{"metadata": {"fast": true}}');
+-- Text sub-key (color) -> Str fast field. ORDER BY metadata->>'color' is TEXT,
+-- and Tantivy stores it as Str, so pushdown is safe.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'color' AS color FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY color ASC, id ASC
+LIMIT 5;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort
+         Table: mock_items_jsonsort
+         Index: jsonsort_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: metadata.color asc, id asc
+            TopK Limit: 5
+         Full Index Scan: true
+         Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, metadata->>'color' AS color FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY color ASC, id ASC
+LIMIT 5;
+  description   | color 
+----------------+-------
+ Keyboard       | black
+ Printer        | black
+ Computer mouse | white
+ Monitor        | white
+ Speaker        | white
+(5 rows)
+
+-- Numeric sub-key sorted as TEXT must NOT push down to Tantivy: PG's lexicographic
+-- text sort ('80', '200', '150', '120', '100' DESC) differs from Tantivy's numeric
+-- order. The planner gate rejects the JSON sort, so PG performs the sort and the
+-- output reflects text ordering.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'price' AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort)
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: ((metadata ->> 'price'::text)) DESC
+         ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort
+               Table: mock_items_jsonsort
+               Index: jsonsort_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Full Index Scan: true
+               Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, metadata->>'price' AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort)
+  description   | price 
+----------------+-------
+ Speaker        | 80
+ Monitor        | 200
+ Keyboard       | 150
+ Printer        | 120
+ Computer mouse | 100
+(5 rows)
+
+-- Explicit ::int cast on the same key matches the I64 fast field type, so pushdown
+-- is allowed and the result is in numeric order.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'price')::int AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort
+         Table: mock_items_jsonsort
+         Index: jsonsort_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: metadata.price desc
+            TopK Limit: 5
+         Full Index Scan: true
+         Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, (metadata->>'price')::int AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+  description   | price 
+----------------+-------
+ Monitor        |   200
+ Keyboard       |   150
+ Printer        |   120
+ Computer mouse |   100
+ Speaker        |    80
+(5 rows)
+
+-- Explicit ::numeric cast maps to F64 expected type, but the stored fast field is
+-- I64 (integer JSON values). The probe disagrees, so pushdown is rejected and PG
+-- performs the sort itself.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'price')::numeric AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort)
+                             QUERY PLAN                              
+---------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (((metadata ->> 'price'::text))::numeric) DESC
+         ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort
+               Table: mock_items_jsonsort
+               Index: jsonsort_idx
+               Exec Method: NormalScanExecState
+               Scores: false
+               Full Index Scan: true
+               Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, (metadata->>'price')::numeric AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+WARNING:  Query has LIMIT 5 but is not using Top K scan (using Normal instead). Reason: ORDER BY columns cannot be pushed down to the index. This may cause poor performance on large datasets. Remedies: Ensure ORDER BY columns are indexed. Numeric columns are fast by default. For string columns, use pdb.literal tokenizer. To disable this warning: SET paradedb.check_topk_scan = false (table: mock_items_jsonsort)
+  description   | price 
+----------------+-------
+ Monitor        |   200
+ Keyboard       |   150
+ Printer        |   120
+ Computer mouse |   100
+ Speaker        |    80
+(5 rows)
+
+-- Boolean cast matches the Bool fast field type.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'in_stock')::boolean AS in_stock FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY in_stock DESC, id ASC
+LIMIT 5;
+                          QUERY PLAN                           
+---------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on mock_items_jsonsort
+         Table: mock_items_jsonsort
+         Index: jsonsort_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: metadata.in_stock desc, id asc
+            TopK Limit: 5
+         Full Index Scan: true
+         Tantivy Query: {"with_index":{"query":"all"}}
+(10 rows)
+
+SELECT description, (metadata->>'in_stock')::boolean AS in_stock FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY in_stock DESC, id ASC
+LIMIT 5;
+  description   | in_stock 
+----------------+----------
+ Computer mouse | t
+ Monitor        | t
+ Speaker        | t
+ Keyboard       | f
+ Printer        | f
+(5 rows)
+
+DROP TABLE mock_items_jsonsort;
+\i common/common_cleanup.sql
+-- Reset parallel workers setting to default
+RESET max_parallel_workers_per_gather;
+RESET enable_indexscan;
+RESET paradedb.enable_columnar_exec;
+SELECT 'Common tests cleanup complete' AS status; 
+            status             
+-------------------------------
+ Common tests cleanup complete
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/tokenizer-fast-field.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-fast-field.sql
@@ -48,7 +48,8 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT metadata->>'key', COUNT(*) FROM tokenizer_fast WHERE id @@@ pdb.all() GROUP BY metadata->>'key' ORDER BY metadata->>'key' LIMIT 5;
 SELECT metadata->>'key', COUNT(*) FROM tokenizer_fast WHERE id @@@ pdb.all() GROUP BY metadata->>'key' ORDER BY metadata->>'key' LIMIT 5;
 
--- Order by JSON not supported
+-- Order by JSON text sub-key is pushed down when the stored fast-field leaf type
+-- (Str) matches the expression's text type.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT * FROM tokenizer_fast WHERE id @@@ pdb.all() ORDER BY metadata->>'key', id LIMIT 5;
 SELECT * FROM tokenizer_fast WHERE id @@@ pdb.all() ORDER BY metadata->>'key', id LIMIT 5;

--- a/pg_search/tests/pg_regress/sql/topn-json-orderby-edges.sql
+++ b/pg_search/tests/pg_regress/sql/topn-json-orderby-edges.sql
@@ -1,0 +1,148 @@
+-- Additional coverage for JSON sub-path Top K pushdown (see topn-json-orderby.sql).
+--
+-- These cases exercise the JsonSortGate code paths that are not covered by the
+-- primary regression file:
+--   * JSON string value with a ::timestamp cast (probed leaf is Str, expected
+--     is Date) -> pushdown rejected
+--   * Float leaf type (Type::F64) with true decimal JSON numbers -> pushdown
+--   * Probe miss when the requested JSON key is absent from every document
+--   * Non-fast JSON field (fast: false) -> is_raw_sortable returns false
+--   * DESC sort direction on a Str leaf
+--   * JSON sub-path as a secondary sort key
+--   * Aggregate scan ORDER BY (metadata->>'k')::cast LIMIT (aggregatescan/orderby.rs)
+
+\i common/common_setup.sql
+
+SET paradedb.enable_aggregate_custom_scan = true;
+
+DROP TABLE IF EXISTS mock_items_jsonsort_edges;
+CREATE TABLE mock_items_jsonsort_edges (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    metadata JSONB,
+    raw_metadata JSONB
+);
+
+INSERT INTO mock_items_jsonsort_edges (description, metadata, raw_metadata) VALUES
+('Computer mouse', '{"price":100,   "color":"white","released":"2021-05-01","weight":1.5,  "tier":1}',
+                    '{"hidden":"a"}'),
+('Keyboard',       '{"price":150,   "color":"black","released":"2020-01-15","weight":2.25, "tier":2}',
+                    '{"hidden":"b"}'),
+('Monitor',        '{"price":200,   "color":"white","released":"2022-08-20","weight":7.0,  "tier":1}',
+                    '{"hidden":"c"}'),
+('Printer',        '{"price":120,   "color":"black","released":"2019-11-30","weight":4.4,  "tier":3}',
+                    '{"hidden":"d"}'),
+('Speaker',        '{"price":80,    "color":"white","released":"2023-03-10","weight":3.1,  "tier":2}',
+                    '{"hidden":"e"}');
+
+CREATE INDEX jsonsort_edges_idx ON mock_items_jsonsort_edges
+USING bm25 (id, description, metadata, raw_metadata)
+WITH (
+    key_field='id',
+    json_fields='{"metadata": {"fast": true}, "raw_metadata": {"fast": false}}'
+);
+
+-- 1. JSON string sorted via ::timestamp cast. Tantivy stores "released" as a
+--    Str leaf inside the JSON object (JSON strings are not auto-promoted to
+--    Date), but the SQL expression's expected leaf type is Date. The leaf
+--    types disagree, so JsonSortGate refuses pushdown and Postgres performs
+--    the sort itself. The final result is still in chronological order
+--    because Postgres compares as timestamp.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'released')::timestamp AS released
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY released ASC
+LIMIT 5;
+
+SELECT description, (metadata->>'released')::timestamp AS released
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY released ASC
+LIMIT 5;
+
+-- 2. F64 leaf type. The "weight" key stores true decimals, so the column is an
+--    F64 fast field and a ::float8 cast pushes down to Top K.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'weight')::float8 AS weight
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY weight DESC
+LIMIT 5;
+
+SELECT description, (metadata->>'weight')::float8 AS weight
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY weight DESC
+LIMIT 5;
+
+-- 3. Probe miss: no document defines metadata->>'nonexistent', so probe_json_leaf_type
+--    returns None across every segment and the JsonSortGate rejects the pushdown.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'nonexistent' AS missing
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY missing ASC, id ASC
+LIMIT 5;
+
+-- 4. raw_metadata is declared with fast:false, so SearchField::is_raw_sortable
+--    must return false and the JSON sort cannot be pushed down regardless of the
+--    expression type.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, raw_metadata->>'hidden' AS h
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY h ASC, id ASC
+LIMIT 5;
+
+-- 5. DESC sort direction on a Str leaf -- confirms ORDER BY direction flows
+--    through the new JSON pushdown branch.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'color' AS color
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY color DESC, id ASC
+LIMIT 5;
+
+SELECT description, metadata->>'color' AS color
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY color DESC, id ASC
+LIMIT 5;
+
+-- 6. JSON sub-path as a secondary sort key together with a primary fast field
+--    (id). The full pathkey list must remain Top K compatible.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT id, description, (metadata->>'tier')::int AS tier
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY (metadata->>'tier')::int ASC, id ASC
+LIMIT 5;
+
+SELECT id, description, (metadata->>'tier')::int AS tier
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+ORDER BY (metadata->>'tier')::int ASC, id ASC
+LIMIT 5;
+
+-- 7. Aggregate scan path: GROUP BY ... ORDER BY (metadata->>'k')::cast LIMIT.
+--    Confirms that aggregatescan/orderby.rs threads the JsonSortGate through
+--    when the sort key is a cast over a JSON sub-path.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT (metadata->>'tier')::int AS tier, COUNT(*)
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+GROUP BY (metadata->>'tier')::int
+ORDER BY (metadata->>'tier')::int ASC
+LIMIT 5;
+
+SELECT (metadata->>'tier')::int AS tier, COUNT(*)
+FROM mock_items_jsonsort_edges
+WHERE id @@@ paradedb.all()
+GROUP BY (metadata->>'tier')::int
+ORDER BY (metadata->>'tier')::int ASC
+LIMIT 5;
+
+DROP TABLE mock_items_jsonsort_edges;
+
+\i common/common_cleanup.sql

--- a/pg_search/tests/pg_regress/sql/topn-json-orderby.sql
+++ b/pg_search/tests/pg_regress/sql/topn-json-orderby.sql
@@ -1,0 +1,90 @@
+\i common/common_setup.sql
+
+DROP TABLE IF EXISTS mock_items_jsonsort;
+CREATE TABLE mock_items_jsonsort (
+    id SERIAL PRIMARY KEY,
+    description TEXT,
+    metadata JSONB
+);
+
+INSERT INTO mock_items_jsonsort (description, metadata) VALUES
+('Computer mouse', '{"price": 100, "color": "white", "in_stock": true,  "released": "2021-05-01"}'),
+('Keyboard',       '{"price": 150, "color": "black", "in_stock": false, "released": "2020-01-15"}'),
+('Monitor',        '{"price": 200, "color": "white", "in_stock": true,  "released": "2022-08-20"}'),
+('Printer',        '{"price": 120, "color": "black", "in_stock": false, "released": "2019-11-30"}'),
+('Speaker',        '{"price":  80, "color": "white", "in_stock": true,  "released": "2023-03-10"}');
+
+CREATE INDEX jsonsort_idx ON mock_items_jsonsort
+USING bm25 (id, description, metadata)
+WITH (key_field='id', json_fields='{"metadata": {"fast": true}}');
+
+-- Text sub-key (color) -> Str fast field. ORDER BY metadata->>'color' is TEXT,
+-- and Tantivy stores it as Str, so pushdown is safe.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'color' AS color FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY color ASC, id ASC
+LIMIT 5;
+
+SELECT description, metadata->>'color' AS color FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY color ASC, id ASC
+LIMIT 5;
+
+-- Numeric sub-key sorted as TEXT must NOT push down to Tantivy: PG's lexicographic
+-- text sort ('80', '200', '150', '120', '100' DESC) differs from Tantivy's numeric
+-- order. The planner gate rejects the JSON sort, so PG performs the sort and the
+-- output reflects text ordering.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, metadata->>'price' AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+
+SELECT description, metadata->>'price' AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+
+-- Explicit ::int cast on the same key matches the I64 fast field type, so pushdown
+-- is allowed and the result is in numeric order.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'price')::int AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+
+SELECT description, (metadata->>'price')::int AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+
+-- Explicit ::numeric cast maps to F64 expected type, but the stored fast field is
+-- I64 (integer JSON values). The probe disagrees, so pushdown is rejected and PG
+-- performs the sort itself.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'price')::numeric AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+
+SELECT description, (metadata->>'price')::numeric AS price FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY price DESC
+LIMIT 5;
+
+-- Boolean cast matches the Bool fast field type.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT description, (metadata->>'in_stock')::boolean AS in_stock FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY in_stock DESC, id ASC
+LIMIT 5;
+
+SELECT description, (metadata->>'in_stock')::boolean AS in_stock FROM mock_items_jsonsort
+WHERE id @@@ paradedb.all()
+ORDER BY in_stock DESC, id ASC
+LIMIT 5;
+
+DROP TABLE mock_items_jsonsort;
+
+\i common/common_cleanup.sql


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #1917 

## What
Add support for fast ordering by JSON value

## Why

## How
Use json_sub_path_sort_pushable to determine whether an ORDER BY over a JSON sub-path can be pushed down. When it returns true, record the pathkey so the Top K scan executes the sort in Tantivy.

## Tests
pg_search/tests/pg_regress/sql/topn-json-orderby-edges.sql