### PR TITLE
fix(stressgres): patch base image CVEs

### DIFF
--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -11,10 +11,11 @@
 #       memory: "4Gi"
 #       cpu: "2000m"
 
-FROM rust:1.95-slim
+FROM rust:1.95-slim-trixie
 
-# Install build and runtime dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+# Install build and runtime dependencies. Upgrade existing OS packages first so
+# we pick up the latest Debian security fixes regardless of the base layer's age.
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     build-essential \
     pkg-config \
     libpq-dev \


### PR DESCRIPTION
## What

Move the Stressgres Docker base image from `rust:1.95-slim` (Debian bookworm) to `rust:1.95-slim-trixie` (Debian 13), and run `apt-get upgrade -y` before installing build deps.

## Why

Docker Scout flagged the published `paradedb/stressgres` image with:
- **Fixable critical/high vulnerabilities** — CVEs in Debian OS packages baked into the frozen base layer.
- **Outdated base images** — the base digest was behind the current upstream.

Both findings were inherited entirely from stale OS packages in the base image, not from any ParadeDB/stressgres code. Republishing alone didn't help because `rust:1.95-slim` still resolves to bookworm and buildx reused a cached base layer. Switching to the trixie variant forces a genuinely newer base, and `apt-get upgrade` guarantees the latest Debian security patches even if a layer is cached. Rust itself stays on 1.95 (latest stable).

This is an internal, air-gapped Antithesis test image, so real-world exposure was low — this is hygiene.

## Notes

- All installed packages exist in trixie, so the build is unaffected.
- Scout pins findings per-tag, so the score only refreshes once a new SHA tag is pushed via the *Publish Stressgres (Docker)* workflow.
- `test-stressgres-docker.yml` validates the trixie build compiles.