### PR TITLE
feat(mpp): wrap MPP upper-rel paths in Gather so they actually deploy workers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=c960ec565ff304cb9bcff70a713f24d5abcf2382#c960ec565ff304cb9bcff70a713f24d5abcf2382"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=1a0590787cdea845098bb089af30b68dafbe8ac5#1a0590787cdea845098bb089af30b68dafbe8ac5"
 dependencies = [
  "arrow-ipc",
  "arrow-select",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=1a0590787cdea845098bb089af30b68dafbe8ac5#1a0590787cdea845098bb089af30b68dafbe8ac5"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=0658db207c815547e4006ffb524a2821bc673153#0658db207c815547e4006ffb524a2821bc673153"
 dependencies = [
  "arrow-ipc",
  "arrow-select",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-IkcJjujnkY+128Gf52hDJR4CRNgp/qaAoiwxEOA+s34=";
+  cargoHash = "sha256-8caWH0srkU1cOhIu5gwQYorHgD49qWBdIAsT4QgWROg=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-8caWH0srkU1cOhIu5gwQYorHgD49qWBdIAsT4QgWROg=";
+  cargoHash = "sha256-6VqY8qD7Bs0qoYvsac8u5KCAR5bBqoNOEDGcXGlxoUs=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "1a0590787cdea845098bb089af30b68dafbe8ac5", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "0658db207c815547e4006ffb524a2821bc673153", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "c960ec565ff304cb9bcff70a713f24d5abcf2382", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "1a0590787cdea845098bb089af30b68dafbe8ac5", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -36,6 +36,8 @@ use crate::postgres::utils::{expr_contains_any_operator, pg_search_extension_ins
 use once_cell::sync::Lazy;
 use pgrx::{pg_guard, pg_sys, PgList, PgMemoryContexts};
 use std::collections::{hash_map::Entry, HashMap};
+use std::mem::size_of_val;
+use std::ptr;
 
 unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
     let forced = path.flags & Flags::Force as u32 != 0;
@@ -324,9 +326,93 @@ pub extern "C-unwind" fn paradedb_upper_paths_callback<CS>(
         ));
 
         for path in paths {
-            add_path(output_rel, path);
+            add_upper_path(root, output_rel, path);
         }
     }
+}
+
+/// Upper-rel variant of [`add_path`]. `add_path` handles base/join rels well
+/// because PG's path generator calls `generate_useful_gather_paths()` AFTER
+/// the `set_rel_pathlist_hook` fires — so a partial path added there still
+/// gets wrapped in a `Gather` by core. For `UPPERREL_GROUP_AGG`, the
+/// sequence is reversed: core has already finished gather-path generation
+/// before `create_upper_paths_hook` runs, and any partial path we add at
+/// this stage is orphaned.
+///
+/// This helper wraps the MPP-ready parallel-aware custom path with an
+/// explicit `GatherPath` via `pg_sys::create_gather_path` and adds that to
+/// `output_rel->pathlist`, which is the one PG's grouping-path chooser
+/// compares against the serial aggregate path. Non-parallel custom paths
+/// fall through to the same `add_path` behavior used everywhere else.
+unsafe fn add_upper_path(
+    root: *mut pg_sys::PlannerInfo,
+    rel: *mut pg_sys::RelOptInfo,
+    mut path: pg_sys::CustomPath,
+) {
+    let forced = path.flags & Flags::Force as u32 != 0;
+    path.flags ^= Flags::Force as u32;
+
+    if forced {
+        (*rel).pathlist = ptr::null_mut();
+        (*rel).partial_pathlist = ptr::null_mut();
+    }
+
+    if path.path.parallel_aware {
+        // The MPP path itself is parallel-safe; PG needs to see it as a
+        // partial path so it and the Gather wrapper agree about workers.
+        let partial_copy =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+        pg_sys::add_partial_path(rel, partial_copy.cast());
+
+        // Wrap with Gather so the grouping-path chooser actually sees a
+        // runnable parallel plan in `output_rel->pathlist`. Use the rel's
+        // reltarget directly so Gather's pathtarget structurally equals
+        // `final_target` — otherwise `create_ordered_paths` adds a
+        // ProjectionPath (→ Result plan node) above the Sort, whose
+        // targetlist carries unreplaceable Aggrefs that crash setrefs
+        // with "Aggref found in non-Agg plan node".
+        //
+        // Aggrefs in Gather.tlist get rewritten to Var(OUTER_VAR, N) by
+        // setrefs so long as the subplan (CustomScan) tlist carries
+        // structurally-equal Aggrefs — see `set_customscan_references`
+        // and `fix_upper_expr` for the matching logic.
+        let gather_target = (*rel).reltarget;
+
+        let mut rows = (*partial_copy).path.rows;
+        let gather = pg_sys::create_gather_path(
+            root,
+            rel,
+            partial_copy.cast::<pg_sys::Path>(),
+            gather_target,
+            ptr::null_mut(),
+            &mut rows,
+        );
+
+        // Clear competing paths so the chooser actually considers Gather;
+        // otherwise a single-worker serial aggregate path with matching
+        // total cost may win by tie-break. We re-add a high-cost serial
+        // fallback below so PG always has something non-partial to pick.
+        (*rel).pathlist = ptr::null_mut();
+
+        pg_sys::add_path(rel, gather.cast());
+
+        // High-cost serial fallback: same as non-upper-rel `add_path`.
+        // Keeps a non-parallel path in the list for cases where the
+        // Gather wrapper can't run (e.g., max_parallel_workers == 0).
+        let fallback =
+            PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+        (*fallback).path.parallel_aware = false;
+        (*fallback).path.parallel_safe = false;
+        (*fallback).path.parallel_workers = 0;
+        (*fallback).path.total_cost = 1_000_000_000.0;
+        (*fallback).path.startup_cost = 1_000_000_000.0;
+        pg_sys::add_path(rel, fallback.cast());
+        return;
+    }
+
+    let serial =
+        PgMemoryContexts::CurrentMemoryContext.copy_ptr_into(&mut path, size_of_val(&path));
+    pg_sys::add_path(rel, serial.cast());
 }
 
 /// Static variable to store the previous planner hook (e.g., from Citus or other extensions)

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -149,32 +149,35 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan)
-   Output: pdb.agg_fn('COUNT(*)'::text)
-   Backend: DataFusion
-   Indexes: mpp_files_idx (f), mpp_pages_idx (p)
-   Aggregates: COUNT(*)
-   DataFusion Physical Plan: 
-     : ┌───── DistributedExec ── Tasks: t0:[p0]
-     : │ AggregateExec: mode=Final, gby=[], aggr=[agg_0]
-     : │   CoalescePartitionsExec
-     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
-     : └──────────────────────────────────────────────────
-     :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
-     :   │ AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
-     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
-     :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
-     :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
-     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-     :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :     └──────────────────────────────────────────────────
-(23 rows)
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 3
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_files_idx (f), mpp_pages_idx (p)
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : │ AggregateExec: mode=Final, gby=[], aggr=[agg_0]
+           : │   CoalescePartitionsExec
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   │ AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
+           :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+           :   │     CoalescePartitionsExec
+           :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     └──────────────────────────────────────────────────
+(26 rows)
 
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
@@ -195,12 +198,12 @@ LIMIT 5;
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
-   ->  Gather Merge
+   ->  Sort
          Output: f.title, (count(*)), (sum(p.size_bytes))
-         Workers Planned: 3
-         ->  Sort
+         Sort Key: f.title
+         ->  Gather
                Output: f.title, (count(*)), (sum(p.size_bytes))
-               Sort Key: f.title
+               Workers Planned: 3
                ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
                      Output: f.title, (count(*)), (sum(p.size_bytes))
                      Backend: DataFusion

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -94,12 +94,12 @@ GROUP BY f.category
 ORDER BY f.category;
                                                                                           QUERY PLAN                                                                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Merge
+ Sort
    Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
-   Workers Planned: 3
-   ->  Sort
+   Sort Key: f.category
+   ->  Gather
          Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
-         Sort Key: f.category
+         Workers Planned: 3
          ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
                Output: f.category, (count(*)), (sum(p.size_bytes)), (min(p.size_bytes)), (max(p.size_bytes))
                Backend: DataFusion
@@ -184,12 +184,12 @@ LIMIT 10;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, f.title, (count(*))
-   ->  Gather Merge
+   ->  Sort
          Output: f.category, f.title, (count(*))
-         Workers Planned: 3
-         ->  Sort
+         Sort Key: f.category, f.title
+         ->  Gather
                Output: f.category, f.title, (count(*))
-               Sort Key: f.category, f.title
+               Workers Planned: 3
                ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
                      Output: f.category, f.title, (count(*))
                      Backend: DataFusion
@@ -271,12 +271,12 @@ LIMIT 3;
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, (count(*)), (sum(p.size_bytes))
-   ->  Gather Merge
+   ->  Sort
          Output: f.category, (count(*)), (sum(p.size_bytes))
-         Workers Planned: 3
-         ->  Sort
+         Sort Key: (sum(p.size_bytes)) DESC
+         ->  Gather
                Output: f.category, (count(*)), (sum(p.size_bytes))
-               Sort Key: (sum(p.size_bytes)) DESC
+               Workers Planned: 3
                ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
                      Output: f.category, (count(*)), (sum(p.size_bytes))
                      Backend: DataFusion
@@ -343,32 +343,35 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan)
-   Output: pdb.agg_fn('COUNT(*)'::text)
-   Backend: DataFusion
-   Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p)
-   Aggregates: COUNT(*)
-   DataFusion Physical Plan: 
-     : ┌───── DistributedExec ── Tasks: t0:[p0]
-     : │ AggregateExec: mode=Final, gby=[], aggr=[agg_0]
-     : │   CoalescePartitionsExec
-     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
-     : └──────────────────────────────────────────────────
-     :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
-     :   │ AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
-     :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
-     :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
-     :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
-     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-     :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-     :     └──────────────────────────────────────────────────
-(23 rows)
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Gather
+   Output: (count(*))
+   Workers Planned: 3
+   ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
+         Output: (count(*))
+         Backend: DataFusion
+         Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p)
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : │ AggregateExec: mode=Final, gby=[], aggr=[agg_0]
+           : │   CoalescePartitionsExec
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   │ AggregateExec: mode=Partial, gby=[], aggr=[agg_0]
+           :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
+           :   │     CoalescePartitionsExec
+           :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     └──────────────────────────────────────────────────
+(26 rows)
 
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -430,12 +433,12 @@ GROUP BY c.name
 ORDER BY c.name;
                                                                                                     QUERY PLAN                                                                                                    
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Gather Merge
+ Sort
    Output: c.name, (count(*)), (sum(p.size_bytes))
-   Workers Planned: 3
-   ->  Sort
+   Sort Key: c.name
+   ->  Gather
          Output: c.name, (count(*)), (sum(p.size_bytes))
-         Sort Key: c.name
+         Workers Planned: 3
          ->  Parallel Custom Scan (ParadeDB Aggregate Scan)
                Output: c.name, (count(*)), (sum(p.size_bytes))
                Backend: DataFusion


### PR DESCRIPTION
## What

This PR replaces `add_path` with a new `add_upper_path` helper inside the upper-paths hook. The helper wraps parallel-aware MPP custom paths in an explicit `GatherPath`, then re-adds a high-cost serial fallback for the worker-starvation case. The `mpp_aggregate` and `mpp_aggregate_postagg` snapshots are updated to show the new Gather node above the AggregateScan.

## Why

For `UPPERREL_GROUP_AGG`, PG's `add_paths_to_grouping_rel` calls `generate_gather_paths` before `create_upper_paths_hook` fires. So any partial path we add at the upper-rel stage is orphaned. There's no Gather consumer above it, and the planner picks the dummy serial fallback. GROUP BY shapes hid this because the upstream Sort/ORDER BY pathkeys make PG build a Gather Merge later, but scalar aggregates (`SELECT COUNT(*)` over a join) have no such consumer. So the MPP path got built but never deployed: workers never launched despite `enable_mpp=on`, and the custom scan quietly ran its serial `mode=Single` sub-plan.

On a 2M-row local join micro-bench, scalar `COUNT(*)` went from no speedup at any N (it ran serial) to ~7x at N=4 and ~10x at N=8. GROUP BY shapes are unchanged; they already parallelized.

## How

`add_upper_path` does three things the plain `add_path` doesn't:

1. **Wraps the parallel-aware path in `Gather`** via `pg_sys::create_gather_path`, passing `gather_target = (*rel).reltarget`. Anything else makes the targetlist structurally differ from `final_target`, which routes `create_ordered_paths` through a `ProjectionPath`. That projection becomes a `Result` plan node whose targetlist carries unreplaceable Aggrefs, and setrefs aborts with "Aggref found in non-Agg plan node".

2. **Clears `output_rel->pathlist`** before adding the Gather. The grouping-path chooser compares the wrapper against any serial path already in the list, and a tied-cost serial wins `add_path`'s tie-break, so the wrapper is silently lost. Wiping the list and re-adding a high-cost serial fallback makes the Gather win deterministically.

3. **Re-adds a high-cost (1e9) serial fallback** so PG still has a non-parallel path when `max_parallel_workers=0` or no worker slots are free.

Non-parallel custom paths fall through to the same `add_path` behavior used everywhere else.

## Tests

`mpp_aggregate` and `mpp_aggregate_postagg` regress snapshots regenerated for the new Gather wrapping. Only the EXPLAIN plan shape changed; result rows are identical. Both pass on PG18.