### PR TITLE
feat(mpp): two shuffle-tuning knobs (mpp_target_partitions GUC + mpp_queue_size note)

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -174,6 +174,16 @@ static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024
 /// derive this from index stats per query.
 static MPP_CACHE_PER_SLOT: GucSetting<i32> = GucSetting::<i32>::new(256 * 1024 * 1024);
 
+/// Inner partition fanout per producer task (passed as
+/// `SessionConfig::target_partitions` when building the distributed plan). A
+/// value of `0` keeps the historical behavior of scaling with
+/// `mpp_worker_count`, which gives each shuffle stage `N²` mesh edges. A
+/// positive value pins the fanout to a constant so the mesh edge count grows
+/// linearly with `N` instead. Single-thread Tokio runtimes per producer don't
+/// actually parallelize across inner partitions, so a small constant is
+/// usually pure overhead savings; the right value depends on workload.
+static MPP_TARGET_PARTITIONS: GucSetting<i32> = GucSetting::<i32>::new(0);
+
 /// The maximum size of an InList that can be pushed down to a TermSet Query.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
     GucSetting::<i32>::new(16 * 1024 * 1024);
@@ -624,6 +634,22 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_target_partitions",
+        c"Inner partition fanout per producer task; 0 = scale with mpp_worker_count",
+        c"Sets `target_partitions` on the per-query distributed SessionConfig. 0 keeps \
+          the historical behavior of scaling with mpp_worker_count, which makes each \
+          shuffle stage carry N² mesh edges. A positive value pins the fanout so the \
+          mesh edge count grows linearly with N instead. Each producer runs on a \
+          single-thread Tokio runtime, so inner partitions are pure overhead — most \
+          workloads benefit from a small constant (2 is a sensible starting point).",
+        &MPP_TARGET_PARTITIONS,
+        0,
+        64,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -820,6 +846,10 @@ pub fn mpp_queue_size() -> usize {
 
 pub fn mpp_cache_per_slot() -> usize {
     MPP_CACHE_PER_SLOT.get() as usize
+}
+
+pub fn mpp_target_partitions() -> i32 {
+    MPP_TARGET_PARTITIONS.get()
 }
 
 pub fn hash_join_inlist_pushdown_max_size() -> i32 {

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -611,6 +611,11 @@ pub fn init() {
           `num_meshes × N×(N-1) × mpp_queue_size`; at the default 64MB and N=4 with \
           3 meshes that is ~2.3GB per query. Lower this on memory-constrained boxes; \
           raise it only if a single shuffle batch routinely backs up the queue. \
+          Tuning note: when the post-agg shuffle stays under a few MB per consumer, \
+          dropping to '4MB' or '8MB' saves DSM-init latency for a measurable wall-time \
+          win, biggest at higher producer counts where mesh edge count scales as N². \
+          The default stays 64MB because large workloads can burst 100MB+ into the \
+          post-agg mesh and need the headroom. \
           Foundation-era knob — likely to be replaced by a per-query DSM cap once \
           mesh multiplexing lands.",
         &MPP_QUEUE_SIZE,

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -101,9 +101,19 @@ pub(crate) fn build_mpp_session_context(
     //      worker subplans for gRPC shipment; without a codec for our custom physical execs,
     //      encoding errors before execution. In our model the encoded bytes are never observed
     //      (workers re-plan from the logical plan in DSM), so the codec is a stub.
+    // `paradedb.mpp_target_partitions = 0` (default) preserves the historical N²-edge mesh by
+    // scaling inner fanout with n_workers. A positive value pins the fanout to a constant so
+    // edges grow linearly with N. Single-thread Tokio runtimes per producer don't parallelize
+    // across inner partitions, so a small constant is usually pure overhead savings.
+    let configured = crate::gucs::mpp_target_partitions();
+    let target_partitions = if configured > 0 {
+        (configured as usize).max(2)
+    } else {
+        n_workers.max(2)
+    };
     let cfg = seed
         .copied_config()
-        .with_target_partitions(n_workers.max(2));
+        .with_target_partitions(target_partitions);
 
     // Start from the seed's existing state so the customscan's query planner (`PgSearchQueryPlanner`),
     // optimizer rules, and registered extensions all carry over. JoinScan relies on this for


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #

## What

Two MPP shuffle-tuning levers in one PR.

1. **New `paradedb.mpp_target_partitions` GUC.** Pins DataFusion's `target_partitions` to a constant inner fanout. Default `0` keeps current behavior (scale with `mpp_worker_count`).
2. **Docstring update on `paradedb.mpp_queue_size`.** Adds a tuning note telling operators when it's worth dropping below the 64MB default.

## Why

### mpp_target_partitions

Today the distributed planner sets `target_partitions = mpp_worker_count` on every per-query `SessionConfig`. Each producer fragment then emits `N (target) x N (consumer tasks) = N²` output partitions per shuffle, so the mesh carries N² edges per stage. That's expensive: more channels, more scheduling, more shm_mq slots.

The catch is each producer runs on a single-thread Tokio runtime. Inner partitions don't actually parallelize anything there. They're pure overhead. Pinning the fanout to a small constant collapses the mesh to roughly linear in N while still giving DataFusion enough partitions to keep the planner from eliding shuffles.

This is a per-workload knob: low-cardinality GROUP BY tends to win with `mpp_target_partitions=2` (saw ~10% wall-time wins on the mpp_scaling micro-bench at producers=4), high-cardinality GROUP BY can regress. So the default stays `0` and operators tune.

### mpp_queue_size docstring

64MB per edge is fine for production-scale workloads whose post-agg shuffle can burst 100MB+ per consumer. But for smaller workloads, where each consumer only sees a few MB of shuffle traffic, that 64MB allocation is mostly idle. The DSM-init cost (mmap + page-fault) adds up, especially as producer count grows because the mesh has N² edges.

Sweep on the mpp_scaling micro-bench (5M parent / 25M child, GROUP BY queries x producers {4, 8, 12} x queue size {4MB, 8MB, 16MB, 64MB}) showed dropping to 4MB gives ~6% wall-time win at producers=4 and up to ~11% at producers=12. Biggest absolute win is at the high producer counts because DSM init scales as N². Default stays 64MB because that's the safer floor for large workloads.

## How

`mpp_target_partitions`:
- New `MPP_TARGET_PARTITIONS` GucSetting in `gucs.rs`, range `[0, 64]`.
- New accessor `mpp_target_partitions()`.
- In `build_mpp_session_context`, read the GUC. If `> 0`, use `(configured as usize).max(2)`. If `0`, fall through to existing `n_workers.max(2)`. The `.max(2)` floor in both arms keeps the planner from collapsing shuffles when the value is small.

`mpp_queue_size`: five new lines in the long description telling operators (a) when smaller is faster, (b) why, and (c) why the default doesn't change. No code change.

## Tests

Default values preserve the existing paths, so all existing MPP regress + integration coverage applies unchanged. The active path (positive `mpp_target_partitions`) is exercised by the mpp_scaling micro-bench out of tree.