### PR TITLE
docs(mpp): note that smaller mpp_queue_size wins on small-shuffle workloads

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -601,6 +601,11 @@ pub fn init() {
           `num_meshes × N×(N-1) × mpp_queue_size`; at the default 64MB and N=4 with \
           3 meshes that is ~2.3GB per query. Lower this on memory-constrained boxes; \
           raise it only if a single shuffle batch routinely backs up the queue. \
+          Tuning note: when the post-agg shuffle stays under a few MB per consumer, \
+          dropping to '4MB' or '8MB' saves DSM-init latency for a measurable wall-time \
+          win, biggest at higher producer counts where mesh edge count scales as N². \
+          The default stays 64MB because large workloads can burst 100MB+ into the \
+          post-agg mesh and need the headroom. \
           Foundation-era knob — likely to be replaced by a per-query DSM cap once \
           mesh multiplexing lands.",
         &MPP_QUEUE_SIZE,


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #

## What

Docstring update on `paradedb.mpp_queue_size`. No code change. Adds a tuning note telling operators when it's worth dropping below the 64MB default.

## Why

`mpp_queue_size` defaults to 64MB per edge, which is fine for production-scale workloads whose post-agg shuffle can burst 100MB+ per consumer. But for smaller workloads, where each consumer only sees a few MB of shuffle traffic, that 64MB allocation is mostly idle. The DSM-init cost (mmap + page-fault) adds up, especially as producer count grows because the mesh has N² edges.

Sweep on the mpp_scaling micro-bench (5M parent / 25M child, GROUP BY queries x producers {4, 8, 12} x queue size {4MB, 8MB, 16MB, 64MB}) showed dropping to 4MB gives ~6% wall-time win at producers=4 and up to ~11% at producers=12. Biggest absolute win is at the high producer counts because DSM init scales as N². Default stays 64MB because that's the safer floor for large workloads.

## How

Five new lines in the GUC's long description telling operators (a) when smaller is faster, (b) why, and (c) why the default doesn't change.

## Tests

Docstring only. Compiles. Nothing else to verify.