### PR TITLE
fix: range query Option::unwrap panic with differently typed lower and upper bounds

### DIFF
--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -895,6 +895,171 @@ fn coerce_bound_to_field_type(
     }
 }
 
+#[derive(Clone, Copy, PartialEq)]
+enum ParseRangeNumberKind {
+    Integer,
+    Float,
+}
+
+fn normalize_parse_json_range_bounds(
+    query_string: &str,
+    schema: &SearchIndexSchema,
+) -> Result<String, QueryError> {
+    let mut normalized = String::with_capacity(query_string.len());
+    let mut cursor = 0;
+    let mut search_start = 0;
+
+    while let Some((open_idx, open_char)) = find_next_parse_range_open(query_string, search_start) {
+        let close_char = match open_char {
+            '[' => ']',
+            '{' => '}',
+            _ => unreachable!(),
+        };
+        let inner_start = open_idx + open_char.len_utf8();
+        let Some(close_rel_idx) = query_string[inner_start..].find(close_char) else {
+            break;
+        };
+        let close_idx = inner_start + close_rel_idx;
+        search_start = close_idx + close_char.len_utf8();
+
+        let Some(colon_idx) = query_string[..open_idx].rfind(':') else {
+            continue;
+        };
+        if !query_string[colon_idx + 1..open_idx].trim().is_empty() {
+            continue;
+        }
+
+        let field_start = query_string[..colon_idx]
+            .rfind(|ch: char| ch.is_whitespace() || matches!(ch, '(' | ')' | '+' | '-'))
+            .map_or(0, |idx| idx + 1);
+        let field_name = &query_string[field_start..colon_idx];
+        if !parse_range_field_is_json(field_name, schema) {
+            continue;
+        }
+
+        let range_inner = &query_string[inner_start..close_idx];
+        let Some(to_idx) = range_inner.find(" TO ") else {
+            continue;
+        };
+        let lower = &range_inner[..to_idx];
+        let upper = &range_inner[to_idx + " TO ".len()..];
+        if parse_bound_has_value(lower)
+            && parse_bound_has_value(upper)
+            && (parse_range_number_kind(lower).is_some()
+                != parse_range_number_kind(upper).is_some())
+        {
+            return Err(QueryError::FieldTypeMismatch);
+        }
+        let Some((lower, upper)) = normalize_parse_numeric_bounds(lower, upper) else {
+            continue;
+        };
+
+        normalized.push_str(&query_string[cursor..inner_start]);
+        normalized.push_str(&lower);
+        normalized.push_str(" TO ");
+        normalized.push_str(&upper);
+        cursor = close_idx;
+    }
+
+    if cursor == 0 {
+        Ok(query_string.to_string())
+    } else {
+        normalized.push_str(&query_string[cursor..]);
+        Ok(normalized)
+    }
+}
+
+fn find_next_parse_range_open(query_string: &str, start: usize) -> Option<(usize, char)> {
+    let mut in_quote = false;
+    let mut escaped = false;
+
+    for (idx, ch) in query_string[start..].char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if ch == '\\' {
+            escaped = true;
+            continue;
+        }
+        if ch == '"' {
+            in_quote = !in_quote;
+            continue;
+        }
+        if !in_quote && matches!(ch, '[' | '{') {
+            return Some((start + idx, ch));
+        }
+    }
+
+    None
+}
+
+fn parse_range_field_is_json(field_name: &str, schema: &SearchIndexSchema) -> bool {
+    let root = FieldName::from(field_name.to_string()).root();
+    matches!(
+        schema
+            .search_field(&root)
+            .map(|search_field| search_field.field_entry().field_type().is_json()),
+        Some(true)
+    )
+}
+
+fn parse_range_number_kind(bound: &str) -> Option<ParseRangeNumberKind> {
+    let trimmed = bound.trim();
+    if trimmed.is_empty()
+        || trimmed == "*"
+        || trimmed.contains('"')
+        || trimmed.contains('\'')
+        || trimmed.eq_ignore_ascii_case("true")
+        || trimmed.eq_ignore_ascii_case("false")
+    {
+        return None;
+    }
+
+    if trimmed.contains('.') || trimmed.contains('e') || trimmed.contains('E') {
+        trimmed
+            .parse::<f64>()
+            .ok()
+            .map(|_| ParseRangeNumberKind::Float)
+    } else if trimmed.parse::<i64>().is_ok() || trimmed.parse::<u64>().is_ok() {
+        Some(ParseRangeNumberKind::Integer)
+    } else {
+        None
+    }
+}
+
+fn append_decimal_to_parse_bound(bound: &str) -> String {
+    let trimmed = bound.trim();
+    let leading_len = bound.find(trimmed).unwrap_or(0);
+    let trailing_start = leading_len + trimmed.len();
+    format!(
+        "{}{}.0{}",
+        &bound[..leading_len],
+        trimmed,
+        &bound[trailing_start..]
+    )
+}
+
+fn parse_bound_has_value(bound: &str) -> bool {
+    let trimmed = bound.trim();
+    !trimmed.is_empty() && trimmed != "*"
+}
+
+fn normalize_parse_numeric_bounds(lower: &str, upper: &str) -> Option<(String, String)> {
+    match (
+        parse_range_number_kind(lower),
+        parse_range_number_kind(upper),
+    ) {
+        (Some(ParseRangeNumberKind::Float), Some(ParseRangeNumberKind::Integer)) => {
+            Some((lower.to_string(), append_decimal_to_parse_bound(upper)))
+        }
+        (Some(ParseRangeNumberKind::Integer), Some(ParseRangeNumberKind::Float)) => {
+            Some((append_decimal_to_parse_bound(lower), upper.to_string()))
+        }
+        _ => None,
+    }
+}
+
 impl SearchQueryInput {
     #[allow(clippy::too_many_arguments)]
     pub fn into_tantivy_query<QueryParserCtor: Fn() -> QueryParser>(
@@ -1253,6 +1418,8 @@ impl SearchQueryInput {
                 lenient,
                 conjunction_mode,
             } => {
+                let normalized_query_string =
+                    normalize_parse_json_range_bounds(&query_string, schema)?;
                 let mut query_parser = parser();
                 if let Some(true) = conjunction_mode {
                     query_parser.set_conjunction_by_default();
@@ -1260,12 +1427,13 @@ impl SearchQueryInput {
 
                 let query = match lenient {
                     Some(true) => {
-                        let (parsed_query, _) = query_parser.parse_query_lenient(&query_string);
+                        let (parsed_query, _) =
+                            query_parser.parse_query_lenient(&normalized_query_string);
                         Box::new(parsed_query) as Box<dyn TantivyQuery>
                     }
                     _ => Box::new(
                         query_parser
-                            .parse_query(&query_string)
+                            .parse_query(&normalized_query_string)
                             .map_err(|err| QueryError::ParseError(err, query_string.clone()))?,
                     ) as Box<dyn TantivyQuery>,
                 };

--- a/pg_search/src/query/numeric.rs
+++ b/pg_search/src/query/numeric.rs
@@ -279,10 +279,15 @@ pub fn string_to_u64(value: OwnedValue) -> OwnedValue {
 
 /// Convert a string-encoded numeric value to F64.
 pub fn string_to_f64(value: OwnedValue) -> OwnedValue {
-    if let OwnedValue::Str(s) = &value {
-        if let Ok(f) = s.parse::<f64>() {
-            return OwnedValue::F64(f);
+    match &value {
+        OwnedValue::Str(s) => {
+            if let Ok(f) = s.parse::<f64>() {
+                return OwnedValue::F64(f);
+            }
         }
+        OwnedValue::I64(i) => return OwnedValue::F64(*i as f64),
+        OwnedValue::U64(u) => return OwnedValue::F64(*u as f64),
+        _ => {}
     }
     value
 }

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -1447,6 +1447,7 @@ fn range(
             // For JSON fields, convert string numeric values to appropriate JSON types
             let lower = map_bound(lower_bound, string_to_json_numeric);
             let upper = map_bound(upper_bound, string_to_json_numeric);
+            let (lower, upper) = normalize_json_range_bounds(lower, upper)?;
             check_range_bounds(typeoid, lower, upper)?
         }
         SearchFieldType::I64(_) => {
@@ -1508,7 +1509,119 @@ fn range(
         Bound::Unbounded => Bound::Unbounded,
     };
 
+    validate_range_term_bounds(&lower_bound, &upper_bound)?;
+
     Ok(Box::new(RangeQuery::new(lower_bound, upper_bound)))
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum JsonNumericType {
+    I64,
+    U64,
+    F64,
+}
+
+fn json_numeric_type(value: &OwnedValue) -> Option<JsonNumericType> {
+    match value {
+        OwnedValue::I64(_) => Some(JsonNumericType::I64),
+        OwnedValue::U64(_) => Some(JsonNumericType::U64),
+        OwnedValue::F64(_) => Some(JsonNumericType::F64),
+        _ => None,
+    }
+}
+
+fn bound_json_numeric_type(bound: &Bound<OwnedValue>) -> Option<JsonNumericType> {
+    match bound {
+        Bound::Included(value) | Bound::Excluded(value) => json_numeric_type(value),
+        Bound::Unbounded => None,
+    }
+}
+
+fn map_json_bound_value<F>(bound: Bound<OwnedValue>, convert: F) -> Bound<OwnedValue>
+where
+    F: Fn(OwnedValue) -> OwnedValue,
+{
+    match bound {
+        Bound::Included(value) => Bound::Included(convert(value)),
+        Bound::Excluded(value) => Bound::Excluded(convert(value)),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+fn owned_value_to_f64(value: OwnedValue) -> OwnedValue {
+    match value {
+        OwnedValue::I64(value) => OwnedValue::F64(value as f64),
+        OwnedValue::U64(value) => OwnedValue::F64(value as f64),
+        value => value,
+    }
+}
+
+fn owned_value_to_i64(value: OwnedValue) -> OwnedValue {
+    match value {
+        OwnedValue::U64(value) => i64::try_from(value)
+            .map(OwnedValue::I64)
+            .unwrap_or(OwnedValue::U64(value)),
+        value => value,
+    }
+}
+
+fn bound_has_value(bound: &Bound<OwnedValue>) -> bool {
+    !matches!(bound, Bound::Unbounded)
+}
+
+fn normalize_json_range_bounds(
+    lower_bound: Bound<OwnedValue>,
+    upper_bound: Bound<OwnedValue>,
+) -> Result<(Bound<OwnedValue>, Bound<OwnedValue>), QueryError> {
+    let lower_type = bound_json_numeric_type(&lower_bound);
+    let upper_type = bound_json_numeric_type(&upper_bound);
+
+    if lower_type.is_some() != upper_type.is_some()
+        && bound_has_value(&lower_bound)
+        && bound_has_value(&upper_bound)
+    {
+        return Err(QueryError::FieldTypeMismatch);
+    }
+
+    match (lower_type, upper_type) {
+        (Some(JsonNumericType::F64), Some(_)) | (Some(_), Some(JsonNumericType::F64)) => Ok((
+            map_json_bound_value(lower_bound, owned_value_to_f64),
+            map_json_bound_value(upper_bound, owned_value_to_f64),
+        )),
+        (Some(JsonNumericType::I64), Some(JsonNumericType::U64))
+        | (Some(JsonNumericType::U64), Some(JsonNumericType::I64)) => {
+            let lower = map_json_bound_value(lower_bound, owned_value_to_i64);
+            let upper = map_json_bound_value(upper_bound, owned_value_to_i64);
+            if bound_json_numeric_type(&lower) == bound_json_numeric_type(&upper) {
+                Ok((lower, upper))
+            } else {
+                Ok((
+                    map_json_bound_value(lower, owned_value_to_f64),
+                    map_json_bound_value(upper, owned_value_to_f64),
+                ))
+            }
+        }
+        _ => Ok((lower_bound, upper_bound)),
+    }
+}
+
+fn term_bound_type(bound: &Bound<Term>) -> Option<tantivy::schema::Type> {
+    match bound {
+        Bound::Included(term) | Bound::Excluded(term) => Some(term.typ()),
+        Bound::Unbounded => None,
+    }
+}
+
+fn validate_range_term_bounds(
+    lower_bound: &Bound<Term>,
+    upper_bound: &Bound<Term>,
+) -> Result<(), QueryError> {
+    match (term_bound_type(lower_bound), term_bound_type(upper_bound)) {
+        (Some(lower_type), Some(upper_type)) if lower_type != upper_type => {
+            Err(QueryError::FieldTypeMismatch)
+        }
+        _ => Ok(()),
+    }
 }
 
 fn resolve_search_tokenizer(

--- a/tests/tests/range.rs
+++ b/tests/tests/range.rs
@@ -353,7 +353,12 @@ fn json_numeric_range_mixed_bound_types(mut conn: PgConnection) {
     WHERE id @@@ paradedb.parse('metadata.price:[not-a-number TO 36]')
     ORDER BY id"#
         .fetch_result::<(i32,)>(&mut conn);
-    assert!(result.is_err());
+    let err = result.expect_err("non-numeric lower bound should error, not panic");
+    let err_msg = format!("{err}");
+    assert!(
+        err_msg.contains("not-a-number") || err_msg.to_lowercase().contains("type"),
+        "expected an error mentioning the bad token or a type-mismatch reason, got: {err_msg}"
+    );
 
     let result = r#"
     SELECT id FROM test_table
@@ -366,7 +371,12 @@ fn json_numeric_range_mixed_bound_types(mut conn: PgConnection) {
     }'::jsonb
     ORDER BY id"#
         .fetch_result::<(i32,)>(&mut conn);
-    assert!(result.is_err());
+    let err = result.expect_err("string-typed lower bound vs numeric upper bound should error, not panic");
+    let err_msg = format!("{err}");
+    assert!(
+        err_msg.to_lowercase().contains("type") || err_msg.to_lowercase().contains("mismatch") || err_msg.contains("not-a-number"),
+        "expected an error mentioning type/mismatch, got: {err_msg}"
+    );
 
     "SELECT 1".execute(&mut conn);
 }

--- a/tests/tests/range.rs
+++ b/tests/tests/range.rs
@@ -289,3 +289,84 @@ fn integer_bounds_coercion(mut conn: PgConnection) {
     assert_eq!(rows[0].1, 2222.2222);
     assert_eq!(rows[1].1, 3333.3333);
 }
+
+#[rstest]
+fn json_numeric_range_mixed_bound_types(mut conn: PgConnection) {
+    r#"
+    CREATE TABLE test_table (
+        id SERIAL PRIMARY KEY,
+        metadata JSONB
+    );
+
+    INSERT INTO test_table (metadata) VALUES
+        ('{"price": 35}'::jsonb),
+        ('{"price": 35.5}'::jsonb),
+        ('{"price": 36}'::jsonb),
+        ('{"price": 40}'::jsonb),
+        ('{"price": 40.1}'::jsonb);
+
+    CREATE INDEX test_index ON test_table
+    USING bm25 (id, metadata)
+    WITH (
+        key_field = 'id',
+        json_fields = '{"metadata": {"fast": true}}'
+    );
+    "#
+    .execute(&mut conn);
+
+    let rows: Vec<(i32,)> = r#"
+    SELECT id FROM test_table
+    WHERE id @@@ paradedb.parse('metadata.price:[35.1 TO 40]')
+    ORDER BY id"#
+        .fetch(&mut conn);
+    assert_eq!(rows, vec![(2,), (3,), (4,)]);
+
+    let rows_with_integer_upper: Vec<(i32,)> = r#"
+    SELECT id FROM test_table
+    WHERE id @@@ '{
+        "range": {
+            "field": "metadata.price",
+            "lower_bound": {"included": 35.1},
+            "upper_bound": {"excluded": 36}
+        }
+    }'::jsonb
+    ORDER BY id"#
+        .fetch(&mut conn);
+
+    let rows_with_float_upper: Vec<(i32,)> = r#"
+    SELECT id FROM test_table
+    WHERE id @@@ '{
+        "range": {
+            "field": "metadata.price",
+            "lower_bound": {"included": 35.1},
+            "upper_bound": {"excluded": 36.0}
+        }
+    }'::jsonb
+    ORDER BY id"#
+        .fetch(&mut conn);
+
+    assert_eq!(rows_with_integer_upper, vec![(2,)]);
+    assert_eq!(rows_with_integer_upper, rows_with_float_upper);
+
+    let result = r#"
+    SELECT id FROM test_table
+    WHERE id @@@ paradedb.parse('metadata.price:[not-a-number TO 36]')
+    ORDER BY id"#
+        .fetch_result::<(i32,)>(&mut conn);
+    assert!(result.is_err());
+
+    let result = r#"
+    SELECT id FROM test_table
+    WHERE id @@@ '{
+        "range": {
+            "field": "metadata.price",
+            "lower_bound": {"included": "not-a-number"},
+            "upper_bound": {"excluded": 36}
+        }
+    }'::jsonb
+    ORDER BY id"#
+        .fetch_result::<(i32,)>(&mut conn);
+    assert!(result.is_err());
+
+    "SELECT 1".execute(&mut conn);
+}

--- a/tests/tests/range.rs
+++ b/tests/tests/range.rs
@@ -371,10 +371,13 @@ fn json_numeric_range_mixed_bound_types(mut conn: PgConnection) {
     }'::jsonb
     ORDER BY id"#
         .fetch_result::<(i32,)>(&mut conn);
-    let err = result.expect_err("string-typed lower bound vs numeric upper bound should error, not panic");
+    let err = result
+        .expect_err("string-typed lower bound vs numeric upper bound should error, not panic");
     let err_msg = format!("{err}");
     assert!(
-        err_msg.to_lowercase().contains("type") || err_msg.to_lowercase().contains("mismatch") || err_msg.contains("not-a-number"),
+        err_msg.to_lowercase().contains("type")
+            || err_msg.to_lowercase().contains("mismatch")
+            || err_msg.contains("not-a-number"),
         "expected an error mentioning type/mismatch, got: {err_msg}"
     );
 


### PR DESCRIPTION
## Summary

fix: range query Option::unwrap panic with differently typed lower and upper bounds

Closes #5077

---
AI was used for assistance.