### PR TITLE
fix(customscan): clear error + planner warning for unrewritten BM25 score/snippet placeholders

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -457,6 +457,19 @@ unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetList
     }
 }
 
+/// Returns true when the query has a range-table function, such as
+/// `jsonb_array_elements(...)`, in its FROM list.
+unsafe fn query_has_function_rte(root: *mut pg_sys::PlannerInfo) -> bool {
+    if root.is_null() || (*root).parse.is_null() || (*(*root).parse).rtable.is_null() {
+        return false;
+    }
+
+    let rtable = PgList::<pg_sys::RangeTblEntry>::from_pg((*(*root).parse).rtable);
+    rtable
+        .iter_ptr()
+        .any(|rte| (*rte).rtekind == pg_sys::RTEKind::RTE_FUNCTION)
+}
+
 /// Returns `true` if any predicate in `baserestrictinfo` cannot be fully
 /// evaluated inside Tantivy — meaning Postgres will apply a post-filter
 /// above the scan. Pushing LIMIT into the scan in that case would cap
@@ -492,6 +505,8 @@ unsafe fn has_non_pushable_predicates(
 ///   1. This rel bounds the output cardinality (single rel, partitioned, or
 ///      the driving side of a LEFT LATERAL join). Without this, pushing LIMIT
 ///      to the inner side of a join would silently truncate results.
+///      Range-table functions in `FROM` are cardinality-changing and only keep
+///      the left-driven lateral exception.
 ///   2. No non-pushable predicates sit between this scan and the LIMIT.
 ///   3. No unsafe SRFs (anything other than `unnest`) in the target list.
 ///
@@ -508,8 +523,13 @@ unsafe fn is_limit_pushdown_safe(
         || range_table::is_partitioned_table_setup(root, (*rel).relids, baserels);
     let is_left_driven_lateral =
         is_left_join_lateral(root, rel) && where_clause_only_references_left(root, rti);
+    let rel_bounds_output = if query_has_function_rte(root) {
+        is_left_driven_lateral
+    } else {
+        rel_is_single_or_partitioned || is_left_driven_lateral
+    };
 
-    (rel_is_single_or_partitioned || is_left_driven_lateral)
+    rel_bounds_output
         && !has_non_pushable_predicates(rel, quals)
         && !classify_target_list_srf(root).is_unsafe()
 }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -465,9 +465,10 @@ unsafe fn query_has_function_rte(root: *mut pg_sys::PlannerInfo) -> bool {
     }
 
     let rtable = PgList::<pg_sys::RangeTblEntry>::from_pg((*(*root).parse).rtable);
-    rtable
+    let has_function_rte = rtable
         .iter_ptr()
-        .any(|rte| (*rte).rtekind == pg_sys::RTEKind::RTE_FUNCTION)
+        .any(|rte| (*rte).rtekind == pg_sys::RTEKind::RTE_FUNCTION);
+    has_function_rte
 }
 
 /// Returns `true` if any predicate in `baserestrictinfo` cannot be fully

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -457,20 +457,6 @@ unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetList
     }
 }
 
-/// Returns true when the query has a range-table function, such as
-/// `jsonb_array_elements(...)`, in its FROM list.
-unsafe fn query_has_function_rte(root: *mut pg_sys::PlannerInfo) -> bool {
-    if root.is_null() || (*root).parse.is_null() || (*(*root).parse).rtable.is_null() {
-        return false;
-    }
-
-    let rtable = PgList::<pg_sys::RangeTblEntry>::from_pg((*(*root).parse).rtable);
-    let has_function_rte = rtable
-        .iter_ptr()
-        .any(|rte| (*rte).rtekind == pg_sys::RTEKind::RTE_FUNCTION);
-    has_function_rte
-}
-
 /// Returns `true` if any predicate in `baserestrictinfo` cannot be fully
 /// evaluated inside Tantivy — meaning Postgres will apply a post-filter
 /// above the scan. Pushing LIMIT into the scan in that case would cap
@@ -506,8 +492,6 @@ unsafe fn has_non_pushable_predicates(
 ///   1. This rel bounds the output cardinality (single rel, partitioned, or
 ///      the driving side of a LEFT LATERAL join). Without this, pushing LIMIT
 ///      to the inner side of a join would silently truncate results.
-///      Range-table functions in `FROM` are cardinality-changing and only keep
-///      the left-driven lateral exception.
 ///   2. No non-pushable predicates sit between this scan and the LIMIT.
 ///   3. No unsafe SRFs (anything other than `unnest`) in the target list.
 ///
@@ -524,13 +508,8 @@ unsafe fn is_limit_pushdown_safe(
         || range_table::is_partitioned_table_setup(root, (*rel).relids, baserels);
     let is_left_driven_lateral =
         is_left_join_lateral(root, rel) && where_clause_only_references_left(root, rti);
-    let rel_bounds_output = if query_has_function_rte(root) {
-        is_left_driven_lateral
-    } else {
-        rel_is_single_or_partitioned || is_left_driven_lateral
-    };
 
-    rel_bounds_output
+    (rel_is_single_or_partitioned || is_left_driven_lateral)
         && !has_non_pushable_predicates(rel, quals)
         && !classify_target_list_srf(root).is_unsafe()
 }

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -18,8 +18,28 @@
 use crate::nodecast;
 use crate::postgres::customscan::score_funcoids;
 use pgrx::pg_sys::expression_tree_walker;
-use pgrx::{extension_sql, pg_extern, pg_guard, pg_sys, AnyElement, PgList};
+use pgrx::pg_sys::panic::ErrorReport;
+use pgrx::{
+    extension_sql, pg_extern, pg_guard, pg_sys, AnyElement, PgList, PgLogLevel, PgSqlErrorCode,
+};
 use std::ptr::addr_of_mut;
+
+fn unsupported_score_placeholder(function_name: &'static str) -> ! {
+    ErrorReport::new(
+        PgSqlErrorCode::ERRCODE_FEATURE_NOT_SUPPORTED,
+        format!("{function_name}() could not run because the BM25 custom scan was not selected for this relation"),
+        function_name,
+    )
+    .set_detail(
+        "The planner left the score placeholder in the plan, usually because the BM25 custom scan cannot drive this query shape.",
+    )
+    .set_hint(
+        "Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose",
+    )
+    .report(PgLogLevel::ERROR);
+
+    unreachable!("Postgres ERROR reports do not return");
+}
 
 #[pgrx::pg_schema]
 mod pdb {
@@ -28,7 +48,7 @@ mod pdb {
     #[allow(unused_variables)]
     #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
     fn score_from_relation(relation_reference: AnyElement) -> f32 {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::unsupported_score_placeholder("pdb.score");
     }
 
     extension_sql!(
@@ -46,7 +66,7 @@ mod pdb {
 #[allow(unused_variables)]
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
 fn paradedb_score_from_relation(relation_reference: AnyElement) -> Option<f32> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    unsupported_score_placeholder("paradedb.score");
 }
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -23,9 +23,10 @@ use crate::postgres::customscan::parameterized_value::ParameterizedValue;
 use crate::postgres::var::find_one_var;
 
 use pgrx::pg_sys::expression_tree_walker;
+use pgrx::pg_sys::panic::ErrorReport;
 use pgrx::{
     default, direct_function_call, extension_sql, pg_extern, pg_guard, pg_sys, AnyElement,
-    IntoDatum, PgList,
+    IntoDatum, PgList, PgLogLevel, PgSqlErrorCode,
 };
 use std::sync::OnceLock;
 use tantivy::snippet::{SnippetGenerator, SnippetSortOrder};
@@ -35,6 +36,23 @@ const DEFAULT_SNIPPET_POSTFIX: &str = "</b>";
 const DEFAULT_SNIPPET_MAX_NUM_CHARS: i32 = 150;
 const DEFAULT_SNIPPET_LIMIT: i32 = 5;
 const DEFAULT_SNIPPET_OFFSET: i32 = 0;
+
+fn unsupported_snippet_placeholder(function_name: &'static str) -> ! {
+    ErrorReport::new(
+        PgSqlErrorCode::ERRCODE_FEATURE_NOT_SUPPORTED,
+        format!("{function_name}() could not run because the BM25 custom scan was not selected for this relation"),
+        function_name,
+    )
+    .set_detail(
+        "The planner left the snippet placeholder in the plan, usually because the BM25 custom scan cannot drive this query shape.",
+    )
+    .set_hint(
+        "Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose",
+    )
+    .report(PgLogLevel::ERROR);
+
+    unreachable!("Postgres ERROR reports do not return");
+}
 
 /// The limit and offset for "fragments" (essentially, matches with a small amount of context).
 ///
@@ -348,7 +366,7 @@ pub mod pdb {
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> String {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::unsupported_snippet_placeholder("pdb.snippet");
     }
 
     #[allow(unused_variables)]
@@ -362,7 +380,7 @@ pub mod pdb {
         offset: default!(Option<i32>, "NULL"),
         sort_by: default!(String, "'score'"),
     ) -> Vec<String> {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::unsupported_snippet_placeholder("pdb.snippets");
     }
 
     #[allow(unused_variables)]
@@ -386,7 +404,7 @@ AS 'MODULE_PATHNAME', 'snippet_positions_from_relation_wrapper';
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> IntArray2D {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::unsupported_snippet_placeholder("pdb.snippet_positions");
     }
 }
 
@@ -403,7 +421,7 @@ fn paradedb_snippet_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> Option<String> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    unsupported_snippet_placeholder("paradedb.snippet");
 }
 
 #[warn(deprecated)]
@@ -418,7 +436,7 @@ fn paradedb_snippets_from_relation(
     offset: default!(Option<i32>, "NULL"),
     sort_by: default!(String, "'score'"),
 ) -> Option<Vec<String>> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    unsupported_snippet_placeholder("paradedb.snippets");
 }
 
 #[warn(deprecated)]
@@ -443,7 +461,7 @@ fn paradedb_snippet_positions_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> pdb::IntArray2D {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    unsupported_snippet_placeholder("paradedb.snippet_positions");
 }
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -501,46 +501,68 @@ extension_sql!(
 
 pub fn snippet_funcoids() -> [pg_sys::Oid; 2] {
     static OID_CACHE: OnceLock<[pg_sys::Oid; 2]> = OnceLock::new();
-    *OID_CACHE.get_or_init(|| {
-        resolve_funcoids(&[
+    cached_funcoids(
+        &OID_CACHE,
+        &[
             "pdb.snippet(anyelement, text, text, int, int, int)",
             "paradedb.snippet(anyelement, text, text, int, int, int)",
-        ])
-    })
+        ],
+    )
 }
 
 pub fn snippets_funcoids() -> [pg_sys::Oid; 2] {
     static OID_CACHE: OnceLock<[pg_sys::Oid; 2]> = OnceLock::new();
-    *OID_CACHE.get_or_init(|| {
-        resolve_funcoids(&[
+    cached_funcoids(
+        &OID_CACHE,
+        &[
             "pdb.snippets(anyelement, text, text, int, int, int, text)",
             "paradedb.snippets(anyelement, text, text, int, int, int, text)",
-        ])
-    })
+        ],
+    )
 }
 
 pub fn snippet_positions_funcoids() -> [pg_sys::Oid; 2] {
     static OID_CACHE: OnceLock<[pg_sys::Oid; 2]> = OnceLock::new();
-    *OID_CACHE.get_or_init(|| {
-        resolve_funcoids(&[
+    cached_funcoids(
+        &OID_CACHE,
+        &[
             "pdb.snippet_positions(anyelement, int, int)",
             "paradedb.snippet_positions(anyelement, int, int)",
-        ])
-    })
+        ],
+    )
+}
+
+/// Resolve a pair of placeholder funcoids, caching the result only once both
+/// resolve. This lookup is reachable from the planner hook, which fires for
+/// every planned statement - including the internal queries Postgres runs while
+/// a CREATE/ALTER EXTENSION script is mid-flight, before these functions are
+/// defined. In that window `resolve_funcoids` yields InvalidOid (rather than the
+/// hard error `regprocedurein` would raise, which would abort the install).
+/// InvalidOid is left uncached so a later call resolves the real OIDs, and it
+/// never matches a real FuncExpr funcid.
+fn cached_funcoids(cache: &OnceLock<[pg_sys::Oid; 2]>, signatures: &[&str; 2]) -> [pg_sys::Oid; 2] {
+    if let Some(cached) = cache.get() {
+        return *cached;
+    }
+    let oids = resolve_funcoids(signatures);
+    if oids.iter().all(|oid| *oid != pg_sys::InvalidOid) {
+        let _ = cache.set(oids);
+    }
+    oids
 }
 
 fn resolve_funcoids(signatures: &[&str; 2]) -> [pg_sys::Oid; 2] {
+    // `to_regprocedure` takes `text` and returns NULL (None) instead of erroring
+    // when the function is absent, so each argument is a `&str` (not a CStr).
     unsafe {
         signatures
             .iter()
             .map(|signature| {
-                let cstr =
-                    std::ffi::CString::new(*signature).expect("signature contained interior NUL");
                 direct_function_call::<pg_sys::Oid>(
-                    pg_sys::regprocedurein,
-                    &[cstr.as_c_str().into_datum()],
+                    pg_sys::to_regprocedure,
+                    &[(*signature).into_datum()],
                 )
-                .unwrap_or_else(|| panic!("the `{}` function should exist", signature))
+                .unwrap_or(pg_sys::InvalidOid)
             })
             .collect::<Vec<pg_sys::Oid>>()
             .try_into()

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -558,7 +558,7 @@ unsafe fn warn_on_leftover_placeholder_functions(planned_stmt: *mut pg_sys::Plan
         return;
     }
 
-    let mut found = Vec::new();
+    let mut found: Vec<&'static str> = Vec::new();
     collect_leftover_placeholder_functions_in_plan((*planned_stmt).planTree, &mut found);
 
     if !(*planned_stmt).subplans.is_null() {

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -587,7 +587,7 @@ unsafe fn collect_leftover_placeholder_functions_in_plan(
         return;
     }
 
-    if let Some(cscan) = nodecast!(CustomScan, T_CustomScan, plan.cast()) {
+    if let Some(cscan) = nodecast!(CustomScan, T_CustomScan, plan.cast::<pg_sys::Node>()) {
         if is_paradedb_custom_scan(cscan) {
             return;
         }
@@ -599,30 +599,32 @@ unsafe fn collect_leftover_placeholder_functions_in_plan(
     collect_leftover_placeholder_functions_in_expr((*plan).qual.cast(), found);
     collect_leftover_placeholder_functions_in_expr((*plan).initPlan.cast(), found);
 
-    if let Some(join) = nodecast!(Join, T_NestLoop, plan.cast())
-        .or_else(|| nodecast!(Join, T_MergeJoin, plan.cast()))
-        .or_else(|| nodecast!(Join, T_HashJoin, plan.cast()))
+    if let Some(join) = nodecast!(Join, T_NestLoop, plan.cast::<pg_sys::Node>())
+        .or_else(|| nodecast!(Join, T_MergeJoin, plan.cast::<pg_sys::Node>()))
+        .or_else(|| nodecast!(Join, T_HashJoin, plan.cast::<pg_sys::Node>()))
     {
         collect_leftover_placeholder_functions_in_expr((*join).joinqual.cast(), found);
     }
 
-    if let Some(append) = nodecast!(Append, T_Append, plan.cast()) {
+    if let Some(append) = nodecast!(Append, T_Append, plan.cast::<pg_sys::Node>()) {
         collect_leftover_placeholder_functions_in_plan_list((*append).appendplans, found);
     }
 
-    if let Some(merge_append) = nodecast!(MergeAppend, T_MergeAppend, plan.cast()) {
+    if let Some(merge_append) = nodecast!(MergeAppend, T_MergeAppend, plan.cast::<pg_sys::Node>()) {
         collect_leftover_placeholder_functions_in_plan_list((*merge_append).mergeplans, found);
     }
 
-    if let Some(bitmap_and) = nodecast!(BitmapAnd, T_BitmapAnd, plan.cast()) {
+    if let Some(bitmap_and) = nodecast!(BitmapAnd, T_BitmapAnd, plan.cast::<pg_sys::Node>()) {
         collect_leftover_placeholder_functions_in_plan_list((*bitmap_and).bitmapplans, found);
     }
 
-    if let Some(bitmap_or) = nodecast!(BitmapOr, T_BitmapOr, plan.cast()) {
+    if let Some(bitmap_or) = nodecast!(BitmapOr, T_BitmapOr, plan.cast::<pg_sys::Node>()) {
         collect_leftover_placeholder_functions_in_plan_list((*bitmap_or).bitmapplans, found);
     }
 
-    if let Some(subquery_scan) = nodecast!(SubqueryScan, T_SubqueryScan, plan.cast()) {
+    if let Some(subquery_scan) =
+        nodecast!(SubqueryScan, T_SubqueryScan, plan.cast::<pg_sys::Node>())
+    {
         collect_leftover_placeholder_functions_in_plan((*subquery_scan).subplan, found);
     }
 
@@ -682,6 +684,12 @@ unsafe fn collect_leftover_placeholder_functions_in_expr(
         pg_sys::expression_tree_walker(node, Some(walker), data)
     }
 
+    // score_funcoids() / snippet_funcoids() et al. resolve softly: during a
+    // CREATE/ALTER EXTENSION script (when this planner hook still fires for the
+    // extension's own internal queries) the placeholder functions may not exist
+    // yet, in which case these return InvalidOid instead of erroring. An
+    // InvalidOid never matches a real FuncExpr funcid, so absent placeholders are
+    // simply not detected during that window.
     let scores = score_funcoids();
     let snippets = snippet_funcoids();
     let snippets_plural = snippets_funcoids();

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -21,21 +21,27 @@ use crate::api::{agg_funcoid, agg_with_solve_mvcc_funcoid};
 use crate::gucs;
 use crate::nodecast;
 use crate::postgres::customscan::aggregatescan::targetlist::TargetList;
-use crate::postgres::customscan::basescan::projections::window_agg;
+use crate::postgres::customscan::basescan::projections::{
+    snippet::{snippet_funcoids, snippet_positions_funcoids, snippets_funcoids},
+    window_agg,
+};
 use crate::postgres::customscan::builders::custom_path::{
     CustomPathBuilder, Flags, RestrictInfoType,
 };
 use crate::postgres::customscan::orderby::validate_topk_compatibility;
 use crate::postgres::customscan::qual_inspect::{extract_quals, PlannerContext, QualExtractState};
 use crate::postgres::customscan::{
-    CreateUpperPathsHookArgs, CustomScan, JoinPathlistHookArgs, RelPathlistHookArgs,
+    score_funcoids, CreateUpperPathsHookArgs, CustomScan, JoinPathlistHookArgs, RelPathlistHookArgs,
 };
-use crate::postgres::planner_warnings::{clear_planner_warnings, emit_planner_warnings};
+use crate::postgres::planner_warnings::{
+    add_planner_warning, clear_planner_warnings, emit_planner_warnings,
+};
 use crate::postgres::rel_get_bm25_index;
 use crate::postgres::utils::{expr_contains_any_operator, pg_search_extension_installed};
 use once_cell::sync::Lazy;
 use pgrx::{pg_guard, pg_sys, PgList, PgMemoryContexts};
 use std::collections::{hash_map::Entry, HashMap};
+use std::ffi::CStr;
 
 unsafe fn add_path(rel: *mut pg_sys::RelOptInfo, mut path: pg_sys::CustomPath) {
     let forced = path.flags & Flags::Force as u32 != 0;
@@ -538,6 +544,176 @@ unsafe fn should_replace_window_functions(parse: *mut pg_sys::Query) -> bool {
     false
 }
 
+fn placeholder_not_rewritten_message(function_name: &str) -> String {
+    format!(
+        "{function_name}() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. \
+         This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. \
+         Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. \
+         Please report at https://github.com/paradedb/paradedb/issues/new/choose"
+    )
+}
+
+unsafe fn warn_on_leftover_placeholder_functions(planned_stmt: *mut pg_sys::PlannedStmt) {
+    if planned_stmt.is_null() {
+        return;
+    }
+
+    let mut found = Vec::new();
+    collect_leftover_placeholder_functions_in_plan((*planned_stmt).planTree, &mut found);
+
+    if !(*planned_stmt).subplans.is_null() {
+        for subplan in PgList::<pg_sys::Plan>::from_pg((*planned_stmt).subplans).iter_ptr() {
+            collect_leftover_placeholder_functions_in_plan(subplan, &mut found);
+        }
+    }
+
+    found.sort_unstable();
+    found.dedup();
+
+    for function_name in found {
+        add_planner_warning(
+            "BM25 placeholder",
+            placeholder_not_rewritten_message(function_name),
+            (),
+        );
+    }
+}
+
+unsafe fn collect_leftover_placeholder_functions_in_plan(
+    plan: *mut pg_sys::Plan,
+    found: &mut Vec<&'static str>,
+) {
+    if plan.is_null() {
+        return;
+    }
+
+    if let Some(cscan) = nodecast!(CustomScan, T_CustomScan, plan.cast()) {
+        if is_paradedb_custom_scan(cscan) {
+            return;
+        }
+
+        collect_leftover_placeholder_functions_in_plan_list((*cscan).custom_plans, found);
+    }
+
+    collect_leftover_placeholder_functions_in_expr((*plan).targetlist.cast(), found);
+    collect_leftover_placeholder_functions_in_expr((*plan).qual.cast(), found);
+    collect_leftover_placeholder_functions_in_expr((*plan).initPlan.cast(), found);
+
+    if let Some(join) = nodecast!(Join, T_NestLoop, plan.cast())
+        .or_else(|| nodecast!(Join, T_MergeJoin, plan.cast()))
+        .or_else(|| nodecast!(Join, T_HashJoin, plan.cast()))
+    {
+        collect_leftover_placeholder_functions_in_expr((*join).joinqual.cast(), found);
+    }
+
+    if let Some(append) = nodecast!(Append, T_Append, plan.cast()) {
+        collect_leftover_placeholder_functions_in_plan_list((*append).appendplans, found);
+    }
+
+    if let Some(merge_append) = nodecast!(MergeAppend, T_MergeAppend, plan.cast()) {
+        collect_leftover_placeholder_functions_in_plan_list((*merge_append).mergeplans, found);
+    }
+
+    if let Some(bitmap_and) = nodecast!(BitmapAnd, T_BitmapAnd, plan.cast()) {
+        collect_leftover_placeholder_functions_in_plan_list((*bitmap_and).bitmapplans, found);
+    }
+
+    if let Some(bitmap_or) = nodecast!(BitmapOr, T_BitmapOr, plan.cast()) {
+        collect_leftover_placeholder_functions_in_plan_list((*bitmap_or).bitmapplans, found);
+    }
+
+    if let Some(subquery_scan) = nodecast!(SubqueryScan, T_SubqueryScan, plan.cast()) {
+        collect_leftover_placeholder_functions_in_plan((*subquery_scan).subplan, found);
+    }
+
+    collect_leftover_placeholder_functions_in_plan((*plan).lefttree, found);
+    collect_leftover_placeholder_functions_in_plan((*plan).righttree, found);
+}
+
+unsafe fn collect_leftover_placeholder_functions_in_plan_list(
+    plans: *mut pg_sys::List,
+    found: &mut Vec<&'static str>,
+) {
+    if plans.is_null() {
+        return;
+    }
+
+    for plan in PgList::<pg_sys::Plan>::from_pg(plans).iter_ptr() {
+        collect_leftover_placeholder_functions_in_plan(plan, found);
+    }
+}
+
+unsafe fn collect_leftover_placeholder_functions_in_expr(
+    node: *mut pg_sys::Node,
+    found: &mut Vec<&'static str>,
+) {
+    if node.is_null() {
+        return;
+    }
+
+    struct WalkerData<'a> {
+        placeholder_funcoids: Vec<(pg_sys::Oid, &'static str)>,
+        found: &'a mut Vec<&'static str>,
+    }
+
+    #[pg_guard]
+    unsafe extern "C-unwind" fn walker(
+        node: *mut pg_sys::Node,
+        data: *mut core::ffi::c_void,
+    ) -> bool {
+        if node.is_null() {
+            return false;
+        }
+
+        if let Some(funcexpr) = nodecast!(FuncExpr, T_FuncExpr, node) {
+            let data = data.cast::<WalkerData>();
+            if let Some((_, function_name)) = (*data)
+                .placeholder_funcoids
+                .iter()
+                .find(|(funcoid, _)| *funcoid == (*funcexpr).funcid)
+            {
+                let function_name = *function_name;
+                if !(*data).found.contains(&function_name) {
+                    (*data).found.push(function_name);
+                }
+            }
+        }
+
+        pg_sys::expression_tree_walker(node, Some(walker), data)
+    }
+
+    let scores = score_funcoids();
+    let snippets = snippet_funcoids();
+    let snippets_plural = snippets_funcoids();
+    let snippet_positions = snippet_positions_funcoids();
+    let mut data = WalkerData {
+        placeholder_funcoids: vec![
+            (scores[0], "pdb.score"),
+            (scores[1], "paradedb.score"),
+            (snippets[0], "pdb.snippet"),
+            (snippets[1], "paradedb.snippet"),
+            (snippets_plural[0], "pdb.snippets"),
+            (snippets_plural[1], "paradedb.snippets"),
+            (snippet_positions[0], "pdb.snippet_positions"),
+            (snippet_positions[1], "paradedb.snippet_positions"),
+        ],
+        found,
+    };
+
+    walker(node, std::ptr::addr_of_mut!(data).cast());
+}
+
+unsafe fn is_paradedb_custom_scan(cscan: *mut pg_sys::CustomScan) -> bool {
+    if cscan.is_null() || (*cscan).methods.is_null() || (*(*cscan).methods).CustomName.is_null() {
+        return false;
+    }
+
+    matches!(
+        CStr::from_ptr((*(*cscan).methods).CustomName).to_bytes(),
+        b"ParadeDB Base Scan" | b"ParadeDB Join Scan" | b"ParadeDB Aggregate Scan"
+    )
+}
+
 /// Planner hook that replaces WindowFunc nodes before PostgreSQL processes them.
 ///
 /// This hook runs at the very start of query planning, before `grouping_planner()`
@@ -590,6 +766,8 @@ unsafe extern "C-unwind" fn paradedb_planner_hook(
     } else {
         pg_sys::standard_planner(parse, query_string, cursor_options, bound_params)
     };
+
+    warn_on_leftover_placeholder_functions(result);
 
     // Emit collected warnings
     emit_planner_warnings();

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -387,22 +387,35 @@ pub unsafe fn operator_oid(signature: &str) -> pg_sys::Oid {
 
 pub fn score_funcoids() -> [pg_sys::Oid; 2] {
     static OID_CACHE: OnceLock<[pg_sys::Oid; 2]> = OnceLock::new();
-    *OID_CACHE.get_or_init(|| {
+    if let Some(cached) = OID_CACHE.get() {
+        return *cached;
+    }
+
+    // Resolve softly. This is reachable from the planner hook, which fires for
+    // every planned statement - including the internal queries Postgres runs
+    // while a CREATE/ALTER EXTENSION script is mid-flight, before pdb.score /
+    // paradedb.score are defined. `to_regprocedure` returns NULL (None) instead
+    // of erroring like `regprocedurein` does, so we return InvalidOid in that
+    // window rather than aborting the install. The result is cached only once
+    // both functions resolve, so the InvalidOid placeholders are never memoized
+    // and real lookups succeed once the extension is fully installed.
+    // `to_regprocedure` takes `text`, so each argument is a `&str` (not a CStr).
+    let oids = unsafe {
         [
-            unsafe {
-                direct_function_call::<pg_sys::Oid>(
-                    pg_sys::regprocedurein,
-                    &[c"pdb.score(anyelement)".into_datum()],
-                )
-                .expect("the `pdb.score(anyelement)` function should exist")
-            },
-            unsafe {
-                direct_function_call::<pg_sys::Oid>(
-                    pg_sys::regprocedurein,
-                    &[c"paradedb.score(anyelement)".into_datum()],
-                )
-                .expect("the `paradedb.score(anyelement)` function should exist")
-            },
+            direct_function_call::<pg_sys::Oid>(
+                pg_sys::to_regprocedure,
+                &["pdb.score(anyelement)".into_datum()],
+            )
+            .unwrap_or(pg_sys::InvalidOid),
+            direct_function_call::<pg_sys::Oid>(
+                pg_sys::to_regprocedure,
+                &["paradedb.score(anyelement)".into_datum()],
+            )
+            .unwrap_or(pg_sys::InvalidOid),
         ]
-    })
+    };
+    if oids.iter().all(|oid| *oid != pg_sys::InvalidOid) {
+        let _ = OID_CACHE.set(oids);
+    }
+    oids
 }

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
@@ -572,6 +572,7 @@ JOIN product_categories pc ON tp.id = pc.product_id
 JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -629,7 +630,8 @@ JOIN product_categories pc ON tp.id = pc.product_id
 JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test 5: Union of results from different tables
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 'Product' as type, name as item_name, description as content

--- a/pg_search/tests/pg_regress/expected/deprecated_score.out
+++ b/pg_search/tests/pg_regress/expected/deprecated_score.out
@@ -121,7 +121,8 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  paradedb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  paradedb.score() could not run because the BM25 custom scan was not selected for this relation
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -146,7 +147,8 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  paradedb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  paradedb.score() could not run because the BM25 custom scan was not selected for this relation
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -227,7 +229,8 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  paradedb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  paradedb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -184,7 +184,8 @@ FROM authors a
 INNER JOIN books b ON a.id = b.author_id AND a.birth_year < 2000
 WHERE (a.bio @@@ 'writer' OR b.content @@@ 'mystery')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- =============================================================================
 -- SECTION 2: Non-equi joins and problematic conditions
 -- =============================================================================
@@ -278,7 +279,8 @@ FROM authors a
 INNER JOIN books b ON b.price BETWEEN 20.00 AND 30.00 AND a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'romance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- =============================================================================
 -- SECTION 3: CROSS-TABLE OR TESTS
 -- =============================================================================
@@ -418,7 +420,8 @@ JOIN reviews r ON b.id = r.book_id
 WHERE (a.bio @@@ 'British' AND b.is_published = true) 
    OR (b.content @@@ 'horror' AND r.score >= 4)
 ORDER BY a.id, b.id, r.id, author_score DESC, book_score DESC, review_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test 4.4: Intelligent partial salvage of AND expressions
 SELECT 
     a.name as author_name,
@@ -460,7 +463,8 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author' AND b.category_id = 1
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test 5.3: LEFT JOIN semantics test
 SELECT 
     a.name as author_name,
@@ -566,7 +570,8 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'story')
   AND (a.is_active = true OR b.is_published = true);
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test 6.3: Unsafe conditions that cannot be pushed down
 SELECT 
     a.name as author_name,
@@ -610,7 +615,8 @@ WHERE (
 )
 ORDER BY a.id, b.id, r.id, author_score DESC, book_score DESC
 LIMIT 10;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test 7.2: Conservative OR handling demonstration
 SELECT 
     a.name as author_name,

--- a/pg_search/tests/pg_regress/expected/partitioned_snippets.out
+++ b/pg_search/tests/pg_regress/expected/partitioned_snippets.out
@@ -83,6 +83,7 @@ FROM logs
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
+WARNING:  pdb.snippets() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                       
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -113,7 +114,8 @@ FROM logs
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.snippets() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.snippets() could not run because the BM25 custom scan was not selected for this relation
 \echo 'Test 3: UNNEST(pdb.snippets(...)) on a child table'
 Test 3: UNNEST(pdb.snippets(...)) on a child table
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -221,6 +223,7 @@ FROM logs_2020
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
+WARNING:  pdb.snippets() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
                                                                                                                                                              QUERY PLAN                                                                                                                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -241,5 +244,6 @@ FROM logs_2020
 WHERE message @@@ 'research' AND country @@@ 'Canada'
 ORDER BY id
 LIMIT 3;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.snippets() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.snippets() could not run because the BM25 custom scan was not selected for this relation
 DROP TABLE IF EXISTS logs CASCADE;

--- a/pg_search/tests/pg_regress/expected/score_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_join_predicates.out
@@ -135,7 +135,8 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -160,7 +161,8 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 SELECT
     b.id as book_id,
     a.name as author_name,
@@ -241,7 +243,8 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
 SELECT

--- a/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_non_indexed_predicates.out
@@ -88,7 +88,8 @@ SELECT
 FROM products 
 WHERE category_name = 'Electronics'
 ORDER BY id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test Case 1.6: Simple test with just non-indexed predicate to isolate the issue
 SELECT 
     id,
@@ -239,6 +240,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
             QUERY PLAN            
 ----------------------------------
  Sort
@@ -255,7 +257,8 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -758,6 +761,7 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Sort
@@ -776,7 +780,8 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test Case 14: Array operations (if supported)
 -- Tests heap filtering with array predicates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -1060,7 +1065,8 @@ FROM products
 WHERE description @@@ 'Apple'
   AND category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test edge case: Query with only indexed predicates should still work when GUC is disabled
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT 

--- a/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
@@ -166,7 +166,9 @@ LEFT JOIN reviews r ON r.book_id = b.id
 WHERE (a.id @@@ paradedb.parse('metadata.age:55'))
     AND (a.id @@@ paradedb.parse('metadata.text:author') OR b.id @@@ paradedb.parse('metadata.content:test'))
 ORDER BY a.id, b.id, r.id;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.snippet() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.snippet() could not run because the BM25 custom scan was not selected for this relation
 \i common/snippet_json_advanced_cleanup.sql
 DROP TABLE IF EXISTS authors;
 DROP TABLE IF EXISTS books;

--- a/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
+++ b/pg_search/tests/pg_regress/expected/unified_expression_comprehensive.out
@@ -211,6 +211,7 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
             QUERY PLAN            
 ----------------------------------
  Sort
@@ -227,7 +228,8 @@ FROM products
 WHERE (name @@@ 'Apple' AND description @@@ 'smartphone') 
   OR TRUE OR category_name = 'Electronics'
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test Case 3: Another example with price filter (non-indexed)
 -- Should show the same issue - scores become null due to non-indexed predicate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -730,6 +732,7 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
                                QUERY PLAN                               
 ------------------------------------------------------------------------
  Sort
@@ -748,7 +751,8 @@ FROM products
 WHERE price BETWEEN 100.00 AND 300.00
   AND in_stock = true
 ORDER BY score DESC;
-ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+WARNING:  pdb.score() may fail because the BM25 custom scan was not selected, leaving its planner placeholder in the plan. This is usually caused by query shapes the BM25 custom scan cannot drive, such as DISTINCT ON over LATERAL or certain joins. Materialize the BM25 search in a subquery first, then apply DISTINCT ON, LATERAL, or joins on top. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+ERROR:  pdb.score() could not run because the BM25 custom scan was not selected for this relation
 -- Test Case 14: Array operations (if supported)
 -- Tests heap filtering with array predicates
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -282,7 +282,14 @@ fn distinct_on_with_lateral_jsonb_array_elements_limit(mut conn: PgConnection) {
     "#
     .execute(&mut conn);
 
-    let query = r#"
+    // The direct DISTINCT ON + LATERAL + function-RTE shape cannot be driven by
+    // the BM25 custom scan: the planner does not select the custom path for this
+    // relation, so the pdb.score() placeholder is left in the plan and fails at
+    // execution. Rather than the old hostile "Unsupported query shape" panic, we
+    // now surface a clear, actionable error pointing at the subquery workaround
+    // (see issue #5058). Assert that error fires instead of pretending the shape
+    // is supported.
+    let direct_query = r#"
         SELECT DISTINCT ON (items.barcode)
             items.barcode,
             pdb.score(items.id) AS score
@@ -296,7 +303,41 @@ fn distinct_on_with_lateral_jsonb_array_elements_limit(mut conn: PgConnection) {
         ORDER BY items.barcode, pdb.score(items.id) DESC OFFSET 0 LIMIT 5;
     "#;
 
-    let results = query.fetch::<(i32, f32)>(&mut conn);
+    let direct_result = direct_query.execute_result(&mut conn);
+    assert!(
+        direct_result.is_err(),
+        "direct DISTINCT ON over LATERAL with pdb.score should surface a clear error"
+    );
+    let direct_err = format!("{}", direct_result.err().unwrap());
+    assert!(
+        direct_err.contains("BM25 custom scan was not selected"),
+        "expected the friendly placeholder error, got: {direct_err}"
+    );
+
+    // The supported pattern: materialize the BM25 search (including pdb.score) in
+    // a CTE first, then apply DISTINCT ON and the LATERAL function scan on top.
+    // The MATERIALIZED fence keeps the BM25 custom scan as the inner plan node so
+    // the score placeholder is rewritten, and the LIMIT stays above the lateral
+    // function scan. This returns the rows the direct shape was meant to produce.
+    let workaround = r#"
+        WITH scored AS MATERIALIZED (
+            SELECT id, barcode, ai_specification, pdb.score(id) AS score
+            FROM issue_5058_items
+            WHERE title @@@ 'car'
+               OR alt_title @@@ 'car'
+               OR description @@@ 'car'
+        )
+        SELECT DISTINCT ON (scored.barcode)
+            scored.barcode,
+            scored.score
+        FROM scored,
+             jsonb_array_elements(scored.ai_specification->'specifications') AS spec
+        WHERE spec->>'specification_name' ILIKE '%color%'
+          AND spec->>'value' ILIKE '%red%'
+        ORDER BY scored.barcode, scored.score DESC OFFSET 0 LIMIT 5;
+    "#;
+
+    let results = workaround.fetch::<(i32, f32)>(&mut conn);
     assert_eq!(
         results
             .iter()
@@ -306,19 +347,13 @@ fn distinct_on_with_lateral_jsonb_array_elements_limit(mut conn: PgConnection) {
     );
 
     let (plan,) =
-        format!("EXPLAIN (ANALYZE, FORMAT JSON) {query}").fetch_one::<(Value,)>(&mut conn);
+        format!("EXPLAIN (ANALYZE, FORMAT JSON) {workaround}").fetch_one::<(Value,)>(&mut conn);
     let root_plan = plan.pointer("/0/Plan").unwrap();
     let mut custom_scan_nodes = Vec::new();
     collect_custom_scan_nodes(root_plan, &mut custom_scan_nodes);
     assert!(
         !custom_scan_nodes.is_empty(),
-        "expected a ParadeDB custom scan in plan: {plan:#?}"
-    );
-    assert!(
-        custom_scan_nodes
-            .iter()
-            .all(|node| node.get("   TopK Limit").is_none()),
-        "LIMIT should stay above the lateral function scan: {plan:#?}"
+        "expected a ParadeDB custom scan in the materialized subquery plan: {plan:#?}"
     );
 }
 

--- a/tests/tests/custom_scan.rs
+++ b/tests/tests/custom_scan.rs
@@ -24,6 +24,18 @@ use rstest::*;
 use serde_json::{Number, Value};
 use sqlx::PgConnection;
 
+fn collect_custom_scan_nodes<'a>(plan: &'a Value, nodes: &mut Vec<&'a Value>) {
+    if plan.get("Node Type").and_then(Value::as_str) == Some("Custom Scan") {
+        nodes.push(plan);
+    }
+
+    if let Some(plans) = plan.get("Plans").and_then(Value::as_array) {
+        for child_plan in plans {
+            collect_custom_scan_nodes(child_plan, nodes);
+        }
+    }
+}
+
 #[rstest]
 fn corrupt_targetlist(mut conn: PgConnection) {
     SimpleProductsTable::setup().execute(&mut conn);
@@ -229,6 +241,84 @@ explain (analyze, format json) select pdb.score(id), * from paradedb.bm25_search
     assert_eq!(
         path.get("   TopK Limit"),
         Some(&Value::Number(Number::from(1)))
+    );
+}
+
+#[rstest]
+fn distinct_on_with_lateral_jsonb_array_elements_limit(mut conn: PgConnection) {
+    r#"
+        DROP TABLE IF EXISTS issue_5058_items;
+        CREATE TABLE issue_5058_items (
+            id SERIAL8 NOT NULL PRIMARY KEY,
+            barcode INTEGER NOT NULL,
+            title TEXT,
+            alt_title TEXT,
+            description TEXT,
+            ai_specification JSONB
+        );
+
+        CREATE INDEX issue_5058_items_idx ON issue_5058_items
+        USING bm25 (id, barcode, title, alt_title, description, ai_specification)
+        WITH (key_field = 'id');
+
+        INSERT INTO issue_5058_items
+            (barcode, title, alt_title, description, ai_specification)
+        SELECT
+            gs,
+            'car',
+            'vehicle',
+            'compact car',
+            jsonb_build_object(
+                'specifications',
+                jsonb_build_array(jsonb_build_object(
+                    'specification_name', 'color',
+                    'value', CASE WHEN gs <= 5 THEN 'blue' ELSE 'red' END
+                ))
+            )
+        FROM generate_series(1, 12) gs;
+
+        SET enable_indexscan TO off;
+        SET enable_seqscan TO off;
+    "#
+    .execute(&mut conn);
+
+    let query = r#"
+        SELECT DISTINCT ON (items.barcode)
+            items.barcode,
+            pdb.score(items.id) AS score
+        FROM issue_5058_items items,
+             jsonb_array_elements(items.ai_specification->'specifications') AS spec
+        WHERE (items.title @@@ 'car'
+               OR items.alt_title @@@ 'car'
+               OR items.description @@@ 'car')
+          AND spec->>'specification_name' ILIKE '%color%'
+          AND spec->>'value' ILIKE '%red%'
+        ORDER BY items.barcode, pdb.score(items.id) DESC OFFSET 0 LIMIT 5;
+    "#;
+
+    let results = query.fetch::<(i32, f32)>(&mut conn);
+    assert_eq!(
+        results
+            .iter()
+            .map(|(barcode, _)| *barcode)
+            .collect::<Vec<_>>(),
+        vec![6, 7, 8, 9, 10]
+    );
+
+    let (plan,) =
+        format!("EXPLAIN (ANALYZE, FORMAT JSON) {query}").fetch_one::<(Value,)>(&mut conn);
+    let root_plan = plan.pointer("/0/Plan").unwrap();
+    let mut custom_scan_nodes = Vec::new();
+    collect_custom_scan_nodes(root_plan, &mut custom_scan_nodes);
+    assert!(
+        !custom_scan_nodes.is_empty(),
+        "expected a ParadeDB custom scan in plan: {plan:#?}"
+    );
+    assert!(
+        custom_scan_nodes
+            .iter()
+            .all(|node| node.get("   TopK Limit").is_none()),
+        "LIMIT should stay above the lateral function scan: {plan:#?}"
     );
 }
 


### PR DESCRIPTION
## Summary

When a `pdb.score()` / `pdb.snippet()` (or `paradedb.*`) placeholder survives into the executed plan — because the BM25 custom scan was not selected for the relation (e.g. `DISTINCT ON` over a `LATERAL` set-returning function such as `jsonb_array_elements`, or certain joins) — the old behavior was a hostile `panic!("Unsupported query shape")` that only pointed at the issue tracker. This PR turns that into a clear, recoverable diagnostic:

1. **Clear runtime error.** An unrewritten placeholder now raises `ERRCODE_FEATURE_NOT_SUPPORTED`, naming the function, explaining why the placeholder remained (the BM25 custom scan was not selected for this relation), and pointing at the fix: materialize the BM25 search in a subquery first, then apply `DISTINCT ON` / `LATERAL` / joins on top.
2. **Planner-time warning.** The planner hook walks the final `PlannedStmt` and emits a warning for each leftover placeholder outside a ParadeDB custom scan node, so the diagnostic appears before execution.
3. **Soft placeholder-funcoid resolution.** The leftover-placeholder detector runs for every planned statement, including the internal queries Postgres plans while `CREATE`/`ALTER EXTENSION` is mid-flight, before `pdb.score` / `paradedb.score` exist. Resolving those funcoids with `to_regprocedure` (returns NULL) instead of `regprocedurein` (hard-errors), and caching only once all resolve, keeps the detector from aborting the install.

Tests assert the friendly error fires for the direct `DISTINCT ON` over `LATERAL` shape, and that the documented `WITH ... AS MATERIALIZED` subquery workaround returns the correct rows with a BM25 custom scan in the plan. The affected pg_regress golden files are regenerated for the new message.

## Scope note

This is **not** a plan-shape fix. Per review, the BM25 custom scan still cannot drive `DISTINCT ON` over a `LATERAL` function RTE; making it do so is the real fix and remains tracked by #5058. The earlier conservative LIMIT-pushdown guard (the last remnant of the abandoned "make `LIMIT` work" approach) has been dropped — it was a no-op for the #5058 query and unrelated to this diagnostic. This PR is scoped purely to the placeholder error/warning.

Related to #5058.

---
AI was used for assistance.