### PR TITLE
chore: Bump all Rust tool cache keys

### DIFF
--- a/.github/workflows/benchmark-pg_search-benchmarks.yml
+++ b/.github/workflows/benchmark-pg_search-benchmarks.yml
@@ -223,7 +223,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-benchmarks-rust-cache"
+          prefix-key: "v2-benchmarks-rust-cache"
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -195,7 +195,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "v1-stressgres-rust-cache"
+          prefix-key: "v2-stressgres-rust-cache"
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "rust-cache"
+          prefix-key: "v2-rust-cache"
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "rust-cache"
+          prefix-key: "v2-rust-cache"
           shared-key: pg${{ env.pg_version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/schemabot-generate-diff.yml
+++ b/.github/workflows/schemabot-generate-diff.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "rust-cache"
+          prefix-key: "v2-rust-cache"
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/test-docs.yml
+++ b/.github/workflows/test-docs.yml
@@ -138,7 +138,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "rust-cache"
+          prefix-key: "v2-rust-cache"
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -104,7 +104,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "rust-cache"
+          prefix-key: "v2-rust-cache"
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install Rust Cache
         uses: swatinem/rust-cache@v2
         with:
-          prefix-key: "rust-cache"
+          prefix-key: "v2-rust-cache"
           shared-key: pg${{ matrix.pg_version }}
           cache-targets: true
           cache-all-crates: true


### PR DESCRIPTION
After yesterday's Github Actions outage, some jobs are showing strange, potentially-cache-related behavior. Wipe caches to rule out corruption.