### PR TITLE
chore: Switch to thin LTO to reduce compile time memory usage.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,10 @@ license = "AGPL-3.0"
 panic = "unwind"
 
 [profile.release]
-lto = "fat"
+# Note: We switched from `fat` to `thin` LTO to reduce compile time memory usage, which had been
+# sufficient to cause swapping on local machines, and to kill Docker-based CI builds on smaller
+# instances. Benchmarks were unaffected.
+lto = "thin"
 panic = "unwind"
 opt-level = 3
 codegen-units = 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,8 @@ panic = "unwind"
 
 [profile.release]
 # Note: We switched from `fat` to `thin` LTO to reduce compile time memory usage, which had been
-# sufficient to cause swapping on local machines, and to kill Docker-based CI builds on smaller
-# instances. Benchmarks were unaffected.
+# sufficient to cause swapping on local machines, and to kill CI builds on smaller instances.
+# Benchmarks were unaffected.
 lto = "thin"
 panic = "unwind"
 opt-level = 3


### PR DESCRIPTION
## What

Switch from `fat` to `thin` LTO.

## Why

We have previously needed to switch to larger CI runners due to memory issues during compilation. Additionally, locally I have observed swapping on macOS during release mode compilation, due to more than 20 GB of RAM being used, as well as 10+GB of compressed RAM.

`thin` LTO gets 98% of the performance benefits of `fat` LTO, with reduced memory usage. I observed about a 50% reduction in memory usage during compilation locally, and no more swapping.

## Tests

Benchmarks are unchanged.