### PR TITLE
feat(mpp): paradedb.mpp_target_partitions to pin shuffle fanout

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -174,6 +174,16 @@ static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024
 /// derive this from index stats per query.
 static MPP_CACHE_PER_SLOT: GucSetting<i32> = GucSetting::<i32>::new(256 * 1024 * 1024);
 
+/// Inner partition fanout per producer task (passed as
+/// `SessionConfig::target_partitions` when building the distributed plan). A
+/// value of `0` keeps the historical behavior of scaling with
+/// `mpp_worker_count`, which gives each shuffle stage `N²` mesh edges. A
+/// positive value pins the fanout to a constant so the mesh edge count grows
+/// linearly with `N` instead. Single-thread Tokio runtimes per producer don't
+/// actually parallelize across inner partitions, so a small constant is
+/// usually pure overhead savings; the right value depends on workload.
+static MPP_TARGET_PARTITIONS: GucSetting<i32> = GucSetting::<i32>::new(0);
+
 /// The maximum size of an InList that can be pushed down to a TermSet Query.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
     GucSetting::<i32>::new(16 * 1024 * 1024);
@@ -624,6 +634,22 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_target_partitions",
+        c"Inner partition fanout per producer task; 0 = scale with mpp_worker_count",
+        c"Sets `target_partitions` on the per-query distributed SessionConfig. 0 keeps \
+          the historical behavior of scaling with mpp_worker_count, which makes each \
+          shuffle stage carry N² mesh edges. A positive value pins the fanout so the \
+          mesh edge count grows linearly with N instead. Each producer runs on a \
+          single-thread Tokio runtime, so inner partitions are pure overhead — most \
+          workloads benefit from a small constant (2 is a sensible starting point).",
+        &MPP_TARGET_PARTITIONS,
+        0,
+        64,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -820,6 +846,10 @@ pub fn mpp_queue_size() -> usize {
 
 pub fn mpp_cache_per_slot() -> usize {
     MPP_CACHE_PER_SLOT.get() as usize
+}
+
+pub fn mpp_target_partitions() -> i32 {
+    MPP_TARGET_PARTITIONS.get()
 }
 
 pub fn hash_join_inlist_pushdown_max_size() -> i32 {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -112,9 +112,19 @@ pub(crate) fn build_mpp_session_context(
     //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
     //   4. distributed_in_process_mode(true): skips the gRPC plan-send / metrics /
     //      work-unit-feed tasks. Workers re-plan from the logical plan in DSM.
+    // `paradedb.mpp_target_partitions = 0` (default) preserves the historical N²-edge mesh by
+    // scaling inner fanout with n_workers. A positive value pins the fanout to a constant so
+    // edges grow linearly with N. Single-thread Tokio runtimes per producer don't parallelize
+    // across inner partitions, so a small constant is usually pure overhead savings.
+    let configured = crate::gucs::mpp_target_partitions();
+    let target_partitions = if configured > 0 {
+        (configured as usize).max(2)
+    } else {
+        n_workers.max(2)
+    };
     let cfg = seed
         .copied_config()
-        .with_target_partitions(n_workers.max(2));
+        .with_target_partitions(target_partitions);
 
     // Start from the seed's existing state so the customscan's query planner
     // (`PgSearchQueryPlanner`), optimizer rules, and registered extensions all carry over.


### PR DESCRIPTION
## What

Adds `paradedb.mpp_target_partitions` GUC that pins DataFusion's `target_partitions` to a constant when MPP is active. Default `0` preserves historical behavior (target_partitions = mpp_worker_count, so each producer fragment emits N×N output partitions per shuffle).

## Why

DataFusion's distributed planner sets `target_partitions = mpp_worker_count`, which makes each producer fragment emit `N (target) × N (consumer tasks) = N²` output partitions per shuffle. Each producer runs on a single-thread tokio runtime, so the inner fanout doesn't actually parallelize anything — it just adds per-partition scheduling and channel state.

For repeatable scaling-curve benchmarks where we want to isolate the N axis from plan shape, we need a knob that pins the inner fanout independent of N. Otherwise different N values pick different plans and the curve confounds plan shape with parallelism.

## How

- New GUC `paradedb.mpp_target_partitions` (default `0`, range `0..1024`).
- `0` = current behavior (`target_partitions = mpp_worker_count`).
- Non-zero value pins `target_partitions` to that value in `build_mpp_session_context`.

Extracted from PR #5155 (the linear-scaling investigation branch) as a focused PR. The omnibus contains a FINDINGS.md update with the tuning results which is omitted here since the doc file doesn't live in main yet.

## Tests

- Existing MPP regress + integration suites continue to pass with the default `0` (no behavior change).
- `mpp_target_partitions=2` was used throughout the N-sweep bench harness on `moe/mpp-bench-linear` to keep plan shape fixed across N={4,8,12,16,24}.