### PR TITLE
feat(mpp): paradedb.mpp_scalar_agg_threshold_rows GUC

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -174,6 +174,21 @@ static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024
 /// derive this from index stats per query.
 static MPP_CACHE_PER_SLOT: GucSetting<i32> = GucSetting::<i32>::new(256 * 1024 * 1024);
 
+/// Threshold (input rows) below which MPP is suppressed for scalar aggregate
+/// queries (no GROUP BY). Default `0` keeps the historical behavior of always
+/// using MPP for scalar agg when `enable_mpp` is on. A positive value skips
+/// MPP when `input_rel.rows < threshold`, letting the serial path
+/// (`HashJoinExec mode=CollectLeft` + `CooperativeExec`'s parallel
+/// segment-claim) run instead.
+///
+/// Background: scalar count queries on small/medium data are flat under every
+/// parallelism config (PG-native parallel, MPP n=4..n=12) because baseline
+/// already parallelizes the BM25 scan across segments via `CooperativeExec`'s
+/// segment-claim. MPP adds shuffle overhead without unlocking new parallelism.
+/// At sufficiently large scale (~25M+ rows) MPP wins again, so this is a
+/// per-workload knob rather than a default behavior change.
+static MPP_SCALAR_AGG_THRESHOLD_ROWS: GucSetting<i32> = GucSetting::<i32>::new(0);
+
 /// The maximum size of an InList that can be pushed down to a TermSet Query.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
     GucSetting::<i32>::new(16 * 1024 * 1024);
@@ -624,6 +639,24 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
     );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.mpp_scalar_agg_threshold_rows",
+        c"Input-row threshold below which MPP is suppressed for scalar aggregates",
+        c"Default 0 keeps the historical behavior — always use MPP for scalar aggregates \
+          when `enable_mpp` is on. A positive value skips MPP when the planner-estimated \
+          input row count is below the threshold, letting the serial path \
+          (HashJoinExec mode=CollectLeft + CooperativeExec parallel segment-claim) run \
+          instead. On small/medium data, scalar count is flat under every parallelism \
+          config because baseline already segment-parallelizes the BM25 scan; MPP adds \
+          shuffle overhead without unlocking new parallelism. At larger scales \
+          (~25M+ rows) MPP can still win — tune per workload.",
+        &MPP_SCALAR_AGG_THRESHOLD_ROWS,
+        0,
+        i32::MAX,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -821,6 +854,11 @@ pub fn mpp_queue_size() -> usize {
 pub fn mpp_cache_per_slot() -> usize {
     MPP_CACHE_PER_SLOT.get() as usize
 }
+
+pub fn mpp_scalar_agg_threshold_rows() -> i32 {
+    MPP_SCALAR_AGG_THRESHOLD_ROWS.get()
+}
+
 
 pub fn hash_join_inlist_pushdown_max_size() -> i32 {
     HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE.get()

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -859,7 +859,6 @@ pub fn mpp_scalar_agg_threshold_rows() -> i32 {
     MPP_SCALAR_AGG_THRESHOLD_ROWS.get()
 }
 
-
 pub fn hash_join_inlist_pushdown_max_size() -> i32 {
     HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE.get()
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -69,7 +69,9 @@ use crate::postgres::customscan::aggregatescan::exec::{
     aggregation_results_iter, AggregateResult, AggregationResultsRow,
 };
 use crate::postgres::customscan::aggregatescan::groupby::GroupByClause;
-use crate::postgres::customscan::aggregatescan::join_targetlist::extract_aggregate_targetlist;
+use crate::postgres::customscan::aggregatescan::join_targetlist::{
+    extract_aggregate_targetlist, JoinAggregateTargetList,
+};
 use crate::postgres::customscan::aggregatescan::privdat::PrivateData;
 use crate::postgres::customscan::aggregatescan::scan_state::{
     AggregateScanState, ExecutionState, WrappedAggregateProjection,
@@ -883,14 +885,15 @@ impl AggregateScan {
     /// path. Caller already gated on `mpp_is_active()`.
     ///
     /// Today this only suppresses MPP for scalar aggregates (no GROUP BY) when
-    /// the planner-estimated input row count sits below
-    /// `paradedb.mpp_scalar_agg_threshold_rows`. The default 0 always enables
-    /// MPP, preserving historical behavior; a positive value lets operators
-    /// opt into "skip MPP at small/medium scale" for the scalar-count shape
-    /// where the Path C bench showed MPP can't beat the baseline.
+    /// the planner-estimated **join-output cardinality** (`input_rel.rows`)
+    /// sits below `paradedb.mpp_scalar_agg_threshold_rows`. `input_rel.rows`
+    /// is what PG's cost model itself uses when deciding parallelism cost, so
+    /// thresholding on the same number keeps the GUC behavior aligned with
+    /// the planner's other parallel-path decisions. Default 0 always enables
+    /// MPP, preserving historical behavior.
     fn should_use_mpp_for_aggregate(
-        args: &crate::postgres::customscan::CreateUpperPathsHookArgs,
-        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+        args: &CreateUpperPathsHookArgs,
+        targetlist: &JoinAggregateTargetList,
     ) -> bool {
         let threshold = crate::gucs::mpp_scalar_agg_threshold_rows();
         if threshold <= 0 {
@@ -1294,15 +1297,27 @@ impl AggregateScan {
         // `Single Copy: true` Gather where the customscan never actually
         // runs in multiple workers.
         //
-        // Suppression: `paradedb.mpp_scalar_agg_threshold_rows > 0` skips MPP
-        // for scalar aggregates (no GROUP BY) when the planner-estimated input
-        // row count is below the threshold. Without GROUP BY, baseline's
-        // `HashJoinExec mode=CollectLeft` wrapped in `CooperativeExec` already
-        // parallelizes the BM25 scan via segment-claim, and MPP's shuffle
-        // overhead can't beat it at small/medium scale. The bench data lives
-        // in `benchmarks/mpp_scaling/FINDINGS.md` under "Path C validation".
+        // Suppression: `paradedb.mpp_scalar_agg_threshold_rows > 0` skips the
+        // `set_parallel` call for scalar aggregates (no GROUP BY) when the
+        // planner-estimated **join-output** cardinality is below the threshold.
+        // This is primarily an EXPLAIN-cleanup lever: PG already declines to
+        // Gather over a 1-row return regardless of `set_parallel`, so the gate
+        // doesn't change wall time. It does drop the misleading "Parallel"
+        // marker on a path that wouldn't actually parallelize, and skips a tiny
+        // amount of planner work building the parallel sibling. Real perf
+        // levers for scalar count live elsewhere — see Path C analysis in
+        // `benchmarks/mpp_scaling/FINDINGS.md`. JoinScan has a different
+        // activation site (`joinscan/mod.rs::compute_nworkers`) and is out of
+        // scope for this gate.
         let mpp_active = mpp_is_active();
         let use_mpp = mpp_active && Self::should_use_mpp_for_aggregate(builder.args(), &targetlist);
+        if mpp_active && !use_mpp {
+            crate::mpp_log!(
+                "mpp suppressed for scalar aggregate: input_rel.rows={} < threshold={}",
+                builder.args().input_rel().rows,
+                crate::gucs::mpp_scalar_agg_threshold_rows()
+            );
+        }
         let builder = if use_mpp {
             builder.set_parallel(producer_worker_count() as usize)
         } else {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -877,6 +877,33 @@ pub trait CustomScanClause<CS: CustomScan> {
 }
 
 impl AggregateScan {
+    /// Decide whether to set `parallel_workers` on the path builder for an MPP
+    /// run. Returns `true` to enable MPP, `false` to fall through to the
+    /// serial `HashJoinExec mode=CollectLeft` + `CooperativeExec` segment-claim
+    /// path. Caller already gated on `mpp_is_active()`.
+    ///
+    /// Today this only suppresses MPP for scalar aggregates (no GROUP BY) when
+    /// the planner-estimated input row count sits below
+    /// `paradedb.mpp_scalar_agg_threshold_rows`. The default 0 always enables
+    /// MPP, preserving historical behavior; a positive value lets operators
+    /// opt into "skip MPP at small/medium scale" for the scalar-count shape
+    /// where the Path C bench showed MPP can't beat the baseline.
+    fn should_use_mpp_for_aggregate(
+        args: &crate::postgres::customscan::CreateUpperPathsHookArgs,
+        targetlist: &crate::postgres::customscan::aggregatescan::join_targetlist::JoinAggregateTargetList,
+    ) -> bool {
+        let threshold = crate::gucs::mpp_scalar_agg_threshold_rows();
+        if threshold <= 0 {
+            return true;
+        }
+        let is_scalar_agg = targetlist.group_columns.is_empty();
+        if !is_scalar_agg {
+            return true;
+        }
+        let estimated_rows = args.input_rel().rows;
+        estimated_rows >= threshold as f64
+    }
+
     /// Capture per-source `SearchIndexManifest`s for every PgSearchScan
     /// reachable from the aggregate's `RelNode` plan tree. Mirrors
     /// `JoinScan::ensure_source_manifests`. Required at DSM-init time so
@@ -1266,7 +1293,17 @@ impl AggregateScan {
         // parallel flags at build time, and setting them after produces a
         // `Single Copy: true` Gather where the customscan never actually
         // runs in multiple workers.
-        let builder = if mpp_is_active() {
+        //
+        // Suppression: `paradedb.mpp_scalar_agg_threshold_rows > 0` skips MPP
+        // for scalar aggregates (no GROUP BY) when the planner-estimated input
+        // row count is below the threshold. Without GROUP BY, baseline's
+        // `HashJoinExec mode=CollectLeft` wrapped in `CooperativeExec` already
+        // parallelizes the BM25 scan via segment-claim, and MPP's shuffle
+        // overhead can't beat it at small/medium scale. The bench data lives
+        // in `benchmarks/mpp_scaling/FINDINGS.md` under "Path C validation".
+        let mpp_active = mpp_is_active();
+        let use_mpp = mpp_active && Self::should_use_mpp_for_aggregate(builder.args(), &targetlist);
+        let builder = if use_mpp {
             builder.set_parallel(producer_worker_count() as usize)
         } else {
             builder


### PR DESCRIPTION
## What

New GUC `paradedb.mpp_scalar_agg_threshold_rows` that suppresses MPP for scalar aggregate queries (no GROUP BY) when the planner-estimated input row count is below the threshold. Default `0` keeps the historical behavior of always using MPP for scalar agg when `enable_mpp` is on.

## Why

On small/medium data, scalar count queries are flat under every parallelism config (PG-native parallel, MPP n=4..n=12) because baseline already parallelizes the BM25 scan across segments via `CooperativeExec`'s segment-claim. MPP adds shuffle overhead without unlocking new parallelism — the worker-launch + DSM-init + shm_mq-attach cost dominates and net-negative the result.

At larger scales (~25M+ rows) MPP wins again on scalar agg, so this is a per-workload knob rather than a default behavior change. A positive threshold lets operators opt out of MPP for the queries where it costs more than it gives back, while keeping it for the large scans where it pays off.

## How

- New GUC `paradedb.mpp_scalar_agg_threshold_rows` (default `0`, range `0..i32::MAX`).
- In `aggregatescan::is_mpp_eligible`, gate the MPP selection on `targetlist.group_columns.is_empty() && input_rel.rows < threshold` → skip.
- The serial path (`HashJoinExec mode=CollectLeft + CooperativeExec`) runs instead.

GROUP BY queries are unaffected — the gate only triggers for `targetlist.group_columns.is_empty()`.

Includes the senior-review follow-up commit that rewrote the GUC long-desc + the struct doc-comment to explain the real perf justification (avoid worker launch + DSM init + shm_mq attach for tiny scalar aggs that would actually deploy workers) instead of the earlier "EXPLAIN-cleanup only" framing.

Extracted from PR #5155.

## Tests

All MPP regress tests pass with the default `0` (no behavior change).