### PR TITLE
feat(mpp): three diagnostic instruments under paradedb.mpp_trace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5747,6 +5747,7 @@ dependencies = [
  "half 2.7.1",
  "json5",
  "lazy_static",
+ "libc",
  "macros",
  "memoffset",
  "once_cell",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-sWBPbf8vcychdEk9y6zTkYNZ/SsZdJ4dCk2MYnYS8ZM=";
+  cargoHash = "sha256-6j9hVoqw6UfpzQwlzWzgAdBwgl2TvwXwpvj62E5ysOQ=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -82,6 +82,7 @@ datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distrib
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"
+libc = "0.2"
 
 [dev-dependencies]
 pgrx-tests.workspace = true

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -282,6 +282,10 @@ pub(super) unsafe fn leader_init(
     // it only attaches to its own row and column below.
     let header = MppDsmHeader::from_layout(layout);
     let n_procs = layout.n_procs;
+    // `crate::gucs::mpp_trace()` reads a pgrx GucSetting, which requires the backend thread.
+    // Safe here because `leader_init` runs synchronously from `initialize_dsm_custom_scan`
+    // on the backend before any tokio runtime spins up — same property the surrounding
+    // `pgrx::warning!` callers rely on.
     let trace_on = crate::gucs::mpp_trace();
     let t_create = trace_on.then(Instant::now);
     for s in 0..n_procs {
@@ -297,19 +301,20 @@ pub(super) unsafe fn leader_init(
     let attach = unsafe { attach_proc_row_and_column(base, &header, 0, seg) };
     let attach_ms = t_attach.map(|t| t.elapsed().as_secs_f64() * 1000.0);
 
-    if let (Some(create_ms), Some(attach_ms)) = (create_ms, attach_ms) {
-        // Peer-attach count excludes the self-loop slot, so N×(N-1). create touched all N² slots.
-        let peer_attaches = (n_procs as usize).saturating_sub(1);
+    if trace_on {
+        // attach_proc_row_and_column makes 2*(N-1) shm_mq_attach calls per proc:
+        // N-1 row senders + N-1 column receivers. create touched all N² slots.
+        let peer_attach_calls = 2 * (n_procs as usize).saturating_sub(1);
         let total_slots = (n_procs as usize) * (n_procs as usize);
         pgrx::warning!(
-            "mpp_trace mesh_init role=leader procs={} slots_created={} peer_attaches={} queue_bytes={} plan_bytes={} create_ms={:.2} attach_ms={:.2}",
+            "mpp_trace mesh_init role=leader procs={} slots_created={} peer_attach_calls={} queue_bytes={} plan_bytes={} create_ms={:.2} attach_ms={:.2}",
             n_procs,
             total_slots,
-            peer_attaches,
+            peer_attach_calls,
             layout.queue_bytes,
             plan_bytes.len(),
-            create_ms,
-            attach_ms,
+            create_ms.unwrap(),
+            attach_ms.unwrap(),
         );
     }
 
@@ -407,17 +412,20 @@ pub(super) unsafe fn worker_attach(
         .to_vec()
     };
 
+    // Same backend-thread safety story as leader_init: `initialize_worker_custom_scan` runs on
+    // the parallel-worker backend before tokio starts, so reading `mpp_trace` directly is safe.
     let trace_on = crate::gucs::mpp_trace();
     let t_attach = trace_on.then(Instant::now);
     let attach = unsafe { attach_proc_row_and_column(base, &header, proc_idx, seg) };
-    if let Some(t_attach) = t_attach {
-        let attach_ms = t_attach.elapsed().as_secs_f64() * 1000.0;
-        let peer_attaches = (header.n_procs as usize).saturating_sub(1);
+    if trace_on {
+        let attach_ms = t_attach.unwrap().elapsed().as_secs_f64() * 1000.0;
+        // 2*(N-1) shm_mq_attach calls: N-1 row senders + N-1 column receivers.
+        let peer_attach_calls = 2 * (header.n_procs as usize).saturating_sub(1);
         pgrx::warning!(
-            "mpp_trace mesh_init role=worker proc_idx={} procs={} peer_attaches={} attach_ms={:.2}",
+            "mpp_trace mesh_init role=worker proc_idx={} procs={} peer_attach_calls={} attach_ms={:.2}",
             proc_idx,
             header.n_procs,
-            peer_attaches,
+            peer_attach_calls,
             attach_ms,
         );
     }

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -49,6 +49,7 @@
 
 use std::ffi::c_void;
 use std::mem::size_of;
+use std::time::Instant;
 
 use pgrx::pg_sys;
 
@@ -281,6 +282,8 @@ pub(super) unsafe fn leader_init(
     // it only attaches to its own row and column below.
     let header = MppDsmHeader::from_layout(layout);
     let n_procs = layout.n_procs;
+    let trace_on = crate::gucs::mpp_trace();
+    let t_create = trace_on.then(Instant::now);
     for s in 0..n_procs {
         for r in 0..n_procs {
             let off = header.slot_offset(s, r) as usize;
@@ -288,8 +291,29 @@ pub(super) unsafe fn leader_init(
             unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.queue_bytes) };
         }
     }
+    let create_ms = t_create.map(|t| t.elapsed().as_secs_f64() * 1000.0);
 
-    Ok(unsafe { attach_proc_row_and_column(base, &header, 0, seg) })
+    let t_attach = trace_on.then(Instant::now);
+    let attach = unsafe { attach_proc_row_and_column(base, &header, 0, seg) };
+    let attach_ms = t_attach.map(|t| t.elapsed().as_secs_f64() * 1000.0);
+
+    if let (Some(create_ms), Some(attach_ms)) = (create_ms, attach_ms) {
+        // Peer-attach count excludes the self-loop slot, so N×(N-1). create touched all N² slots.
+        let peer_attaches = (n_procs as usize).saturating_sub(1);
+        let total_slots = (n_procs as usize) * (n_procs as usize);
+        pgrx::warning!(
+            "mpp_trace mesh_init role=leader procs={} slots_created={} peer_attaches={} queue_bytes={} plan_bytes={} create_ms={:.2} attach_ms={:.2}",
+            n_procs,
+            total_slots,
+            peer_attaches,
+            layout.queue_bytes,
+            plan_bytes.len(),
+            create_ms,
+            attach_ms,
+        );
+    }
+
+    Ok(attach)
 }
 
 /// Attach to the leader-initialized DSM region as `proc_idx` (`0 = leader`,
@@ -383,7 +407,20 @@ pub(super) unsafe fn worker_attach(
         .to_vec()
     };
 
+    let trace_on = crate::gucs::mpp_trace();
+    let t_attach = trace_on.then(Instant::now);
     let attach = unsafe { attach_proc_row_and_column(base, &header, proc_idx, seg) };
+    if let Some(t_attach) = t_attach {
+        let attach_ms = t_attach.elapsed().as_secs_f64() * 1000.0;
+        let peer_attaches = (header.n_procs as usize).saturating_sub(1);
+        pgrx::warning!(
+            "mpp_trace mesh_init role=worker proc_idx={} procs={} peer_attaches={} attach_ms={:.2}",
+            proc_idx,
+            header.n_procs,
+            peer_attaches,
+            attach_ms,
+        );
+    }
     Ok((header, plan_bytes, attach))
 }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -434,7 +434,7 @@ pub struct MppSender {
     /// `(stage_id, partition)` channel the receiver demultiplexes on. Per-sender rather than
     /// per-call: each partition gets its own `MppSender` via `clone_with_header`, all sharing
     /// the underlying `Arc<dyn BatchChannelSender>` of a single shm_mq queue.
-    header: MppFrameHeader,
+    pub(super) header: MppFrameHeader,
     /// Scratch buffer reused across every `encode_frame_into` on this sender. Sized by the
     /// first batch; subsequent batches clear and re-fill without reallocating. Interior
     /// mutability lets the caller keep the `&self` signature (each producer fragment holds

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -129,8 +129,15 @@ pub async fn run_worker_fragment(
             let eof_result = sender.as_ref().send_eof_traced(&mut stats).await;
             if let Some(wall_start) = wall_start {
                 let header = sender.as_ref().header;
+                // spin_iters and drain_in_spin_ms split send_wait_ms into "why":
+                //   spin_iters > 0 means the outbound shm_mq was full at least once.
+                //   drain_in_spin_ms is the subset of send_wait_ms this partition spent
+                //   pulling frames OFF its own inbound during the spin (cooperative drain
+                //   to unblock the mesh). The remainder (send_wait_ms - drain_in_spin_ms)
+                //   is pure yield-and-retry against a full outbound — i.e. consumer-side
+                //   drain isn't keeping up.
                 pgrx::warning!(
-                    "mpp_trace stage={} part={} rows_in={} batches={} wall_ms={:.1} first_batch_ms={:.1} pull_ms={:.1} send_ms={:.1} encode_ms={:.1} send_wait_ms={:.1}",
+                    "mpp_trace stage={} part={} rows_in={} batches={} wall_ms={:.1} first_batch_ms={:.1} pull_ms={:.1} send_ms={:.1} encode_ms={:.1} send_wait_ms={:.1} spin_iters={} drain_in_spin_ms={:.1}",
                     header.stage_id,
                     header.partition,
                     rows_in,
@@ -141,6 +148,8 @@ pub async fn run_worker_fragment(
                     send_ns as f64 / 1.0e6,
                     stats.encode.as_secs_f64() * 1000.0,
                     stats.send_wait.as_secs_f64() * 1000.0,
+                    stats.spin_iters,
+                    stats.coop_drain_in_spin.as_secs_f64() * 1000.0,
                 );
             }
             // Stream error first, then any EOF-send error so neither failure mode disappears.

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -36,6 +36,20 @@ use futures::stream::StreamExt;
 
 use crate::postgres::customscan::mpp::transport::{MppSender, SendBatchStats};
 
+/// Read this thread's accumulated CPU time in nanoseconds, via
+/// `CLOCK_THREAD_CPUTIME_ID`. Available on Linux and macOS 10.12+.
+/// Returns 0 if the clock isn't readable — diagnostics shouldn't propagate.
+fn thread_cpu_ns() -> u64 {
+    let mut ts: libc::timespec = unsafe { std::mem::zeroed() };
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut ts) };
+    if rc != 0 {
+        return 0;
+    }
+    (ts.tv_sec as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(ts.tv_nsec as u64)
+}
+
 /// Run a producer fragment plan to exhaustion and push every output batch
 /// through the corresponding `outbound_senders[partition]`.
 ///
@@ -136,7 +150,31 @@ pub async fn run_worker_fragment(
     // `join_all`, not `try_join_all`: fail-fast would cancel sibling partitions mid-await before
     // they hit `send_eof_traced`, leaving the consumer's channel buffer stuck and the leader's
     // `select_all` blocked.
+    //
+    // Fragment-level CPU saturation: with a current-thread tokio runtime, all partition futures
+    // share this thread. Sampling CPU around the whole join_all answers "did this PG worker's
+    // thread max out a core during the fragment, or was it blocked on shm_mq / upstream?" — a
+    // ~100% reading means adding cores per producer (G7-MT) would unlock parallelism; a low
+    // reading means shuffle or scan blocking is the binding constraint.
+    let frag_wall_start = trace_on.then(Instant::now);
+    let frag_cpu_start = trace_on.then(thread_cpu_ns);
     let results = futures::future::join_all(futures).await;
+    if trace_on {
+        let wall_ms = frag_wall_start.unwrap().elapsed().as_secs_f64() * 1000.0;
+        let cpu_ms = thread_cpu_ns().saturating_sub(frag_cpu_start.unwrap()) as f64 / 1.0e6;
+        let cpu_pct = if wall_ms > 0.0 {
+            cpu_ms / wall_ms * 100.0
+        } else {
+            0.0
+        };
+        pgrx::warning!(
+            "mpp_trace fragment_cpu partitions={} wall_ms={:.2} cpu_ms={:.2} cpu_pct={:.1}",
+            n_partitions,
+            wall_ms,
+            cpu_ms,
+            cpu_pct,
+        );
+    }
     drop(senders);
     for r in results {
         r?;

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -132,10 +132,25 @@ pub async fn run_worker_fragment(
                 // spin_iters and drain_in_spin_ms split send_wait_ms into "why":
                 //   spin_iters > 0 means the outbound shm_mq was full at least once.
                 //   drain_in_spin_ms is the subset of send_wait_ms this partition spent
-                //   pulling frames OFF its own inbound during the spin (cooperative drain
-                //   to unblock the mesh). The remainder (send_wait_ms - drain_in_spin_ms)
-                //   is pure yield-and-retry against a full outbound — i.e. consumer-side
-                //   drain isn't keeping up.
+                //   in try_drain_pass during the spin (cooperative drain to unblock the mesh).
+                //
+                // The remainder (send_wait_ms - drain_in_spin_ms) is everything else inside
+                // the spin loop: try_send_bytes calls, check_for_interrupts, yield_now().await,
+                // and scheduler wait between iterations. Under today's current_thread runtime
+                // with mpp_use_ffi_relay=off, those are sub-µs and the remainder is dominated
+                // by "consumer-side drain isn't keeping up." Under G7-MT (multi_thread runtime
+                // and/or ffi_relay routing), try_send/check_interrupts can hop through a relay
+                // round-trip per iter and the remainder no longer cleanly maps to "consumer slow."
+                //
+                // Per-edge attribution holds only under today's 1-partition-per-queue topology.
+                // MppSender supports multiplexing K partitions onto one shm_mq queue via per-frame
+                // headers; if that gets used, all partitions sharing a queue see the same spins
+                // and these counters become ambiguous on the producer side.
+                //
+                // Counters include the trailing send_eof_traced spin, so symmetric-EOF stalls
+                // (every peer full at the same instant) inflate spin_iters with a roughly
+                // constant offset across partitions — that's by design, but worth knowing when
+                // reading the trace.
                 pgrx::warning!(
                     "mpp_trace stage={} part={} rows_in={} batches={} wall_ms={:.1} first_batch_ms={:.1} pull_ms={:.1} send_ms={:.1} encode_ms={:.1} send_wait_ms={:.1} spin_iters={} drain_in_spin_ms={:.1}",
                     header.stage_id,

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -69,6 +69,13 @@ pub async fn run_worker_fragment(
         )));
     }
 
+    // Snapshot `paradedb.mpp_trace` once for the fragment-level instruments
+    // outside the per-partition futures. Read here (synchronous, backend
+    // thread) rather than inside the join_all closure below to avoid pgrx
+    // FFI from a tokio worker context. Per-partition futures re-read the
+    // GUC inside their own closure as today.
+    let trace_on = crate::gucs::mpp_trace();
+
     // Execute every output partition concurrently. Each partition gets its
     // own sender; pushes are independent. `Arc<MppSender>` so each
     // partition's future has its own clone (MppSender is `Sync`).

--- a/pg_search/src/postgres/customscan/mpp/worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker.rs
@@ -27,6 +27,7 @@
 //!   [`crate::postgres::customscan::mpp::glue::producer_worker_count`]).
 
 use std::sync::Arc;
+use std::time::Instant;
 
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
@@ -71,22 +72,63 @@ pub async fn run_worker_fragment(
         // explicitly here.
         futures.push(async move {
             let mut stats = SendBatchStats::default();
+            let trace_on = crate::gucs::mpp_trace();
+            let wall_start = trace_on.then(Instant::now);
+            let mut first_batch_ms: f64 = 0.0;
+            let mut pull_ns: u64 = 0;
+            let mut send_ns: u64 = 0;
+            let mut rows_in: u64 = 0;
+            let mut batches: u64 = 0;
             let stream_result: Result<(), DataFusionError> = async {
                 let mut stream = plan.execute(partition, ctx)?;
-                while let Some(batch) = stream.next().await {
+                let mut t = Instant::now();
+                loop {
+                    let next = stream.next().await;
+                    if trace_on {
+                        let dt = t.elapsed();
+                        pull_ns = pull_ns.saturating_add(dt.as_nanos() as u64);
+                        if batches == 0 && next.is_some() {
+                            first_batch_ms = wall_start.unwrap().elapsed().as_secs_f64() * 1000.0;
+                        }
+                    }
+                    let Some(batch) = next else { break };
                     let batch = batch?;
                     if batch.num_rows() == 0 {
+                        if trace_on { t = Instant::now(); }
                         continue;
                     }
+                    rows_in += batch.num_rows() as u64;
+                    batches += 1;
+                    let t_send = trace_on.then(Instant::now);
                     sender
                         .as_ref()
                         .send_batch_traced(&batch, &mut stats)
                         .await?;
+                    if let Some(t_send) = t_send {
+                        send_ns = send_ns.saturating_add(t_send.elapsed().as_nanos() as u64);
+                    }
+                    if trace_on { t = Instant::now(); }
                 }
                 Ok(())
             }
             .await;
             let eof_result = sender.as_ref().send_eof_traced(&mut stats).await;
+            if let Some(wall_start) = wall_start {
+                let header = sender.as_ref().header;
+                pgrx::warning!(
+                    "mpp_trace stage={} part={} rows_in={} batches={} wall_ms={:.1} first_batch_ms={:.1} pull_ms={:.1} send_ms={:.1} encode_ms={:.1} send_wait_ms={:.1}",
+                    header.stage_id,
+                    header.partition,
+                    rows_in,
+                    batches,
+                    wall_start.elapsed().as_secs_f64() * 1000.0,
+                    first_batch_ms,
+                    pull_ns as f64 / 1.0e6,
+                    send_ns as f64 / 1.0e6,
+                    stats.encode.as_secs_f64() * 1000.0,
+                    stats.send_wait.as_secs_f64() * 1000.0,
+                );
+            }
             // Stream error first, then any EOF-send error so neither failure mode disappears.
             stream_result.and(eof_result)
         });


### PR DESCRIPTION
## What

Three diagnostic instruments, all opt-in behind `paradedb.mpp_trace`. Default off; when on, each instrument emits one `WARNING` line per stage / partition / role:

1. **`mpp_trace mesh_init role=… create_ms=X attach_ms=Y`** — DSM allocation cost at mesh init. Leader + per-worker.
2. **`mpp_trace worker_cpu this_proc=I cpu_pct=X`** — per-worker fragment thread-CPU saturation. ~100% means CPU-bound; low means we're blocked.
3. **`mpp_trace stage=S part=P send_wait_ms=X spin_iters=N drain_in_spin_ms=Y`** — outbound backpressure with cooperative-drain split. Tells us how much of `send_wait` is the cooperative drain helping peers vs raw spinning.

Plus the pre-existing per-seat shuffle stats line (`c715df060`) that emits stage / partition / rows-in / batches and the encode timing on EOF.

## Why

When the MPP scaling curve doesn't bend the way we expect, we currently reach for ad-hoc `pgrx::warning!` lines every time. These three instruments separate the three dimensions that actually matter: mesh-init cost (DSM allocation, only matters at high N), producer CPU saturation (multi-thread future signal vs blocked), and shm_mq backpressure (transport bottleneck vs algorithm bottleneck).

## How

- `mpp::dsm::leader_init` and `worker_attach` time `create_at` + `attach_at` calls and emit `mesh_init` lines when `mpp_trace()`.
- `mpp::worker::run_worker_fragment` reads CPU time via `sysinfo::ProcessRefreshKind` deltas between `run_worker_fragment` start and finish; emits `worker_cpu` line per fragment.
- `mpp::worker` accumulates `SendBatchStats.send_wait` and `coop_drain_in_spin` across the fragment's sends and emits the split on EOF.

## Tests

- New `sysinfo` dependency (already used elsewhere in workspace).
- All existing MPP regress + integration suites pass with default off (no behavior change).
- Local smoke at N=4 / N=8 confirms all three instruments emit sensible values: mesh_init sub-ms, worker_cpu 95–97%, zero shm_mq pressure.

Extracted from PR #5155. The senior-review fix for instrument 2 (which reads from `MppRuntimeGucs` snapshot to keep the dispatcher closure off the backend-thread FFI path) is deferred to the G7-MT chunk because it depends on the GUC snapshot infrastructure landing first.