### PR TITLE
fix(mpp): split non-partitioning source segments across MPP workers.

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -662,6 +662,9 @@ impl SearchIndexReader {
     /// Search all available index segments for matching documents using lazy checkout from the
     /// parallel state to allow load balancing across parallel workers.
     ///
+    /// `source_idx = Some(i)` routes to `checkout_segment_for_source(i)` for MPP
+    /// non-partitioning sources. `None` uses the single-counter `checkout_segment` path.
+    ///
     /// `estimated_rows` is required because a lazily-evaluated iterator does not inherently know
     /// which or how many segments it will eventually open, and thus cannot compute an accurate
     /// sum of matching documents by asking each segment upfront. It should be passed the value
@@ -669,11 +672,18 @@ impl SearchIndexReader {
     pub fn search_lazy(
         &self,
         parallel_state: *mut crate::postgres::ParallelScanState,
+        source_idx: Option<usize>,
         estimated_rows: u64,
     ) -> MultiSegmentSearchResults {
         struct ParallelSegmentIterator {
             parallel_state: *mut crate::postgres::ParallelScanState,
+            source_idx: Option<usize>,
         }
+        // SAFETY: the pointer addresses DSM shared memory; the state's mutex serializes
+        // every access, including the cross-process claims this iterator drives.
+        // `Send`/`Sync` are required so DataFusion can wrap the iterator in
+        // `Box<dyn Iterator<...> + Send + Sync>` even though the runtime is
+        // current-thread.
         unsafe impl Send for ParallelSegmentIterator {}
         unsafe impl Sync for ParallelSegmentIterator {}
         impl Iterator for ParallelSegmentIterator {
@@ -681,13 +691,20 @@ impl SearchIndexReader {
             fn next(&mut self) -> Option<Self::Item> {
                 pgrx::check_for_interrupts!();
                 unsafe {
-                    crate::postgres::customscan::parallel::checkout_segment(self.parallel_state)
+                    match self.source_idx {
+                        Some(idx) => (*self.parallel_state).checkout_segment_for_source(idx),
+                        None => crate::postgres::customscan::parallel::checkout_segment(
+                            self.parallel_state,
+                        ),
+                    }
                 }
             }
         }
 
-        let segment_ids = ParallelSegmentIterator { parallel_state };
-
+        let segment_ids = ParallelSegmentIterator {
+            parallel_state,
+            source_idx,
+        };
         let searcher = self.searcher.clone();
         let query = self.query.box_clone();
         let need_scores = self.need_scores;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -601,6 +601,11 @@ async fn build_source_df(
     let mut provider = PgSearchTableProvider::new(scan_info, fields, is_parallel);
     if let Some(idx) = np_idx {
         provider.set_non_partitioning_index(idx);
+        // MPP: this source claims via `checkout_segment_for_source(plan_position)`
+        // instead of scanning the full data. Non-MPP: no `parallel_state`, no-op.
+        if mpp_ctx.is_some() {
+            provider.set_mpp_source_idx(plan_position);
+        }
     }
     // HeapFilter queries (e.g. `=` on a column indexed via a
     // `pdb.literal(...)` cast) compile to runtime Postgres expressions

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -411,6 +411,7 @@ impl ColumnarExecState {
         let state_partition = ScanState {
             recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
                 parallel_state: state.parallel_state,
+                source_idx: None,
                 planner_estimated_rows: 0,
                 scanner_config,
             },

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/normal.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/normal.rs
@@ -79,7 +79,7 @@ impl ExecMethod for NormalScanExecState {
         self.search_results = if let Some(parallel_state) = state.parallel_state {
             // NormalScanExecState evaluates isolated batches directly, so it does not participate
             // in global statistics planning for `estimated_rows`. Thus, we pass 0 here.
-            Some(search_reader.search_lazy(parallel_state, 0))
+            Some(search_reader.search_lazy(parallel_state, None, 0))
         } else {
             // not parallel, first time query
             Some(search_reader.search())

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -1058,6 +1058,13 @@ fn build_source_df<'a>(
         // canonical segment IDs during decode.
         if let Some(idx) = np_idx {
             provider.set_non_partitioning_index(idx);
+            // Gate on `mpp_is_active()`: joinscan EXEC passes `parallel_state` to the
+            // codec on both MPP and PG-parallel runs, but PG-parallel hash join still
+            // needs canonical-segment-ids replication so every worker sees the full
+            // build side.
+            if crate::postgres::customscan::mpp::glue::mpp_is_active() {
+                provider.set_mpp_source_idx(plan_position);
+            }
         }
 
         if let Some(ref sort_order) = scan_info.sort_order {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -1054,14 +1054,12 @@ fn build_source_df<'a>(
         let mut provider =
             PgSearchTableProvider::new(scan_info.clone(), fields.clone(), is_parallel);
 
-        // Mark non-partitioning sources so execution can retrieve the correct
-        // canonical segment IDs during decode.
+        // Both MPP and PG-parallel hash join need the canonical-segment-id
+        // replication so every worker sees the full build side, hence the outer
+        // `set_non_partitioning_index`. The MPP per-source claim counter goes on
+        // top of that and PG-parallel doesn't want it.
         if let Some(idx) = np_idx {
             provider.set_non_partitioning_index(idx);
-            // Gate on `mpp_is_active()`: joinscan EXEC passes `parallel_state` to the
-            // codec on both MPP and PG-parallel runs, but PG-parallel hash join still
-            // needs canonical-segment-ids replication so every worker sees the full
-            // build side.
             if crate::postgres::customscan::mpp::glue::mpp_is_active() {
                 provider.set_mpp_source_idx(plan_position);
             }

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -176,11 +176,18 @@ struct ParallelScanPayloadLayout {
     all_counts: Range<usize>,
     /// Concatenated 16-byte segment UUIDs for all sources, in ascending source-index order.
     all_ids: Range<usize>,
+    /// One `u32` per source: remaining unclaimed segments. Lets every source in a
+    /// multi-source MPP plan be partitioned across workers, not just the planner-chosen
+    /// partitioning source.
+    remaining_by_source: Range<usize>,
     /// One `u32` per segment in the partitioning source: deleted doc count.
     partitioning_deleted_docs: Range<usize>,
     /// One `u32` per segment in the partitioning source: max doc count.
     partitioning_max_docs: Range<usize>,
     /// One `i32` per segment in the partitioning source: which worker claimed it.
+    /// Sized to `partitioning_nsegments`, so non-partitioning sources have no slot
+    /// here. Read by [`ParallelScanState::explain_data`] to populate the "Parallel
+    /// Workers" section of `EXPLAIN ANALYZE`.
     claims: Range<usize>,
     aggregates_header: Option<Range<usize>>,
     aggregates_data: Option<Range<usize>>,
@@ -215,6 +222,10 @@ impl ParallelScanPayloadLayout {
         let all_ids_layout = Layout::from_size_align(total_segs * SEGMENT_ID_SIZE, 1)?;
         let (layout, all_ids_offset) = layout.extend(all_ids_layout)?;
         let all_ids_range = all_ids_offset..(all_ids_offset + all_ids_layout.size());
+
+        let remaining_layout = Layout::array::<u32>(n_sources)?;
+        let (layout, remaining_offset) = layout.extend(remaining_layout)?;
+        let remaining_range = remaining_offset..(remaining_offset + remaining_layout.size());
 
         // Deleted doc counts for the partitioning source only: [u32; partitioning_nsegments].
         let partitioning_del_layout = Layout::array::<u32>(partitioning_nsegments)?;
@@ -253,6 +264,7 @@ impl ParallelScanPayloadLayout {
             query: query_range,
             all_counts: all_counts_range,
             all_ids: all_ids_range,
+            remaining_by_source: remaining_range,
             partitioning_deleted_docs: partitioning_deleted_docs_range,
             partitioning_max_docs: partitioning_max_docs_range,
             claims: claims_range,
@@ -345,6 +357,17 @@ impl ParallelScanPayload {
         for claim in self.claims_mut().iter_mut() {
             *claim = SEGMENT_CLAIM_UNCLAIMED;
         }
+
+        // Skip slab init on single-source scans to keep the non-MPP parallel hot
+        // path free of per-source bookkeeping.
+        if all_sources.len() > 1 {
+            let remaining_range = self.layout.remaining_by_source.clone();
+            let remaining_slice: &mut [u32] =
+                bytemuck::try_cast_slice_mut(&mut self.data_mut()[remaining_range]).unwrap();
+            for (source, target) in all_sources.iter().zip(remaining_slice.iter_mut()) {
+                *target = source.len() as u32;
+            }
+        }
     }
 
     fn data(&self) -> &[u8] {
@@ -396,6 +419,11 @@ impl ParallelScanPayload {
 
     fn partitioning_max_docs(&self) -> &[u32] {
         bytemuck::try_cast_slice(&self.data()[self.layout.partitioning_max_docs.clone()]).unwrap()
+    }
+
+    fn remaining_by_source_mut(&mut self) -> &mut [u32] {
+        let range = self.layout.remaining_by_source.clone();
+        bytemuck::try_cast_slice_mut(&mut self.data_mut()[range]).unwrap()
     }
 
     /// An array of `i32` parallel worker numbers (as returned by pg_sys::ParallelWorkerNumber)
@@ -633,6 +661,12 @@ impl ParallelScanState {
     pub fn mark_initialized_empty(&mut self) {
         self.nsegments = 0;
         self.remaining_segments = 0;
+        // Mirror `populate()`'s gate: nothing to zero on single-source scans.
+        if self.payload.all_counts().len() > 1 {
+            for slot in self.payload.remaining_by_source_mut() {
+                *slot = 0;
+            }
+        }
         self.init_cv.broadcast();
     }
 
@@ -839,8 +873,35 @@ impl ParallelScanState {
             // this means we're purposely checking out segments from largest-to-smallest.
             let claimed_segment = self.decrement_remaining_segments();
             self.payload.claims_mut()[claimed_segment] = parallel_worker_number;
+            // `checkout_segment_for_source` never reads the partitioning slot, so
+            // don't mirror this decrement onto `remaining_by_source[partitioning_idx]`.
             break Some(self.segment_id(claimed_segment));
         }
+    }
+
+    /// Source-aware checkout for MPP non-partitioning sources. The `claims` array is
+    /// sized to the partitioning source's segment count and indexed by its segment
+    /// positions, so there's no slot to record a non-partitioning claim.
+    pub fn checkout_segment_for_source(&mut self, source_idx: usize) -> Option<SegmentId> {
+        self.wait_for_initialization();
+        let _mutex = self.acquire_mutex();
+        let counts = self.payload.all_counts();
+        let count_for_source = *counts.get(source_idx)? as usize;
+        if count_for_source == 0 {
+            return None;
+        }
+        let by_source = self.payload.remaining_by_source_mut();
+        let slot = by_source.get_mut(source_idx)?;
+        if *slot == 0 {
+            return None;
+        }
+        *slot -= 1;
+        let claimed_idx = *slot as usize;
+        // Positional lookup gives the same largest-to-smallest claim order
+        // `checkout_segment` uses on the partitioning source.
+        Some(SegmentId::from_bytes(
+            self.payload.source_ids(source_idx)[claimed_idx],
+        ))
     }
 
     /// Returns a map of segment IDs to their deleted document counts.
@@ -940,8 +1001,35 @@ impl ParallelScanState {
     /// Reset remaining_segments for a rescan. Called by amparallelrescan.
     pub fn reset(&mut self) {
         self.remaining_segments = self.nsegments;
+        // Rescan must re-partition the same way as the initial scan; without this,
+        // every source observes zero remaining and emits nothing. Skip for
+        // single-source (slab never populated).
+        if self.payload.all_counts().len() > 1 {
+            let counts: Vec<u32> = self.payload.all_counts().to_vec();
+            for (slot, count) in self
+                .payload
+                .remaining_by_source_mut()
+                .iter_mut()
+                .zip(counts.iter())
+            {
+                *slot = *count;
+            }
+        }
         // NOTE: We do not reset `queries_per_worker` here, so that it can be tracked across
         // rescans.
+    }
+
+    /// Per-source frozen segment set for `MvccSatisfies::ParallelWorker(ids)`. Lives
+    /// in the shared payload so workers don't need a codec channel for it. Waits for
+    /// leader init; otherwise a racing worker reads zero IDs.
+    pub fn segment_ids_for_source(&mut self, source_idx: usize) -> HashSet<SegmentId> {
+        self.wait_for_initialization();
+        let _mutex = self.acquire_mutex();
+        self.payload
+            .source_ids(source_idx)
+            .iter()
+            .map(|b| SegmentId::from_bytes(*b))
+            .collect()
     }
 }
 

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -528,10 +528,9 @@ pub struct ParallelScanState {
     /// Workers sleep on this CV instead of busy-waiting, and are woken
     /// when the leader calls `populate()`.
     init_cv: ConditionVariable,
-    /// Remaining segments to be claimed. Protected by mutex.
-    remaining_segments: usize,
     /// Number of segments in the partitioning source. Set to PARALLEL_STATE_UNINITIALIZED
-    /// until leader initializes. Protected by mutex.
+    /// until the leader initializes. Protected by mutex. Remaining work lives in
+    /// `payload.remaining_by_source[partitioning_source_idx]`.
     nsegments: usize,
     /// Index into the unified sources array identifying the partitioning source —
     /// the one from which workers claim segments via `checkout_segment`.
@@ -607,8 +606,10 @@ impl ParallelScanState {
             .get(partitioning_source_idx)
             .expect("partitioning_source_idx out of bounds")
             .len();
-        self.remaining_segments = partitioning_count;
-        // Set nsegments LAST - this signals initialization is complete
+        // Set nsegments LAST - this signals initialization is complete.
+        // Remaining counts live in `payload.remaining_by_source` (initialized in
+        // `ParallelScanPayload::init`); for the partitioning source the slot starts
+        // at `partitioning_count`.
         self.nsegments = partitioning_count;
 
         // Wake up any workers waiting in `wait_for_initialization()`.
@@ -648,7 +649,6 @@ impl ParallelScanState {
     /// Called by amparallelrescan before rescans.
     pub fn mark_uninitialized(&mut self) {
         self.nsegments = PARALLEL_STATE_UNINITIALIZED;
-        self.remaining_segments = 0;
     }
 
     /// Signal that initialization is complete with zero segments available.
@@ -656,23 +656,14 @@ impl ParallelScanState {
     /// segment count. Wakes workers so they exit cleanly.
     pub fn mark_initialized_empty(&mut self) {
         self.nsegments = 0;
-        self.remaining_segments = 0;
-        // Mirror `populate()`'s gate: nothing to zero on single-source scans.
-        if self.payload.all_counts().len() > 1 {
-            for slot in self.payload.remaining_by_source_mut() {
-                *slot = 0;
-            }
+        for slot in self.payload.remaining_by_source_mut() {
+            *slot = 0;
         }
         self.init_cv.broadcast();
     }
 
     pub fn acquire_mutex(&mut self) -> impl Drop {
         self.mutex.acquire()
-    }
-
-    fn decrement_remaining_segments(&mut self) -> usize {
-        self.remaining_segments -= 1;
-        self.remaining_segments
     }
 
     fn query_count(&mut self, parallel_worker_number: i32) -> Option<&mut u16> {
@@ -828,83 +819,76 @@ impl ParallelScanState {
         }
     }
 
-    /// Claim a segment from the shared pool.
-    /// Waits for initialization if needed, then returns None if no segments remain.
+    /// Claim a segment from the shared pool for the partitioning source.
     ///
-    /// Sibling of [`Self::checkout_segment_for_source`]; the two are kept apart
-    /// because the `claims` array is sized to the partitioning source's segment
-    /// count and only this path writes it, and the `debug_parallel_query` deadline
-    /// retry only matters on the partitioning source. A future refactor could fold
-    /// both into one source-indexed checkout once the `claims` array can grow over
-    /// all sources.
+    /// Thin wrapper over [`Self::checkout_for_source`] with `defer_leader_for_debug = true`,
+    /// which engages the `debug_parallel_query` deadline retry that only matters on
+    /// the partitioning source.
     pub fn checkout_segment(&mut self) -> Option<SegmentId> {
-        let parallel_worker_number = unsafe { pg_sys::ParallelWorkerNumber };
+        self.checkout_for_source(self.partitioning_source_idx, true)
+    }
 
-        // Wait for state to be initialized (defensive - should already be initialized
-        // by the time we get here since amrescan calls maybe_init_parallel_scan first)
+    /// Source-aware segment checkout. For the partitioning source, also records the
+    /// claim in the per-segment `claims` array (which is sized to that source's segment
+    /// count, so non-partitioning sources have no slot to write).
+    pub fn checkout_segment_for_source(&mut self, source_idx: usize) -> Option<SegmentId> {
+        self.checkout_for_source(source_idx, false)
+    }
+
+    fn checkout_for_source(
+        &mut self,
+        source_idx: usize,
+        defer_leader_for_debug: bool,
+    ) -> Option<SegmentId> {
+        let parallel_worker_number = unsafe { pg_sys::ParallelWorkerNumber };
         self.wait_for_initialization();
+
+        let total = *self.payload.all_counts().get(source_idx)? as usize;
+        if total == 0 {
+            return None;
+        }
+        let writes_claims = source_idx == self.partitioning_source_idx;
 
         #[cfg(not(feature = "pg15"))]
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
 
         loop {
             let _mutex = self.acquire_mutex();
-            let remaining = self.remaining_segments;
+            let remaining = *self.payload.remaining_by_source_mut().get(source_idx)? as usize;
             if remaining == 0 {
-                break None;
+                return None;
             }
 
-            // If debug_parallel_query is enabled and we're the leader, then do not take the first
-            // segment (unless a deadline has passed, since in some cases we may not have any workers:
-            // e.g. UNIONS under a Gather node, etc).
-            //
-            // This significantly improves the reproducibility of parallel worker issues with small
-            // datasets, since it means that unlike in the non-parallel case, the leader will be
-            // unlikely to emit all of the segments before the workers have had a chance to start up.
+            // `debug_parallel_query` leader-defer applies only to the partitioning
+            // source. With small datasets it gives workers a chance to start up
+            // before the leader walks the whole pool, which improves the
+            // reproducibility of parallel-worker issues; UNIONs under a Gather node
+            // may run without workers at all, hence the deadline escape.
             #[cfg(not(feature = "pg15"))]
-            if unsafe { pg_sys::debug_parallel_query } != 0
+            if defer_leader_for_debug
+                && unsafe { pg_sys::debug_parallel_query } != 0
                 && parallel_worker_number == -1
-                && remaining == self.nsegments
+                && remaining == total
                 && std::time::Instant::now() < deadline
             {
                 continue;
             }
 
-            // segments are claimed back-to-front and they were already organized smallest-to-largest
-            // by num_docs over in [`ParallelScanPayload::init()`].
-            //
-            // this means we're purposely checking out segments from largest-to-smallest.
-            let claimed_segment = self.decrement_remaining_segments();
-            self.payload.claims_mut()[claimed_segment] = parallel_worker_number;
-            // `checkout_segment_for_source` never reads the partitioning slot, so
-            // don't mirror this decrement onto `remaining_by_source[partitioning_idx]`.
-            break Some(self.segment_id(claimed_segment));
+            // segments are claimed back-to-front; the per-source ids were organized
+            // smallest-to-largest by num_docs in `ParallelScanPayload::init`, so
+            // claiming back-to-front gives largest-first.
+            let claimed_idx = {
+                let slot = self.payload.remaining_by_source_mut().get_mut(source_idx)?;
+                *slot -= 1;
+                *slot as usize
+            };
+            if writes_claims {
+                self.payload.claims_mut()[claimed_idx] = parallel_worker_number;
+            }
+            return Some(SegmentId::from_bytes(
+                self.payload.source_ids(source_idx)[claimed_idx],
+            ));
         }
-    }
-
-    /// Source-aware checkout for MPP non-partitioning sources. The `claims` array is
-    /// sized to the partitioning source's segment count and indexed by its segment
-    /// positions, so there's no slot to record a non-partitioning claim.
-    pub fn checkout_segment_for_source(&mut self, source_idx: usize) -> Option<SegmentId> {
-        self.wait_for_initialization();
-        let _mutex = self.acquire_mutex();
-        let counts = self.payload.all_counts();
-        let count_for_source = *counts.get(source_idx)? as usize;
-        if count_for_source == 0 {
-            return None;
-        }
-        let by_source = self.payload.remaining_by_source_mut();
-        let slot = by_source.get_mut(source_idx)?;
-        if *slot == 0 {
-            return None;
-        }
-        *slot -= 1;
-        let claimed_idx = *slot as usize;
-        // Positional lookup gives the same largest-to-smallest claim order
-        // `checkout_segment` uses on the partitioning source.
-        Some(SegmentId::from_bytes(
-            self.payload.source_ids(source_idx)[claimed_idx],
-        ))
     }
 
     /// Returns a map of segment IDs to their deleted document counts.
@@ -1001,22 +985,18 @@ impl ParallelScanState {
         self.payload.query()
     }
 
-    /// Reset remaining_segments for a rescan. Called by amparallelrescan.
+    /// Restore the per-source remaining counts for a rescan. Called by amparallelrescan.
     pub fn reset(&mut self) {
-        self.remaining_segments = self.nsegments;
-        // Rescan must re-partition the same way as the initial scan; without this,
-        // every source observes zero remaining and emits nothing. Skip for
-        // single-source (slab never populated).
-        if self.payload.all_counts().len() > 1 {
-            let counts: Vec<u32> = self.payload.all_counts().to_vec();
-            for (slot, count) in self
-                .payload
-                .remaining_by_source_mut()
-                .iter_mut()
-                .zip(counts.iter())
-            {
-                *slot = *count;
-            }
+        // Rescan re-partitions the same way as the initial scan, so reset every source's
+        // remaining count back to its initial value.
+        let counts: Vec<u32> = self.payload.all_counts().to_vec();
+        for (slot, count) in self
+            .payload
+            .remaining_by_source_mut()
+            .iter_mut()
+            .zip(counts.iter())
+        {
+            *slot = *count;
         }
         // NOTE: We do not reset `queries_per_worker` here, so that it can be tracked across
         // rescans.
@@ -1025,11 +1005,6 @@ impl ParallelScanState {
     /// Per-source frozen segment set for `MvccSatisfies::ParallelWorker(ids)`. Lives
     /// in the shared payload so workers don't need a codec channel for it. Waits for
     /// leader init; otherwise a racing worker reads zero IDs.
-    ///
-    /// Sibling of [`Self::non_partitioning_segment_ids`] which folds every
-    /// non-partitioning source in one mutex acquire; this one takes the mutex per
-    /// call. Same TODO as the checkout pair: a single source-indexed entry point
-    /// would be cleaner once the locking discipline is unified.
     pub fn segment_ids_for_source(&mut self, source_idx: usize) -> HashSet<SegmentId> {
         self.wait_for_initialization();
         let _mutex = self.acquire_mutex();

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -622,17 +622,10 @@ impl ParallelScanState {
     /// segments that the leader snapshotted for each replicated source. Returns an empty
     /// `Vec` for non-join or serial scans.
     pub fn non_partitioning_segment_ids(&self) -> Vec<HashSet<SegmentId>> {
-        let counts = self.payload.all_counts();
-        let mut result = Vec::new();
-        for i in 0..counts.len() {
-            if i == self.partitioning_source_idx {
-                continue;
-            }
-            let ids = self.payload.source_ids(i);
-            let set: HashSet<SegmentId> = ids.iter().map(|b| SegmentId::from_bytes(*b)).collect();
-            result.push(set);
-        }
-        result
+        (0..self.payload.all_counts().len())
+            .filter(|&i| i != self.partitioning_source_idx)
+            .map(|i| self.segment_ids_for_source_unlocked(i))
+            .collect()
     }
 
     /// Phase 1: Create the mutex but mark state as uninitialized.
@@ -1007,7 +1000,13 @@ impl ParallelScanState {
     /// leader init; otherwise a racing worker reads zero IDs.
     pub fn segment_ids_for_source(&mut self, source_idx: usize) -> HashSet<SegmentId> {
         self.wait_for_initialization();
-        let _mutex = self.acquire_mutex();
+        self.segment_ids_for_source_unlocked(source_idx)
+    }
+
+    /// Read-only sibling of [`Self::segment_ids_for_source`] for callers that already
+    /// know initialization is complete. No mutex acquire because the IDs are immutable
+    /// after `populate`.
+    fn segment_ids_for_source_unlocked(&self, source_idx: usize) -> HashSet<SegmentId> {
         self.payload
             .source_ids(source_idx)
             .iter()

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -358,15 +358,11 @@ impl ParallelScanPayload {
             *claim = SEGMENT_CLAIM_UNCLAIMED;
         }
 
-        // Skip slab init on single-source scans to keep the non-MPP parallel hot
-        // path free of per-source bookkeeping.
-        if all_sources.len() > 1 {
-            let remaining_range = self.layout.remaining_by_source.clone();
-            let remaining_slice: &mut [u32] =
-                bytemuck::try_cast_slice_mut(&mut self.data_mut()[remaining_range]).unwrap();
-            for (source, target) in all_sources.iter().zip(remaining_slice.iter_mut()) {
-                *target = source.len() as u32;
-            }
+        let remaining_range = self.layout.remaining_by_source.clone();
+        let remaining_slice: &mut [u32] =
+            bytemuck::try_cast_slice_mut(&mut self.data_mut()[remaining_range]).unwrap();
+        for (source, target) in all_sources.iter().zip(remaining_slice.iter_mut()) {
+            *target = source.len() as u32;
         }
     }
 
@@ -834,6 +830,13 @@ impl ParallelScanState {
 
     /// Claim a segment from the shared pool.
     /// Waits for initialization if needed, then returns None if no segments remain.
+    ///
+    /// Sibling of [`Self::checkout_segment_for_source`]; the two are kept apart
+    /// because the `claims` array is sized to the partitioning source's segment
+    /// count and only this path writes it, and the `debug_parallel_query` deadline
+    /// retry only matters on the partitioning source. A future refactor could fold
+    /// both into one source-indexed checkout once the `claims` array can grow over
+    /// all sources.
     pub fn checkout_segment(&mut self) -> Option<SegmentId> {
         let parallel_worker_number = unsafe { pg_sys::ParallelWorkerNumber };
 
@@ -1022,6 +1025,11 @@ impl ParallelScanState {
     /// Per-source frozen segment set for `MvccSatisfies::ParallelWorker(ids)`. Lives
     /// in the shared payload so workers don't need a codec channel for it. Waits for
     /// leader init; otherwise a racing worker reads zero IDs.
+    ///
+    /// Sibling of [`Self::non_partitioning_segment_ids`] which folds every
+    /// non-partitioning source in one mutex acquire; this one takes the mutex per
+    /// call. Same TODO as the checkout pair: a single source-indexed entry point
+    /// would be cleaner once the locking discipline is unified.
     pub fn segment_ids_for_source(&mut self, source_idx: usize) -> HashSet<SegmentId> {
         self.wait_for_initialization();
         let _mutex = self.acquire_mutex();

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -219,7 +219,9 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         let mut provider: PgSearchTableProvider = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("Failed to deserialize PgSearchTableProvider: {e}"))
         })?;
-        if provider.is_parallel() {
+        // Non-partitioning MPP sources also call `checkout_segment_for_source` against
+        // `parallel_state`, so inject the pointer for them too.
+        if provider.is_parallel() || provider.mpp_source_idx().is_some() {
             provider.set_parallel_state(self.parallel_state);
         }
         if let Some(np_idx) = provider.non_partitioning_index() {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -93,9 +93,14 @@ pub enum ScanRecipe {
         segment_ids: Vec<SegmentId>,
         scanner_config: ScannerConfig,
     },
-    /// Lazy scan: segments are claimed dynamically from parallel state.
+    /// Lazy claim from `ParallelScanState`. `source_idx = Some(i)` claims from source
+    /// `i`'s pool for MPP non-partitioning sources; `None` uses the single-counter
+    /// `checkout_segment` for the basescan IAM, the MPP partitioning source, and
+    /// non-MPP parallel hash join. The non-partitioning path can't update the
+    /// partitioning-source-sized `claims` array.
     Lazy {
         parallel_state: Option<*mut ParallelScanState>,
+        source_idx: Option<usize>,
         planner_estimated_rows: u64,
         scanner_config: ScannerConfig,
     },
@@ -488,13 +493,18 @@ impl ExecutionPlan for PgSearchScanPlan {
                         }
                         ScanRecipe::Lazy {
                             parallel_state,
+                            source_idx,
                             planner_estimated_rows,
                             scanner_config,
                         } => {
-                            let res = if let Some(ps) = parallel_state {
-                                reader.search_lazy(ps, planner_estimated_rows)
-                            } else {
-                                reader.search()
+                            let res = match (parallel_state, source_idx) {
+                                (Some(ps), idx) => {
+                                    reader.search_lazy(ps, idx, planner_estimated_rows)
+                                }
+                                (None, Some(_)) => panic!(
+                                    "per-source claim needs `parallel_state` installed before recipe execution"
+                                ),
+                                (None, None) => reader.search(),
                             };
                             (res, scanner_config)
                         }

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -137,7 +137,6 @@ pub struct PgSearchTableProvider {
     /// `checkout_segment_for_source(source_idx)`, so `NetworkShuffleExec` doesn't
     /// receive N copies. `None` for serial, the partitioning source, and non-MPP
     /// parallel hash join.
-    #[serde(default)]
     mpp_source_idx: Option<usize>,
 }
 
@@ -234,6 +233,7 @@ impl PgSearchTableProvider {
     pub(crate) fn mpp_source_idx(&self) -> Option<usize> {
         self.mpp_source_idx
     }
+
     fn enable_deferred_columns(&mut self, required_early_columns: &HashSet<String>) {
         for wff in self.fields.iter_mut() {
             if let WhichFastField::Named(name, field_type) = wff {

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -131,6 +131,14 @@ pub struct PgSearchTableProvider {
     /// and load (in get_schema) execute sequentially within the same single-threaded optimization pass.
     #[serde(with = "atomic_bool_serde")]
     late_materialization_active: AtomicBool,
+
+    /// Source position in the MPP unified-sources array. When set, the codec's
+    /// `parallel_state` routes per-source claims via
+    /// `checkout_segment_for_source(source_idx)`, so `NetworkShuffleExec` doesn't
+    /// receive N copies. `None` for serial, the partitioning source, and non-MPP
+    /// parallel hash join.
+    #[serde(default)]
+    mpp_source_idx: Option<usize>,
 }
 
 mod atomic_bool_serde {
@@ -171,6 +179,7 @@ impl PgSearchTableProvider {
             canonical_segment_ids: None,
             visibility_mode: VisibilityMode::Eager,
             late_materialization_active: AtomicBool::new(false),
+            mpp_source_idx: None,
         }
     }
 
@@ -185,7 +194,10 @@ impl PgSearchTableProvider {
     }
 
     pub(crate) fn set_parallel_state(&mut self, parallel_state: Option<*mut ParallelScanState>) {
-        assert!(self.is_parallel);
+        // Non-partitioning MPP sources need `parallel_state` for
+        // `checkout_segment_for_source`, but `is_parallel` stays false so the
+        // logical-plan rules (partitioning-source-only segment ordering) keep working.
+        assert!(self.is_parallel || self.mpp_source_idx.is_some());
         self.parallel_state = parallel_state;
     }
 
@@ -212,6 +224,15 @@ impl PgSearchTableProvider {
 
     pub(crate) fn set_planstate(&mut self, planstate: Option<*mut pg_sys::PlanState>) {
         self.planstate = planstate;
+    }
+
+    /// See [`PgSearchTableProvider::mpp_source_idx`] for what this gates.
+    pub(crate) fn set_mpp_source_idx(&mut self, idx: usize) {
+        self.mpp_source_idx = Some(idx);
+    }
+
+    pub(crate) fn mpp_source_idx(&self) -> Option<usize> {
+        self.mpp_source_idx
     }
     fn enable_deferred_columns(&mut self, required_early_columns: &HashSet<String>) {
         for wff in self.fields.iter_mut() {
@@ -617,6 +638,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         query_for_display: SearchQueryInput,
         planner_estimated_rows: u64,
+        mpp_source_idx: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -624,12 +646,14 @@ impl PgSearchTableProvider {
             heap_relid: heap_relid.into(),
             batch_size_hint: None,
         };
+        let recipe = crate::scan::execution_plan::ScanRecipe::Lazy {
+            parallel_state,
+            source_idx: mpp_source_idx,
+            planner_estimated_rows,
+            scanner_config,
+        };
         let state = ScanState {
-            recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
-                parallel_state,
-                planner_estimated_rows,
-                scanner_config,
-            },
+            recipe,
             ffhelper: ffhelper.clone(),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader: reader.clone(),
@@ -759,22 +783,35 @@ impl PgSearchTableProvider {
             query.solve_postgres_expressions(expr_context);
         }
 
-        // Determine MVCC strategy based on whether we are running in parallel mode.
+        // MVCC dispatch by (`mpp_source_idx`, `parallel_state`, `canonical_segment_ids`):
         //
-        // For the partitioning source (`parallel_state` is Some):
-        //   - Leader: Snapshot (claims segments dynamically; its own snapshot is the source
-        //             of truth for which segments exist).
-        //   - Workers: ParallelWorker(partitioning_segment_ids) – frozen set from leader.
+        // MPP non-partitioning (`mpp_source_idx` Some, `parallel_state` Some): every
+        // worker opens the leader's frozen segment set from `ParallelScanState`, then
+        // claims a slice via `checkout_segment_for_source`.
         //
-        // For non-partitioning / replicated sources (`canonical_segment_ids` is Some):
-        //   - Both leader and workers use ParallelWorker(canonical_ids) so that every
-        //     participant opens exactly the same frozen segment set, preventing DocAddress
-        //     mismatches when late materialization stores (segment_ord, doc_id) pairs.
+        // Non-MPP parallel hash join (`canonical_segment_ids` Some): every worker opens
+        // the leader-snapshotted set, matching PG's worker scheduling.
         //
-        // Serial scans (both fields None): Snapshot.
-        let mvcc_style = if let Some(ids) = canonical_segment_ids {
-            // Non-partitioning source in a parallel join scan: use the frozen segment list
-            // that the leader snapshotted and wrote to shared memory.
+        // Partitioning source (`parallel_state` Some): leader uses Snapshot, workers use
+        // `ParallelWorker(partitioning_segment_ids)`.
+        //
+        // Serial (all None): Snapshot.
+        let mvcc_style = if let Some(source_idx) = self.mpp_source_idx {
+            if let Some(parallel_state) = parallel_state {
+                unsafe {
+                    let ids = (*parallel_state).segment_ids_for_source(source_idx);
+                    MvccSatisfies::ParallelWorker(ids)
+                }
+            } else if let Some(ids) = canonical_segment_ids.clone() {
+                // Codec injected canonical IDs without `parallel_state`. Fallback to the
+                // frozen set the leader recorded.
+                MvccSatisfies::ParallelWorker(ids)
+            } else {
+                MvccSatisfies::Snapshot
+            }
+        } else if let Some(ids) = canonical_segment_ids {
+            // Non-MPP parallel join scan: open the leader's frozen segment list from
+            // shared memory.
             MvccSatisfies::ParallelWorker(ids)
         } else if let Some(parallel_state) = parallel_state {
             unsafe {
@@ -851,6 +888,7 @@ impl PgSearchTableProvider {
                 projected_schema,
                 query,
                 total_estimated_rows,
+                self.mpp_source_idx,
             )
         }
     }


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR adds a per-source segment-claim counter to `ParallelScanState`. Each source in a multi-source MPP plan gets its own dynamic checkout, instead of every worker scanning the full data for every non-partitioning source.

## Why

MPP returned `n_workers * correct_count` on every join shape. PG-only returned 7.5M; MPP at N=3 returned 15M, N=5 returned 30M, N=9 returned 60M. Workers all opened the same frozen segment set for every non-partitioning source and scanned the full data. The shuffle then shipped N copies of those rows to consumer tasks, and the join + aggregate above counted each row N times.

The frozen-set replication is deliberate. It keeps `(segment_ord, doc_id)` pairs consistent across workers for late materialization. The bug was the missing follow-up step to actually divide the segments between workers.

## How

The shared parallel-scan state used to track remaining segments only for the partitioning source. It now tracks them for every source. When MPP runs a multi-source plan, each non-partitioning source gets its own counter in shared memory, and workers claim from whichever source they're scanning. Each source's segments get divided between workers the same way the partitioning source's already were.

Workers still open the same frozen segment set per non-partitioning source, which is what keeps late materialization correct after the shuffle. The set itself moved out of the per-fragment codec channel into shared payload state, since every worker can read it directly once the leader has snapshotted.

The two MPP customscans tag each non-partitioning source with its position in the source list. The tag activates the per-source claim path only when MPP is the active execution mode. Under PG's own parallel hash join, the driver does its own work splitting and still wants every worker to open the full set, so the replication path stays in place there.

Single-source scans (BaseScan parallel, single-table top-k, paging, count) never enter any of this. The per-source bookkeeping is gated on multiple sources being present, so the non-MPP parallel hot path pays no extra cost.

## Tests

MPP multi-source join + aggregate returns correct result. Non-MPP parallel hash join returns the same.

Caveat: per-source work distribution is bounded by segment count. With one segment and N workers, only one worker scans that source. A low-segment fallback (doc-modulo or `target_min_segments` GUC) is a follow-up.