### PR TITLE
chore: Prepare 0.23.5

### DIFF
--- a/docs/changelog/0.23.5.mdx
+++ b/docs/changelog/0.23.5.mdx
@@ -1,0 +1,23 @@
+---
+title: 0.23.5
+noindex: true
+---
+
+## New Features 🎉
+
+- Aggregate-on-join pushdown now handles `IN (SELECT ...)`, `NOT IN (SELECT ...)`, `EXISTS`, and `NOT EXISTS` subqueries end-to-end, including null-aware semantics for `NOT IN` against NULL-bearing inner rows.
+
+## Stability Improvements 💪
+
+- Hold the header shared lock during `LinkedItemList` iteration to prevent an FSM race that could cause segfaults or index corruption under sustained write traffic.
+- Ignore segments with dead PIDs during merge so that segments from aborted merges are not permanently blocked from re-merging.
+- Quote the `key_field` identifier in `pdb.more_like_this`'s internal SPI lookup so that mixed-case key field columns (e.g. `"Id"`, `"DocumentId"`) work correctly.
+- Fix text casts and memory layout for tokenizer types so that they function as regular SQL types (writable to disk, reallocatable across memory contexts).
+- Turn off `paradedb.enable_columnar_sort` by default.
+
+## New Contributors 👋
+
+- [@SBALAVIGNESH123](https://github.com/SBALAVIGNESH123) made their first contribution in [#5067](https://github.com/paradedb/paradedb/pull/5067)
+- [@daniel3303](https://github.com/daniel3303) made their first contribution in [#5078](https://github.com/paradedb/paradedb/pull/5078)
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.23.5).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -39,7 +39,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.23.4-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.23.5-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -36,7 +36,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.23.4` with the `pg_search` version you wish to install and
+  You can replace `0.23.5` with the `pg_search` version you wish to install and
   `18` with the version of Postgres you are using.
 </Note>
 
@@ -44,49 +44,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/postgresql-18-pg-search_0.23.4-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/postgresql-18-pg-search_0.23.5-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/postgresql-18-pg-search_0.23.4-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/postgresql-18-pg-search_0.23.5-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/postgresql-18-pg-search_0.23.4-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/postgresql-18-pg-search_0.23.5-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/postgresql-18-pg-search_0.23.4-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/postgresql-18-pg-search_0.23.5-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/pg_search_18-0.23.4-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/pg_search_18-0.23.5-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/pg_search_18-0.23.4-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/pg_search_18-0.23.5-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/pg_search@18--0.23.4.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/pg_search@18--0.23.5.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.4/pg_search@18--0.23.4.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.23.5/pg_search@18--0.23.5.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -37,7 +37,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.23.4`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.23.5`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -79,10 +79,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.23.4
+docker pull paradedb/paradedb:0.23.5
 ```
 
-The latest version of the Docker image should be `0.23.4`.
+The latest version of the Docker image should be `0.23.5`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -99,7 +99,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.23.4';
+ALTER EXTENSION pg_search UPDATE TO '0.23.5';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.23.4",
+        "version": "v0.23.5",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -345,6 +345,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.23.5",
                   "changelog/0.23.4",
                   "changelog/0.23.3",
                   "changelog/0.23.2",

--- a/pg_search/sql/pg_search--0.23.3--0.23.4.sql
+++ b/pg_search/sql/pg_search--0.23.3--0.23.4.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.4'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.23.3--0.23.4.sql
+++ b/pg_search/sql/pg_search--0.23.3--0.23.4.sql
@@ -1,1 +1,0 @@
-\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.4'" to load this file. \quit

--- a/pg_search/sql/pg_search--0.23.4--0.23.5.sql
+++ b/pg_search/sql/pg_search--0.23.4--0.23.5.sql
@@ -1,3 +1,5 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.5'" to load this file. \quit
+
 ALTER TYPE pdb.ngram SET (RECEIVE = NONE, SEND = NONE, STORAGE = EXTENDED);
 DROP FUNCTION IF EXISTS pdb.ngram_send(pdb.ngram);
 DROP FUNCTION IF EXISTS pdb.ngram_recv(internal);


### PR DESCRIPTION
Release preparation for 0.23.5, cut from the [`0.23.x`](https://github.com/paradedb/paradedb/tree/0.23.x) stable branch.

## Summary

- Add `docs/changelog/0.23.5.mdx` summarizing user-facing changes since 0.23.4 on the `0.23.x` branch
- Add the `\echo Use "ALTER EXTENSION ..."` guard to `pg_search--0.23.4--0.23.5.sql` and remove the now-superseded guard from `pg_search--0.23.3--0.23.4.sql`
- Bump version references in the upgrade docs and `docs/docs.json` to `0.23.5`

`Cargo.toml`/`Cargo.lock` are already at `0.23.5` (bumped in [#4900](https://github.com/paradedb/paradedb/pull/4900)).