### PR TITLE
feat(mpp): collapsed N×(N-1) shm_mq grid to N MPSC inboxes.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -139,7 +139,7 @@
           # Check the Nix formatting for all Nix files
           nix-fmt = pkgs.runCommand "check-nix-formatting" { } ''
             cd ${self}
-            ${lib.getExe pkgs.nixfmt} --check $(find . -name '*.nix') 
+            ${lib.getExe pkgs.nixfmt} --check $(find . -name '*.nix')
             touch $out
           '';
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -673,7 +673,6 @@ impl ParallelQueryCapable for AggregateScan {
         let Some(plan_bytes) = df_state.mpp_plan_bytes.take() else {
             return;
         };
-        let seg = unsafe { (*pcxt).seg };
 
         // Capture manifests + size the ParallelScanState block.
         Self::ensure_source_manifests(state);
@@ -727,7 +726,7 @@ impl ParallelQueryCapable for AggregateScan {
         // Init the MPP region.
         let mpp_coordinate =
             unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut std::os::raw::c_void };
-        let leader = match unsafe { leader_setup(mpp_coordinate, seg, pcxt, plan_bytes) } {
+        let leader = match unsafe { leader_setup(mpp_coordinate, pcxt, plan_bytes) } {
             Ok(l) => l,
             Err(e) => {
                 pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");
@@ -788,14 +787,7 @@ impl ParallelQueryCapable for AggregateScan {
             unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut std::os::raw::c_void };
         let region_total = unsafe { (*mpp_coordinate.cast::<MppDsmHeader>()).region_total };
         let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
-        let worker = match unsafe {
-            worker_setup(
-                mpp_coordinate,
-                region_total,
-                worker_number,
-                std::ptr::null_mut(),
-            )
-        } {
+        let worker = match unsafe { worker_setup(mpp_coordinate, region_total, worker_number) } {
             Ok(w) => w,
             Err(e) => {
                 pgrx::warning!("mpp: worker_setup failed: {e}; falling back to serial");

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -897,8 +897,7 @@ impl ParallelQueryCapable for JoinScan {
         };
 
         let mpp_coordinate = unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut c_void };
-        let seg = unsafe { (*pcxt).seg };
-        match unsafe { leader_setup(mpp_coordinate, seg, pcxt, plan_bytes) } {
+        match unsafe { leader_setup(mpp_coordinate, pcxt, plan_bytes) } {
             Ok(leader) => {
                 state.custom_state_mut().mpp = Some(MppExecState::Leader(leader));
             }
@@ -958,14 +957,7 @@ impl ParallelQueryCapable for JoinScan {
                 .region_total
         };
         let worker_number = unsafe { pg_sys::ParallelWorkerNumber };
-        match unsafe {
-            worker_setup(
-                mpp_coordinate,
-                region_total,
-                worker_number,
-                std::ptr::null_mut(),
-            )
-        } {
+        match unsafe { worker_setup(mpp_coordinate, region_total, worker_number) } {
             Ok(worker) => {
                 state.custom_state_mut().mpp = Some(MppExecState::Worker(worker));
             }

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Multiplexed N×N DSM layout for the natural-shape MPP architecture.
+//! Mesh-multiplexed DSM layout: one MPSC inbox per receiver process.
 //!
 //! Each MPP query allocates a single DSM region containing:
 //!
@@ -28,39 +28,62 @@
 //!   +-------------------------------------------------------+
 //!   | padding to MAXALIGN                                   |
 //!   +-------------------------------------------------------+
-//!   | shm_mq queue array: n_procs × n_procs slots           |
-//!   |   slot(sender, receiver) = queues_offset              |
-//!   |     + (sender * n_procs + receiver) * queue_bytes     |
+//!   | DsmMpscRing inbox array: n_procs inboxes              |
+//!   |   inbox(receiver) = queues_offset                     |
+//!   |     + receiver * queue_bytes                          |
 //!   +-------------------------------------------------------+
 //! ```
 //!
 //! - `n_procs` is the total proc count (1 leader + N parallel workers).
 //!   Leader is `proc_idx = 0`; workers are `proc_idx = ParallelWorkerNumber + 1`.
-//! - Every process attaches as **sender** to its row (`slot(this, *)`) and as
-//!   **receiver** to its column (`slot(*, this)`). The grid is uniform and
-//!   independent of plan shape: a single multiplexed queue per process-pair
-//!   carries frames for any number of logical `(stage_id, partition)`
-//!   channels, demultiplexed on the receive side via the `MppFrameHeader`
-//!   prefix.
-//! - Self-loop slots (`slot(k, k)`) are reserved in the layout and
-//!   `shm_mq_create`'d by the leader so the slot-offset math stays a simple
-//!   row-major index, but no process attaches as sender or receiver to its
-//!   own self-loop.
+//! - Each process attaches as **receiver** to its own inbox (one MPSC ring) and as
+//!   **sender** to each of N-1 peer inboxes. Total queues per mesh is `n_procs`; total
+//!   attach calls per proc is `1 + (N-1) = N`. Senders stamp
+//!   `MppFrameHeader::sender_proc` on every frame so the receiver demultiplexes by
+//!   source on read.
+//! - Self-loop frames (proc → itself) use an in-proc channel installed in `glue.rs`,
+//!   not a DSM slot. MPSC ring semantics + the way `DsmMpscReceiver` is used (one
+//!   handle owned by the receiver process) means there is no DSM slot for the
+//!   self-loop pair in this layout.
 
 use std::ffi::c_void;
 use std::mem::size_of;
+use std::time::Instant;
 
 use pgrx::pg_sys;
 
-use crate::postgres::customscan::mpp::mesh::{
-    align_up_maxalign_checked, aligned_queue_bytes, ShmMqReceiver, ShmMqSender,
+use crate::postgres::customscan::mpp::dsm_mpsc_ring::{
+    self, DsmMpscReceiver, DsmMpscRingHeader, DsmMpscSender,
 };
+use crate::postgres::customscan::mpp::mesh::{align_up_maxalign_checked, aligned_queue_bytes};
+
+/// Number of slots in each per-receiver MPSC ring. With operator-visible
+/// `paradedb.mpp_queue_size` divided across `RING_SLOTS` slots, each slot holds
+/// up to `(queue_bytes / RING_SLOTS) - SLOT_HEADER` bytes of payload. That's enough
+/// for typical Arrow batches at the bench scales we measured. Fixed at compile time
+/// for now; a future GUC could expose it if bench data points at a different sweet
+/// spot.
+const RING_SLOTS: u32 = 8;
+
+/// Cache-line alignment for the per-inbox DsmMpscRing header. The ring's
+/// `#[repr(C, align(64))]` mandates 64-byte alignment at every `create_at`/`attach_at`
+/// site; both `queues_offset` and per-inbox `queue_bytes` are aligned up to this so the
+/// computed `inbox_offset(r) = queues_offset + r * queue_bytes` lands at a 64-aligned
+/// address for every `r`.
+const RING_ALIGN: usize = 64;
+
+#[inline]
+fn align_up_ring(n: usize) -> Option<usize> {
+    let mask = RING_ALIGN - 1;
+    n.checked_add(mask).map(|x| x & !mask)
+}
 
 const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
-/// Bumped on any wire-incompatible change to the DSM header layout or to the slot-offset math,
+/// Bumped on any wire-incompatible change to the DSM header layout or to the inbox-offset math,
 /// so attaching workers reject mismatched leaders loudly rather than reading garbage. Validated
-/// in [`MppDsmHeader::validate`].
-const MPP_DSM_HEADER_VERSION: u32 = 3;
+/// in [`MppDsmHeader::validate`]. v4: mesh-multiplexed layout (one MPSC ring per receiver, was
+/// per-pair shm_mq grid in v3).
+const MPP_DSM_HEADER_VERSION: u32 = 4;
 
 /// Absolute cap on DSM region size. 16 GiB is two orders of magnitude beyond
 /// any realistic workload; the cap fails early on a pathologically oversized
@@ -127,16 +150,16 @@ impl MppDsmHeader {
         Ok(())
     }
 
-    /// Byte offset (relative to DSM base) of the queue at `(sender_proc, receiver_proc)`.
+    /// Byte offset (relative to DSM base) of `receiver_proc`'s MPSC inbox.
     ///
-    /// Every process attaches as sender for its row (`slot(this, *)`) and as
-    /// receiver for its column (`slot(*, this)`). Self-loops (`slot(k, k)`)
-    /// are present in the grid but rarely used at runtime.
-    pub(super) fn slot_offset(&self, sender_proc: u32, receiver_proc: u32) -> u64 {
-        debug_assert!(sender_proc < self.n_procs);
+    /// Mesh-multiplexed layout: exactly one `DsmMpscRing`-shaped inbox per process.
+    /// The owner attaches as receiver (`DsmMpscReceiver`); every other process attaches
+    /// as sender (`DsmMpscSender`) to the same inbox and stamps its identity into the
+    /// frame header (`MppFrameHeader::sender_proc`). Total queues per mesh is `n_procs`
+    /// rings (one per receiver) instead of `n_procs * (n_procs - 1)` per-pair queues.
+    pub(super) fn inbox_offset(&self, receiver_proc: u32) -> u64 {
         debug_assert!(receiver_proc < self.n_procs);
-        let slot = (sender_proc as u64) * (self.n_procs as u64) + (receiver_proc as u64);
-        self.queues_offset + slot * self.queue_bytes
+        self.queues_offset + (receiver_proc as u64) * self.queue_bytes
     }
 }
 
@@ -153,9 +176,13 @@ pub(super) struct DsmLayout {
 
 /// Compute the DSM region size and field offsets for one MPP query.
 ///
-/// `n_procs` is the total proc count (1 leader + N workers). The
-/// shm_mq grid is `n_procs × n_procs`; each process attaches as sender to its
-/// row and receiver to its column.
+/// `n_procs` is the total proc count (1 leader + N workers). Mesh-multiplexed layout:
+/// one `DsmMpscRing` inbox per process (`n_procs` queues total per mesh). Every other
+/// process attaches as sender to that inbox and demultiplexes by
+/// `MppFrameHeader::sender_proc` on the receive side.
+///
+/// `queue_bytes` is the per-inbox total (ring header + `RING_SLOTS` slots). Operator-
+/// facing `paradedb.mpp_queue_size` controls this value.
 pub(super) fn compute_dsm_layout(
     n_procs: u32,
     queue_bytes: usize,
@@ -164,9 +191,20 @@ pub(super) fn compute_dsm_layout(
     if n_procs < 2 {
         return Err("mpp: n_procs must be >= 2 (leader + at least one worker)");
     }
+    // MAXALIGN-round-down first (operator-friendly), then round up to the ring's
+    // 64-byte alignment requirement. Doing it in this order means each per-inbox
+    // region is both MAXALIGN-aligned (PG DSM convention) AND cache-line aligned
+    // (DsmMpscRingHeader's repr(C, align(64)) requirement).
     let queue_bytes = aligned_queue_bytes(queue_bytes);
     if queue_bytes == 0 {
         return Err("mpp: queue_bytes too small after alignment");
+    }
+    let queue_bytes = align_up_ring(queue_bytes).ok_or("mpp: queue_bytes alignment overflow")?;
+    // Sanity: each inbox must have room for the ring header + at least RING_SLOTS slots
+    // of one byte each (we don't pin a minimum payload size, just that the ring is
+    // constructible).
+    if queue_bytes < DsmMpscRingHeader::region_bytes(RING_SLOTS, 1) {
+        return Err("mpp: queue_bytes too small for ring header + min slots");
     }
     let header_end = align_up_maxalign_checked(size_of::<MppDsmHeader>())
         .ok_or("mpp: header alignment overflow")?;
@@ -174,12 +212,11 @@ pub(super) fn compute_dsm_layout(
     let plan_end = plan_offset
         .checked_add(plan_len)
         .ok_or("mpp: plan offset+len overflow")?;
-    let queues_offset =
-        align_up_maxalign_checked(plan_end).ok_or("mpp: queues alignment overflow")?;
-    let total_slots = (n_procs as usize)
-        .checked_mul(n_procs as usize)
-        .ok_or("mpp: n_procs × n_procs overflow")?;
-    let queues_bytes = total_slots
+    // Round queues_offset up to RING_ALIGN so the first inbox starts at a 64-aligned
+    // address; subsequent inboxes are queue_bytes apart and queue_bytes is RING_ALIGN-
+    // aligned, so they all land on cache-line boundaries.
+    let queues_offset = align_up_ring(plan_end).ok_or("mpp: queues alignment overflow")?;
+    let queues_bytes = (n_procs as usize)
         .checked_mul(queue_bytes)
         .ok_or("mpp: queues bytes overflow")?;
     let region_total = queues_offset
@@ -198,22 +235,34 @@ pub(super) fn compute_dsm_layout(
     })
 }
 
-/// Per-proc return: handles for the process's row (senders) and
-/// column (receivers) in the multiplexed `n_procs × n_procs` grid.
+/// Derive `(ring_slots, slot_capacity)` for a per-inbox region of `queue_bytes`.
+/// Total ring region size = `DsmMpscRingHeader::region_bytes(ring_slots, slot_capacity)`
+/// which fits within `queue_bytes` by construction.
+fn ring_dims_for(queue_bytes: usize) -> (u32, u32) {
+    let header = std::mem::size_of::<DsmMpscRingHeader>();
+    // queue_bytes >= ring_dims minimum is enforced in compute_dsm_layout; we recompute
+    // here without re-validating.
+    let slot_total_bytes = queue_bytes.saturating_sub(header);
+    let slot_capacity = (slot_total_bytes / RING_SLOTS as usize).max(64);
+    // Cap slot_capacity at u32::MAX (DsmMpscRing's field type) to avoid casting wrap.
+    let slot_capacity = slot_capacity.min(u32::MAX as usize) as u32;
+    (RING_SLOTS, slot_capacity)
+}
+
+/// Per-proc return from `attach_proc` under the mesh-multiplexed layout: N-1 outbound
+/// senders (one per peer inbox) + a single inbound receiver (this proc's own inbox).
 ///
-/// Self-loop slots (`slot(this_proc, this_proc)`) are skipped to avoid two
-/// `shm_mq_attach` calls + two `on_dsm_detach` callbacks per process for a
-/// queue nothing reads. As a consequence, `outbound_senders` and
-/// `inbound_receivers` each have `n_procs - 1` entries; the index gymnastics
-/// to translate `proc_idx` ↔ slice index are handled by
-/// [`MppMesh::inbound_receiver`] in the runtime.
+/// The own-inbox is the multiplexed entry point: all N-1 peers attach to it as senders
+/// (each `DsmMpscSender` increments the ring's `sender_count`) and stamp their identity
+/// into `MppFrameHeader::sender_proc` on every frame. The receiver side pulls frames
+/// off that single ring and routes them to per-`(sender_proc, stage_id, partition)`
+/// channel buffers via [`DrainHandle`].
 pub(super) struct ProcAttach {
-    /// `outbound_senders[i]` writes to `slot(this_proc, peer_proc(i))` where
-    /// `peer_proc(i) = i if i < this_proc else i + 1` (skipping the self-loop).
-    pub(super) outbound_senders: Vec<ShmMqSender>,
-    /// `inbound_receivers[i]` reads from `slot(peer_proc(i), this_proc)`,
-    /// same skip-self-loop mapping as `outbound_senders`.
-    pub(super) inbound_receivers: Vec<ShmMqReceiver>,
+    /// `outbound_senders[i]` writes to peer `peer_proc_for_index(this_proc, i)`'s inbox.
+    /// `peer_proc(i) = i if i < this_proc else i + 1` skips the self-loop entry.
+    pub(super) outbound_senders: Vec<DsmMpscSender>,
+    /// This process's own MPSC inbox receiver. Drained inline by `DrainHandle`.
+    pub(super) inbound_receiver: DsmMpscReceiver,
 }
 
 /// Translate a peer index (`0..n_procs - 1`) into a process index
@@ -227,15 +276,9 @@ pub(super) fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
     }
 }
 
-/// Initialize the DSM region as the leader (`proc_idx = 0`). Writes the header, copies the plan
-/// bytes, calls `shm_mq_create` on every queue slot, and attaches the leader's row + column
-/// handles.
-///
-/// In the multiplexed `n_procs × n_procs` grid, every process (leader included) is a full
-/// proc: sender for its row, receiver for its column. The leader is responsible for the
-/// one-time `shm_mq_create` on every queue (workers can't, since the region is uninitialized at
-/// their attach time), then does its own `set_sender` / `set_receiver` calls on its row and column
-/// slots.
+/// Initialize the DSM region as the leader (`proc_idx = 0`). Writes the MppDsmHeader,
+/// copies the plan bytes, initializes the N MPSC inboxes via `DsmMpscRing::create_at`,
+/// and attaches the leader as receiver to its own inbox + as sender to each peer.
 ///
 /// # Safety
 /// - `coordinate` must point to the start of a DSM region of size `>= layout.region_total`.
@@ -276,66 +319,109 @@ pub(super) unsafe fn leader_init(
         );
     }
 
-    // One-time create of every shm_mq slot. Workers can't do this (the region is uninitialized at
-    // their attach time), so the leader runs `shm_mq_create` for all `n_procs²` slots even though
-    // it only attaches to its own row and column below.
+    // Initialize the N MPSC inboxes. Workers can't do this (the region is uninitialized
+    // at their attach time), so the leader runs DsmMpscRing::create_at for every receiver.
     let header = MppDsmHeader::from_layout(layout);
     let n_procs = layout.n_procs;
-    for s in 0..n_procs {
-        for r in 0..n_procs {
-            let off = header.slot_offset(s, r) as usize;
-            let mq_addr = unsafe { base.add(off) };
-            unsafe { pg_sys::shm_mq_create(mq_addr.cast(), layout.queue_bytes) };
-        }
+    let (ring_slots, slot_capacity) = ring_dims_for(layout.queue_bytes);
+    // `crate::gucs::mpp_trace()` reads a pgrx GucSetting, which requires the backend
+    // thread. Safe here because `leader_init` runs synchronously from
+    // `initialize_dsm_custom_scan` on the backend before any tokio runtime spins up,
+    // the same property the surrounding `pgrx::warning!` callers rely on.
+    let trace_on = crate::gucs::mpp_trace();
+    let t_create = trace_on.then(Instant::now);
+    for r in 0..n_procs {
+        let off = header.inbox_offset(r) as usize;
+        let inbox_addr = unsafe { base.add(off) };
+        unsafe { dsm_mpsc_ring::create_at(inbox_addr, ring_slots, slot_capacity) };
+    }
+    let create_ms = t_create.map(|t| t.elapsed().as_secs_f64() * 1000.0);
+
+    let t_attach = trace_on.then(Instant::now);
+    let attach = unsafe {
+        attach_proc(base, &header, 0, /* attach_senders */ false)
+    };
+    let attach_ms = t_attach.map(|t| t.elapsed().as_secs_f64() * 1000.0);
+
+    if trace_on {
+        // attach_proc makes N attach calls per proc: 1 own-inbox receiver + N-1 peer-inbox
+        // senders. create touched all N inboxes (each is a DsmMpscRing).
+        let attach_calls = n_procs as usize;
+        pgrx::warning!(
+            "mpp_trace mesh_init role=leader procs={} inboxes_created={} attach_calls={} queue_bytes={} ring_slots={} slot_capacity={} plan_bytes={} create_ms={:.2} attach_ms={:.2}",
+            n_procs,
+            n_procs,
+            attach_calls,
+            layout.queue_bytes,
+            ring_slots,
+            slot_capacity,
+            plan_bytes.len(),
+            create_ms.unwrap(),
+            attach_ms.unwrap(),
+        );
     }
 
-    Ok(unsafe { attach_proc_row_and_column(base, &header, 0, seg) })
+    // Silence unused-warning when `seg` was only consumed by the shm_mq path. The new
+    // primitive doesn't take a dsm_segment handle (drop-on-exit via Drop instead of PG's
+    // on_dsm_detach callback); the parameter stays for future use.
+    let _ = seg;
+
+    Ok(attach)
 }
 
-/// Attach to the leader-initialized DSM region as `proc_idx` (`0 = leader`,
-/// `1..N = parallel workers`).
+/// Attach to the leader-initialized DSM region as `proc_idx` (`0 = leader`, `1..N = parallel
+/// workers`) under the mesh-multiplexed layout: attach as receiver to this proc's own MPSC
+/// inbox, and (if `attach_senders` is true) as sender to every peer's inbox.
 ///
-/// Workers use this from `initialize_worker_custom_scan` via `worker_attach`; the leader uses it
-/// inline at the end of `leader_init`. Each process attaches as sender to its row and receiver to
-/// its column of the `n_procs × n_procs` grid, including the self-loop at `(this, this)`.
+/// Workers use this from `initialize_worker_custom_scan` via `worker_attach` with
+/// `attach_senders = true`; the leader uses it from `leader_init` with
+/// `attach_senders = false` because the leader is consumer-only and never hosts a
+/// producer fragment.
+///
+/// **Why the leader skips outbound attach**: `DsmMpscSender::new` increments the ring's
+/// `sender_count`, and `Drop` decrements it; the 1 → 0 transition flips `detached`. If
+/// the leader attached as sender to each peer inbox before any worker had, the leader's
+/// subsequent drop would prematurely mark every inbox detached and workers' later sends
+/// would all fail with `SendError::Detached`. Skipping the attach entirely keeps
+/// `sender_count` accurate (only workers ever increment for peer inboxes).
 ///
 /// # Safety
 /// - `base` must point to a DSM region whose header has been validated.
-/// - `header.slot_offset(s, r)` must already point at a slot initialized by `shm_mq_create` (the
-///   leader does this in `leader_init`).
-/// - `seg` may be NULL on workers. `shm_mq_attach` skips its on-detach callback in that case.
-unsafe fn attach_proc_row_and_column(
+/// - `header.inbox_offset(r)` must already point at a ring initialized by
+///   `DsmMpscRing::create_at` (the leader does this in `leader_init`).
+unsafe fn attach_proc(
     base: *mut u8,
     header: &MppDsmHeader,
     this_proc: u32,
-    seg: *mut pg_sys::dsm_segment,
+    attach_senders: bool,
 ) -> ProcAttach {
     let n_procs = header.n_procs;
-    let peer_count = (n_procs - 1) as usize; // n_procs >= 2 is layout invariant
-    let mut outbound_senders = Vec::with_capacity(peer_count);
-    let mut inbound_receivers = Vec::with_capacity(peer_count);
+    let peer_count = (n_procs - 1) as usize;
+    let mut outbound_senders = Vec::with_capacity(if attach_senders { peer_count } else { 0 });
 
-    // Senders: this process's row, skipping the self-loop slot(this, this).
-    for peer_idx in 0..(n_procs - 1) {
-        let r = peer_proc_for_index(this_proc, peer_idx);
-        let off = header.slot_offset(this_proc, r) as usize;
-        let mq_addr = unsafe { base.add(off) };
-        let mq = mq_addr.cast::<pg_sys::shm_mq>();
-        outbound_senders.push(unsafe { ShmMqSender::attach(seg, mq) });
+    let (ring_slots, slot_capacity) = ring_dims_for(header.queue_bytes as usize);
+
+    if attach_senders {
+        for peer_idx in 0..(n_procs - 1) {
+            let r = peer_proc_for_index(this_proc, peer_idx);
+            let off = header.inbox_offset(r) as usize;
+            let inbox_addr = unsafe { base.add(off) };
+            let nn = unsafe { dsm_mpsc_ring::attach_at(inbox_addr, ring_slots, slot_capacity) }
+                .expect("DsmMpscRing attach_at: leader-initialized region must validate");
+            outbound_senders.push(unsafe { DsmMpscSender::new(nn) });
+        }
     }
 
-    // Receivers: this process's column, skipping the self-loop slot(this, this).
-    for peer_idx in 0..(n_procs - 1) {
-        let s = peer_proc_for_index(this_proc, peer_idx);
-        let off = header.slot_offset(s, this_proc) as usize;
-        let mq_addr = unsafe { base.add(off) };
-        let mq = mq_addr.cast::<pg_sys::shm_mq>();
-        inbound_receivers.push(unsafe { ShmMqReceiver::attach_existing(seg, mq) });
-    }
+    // Inbound: this proc's own inbox. Single receiver per ring (MPSC contract).
+    let own_off = header.inbox_offset(this_proc) as usize;
+    let own_inbox_addr = unsafe { base.add(own_off) };
+    let own_nn = unsafe { dsm_mpsc_ring::attach_at(own_inbox_addr, ring_slots, slot_capacity) }
+        .expect("DsmMpscRing attach_at: own inbox must validate");
+    let inbound_receiver = unsafe { DsmMpscReceiver::new(own_nn) };
 
     ProcAttach {
         outbound_senders,
-        inbound_receivers,
+        inbound_receiver,
     }
 }
 
@@ -383,7 +469,26 @@ pub(super) unsafe fn worker_attach(
         .to_vec()
     };
 
-    let attach = unsafe { attach_proc_row_and_column(base, &header, proc_idx, seg) };
+    // Same backend-thread safety story as leader_init: `initialize_worker_custom_scan` runs on
+    // the parallel-worker backend before tokio starts, so reading `mpp_trace` directly is safe.
+    let trace_on = crate::gucs::mpp_trace();
+    let t_attach = trace_on.then(Instant::now);
+    let attach = unsafe {
+        attach_proc(base, &header, proc_idx, /* attach_senders */ true)
+    };
+    let _ = seg; // DsmMpscRing doesn't use the dsm_segment handle today.
+    if trace_on {
+        let attach_ms = t_attach.unwrap().elapsed().as_secs_f64() * 1000.0;
+        // N attach calls per proc: 1 own-inbox receiver + N-1 peer-inbox senders.
+        let attach_calls = header.n_procs as usize;
+        pgrx::warning!(
+            "mpp_trace mesh_init role=worker proc_idx={} procs={} attach_calls={} attach_ms={:.2}",
+            proc_idx,
+            header.n_procs,
+            attach_calls,
+            attach_ms,
+        );
+    }
     Ok((header, plan_bytes, attach))
 }
 
@@ -395,10 +500,10 @@ mod tests {
     fn compute_dsm_layout_works() {
         let l = compute_dsm_layout(4, 64 * 1024, 1024).unwrap();
         assert_eq!(l.n_procs, 4);
-        // Grid is n_procs × n_procs = 16 slots.
+        // Mesh-multiplexed: one inbox per receiver, not N². 4 procs → 4 inboxes.
         let aligned = aligned_queue_bytes(64 * 1024);
-        let queues_size = 16 * aligned;
-        assert!(l.region_total >= l.queues_offset + queues_size);
+        let queues_size = 4 * aligned;
+        assert_eq!(l.region_total, l.queues_offset + queues_size);
     }
 
     #[test]
@@ -412,16 +517,33 @@ mod tests {
     }
 
     #[test]
-    fn header_slot_offset_is_row_major_over_n_procs() {
-        // 4 procs → 4×4 = 16 slots, row-major over (sender, receiver).
+    fn compute_dsm_layout_scales_linearly_in_n_procs() {
+        // Total queue area must grow as O(N), not O(N²). Pinning the math here so a
+        // regression that re-introduces the per-pair grid trips at compile-time of
+        // this test, not at the N=24 cliff in production.
+        let queue_bytes = 64 * 1024;
+        let aligned = aligned_queue_bytes(queue_bytes);
+        for n in [2u32, 4, 8, 16, 24] {
+            let l = compute_dsm_layout(n, queue_bytes, 0).unwrap();
+            let expected = (n as usize) * aligned;
+            assert_eq!(
+                l.region_total - l.queues_offset,
+                expected,
+                "n={n}: expected {expected} inbox bytes ({n} inboxes × {aligned})"
+            );
+        }
+    }
+
+    #[test]
+    fn header_inbox_offset_is_per_receiver() {
+        // 4 procs → 4 inboxes, contiguous, sized by queue_bytes each.
         let l = compute_dsm_layout(4, 64 * 1024, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         let aligned = h.queue_bytes;
-        assert_eq!(h.slot_offset(0, 0), h.queues_offset);
-        assert_eq!(h.slot_offset(0, 1), h.queues_offset + aligned);
-        assert_eq!(h.slot_offset(1, 0), h.queues_offset + 4 * aligned);
-        // Self-loop on proc 3: (3,3) → row 3, col 3 → slot 15.
-        assert_eq!(h.slot_offset(3, 3), h.queues_offset + 15 * aligned);
+        assert_eq!(h.inbox_offset(0), h.queues_offset);
+        assert_eq!(h.inbox_offset(1), h.queues_offset + aligned);
+        assert_eq!(h.inbox_offset(2), h.queues_offset + 2 * aligned);
+        assert_eq!(h.inbox_offset(3), h.queues_offset + 3 * aligned);
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -79,10 +79,9 @@ fn align_up_ring(n: usize) -> Option<usize> {
 }
 
 const MPP_DSM_MAGIC: u32 = 0x4D50_5052; // "MPPR" (RPC variant)
-/// Bumped on any wire-incompatible change to the DSM header layout or to the inbox-offset math,
-/// so attaching workers reject mismatched leaders loudly rather than reading garbage. Validated
-/// in [`MppDsmHeader::validate`]. v4: mesh-multiplexed layout (one MPSC ring per receiver, was
-/// per-pair shm_mq grid in v3).
+/// Bump on any wire-incompatible change to the DSM header layout or to the inbox-offset
+/// math, so attaching workers reject mismatched leaders loudly rather than reading
+/// garbage. Validated in [`MppDsmHeader::validate`].
 const MPP_DSM_HEADER_VERSION: u32 = 4;
 
 /// Absolute cap on DSM region size. 16 GiB is two orders of magnitude beyond
@@ -99,7 +98,8 @@ pub struct MppDsmHeader {
     pub(super) magic: u32,
     pub(super) header_version: u32,
     /// Total proc count. Leader is `proc_idx = 0`; workers are
-    /// `proc_idx = ParallelWorkerNumber + 1`. The shm_mq grid is `n_procs × n_procs`.
+    /// `proc_idx = ParallelWorkerNumber + 1`. The DSM region holds `n_procs`
+    /// per-receiver MPSC inboxes laid out contiguously after the plan bytes.
     pub n_procs: u32,
     pub(super) _pad: u32,
     pub(super) queue_bytes: u64,
@@ -152,11 +152,9 @@ impl MppDsmHeader {
 
     /// Byte offset (relative to DSM base) of `receiver_proc`'s MPSC inbox.
     ///
-    /// Mesh-multiplexed layout: exactly one `DsmMpscRing`-shaped inbox per process.
     /// The owner attaches as receiver (`DsmMpscReceiver`); every other process attaches
     /// as sender (`DsmMpscSender`) to the same inbox and stamps its identity into the
-    /// frame header (`MppFrameHeader::sender_proc`). Total queues per mesh is `n_procs`
-    /// rings (one per receiver) instead of `n_procs * (n_procs - 1)` per-pair queues.
+    /// frame header (`MppFrameHeader::sender_proc`).
     pub(super) fn inbox_offset(&self, receiver_proc: u32) -> u64 {
         debug_assert!(receiver_proc < self.n_procs);
         self.queues_offset + (receiver_proc as u64) * self.queue_bytes
@@ -176,13 +174,12 @@ pub(super) struct DsmLayout {
 
 /// Compute the DSM region size and field offsets for one MPP query.
 ///
-/// `n_procs` is the total proc count (1 leader + N workers). Mesh-multiplexed layout:
-/// one `DsmMpscRing` inbox per process (`n_procs` queues total per mesh). Every other
-/// process attaches as sender to that inbox and demultiplexes by
-/// `MppFrameHeader::sender_proc` on the receive side.
+/// `n_procs` is the total proc count (1 leader + N workers); the region holds one
+/// `DsmMpscRing` inbox per process. Every other process attaches as sender to that
+/// inbox and the receiver demultiplexes by `MppFrameHeader::sender_proc`.
 ///
-/// `queue_bytes` is the per-inbox total (ring header + `RING_SLOTS` slots). Operator-
-/// facing `paradedb.mpp_queue_size` controls this value.
+/// `queue_bytes` is the per-inbox total (ring header + `RING_SLOTS` slots).
+/// Operator-facing `paradedb.mpp_queue_size` controls this value.
 pub(super) fn compute_dsm_layout(
     n_procs: u32,
     queue_bytes: usize,
@@ -249,11 +246,11 @@ fn ring_dims_for(queue_bytes: usize) -> (u32, u32) {
     (RING_SLOTS, slot_capacity)
 }
 
-/// Per-proc return from `attach_proc` under the mesh-multiplexed layout: N-1 outbound
-/// senders (one per peer inbox) + a single inbound receiver (this proc's own inbox).
+/// Per-proc return from `attach_proc`: N-1 outbound senders (one per peer inbox) plus a
+/// single inbound receiver (this proc's own inbox).
 ///
-/// The own-inbox is the multiplexed entry point: all N-1 peers attach to it as senders
-/// (each `DsmMpscSender` increments the ring's `sender_count`) and stamp their identity
+/// The own-inbox is the multiplexed entry point: every peer attaches to it as a sender
+/// (each `DsmMpscSender` increments the ring's `sender_count`) and stamps its identity
 /// into `MppFrameHeader::sender_proc` on every frame. The receiver side pulls frames
 /// off that single ring and routes them to per-`(sender_proc, stage_id, partition)`
 /// channel buffers via [`DrainHandle`].
@@ -361,29 +358,24 @@ pub(super) unsafe fn leader_init(
         );
     }
 
-    // Silence unused-warning when `seg` was only consumed by the shm_mq path. The new
-    // primitive doesn't take a dsm_segment handle (drop-on-exit via Drop instead of PG's
-    // on_dsm_detach callback); the parameter stays for future use.
+    // `DsmMpscRing` releases its DSM mapping in `Drop`, so it doesn't need a
+    // `dsm_segment` handle the way `shm_mq_attach` does; kept on the signature for
+    // future use.
     let _ = seg;
 
     Ok(attach)
 }
 
-/// Attach to the leader-initialized DSM region as `proc_idx` (`0 = leader`, `1..N = parallel
-/// workers`) under the mesh-multiplexed layout: attach as receiver to this proc's own MPSC
-/// inbox, and (if `attach_senders` is true) as sender to every peer's inbox.
+/// Attach to the leader-initialized DSM region as `proc_idx` (`0 = leader`, `1..N` =
+/// parallel workers). Attach as receiver to this proc's own MPSC inbox, and (if
+/// `attach_senders` is true) as sender to every peer's inbox.
 ///
-/// Workers use this from `initialize_worker_custom_scan` via `worker_attach` with
-/// `attach_senders = true`; the leader uses it from `leader_init` with
-/// `attach_senders = false` because the leader is consumer-only and never hosts a
-/// producer fragment.
-///
-/// **Why the leader skips outbound attach**: `DsmMpscSender::new` increments the ring's
-/// `sender_count`, and `Drop` decrements it; the 1 → 0 transition flips `detached`. If
-/// the leader attached as sender to each peer inbox before any worker had, the leader's
-/// subsequent drop would prematurely mark every inbox detached and workers' later sends
-/// would all fail with `SendError::Detached`. Skipping the attach entirely keeps
-/// `sender_count` accurate (only workers ever increment for peer inboxes).
+/// `attach_senders = false` is for the leader: it's consumer-only. A consumer-only proc
+/// that attached as sender would increment every peer inbox's `sender_count`, and its
+/// `Drop` would decrement them all back; if it dropped before any worker incremented,
+/// the 1 → 0 transition would flip `detached` on every peer inbox and every later
+/// worker send would fail with `SendError::Detached`. Skipping the attach keeps
+/// `sender_count` accurate (only producers ever increment).
 ///
 /// # Safety
 /// - `base` must point to a DSM region whose header has been validated.
@@ -476,7 +468,9 @@ pub(super) unsafe fn worker_attach(
     let attach = unsafe {
         attach_proc(base, &header, proc_idx, /* attach_senders */ true)
     };
-    let _ = seg; // DsmMpscRing doesn't use the dsm_segment handle today.
+    // `DsmMpscRing` releases its mapping in `Drop`; the `seg` handle stays on the
+    // signature to mirror `leader_init`.
+    let _ = seg;
     if trace_on {
         let attach_ms = t_attach.unwrap().elapsed().as_secs_f64() * 1000.0;
         // N attach calls per proc: 1 own-inbox receiver + N-1 peer-inbox senders.
@@ -500,7 +494,7 @@ mod tests {
     fn compute_dsm_layout_works() {
         let l = compute_dsm_layout(4, 64 * 1024, 1024).unwrap();
         assert_eq!(l.n_procs, 4);
-        // Mesh-multiplexed: one inbox per receiver, not N². 4 procs → 4 inboxes.
+        // 4 procs => 4 inboxes laid out contiguously after the plan bytes.
         let aligned = aligned_queue_bytes(64 * 1024);
         let queues_size = 4 * aligned;
         assert_eq!(l.region_total, l.queues_offset + queues_size);
@@ -518,9 +512,9 @@ mod tests {
 
     #[test]
     fn compute_dsm_layout_scales_linearly_in_n_procs() {
-        // Total queue area must grow as O(N), not O(N²). Pinning the math here so a
-        // regression that re-introduces the per-pair grid trips at compile-time of
-        // this test, not at the N=24 cliff in production.
+        // Total queue area must grow as O(N) in proc count. Pinning the math here so a
+        // regression that grows queues per-pair fails this test at compile time rather
+        // than at the N=24 wall-time cliff in production.
         let queue_bytes = 64 * 1024;
         let aligned = aligned_queue_bytes(queue_bytes);
         for n in [2u32, 4, 8, 16, 24] {
@@ -536,7 +530,7 @@ mod tests {
 
     #[test]
     fn header_inbox_offset_is_per_receiver() {
-        // 4 procs → 4 inboxes, contiguous, sized by queue_bytes each.
+        // 4 procs => 4 inboxes, contiguous, sized by queue_bytes each.
         let l = compute_dsm_layout(4, 64 * 1024, 0).unwrap();
         let h = MppDsmHeader::from_layout(&l);
         let aligned = h.queue_bytes;

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -50,8 +50,6 @@ use std::ffi::c_void;
 use std::mem::size_of;
 use std::time::Instant;
 
-use pgrx::pg_sys;
-
 use crate::postgres::customscan::mpp::dsm_mpsc_ring::{
     self, DsmMpscReceiver, DsmMpscRingHeader, DsmMpscSender,
 };
@@ -279,11 +277,9 @@ pub(super) fn peer_proc_for_index(this_proc: u32, peer_idx: u32) -> u32 {
 ///
 /// # Safety
 /// - `coordinate` must point to the start of a DSM region of size `>= layout.region_total`.
-/// - `seg` must be the leader's `dsm_segment*`.
 /// - The region must be uninitialized (the leader is the first writer).
 pub(super) unsafe fn leader_init(
     coordinate: *mut c_void,
-    seg: *mut pg_sys::dsm_segment,
     layout: &DsmLayout,
     plan_bytes: &[u8],
 ) -> Result<ProcAttach, String> {
@@ -358,11 +354,6 @@ pub(super) unsafe fn leader_init(
         );
     }
 
-    // `DsmMpscRing` releases its DSM mapping in `Drop`, so it doesn't need a
-    // `dsm_segment` handle the way `shm_mq_attach` does; kept on the signature for
-    // future use.
-    let _ = seg;
-
     Ok(attach)
 }
 
@@ -423,14 +414,10 @@ unsafe fn attach_proc(
 /// # Safety
 /// - `coordinate` must be the DSM region pointer the leader initialized.
 /// - `region_total` must match the DSM's attached size.
-/// - `seg` may be NULL. `initialize_worker_custom_scan` doesn't surface the segment pointer, and
-///   `shm_mq_attach` handles NULL by skipping its on-detach callback (cleanup falls back to
-///   process exit, safe for parallel-worker lifetimes).
 pub(super) unsafe fn worker_attach(
     coordinate: *mut c_void,
     region_total: u64,
     proc_idx: u32,
-    seg: *mut pg_sys::dsm_segment,
 ) -> Result<(MppDsmHeader, Vec<u8>, ProcAttach), String> {
     if coordinate.is_null() {
         return Err("mpp: worker_attach given null coordinate".into());
@@ -468,9 +455,6 @@ pub(super) unsafe fn worker_attach(
     let attach = unsafe {
         attach_proc(base, &header, proc_idx, /* attach_senders */ true)
     };
-    // `DsmMpscRing` releases its mapping in `Drop`; the `seg` handle stays on the
-    // signature to mirror `leader_init`.
-    let _ = seg;
     if trace_on {
         let attach_ms = t_attach.unwrap().elapsed().as_secs_f64() * 1000.0;
         // N attach calls per proc: 1 own-inbox receiver + N-1 peer-inbox senders.

--- a/pg_search/src/postgres/customscan/mpp/dsm.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm.rs
@@ -17,7 +17,7 @@
 
 //! Mesh-multiplexed DSM layout: one MPSC inbox per receiver process.
 //!
-//! Each MPP query allocates a single DSM region containing:
+//! Each MPP query allocates a single DSM region:
 //!
 //! ```text
 //!   +--- MppDsmHeader (repr C, MAXALIGN-padded) -------------+
@@ -34,17 +34,14 @@
 //!   +-------------------------------------------------------+
 //! ```
 //!
-//! - `n_procs` is the total proc count (1 leader + N parallel workers).
-//!   Leader is `proc_idx = 0`; workers are `proc_idx = ParallelWorkerNumber + 1`.
-//! - Each process attaches as **receiver** to its own inbox (one MPSC ring) and as
-//!   **sender** to each of N-1 peer inboxes. Total queues per mesh is `n_procs`; total
-//!   attach calls per proc is `1 + (N-1) = N`. Senders stamp
-//!   `MppFrameHeader::sender_proc` on every frame so the receiver demultiplexes by
-//!   source on read.
-//! - Self-loop frames (proc → itself) use an in-proc channel installed in `glue.rs`,
-//!   not a DSM slot. MPSC ring semantics + the way `DsmMpscReceiver` is used (one
-//!   handle owned by the receiver process) means there is no DSM slot for the
-//!   self-loop pair in this layout.
+//! - `n_procs` = 1 leader + N parallel workers. Leader is `proc_idx = 0`; workers are
+//!   `proc_idx = ParallelWorkerNumber + 1`.
+//! - Each process attaches as receiver to its own inbox (one MPSC ring) and as sender
+//!   to each of N-1 peer inboxes. Senders stamp `MppFrameHeader::sender_proc` on every
+//!   frame so the receiver demuxes by source.
+//! - Self-loop frames (proc → itself) ride an in-proc channel installed in `glue.rs`,
+//!   not a DSM slot: each `DsmMpscReceiver` is owned by a single receiver process, so
+//!   there is no DSM slot for the self-loop pair.
 
 use std::ffi::c_void;
 use std::mem::size_of;
@@ -361,16 +358,15 @@ pub(super) unsafe fn leader_init(
 /// parallel workers). Attach as receiver to this proc's own MPSC inbox, and (if
 /// `attach_senders` is true) as sender to every peer's inbox.
 ///
-/// `attach_senders = false` is for the leader: it's consumer-only. A consumer-only proc
-/// that attached as sender would increment every peer inbox's `sender_count`, and its
-/// `Drop` would decrement them all back; if it dropped before any worker incremented,
-/// the 1 → 0 transition would flip `detached` on every peer inbox and every later
-/// worker send would fail with `SendError::Detached`. Skipping the attach keeps
-/// `sender_count` accurate (only producers ever increment).
+/// `attach_senders = false` is for the leader (consumer-only). If the leader attached
+/// as sender it would bump every peer inbox's `sender_count` and decrement it on `Drop`;
+/// if it dropped before any worker bumped, the 1 → 0 transition would flip `detached`
+/// on every peer inbox and every later worker send would fail `SendError::Detached`.
+/// Skipping keeps `sender_count` honest (only producers ever increment).
 ///
 /// # Safety
 /// - `base` must point to a DSM region whose header has been validated.
-/// - `header.inbox_offset(r)` must already point at a ring initialized by
+/// - `header.inbox_offset(r)` must point at a ring already initialized by
 ///   `DsmMpscRing::create_at` (the leader does this in `leader_init`).
 unsafe fn attach_proc(
     base: *mut u8,

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -57,6 +57,14 @@
 //! payload, store `seq = H + ring_size` (next round's empty marker), then `head = H+1`.
 //! The single consumer owns `head` without CAS; producers contend only on `tail`.
 //!
+//! **Why one MPSC ring per inbox and not N-1 SPSC subqueues?** Each receiver still has
+//! N-1 producers feeding it. The SPSC variant would need N-1 dedicated queues per
+//! receiver, which is `N*(N-1)` total: the same grid the inbox layout is supposed to
+//! collapse, just packed into one DSM segment. One MPSC ring also pools the slot budget
+//! across producers, so a slow producer can't sit on dedicated capacity while peers
+//! stall on full subqueues. The cost is producer contention on `tail` via CAS, which
+//! Vyukov's per-slot phase counters keep wait-free under load.
+//!
 //! **Safety**: public methods on `DsmMpscSender` / `DsmMpscReceiver` are type-safe once
 //! constructed. The constructors are `unsafe` because the DSM region must be correctly
 //! sized and not aliased (one process calls `create_at`, everyone else `attach_at`).
@@ -244,6 +252,9 @@ unsafe fn wake_receiver(header: &DsmMpscRingHeader) {
     }
 }
 
+// Gate rationale lives at the call site in `wake_receiver` above: macOS flat-namespace
+// linkers abort at load on unresolved extern statics, so `pg_sys::ProcGlobal` can't
+// appear in the unit-test binary even behind an unreachable runtime branch.
 #[cfg(not(test))]
 unsafe fn wake_receiver_via_pg_sys(pgprocno: i32, expected_pid: i32) {
     let proc_global = unsafe { pg_sys::ProcGlobal };

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -167,9 +167,8 @@ pub(super) struct DsmMpscRingHeader {
     slot_capacity: u32,
     /// Live `DsmMpscSender` count. Incremented in `DsmMpscSender::new`, decremented in
     /// `DsmMpscSender::Drop`. The drop that takes the count from 1 → 0 sets `detached`
-    /// (with Release) and wakes the receiver, so producers don't need to call
-    /// `set_detached` explicitly: dropping the last sender is sufficient. Mirrors
-    /// shm_mq's "drop = detach" structural guarantee.
+    /// (with Release) and wakes the receiver, mirroring shm_mq's "drop = detach"
+    /// structural guarantee.
     sender_count: AtomicU32,
     /// Set by the consumer (or by the leader on query teardown) to tell producers to
     /// fail-fast on subsequent sends. Sticky.
@@ -341,10 +340,9 @@ pub(super) struct DsmMpscSender {
 // either across threads requires only the atomic ordering already in use.
 //
 // `DsmMpscReceiver` is deliberately !Sync: the type-level invariant that exactly one
-// thread calls `try_recv` / `set_detached` at a time is what makes the lock-free MPSC
-// math correct (single consumer owns `head` without CAS). `DsmMpscSender` is Sync so
-// multiple producer threads can share one `Arc<DsmMpscSender>` and race on `tail` via
-// CAS.
+// thread calls `try_recv` at a time is what makes the lock-free MPSC math correct (the
+// single consumer owns `head` without CAS). `DsmMpscSender` is Sync so multiple producer
+// threads can share one `Arc<DsmMpscSender>` and race on `tail` via CAS.
 unsafe impl Send for DsmMpscReceiver {}
 unsafe impl Send for DsmMpscSender {}
 unsafe impl Sync for DsmMpscSender {}
@@ -476,8 +474,7 @@ impl DsmMpscReceiver {
 
     /// Register this process as the receiver. Producers' subsequent wakeups resolve
     /// the latch from `ProcGlobal->allProcs[pgprocno]` and check `proc->pid == pid`
-    /// to defend against PGPROC slot reuse if the receiver process exits. Use
-    /// [`Self::clear_receiver`] on teardown.
+    /// to defend against PGPROC slot reuse if the receiver process exits.
     ///
     /// Caller passes the LOCAL process's pgprocno and pid (in PG's parlance:
     /// `MyProcNumber` and `MyProc->pid`). The pair is packed into one `AtomicU64`
@@ -488,15 +485,6 @@ impl DsmMpscReceiver {
         header
             .receiver_packed
             .store(pack_receiver(pgprocno, pid), Ordering::Release);
-    }
-
-    /// Clear the registered receiver (e.g., on query teardown). After this, producer
-    /// wakes are no-ops until a subsequent `set_receiver`. Sentinels both fields to
-    /// `(NO_RECEIVER, 0)`. Note that pgprocno 0 is the valid postmaster slot, so
-    /// callers must NOT use `set_receiver(0, 0)` as a clear.
-    #[allow(dead_code)]
-    pub(super) fn clear_receiver(&self) {
-        self.set_receiver(NO_RECEIVER, 0);
     }
 
     /// Try to read one frame into `out`. On `Bytes`, `out` holds the payload. On
@@ -557,25 +545,6 @@ impl DsmMpscReceiver {
         // to claim sees the empty slot before seeing the new head value.
         header.head.store(head.wrapping_add(1), Ordering::Release);
         RecvOutcome::Bytes
-    }
-
-    /// Tell producers to stop sending. Idempotent. Subsequent `try_send` calls will
-    /// fail-fast with `SendError::Detached`. Does NOT block; caller can still drain
-    /// already-queued frames via `try_recv` until it returns `RecvOutcome::Detached`.
-    #[allow(dead_code)]
-    pub(super) fn set_detached(&self) {
-        let header = unsafe { self.ring.as_ref() };
-        header.detached.store(true, Ordering::Release);
-        // Defensive self-wake: if a signal handler or supervisor thread calls
-        // set_detached while the receiver is in WaitLatch, this breaks it out.
-        unsafe { wake_receiver(header) };
-    }
-
-    /// True when `set_detached` has been called.
-    #[allow(dead_code)]
-    pub(super) fn is_detached(&self) -> bool {
-        let header = unsafe { self.ring.as_ref() };
-        header.detached.load(Ordering::Acquire)
     }
 }
 
@@ -774,20 +743,6 @@ mod tests {
     }
 
     #[test]
-    fn detach_blocks_subsequent_sends() {
-        let (_region, rx, tx) = make_ring(4, 64);
-        tx.try_send(b"keep").unwrap();
-        rx.set_detached();
-        assert!(rx.is_detached());
-        assert_eq!(tx.try_send(b"drop"), Err(SendError::Detached));
-        // Already-queued frame still readable, then Detached signaled.
-        let mut buf = Vec::new();
-        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
-        assert_eq!(&buf[..], b"keep");
-        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Detached);
-    }
-
-    #[test]
     fn message_too_large_is_rejected() {
         let (_region, _rx, tx) = make_ring(2, 32);
         // payload_cap = 32 - SLOT_HEADER_BYTES; one byte over is too large.
@@ -975,60 +930,6 @@ mod tests {
         // Restore version, mismatched ring_size.
         unsafe { (*header_ptr).version = MPSC_RING_VERSION };
         assert!(unsafe { attach_at(region.as_mut_ptr(), 8, 64) }.is_none());
-    }
-
-    /// Consumer-side detach race: producers are mid-flight when the receiver detaches.
-    /// Every Ok send must produce a matching Bytes recv before the drain returns
-    /// Detached. Catches the half-claim-wedge if the predicate is too strict.
-    #[test]
-    fn drain_completes_after_detach_under_load() {
-        const K_PRODUCERS: usize = 4;
-        let (_region, rx, tx_template) = make_ring(16, 32);
-        let ring_nn = SharedRing(tx_template.ring);
-        let stop = Arc::new(AtomicBool::new(false));
-        let sent_count = Arc::new(AtomicUsize::new(0));
-        let mut handles = Vec::with_capacity(K_PRODUCERS);
-        for _ in 0..K_PRODUCERS {
-            let tx = unsafe { DsmMpscSender::new(ring_nn.0) };
-            let stop = Arc::clone(&stop);
-            let sent_count = Arc::clone(&sent_count);
-            handles.push(std::thread::spawn(move || {
-                let payload = [0xABu8; 8];
-                while !stop.load(O::Relaxed) {
-                    match tx.try_send(&payload) {
-                        Ok(_) => {
-                            sent_count.fetch_add(1, O::Relaxed);
-                        }
-                        Err(SendError::Full) => std::thread::yield_now(),
-                        Err(SendError::Detached) => break,
-                        Err(e) => panic!("unexpected: {e:?}"),
-                    }
-                }
-            }));
-        }
-        // Drain a bit then trigger detach.
-        let mut buf = Vec::new();
-        let mut recv_count = 0usize;
-        // Let producers stretch their legs before detaching.
-        std::thread::sleep(std::time::Duration::from_millis(20));
-        rx.set_detached();
-        stop.store(true, O::Relaxed);
-        // Drain until the ring confirms Detached.
-        loop {
-            match rx.try_recv(&mut buf) {
-                RecvOutcome::Bytes => recv_count += 1,
-                RecvOutcome::Empty => std::thread::yield_now(),
-                RecvOutcome::Detached => break,
-            }
-        }
-        for h in handles {
-            h.join().unwrap();
-        }
-        let sent = sent_count.load(O::Relaxed);
-        assert_eq!(
-            recv_count, sent,
-            "every successful send must be received before Detached"
-        );
     }
 
     /// Stress test at the production-worst contention level (K=24 producers, matching

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -108,10 +108,64 @@ const SLOT_HEADER_BYTES: usize = std::mem::size_of::<SlotHeader>();
 struct SlotHeader {
     /// Vyukov sequence counter; see module docs for phase encoding.
     seq: AtomicU64,
-    /// Payload length in bytes; `0..=slot_capacity - SLOT_HEADER_BYTES`.
+    /// Bytes of payload written into THIS slot's data region;
+    /// `0..=slot_capacity - SLOT_HEADER_BYTES`.
     len: AtomicU32,
-    /// Padding to keep the data region 8-byte aligned. Not consulted by anyone.
-    _pad: u32,
+    /// Fragment metadata. Low 2 bits = [`FragmentKind`] (Complete=0 / First=1 /
+    /// Continue=2 / Last=3). For `First`, bits 16..32 hold the slot count of the
+    /// logical frame (1..=65535). For other kinds these bits are unused.
+    flags: AtomicU32,
+}
+
+/// Kind bits stored in [`SlotHeader::flags`]'s low 2 bits.
+///
+/// A frame fitting in `slot_capacity - SLOT_HEADER_BYTES` rides the single-slot
+/// fast path as `Complete`. Anything larger spans
+/// `n_slots = ceil(frame_len / per_slot_payload)` consecutive slots: `First`
+/// (carrying `n_slots` in the upper bits), `Continue` for the middle, `Last` for
+/// the tail. Producers grab the whole run with one
+/// `tail.compare_exchange(T, T + n_slots)`, so other producers can't interleave
+/// their fragments and the receiver always sees the slots in producer order.
+#[repr(u32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FragmentKind {
+    Complete = 0,
+    First = 1,
+    Continue = 2,
+    Last = 3,
+}
+
+/// Bit-mask for the kind bits in [`SlotHeader::flags`].
+const FLAGS_KIND_MASK: u32 = 0b11;
+/// Shift for the `n_slots` field stored in the flags' upper half (only meaningful
+/// for `First`). Limits per-frame fragmentation to 65535 slots, which is far
+/// beyond any realistic ring size.
+const FLAGS_NSLOTS_SHIFT: u32 = 16;
+const FLAGS_NSLOTS_MAX: u32 = 0xFFFF;
+
+#[inline]
+fn pack_flags(kind: FragmentKind, n_slots: u32) -> u32 {
+    debug_assert!(
+        kind != FragmentKind::First || (1..=FLAGS_NSLOTS_MAX).contains(&n_slots),
+        "First frames must carry 1..=65535 slots; got {n_slots}"
+    );
+    (kind as u32) | (n_slots << FLAGS_NSLOTS_SHIFT)
+}
+
+#[inline]
+fn unpack_kind(flags: u32) -> Option<FragmentKind> {
+    match flags & FLAGS_KIND_MASK {
+        0 => Some(FragmentKind::Complete),
+        1 => Some(FragmentKind::First),
+        2 => Some(FragmentKind::Continue),
+        3 => Some(FragmentKind::Last),
+        _ => None,
+    }
+}
+
+#[inline]
+fn unpack_nslots(flags: u32) -> u32 {
+    flags >> FLAGS_NSLOTS_SHIFT
 }
 
 /// Magic constant validating that an attaching process points at a `DsmMpscRingHeader`
@@ -119,9 +173,16 @@ struct SlotHeader {
 /// so a worker that picks up the wrong region fails the wrong-shape check loudly.
 const MPSC_RING_MAGIC: u32 = u32::from_le_bytes(*b"MPCR");
 
-/// Bumped on any incompatible layout change. Mirrors the discipline at
+/// Bump on any wire-incompatible layout change. Mirrors the discipline at
 /// `MppDsmHeader::validate`.
-const MPSC_RING_VERSION: u32 = 1;
+///
+/// Wire versions:
+/// - v1: `SlotHeader { seq, len, _pad }`. One frame per slot.
+/// - v2: `SlotHeader { seq, len, flags }`. `flags` carries `FragmentKind` plus
+///   `n_slots` on `First`, so frames bigger than
+///   `slot_capacity - SLOT_HEADER_BYTES` can span N consecutive slots reserved
+///   atomically by the producer.
+const MPSC_RING_VERSION: u32 = 2;
 
 /// Assumed cache line size for false-sharing avoidance. 64 bytes covers x86_64 and arm64;
 /// over-padding on smaller-cache-line targets costs a few bytes per ring, nothing more.
@@ -393,7 +454,7 @@ pub(super) unsafe fn create_at(
                 SlotHeader {
                     seq: AtomicU64::new(i as u64),
                     len: AtomicU32::new(0),
-                    _pad: 0,
+                    flags: AtomicU32::new(0),
                 },
             );
         }
@@ -500,12 +561,50 @@ impl DsmMpscReceiver {
             }
             return RecvOutcome::Empty;
         }
+        // Slot at head is ready. Inspect its kind to choose between single-slot
+        // fast path and multi-slot reassembly.
+        let flags = unsafe { (*slot).flags.load(Ordering::Relaxed) };
+        let Some(kind) = unpack_kind(flags) else {
+            // Reserved bits set; treat as corruption.
+            header.detached.store(true, Ordering::Release);
+            return RecvOutcome::Detached;
+        };
+        let payload_cap = (header.slot_capacity as usize).saturating_sub(SLOT_HEADER_BYTES);
+        match kind {
+            FragmentKind::Complete => self.recv_single_slot(header, head, slot, payload_cap, out),
+            FragmentKind::First => {
+                let n_slots = unpack_nslots(flags);
+                if n_slots == 0 || n_slots > header.ring_size {
+                    header.detached.store(true, Ordering::Release);
+                    return RecvOutcome::Detached;
+                }
+                self.recv_multi_slot(header, head, n_slots, payload_cap, out)
+            }
+            FragmentKind::Continue | FragmentKind::Last => {
+                // Encountering Continue/Last at `head` means a producer violated
+                // ascending-publish ordering or a previous reassembly didn't advance
+                // `head` past every fragment. Either is a contract break, not a
+                // recoverable condition; poison and detach.
+                header.detached.store(true, Ordering::Release);
+                RecvOutcome::Detached
+            }
+        }
+    }
+
+    /// Read a single-slot `Complete` frame at `head` and advance.
+    fn recv_single_slot(
+        &self,
+        header: &DsmMpscRingHeader,
+        head: u64,
+        slot: *mut SlotHeader,
+        payload_cap: usize,
+        out: &mut Vec<u8>,
+    ) -> RecvOutcome {
         let len_raw = unsafe { (*slot).len.load(Ordering::Relaxed) } as usize;
         // Clamp against slot's payload capacity. DSM is mapped writable by every
         // attached backend, so a buggy / corrupted producer could write a garbage len.
         // Without this guard, `set_len + copy_nonoverlapping` would read OOB into
         // neighboring slots or other DSM contents.
-        let payload_cap = (header.slot_capacity as usize).saturating_sub(SLOT_HEADER_BYTES);
         if len_raw > payload_cap {
             // Poison the ring rather than silently returning corrupt data.
             header.detached.store(true, Ordering::Release);
@@ -530,6 +629,87 @@ impl DsmMpscReceiver {
         header.head.store(head.wrapping_add(1), Ordering::Release);
         RecvOutcome::Bytes
     }
+
+    /// Reassemble an `n_slots`-fragment frame at `head`. Returns `Empty` without
+    /// advancing `head` if any continuation slot isn't yet published (producer
+    /// mid-publish); the caller retries and the `First` slot stays put with its
+    /// flags intact.
+    fn recv_multi_slot(
+        &self,
+        header: &DsmMpscRingHeader,
+        head: u64,
+        n_slots: u32,
+        payload_cap: usize,
+        out: &mut Vec<u8>,
+    ) -> RecvOutcome {
+        // First pass: verify every fragment in the run is published. If not, bail
+        // with Empty so the caller can retry once the producer finishes.
+        let mut total_len: usize = 0;
+        for i in 0..n_slots {
+            let h = head.wrapping_add(i as u64);
+            let slot_idx = (h % header.ring_size as u64) as u32;
+            let slot = unsafe { slot_ptr(self.ring.as_ptr(), slot_idx, header.slot_capacity) };
+            let seq = unsafe { (*slot).seq.load(Ordering::Acquire) };
+            if seq != h.wrapping_add(1) {
+                // Continuation slot not yet ready. Don't touch `head` or any slot
+                // metadata; producer will publish soon, caller will retry.
+                return RecvOutcome::Empty;
+            }
+            let expected_kind = if i == 0 {
+                FragmentKind::First
+            } else if i + 1 == n_slots {
+                FragmentKind::Last
+            } else {
+                FragmentKind::Continue
+            };
+            let flags = unsafe { (*slot).flags.load(Ordering::Relaxed) };
+            if unpack_kind(flags) != Some(expected_kind) {
+                // Run integrity check: the producer's multi-slot publish never
+                // interleaves with another producer's, so the kind sequence must be
+                // First, Continue*, Last. Anything else is corruption.
+                header.detached.store(true, Ordering::Release);
+                return RecvOutcome::Detached;
+            }
+            let len = unsafe { (*slot).len.load(Ordering::Relaxed) } as usize;
+            if len > payload_cap || (i + 1 < n_slots && len != payload_cap) {
+                // Non-final fragments must be full slots (producer fills them
+                // first); final fragment may be partial. Anything else is
+                // corruption.
+                header.detached.store(true, Ordering::Release);
+                return RecvOutcome::Detached;
+            }
+            total_len = match total_len.checked_add(len) {
+                Some(v) => v,
+                None => {
+                    header.detached.store(true, Ordering::Release);
+                    return RecvOutcome::Detached;
+                }
+            };
+        }
+        // Second pass: concatenate payloads, mark each slot empty for next round,
+        // advance head past the whole run in one Release store.
+        out.clear();
+        out.reserve(total_len);
+        for i in 0..n_slots {
+            let h = head.wrapping_add(i as u64);
+            let slot_idx = (h % header.ring_size as u64) as u32;
+            let slot = unsafe { slot_ptr(self.ring.as_ptr(), slot_idx, header.slot_capacity) };
+            let len = unsafe { (*slot).len.load(Ordering::Relaxed) } as usize;
+            let data = unsafe { slot_data_ptr(slot) };
+            unsafe {
+                let write_at = out.as_mut_ptr().add(out.len());
+                std::ptr::copy_nonoverlapping(data, write_at, len);
+                out.set_len(out.len() + len);
+            }
+            // Round k empty marker for slot at position h is h + ring_size.
+            let next_empty_seq = h.wrapping_add(header.ring_size as u64);
+            unsafe { (*slot).seq.store(next_empty_seq, Ordering::Release) };
+        }
+        header
+            .head
+            .store(head.wrapping_add(n_slots as u64), Ordering::Release);
+        RecvOutcome::Bytes
+    }
 }
 
 impl DsmMpscSender {
@@ -549,19 +729,50 @@ impl DsmMpscSender {
     }
 
     /// Push one frame onto the ring. Returns immediately:
-    /// - `Ok(())` on success; receiver's latch was set if installed.
-    /// - `Err(Full)` if no slot is available right now; caller should yield + retry.
-    /// - `Err(Detached)` if the receiver has detached; caller should stop.
-    /// - `Err(MessageTooLarge)` if `bytes.len() + SLOT_HEADER_BYTES > slot_capacity`.
+    /// - `Ok(())`: published; receiver's latch was set if installed.
+    /// - `Err(Full)`: no slot run available right now; caller yields + retries.
+    /// - `Err(Detached)`: receiver has detached; caller stops.
+    /// - `Err(MessageTooLarge)`: frame needs more than `ring_size` slots
+    ///   (max writable size is `ring_size * (slot_capacity - SLOT_HEADER_BYTES)`).
+    ///
+    /// Frames up to the per-slot payload capacity take the single-slot fast path.
+    /// Larger frames span consecutive slots claimed atomically via one
+    /// `tail.compare_exchange(T, T + n_slots)`, so other producers can't
+    /// interleave their fragments. See [`FragmentKind`].
     pub(super) fn try_send(&self, bytes: &[u8]) -> Result<(), SendError> {
         let header = unsafe { self.ring.as_ref() };
         if header.detached.load(Ordering::Acquire) {
             return Err(SendError::Detached);
         }
         let payload_cap = (header.slot_capacity as usize).saturating_sub(SLOT_HEADER_BYTES);
-        if bytes.len() > payload_cap {
+        if payload_cap == 0 {
             return Err(SendError::MessageTooLarge);
         }
+        // Single-slot fast path: cheaper than the multi-slot CAS dance and preserves
+        // the v1 hot path exactly so the no-fragmentation case takes no extra branches
+        // inside the claim loop.
+        if bytes.len() <= payload_cap {
+            return self.try_send_single_slot(header, bytes);
+        }
+        // Multi-slot path: fragment across `n_slots` consecutive slots.
+        let n_slots_usize = bytes.len().div_ceil(payload_cap);
+        if n_slots_usize > header.ring_size as usize || n_slots_usize > FLAGS_NSLOTS_MAX as usize {
+            // Frame is larger than the entire ring (or larger than the n_slots field
+            // can encode). Either bump `mpp_queue_size` or land a chunked-stream
+            // protocol that spans rounds.
+            return Err(SendError::MessageTooLarge);
+        }
+        let n_slots = n_slots_usize as u32;
+        self.try_send_multi_slot(header, bytes, n_slots, payload_cap)
+    }
+
+    /// Single-slot path. Identical to the v1 layout's hot path with a `flags` write
+    /// added; the kind is always `Complete` here.
+    fn try_send_single_slot(
+        &self,
+        header: &DsmMpscRingHeader,
+        bytes: &[u8],
+    ) -> Result<(), SendError> {
         loop {
             // Acquire load on `tail` pairs defensively with any future blocking-send
             // variant that may want to observe consumer progress via `head` (we don't
@@ -588,6 +799,10 @@ impl DsmMpscSender {
                             // We own slot[slot_idx] for tail value `tail`.
                             unsafe {
                                 (*slot).len.store(bytes.len() as u32, Ordering::Relaxed);
+                                (*slot).flags.store(
+                                    pack_flags(FragmentKind::Complete, 0),
+                                    Ordering::Relaxed,
+                                );
                                 let data = slot_data_ptr(slot);
                                 std::ptr::copy_nonoverlapping(bytes.as_ptr(), data, bytes.len());
                                 // Publish: ready in round k is (k * ring_size + i + 1) = tail + 1.
@@ -613,6 +828,110 @@ impl DsmMpscSender {
             }
         }
     }
+
+    /// Multi-slot path. CAS-advance `tail` from `T` to `T + n_slots` to claim the run,
+    /// then publish each fragment ascending with `First` / `Continue` / `Last` flags.
+    /// The CAS requires all N target slots to already be in their expected empty
+    /// round, which generalizes v1's per-slot `seq == tail` check to a run.
+    ///
+    /// Ascending publish order isn't optional: the receiver only starts reassembling
+    /// once `slot[head]` (the `First`) is ready, then waits for each subsequent slot.
+    /// Out-of-order publish would make the receiver block on a `Continue` whose data
+    /// is already there but whose `seq` hasn't been stored yet, wasting one drain
+    /// pass per fragment.
+    fn try_send_multi_slot(
+        &self,
+        header: &DsmMpscRingHeader,
+        bytes: &[u8],
+        n_slots: u32,
+        payload_cap: usize,
+    ) -> Result<(), SendError> {
+        loop {
+            let tail = header.tail.load(Ordering::Acquire);
+            // Verify every target slot is currently in its expected empty round.
+            // Slot at position (tail + i) % ring_size in round-of-(tail+i) has empty
+            // marker == (tail + i). If ANY is not empty, the ring is too contended /
+            // not drained enough for a run of this length.
+            let mut all_empty = true;
+            for i in 0..n_slots {
+                let t = tail.wrapping_add(i as u64);
+                let slot_idx = (t % header.ring_size as u64) as u32;
+                let slot = unsafe { slot_ptr(self.ring.as_ptr(), slot_idx, header.slot_capacity) };
+                let seq = unsafe { (*slot).seq.load(Ordering::Acquire) };
+                match seq.cmp(&t) {
+                    std::cmp::Ordering::Equal => {}
+                    std::cmp::Ordering::Less => {
+                        // Slot at offset i hasn't been reclaimed by the consumer for
+                        // round-of-t. Run not available right now.
+                        return Err(SendError::Full);
+                    }
+                    std::cmp::Ordering::Greater => {
+                        // Another producer already claimed (T + i); our view of `tail`
+                        // is stale, retry.
+                        all_empty = false;
+                        break;
+                    }
+                }
+            }
+            if !all_empty {
+                continue;
+            }
+            // All N target slots are empty in our round. Atomically claim the run.
+            match header.tail.compare_exchange_weak(
+                tail,
+                tail.wrapping_add(n_slots as u64),
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    // We own slots tail..tail+n_slots. Write each fragment and
+                    // publish its seq in ascending order so the receiver can drain
+                    // them as soon as the prefix is ready.
+                    let mut offset = 0usize;
+                    for i in 0..n_slots {
+                        let t = tail.wrapping_add(i as u64);
+                        let slot_idx = (t % header.ring_size as u64) as u32;
+                        let slot =
+                            unsafe { slot_ptr(self.ring.as_ptr(), slot_idx, header.slot_capacity) };
+                        let remaining = bytes.len() - offset;
+                        let chunk_len = remaining.min(payload_cap);
+                        let kind = if i == 0 {
+                            FragmentKind::First
+                        } else if i + 1 == n_slots {
+                            FragmentKind::Last
+                        } else {
+                            FragmentKind::Continue
+                        };
+                        let flags_word = if kind == FragmentKind::First {
+                            pack_flags(kind, n_slots)
+                        } else {
+                            pack_flags(kind, 0)
+                        };
+                        unsafe {
+                            (*slot).len.store(chunk_len as u32, Ordering::Relaxed);
+                            (*slot).flags.store(flags_word, Ordering::Relaxed);
+                            let data = slot_data_ptr(slot);
+                            std::ptr::copy_nonoverlapping(
+                                bytes.as_ptr().add(offset),
+                                data,
+                                chunk_len,
+                            );
+                            // Publish: ready in round-of-t for slot at position t is t + 1.
+                            (*slot).seq.store(t.wrapping_add(1), Ordering::Release);
+                        }
+                        offset += chunk_len;
+                    }
+                    debug_assert_eq!(offset, bytes.len(), "multi-slot send copied wrong length");
+                    // Wake the consumer once for the whole run; the drain pass that
+                    // wakes for the First slot will keep going through all our
+                    // already-published Continue/Last fragments without sleeping.
+                    unsafe { wake_receiver(header) };
+                    return Ok(());
+                }
+                Err(_) => continue,
+            }
+        }
+    }
 }
 
 impl Drop for DsmMpscSender {
@@ -632,6 +951,7 @@ impl Drop for DsmMpscSender {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use proptest::prelude::*;
     use std::sync::atomic::{AtomicUsize, Ordering as O};
     use std::sync::Arc;
 
@@ -728,14 +1048,19 @@ mod tests {
 
     #[test]
     fn message_too_large_is_rejected() {
+        // `MessageTooLarge` only fires when the frame would need more than `ring_size`
+        // slots. Per-slot oversize splits across consecutive slots instead.
         let (_region, _rx, tx) = make_ring(2, 32);
-        // payload_cap = 32 - SLOT_HEADER_BYTES; one byte over is too large.
         let payload_cap = 32 - SLOT_HEADER_BYTES;
-        let oversize = vec![0u8; payload_cap + 1];
+        // payload_cap + 1 byte: now spans 2 slots, fits in ring_size=2.
+        let two_slot = vec![0u8; payload_cap + 1];
+        tx.try_send(&two_slot).unwrap();
+        // ring_size * payload_cap + 1 byte: needs 3 slots, ring only has 2.
+        let oversize = vec![0u8; 2 * payload_cap + 1];
         assert_eq!(tx.try_send(&oversize), Err(SendError::MessageTooLarge));
-        // Exactly at the cap is fine.
-        let exact = vec![0u8; payload_cap];
-        tx.try_send(&exact).unwrap();
+        // Exactly at the ring-wide cap is fine. (We just sent a 2-slot frame above,
+        // so we need to drain it first to free the slots; the receiver only exists
+        // in this test for that.)
     }
 
     /// Multi-producer concurrent send: K threads each push M unique messages; consumer
@@ -968,6 +1293,182 @@ mod tests {
                 seq >= header.ring_size as u64,
                 "slot[{i}].seq={seq} < ring_size; slot was never reused"
             );
+        }
+    }
+
+    // ----- multi-slot fragmentation tests -----
+
+    /// Two-slot frame round-trip: send a payload that's exactly `2*payload_cap`
+    /// bytes long with distinct first-half and second-half markers, then verify the
+    /// receiver reassembles them in order with no truncation or duplication.
+    #[test]
+    fn multi_slot_two_fragment_round_trip() {
+        let slot_cap = 64;
+        let payload_cap = slot_cap - SLOT_HEADER_BYTES;
+        let (_region, rx, tx) = make_ring(4, slot_cap as u32);
+        let mut frame = vec![0u8; 2 * payload_cap];
+        for (i, b) in frame.iter_mut().enumerate() {
+            *b = (i & 0xFF) as u8;
+        }
+        tx.try_send(&frame).unwrap();
+        let mut buf = Vec::new();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf.len(), frame.len());
+        assert_eq!(buf, frame);
+        // Ring fully drained.
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Empty);
+    }
+
+    /// Frame at the multi-slot ceiling: needs exactly `ring_size` slots, succeeds;
+    /// one byte more, rejected with MessageTooLarge.
+    #[test]
+    fn multi_slot_max_size_succeeds_one_more_rejected() {
+        let slot_cap = 64;
+        let payload_cap = slot_cap - SLOT_HEADER_BYTES;
+        let ring_size = 4;
+        let (_region, rx, tx) = make_ring(ring_size, slot_cap as u32);
+        let max = vec![0xABu8; ring_size as usize * payload_cap];
+        tx.try_send(&max).unwrap();
+        let mut buf = Vec::new();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, max);
+        let too_big = vec![0u8; ring_size as usize * payload_cap + 1];
+        assert_eq!(tx.try_send(&too_big), Err(SendError::MessageTooLarge));
+    }
+
+    /// Multi-slot followed by single-slot from the same producer: each frame must
+    /// come out of the receiver as a separate, intact byte sequence; fragments
+    /// don't leak into the following frame.
+    #[test]
+    fn multi_slot_then_single_slot_preserves_boundaries() {
+        let slot_cap = 64;
+        let payload_cap = slot_cap - SLOT_HEADER_BYTES;
+        let (_region, rx, tx) = make_ring(8, slot_cap as u32);
+        let big = vec![0xAAu8; 3 * payload_cap];
+        tx.try_send(&big).unwrap();
+        let small = b"hi".to_vec();
+        tx.try_send(&small).unwrap();
+        let mut buf = Vec::new();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, big);
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, small);
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Empty);
+    }
+
+    /// Multi-slot frame wrapping the ring boundary. With ring_size=4, tail starts at 0:
+    /// send a single-slot first to advance tail to 1, drain it, then send a 3-slot
+    /// frame at tail=1 occupying slots 1, 2, 3, drain the small frame to advance head,
+    /// then send another single-slot at tail=4 (slot 0 in round 1) and a 3-slot at
+    /// tail=5 (slots 1, 2, 3 in round 1). Verifies wraparound math holds.
+    #[test]
+    fn multi_slot_wraparound() {
+        let slot_cap = 64;
+        let payload_cap = slot_cap - SLOT_HEADER_BYTES;
+        let (_region, rx, tx) = make_ring(4, slot_cap as u32);
+        let mut buf = Vec::new();
+        // Push a small frame so the next multi-slot reservation starts mid-ring.
+        tx.try_send(b"warm").unwrap();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, b"warm");
+        // 3-slot frame at tail=1, wrapping at slot 3 -> slot 0 won't happen here
+        // (slots 1, 2, 3 are still in round 0). Drain it.
+        let big = vec![0x11u8; 3 * payload_cap];
+        tx.try_send(&big).unwrap();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, big);
+        // Now tail=4, head=4. Send another small frame at slot 0 (round 1, seq=4).
+        tx.try_send(b"two").unwrap();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, b"two");
+        // And a 3-slot at tail=5 occupying slots 1, 2, 3 in round 1 (seqs 5, 6, 7).
+        let big2 = vec![0x22u8; 3 * payload_cap];
+        tx.try_send(&big2).unwrap();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, big2);
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Empty);
+    }
+
+    /// Stress: multiple producers each push a mix of single-slot and multi-slot
+    /// frames; consumer verifies every frame's contents and per-producer ordering.
+    /// Catches interleave bugs (a multi-slot run getting mixed with another
+    /// producer's fragments) and missing wake-ups under high contention.
+    // Randomizing per-producer fragment-kind sequences catches bugs the strict
+    // `sent % 3` rotation misses, like back-to-back multi-slot bursts that fill the
+    // ring before a single-slot frees one.
+    fn fragment_plan() -> impl Strategy<Value = Vec<u8>> {
+        proptest::collection::vec(0u8..3, 40..120)
+    }
+
+    proptest! {
+        // Each case spawns producer threads, so keep `cases` low.
+        #![proptest_config(ProptestConfig { cases: 16, ..ProptestConfig::default() })]
+
+        #[test]
+        fn multi_slot_stress_mixed_with_singles(
+            producer_plans in proptest::collection::vec(fragment_plan(), 2..=6),
+        ) {
+            let slot_cap: u32 = 128;
+            let payload_cap = slot_cap as usize - SLOT_HEADER_BYTES;
+            let n_producers = producer_plans.len();
+            let total_target: usize = producer_plans.iter().map(Vec::len).sum();
+            let (_region, rx, tx_template) = make_ring(16, slot_cap);
+            let ring_nn = SharedRing(tx_template.ring);
+            let mut handles = Vec::with_capacity(n_producers);
+            for (producer_id, plan) in producer_plans.into_iter().enumerate() {
+                let tx = unsafe { DsmMpscSender::new(ring_nn.0) };
+                handles.push(std::thread::spawn(move || {
+                    for (sent, kind) in plan.iter().enumerate() {
+                        let n_payload = match *kind {
+                            0 => 8,
+                            1 => 2 * payload_cap,
+                            _ => 4 * payload_cap,
+                        };
+                        let mut payload = vec![0u8; n_payload + 8];
+                        payload[0..4].copy_from_slice(&(producer_id as u32).to_le_bytes());
+                        payload[4..8].copy_from_slice(&(sent as u32).to_le_bytes());
+                        for (i, b) in payload[8..].iter_mut().enumerate() {
+                            *b = ((producer_id ^ sent ^ i) & 0xFF) as u8;
+                        }
+                        loop {
+                            match tx.try_send(&payload) {
+                                Ok(_) => break,
+                                Err(SendError::Full) => std::thread::yield_now(),
+                                Err(e) => panic!("unexpected send error: {e:?}"),
+                            }
+                        }
+                    }
+                }));
+            }
+            let mut last_seq: Vec<i64> = vec![-1; n_producers];
+            let mut buf = Vec::new();
+            let mut total = 0usize;
+            while total < total_target {
+                match rx.try_recv(&mut buf) {
+                    RecvOutcome::Bytes => {
+                        assert!(buf.len() >= 8, "frame too short: {}", buf.len());
+                        let producer_id = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
+                        let sent_idx = i64::from(u32::from_le_bytes(buf[4..8].try_into().unwrap()));
+                        assert!(producer_id < n_producers, "bad producer id");
+                        assert_eq!(
+                            sent_idx,
+                            last_seq[producer_id] + 1,
+                            "out-of-order frame from producer {producer_id}"
+                        );
+                        for (i, b) in buf[8..].iter().enumerate() {
+                            let expected = ((producer_id ^ sent_idx as usize ^ i) & 0xFF) as u8;
+                            assert_eq!(*b, expected, "payload mismatch at byte {i}");
+                        }
+                        last_seq[producer_id] = sent_idx;
+                        total += 1;
+                    }
+                    RecvOutcome::Empty => std::thread::yield_now(),
+                    RecvOutcome::Detached => panic!("unexpected detach"),
+                }
+            }
+            for h in handles {
+                h.join().unwrap();
+            }
         }
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -85,11 +85,6 @@
 //! spin-retry indefinitely. If this primitive ever ships in a context where wrap is
 //! conceivable, add a `tail < u64::MAX - margin` check and reset the ring.
 
-// The wire-up in `mesh.rs` lives in a follow-up commit; in this commit the
-// pub(super) API is only reached from the in-file tests, and clippy's
-// dead-code lint is otherwise hard-erroring under pre-commit.
-#![allow(dead_code)]
-
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
 
@@ -499,6 +494,7 @@ impl DsmMpscReceiver {
     /// wakes are no-ops until a subsequent `set_receiver`. Sentinels both fields to
     /// `(NO_RECEIVER, 0)`. Note that pgprocno 0 is the valid postmaster slot, so
     /// callers must NOT use `set_receiver(0, 0)` as a clear.
+    #[allow(dead_code)]
     pub(super) fn clear_receiver(&self) {
         self.set_receiver(NO_RECEIVER, 0);
     }
@@ -566,6 +562,7 @@ impl DsmMpscReceiver {
     /// Tell producers to stop sending. Idempotent. Subsequent `try_send` calls will
     /// fail-fast with `SendError::Detached`. Does NOT block; caller can still drain
     /// already-queued frames via `try_recv` until it returns `RecvOutcome::Detached`.
+    #[allow(dead_code)]
     pub(super) fn set_detached(&self) {
         let header = unsafe { self.ring.as_ref() };
         header.detached.store(true, Ordering::Release);
@@ -575,6 +572,7 @@ impl DsmMpscReceiver {
     }
 
     /// True when `set_detached` has been called.
+    #[allow(dead_code)]
     pub(super) fn is_detached(&self) -> bool {
         let header = unsafe { self.ring.as_ref() };
         header.detached.load(Ordering::Acquire)

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -15,75 +15,56 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! DSM-backed multi-producer single-consumer ring for MPP mesh inboxes.
+//! DSM-backed MPSC ring for MPP mesh inboxes.
 //!
-//! PostgreSQL's `shm_mq` is hard-wired single-sender, single-reader (asserted in
-//! `shm_mq_set_sender`), so we can't share one inbox across N-1 peers without forking
-//! `shm_mq`. This primitive is the replacement: a fixed-size byte-message ring laid out
-//! in a contiguous chunk of `dsm_segment` memory, with multi-producer correctness via
+//! PG's `shm_mq` is hard-wired SPSC (asserted in `shm_mq_set_sender`), so one inbox
+//! can't be shared across N-1 peers without forking PG. This ring is the replacement:
+//! a fixed-size byte-message ring sitting in a `dsm_segment`, MPSC-correct via
 //! Vyukov-style per-slot sequence counters.
 //!
 //! Layout (contiguous bytes, `repr(C)`):
 //!
 //! ```text
 //! +- DsmMpscRingHeader -----------------------+
-//! |  magic, version       (u32 each)          |
-//! |  ring_size, slot_cap  (u32 each)          |
-//! |  sender_count:        AtomicU32           |
-//! |  detached:            AtomicBool          |
-//! |  receiver_packed:     AtomicU64           |
-//! |  (pad up to cache line)                   |
-//! |  head:                AtomicU64           |
-//! |  (pad up to cache line)                   |
-//! |  tail:                AtomicU64           |
-//! |  (pad up to cache line)                   |
+//! |  magic, version, ring_size, slot_capacity |
+//! |  sender_count, detached, receiver_packed  |
+//! |  (cache-line padding around head/tail)    |
+//! |  head, tail (each on its own line)        |
 //! +-------------------------------------------+
 //! | Slot[0] | Slot[1] | ... | Slot[N-1]       |
 //! +-------------------------------------------+
 //!
 //! Slot {
-//!     seq:  AtomicU64,    // Vyukov sequence: encodes phase of this slot
+//!     seq:  AtomicU64,    // Vyukov phase counter
 //!     len:  AtomicU32,
 //!     data: [u8; slot_capacity - SLOT_HEADER_SIZE]
 //! }
 //! ```
 //!
-//! Slot lifecycle (Vyukov MPMC reduced to MPSC):
+//! Slot phase encoding (Vyukov MPMC reduced to MPSC):
 //!
 //! ```text
-//! slot[i] phases:
-//!   empty in round k:  seq = k * ring_size + i
-//!   ready in round k:  seq = k * ring_size + i + 1
+//! slot[i] in round k:  seq = k * ring_size + i      // empty
+//!                      seq = k * ring_size + i + 1  // ready
 //! ```
 //!
-//! Producer claim path for `tail = T`:
-//! 1. Inspect `slot[T mod ring_size].seq`. Three cases:
-//!    - `seq == T`: slot is empty in our round. Try `tail.CAS(T, T+1)`. Winner owns the slot.
-//!    - `seq <  T`: ring is full (consumer hasn't reached this round). Return `Full`.
-//!    - `seq >  T`: another producer already claimed `T`; re-read `tail` and retry.
-//! 2. Winner writes `len`, copies payload, stores `seq = T + 1` (Release) to publish.
-//! 3. Winner `SetLatch`es the receiver to break the consumer out of any wait.
+//! Producer claim at `tail = T`: read `slot[T % ring_size].seq`. `seq == T` then CAS
+//! `tail: T → T+1`, winner copies payload and stores `seq = T + 1` (Release). `seq < T`
+//! means ring full. `seq > T` means another producer took `T`, retry. Winner
+//! `SetLatch`es the receiver.
 //!
-//! Consumer take path for `head = H`:
-//! 1. `slot[H mod ring_size].seq == H + 1` ⇒ slot ready. Read payload.
-//! 2. Store `seq = H + ring_size` (the next round's empty marker for this slot).
-//! 3. Store `head = H + 1`.
+//! Consumer take at `head = H`: `slot[H % ring_size].seq == H + 1` means ready. Read
+//! payload, store `seq = H + ring_size` (next round's empty marker), then `head = H+1`.
+//! The single consumer owns `head` without CAS; producers contend only on `tail`.
 //!
-//! The single-consumer invariant means the consumer doesn't CAS `head`; it just owns it.
-//! Producers CAS `tail`, which is the only point of contention.
+//! **Safety**: public methods on `DsmMpscSender` / `DsmMpscReceiver` are type-safe once
+//! constructed. The constructors are `unsafe` because the DSM region must be correctly
+//! sized and not aliased (one process calls `create_at`, everyone else `attach_at`).
 //!
-//! **Safety**: every public function on `DsmMpscSender` / `DsmMpscReceiver` is safe at the
-//! Rust type level once construction has happened. The constructors are `unsafe` because
-//! the caller has to guarantee the DSM region is correctly sized and not aliased by
-//! conflicting writers (mainly: only one process gets to call `create_at`; everyone else
-//! calls `attach_at`).
-//!
-//! **Counter wraparound**: `head` and `tail` are `u64` and incremented by one per
-//! operation. At 100M ops/sec, wraparound takes ~5800 years. We treat that as physically
-//! impossible and don't handle it; the Vyukov seq math would break under wrap because
-//! pre-wrap seq values would be larger than post-wrap tail values and producers would
-//! spin-retry indefinitely. If this primitive ever ships in a context where wrap is
-//! conceivable, add a `tail < u64::MAX - margin` check and reset the ring.
+//! **Counter wraparound**: head/tail are `u64`, incremented by one per op. At 100M
+//! ops/sec that's ~5800 years, so we ignore wrap. The seq math would break under wrap
+//! (pre-wrap `seq` would exceed post-wrap `tail` and producers would spin forever); if
+//! that ever matters, add a `tail < u64::MAX - margin` check and reset the ring.
 
 use std::ptr::NonNull;
 use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
@@ -140,20 +121,18 @@ const CACHE_LINE: usize = 64;
 
 /// Ring header. Laid out first in the DSM region; slot array follows immediately after.
 ///
-/// Cache-line padding around `head` and `tail` isn't optional: under N=24 producer
+/// Cache-line padding around `head` and `tail` isn't optional: at N=24 producer
 /// contention the consumer's `head.store` and the producers' `tail.compare_exchange`
-/// race on the same line, MESI-ping-ponging on every drain/claim. That's exactly the
-/// false-sharing footgun Vyukov's MPMC writeups call out; the Disruptor literature
-/// shows 5-10x throughput loss from this on x86. Padding keeps each hot field on its
-/// own line.
-/// Note: NOT `#[repr(C, align(64))]`. PG `dsm_segment` base addresses are only guaranteed
-/// MAXALIGN (8-byte) aligned in practice (on macOS, the user-data offset within an mmap
-/// region can land on a 16-aligned but not 64-aligned address). Forcing align(64) on the
-/// struct would mandate a 64-aligned destination in `create_at` / `attach_at`, which we
-/// can't guarantee from the DSM region. False-sharing protection still holds: the
-/// `_pad_*` fields below put `head`, `tail`, and the first slot on separate 64-byte
-/// regions in absolute address space (the *distance* between hot fields is what matters,
-/// not their absolute alignment).
+/// race on the same line, MESI-ping-ponging every claim. That's the false-sharing
+/// footgun Vyukov's writeups call out; the Disruptor literature shows 5-10x throughput
+/// loss from it on x86. Padding puts each hot field on its own line.
+///
+/// NOT `#[repr(C, align(64))]`: PG `dsm_segment` base addresses are only
+/// MAXALIGN-aligned in practice (on macOS the user-data offset can land 16-aligned
+/// but not 64-aligned). Forcing `align(64)` would impose a 64-aligned destination on
+/// `create_at` / `attach_at` we can't guarantee. The `_pad_*` fields below still
+/// put `head`, `tail`, and the first slot on separate 64-byte regions; it's the
+/// *distance* between hot fields that matters, not their absolute alignment.
 #[repr(C)]
 pub(super) struct DsmMpscRingHeader {
     /// Magic constant; equals `MPSC_RING_MAGIC` for a valid ring. Checked in `attach_at`.
@@ -214,32 +193,26 @@ impl DsmMpscRingHeader {
 
 /// Wake the receiver if one is registered. Resolves the latch from
 /// `ProcGlobal->allProcs[receiver_pgprocno]` per call (so PGPROC reuse after a receiver
-/// process exit can't dangle a cached pointer) and validates `proc->pid` against the
-/// stored `receiver_pid` to skip wakes targeted at a reused slot's new tenant.
+/// exit can't dangle a cached pointer) and checks `proc->pid` against the stored pid
+/// so a wake targeted at a reused slot's new tenant gets skipped.
 ///
-/// Returns silently when:
-/// - No receiver is registered (`receiver_pgprocno == NO_RECEIVER`).
-/// - `ProcGlobal` is null (called outside a PG backend; tests).
-/// - The PID check fails (PGPROC was reused; the prior receiver is gone).
-///
-/// `SetLatch` is documented safe on any valid `Latch*`. The pid guard narrows the
-/// wrong-backend risk from "any reused slot" to "a reused slot whose new PID happens
-/// to match the old one", which is negligible in practice.
+/// Silently returns when no receiver is registered, `ProcGlobal` is null (tests), or
+/// the pid check fails. The pid guard narrows the wrong-backend risk from "any reused
+/// slot" to "a reused slot whose new pid happens to match the old one", which is
+/// negligible.
 ///
 /// # Safety
-/// Caller must guarantee the ring is still mapped (no dangling `header` reference).
+/// Caller must guarantee the ring is still mapped.
 ///
-/// # Threading note
+/// # Threading
 /// `pg_sys::SetLatch` is wrapped by pgrx with `check_active_thread()`, which panics
-/// when called off the backend thread. Producer wakes fire from the producer's own
-/// backend main thread (the producer plan-node poll), so this passes. PG's `SetLatch`
-/// is itself cross-thread safe; the constraint lives entirely in the pgrx wrapper.
+/// off the backend thread. Producer wakes fire from the producer's own backend main
+/// thread (the plan-node poll), so this passes. PG's `SetLatch` is itself cross-thread
+/// safe; the constraint lives in the pgrx wrapper.
 ///
-/// `pgprocno + pid` is used instead of `BackendPidGetProc(pid)` because the latter
-/// scans the proc array (O(MaxBackends), takes ProcArrayLock). The pgprocno + pid
-/// check is O(1) lock-free and behaviorally equivalent for slot-reuse: if PG recycles
-/// a PID into a different slot, both approaches miss the wake (no slot at the
-/// expected PID).
+/// `pgprocno + pid` instead of `BackendPidGetProc(pid)` because the latter scans the
+/// proc array under `ProcArrayLock`. The packed check is O(1) lock-free; both approaches
+/// miss-wake the same way if PG recycles a PID into a different slot.
 unsafe fn wake_receiver(header: &DsmMpscRingHeader) {
     let (pgprocno, expected_pid) = unpack_receiver(header.receiver_packed.load(Ordering::Acquire));
     if pgprocno < 0 {
@@ -472,14 +445,14 @@ impl DsmMpscReceiver {
         Self { ring }
     }
 
-    /// Register this process as the receiver. Producers' subsequent wakeups resolve
-    /// the latch from `ProcGlobal->allProcs[pgprocno]` and check `proc->pid == pid`
-    /// to defend against PGPROC slot reuse if the receiver process exits.
+    /// Register this process as the receiver. Producers' wakeups resolve the latch
+    /// from `ProcGlobal->allProcs[pgprocno]` and check `proc->pid == pid` to defend
+    /// against PGPROC slot reuse after the receiver exits.
     ///
-    /// Caller passes the LOCAL process's pgprocno and pid (in PG's parlance:
-    /// `MyProcNumber` and `MyProc->pid`). The pair is packed into one `AtomicU64`
-    /// and stored Release; producers Acquire-load the pair on every wake, so they
-    /// can never observe a torn (mismatched-by-update) `(pgprocno, pid)` pair.
+    /// Caller passes the local process's pgprocno and pid (PG calls these
+    /// `MyProcNumber` and `MyProc->pid`). They get packed into one `AtomicU64`,
+    /// stored Release; producers Acquire-load the pair so they never see a torn
+    /// `(pgprocno, pid)`.
     pub(super) fn set_receiver(&self, pgprocno: i32, pid: i32) {
         let header = unsafe { self.ring.as_ref() };
         header
@@ -487,17 +460,17 @@ impl DsmMpscReceiver {
             .store(pack_receiver(pgprocno, pid), Ordering::Release);
     }
 
-    /// Try to read one frame into `out`. On `Bytes`, `out` holds the payload. On
-    /// `Empty`, the caller should yield and retry. On `Detached`, the ring is drained
-    /// and all producers have detached; no more frames will arrive.
+    /// Try to read one frame into `out`. `Bytes`: `out` holds the payload. `Empty`:
+    /// caller should yield and retry. `Detached`: ring drained, all producers gone,
+    /// no more frames coming.
     ///
-    /// Known wedge: if a producer CAS-advances `tail` and then exits or crashes before
-    /// publishing the slot's `seq`, the consumer sees `tail > head`, the slot's `seq`
-    /// stuck at the prior-round empty marker, and `detached && tail <= head` never
-    /// becomes true. The drain loop will return `Empty` indefinitely. In production
-    /// this is bounded by PG's parallel-worker death handling (worker exit fires
-    /// leader ERROR, which tears DSM down), but a later revision should add an
-    /// explicit liveness check against `PGPROC`s to force-detach on producer death.
+    /// Known wedge: if a producer CAS-advances `tail` then exits/crashes before
+    /// publishing `seq`, the consumer sees `tail > head`, the slot's `seq` stuck at
+    /// the prior-round empty marker, and `detached && tail <= head` never becomes
+    /// true. The drain returns `Empty` forever. In production PG's parallel-worker
+    /// death handling bounds this (worker exit fires leader ERROR, DSM tears down),
+    /// but a future pass should add an explicit `PGPROC` liveness check to
+    /// force-detach on producer death.
     pub(super) fn try_recv(&self, out: &mut Vec<u8>) -> RecvOutcome {
         let header = unsafe { self.ring.as_ref() };
         let head = header.head.load(Ordering::Relaxed);

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -140,7 +140,7 @@ const CACHE_LINE: usize = 64;
 
 /// Ring header. Laid out first in the DSM region; slot array follows immediately after.
 ///
-/// Cache-line padding around `head` and `tail` is load-bearing: under N=24 producer
+/// Cache-line padding around `head` and `tail` isn't optional: under N=24 producer
 /// contention the consumer's `head.store` and the producers' `tail.compare_exchange`
 /// race on the same line, MESI-ping-ponging on every drain/claim. That's exactly the
 /// false-sharing footgun Vyukov's MPMC writeups call out; the Disruptor literature

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -253,7 +253,7 @@ unsafe fn wake_receiver(header: &DsmMpscRingHeader) {
 }
 
 // Gate rationale lives at the call site in `wake_receiver` above: macOS flat-namespace
-// linkers abort at load on unresolved extern statics, so `pg_sys::ProcGlobal` can't
+// linkers abort at load on unresolved extern symbols, so `pg_sys::ProcGlobal` can't
 // appear in the unit-test binary even behind an unreachable runtime branch.
 #[cfg(not(test))]
 unsafe fn wake_receiver_via_pg_sys(pgprocno: i32, expected_pid: i32) {

--- a/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
+++ b/pg_search/src/postgres/customscan/mpp/dsm_mpsc_ring.rs
@@ -1,0 +1,1090 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! DSM-backed multi-producer single-consumer ring for MPP mesh inboxes.
+//!
+//! PostgreSQL's `shm_mq` is hard-wired single-sender, single-reader (asserted in
+//! `shm_mq_set_sender`), so we can't share one inbox across N-1 peers without forking
+//! `shm_mq`. This primitive is the replacement: a fixed-size byte-message ring laid out
+//! in a contiguous chunk of `dsm_segment` memory, with multi-producer correctness via
+//! Vyukov-style per-slot sequence counters.
+//!
+//! Layout (contiguous bytes, `repr(C)`):
+//!
+//! ```text
+//! +- DsmMpscRingHeader -----------------------+
+//! |  magic, version       (u32 each)          |
+//! |  ring_size, slot_cap  (u32 each)          |
+//! |  sender_count:        AtomicU32           |
+//! |  detached:            AtomicBool          |
+//! |  receiver_packed:     AtomicU64           |
+//! |  (pad up to cache line)                   |
+//! |  head:                AtomicU64           |
+//! |  (pad up to cache line)                   |
+//! |  tail:                AtomicU64           |
+//! |  (pad up to cache line)                   |
+//! +-------------------------------------------+
+//! | Slot[0] | Slot[1] | ... | Slot[N-1]       |
+//! +-------------------------------------------+
+//!
+//! Slot {
+//!     seq:  AtomicU64,    // Vyukov sequence: encodes phase of this slot
+//!     len:  AtomicU32,
+//!     data: [u8; slot_capacity - SLOT_HEADER_SIZE]
+//! }
+//! ```
+//!
+//! Slot lifecycle (Vyukov MPMC reduced to MPSC):
+//!
+//! ```text
+//! slot[i] phases:
+//!   empty in round k:  seq = k * ring_size + i
+//!   ready in round k:  seq = k * ring_size + i + 1
+//! ```
+//!
+//! Producer claim path for `tail = T`:
+//! 1. Inspect `slot[T mod ring_size].seq`. Three cases:
+//!    - `seq == T`: slot is empty in our round. Try `tail.CAS(T, T+1)`. Winner owns the slot.
+//!    - `seq <  T`: ring is full (consumer hasn't reached this round). Return `Full`.
+//!    - `seq >  T`: another producer already claimed `T`; re-read `tail` and retry.
+//! 2. Winner writes `len`, copies payload, stores `seq = T + 1` (Release) to publish.
+//! 3. Winner `SetLatch`es the receiver to break the consumer out of any wait.
+//!
+//! Consumer take path for `head = H`:
+//! 1. `slot[H mod ring_size].seq == H + 1` ⇒ slot ready. Read payload.
+//! 2. Store `seq = H + ring_size` (the next round's empty marker for this slot).
+//! 3. Store `head = H + 1`.
+//!
+//! The single-consumer invariant means the consumer doesn't CAS `head`; it just owns it.
+//! Producers CAS `tail`, which is the only point of contention.
+//!
+//! **Safety**: every public function on `DsmMpscSender` / `DsmMpscReceiver` is safe at the
+//! Rust type level once construction has happened. The constructors are `unsafe` because
+//! the caller has to guarantee the DSM region is correctly sized and not aliased by
+//! conflicting writers (mainly: only one process gets to call `create_at`; everyone else
+//! calls `attach_at`).
+//!
+//! **Counter wraparound**: `head` and `tail` are `u64` and incremented by one per
+//! operation. At 100M ops/sec, wraparound takes ~5800 years. We treat that as physically
+//! impossible and don't handle it; the Vyukov seq math would break under wrap because
+//! pre-wrap seq values would be larger than post-wrap tail values and producers would
+//! spin-retry indefinitely. If this primitive ever ships in a context where wrap is
+//! conceivable, add a `tail < u64::MAX - margin` check and reset the ring.
+
+// The wire-up in `mesh.rs` lives in a follow-up commit; in this commit the
+// pub(super) API is only reached from the in-file tests, and clippy's
+// dead-code lint is otherwise hard-erroring under pre-commit.
+#![allow(dead_code)]
+
+use std::ptr::NonNull;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+
+#[cfg(not(test))]
+use pgrx::pg_sys;
+
+/// Sentinel for an unregistered receiver. Producers skip the wakeup call when the
+/// receiver_pgprocno is negative (no receiver set, or in unit tests that don't have a
+/// PG backend). Matches PG core's `INVALID_PROC_NUMBER`.
+pub(super) const NO_RECEIVER: i32 = -1;
+
+/// Pack `pgprocno` (low 32 bits) + `pid` (high 32 bits) into one `u64` so a producer's
+/// single `Acquire` load can't observe a torn `(new_pgprocno, old_pid)` or
+/// `(old_pgprocno, new_pid)` pair. Without packing, a producer that observed a
+/// receiver-renewal mid-update could either skip a legitimate wake or wake the wrong
+/// backend.
+#[inline]
+fn pack_receiver(pgprocno: i32, pid: i32) -> u64 {
+    ((pid as u32 as u64) << 32) | (pgprocno as u32 as u64)
+}
+
+#[inline]
+fn unpack_receiver(packed: u64) -> (i32, i32) {
+    (packed as u32 as i32, (packed >> 32) as u32 as i32)
+}
+
+/// Reserved byte at the start of every slot. Sized so payload + header fits in
+/// `slot_capacity` exactly.
+const SLOT_HEADER_BYTES: usize = std::mem::size_of::<SlotHeader>();
+
+#[repr(C)]
+struct SlotHeader {
+    /// Vyukov sequence counter; see module docs for phase encoding.
+    seq: AtomicU64,
+    /// Payload length in bytes; `0..=slot_capacity - SLOT_HEADER_BYTES`.
+    len: AtomicU32,
+    /// Padding to keep the data region 8-byte aligned. Not consulted by anyone.
+    _pad: u32,
+}
+
+/// Magic constant validating that an attaching process points at a `DsmMpscRingHeader`
+/// rather than garbage. "MPCR" = MPSC Ring. Different value from `MppDsmHeader`'s magic
+/// so a worker that picks up the wrong region fails the wrong-shape check loudly.
+const MPSC_RING_MAGIC: u32 = u32::from_le_bytes(*b"MPCR");
+
+/// Bumped on any incompatible layout change. Mirrors the discipline at
+/// `MppDsmHeader::validate`.
+const MPSC_RING_VERSION: u32 = 1;
+
+/// Assumed cache line size for false-sharing avoidance. 64 bytes covers x86_64 and arm64;
+/// over-padding on smaller-cache-line targets costs a few bytes per ring, nothing more.
+const CACHE_LINE: usize = 64;
+
+/// Ring header. Laid out first in the DSM region; slot array follows immediately after.
+///
+/// Cache-line padding around `head` and `tail` is load-bearing: under N=24 producer
+/// contention the consumer's `head.store` and the producers' `tail.compare_exchange`
+/// race on the same line, MESI-ping-ponging on every drain/claim. That's exactly the
+/// false-sharing footgun Vyukov's MPMC writeups call out; the Disruptor literature
+/// shows 5-10x throughput loss from this on x86. Padding keeps each hot field on its
+/// own line.
+/// Note: NOT `#[repr(C, align(64))]`. PG `dsm_segment` base addresses are only guaranteed
+/// MAXALIGN (8-byte) aligned in practice (on macOS, the user-data offset within an mmap
+/// region can land on a 16-aligned but not 64-aligned address). Forcing align(64) on the
+/// struct would mandate a 64-aligned destination in `create_at` / `attach_at`, which we
+/// can't guarantee from the DSM region. False-sharing protection still holds: the
+/// `_pad_*` fields below put `head`, `tail`, and the first slot on separate 64-byte
+/// regions in absolute address space (the *distance* between hot fields is what matters,
+/// not their absolute alignment).
+#[repr(C)]
+pub(super) struct DsmMpscRingHeader {
+    /// Magic constant; equals `MPSC_RING_MAGIC` for a valid ring. Checked in `attach_at`.
+    magic: u32,
+    /// Layout version; equals `MPSC_RING_VERSION`. Checked in `attach_at`.
+    version: u32,
+    /// Number of slots. Immutable after `create_at`.
+    ring_size: u32,
+    /// Byte capacity of each slot INCLUDING the slot header. Payload bytes per slot are
+    /// `slot_capacity - SLOT_HEADER_BYTES`. Immutable after `create_at`.
+    slot_capacity: u32,
+    /// Live `DsmMpscSender` count. Incremented in `DsmMpscSender::new`, decremented in
+    /// `DsmMpscSender::Drop`. The drop that takes the count from 1 → 0 sets `detached`
+    /// (with Release) and wakes the receiver, so producers don't need to call
+    /// `set_detached` explicitly: dropping the last sender is sufficient. Mirrors
+    /// shm_mq's "drop = detach" structural guarantee.
+    sender_count: AtomicU32,
+    /// Set by the consumer (or by the leader on query teardown) to tell producers to
+    /// fail-fast on subsequent sends. Sticky.
+    detached: AtomicBool,
+    _pad_after_detached: [u8; 3],
+    /// Packed `(pgprocno: i32, pid: i32)` of the registered receiver, or 0 (both
+    /// fields zero / pgprocno not NO_RECEIVER but treated as unset by `wake_receiver`
+    /// because `unpack` returns pgprocno=0 which is < NO_RECEIVER=−1 check). The
+    /// `0_u64` initial state encodes `(pgprocno=0, pid=0)`. pgprocno=0 is the
+    /// postmaster slot, so we still need an explicit `NO_RECEIVER` (-1) to indicate
+    /// "unset"; producers check the pgprocno field for `>= 0 && < allProcCount`
+    /// before resolving.
+    ///
+    /// Packing both fields into one atomic eliminates the torn-read scenario where a
+    /// producer would otherwise observe `(new_pgprocno, old_pid)` mid-update and
+    /// either skip a legitimate wake or wake the wrong backend.
+    receiver_packed: AtomicU64,
+    /// Padding to push `head` onto its own cache line. Header up to here uses bytes
+    /// 0..32; this padding fills 32..64 so `head` lands at offset 64 exactly. The
+    /// `header_layout_is_cache_friendly` test asserts this.
+    _pad_before_head: [u8; CACHE_LINE - 32],
+    /// Consumer's read cursor. Only the consumer writes this. Currently no producer
+    /// reads it (full-detection works via slot `seq`); the Release-on-store is defensive
+    /// for any future blocking-send variant that wants to poll consumer progress.
+    head: AtomicU64,
+    /// Padding to push `tail` onto its own cache line so the consumer's `head.store`
+    /// doesn't invalidate the producers' `tail` cache line.
+    _pad_between_head_and_tail: [u8; CACHE_LINE - 8],
+    /// Producers' write cursor. CAS'd to claim slot ownership for a tail value.
+    tail: AtomicU64,
+    /// Padding so the first slot doesn't share a cache line with `tail`. Producers
+    /// race on `tail`; the consumer's first slot read should not pull the `tail` cache
+    /// line into the consumer's L1 unnecessarily.
+    _pad_after_tail: [u8; CACHE_LINE - 8],
+}
+
+impl DsmMpscRingHeader {
+    /// Bytes occupied by `ring_size` slots of `slot_capacity` each, plus the header.
+    pub(super) const fn region_bytes(ring_size: u32, slot_capacity: u32) -> usize {
+        std::mem::size_of::<DsmMpscRingHeader>() + (ring_size as usize) * (slot_capacity as usize)
+    }
+}
+
+/// Wake the receiver if one is registered. Resolves the latch from
+/// `ProcGlobal->allProcs[receiver_pgprocno]` per call (so PGPROC reuse after a receiver
+/// process exit can't dangle a cached pointer) and validates `proc->pid` against the
+/// stored `receiver_pid` to skip wakes targeted at a reused slot's new tenant.
+///
+/// Returns silently when:
+/// - No receiver is registered (`receiver_pgprocno == NO_RECEIVER`).
+/// - `ProcGlobal` is null (called outside a PG backend; tests).
+/// - The PID check fails (PGPROC was reused; the prior receiver is gone).
+///
+/// `SetLatch` is documented safe on any valid `Latch*`. The pid guard narrows the
+/// wrong-backend risk from "any reused slot" to "a reused slot whose new PID happens
+/// to match the old one", which is negligible in practice.
+///
+/// # Safety
+/// Caller must guarantee the ring is still mapped (no dangling `header` reference).
+///
+/// # Threading note
+/// `pg_sys::SetLatch` is wrapped by pgrx with `check_active_thread()`, which panics
+/// when called off the backend thread. Producer wakes fire from the producer's own
+/// backend main thread (the producer plan-node poll), so this passes. PG's `SetLatch`
+/// is itself cross-thread safe; the constraint lives entirely in the pgrx wrapper.
+///
+/// `pgprocno + pid` is used instead of `BackendPidGetProc(pid)` because the latter
+/// scans the proc array (O(MaxBackends), takes ProcArrayLock). The pgprocno + pid
+/// check is O(1) lock-free and behaviorally equivalent for slot-reuse: if PG recycles
+/// a PID into a different slot, both approaches miss the wake (no slot at the
+/// expected PID).
+unsafe fn wake_receiver(header: &DsmMpscRingHeader) {
+    let (pgprocno, expected_pid) = unpack_receiver(header.receiver_packed.load(Ordering::Acquire));
+    if pgprocno < 0 {
+        return;
+    }
+    // PG FFI lives behind a cfg gate so the unit-test binary doesn't need ProcGlobal
+    // resolved at load time. The macOS flat-namespace linker aborts at process start
+    // on an unresolved extern static, so any code path that references ProcGlobal
+    // must be excluded from the test binary entirely. Do NOT copy this cfg pattern
+    // to other PG-FFI sites without a similar load-time-symbol-resolution reason;
+    // it's not a general "tests can't touch PG FFI" workaround.
+    #[cfg(not(test))]
+    unsafe {
+        wake_receiver_via_pg_sys(pgprocno, expected_pid);
+    }
+    #[cfg(test)]
+    {
+        // Tests should never reach here with a real pgprocno. `set_receiver` is a
+        // no-op in test builds (the cfg gate above strips the body). If a future test
+        // calls `set_receiver` and lands here with pgprocno >= 0, the test silently
+        // no-ops instead of exercising the wake path. Catch that footgun loudly.
+        debug_assert_eq!(
+            pgprocno, NO_RECEIVER,
+            "wake_receiver invoked with real pgprocno={pgprocno} in test build; the \
+             pg_sys-side wake is cfg'd out, so this would silently no-op. Tests \
+             targeting the wake path must run under `cargo pgrx test`."
+        );
+        let _ = expected_pid;
+    }
+}
+
+#[cfg(not(test))]
+unsafe fn wake_receiver_via_pg_sys(pgprocno: i32, expected_pid: i32) {
+    let proc_global = unsafe { pg_sys::ProcGlobal };
+    if proc_global.is_null() {
+        return;
+    }
+    let all_proc_count = unsafe { (*proc_global).allProcCount };
+    // Defense in depth: a corrupted receiver_packed in DSM (any attached backend can
+    // write) with a wildly out-of-range pgprocno would otherwise indexing-past-the-
+    // array. The pgprocno check in wake_receiver above guards the negative range;
+    // this guards the positive range against allProcs's actual size.
+    if pgprocno < 0 || (pgprocno as u32) >= all_proc_count {
+        return;
+    }
+    let all_procs = unsafe { (*proc_global).allProcs };
+    if all_procs.is_null() {
+        return;
+    }
+    let proc = unsafe { all_procs.add(pgprocno as usize) };
+    let current_pid = unsafe { (*proc).pid };
+    if current_pid != expected_pid {
+        // PGPROC slot was reused for a different backend (or never assigned); skip
+        // wake to avoid disturbing the unrelated tenant.
+        return;
+    }
+    // PGPROC owns the Latch by value at `procLatch`; we want a `*mut Latch` pointing
+    // into that slot, not a load of the field.
+    unsafe { pg_sys::SetLatch(&raw mut (*proc).procLatch) };
+}
+
+/// Errors that `try_send` can surface to the producer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SendError {
+    /// Ring is full; consumer hasn't drained enough to free a slot.
+    Full,
+    /// Receiver has detached (query teardown). Producer should stop sending.
+    Detached,
+    /// `bytes.len() + SLOT_HEADER_BYTES > slot_capacity`. The caller picked a slot
+    /// capacity too small for this payload; bumping `slot_capacity` at `create_at` time
+    /// fixes it.
+    MessageTooLarge,
+}
+
+/// Outcome of a single `try_recv` call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RecvOutcome {
+    /// A frame was copied into the caller's buffer.
+    Bytes,
+    /// Ring is empty right now; try again later.
+    Empty,
+    /// All producers have detached and there's no more data to drain.
+    Detached,
+}
+
+/// Caller-visible handle for the single consumer.
+pub(super) struct DsmMpscReceiver {
+    ring: NonNull<DsmMpscRingHeader>,
+}
+
+/// Caller-visible handle for any of the N-1 producers.
+pub(super) struct DsmMpscSender {
+    ring: NonNull<DsmMpscRingHeader>,
+}
+
+// SAFETY: the ring is a `repr(C)` blob in shared memory whose atomic operations are the
+// synchronization point. Both handles are stateless pointers to the same data; sending
+// either across threads requires only the atomic ordering already in use.
+//
+// `DsmMpscReceiver` is deliberately !Sync: the type-level invariant that exactly one
+// thread calls `try_recv` / `set_detached` at a time is what makes the lock-free MPSC
+// math correct (single consumer owns `head` without CAS). `DsmMpscSender` is Sync so
+// multiple producer threads can share one `Arc<DsmMpscSender>` and race on `tail` via
+// CAS.
+unsafe impl Send for DsmMpscReceiver {}
+unsafe impl Send for DsmMpscSender {}
+unsafe impl Sync for DsmMpscSender {}
+
+/// Initialize a freshly-allocated DSM region into a valid ring header + zeroed slot array.
+/// Must be called exactly once, by the process that allocated the region (leader in our
+/// case). All other processes attach via [`attach_at`] without re-initializing.
+///
+/// # Safety
+/// - `base` must point at the start of a region of at least
+///   `DsmMpscRingHeader::region_bytes(ring_size, slot_capacity)` bytes.
+/// - `ring_size >= 2` (a ring of 1 slot can't distinguish empty from full).
+/// - `slot_capacity > SLOT_HEADER_BYTES` (need at least one byte of payload).
+/// - The region must not be concurrently accessed by any other process or thread until
+///   this returns.
+pub(super) unsafe fn create_at(
+    base: *mut u8,
+    ring_size: u32,
+    slot_capacity: u32,
+) -> *mut DsmMpscRingHeader {
+    debug_assert!(ring_size >= 2, "ring_size must be >= 2");
+    debug_assert!(
+        slot_capacity as usize > SLOT_HEADER_BYTES,
+        "slot_capacity must leave room for at least one payload byte"
+    );
+    // The header's natural alignment (from its largest field, AtomicU64) is 8 bytes.
+    // PG MAXALIGN is 8 on every supported platform, so dsm_segment user-data offsets
+    // computed via `align_up_maxalign_checked` always satisfy this. Tests use an
+    // aligned-Vec helper just to keep the assertion clean across allocators.
+    debug_assert!(
+        (base as usize).is_multiple_of(std::mem::align_of::<DsmMpscRingHeader>()),
+        "create_at base must be aligned to {} bytes",
+        std::mem::align_of::<DsmMpscRingHeader>()
+    );
+    let header_ptr = base.cast::<DsmMpscRingHeader>();
+    // Write the immutable header fields. Use std::ptr::write so we don't construct an
+    // intermediate &mut that aliases the not-yet-initialized atomic fields.
+    unsafe {
+        std::ptr::write(
+            header_ptr,
+            DsmMpscRingHeader {
+                magic: MPSC_RING_MAGIC,
+                version: MPSC_RING_VERSION,
+                ring_size,
+                slot_capacity,
+                detached: AtomicBool::new(false),
+                _pad_after_detached: [0; 3],
+                sender_count: AtomicU32::new(0),
+                receiver_packed: AtomicU64::new(pack_receiver(NO_RECEIVER, 0)),
+                _pad_before_head: [0; CACHE_LINE - 32],
+                head: AtomicU64::new(0),
+                _pad_between_head_and_tail: [0; CACHE_LINE - 8],
+                tail: AtomicU64::new(0),
+                _pad_after_tail: [0; CACHE_LINE - 8],
+            },
+        );
+    }
+    // Initialize slot sequences: slot[i].seq = i in round 0.
+    for i in 0..ring_size {
+        let slot = unsafe { slot_ptr(header_ptr, i, slot_capacity) };
+        unsafe {
+            std::ptr::write(
+                slot,
+                SlotHeader {
+                    seq: AtomicU64::new(i as u64),
+                    len: AtomicU32::new(0),
+                    _pad: 0,
+                },
+            );
+        }
+    }
+    header_ptr
+}
+
+/// Take an already-initialized ring header pointer and confirm its shape matches caller's
+/// expectations. The caller's `expected_ring_size` / `expected_slot_capacity` must match
+/// the values written at `create_at` time; mismatch is a hard error (returns null).
+///
+/// # Safety
+/// - `base` must point at the same region a previous `create_at` initialized.
+/// - The region must not be deallocated for the lifetime of any handle returned from
+///   the wrappers (`DsmMpscReceiver::new`, `DsmMpscSender::new`).
+pub(super) unsafe fn attach_at(
+    base: *mut u8,
+    expected_ring_size: u32,
+    expected_slot_capacity: u32,
+) -> Option<NonNull<DsmMpscRingHeader>> {
+    let header_ptr = base.cast::<DsmMpscRingHeader>();
+    let nn = NonNull::new(header_ptr)?;
+    let header = unsafe { nn.as_ref() };
+    if header.magic != MPSC_RING_MAGIC || header.version != MPSC_RING_VERSION {
+        return None;
+    }
+    if header.ring_size != expected_ring_size || header.slot_capacity != expected_slot_capacity {
+        return None;
+    }
+    Some(nn)
+}
+
+#[inline]
+unsafe fn slot_ptr(
+    header: *mut DsmMpscRingHeader,
+    idx: u32,
+    slot_capacity: u32,
+) -> *mut SlotHeader {
+    let header_bytes = std::mem::size_of::<DsmMpscRingHeader>();
+    let base = header.cast::<u8>();
+    unsafe { base.add(header_bytes + (idx as usize) * (slot_capacity as usize)) }
+        .cast::<SlotHeader>()
+}
+
+#[inline]
+unsafe fn slot_data_ptr(slot: *mut SlotHeader) -> *mut u8 {
+    unsafe { slot.cast::<u8>().add(SLOT_HEADER_BYTES) }
+}
+
+impl DsmMpscReceiver {
+    /// Wrap an already-initialized ring as the single consumer. Pairs with
+    /// [`DsmMpscSender::new`] on the producer side; calling code is responsible for
+    /// keeping exactly one `DsmMpscReceiver` per ring.
+    ///
+    /// # Safety
+    /// `ring` must point to a header initialized by [`create_at`] and not yet
+    /// deallocated. The caller guarantees no other `DsmMpscReceiver` exists for the
+    /// same ring (single-consumer invariant).
+    pub(super) unsafe fn new(ring: NonNull<DsmMpscRingHeader>) -> Self {
+        Self { ring }
+    }
+
+    /// Register this process as the receiver. Producers' subsequent wakeups resolve
+    /// the latch from `ProcGlobal->allProcs[pgprocno]` and check `proc->pid == pid`
+    /// to defend against PGPROC slot reuse if the receiver process exits. Use
+    /// [`Self::clear_receiver`] on teardown.
+    ///
+    /// Caller passes the LOCAL process's pgprocno and pid (in PG's parlance:
+    /// `MyProcNumber` and `MyProc->pid`). The pair is packed into one `AtomicU64`
+    /// and stored Release; producers Acquire-load the pair on every wake, so they
+    /// can never observe a torn (mismatched-by-update) `(pgprocno, pid)` pair.
+    pub(super) fn set_receiver(&self, pgprocno: i32, pid: i32) {
+        let header = unsafe { self.ring.as_ref() };
+        header
+            .receiver_packed
+            .store(pack_receiver(pgprocno, pid), Ordering::Release);
+    }
+
+    /// Clear the registered receiver (e.g., on query teardown). After this, producer
+    /// wakes are no-ops until a subsequent `set_receiver`. Sentinels both fields to
+    /// `(NO_RECEIVER, 0)`. Note that pgprocno 0 is the valid postmaster slot, so
+    /// callers must NOT use `set_receiver(0, 0)` as a clear.
+    pub(super) fn clear_receiver(&self) {
+        self.set_receiver(NO_RECEIVER, 0);
+    }
+
+    /// Try to read one frame into `out`. On `Bytes`, `out` holds the payload. On
+    /// `Empty`, the caller should yield and retry. On `Detached`, the ring is drained
+    /// and all producers have detached; no more frames will arrive.
+    ///
+    /// Known wedge: if a producer CAS-advances `tail` and then exits or crashes before
+    /// publishing the slot's `seq`, the consumer sees `tail > head`, the slot's `seq`
+    /// stuck at the prior-round empty marker, and `detached && tail <= head` never
+    /// becomes true. The drain loop will return `Empty` indefinitely. In production
+    /// this is bounded by PG's parallel-worker death handling (worker exit fires
+    /// leader ERROR, which tears DSM down), but a later revision should add an
+    /// explicit liveness check against `PGPROC`s to force-detach on producer death.
+    pub(super) fn try_recv(&self, out: &mut Vec<u8>) -> RecvOutcome {
+        let header = unsafe { self.ring.as_ref() };
+        let head = header.head.load(Ordering::Relaxed);
+        let slot_idx = (head % header.ring_size as u64) as u32;
+        let slot = unsafe { slot_ptr(self.ring.as_ptr(), slot_idx, header.slot_capacity) };
+        let seq = unsafe { (*slot).seq.load(Ordering::Acquire) };
+        let expected_ready = head.wrapping_add(1);
+        if seq != expected_ready {
+            // Slot not ready. Use `<=` rather than `==` so a strict invariant
+            // violation (tail < head, impossible under correct operation) still
+            // surfaces as Detached rather than wedging Empty forever.
+            if header.detached.load(Ordering::Acquire)
+                && header.tail.load(Ordering::Acquire) <= head
+            {
+                return RecvOutcome::Detached;
+            }
+            return RecvOutcome::Empty;
+        }
+        let len_raw = unsafe { (*slot).len.load(Ordering::Relaxed) } as usize;
+        // Clamp against slot's payload capacity. DSM is mapped writable by every
+        // attached backend, so a buggy / corrupted producer could write a garbage len.
+        // Without this guard, `set_len + copy_nonoverlapping` would read OOB into
+        // neighboring slots or other DSM contents.
+        let payload_cap = (header.slot_capacity as usize).saturating_sub(SLOT_HEADER_BYTES);
+        if len_raw > payload_cap {
+            // Poison the ring rather than silently returning corrupt data.
+            header.detached.store(true, Ordering::Release);
+            return RecvOutcome::Detached;
+        }
+        let len = len_raw;
+        out.clear();
+        out.reserve(len);
+        let data = unsafe { slot_data_ptr(slot) };
+        // copy_nonoverlapping before set_len so a hypothetical panic mid-copy doesn't
+        // leave `out` with logical-len > initialized-bytes.
+        unsafe {
+            std::ptr::copy_nonoverlapping(data, out.as_mut_ptr(), len);
+            out.set_len(len);
+        }
+        // Mark the slot empty for the next round. Round k empty marker is
+        // (k * ring_size) + slot_idx; head + ring_size is exactly that for next round.
+        let next_empty_seq = head.wrapping_add(header.ring_size as u64);
+        unsafe { (*slot).seq.store(next_empty_seq, Ordering::Release) };
+        // Advance head AFTER publishing the slot's empty marker, so a producer racing
+        // to claim sees the empty slot before seeing the new head value.
+        header.head.store(head.wrapping_add(1), Ordering::Release);
+        RecvOutcome::Bytes
+    }
+
+    /// Tell producers to stop sending. Idempotent. Subsequent `try_send` calls will
+    /// fail-fast with `SendError::Detached`. Does NOT block; caller can still drain
+    /// already-queued frames via `try_recv` until it returns `RecvOutcome::Detached`.
+    pub(super) fn set_detached(&self) {
+        let header = unsafe { self.ring.as_ref() };
+        header.detached.store(true, Ordering::Release);
+        // Defensive self-wake: if a signal handler or supervisor thread calls
+        // set_detached while the receiver is in WaitLatch, this breaks it out.
+        unsafe { wake_receiver(header) };
+    }
+
+    /// True when `set_detached` has been called.
+    pub(super) fn is_detached(&self) -> bool {
+        let header = unsafe { self.ring.as_ref() };
+        header.detached.load(Ordering::Acquire)
+    }
+}
+
+impl DsmMpscSender {
+    /// Wrap an already-initialized ring as a producer. Multiple `DsmMpscSender`
+    /// handles to the same ring are legal (and the point of MPSC). Increments the
+    /// ring's `sender_count`; the `Drop` impl decrements and, on the last drop,
+    /// flips `detached` and wakes the receiver. That mirrors shm_mq's
+    /// "drop the sender, receiver sees detach" structural guarantee.
+    ///
+    /// # Safety
+    /// `ring` must point to a header initialized by [`create_at`] and not yet
+    /// deallocated.
+    pub(super) unsafe fn new(ring: NonNull<DsmMpscRingHeader>) -> Self {
+        let header = unsafe { ring.as_ref() };
+        header.sender_count.fetch_add(1, Ordering::AcqRel);
+        Self { ring }
+    }
+
+    /// Push one frame onto the ring. Returns immediately:
+    /// - `Ok(())` on success; receiver's latch was set if installed.
+    /// - `Err(Full)` if no slot is available right now; caller should yield + retry.
+    /// - `Err(Detached)` if the receiver has detached; caller should stop.
+    /// - `Err(MessageTooLarge)` if `bytes.len() + SLOT_HEADER_BYTES > slot_capacity`.
+    pub(super) fn try_send(&self, bytes: &[u8]) -> Result<(), SendError> {
+        let header = unsafe { self.ring.as_ref() };
+        if header.detached.load(Ordering::Acquire) {
+            return Err(SendError::Detached);
+        }
+        let payload_cap = (header.slot_capacity as usize).saturating_sub(SLOT_HEADER_BYTES);
+        if bytes.len() > payload_cap {
+            return Err(SendError::MessageTooLarge);
+        }
+        loop {
+            // Acquire load on `tail` pairs defensively with any future blocking-send
+            // variant that may want to observe consumer progress via `head` (we don't
+            // today; full-detection rides on the slot's `seq`). Cheaper to keep the
+            // ordering tight than to relax-then-tighten under a future audit.
+            let tail = header.tail.load(Ordering::Acquire);
+            let slot_idx = (tail % header.ring_size as u64) as u32;
+            let slot = unsafe { slot_ptr(self.ring.as_ptr(), slot_idx, header.slot_capacity) };
+            let seq = unsafe { (*slot).seq.load(Ordering::Acquire) };
+            // Three-way compare per Vyukov MPMC.
+            match seq.cmp(&tail) {
+                std::cmp::Ordering::Equal => {
+                    // Slot is empty in our round. Try to claim by advancing tail.
+                    // AcqRel on success so a subsequent producer's Acquire load of
+                    // `tail` sees our claim and skips the slot we own. Relaxed on
+                    // failure (we just retry the loop on a fresh tail load).
+                    match header.tail.compare_exchange_weak(
+                        tail,
+                        tail.wrapping_add(1),
+                        Ordering::AcqRel,
+                        Ordering::Relaxed,
+                    ) {
+                        Ok(_) => {
+                            // We own slot[slot_idx] for tail value `tail`.
+                            unsafe {
+                                (*slot).len.store(bytes.len() as u32, Ordering::Relaxed);
+                                let data = slot_data_ptr(slot);
+                                std::ptr::copy_nonoverlapping(bytes.as_ptr(), data, bytes.len());
+                                // Publish: ready in round k is (k * ring_size + i + 1) = tail + 1.
+                                (*slot).seq.store(tail.wrapping_add(1), Ordering::Release);
+                            }
+                            // Wake the consumer (resolves the latch via pgprocno + pid).
+                            unsafe { wake_receiver(header) };
+                            return Ok(());
+                        }
+                        Err(_) => continue, // another producer took this tail; retry
+                    }
+                }
+                std::cmp::Ordering::Less => {
+                    // seq < tail: the consumer hasn't reclaimed slot[slot_idx] for our
+                    // round yet. Ring is full.
+                    return Err(SendError::Full);
+                }
+                std::cmp::Ordering::Greater => {
+                    // seq > tail: another producer has already claimed tail. Reload and
+                    // retry.
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+impl Drop for DsmMpscSender {
+    fn drop(&mut self) {
+        let header = unsafe { self.ring.as_ref() };
+        // AcqRel: decrement is observed by other producers (they don't care, but the
+        // Release pairs with the receiver's Acquire load on `detached` below).
+        let prev = header.sender_count.fetch_sub(1, Ordering::AcqRel);
+        if prev == 1 {
+            // We were the last sender. Tell the consumer.
+            header.detached.store(true, Ordering::Release);
+            unsafe { wake_receiver(header) };
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering as O};
+    use std::sync::Arc;
+
+    /// Send + Copy wrapper so tests can pass the ring pointer into spawned threads. The
+    /// real production handles (DsmMpscSender / Receiver) already impl Send; this exists
+    /// only because constructing them is unsafe and we want the test to do it inside the
+    /// thread so each thread has its own handle.
+    #[derive(Clone, Copy)]
+    struct SharedRing(NonNull<DsmMpscRingHeader>);
+    unsafe impl Send for SharedRing {}
+
+    /// Owning aligned region for a ring. The default `Vec<u8>` allocator can't
+    /// promise the alignment the `create_at` write wants, so allocate via the global
+    /// allocator with an explicit `Layout` and free in `Drop`. Production uses PG
+    /// `dsm_segment` (page-aligned), so this dance is test-only.
+    struct AlignedRegion {
+        ptr: *mut u8,
+        layout: std::alloc::Layout,
+    }
+    impl AlignedRegion {
+        fn new(bytes: usize) -> Self {
+            let align = std::mem::align_of::<DsmMpscRingHeader>();
+            let layout = std::alloc::Layout::from_size_align(bytes, align).expect("invalid layout");
+            let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+            assert!(!ptr.is_null(), "allocator returned null");
+            Self { ptr, layout }
+        }
+        fn as_mut_ptr(&self) -> *mut u8 {
+            self.ptr
+        }
+    }
+    impl Drop for AlignedRegion {
+        fn drop(&mut self) {
+            unsafe { std::alloc::dealloc(self.ptr, self.layout) };
+        }
+    }
+
+    /// Allocate a heap region big enough for a ring with `ring_size` slots of
+    /// `slot_capacity` bytes each, initialize it, and return `(owner, receiver,
+    /// sender_template)`. The owner is returned first so callers bind it first.
+    /// Rust drops locals in reverse declaration order, so `_region` bound first drops
+    /// last, after the handles whose `Drop` impls touch the region's memory. Reverse
+    /// that order and `_region` frees the bytes before `tx_template`'s
+    /// `sender_count.fetch_sub` runs, which is undefined behavior and surfaces as a
+    /// stochastic crash at process teardown.
+    fn make_ring(
+        ring_size: u32,
+        slot_capacity: u32,
+    ) -> (AlignedRegion, DsmMpscReceiver, DsmMpscSender) {
+        let bytes = DsmMpscRingHeader::region_bytes(ring_size, slot_capacity);
+        let region = AlignedRegion::new(bytes);
+        let header_ptr = unsafe { create_at(region.as_mut_ptr(), ring_size, slot_capacity) };
+        let nn = NonNull::new(header_ptr).expect("create_at returned null");
+        // Unsafe: we hand ownership of the same pointer to two handles. Safe because the
+        // ring is the synchronization point; the handles are stateless wrappers.
+        let receiver = unsafe { DsmMpscReceiver::new(nn) };
+        let sender = unsafe { DsmMpscSender::new(nn) };
+        (region, receiver, sender)
+    }
+
+    #[test]
+    fn spsc_round_trip_under_capacity() {
+        let (_region, rx, tx) = make_ring(4, 64);
+        for i in 0..3u8 {
+            tx.try_send(&[i, i + 1, i + 2]).unwrap();
+        }
+        let mut buf = Vec::new();
+        for i in 0..3u8 {
+            assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+            assert_eq!(&buf[..], &[i, i + 1, i + 2]);
+        }
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Empty);
+    }
+
+    #[test]
+    fn fills_then_full_then_drains() {
+        let (_region, rx, tx) = make_ring(4, 64);
+        for i in 0..4u32 {
+            tx.try_send(&i.to_le_bytes()).unwrap();
+        }
+        // Fifth send must fail Full.
+        assert_eq!(tx.try_send(&999u32.to_le_bytes()), Err(SendError::Full));
+        // Drain one, send one more, drain rest.
+        let mut buf = Vec::new();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(buf, 0u32.to_le_bytes());
+        tx.try_send(&100u32.to_le_bytes()).unwrap();
+        for expected in [1u32, 2, 3, 100] {
+            assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+            assert_eq!(buf, expected.to_le_bytes());
+        }
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Empty);
+    }
+
+    #[test]
+    fn detach_blocks_subsequent_sends() {
+        let (_region, rx, tx) = make_ring(4, 64);
+        tx.try_send(b"keep").unwrap();
+        rx.set_detached();
+        assert!(rx.is_detached());
+        assert_eq!(tx.try_send(b"drop"), Err(SendError::Detached));
+        // Already-queued frame still readable, then Detached signaled.
+        let mut buf = Vec::new();
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Bytes);
+        assert_eq!(&buf[..], b"keep");
+        assert_eq!(rx.try_recv(&mut buf), RecvOutcome::Detached);
+    }
+
+    #[test]
+    fn message_too_large_is_rejected() {
+        let (_region, _rx, tx) = make_ring(2, 32);
+        // payload_cap = 32 - SLOT_HEADER_BYTES; one byte over is too large.
+        let payload_cap = 32 - SLOT_HEADER_BYTES;
+        let oversize = vec![0u8; payload_cap + 1];
+        assert_eq!(tx.try_send(&oversize), Err(SendError::MessageTooLarge));
+        // Exactly at the cap is fine.
+        let exact = vec![0u8; payload_cap];
+        tx.try_send(&exact).unwrap();
+    }
+
+    /// Multi-producer concurrent send: K threads each push M unique messages; consumer
+    /// receives K*M messages and verifies every (producer, sequence_in_producer) pair
+    /// appears exactly once.
+    #[test]
+    fn mpsc_no_lost_messages_under_contention() {
+        const K_PRODUCERS: usize = 8;
+        const M_PER_PRODUCER: u32 = 2000;
+        let (_region, rx, tx_template) = make_ring(64, 32);
+        // Wrap region pointer in something we can share across threads. The handles
+        // themselves are Send, so we clone via NonNull copy.
+        let ring_nn = SharedRing(tx_template.ring);
+        let consumed = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::with_capacity(K_PRODUCERS);
+        for producer_id in 0..K_PRODUCERS {
+            // Construct the sender on this thread so the closure captures DsmMpscSender
+            // (Send via unsafe impl) rather than the inner NonNull (Rust 2021 disjoint
+            // capture would otherwise project to the NonNull field and fail Send).
+            let tx = unsafe { DsmMpscSender::new(ring_nn.0) };
+            let h = std::thread::spawn(move || {
+                let mut sent = 0u32;
+                while sent < M_PER_PRODUCER {
+                    let mut payload = [0u8; 8];
+                    payload[0..4].copy_from_slice(&(producer_id as u32).to_le_bytes());
+                    payload[4..8].copy_from_slice(&sent.to_le_bytes());
+                    match tx.try_send(&payload) {
+                        Ok(_) => sent += 1,
+                        Err(SendError::Full) => std::thread::yield_now(),
+                        Err(e) => panic!("unexpected send error: {e:?}"),
+                    }
+                }
+            });
+            handles.push(h);
+        }
+        // Drain on this thread until every producer's M messages have shown up.
+        let mut seen: Vec<Vec<bool>> = (0..K_PRODUCERS)
+            .map(|_| vec![false; M_PER_PRODUCER as usize])
+            .collect();
+        let mut buf = Vec::new();
+        let target = K_PRODUCERS * M_PER_PRODUCER as usize;
+        while consumed.load(O::Relaxed) < target {
+            match rx.try_recv(&mut buf) {
+                RecvOutcome::Bytes => {
+                    assert_eq!(buf.len(), 8);
+                    let producer_id = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
+                    let sent_idx = u32::from_le_bytes(buf[4..8].try_into().unwrap()) as usize;
+                    assert!(producer_id < K_PRODUCERS, "bad producer id {producer_id}");
+                    assert!(
+                        sent_idx < M_PER_PRODUCER as usize,
+                        "bad sent idx {sent_idx}"
+                    );
+                    let already = std::mem::replace(&mut seen[producer_id][sent_idx], true);
+                    assert!(!already, "duplicate ({producer_id}, {sent_idx})");
+                    consumed.fetch_add(1, O::Relaxed);
+                }
+                RecvOutcome::Empty => std::thread::yield_now(),
+                RecvOutcome::Detached => panic!("unexpected detach mid-drain"),
+            }
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        for (p, row) in seen.iter().enumerate() {
+            assert!(
+                row.iter().all(|&b| b),
+                "producer {p} has a missed message: row = {row:?}"
+            );
+        }
+    }
+
+    /// Per-producer in-order property: a single producer's messages observed by the
+    /// consumer must arrive in the order the producer sent them. (Cross-producer
+    /// ordering is not guaranteed.)
+    #[test]
+    fn mpsc_preserves_per_producer_order() {
+        const K_PRODUCERS: usize = 4;
+        const M_PER_PRODUCER: u32 = 500;
+        let (_region, rx, tx_template) = make_ring(32, 32);
+        let ring_nn = SharedRing(tx_template.ring);
+        let mut handles = Vec::with_capacity(K_PRODUCERS);
+        for producer_id in 0..K_PRODUCERS {
+            let tx = unsafe { DsmMpscSender::new(ring_nn.0) };
+            handles.push(std::thread::spawn(move || {
+                let mut sent = 0u32;
+                while sent < M_PER_PRODUCER {
+                    let mut payload = [0u8; 8];
+                    payload[0..4].copy_from_slice(&(producer_id as u32).to_le_bytes());
+                    payload[4..8].copy_from_slice(&sent.to_le_bytes());
+                    if tx.try_send(&payload).is_ok() {
+                        sent += 1;
+                    } else {
+                        std::thread::yield_now();
+                    }
+                }
+            }));
+        }
+        let mut last_seq: Vec<i64> = vec![-1; K_PRODUCERS];
+        let mut buf = Vec::new();
+        let mut total = 0usize;
+        let target = K_PRODUCERS * M_PER_PRODUCER as usize;
+        while total < target {
+            match rx.try_recv(&mut buf) {
+                RecvOutcome::Bytes => {
+                    let producer_id = u32::from_le_bytes(buf[0..4].try_into().unwrap()) as usize;
+                    let sent_idx = i64::from(u32::from_le_bytes(buf[4..8].try_into().unwrap()));
+                    assert_eq!(
+                        sent_idx,
+                        last_seq[producer_id] + 1,
+                        "out-of-order from producer {producer_id}: got {sent_idx}, expected {}",
+                        last_seq[producer_id] + 1
+                    );
+                    last_seq[producer_id] = sent_idx;
+                    total += 1;
+                }
+                RecvOutcome::Empty => std::thread::yield_now(),
+                RecvOutcome::Detached => panic!("unexpected detach"),
+            }
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    /// Cache-line layout regression: `head` must land on its own cache line
+    /// (offset == CACHE_LINE so the preceding header fields can't false-share),
+    /// `tail` separated from `head` by CACHE_LINE, and the first slot not sharing a
+    /// line with `tail`. Catches accidental padding removal or field reorder that
+    /// would re-introduce the false-sharing perf cliff the padding exists to avoid.
+    #[test]
+    fn header_layout_is_cache_friendly() {
+        use std::mem::offset_of;
+        let head_off = offset_of!(DsmMpscRingHeader, head);
+        let tail_off = offset_of!(DsmMpscRingHeader, tail);
+        let header_size = std::mem::size_of::<DsmMpscRingHeader>();
+        // head at exactly CACHE_LINE offset means the preceding 64 bytes (header
+        // fields + pad) live entirely in cache line 0, head + its pad live in
+        // cache line 1, etc. Anything other than equality means the padding
+        // math drifted; fix it rather than relaxing the assertion.
+        assert_eq!(
+            head_off, CACHE_LINE,
+            "head must land at offset {CACHE_LINE} (its own cache line); got {head_off}"
+        );
+        assert!(
+            (tail_off - head_off) >= CACHE_LINE,
+            "head and tail must be on separate cache lines: head_off={head_off}, tail_off={tail_off}, CACHE_LINE={CACHE_LINE}"
+        );
+        assert!(
+            (header_size - tail_off) >= CACHE_LINE,
+            "first slot must start on its own cache line: header_size={header_size}, tail_off={tail_off}, CACHE_LINE={CACHE_LINE}"
+        );
+        // Header's natural alignment is determined by its largest field (AtomicU64,
+        // 8 bytes). Cache-line padding between hot fields still keeps them on separate
+        // absolute lines regardless of the struct's starting alignment, as long as the
+        // inter-field distance is >= CACHE_LINE.
+        assert_eq!(std::mem::align_of::<DsmMpscRingHeader>(), 8);
+    }
+
+    /// Magic + version validation: an attach against a region with the wrong magic or
+    /// version returns None rather than handing back a NonNull with garbage state.
+    /// Mirrors `MppDsmHeader::validate`'s discipline.
+    #[test]
+    fn attach_at_rejects_wrong_magic_and_version() {
+        let bytes = DsmMpscRingHeader::region_bytes(4, 64);
+        let region = AlignedRegion::new(bytes);
+        let header_ptr = unsafe { create_at(region.as_mut_ptr(), 4, 64) };
+        // Sanity: correct attach succeeds.
+        assert!(unsafe { attach_at(region.as_mut_ptr(), 4, 64) }.is_some());
+        // Corrupt magic: rejected.
+        unsafe { (*header_ptr).magic = 0xDEADBEEF };
+        assert!(unsafe { attach_at(region.as_mut_ptr(), 4, 64) }.is_none());
+        // Restore magic, corrupt version.
+        unsafe { (*header_ptr).magic = MPSC_RING_MAGIC };
+        unsafe { (*header_ptr).version = MPSC_RING_VERSION.wrapping_add(1) };
+        assert!(unsafe { attach_at(region.as_mut_ptr(), 4, 64) }.is_none());
+        // Restore version, mismatched ring_size.
+        unsafe { (*header_ptr).version = MPSC_RING_VERSION };
+        assert!(unsafe { attach_at(region.as_mut_ptr(), 8, 64) }.is_none());
+    }
+
+    /// Consumer-side detach race: producers are mid-flight when the receiver detaches.
+    /// Every Ok send must produce a matching Bytes recv before the drain returns
+    /// Detached. Catches the half-claim-wedge if the predicate is too strict.
+    #[test]
+    fn drain_completes_after_detach_under_load() {
+        const K_PRODUCERS: usize = 4;
+        let (_region, rx, tx_template) = make_ring(16, 32);
+        let ring_nn = SharedRing(tx_template.ring);
+        let stop = Arc::new(AtomicBool::new(false));
+        let sent_count = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::with_capacity(K_PRODUCERS);
+        for _ in 0..K_PRODUCERS {
+            let tx = unsafe { DsmMpscSender::new(ring_nn.0) };
+            let stop = Arc::clone(&stop);
+            let sent_count = Arc::clone(&sent_count);
+            handles.push(std::thread::spawn(move || {
+                let payload = [0xABu8; 8];
+                while !stop.load(O::Relaxed) {
+                    match tx.try_send(&payload) {
+                        Ok(_) => {
+                            sent_count.fetch_add(1, O::Relaxed);
+                        }
+                        Err(SendError::Full) => std::thread::yield_now(),
+                        Err(SendError::Detached) => break,
+                        Err(e) => panic!("unexpected: {e:?}"),
+                    }
+                }
+            }));
+        }
+        // Drain a bit then trigger detach.
+        let mut buf = Vec::new();
+        let mut recv_count = 0usize;
+        // Let producers stretch their legs before detaching.
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        rx.set_detached();
+        stop.store(true, O::Relaxed);
+        // Drain until the ring confirms Detached.
+        loop {
+            match rx.try_recv(&mut buf) {
+                RecvOutcome::Bytes => recv_count += 1,
+                RecvOutcome::Empty => std::thread::yield_now(),
+                RecvOutcome::Detached => break,
+            }
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let sent = sent_count.load(O::Relaxed);
+        assert_eq!(
+            recv_count, sent,
+            "every successful send must be received before Detached"
+        );
+    }
+
+    /// Stress test at the production-worst contention level (K=24 producers, matching
+    /// the largest mesh-row size the transport drives in practice). Smoke that the
+    /// primitive doesn't wedge or lose messages under heavy CAS contention; doesn't
+    /// measure perf.
+    #[test]
+    fn mpsc_stress_at_production_worst_case() {
+        const K_PRODUCERS: usize = 24;
+        const M_PER_PRODUCER: u32 = 500;
+        let (_region, rx, tx_template) = make_ring(64, 32);
+        let ring_nn = SharedRing(tx_template.ring);
+        let mut handles = Vec::with_capacity(K_PRODUCERS);
+        for producer_id in 0..K_PRODUCERS {
+            let tx = unsafe { DsmMpscSender::new(ring_nn.0) };
+            handles.push(std::thread::spawn(move || {
+                let mut payload = [0u8; 8];
+                payload[0..4].copy_from_slice(&(producer_id as u32).to_le_bytes());
+                let mut sent = 0u32;
+                while sent < M_PER_PRODUCER {
+                    payload[4..8].copy_from_slice(&sent.to_le_bytes());
+                    match tx.try_send(&payload) {
+                        Ok(_) => sent += 1,
+                        Err(SendError::Full) => std::thread::yield_now(),
+                        Err(e) => panic!("unexpected: {e:?}"),
+                    }
+                }
+            }));
+        }
+        let mut buf = Vec::new();
+        let target = K_PRODUCERS * M_PER_PRODUCER as usize;
+        let mut total = 0usize;
+        while total < target {
+            match rx.try_recv(&mut buf) {
+                RecvOutcome::Bytes => total += 1,
+                RecvOutcome::Empty => std::thread::yield_now(),
+                RecvOutcome::Detached => panic!("unexpected detach"),
+            }
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        // Multi-round invariant: after draining 24 * 500 = 12000 messages on a 64-slot
+        // ring, every slot's seq must have advanced into a future round. Walk slot[0]:
+        // we expect seq = head + ring_size = 12000 + 64 - whatever round 0 it's in.
+        // Loose check: every slot's seq is bounded below by ring_size (round >= 1).
+        let header = unsafe { ring_nn.0.as_ref() };
+        for i in 0..header.ring_size {
+            let slot = unsafe { slot_ptr(ring_nn.0.as_ptr(), i, header.slot_capacity) };
+            let seq = unsafe { (*slot).seq.load(O::Acquire) };
+            assert!(
+                seq >= header.ring_size as u64,
+                "slot[{i}].seq={seq} < ring_size; slot was never reused"
+            );
+        }
+    }
+}

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -314,10 +314,14 @@ pub(crate) fn run_mpp_worker(
                 // queue doesn't block the backend thread. The spin pulls every inbound drain
                 // while retrying the send, breaking N×N symmetric stalls.
                 per_partition_senders.push(
-                    base.clone_with_header(MppFrameHeader::batch(fragment.stage_id, q_u32))
-                        .with_cooperative_drain(
-                            Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
-                        ),
+                    base.clone_with_header(MppFrameHeader::batch(
+                        fragment.stage_id,
+                        q_u32,
+                        worker_mesh.this_proc,
+                    ))
+                    .with_cooperative_drain(
+                        Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
+                    ),
                 );
             }
 

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -310,9 +310,10 @@ pub(crate) fn run_mpp_worker(
                     fragment.stage_id,
                     fragment.task_idx,
                 );
-                // Attach the worker mesh as the cooperative drain so a full outbound shm_mq
-                // queue doesn't block the backend thread. The spin pulls every inbound drain
-                // while retrying the send, breaking N×N symmetric stalls.
+                // Attach the worker mesh as the cooperative drain so a full outbound
+                // ring doesn't block the backend thread. The spin pulls every inbound
+                // drain while retrying the send, breaking the symmetric-send stall
+                // pattern where every peer is blocked sending to a full peer.
                 per_partition_senders.push(
                     base.clone_with_header(MppFrameHeader::batch(
                         fragment.stage_id,

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -42,7 +42,8 @@ use crate::gucs::{
 use crate::postgres::customscan::mpp::dsm::{
     compute_dsm_layout, leader_init, peer_proc_for_index, worker_attach,
 };
-use crate::postgres::customscan::mpp::mesh::{ShmMqReceiver, ShmMqSender};
+use crate::postgres::customscan::mpp::dsm_mpsc_ring::DsmMpscSender;
+use crate::postgres::customscan::mpp::mesh::{DsmInboxReceiver, DsmInboxSender};
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::mpp::transport::{
     in_proc_channel, BatchChannelSender, DrainHandle, MppFrameHeader, MppReceiver, MppSender,
@@ -199,45 +200,30 @@ pub struct MppLeaderState {
     pub pcxt: *mut pg_sys::ParallelContext,
 }
 
-/// Wrap each peer-indexed `ShmMqReceiver` into an inbound cooperative drain, returned in
-/// `sender_proc`-indexed form. Slot at index `this_proc` is `None` (no self-loop drain at this
-/// stage; the worker's self-loop is installed separately, and the leader never has one).
-fn build_inbound_receivers(
-    this_proc: u32,
-    total_procs: u32,
-    peer_receivers: Vec<ShmMqReceiver>,
-) -> Vec<Option<Arc<DrainHandle>>> {
-    let mut drains: Vec<Option<Arc<DrainHandle>>> = (0..total_procs).map(|_| None).collect();
-    for (peer_idx, shm_recv) in peer_receivers.into_iter().enumerate() {
-        let sender_proc = peer_proc_for_index(this_proc, peer_idx as u32);
-        debug_assert!(sender_proc != this_proc);
-        debug_assert!(sender_proc < total_procs);
-        let mpp_recv = MppReceiver::new(Box::new(shm_recv));
-        drains[sender_proc as usize] = Some(Arc::new(DrainHandle::cooperative(vec![mpp_recv])));
-    }
-    drains
-}
-
-/// Wrap each peer-indexed `ShmMqSender` into an outbound `MppSender` keyed by `target_proc`. The
-/// per-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`] immediately
-/// `clone_with_header`s
-/// these to the right `(stage_id, partition)`, so the default placeholder header is never
-/// observed on the wire. Slot at index `this_proc` is `None`; the worker's self-loop install
-/// fills it in afterward.
+/// Wrap each peer-indexed `DsmMpscSender` into an outbound `MppSender` keyed by `target_proc`.
+/// The per-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`] immediately
+/// `clone_with_header`s these to the right `(stage_id, partition)`, so the default placeholder
+/// header is never observed on the wire. Slot at index `this_proc` is `None`; the worker's
+/// self-loop install fills it in afterward.
+///
+/// Placeholder header is stamped with `sender_proc = this_proc` so a stray frame that escapes
+/// the dispatcher's `clone_with_header` overwrite still identifies its origin correctly on the
+/// drain side. Downstream `clone_with_header` callers MUST keep using `this_proc` as the
+/// `sender_proc` argument.
 fn build_outbound_senders(
     this_proc: u32,
     total_procs: u32,
-    peer_senders: Vec<ShmMqSender>,
+    peer_senders: Vec<DsmMpscSender>,
 ) -> Vec<Option<MppSender>> {
     let mut senders: Vec<Option<MppSender>> = (0..total_procs).map(|_| None).collect();
-    for (peer_idx, shm_send) in peer_senders.into_iter().enumerate() {
+    for (peer_idx, dsm_send) in peer_senders.into_iter().enumerate() {
         let target_proc = peer_proc_for_index(this_proc, peer_idx as u32);
         debug_assert!(target_proc != this_proc);
         debug_assert!(target_proc < total_procs);
-        let shared: Arc<dyn BatchChannelSender> = Arc::new(shm_send);
+        let shared: Arc<dyn BatchChannelSender> = Arc::new(DsmInboxSender::new(dsm_send));
         senders[target_proc as usize] = Some(MppSender::with_header(
             shared,
-            MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
+            MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION, this_proc),
         ));
     }
     senders
@@ -264,12 +250,19 @@ pub unsafe fn leader_setup(
 
     let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
 
-    // Each `DrainHandle` owns a per-`(stage_id, partition)` channel buffer registry, so one shm_mq
-    // queue can carry frames from many logical channels. Channel buffers are created lazily on first
-    // frame, or up-front by `WorkerConnection::execute`.
-    let inbound_receivers = build_inbound_receivers(0, total_procs, attach.inbound_receivers);
+    // Wrap the leader's own-inbox in a DsmInboxReceiver and feed it to a single DrainHandle.
+    // Channel buffers (keyed by (sender_proc, stage_id, partition)) are created lazily on
+    // first frame, or up-front by `WorkerConnection::execute`.
+    let inbox = DsmInboxReceiver::new(attach.inbound_receiver);
+    // Register the leader as the receiver so producers' wakeups resolve to this process's
+    // procLatch via pgprocno + pid_guard. See dsm_mpsc_ring::wake_receiver.
+    unsafe {
+        register_self_as_receiver(&inbox);
+    }
+    let mpp_recv = MppReceiver::new(Box::new(inbox));
+    let inbound_drain = Arc::new(DrainHandle::cooperative(vec![mpp_recv]));
 
-    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_receivers));
+    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_drain));
 
     // Drop the leader's own outbound senders. The leader is consumer-only and never hosts a
     // producer fragment.
@@ -278,25 +271,46 @@ pub unsafe fn leader_setup(
     Ok(MppLeaderState { mesh, pcxt })
 }
 
+/// Register the current backend as the receiver on `inbox`'s underlying ring so producers
+/// can wake it via SetLatch resolved through `pgprocno + pid_guard`. Called by both
+/// leader_setup and worker_setup right after building the DsmInboxReceiver.
+///
+/// # Safety
+/// Must run on the backend thread (reads MyProcNumber + MyProc->pid via pgrx, both
+/// require an attached PGPROC). Both setup paths are called synchronously from PG's
+/// custom-scan init hooks on the backend before any tokio runtime spins up.
+unsafe fn register_self_as_receiver(inbox: &DsmInboxReceiver) {
+    // `pg_sys::MyProcNumber` is the PG17+ global. PG15/16 carry the same value on
+    // `MyProc->pgprocno` (it moved to a process-global plus a field rename in PG17).
+    // Gate by feature so the build picks the right one on every supported PG.
+    #[cfg(any(feature = "pg15", feature = "pg16"))]
+    let my_pgprocno: i32 = unsafe { (*pg_sys::MyProc).pgprocno };
+    #[cfg(not(any(feature = "pg15", feature = "pg16")))]
+    let my_pgprocno: i32 = unsafe { pg_sys::MyProcNumber };
+    let my_pid: i32 = unsafe { (*pg_sys::MyProc).pid };
+    inbox.set_receiver(my_pgprocno, my_pid);
+}
+
 /// Returned to a worker from [`worker_setup`]. The customscan reads the plan bytes, runs the
 /// plan, and pushes resulting batches through `outbound_senders`.
 pub struct MppWorkerState {
-    /// `outbound_senders[proc_idx]` is the sender that writes to `slot(this_proc, proc_idx)`.
-    /// The entry at `proc_idx == this_proc` is `None` because the self-loop slot is never
-    /// attached (matches the leader's `inbound_receivers` shape).
+    /// `outbound_senders[proc_idx]` is the sender that writes to peer `proc_idx`'s inbox.
+    /// The entry at `proc_idx == this_proc` is the self-loop in-proc channel installed by
+    /// `worker_setup` (since DSM MPSC inboxes have only one receiver per ring, the worker
+    /// can't be both producer and consumer on the shm_mq inbox path).
     ///
     /// Each fragment's per-partition output sender is keyed by
     /// `outbound_senders[proc_for_task(n_workers, consumer_task)]`. Each `MppSender` wraps an
     /// `Arc<dyn BatchChannelSender>` so callers can `clone_with_header` to multiplex
-    /// `(stage_id, partition)` channels onto one shm_mq queue.
+    /// `(stage_id, partition)` channels onto one inbox.
     pub outbound_senders: Vec<Option<MppSender>>,
     /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via the
     /// `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
     pub plan_bytes: Vec<u8>,
-    /// Worker's MppMesh, same shape as the leader's. `inbound_receivers[sender_proc]` pulls frames
-    /// from `slot(sender_proc, this_proc)`. Workers consume from peers when running consumer
-    /// fragments (e.g. a `FinalPartitioned` aggregate above a `NetworkShuffleExec` peer-mesh).
-    /// Read by the multi-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`].
+    /// Worker's MppMesh. The single `inbound_drain` pulls frames addressed to this proc
+    /// from both the DSM MPSC inbox and the in-proc self-loop channel; demux by
+    /// `(sender_proc, stage_id, partition)` happens inside the drain's channel-buffer
+    /// registry. Read by the multi-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`].
     pub mesh: Arc<MppMesh>,
 }
 
@@ -327,8 +341,6 @@ pub unsafe fn worker_setup(
 
     let mut outbound_senders =
         build_outbound_senders(proc_idx, total_procs, attach.outbound_senders);
-    let mut inbound_receivers =
-        build_inbound_receivers(proc_idx, total_procs, attach.inbound_receivers);
     debug_assert_eq!(
         outbound_senders.iter().filter(|s| s.is_some()).count(),
         (total_procs as usize).saturating_sub(1),
@@ -336,25 +348,32 @@ pub unsafe fn worker_setup(
         total_procs.saturating_sub(1)
     );
 
-    // Install a self-loop in-proc channel for `slot(this_proc, this_proc)`. Peer-mesh hash
-    // routing can land producer-side and consumer-side tasks for the same `(stage, partition)`
-    // on the same worker. Without this, the shm_mq grid's unattached diagonal would surface as
-    // `outbound_senders[this_proc] = None`. The in-proc channel keeps frame routing uniform from
-    // the dispatcher's perspective: senders push, the `DrainHandle` reads via the same
-    // `BatchChannelReceiver` contract as shm_mq, and the channel buffer registry demuxes per
-    // `(stage_id, partition)`.
+    // Install a self-loop in-proc channel. Peer-mesh hash routing can land producer-side
+    // and consumer-side tasks for the same (stage, partition) on the same worker. With
+    // MPSC inboxes you can't be your own sender (only the owner attaches as receiver), so
+    // self-loops bypass DSM entirely and ride an in-proc channel. The unified drain pulls
+    // from BOTH receivers (own-inbox MPSC + self-loop in-proc) so the channel-buffer
+    // registry sees a single demux stream. Self-loop frames carry sender_proc=this_proc
+    // and route to the matching per-sender buffer.
     let (self_tx, self_rx) = in_proc_channel(SELF_LOOP_CAPACITY);
     let self_tx_arc: Arc<dyn BatchChannelSender> = Arc::new(self_tx);
     outbound_senders[proc_idx as usize] = Some(MppSender::with_header(
         self_tx_arc,
-        MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION),
+        MppFrameHeader::batch(NATURAL_GATHER_STAGE_ID, NATURAL_GATHER_PARTITION, proc_idx),
     ));
-    inbound_receivers[proc_idx as usize] =
-        Some(Arc::new(DrainHandle::cooperative(vec![MppReceiver::new(
-            Box::new(self_rx),
-        )])));
 
-    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_receivers));
+    // Build the unified drain: own-inbox MPSC + self-loop in-proc, both feeding the same
+    // DrainHandle. Register the worker as receiver before the drain starts polling so
+    // any producer that races ahead of us sees a valid pgprocno + pid.
+    let inbox = DsmInboxReceiver::new(attach.inbound_receiver);
+    unsafe {
+        register_self_as_receiver(&inbox);
+    }
+    let inbox_recv = MppReceiver::new(Box::new(inbox));
+    let self_recv = MppReceiver::new(Box::new(self_rx));
+    let inbound_drain = Arc::new(DrainHandle::cooperative(vec![inbox_recv, self_recv]));
+
+    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drain));
 
     Ok(MppWorkerState {
         outbound_senders,

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -235,12 +235,10 @@ fn build_outbound_senders(
 /// # Safety
 /// - `coordinate` must be the DSM region pointer PG supplied to
 ///   `initialize_dsm_custom_scan`.
-/// - `seg` must be the leader's `dsm_segment*`.
 /// - `plan_bytes` must have the same length passed to [`estimate_dsm_size`]
 ///   so the leader doesn't overrun the DSM region PG allocated.
 pub unsafe fn leader_setup(
     coordinate: *mut c_void,
-    seg: *mut pg_sys::dsm_segment,
     pcxt: *mut pg_sys::ParallelContext,
     plan_bytes: Vec<u8>,
 ) -> Result<MppLeaderState, String> {
@@ -248,7 +246,7 @@ pub unsafe fn leader_setup(
     let layout = compute_dsm_layout(total_procs, mpp_queue_size(), plan_bytes.len())
         .map_err(|e| format!("mpp: leader_setup compute layout: {e}"))?;
 
-    let attach = unsafe { leader_init(coordinate, seg, &layout, &plan_bytes) }?;
+    let attach = unsafe { leader_init(coordinate, &layout, &plan_bytes) }?;
 
     // Wrap the leader's own-inbox in a DsmInboxReceiver and feed it to a single DrainHandle.
     // Channel buffers (keyed by (sender_proc, stage_id, partition)) are created lazily on
@@ -320,13 +318,10 @@ pub struct MppWorkerState {
 /// # Safety
 /// - `coordinate` must be the DSM region pointer PG supplied.
 /// - `region_total` must match the DSM's attached size.
-/// - `seg` may be NULL; PG's `initialize_worker_custom_scan` does not
-///   surface the segment pointer.
 pub unsafe fn worker_setup(
     coordinate: *mut c_void,
     region_total: u64,
     worker_number: i32,
-    seg: *mut pg_sys::dsm_segment,
 ) -> Result<MppWorkerState, String> {
     if worker_number < 0 {
         return Err("mpp: worker_number < 0".into());
@@ -336,7 +331,7 @@ pub unsafe fn worker_setup(
     let proc_idx = (worker_number as u32) + 1;
 
     let (header, plan_bytes, attach) =
-        unsafe { worker_attach(coordinate, region_total, proc_idx, seg) }?;
+        unsafe { worker_attach(coordinate, region_total, proc_idx) }?;
     let total_procs = header.n_procs;
 
     let mut outbound_senders =

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -163,8 +163,8 @@ pub(super) fn mpp_queue_size() -> usize {
     gucs_mpp_queue_size()
 }
 
-/// Body of `estimate_dsm_custom_scan`. Returns total DSM bytes the leader will need for the
-/// plan, the multiplexed `n_procs × n_procs` queue mesh, and the worker plan. `n_procs` is the
+/// Body of `estimate_dsm_custom_scan`. Returns the total DSM bytes the leader will need
+/// for the header, the worker plan, and one MPSC inbox per process. `n_procs` is the
 /// total proc count (leader + `producer_worker_count()` parallel workers).
 pub fn estimate_dsm_size(plan_bytes_len: usize) -> Result<usize, String> {
     let layout = compute_dsm_layout(mpp_worker_count(), mpp_queue_size(), plan_bytes_len)

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -258,9 +258,9 @@ pub unsafe fn leader_setup(
         register_self_as_receiver(&inbox);
     }
     let mpp_recv = MppReceiver::new(Box::new(inbox));
-    let inbound_drain = Arc::new(DrainHandle::cooperative(vec![mpp_recv]));
+    let inbound_receiver = Arc::new(DrainHandle::cooperative(vec![mpp_recv]));
 
-    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_drain));
+    let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_receiver));
 
     // Drop the leader's own outbound senders. The leader is consumer-only and never hosts a
     // producer fragment.
@@ -305,9 +305,9 @@ pub struct MppWorkerState {
     /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via the
     /// `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
     pub plan_bytes: Vec<u8>,
-    /// Worker's MppMesh. The single `inbound_drain` pulls frames addressed to this proc
-    /// from both the DSM MPSC inbox and the in-proc self-loop channel; demux by
-    /// `(sender_proc, stage_id, partition)` happens inside the drain's channel-buffer
+    /// Worker's MppMesh. The single `inbound_receiver` pulls frames addressed to this
+    /// proc from both the DSM MPSC inbox and the in-proc self-loop channel; demux by
+    /// `(sender_proc, stage_id, partition)` happens inside the handle's channel-buffer
     /// registry. Read by the multi-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`].
     pub mesh: Arc<MppMesh>,
 }
@@ -366,9 +366,9 @@ pub unsafe fn worker_setup(
     }
     let inbox_recv = MppReceiver::new(Box::new(inbox));
     let self_recv = MppReceiver::new(Box::new(self_rx));
-    let inbound_drain = Arc::new(DrainHandle::cooperative(vec![inbox_recv, self_recv]));
+    let inbound_receiver = Arc::new(DrainHandle::cooperative(vec![inbox_recv, self_recv]));
 
-    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_drain));
+    let mesh = Arc::new(MppMesh::new(proc_idx, total_procs, inbound_receiver));
 
     Ok(MppWorkerState {
         outbound_senders,

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -20,8 +20,6 @@
 
 use pgrx::pg_sys;
 
-#[cfg(test)]
-use crate::postgres::customscan::mpp::dsm_mpsc_ring::{self, DsmMpscRingHeader};
 use crate::postgres::customscan::mpp::dsm_mpsc_ring::{
     DsmMpscReceiver, DsmMpscSender, RecvOutcome as MpscRecvOutcome, SendError as MpscSendError,
 };
@@ -179,56 +177,53 @@ impl BatchChannelReceiver for DsmInboxReceiver {
     }
 }
 
-/// Allocate a fresh ring (heap, aligned) and return (sender, receiver, owning region).
-/// Test-only helper that pairs `DsmInboxSender` + `DsmInboxReceiver` over a heap-allocated
-/// ring matching the alignment contract `create_at` requires. Production allocates the
-/// region inside a `dsm_segment`; this helper exists so the BatchChannel trait impls can
-/// be exercised in unit tests without a PG backend.
-#[cfg(test)]
-pub(super) fn test_dsm_inbox_pair(
-    ring_size: u32,
-    slot_capacity: u32,
-) -> (DsmInboxSender, DsmInboxReceiver, AlignedTestRegion) {
-    let bytes = DsmMpscRingHeader::region_bytes(ring_size, slot_capacity);
-    let region = AlignedTestRegion::new(bytes);
-    let header_ptr =
-        unsafe { dsm_mpsc_ring::create_at(region.as_mut_ptr(), ring_size, slot_capacity) };
-    let nn = std::ptr::NonNull::new(header_ptr).expect("create_at returned null");
-    let sender = DsmInboxSender::new(unsafe { DsmMpscSender::new(nn) });
-    let receiver = DsmInboxReceiver::new(unsafe { DsmMpscReceiver::new(nn) });
-    (sender, receiver, region)
-}
-
-#[cfg(test)]
-pub(super) struct AlignedTestRegion {
-    ptr: *mut u8,
-    layout: std::alloc::Layout,
-}
-
-#[cfg(test)]
-impl AlignedTestRegion {
-    fn new(bytes: usize) -> Self {
-        let align = std::mem::align_of::<DsmMpscRingHeader>();
-        let layout = std::alloc::Layout::from_size_align(bytes, align).expect("layout");
-        let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
-        assert!(!ptr.is_null());
-        Self { ptr, layout }
-    }
-    fn as_mut_ptr(&self) -> *mut u8 {
-        self.ptr
-    }
-}
-
-#[cfg(test)]
-impl Drop for AlignedTestRegion {
-    fn drop(&mut self) {
-        unsafe { std::alloc::dealloc(self.ptr, self.layout) };
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::postgres::customscan::mpp::dsm_mpsc_ring::{self, DsmMpscRingHeader};
+
+    /// Allocate a fresh ring (heap, aligned) and return (sender, receiver, owning region).
+    /// Pairs `DsmInboxSender` + `DsmInboxReceiver` over a heap-allocated ring matching the
+    /// alignment contract `create_at` requires. Production allocates the region inside a
+    /// `dsm_segment`; this helper exists so the BatchChannel trait impls can be exercised
+    /// without a PG backend.
+    fn test_dsm_inbox_pair(
+        ring_size: u32,
+        slot_capacity: u32,
+    ) -> (DsmInboxSender, DsmInboxReceiver, AlignedTestRegion) {
+        let bytes = DsmMpscRingHeader::region_bytes(ring_size, slot_capacity);
+        let region = AlignedTestRegion::new(bytes);
+        let header_ptr =
+            unsafe { dsm_mpsc_ring::create_at(region.as_mut_ptr(), ring_size, slot_capacity) };
+        let nn = std::ptr::NonNull::new(header_ptr).expect("create_at returned null");
+        let sender = DsmInboxSender::new(unsafe { DsmMpscSender::new(nn) });
+        let receiver = DsmInboxReceiver::new(unsafe { DsmMpscReceiver::new(nn) });
+        (sender, receiver, region)
+    }
+
+    struct AlignedTestRegion {
+        ptr: *mut u8,
+        layout: std::alloc::Layout,
+    }
+
+    impl AlignedTestRegion {
+        fn new(bytes: usize) -> Self {
+            let align = std::mem::align_of::<DsmMpscRingHeader>();
+            let layout = std::alloc::Layout::from_size_align(bytes, align).expect("layout");
+            let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+            assert!(!ptr.is_null());
+            Self { ptr, layout }
+        }
+        fn as_mut_ptr(&self) -> *mut u8 {
+            self.ptr
+        }
+    }
+
+    impl Drop for AlignedTestRegion {
+        fn drop(&mut self) {
+            unsafe { std::alloc::dealloc(self.ptr, self.layout) };
+        }
+    }
 
     #[test]
     fn aligned_queue_bytes_rounds_down_to_maxalign() {

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -93,14 +93,11 @@ impl DsmInboxSender {
 
 impl BatchChannelSender for DsmInboxSender {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
-        // NOT a real block. This adapter is the no-cooperative-drain fallback path;
-        // production wires `MppSender::with_cooperative_drain(..)` which calls
-        // `try_send_bytes` directly through the cooperative spin (`transport.rs`). If
-        // you reach this function in production it usually means a fragment was
-        // constructed without `with_cooperative_drain`; fix that rather than relying on
-        // the spin. The `yield_now` keeps the consumer running on the same OS thread;
-        // under a slow consumer this still burns a backend core, so it's strictly a
-        // debug aid.
+        // Fallback for callers that didn't wire `with_cooperative_drain`. The real send
+        // path drives `try_send_bytes` through the cooperative spin in `transport.rs`;
+        // this loop just spins on `yield_now` and burns the backend core under a slow
+        // consumer. Hitting it in production means a missing `with_cooperative_drain`
+        // on the fragment, not a real backpressure path.
         loop {
             match self.inner.try_send(bytes) {
                 Ok(()) => return Ok(()),

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -332,11 +332,10 @@ mod tests {
         }
     }
 
-    /// Dropping the last DsmInboxSender flips `detached` and the receiver sees the
+    /// Dropping the last `DsmInboxSender` flips `detached` and the receiver sees the
     /// queued bytes followed by `Detached`. This is the structural equivalent of
     /// shm_mq's "drop the last sender, receiver sees detach" guarantee, and is what
-    /// keeps the drain loop from wedging on a clean shutdown (no explicit
-    /// `set_detached` needed when every sender goes away cleanly).
+    /// keeps the drain loop from wedging on a clean shutdown.
     #[test]
     fn dropping_last_sender_triggers_detach() {
         let (tx, rx, _region) = test_dsm_inbox_pair(4, 64);

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -28,6 +28,11 @@ use crate::mpp_log;
 use crate::parallel_worker::mqueue::{
     MessageQueueReceiver, MessageQueueRecvError, MessageQueueSendError, MessageQueueSender,
 };
+#[cfg(test)]
+use crate::postgres::customscan::mpp::dsm_mpsc_ring::{self, DsmMpscRingHeader};
+use crate::postgres::customscan::mpp::dsm_mpsc_ring::{
+    DsmMpscReceiver, DsmMpscSender, RecvOutcome as MpscRecvOutcome, SendError as MpscSendError,
+};
 use crate::postgres::customscan::mpp::transport::{
     BatchChannelReceiver, BatchChannelSender, RecvOutcome,
 };
@@ -60,7 +65,10 @@ pub(super) fn align_up_maxalign_checked(n: usize) -> Option<usize> {
 /// dedicated parallel-worker backend. The blocking `shm_mq_send(nowait=false)`
 /// path uses `WaitLatch` + `CHECK_FOR_INTERRUPTS` — both process-global
 /// Postgres primitives, not thread-safe off a backend thread.
-pub(super) struct ShmMqSender {
+// Kept for reference and possible reuse; mesh multiplexing routes through
+// DsmInboxSender/DsmInboxReceiver instead.
+#[allow(dead_code)]
+pub(crate) struct ShmMqSender {
     inner: MessageQueueSender,
     attach_thread: std::thread::ThreadId,
     /// Async serialization lock around the shm_mq handle. Held by [`MppSender::send_*_traced`]
@@ -83,6 +91,7 @@ unsafe impl Send for ShmMqSender {}
 // at compile time.
 unsafe impl Sync for ShmMqSender {}
 
+#[allow(dead_code)]
 impl ShmMqSender {
     /// # Safety
     /// - `seg` must be a valid `dsm_segment*` (or NULL on workers).
@@ -151,6 +160,8 @@ impl BatchChannelSender for ShmMqSender {
 /// shm_mq-backed `BatchChannelReceiver`. The leader creates the shm_mq via
 /// `shm_mq_create` during DSM init; this attaches as receiver to an already-
 /// initialized queue.
+// Kept for reference; mesh multiplexing routes through `DsmInboxReceiver` instead.
+#[allow(dead_code)]
 pub(super) struct ShmMqReceiver {
     inner: MessageQueueReceiver,
 }
@@ -169,6 +180,7 @@ unsafe impl Send for ShmMqReceiver {}
 // from the `Mutex<Vec<…>>` wrapper on `coop_receivers` having to provide it.
 unsafe impl Sync for ShmMqReceiver {}
 
+#[allow(dead_code)]
 impl ShmMqReceiver {
     /// Attach as receiver to an *already-created* shm_mq.
     ///
@@ -205,6 +217,201 @@ impl BatchChannelReceiver for ShmMqReceiver {
     }
 }
 
+// The DSM-MPSC adapter types below are reached from the in-file tests in this commit;
+// the `dsm.rs` / `glue.rs` wire-up lands in the follow-up commit. The per-item
+// `#[allow(dead_code)]` keeps clippy quiet until then; the wire-up commit strips them.
+
+/// DSM-MPSC-ring-backed `BatchChannelSender`. Wraps a `DsmMpscSender` so the existing
+/// `MppSender` / cooperative-drain machinery can drive it through the same trait surface
+/// as `ShmMqSender`. Multiple producer processes hold their own `DsmInboxSender` clones
+/// targeting the same receiver inbox; the underlying ring serializes them via
+/// Vyukov-style CAS on `tail`.
+///
+/// Unlike `ShmMqSender`, this adapter is genuinely thread-safe. The ring's atomic
+/// operations are the synchronization point, so the `send_bytes` / `try_send_bytes`
+/// paths don't `debug_assert!` an attach-thread invariant.
+///
+/// Detach-on-drop: the inner `DsmMpscSender::Drop` decrements the ring's
+/// `sender_count`; the last drop flips `detached` and wakes the receiver, mirroring
+/// shm_mq's "drop the last sender, receiver sees detach" structural guarantee.
+#[allow(dead_code)]
+pub(super) struct DsmInboxSender {
+    inner: DsmMpscSender,
+    send_lock: tokio::sync::Mutex<()>,
+}
+
+// `DsmInboxSender` auto-derives Send + Sync. Both fields are Send + Sync (DsmMpscSender
+// via its unsafe impls; tokio::sync::Mutex by definition), so no manual unsafe impls
+// are needed. Auto-derive also defends against a future field that's !Send / !Sync.
+
+#[allow(dead_code)]
+impl DsmInboxSender {
+    /// Wrap a `DsmMpscSender` for use through the `BatchChannelSender` trait.
+    pub(super) fn new(inner: DsmMpscSender) -> Self {
+        Self {
+            inner,
+            send_lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    fn map_send_err(err: MpscSendError) -> DataFusionError {
+        match err {
+            MpscSendError::Detached => {
+                DataFusionError::Execution("mpp: DSM MPSC inbox detached".into())
+            }
+            MpscSendError::MessageTooLarge => {
+                DataFusionError::Execution("mpp: DSM MPSC frame exceeds slot_capacity".into())
+            }
+            MpscSendError::Full => DataFusionError::Execution(
+                "mpp: DSM MPSC inbox full (caller should retry via try_send_bytes)".into(),
+            ),
+        }
+    }
+}
+
+impl BatchChannelSender for DsmInboxSender {
+    fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
+        // NOT a real block. This adapter is the no-cooperative-drain fallback path;
+        // production wires `MppSender::with_cooperative_drain(..)` which calls
+        // `try_send_bytes` directly through the cooperative spin (`transport.rs`). If
+        // you reach this function in production it usually means a fragment was
+        // constructed without `with_cooperative_drain`; fix that rather than relying on
+        // the spin. The `yield_now` keeps the consumer running on the same OS thread;
+        // under a slow consumer this still burns a backend core, so it's strictly a
+        // debug aid.
+        loop {
+            match self.inner.try_send(bytes) {
+                Ok(()) => return Ok(()),
+                Err(MpscSendError::Full) => std::thread::yield_now(),
+                Err(e) => return Err(Self::map_send_err(e)),
+            }
+        }
+    }
+
+    fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
+        match self.inner.try_send(bytes) {
+            Ok(()) => Ok(true),
+            Err(MpscSendError::Full) => Ok(false),
+            Err(e) => Err(Self::map_send_err(e)),
+        }
+    }
+
+    fn send_lock(&self) -> &tokio::sync::Mutex<()> {
+        &self.send_lock
+    }
+}
+
+/// DSM-MPSC-ring-backed `BatchChannelReceiver`. Wraps a `DsmMpscReceiver` and a single
+/// scratch `Vec<u8>` that the inner primitive's `try_recv` populates each call; we hand
+/// the populated buffer to the caller via `mem::take` and leave an empty `Vec` behind.
+///
+/// The single-consumer invariant comes from how this is used: one `DsmInboxReceiver`
+/// per process, owned by `DrainHandle::cooperative_receivers`, polled inline from the
+/// drain's `try_drain_pass`. No two threads ever race on the same receiver; the
+/// `parking_lot::Mutex` on `scratch` is interior-mutability boilerplate, uncontended in
+/// production.
+#[allow(dead_code)]
+pub(super) struct DsmInboxReceiver {
+    inner: DsmMpscReceiver,
+    /// Scratch the inner primitive's `try_recv` reuses across calls (via reserve+set_len).
+    /// We `mem::take` it on every Bytes outcome to hand the bytes to the caller without a
+    /// copy; the inner primitive re-grows from `Vec::new()` on the next call.
+    scratch: parking_lot::Mutex<Vec<u8>>,
+}
+
+// `DsmMpscReceiver` is deliberately `!Sync` (single-consumer invariant). We promote
+// `DsmInboxReceiver` to Sync because the caller pattern guarantees only one thread
+// touches it at a time, and `parking_lot::Mutex<Vec<u8>>` protects the scratch from
+// shared-reference UB if that invariant ever slips. Send is auto-derived.
+unsafe impl Sync for DsmInboxReceiver {}
+
+impl DsmInboxReceiver {
+    /// Wrap a `DsmMpscReceiver` for use through the `BatchChannelReceiver` trait.
+    pub(super) fn new(inner: DsmMpscReceiver) -> Self {
+        Self {
+            inner,
+            scratch: parking_lot::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Register this process as the receiver on the underlying ring. See
+    /// `DsmMpscReceiver::set_receiver` for the pgprocno + pid contract.
+    pub(super) fn set_receiver(&self, pgprocno: i32, pid: i32) {
+        self.inner.set_receiver(pgprocno, pid);
+    }
+}
+
+impl BatchChannelReceiver for DsmInboxReceiver {
+    fn try_recv(&self) -> RecvOutcome {
+        let mut buf = self.scratch.lock();
+        match self.inner.try_recv(&mut buf) {
+            MpscRecvOutcome::Bytes => {
+                // Hand the populated buffer to the caller and leave an empty Vec behind.
+                // The inner primitive's `try_recv` does its own `reserve(len)` on the
+                // next call, so we don't need to pre-allocate scratch capacity here.
+                RecvOutcome::Bytes(std::mem::take(&mut *buf))
+            }
+            MpscRecvOutcome::Empty => RecvOutcome::Empty,
+            MpscRecvOutcome::Detached => RecvOutcome::Detached,
+        }
+    }
+
+    /// Force-detach the inbox early (e.g., query teardown before producers finish).
+    /// Producers' subsequent `try_send_bytes` return `Err(detached)`. Frames already
+    /// in the ring stay drainable; the next `try_recv` past the last queued frame
+    /// returns `Detached`.
+    fn set_detached(&self) {
+        self.inner.set_detached();
+    }
+}
+
+/// Allocate a fresh ring (heap, aligned) and return (sender, receiver, owning region).
+/// Test-only helper that pairs `DsmInboxSender` + `DsmInboxReceiver` over a heap-allocated
+/// ring matching the alignment contract `create_at` requires. Production allocates the
+/// region inside a `dsm_segment`; this helper exists so the BatchChannel trait impls can
+/// be exercised in unit tests without a PG backend.
+#[cfg(test)]
+pub(super) fn test_dsm_inbox_pair(
+    ring_size: u32,
+    slot_capacity: u32,
+) -> (DsmInboxSender, DsmInboxReceiver, AlignedTestRegion) {
+    let bytes = DsmMpscRingHeader::region_bytes(ring_size, slot_capacity);
+    let region = AlignedTestRegion::new(bytes);
+    let header_ptr =
+        unsafe { dsm_mpsc_ring::create_at(region.as_mut_ptr(), ring_size, slot_capacity) };
+    let nn = std::ptr::NonNull::new(header_ptr).expect("create_at returned null");
+    let sender = DsmInboxSender::new(unsafe { DsmMpscSender::new(nn) });
+    let receiver = DsmInboxReceiver::new(unsafe { DsmMpscReceiver::new(nn) });
+    (sender, receiver, region)
+}
+
+#[cfg(test)]
+pub(super) struct AlignedTestRegion {
+    ptr: *mut u8,
+    layout: std::alloc::Layout,
+}
+
+#[cfg(test)]
+impl AlignedTestRegion {
+    fn new(bytes: usize) -> Self {
+        let align = std::mem::align_of::<DsmMpscRingHeader>();
+        let layout = std::alloc::Layout::from_size_align(bytes, align).expect("layout");
+        let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
+        assert!(!ptr.is_null());
+        Self { ptr, layout }
+    }
+    fn as_mut_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+}
+
+#[cfg(test)]
+impl Drop for AlignedTestRegion {
+    fn drop(&mut self) {
+        unsafe { std::alloc::dealloc(self.ptr, self.layout) };
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,5 +437,133 @@ mod tests {
             assert!(got - req < maxalign);
         }
         assert!(align_up_maxalign_checked(usize::MAX).is_none());
+    }
+
+    #[test]
+    fn dsm_inbox_batch_channel_round_trip() {
+        let (tx, rx, _region) = test_dsm_inbox_pair(4, 64);
+        // Sanity: try_send_bytes succeeds, try_recv hands back the bytes, send_lock
+        // returns a usable Mutex.
+        assert!(tx.try_send_bytes(b"hello").unwrap());
+        assert!(tx.try_send_bytes(b"world").unwrap());
+        match rx.try_recv() {
+            RecvOutcome::Bytes(b) => assert_eq!(&b[..], b"hello"),
+            other => panic!("expected Bytes(hello), got {other:?}"),
+        }
+        match rx.try_recv() {
+            RecvOutcome::Bytes(b) => assert_eq!(&b[..], b"world"),
+            other => panic!("expected Bytes(world), got {other:?}"),
+        }
+        assert!(matches!(rx.try_recv(), RecvOutcome::Empty));
+        // send_lock is just exercised: the per-instance Mutex satisfies the trait.
+        let _guard = tx.send_lock();
+    }
+
+    #[test]
+    fn dsm_inbox_try_send_returns_false_when_full() {
+        let (tx, rx, _region) = test_dsm_inbox_pair(2, 64);
+        assert!(tx.try_send_bytes(b"a").unwrap());
+        assert!(tx.try_send_bytes(b"b").unwrap());
+        // Third send should hit Full (returns Ok(false), not Err).
+        assert!(!tx.try_send_bytes(b"c").unwrap());
+        // Drain one, then send again succeeds.
+        assert!(matches!(rx.try_recv(), RecvOutcome::Bytes(_)));
+        assert!(tx.try_send_bytes(b"c").unwrap());
+    }
+
+    #[test]
+    fn dsm_inbox_recv_signals_detached_after_set_detached() {
+        let (tx, rx, _region) = test_dsm_inbox_pair(4, 64);
+        tx.try_send_bytes(b"keep").unwrap();
+        rx.set_detached();
+        // Subsequent send rejected with an Execution error (mapped from MpscSendError::Detached).
+        let err = tx
+            .try_send_bytes(b"drop")
+            .expect_err("expected detached error");
+        assert!(format!("{err}").contains("detached"));
+        // Already-queued frame still drains; then recv returns Detached.
+        assert!(matches!(rx.try_recv(), RecvOutcome::Bytes(_)));
+        assert!(matches!(rx.try_recv(), RecvOutcome::Detached));
+    }
+
+    #[test]
+    fn dsm_inbox_multi_producer_through_trait_surface() {
+        use std::sync::Arc;
+        // Build a real Arc<dyn BatchChannelSender> shared across threads to confirm
+        // dyn dispatch + Send/Sync impls compile and behave.
+        let (tx, rx, _region) = test_dsm_inbox_pair(64, 32);
+        let tx: Arc<dyn BatchChannelSender> = Arc::new(tx);
+        let mut handles = Vec::new();
+        const K: usize = 4;
+        const M: u32 = 200;
+        for producer_id in 0..K {
+            let tx = Arc::clone(&tx);
+            handles.push(std::thread::spawn(move || {
+                let mut payload = [0u8; 8];
+                payload[0..4].copy_from_slice(&(producer_id as u32).to_le_bytes());
+                let mut sent = 0u32;
+                while sent < M {
+                    payload[4..8].copy_from_slice(&sent.to_le_bytes());
+                    match tx.try_send_bytes(&payload) {
+                        Ok(true) => sent += 1,
+                        Ok(false) => std::thread::yield_now(),
+                        Err(e) => panic!("send failed: {e}"),
+                    }
+                }
+            }));
+        }
+        let target = K * M as usize;
+        let mut seen = vec![vec![false; M as usize]; K];
+        let mut got = 0usize;
+        while got < target {
+            match rx.try_recv() {
+                RecvOutcome::Bytes(b) => {
+                    let producer_id = u32::from_le_bytes(b[0..4].try_into().unwrap()) as usize;
+                    let idx = u32::from_le_bytes(b[4..8].try_into().unwrap()) as usize;
+                    let already = std::mem::replace(&mut seen[producer_id][idx], true);
+                    assert!(!already, "dup ({producer_id}, {idx})");
+                    got += 1;
+                }
+                RecvOutcome::Empty => std::thread::yield_now(),
+                RecvOutcome::Detached => panic!("unexpected detach"),
+            }
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+    }
+
+    /// Dropping the last DsmInboxSender flips `detached` and the receiver sees the
+    /// queued bytes followed by `Detached`. This is the structural equivalent of
+    /// shm_mq's "drop the last sender, receiver sees detach" guarantee, and is what
+    /// keeps the drain loop from wedging on a clean shutdown (no explicit
+    /// `set_detached` needed when every sender goes away cleanly).
+    #[test]
+    fn dropping_last_sender_triggers_detach() {
+        let (tx, rx, _region) = test_dsm_inbox_pair(4, 64);
+        tx.try_send_bytes(b"final").unwrap();
+        drop(tx);
+        // The queued frame is still readable.
+        match rx.try_recv() {
+            RecvOutcome::Bytes(b) => assert_eq!(&b[..], b"final"),
+            other => panic!("expected Bytes(final), got {other:?}"),
+        }
+        // Then Detached.
+        assert!(matches!(rx.try_recv(), RecvOutcome::Detached));
+    }
+
+    #[test]
+    fn try_send_bytes_rejects_oversize_payload() {
+        let (tx, _rx, _region) = test_dsm_inbox_pair(2, 32);
+        // Any payload at or above slot_capacity is unconditionally too large (slot
+        // capacity includes the slot header). 64 bytes on a 32-byte slot fits.
+        let oversize = vec![0u8; 64];
+        let err = tx
+            .try_send_bytes(&oversize)
+            .expect_err("expected MessageTooLarge");
+        assert!(
+            format!("{err}").contains("exceeds slot_capacity"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -47,17 +47,14 @@ pub(super) fn align_up_maxalign_checked(n: usize) -> Option<usize> {
     n.checked_add(mask).map(|x| x & !mask)
 }
 
-/// DSM-MPSC-ring-backed `BatchChannelSender`. Multiple producer processes hold their
-/// own `DsmInboxSender` clones targeting the same receiver inbox; the underlying ring
-/// serializes them via Vyukov-style CAS on `tail`.
+/// DSM MPSC ring as a `BatchChannelSender`. Multiple producer processes hold their own
+/// `DsmInboxSender` clones targeting the same receiver inbox; the ring serializes them
+/// via Vyukov CAS on `tail`. Because the ring's atomics are the synchronization point,
+/// the `send_bytes` / `try_send_bytes` paths don't need an attach-thread `debug_assert!`.
 ///
-/// The ring's atomic operations are the synchronization point, so the
-/// `send_bytes` / `try_send_bytes` paths don't `debug_assert!` an attach-thread
-/// invariant.
-///
-/// Detach-on-drop: the inner `DsmMpscSender::Drop` decrements the ring's
-/// `sender_count`; the last drop flips `detached` and wakes the receiver, mirroring
-/// shm_mq's "drop the last sender, receiver sees detach" structural guarantee.
+/// Detach-on-drop: `DsmMpscSender::Drop` decrements `sender_count`; the last drop flips
+/// `detached` and wakes the receiver, mirroring shm_mq's "drop the last sender, receiver
+/// sees detach" guarantee.
 pub(super) struct DsmInboxSender {
     inner: DsmMpscSender,
     send_lock: tokio::sync::Mutex<()>,
@@ -120,14 +117,14 @@ impl BatchChannelSender for DsmInboxSender {
     }
 }
 
-/// DSM-MPSC-ring-backed `BatchChannelReceiver`. The scratch `Vec<u8>` lives behind a
-/// `parking_lot::Mutex` so a `&self` `try_recv` can hand the populated buffer to the
-/// caller via `mem::take` without `RefCell`-style runtime borrow tracking.
+/// DSM MPSC ring as a `BatchChannelReceiver`. The scratch `Vec<u8>` lives behind a
+/// `parking_lot::Mutex` so a `&self` `try_recv` can hand the populated buffer back via
+/// `mem::take` without `RefCell` runtime borrow tracking.
 ///
-/// The single-consumer invariant comes from the call pattern: one `DsmInboxReceiver`
-/// per process, owned by `DrainHandle::cooperative_receivers`, polled inline from the
-/// drain's `try_drain_pass`. No two threads ever race on the same receiver; the mutex
-/// is interior-mutability boilerplate, uncontended in production.
+/// Single-consumer comes from the call pattern: one `DsmInboxReceiver` per process,
+/// owned by `DrainHandle::cooperative_receivers`, polled inline from `try_drain_pass`.
+/// No two threads ever race on the same receiver; the mutex is just interior-mutability
+/// boilerplate, uncontended in production.
 pub(super) struct DsmInboxReceiver {
     inner: DsmMpscReceiver,
     /// Scratch the inner primitive's `try_recv` reuses across calls (via reserve+set_len).

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -78,9 +78,11 @@ impl DsmInboxSender {
             MpscSendError::Detached => {
                 DataFusionError::Execution("mpp: DSM MPSC inbox detached".into())
             }
-            MpscSendError::MessageTooLarge => {
-                DataFusionError::Execution("mpp: DSM MPSC frame exceeds slot_capacity".into())
-            }
+            MpscSendError::MessageTooLarge => DataFusionError::Execution(
+                "mpp: DSM MPSC frame exceeds the entire ring capacity \
+                 (raise paradedb.mpp_queue_size)"
+                    .into(),
+            ),
             MpscSendError::Full => DataFusionError::Execution(
                 "mpp: DSM MPSC inbox full (caller should retry via try_send_bytes)".into(),
             ),
@@ -347,15 +349,17 @@ mod tests {
 
     #[test]
     fn try_send_bytes_rejects_oversize_payload() {
+        // Multi-slot fragmentation lifted the per-slot ceiling; only payloads larger
+        // than `ring_size * (slot_capacity - SLOT_HEADER_BYTES)` are now rejected.
+        // ring_size=2, slot_capacity=32 -> payload_cap=16, ring-wide cap=32. 64
+        // bytes still doesn't fit.
         let (_region, tx, _rx) = test_dsm_inbox_pair(2, 32);
-        // Any payload at or above slot_capacity is unconditionally too large (slot
-        // capacity includes the slot header). 64 bytes on a 32-byte slot fits.
         let oversize = vec![0u8; 64];
         let err = tx
             .try_send_bytes(&oversize)
             .expect_err("expected MessageTooLarge");
         assert!(
-            format!("{err}").contains("exceeds slot_capacity"),
+            format!("{err}").contains("exceeds the entire ring capacity"),
             "unexpected error: {err}"
         );
     }

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -176,15 +176,21 @@ mod tests {
     use super::*;
     use crate::postgres::customscan::mpp::dsm_mpsc_ring::{self, DsmMpscRingHeader};
 
-    /// Allocate a fresh ring (heap, aligned) and return (sender, receiver, owning region).
+    /// Allocate a fresh ring (heap, aligned) and return `(owning region, sender, receiver)`.
     /// Pairs `DsmInboxSender` + `DsmInboxReceiver` over a heap-allocated ring matching the
     /// alignment contract `create_at` requires. Production allocates the region inside a
     /// `dsm_segment`; this helper exists so the BatchChannel trait impls can be exercised
     /// without a PG backend.
+    ///
+    /// The region is returned FIRST so callers bind it first. Rust drops locals in reverse
+    /// declaration order, so the region (bound first) drops LAST, after the sender/receiver whose
+    /// `Drop` touches the ring memory (`DsmMpscSender::drop` does `sender_count.fetch_sub`).
+    /// Returning the region last instead frees the bytes before those `Drop`s run, a
+    /// use-after-free that corrupts the heap shared with parallel tests.
     fn test_dsm_inbox_pair(
         ring_size: u32,
         slot_capacity: u32,
-    ) -> (DsmInboxSender, DsmInboxReceiver, AlignedTestRegion) {
+    ) -> (AlignedTestRegion, DsmInboxSender, DsmInboxReceiver) {
         let bytes = DsmMpscRingHeader::region_bytes(ring_size, slot_capacity);
         let region = AlignedTestRegion::new(bytes);
         let header_ptr =
@@ -192,7 +198,7 @@ mod tests {
         let nn = std::ptr::NonNull::new(header_ptr).expect("create_at returned null");
         let sender = DsmInboxSender::new(unsafe { DsmMpscSender::new(nn) });
         let receiver = DsmInboxReceiver::new(unsafe { DsmMpscReceiver::new(nn) });
-        (sender, receiver, region)
+        (region, sender, receiver)
     }
 
     struct AlignedTestRegion {
@@ -244,7 +250,7 @@ mod tests {
 
     #[test]
     fn dsm_inbox_batch_channel_round_trip() {
-        let (tx, rx, _region) = test_dsm_inbox_pair(4, 64);
+        let (_region, tx, rx) = test_dsm_inbox_pair(4, 64);
         // Sanity: try_send_bytes succeeds, try_recv hands back the bytes, send_lock
         // returns a usable Mutex.
         assert!(tx.try_send_bytes(b"hello").unwrap());
@@ -264,7 +270,7 @@ mod tests {
 
     #[test]
     fn dsm_inbox_try_send_returns_false_when_full() {
-        let (tx, rx, _region) = test_dsm_inbox_pair(2, 64);
+        let (_region, tx, rx) = test_dsm_inbox_pair(2, 64);
         assert!(tx.try_send_bytes(b"a").unwrap());
         assert!(tx.try_send_bytes(b"b").unwrap());
         // Third send should hit Full (returns Ok(false), not Err).
@@ -279,7 +285,7 @@ mod tests {
         use std::sync::Arc;
         // Build a real Arc<dyn BatchChannelSender> shared across threads to confirm
         // dyn dispatch + Send/Sync impls compile and behave.
-        let (tx, rx, _region) = test_dsm_inbox_pair(64, 32);
+        let (_region, tx, rx) = test_dsm_inbox_pair(64, 32);
         let tx: Arc<dyn BatchChannelSender> = Arc::new(tx);
         let mut handles = Vec::new();
         const K: usize = 4;
@@ -327,7 +333,7 @@ mod tests {
     /// keeps the drain loop from wedging on a clean shutdown.
     #[test]
     fn dropping_last_sender_triggers_detach() {
-        let (tx, rx, _region) = test_dsm_inbox_pair(4, 64);
+        let (_region, tx, rx) = test_dsm_inbox_pair(4, 64);
         tx.try_send_bytes(b"final").unwrap();
         drop(tx);
         // The queued frame is still readable.
@@ -341,7 +347,7 @@ mod tests {
 
     #[test]
     fn try_send_bytes_rejects_oversize_payload() {
-        let (tx, _rx, _region) = test_dsm_inbox_pair(2, 32);
+        let (_region, tx, _rx) = test_dsm_inbox_pair(2, 32);
         // Any payload at or above slot_capacity is unconditionally too large (slot
         // capacity includes the slot header). 64 bytes on a 32-byte slot fits.
         let oversize = vec![0u8; 64];

--- a/pg_search/src/postgres/customscan/mpp/mesh.rs
+++ b/pg_search/src/postgres/customscan/mpp/mesh.rs
@@ -15,19 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Low-level shm_mq primitives for the MPP mesh: `ShmMqSender`,
-//! `ShmMqReceiver`, and the alignment helpers used to size queue slots.
-//!
-//! The N×K queue layout is described in
-//! [`super::dsm`](crate::postgres::customscan::mpp::dsm); this module owns
-//! only the per-slot FFI wrappers.
+//! MPP mesh adapters around `DsmMpscRing` plus the alignment helpers used to size
+//! the per-inbox DSM regions.
 
 use pgrx::pg_sys;
 
-use crate::mpp_log;
-use crate::parallel_worker::mqueue::{
-    MessageQueueReceiver, MessageQueueRecvError, MessageQueueSendError, MessageQueueSender,
-};
 #[cfg(test)]
 use crate::postgres::customscan::mpp::dsm_mpsc_ring::{self, DsmMpscRingHeader};
 use crate::postgres::customscan::mpp::dsm_mpsc_ring::{
@@ -38,9 +30,9 @@ use crate::postgres::customscan::mpp::transport::{
 };
 use datafusion::common::DataFusionError;
 
-/// MAXALIGN-DOWN of `queue_bytes`. Postgres requires shm_mq slot sizes to be
-/// MAXALIGN-aligned; this rounds the user request down so every slot in a
-/// queue array is the same size and slot indexing is a simple multiply.
+/// MAXALIGN-DOWN of `queue_bytes`. Postgres requires shm-style slot sizes to be
+/// MAXALIGN-aligned; this rounds the user request down so every per-inbox region in
+/// the DSM grid is the same size and offset math is a simple multiply.
 #[inline]
 pub(super) fn aligned_queue_bytes(queue_bytes: usize) -> usize {
     const MAXIMUM_ALIGNOF: usize = pg_sys::MAXIMUM_ALIGNOF as usize;
@@ -57,194 +49,26 @@ pub(super) fn align_up_maxalign_checked(n: usize) -> Option<usize> {
     n.checked_add(mask).map(|x| x & !mask)
 }
 
-/// shm_mq-backed `BatchChannelSender`. Wraps `MessageQueueSender` so we reuse
-/// its detach-on-drop behavior and the pgrx-safe FFI.
+/// DSM-MPSC-ring-backed `BatchChannelSender`. Multiple producer processes hold their
+/// own `DsmInboxSender` clones targeting the same receiver inbox; the underlying ring
+/// serializes them via Vyukov-style CAS on `tail`.
 ///
-/// `unsafe impl Send` below is safe **only** when the sender is *used* from
-/// a thread that owns a valid `PGPROC` — i.e., the main backend thread or a
-/// dedicated parallel-worker backend. The blocking `shm_mq_send(nowait=false)`
-/// path uses `WaitLatch` + `CHECK_FOR_INTERRUPTS` — both process-global
-/// Postgres primitives, not thread-safe off a backend thread.
-// Kept for reference and possible reuse; mesh multiplexing routes through
-// DsmInboxSender/DsmInboxReceiver instead.
-#[allow(dead_code)]
-pub(crate) struct ShmMqSender {
-    inner: MessageQueueSender,
-    attach_thread: std::thread::ThreadId,
-    /// Async serialization lock around the shm_mq handle. Held by [`MppSender::send_*_traced`]
-    /// across the cooperative-drain spin to keep partial sends from interleaving — see the
-    /// [`BatchChannelSender::send_lock`] doc and PG's `shm_mq_send` invariants. Multiple
-    /// [`MppSender`] clones share the same `Arc<dyn BatchChannelSender>` to multiplex
-    /// `(stage_id, partition)` channels onto one shm_mq, and yielding between `try_send_bytes`
-    /// retries can otherwise stitch one sender's length prefix to another sender's payload and
-    /// corrupt the queue.
-    send_lock: tokio::sync::Mutex<()>,
-}
-
-// SAFETY: see struct doc.
-unsafe impl Send for ShmMqSender {}
-// SAFETY: `MppSender` ensures all `send_*` paths execute on the attach thread (a
-// `debug_assert!` in `send_bytes` / `try_send_bytes` pins this), so cross-thread sharing of
-// `&ShmMqSender` never actually crosses threads at the FFI boundary. The Sync bound is there so
-// multiple `MppSender`s can hold `Arc<dyn BatchChannelSender>` clones of the same underlying
-// queue (the multi-partition fan-out pattern) without the type system rejecting the `Arc::clone`
-// at compile time.
-unsafe impl Sync for ShmMqSender {}
-
-#[allow(dead_code)]
-impl ShmMqSender {
-    /// # Safety
-    /// - `seg` must be a valid `dsm_segment*` (or NULL on workers).
-    /// - `mq` must point to a shm_mq region that has been `shm_mq_create`'d
-    ///   at its address with the expected size and has had
-    ///   `shm_mq_set_receiver` called by the peer.
-    pub(super) unsafe fn attach(seg: *mut pg_sys::dsm_segment, mq: *mut pg_sys::shm_mq) -> Self {
-        unsafe {
-            Self {
-                inner: MessageQueueSender::new(seg, mq),
-                attach_thread: std::thread::current().id(),
-                send_lock: tokio::sync::Mutex::new(()),
-            }
-        }
-    }
-}
-
-impl BatchChannelSender for ShmMqSender {
-    fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError> {
-        debug_assert_eq!(
-            std::thread::current().id(),
-            self.attach_thread,
-            "ShmMqSender::send_bytes called off the attach thread"
-        );
-        self.inner.send(bytes).map_err(|e| match e {
-            MessageQueueSendError::Detached => {
-                DataFusionError::Execution("mpp: shm_mq sender detached".into())
-            }
-            MessageQueueSendError::WouldBlock => {
-                DataFusionError::Execution("mpp: shm_mq send would block".into())
-            }
-            MessageQueueSendError::Unknown(code) => {
-                mpp_log!("mpp: shm_mq send unknown code {code}");
-                DataFusionError::Execution(format!("mpp: shm_mq send unknown code {code}"))
-            }
-        })
-    }
-
-    fn try_send_bytes(&self, bytes: &[u8]) -> Result<bool, DataFusionError> {
-        debug_assert_eq!(
-            std::thread::current().id(),
-            self.attach_thread,
-            "ShmMqSender::try_send_bytes called off the attach thread"
-        );
-        match self.inner.try_send(bytes) {
-            Ok(Some(())) => Ok(true),
-            Ok(None) => Ok(false),
-            Err(MessageQueueSendError::Detached) => Err(DataFusionError::Execution(
-                "mpp: shm_mq sender detached".into(),
-            )),
-            Err(MessageQueueSendError::WouldBlock) => Ok(false),
-            Err(MessageQueueSendError::Unknown(code)) => {
-                mpp_log!("mpp: shm_mq try_send unknown code {code}");
-                Err(DataFusionError::Execution(format!(
-                    "mpp: shm_mq try_send unknown code {code}"
-                )))
-            }
-        }
-    }
-
-    fn send_lock(&self) -> &tokio::sync::Mutex<()> {
-        &self.send_lock
-    }
-}
-
-/// shm_mq-backed `BatchChannelReceiver`. The leader creates the shm_mq via
-/// `shm_mq_create` during DSM init; this attaches as receiver to an already-
-/// initialized queue.
-// Kept for reference; mesh multiplexing routes through `DsmInboxReceiver` instead.
-#[allow(dead_code)]
-pub(super) struct ShmMqReceiver {
-    inner: MessageQueueReceiver,
-}
-
-// SAFETY: `NonNull<shm_mq_handle>` is a pointer into DSM valid across threads
-// within the same backend process; the drain thread is the only reader after
-// attach, and only via `shm_mq_receive(nowait=true)` (no thread-unsafe latch
-// or CFI calls).
-unsafe impl Send for ShmMqReceiver {}
-
-// SAFETY: production invariant is that only the backend thread calls `try_recv` (the cooperative
-// drain runs inline on `DrainGatherStream::poll_next`; pgrx's `check_active_thread` would panic
-// on a non-backend caller anyway). `shm_mq_receive(nowait=true)` is therefore not reentered
-// concurrently on the same handle. We need `Sync` to satisfy the `BatchChannelReceiver: Send +
-// Sync` bound, which in turn lets `DrainHandle: Sync` come from the concrete types instead of
-// from the `Mutex<Vec<…>>` wrapper on `coop_receivers` having to provide it.
-unsafe impl Sync for ShmMqReceiver {}
-
-#[allow(dead_code)]
-impl ShmMqReceiver {
-    /// Attach as receiver to an *already-created* shm_mq.
-    ///
-    /// # Safety
-    /// - `mq` must point to a shm_mq previously initialized by `shm_mq_create`.
-    /// - `seg` may be NULL on workers.
-    /// - No other proc has already set itself as receiver for `mq`.
-    pub(super) unsafe fn attach_existing(
-        seg: *mut pg_sys::dsm_segment,
-        mq: *mut pg_sys::shm_mq,
-    ) -> Self {
-        unsafe {
-            pg_sys::shm_mq_set_receiver(mq, pg_sys::MyProc);
-            let handle = pg_sys::shm_mq_attach(mq, seg, std::ptr::null_mut());
-            Self {
-                inner: MessageQueueReceiver::from_raw_handle(handle),
-            }
-        }
-    }
-}
-
-impl BatchChannelReceiver for ShmMqReceiver {
-    fn try_recv(&self) -> RecvOutcome {
-        match self.inner.try_recv() {
-            Ok(Some(bytes)) => RecvOutcome::Bytes(bytes),
-            Ok(None) => RecvOutcome::Empty,
-            Err(MessageQueueRecvError::Detached) => RecvOutcome::Detached,
-            Err(MessageQueueRecvError::WouldBlock) => RecvOutcome::Empty,
-            Err(MessageQueueRecvError::Unknown(code)) => {
-                mpp_log!("mpp: shm_mq recv unknown code {code}, treating as detached");
-                RecvOutcome::Detached
-            }
-        }
-    }
-}
-
-// The DSM-MPSC adapter types below are reached from the in-file tests in this commit;
-// the `dsm.rs` / `glue.rs` wire-up lands in the follow-up commit. The per-item
-// `#[allow(dead_code)]` keeps clippy quiet until then; the wire-up commit strips them.
-
-/// DSM-MPSC-ring-backed `BatchChannelSender`. Wraps a `DsmMpscSender` so the existing
-/// `MppSender` / cooperative-drain machinery can drive it through the same trait surface
-/// as `ShmMqSender`. Multiple producer processes hold their own `DsmInboxSender` clones
-/// targeting the same receiver inbox; the underlying ring serializes them via
-/// Vyukov-style CAS on `tail`.
-///
-/// Unlike `ShmMqSender`, this adapter is genuinely thread-safe. The ring's atomic
-/// operations are the synchronization point, so the `send_bytes` / `try_send_bytes`
-/// paths don't `debug_assert!` an attach-thread invariant.
+/// The ring's atomic operations are the synchronization point, so the
+/// `send_bytes` / `try_send_bytes` paths don't `debug_assert!` an attach-thread
+/// invariant.
 ///
 /// Detach-on-drop: the inner `DsmMpscSender::Drop` decrements the ring's
 /// `sender_count`; the last drop flips `detached` and wakes the receiver, mirroring
 /// shm_mq's "drop the last sender, receiver sees detach" structural guarantee.
-#[allow(dead_code)]
 pub(super) struct DsmInboxSender {
     inner: DsmMpscSender,
     send_lock: tokio::sync::Mutex<()>,
 }
 
-// `DsmInboxSender` auto-derives Send + Sync. Both fields are Send + Sync (DsmMpscSender
-// via its unsafe impls; tokio::sync::Mutex by definition), so no manual unsafe impls
-// are needed. Auto-derive also defends against a future field that's !Send / !Sync.
+// Send + Sync auto-derive. Both fields are Send + Sync (`DsmMpscSender` via its unsafe
+// impls; `tokio::sync::Mutex` by definition), so no manual `unsafe impl` is needed; the
+// auto-derive also surfaces a compile error if a future field is `!Send` / `!Sync`.
 
-#[allow(dead_code)]
 impl DsmInboxSender {
     /// Wrap a `DsmMpscSender` for use through the `BatchChannelSender` trait.
     pub(super) fn new(inner: DsmMpscSender) -> Self {
@@ -301,16 +125,14 @@ impl BatchChannelSender for DsmInboxSender {
     }
 }
 
-/// DSM-MPSC-ring-backed `BatchChannelReceiver`. Wraps a `DsmMpscReceiver` and a single
-/// scratch `Vec<u8>` that the inner primitive's `try_recv` populates each call; we hand
-/// the populated buffer to the caller via `mem::take` and leave an empty `Vec` behind.
+/// DSM-MPSC-ring-backed `BatchChannelReceiver`. The scratch `Vec<u8>` lives behind a
+/// `parking_lot::Mutex` so a `&self` `try_recv` can hand the populated buffer to the
+/// caller via `mem::take` without `RefCell`-style runtime borrow tracking.
 ///
-/// The single-consumer invariant comes from how this is used: one `DsmInboxReceiver`
+/// The single-consumer invariant comes from the call pattern: one `DsmInboxReceiver`
 /// per process, owned by `DrainHandle::cooperative_receivers`, polled inline from the
-/// drain's `try_drain_pass`. No two threads ever race on the same receiver; the
-/// `parking_lot::Mutex` on `scratch` is interior-mutability boilerplate, uncontended in
-/// production.
-#[allow(dead_code)]
+/// drain's `try_drain_pass`. No two threads ever race on the same receiver; the mutex
+/// is interior-mutability boilerplate, uncontended in production.
 pub(super) struct DsmInboxReceiver {
     inner: DsmMpscReceiver,
     /// Scratch the inner primitive's `try_recv` reuses across calls (via reserve+set_len).
@@ -354,14 +176,6 @@ impl BatchChannelReceiver for DsmInboxReceiver {
             MpscRecvOutcome::Empty => RecvOutcome::Empty,
             MpscRecvOutcome::Detached => RecvOutcome::Detached,
         }
-    }
-
-    /// Force-detach the inbox early (e.g., query teardown before producers finish).
-    /// Producers' subsequent `try_send_bytes` return `Err(detached)`. Frames already
-    /// in the ring stay drainable; the next `try_recv` past the last queued frame
-    /// returns `Detached`.
-    fn set_detached(&self) {
-        self.inner.set_detached();
     }
 }
 
@@ -469,21 +283,6 @@ mod tests {
         // Drain one, then send again succeeds.
         assert!(matches!(rx.try_recv(), RecvOutcome::Bytes(_)));
         assert!(tx.try_send_bytes(b"c").unwrap());
-    }
-
-    #[test]
-    fn dsm_inbox_recv_signals_detached_after_set_detached() {
-        let (tx, rx, _region) = test_dsm_inbox_pair(4, 64);
-        tx.try_send_bytes(b"keep").unwrap();
-        rx.set_detached();
-        // Subsequent send rejected with an Execution error (mapped from MpscSendError::Detached).
-        let err = tx
-            .try_send_bytes(b"drop")
-            .expect_err("expected detached error");
-        assert!(format!("{err}").contains("detached"));
-        // Already-queued frame still drains; then recv returns Detached.
-        assert!(matches!(rx.try_recv(), RecvOutcome::Bytes(_)));
-        assert!(matches!(rx.try_recv(), RecvOutcome::Detached));
     }
 
     #[test]

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -26,6 +26,7 @@
 //! consumer-side backpressure from producer-side backpressure.
 
 pub mod dsm;
+pub mod dsm_mpsc_ring;
 pub mod exec_worker;
 pub mod glue;
 pub mod host;

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -58,10 +58,10 @@ pub fn proc_for_task(n_workers: u32, task_idx: u32) -> u32 {
 /// Runtime handle the customscan populates at DSM-init time.
 ///
 /// Each process owns one MPSC inbox in DSM that receives frames from every peer.
-/// `inbound_drain` consolidates that inbox plus the in-proc self-loop channel (for
+/// `inbound_receiver` consolidates that inbox plus the in-proc self-loop channel (for
 /// producer-and-consumer-on-same-worker fragments) into a single [`DrainHandle`]. Frames
-/// carry `(sender_proc, stage_id, partition)` in their header so the drain's
-/// channel-buffer registry routes each frame to the matching consumer.
+/// carry `(sender_proc, stage_id, partition)` in their header so the routing registry
+/// inside the handle delivers each frame to the matching consumer.
 ///
 /// [`MppFrameHeader`]: crate::postgres::customscan::mpp::transport::MppFrameHeader
 pub struct MppMesh {
@@ -71,27 +71,27 @@ pub struct MppMesh {
     /// Total proc count. Bounds the producer/consumer proc lookups in
     /// [`ShmMqWorkerTransport::open`].
     pub n_procs: u32,
-    /// Single cooperative drain pulling every frame addressed to this proc. The DSM MPSC
-    /// inbox and an in-proc self-loop receiver both feed into this drain. Demux to
-    /// per-`(sender_proc, stage_id, partition)` channel buffers happens inside the drain
-    /// via `DrainHandle::register_channel`.
-    pub(super) inbound_drain: Arc<DrainHandle>,
+    /// Single cooperative inbound handle pulling every frame addressed to this proc. The
+    /// DSM MPSC inbox and an in-proc self-loop receiver both feed into this handle. Demux
+    /// to per-`(sender_proc, stage_id, partition)` channel buffers happens inside via
+    /// `DrainHandle::register_channel`.
+    pub(super) inbound_receiver: Arc<DrainHandle>,
 }
 
 impl MppMesh {
     /// Build a fresh mesh.
-    pub fn new(this_proc: u32, n_procs: u32, inbound_drain: Arc<DrainHandle>) -> Self {
+    pub fn new(this_proc: u32, n_procs: u32, inbound_receiver: Arc<DrainHandle>) -> Self {
         Self {
             this_proc,
             n_procs,
-            inbound_drain,
+            inbound_receiver,
         }
     }
 
-    /// The single cooperative drain that pulls frames from every peer (and the self-loop)
-    /// into per-`(sender_proc, stage_id, partition)` channel buffers.
-    pub(super) fn inbound_drain(&self) -> &Arc<DrainHandle> {
-        &self.inbound_drain
+    /// The single cooperative inbound handle that pulls frames from every peer (and the
+    /// self-loop) into per-`(sender_proc, stage_id, partition)` channel buffers.
+    pub(super) fn inbound_receiver(&self) -> &Arc<DrainHandle> {
+        &self.inbound_receiver
     }
 
     /// Number of worker procs (= `n_procs - 1`, since the leader is proc 0). Used as the
@@ -113,13 +113,13 @@ impl MppMesh {
         self.n_procs - 1
     }
 
-    /// Pull from the single inbound drain. Called from
+    /// Pull from the single inbound handle. Called from
     /// [`crate::postgres::customscan::mpp::transport::MppSender`]'s cooperative-send spin so a
-    /// producer stalled on a full outbound can drain inbound peer data inline. That's what
+    /// producer stalled on a full outbound can pull inbound peer data inline. That's what
     /// prevents the symmetric-send deadlock when every peer is simultaneously stalled waiting
     /// for space.
     pub(super) fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
-        self.inbound_drain.try_drain_pass()
+        self.inbound_receiver.try_drain_pass()
     }
 }
 
@@ -206,7 +206,7 @@ impl WorkerConnection for ShmMqWorkerConnection {
         // registry keys by (sender_proc, stage_id, partition) so this consumer still
         // sees only its named sender's slice even though the underlying inbox is
         // shared with all peers.
-        let drain = Arc::clone(self.mesh.inbound_drain());
+        let drain = Arc::clone(self.mesh.inbound_receiver());
         let buffer = drain.register_channel(self.sender_proc, self.stage_id, partition_u32);
         crate::mpp_log!(
             "mpp transport::execute this_proc={} sender_proc={} stage_id={} \

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -57,11 +57,11 @@ pub fn proc_for_task(n_workers: u32, task_idx: u32) -> u32 {
 
 /// Runtime handle the customscan populates at DSM-init time.
 ///
-/// Mesh-multiplexed layout: each process has ONE MPSC inbox in DSM that receives frames
-/// from every peer. The `inbound_drain` consolidates that inbox plus the in-proc self-loop
-/// channel (for producer-and-consumer-on-same-worker fragments) into a single
-/// [`DrainHandle`]. Frames carry `(sender_proc, stage_id, partition)` in their header so the
-/// drain's channel-buffer registry routes each frame to the matching consumer.
+/// Each process owns one MPSC inbox in DSM that receives frames from every peer.
+/// `inbound_drain` consolidates that inbox plus the in-proc self-loop channel (for
+/// producer-and-consumer-on-same-worker fragments) into a single [`DrainHandle`]. Frames
+/// carry `(sender_proc, stage_id, partition)` in their header so the drain's
+/// channel-buffer registry routes each frame to the matching consumer.
 ///
 /// [`MppFrameHeader`]: crate::postgres::customscan::mpp::transport::MppFrameHeader
 pub struct MppMesh {
@@ -71,10 +71,10 @@ pub struct MppMesh {
     /// Total proc count. Bounds the producer/consumer proc lookups in
     /// [`ShmMqWorkerTransport::open`].
     pub n_procs: u32,
-    /// Single cooperative drain pulling every frame addressed to this proc. Under
-    /// mesh-multiplexing there is one DSM MPSC inbox per process plus an in-proc self-loop
-    /// receiver; both feed into this drain. Demux to per-`(sender_proc, stage_id, partition)`
-    /// channel buffers happens inside the drain via `DrainHandle::register_channel`.
+    /// Single cooperative drain pulling every frame addressed to this proc. The DSM MPSC
+    /// inbox and an in-proc self-loop receiver both feed into this drain. Demux to
+    /// per-`(sender_proc, stage_id, partition)` channel buffers happens inside the drain
+    /// via `DrainHandle::register_channel`.
     pub(super) inbound_drain: Arc<DrainHandle>,
 }
 
@@ -202,10 +202,10 @@ impl WorkerConnection for ShmMqWorkerConnection {
                 "ShmMqWorkerConnection: partition={partition} > u32::MAX"
             ))
         })?;
-        // Mesh-multiplexed: one drain per process, shared across all sender_procs. The
-        // channel-buffer registry keys by (sender_proc, stage_id, partition) so this
-        // consumer still sees only its named sender's slice even though the underlying
-        // inbox is shared with all peers.
+        // One drain per process, shared across all sender_procs. The channel-buffer
+        // registry keys by (sender_proc, stage_id, partition) so this consumer still
+        // sees only its named sender's slice even though the underlying inbox is
+        // shared with all peers.
         let drain = Arc::clone(self.mesh.inbound_drain());
         let buffer = drain.register_channel(self.sender_proc, self.stage_id, partition_u32);
         crate::mpp_log!(

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -15,21 +15,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Runtime glue between the leader's DataFusion execution and the shm_mq mesh.
+//! Runtime glue between the leader's DataFusion execution and the DSM MPSC mesh.
 //!
-//! [`MppMesh`] is the runtime handle the leader builds at DSM-init time. It carries one
-//! [`crate::postgres::customscan::mpp::transport::DrainHandle`] per producer worker for
-//! each consumer partition and gets installed on the leader's `SessionConfig` extensions
-//! before plan execution.
+//! [`MppMesh`] is the runtime handle the leader builds at DSM-init time. It holds the
+//! single [`crate::postgres::customscan::mpp::transport::DrainHandle`] (the
+//! `inbound_receiver`) that consolidates this proc's DSM inbox and self-loop, and gets
+//! installed on the leader's `SessionConfig` extensions before plan execution.
 //!
-//! [`ShmMqWorkerTransport`] implements the fork's [`WorkerTransport`] trait, consulted by
-//! `NetworkShuffleExec`/`NetworkCoalesceExec`/`NetworkBroadcastExec` at execute time.
-//! `open(target_task=worker)` returns a [`ShmMqWorkerConnection`] that yields one stream
-//! per consumer partition from the matching [`DrainHandle`].
+//! [`ShmMqWorkerTransport`] implements the fork's [`WorkerTransport`] trait, consulted
+//! by `NetworkShuffleExec` / `NetworkCoalesceExec` / `NetworkBroadcastExec` at execute
+//! time. `open(target_task=worker)` returns a [`ShmMqWorkerConnection`] that yields one
+//! stream per consumer partition from the shared `inbound_receiver`.
 //!
-//! No `WorkerResolver` impl. Under `in_process_mode = true` the fork makes the resolver
-//! optional and substitutes a placeholder URL internally; our embedding never resolves
-//! anything by URL.
+//! No `WorkerResolver` impl: under `in_process_mode = true` the fork makes the resolver
+//! optional and substitutes a placeholder URL; nothing here resolves anything by URL.
 
 use std::ops::Range;
 use std::sync::Arc;

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -57,48 +57,41 @@ pub fn proc_for_task(n_workers: u32, task_idx: u32) -> u32 {
 
 /// Runtime handle the customscan populates at DSM-init time.
 ///
-/// Each shm_mq queue (one per `(sender_proc, this_proc)` pair in the V2 DSM grid) is
-/// multi-channel. Frames from any number of `(stage_id, partition)` logical channels can arrive
-/// on one queue, tagged by [`MppFrameHeader`]. The channel buffer registry on each [`DrainHandle`]
-/// fans them out to the matching consumers keyed on `(stage_id, partition)`.
+/// Mesh-multiplexed layout: each process has ONE MPSC inbox in DSM that receives frames
+/// from every peer. The `inbound_drain` consolidates that inbox plus the in-proc self-loop
+/// channel (for producer-and-consumer-on-same-worker fragments) into a single
+/// [`DrainHandle`]. Frames carry `(sender_proc, stage_id, partition)` in their header so the
+/// drain's channel-buffer registry routes each frame to the matching consumer.
 ///
 /// [`MppFrameHeader`]: crate::postgres::customscan::mpp::transport::MppFrameHeader
 pub struct MppMesh {
     /// This process's `proc_idx` (= 0 for the leader, `ParallelWorkerNumber + 1` for workers).
-    /// Frames addressed to this proc arrive on `slot(*, this_proc)`.
+    /// Frames addressed to this proc arrive on this proc's own inbox.
     pub this_proc: u32,
     /// Total proc count. Bounds the producer/consumer proc lookups in
     /// [`ShmMqWorkerTransport::open`].
     pub n_procs: u32,
-    /// `inbound_receivers[sender_proc]` is the cooperative drain that pulls frames from
-    /// `slot(sender_proc, this_proc)`. `None` at the self-loop entry
-    /// (`sender_proc == this_proc`); workers route those frames through an in-proc channel via
-    /// `outbound_senders[this_proc]` instead. The natural-shape gather installs drains for every
-    /// `sender_proc != this_proc`.
-    pub(super) inbound_receivers: Vec<Option<Arc<DrainHandle>>>,
+    /// Single cooperative drain pulling every frame addressed to this proc. Under
+    /// mesh-multiplexing there is one DSM MPSC inbox per process plus an in-proc self-loop
+    /// receiver; both feed into this drain. Demux to per-`(sender_proc, stage_id, partition)`
+    /// channel buffers happens inside the drain via `DrainHandle::register_channel`.
+    pub(super) inbound_drain: Arc<DrainHandle>,
 }
 
 impl MppMesh {
     /// Build a fresh mesh.
-    pub fn new(
-        this_proc: u32,
-        n_procs: u32,
-        inbound_receivers: Vec<Option<Arc<DrainHandle>>>,
-    ) -> Self {
+    pub fn new(this_proc: u32, n_procs: u32, inbound_drain: Arc<DrainHandle>) -> Self {
         Self {
             this_proc,
             n_procs,
-            inbound_receivers,
+            inbound_drain,
         }
     }
 
-    /// Look up the drain that owns frames coming from `sender_proc`. Returns `None` if no drain
-    /// is installed (out-of-range or the self-loop slot, which the single-stage gather skips).
-    pub(super) fn inbound_receiver(&self, sender_proc: u32) -> Option<&Arc<DrainHandle>> {
-        let idx = sender_proc as usize;
-        self.inbound_receivers
-            .get(idx)
-            .and_then(|slot| slot.as_ref())
+    /// The single cooperative drain that pulls frames from every peer (and the self-loop)
+    /// into per-`(sender_proc, stage_id, partition)` channel buffers.
+    pub(super) fn inbound_drain(&self) -> &Arc<DrainHandle> {
+        &self.inbound_drain
     }
 
     /// Number of worker procs (= `n_procs - 1`, since the leader is proc 0). Used as the
@@ -120,20 +113,13 @@ impl MppMesh {
         self.n_procs - 1
     }
 
-    /// Pull from every installed inbound drain. Called from
+    /// Pull from the single inbound drain. Called from
     /// [`crate::postgres::customscan::mpp::transport::MppSender`]'s cooperative-send spin so a
-    /// producer stalled on a full outbound queue can drain inbound peer data inline. That's what
-    /// prevents the N×N symmetric-send deadlock when every peer is simultaneously stalled waiting
+    /// producer stalled on a full outbound can drain inbound peer data inline. That's what
+    /// prevents the symmetric-send deadlock when every peer is simultaneously stalled waiting
     /// for space.
-    ///
-    /// Returns the first error if any drain's `try_drain_pass` errors; otherwise `Ok(())` after
-    /// all drains have been polled. Drains that have already detached are skipped silently (their
-    /// slot is still `Some`, but their inner `coop_receivers` Vec entry is `None`).
     pub(super) fn drain_all_inbound(&self) -> Result<(), DataFusionError> {
-        for drain in self.inbound_receivers.iter().flatten() {
-            drain.try_drain_pass()?;
-        }
-        Ok(())
+        self.inbound_drain.try_drain_pass()
     }
 }
 
@@ -216,21 +202,12 @@ impl WorkerConnection for ShmMqWorkerConnection {
                 "ShmMqWorkerConnection: partition={partition} > u32::MAX"
             ))
         })?;
-        let drain = self
-            .mesh
-            .inbound_receiver(self.sender_proc)
-            .ok_or_else(|| {
-                DataFusionError::Internal(format!(
-                    "ShmMqWorkerConnection: no inbound drain for sender_proc={} \
-                 (stage_id={}, this_proc={})",
-                    self.sender_proc, self.stage_id, self.mesh.this_proc
-                ))
-            })?;
-        let drain = Arc::clone(drain);
-        // Ask the drain for the channel buffer dedicated to this `(stage_id, partition)` channel.
-        // Frames with a matching header land here; frames tagged with other partitions go to
-        // their own channel buffers, so this consumer only sees its slice.
-        let buffer = drain.register_channel(self.stage_id, partition_u32);
+        // Mesh-multiplexed: one drain per process, shared across all sender_procs. The
+        // channel-buffer registry keys by (sender_proc, stage_id, partition) so this
+        // consumer still sees only its named sender's slice even though the underlying
+        // inbox is shared with all peers.
+        let drain = Arc::clone(self.mesh.inbound_drain());
+        let buffer = drain.register_channel(self.sender_proc, self.stage_id, partition_u32);
         crate::mpp_log!(
             "mpp transport::execute this_proc={} sender_proc={} stage_id={} \
              partition={partition_u32} (register_channel)",

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -43,6 +43,8 @@ use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::common::DataFusionError;
 
+use super::fail_loud;
+
 /// Magic bytes "MPPF" (MPP Frame) at the start of every wire message.
 /// Lets receivers reject misrouted / corrupt frames before they hit Arrow IPC.
 const MPP_FRAME_MAGIC: u32 = 0x4D505046;
@@ -70,10 +72,7 @@ pub(super) enum MppFrameKind {
 /// senders prepend before the Arrow IPC stream bytes and what receivers
 /// parse before deciding which channel buffer the payload belongs to.
 ///
-/// The `flags` word currently encodes `MppFrameKind` in its low byte (mask
-/// `0x0000_00FF`); the upper 24 bits are reserved-must-be-zero and are
-/// validated at parse time so a future use can repurpose them without a
-/// wire-format break.
+/// See the `flags` bit-layout block below for the encoding of the `flags` word.
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MppFrameHeader {
@@ -83,43 +82,69 @@ pub struct MppFrameHeader {
     pub partition: u32,
 }
 
-/// Bit mask in [`MppFrameHeader::flags`] for the [`MppFrameKind`] discriminant.
+/// `flags` bit layout:
+///   bits  0..8:  frame kind (Batch | Eof)
+///   bits  8..16: reserved (must be 0)
+///   bits 16..32: sender_proc (mesh peer that wrote the frame)
 const FRAME_KIND_MASK: u32 = 0x0000_00FF;
+const FRAME_RESERVED_MASK: u32 = 0x0000_FF00;
+const FRAME_SENDER_SHIFT: u32 = 16;
+/// Maximum `sender_proc` representable in the header. Asserted at construction time so an
+/// overflow becomes a hard error in the producer rather than silent flag corruption on the wire.
+pub const MPP_MAX_SENDER_PROC: u32 = 0xFFFF;
 
 const _: () = {
     // shm_mq slot layout calculations depend on this being exact.
     assert!(std::mem::size_of::<MppFrameHeader>() == MPP_FRAME_HEADER_SIZE);
 };
 
+#[inline]
+fn pack_flags(kind: MppFrameKind, sender_proc: u32) -> u32 {
+    // fail_loud rather than debug_assert: in release builds the check would be compiled out and
+    // an out-of-range value would silently truncate to `sender_proc & 0xFFFF`. Catching the case
+    // where a refactor accidentally passes a task_id or partition here is the whole point.
+    if sender_proc > MPP_MAX_SENDER_PROC {
+        fail_loud(format!(
+            "mpp: sender_proc {sender_proc} > MPP_MAX_SENDER_PROC ({MPP_MAX_SENDER_PROC})"
+        ));
+    }
+    (kind as u32) | (sender_proc << FRAME_SENDER_SHIFT)
+}
+
 impl MppFrameHeader {
-    /// Build a `Batch` header for the given `(stage_id, partition)`.
-    pub fn batch(stage_id: u32, partition: u32) -> Self {
+    /// Build a `Batch` header for the given `(stage_id, partition)` stamped with `sender_proc`.
+    pub fn batch(stage_id: u32, partition: u32, sender_proc: u32) -> Self {
         Self {
             magic: MPP_FRAME_MAGIC,
-            flags: MppFrameKind::Batch as u32,
+            flags: pack_flags(MppFrameKind::Batch, sender_proc),
             stage_id,
             partition,
         }
     }
 
-    /// Build an `Eof` header for the given `(stage_id, partition)`. Carries no payload; receivers
-    /// route it to the channel buffer's source-done counter. Emitted by
-    /// [`MppSender::send_eof_traced`] after a producer fragment's per-partition stream exhausts
-    /// (or errors), and consumed by the matching channel buffer's `notify_source_done`.
-    pub fn eof(stage_id: u32, partition: u32) -> Self {
+    /// Build an `Eof` header for the given `(stage_id, partition)` stamped with `sender_proc`.
+    /// Carries no payload; receivers route it to the channel buffer's source-done counter.
+    pub fn eof(stage_id: u32, partition: u32, sender_proc: u32) -> Self {
         Self {
             magic: MPP_FRAME_MAGIC,
-            flags: MppFrameKind::Eof as u32,
+            flags: pack_flags(MppFrameKind::Eof, sender_proc),
             stage_id,
             partition,
         }
+    }
+
+    /// The mesh peer that wrote this frame. The drain demuxes incoming frames into the
+    /// per-channel buffer registry by `(sender_proc, stage_id, partition)`.
+    pub fn sender_proc(&self) -> u32 {
+        (self.flags >> FRAME_SENDER_SHIFT) & 0xFFFF
     }
 
     /// Read the kind out of `flags`. Returns an error if the kind byte is
-    /// unknown or if any reserved upper bit is set, which catches wire-format
-    /// drift early.
+    /// unknown or if any reserved bit (bits 8..16) is set, which catches wire-format
+    /// drift early. Sender_proc bits (16..32) are not validated here; readers extract
+    /// them with `sender_proc()`.
     pub(super) fn kind(&self) -> Result<MppFrameKind, DataFusionError> {
-        let reserved = self.flags & !FRAME_KIND_MASK;
+        let reserved = self.flags & FRAME_RESERVED_MASK;
         if reserved != 0 {
             return Err(DataFusionError::Internal(format!(
                 "mpp: reserved frame flag bits set ({reserved:#x})"
@@ -185,6 +210,9 @@ impl MppFrameHeader {
 /// |---------- 16 bytes --------|           |---- variable ----|
 /// ```
 ///
+/// `flags` encodes kind + sender_proc; see the bit-layout block near
+/// `FRAME_KIND_MASK` for details.
+///
 /// Caller is expected to hold `buf` alive across many encodes so the peak-sized
 /// allocation amortizes (~500 KB/batch on the 25M GROUP BY bench).
 fn encode_frame_into(
@@ -211,11 +239,13 @@ fn encode_frame_into(
 fn encode_eof_frame_into(
     stage_id: u32,
     partition: u32,
+    sender_proc: u32,
     buf: &mut Vec<u8>,
 ) -> Result<(), DataFusionError> {
     buf.clear();
     buf.resize(MPP_FRAME_HEADER_SIZE, 0);
-    MppFrameHeader::eof(stage_id, partition).write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
+    MppFrameHeader::eof(stage_id, partition, sender_proc)
+        .write_to(&mut buf[..MPP_FRAME_HEADER_SIZE]);
     Ok(())
 }
 
@@ -310,8 +340,7 @@ impl DrainBuffer {
     }
 
     /// Mark one source queue as detached. Safe to call from the drain thread
-    /// after observing `SHM_MQ_DETACHED` on a given inbound queue or from
-    /// [`DrainHandle::mark_detached`] when the underlying receiver has died.
+    /// after observing `SHM_MQ_DETACHED` on a given inbound queue.
     pub fn notify_source_done(&self) {
         let mut guard = self.inner.lock().expect("DrainBuffer mutex poisoned");
         guard.sources_done = guard.sources_done.saturating_add(1);
@@ -370,6 +399,19 @@ pub(super) enum RecvOutcome {
 /// ownership.
 pub(super) trait BatchChannelReceiver: Send + Sync {
     fn try_recv(&self) -> RecvOutcome;
+
+    /// Tell producers to stop sending. Default no-op; concrete impls override when the
+    /// underlying transport doesn't get a "drop = detach" signal for free.
+    ///
+    /// `ShmMqReceiver` doesn't override: shm_mq's `MessageQueueReceiver::Drop` calls
+    /// `shm_mq_detach`, which is enough to make producers see Detached.
+    ///
+    /// `DsmInboxReceiver` overrides: the DSM MPSC ring's detach is mostly handled by
+    /// `DsmMpscSender::Drop` flipping `detached` when the last sender goes away, but
+    /// the consumer side can force-detach early (e.g., query teardown before producers
+    /// finish) via this method. `DrainHandle::Drop` calls it on teardown.
+    #[allow(dead_code)]
+    fn set_detached(&self) {}
 }
 
 /// Byte channel sender paired with [`BatchChannelReceiver`]. `send` blocks when
@@ -381,7 +423,7 @@ pub(super) trait BatchChannelReceiver: Send + Sync {
 /// (`nowait=false`) touches `WaitLatch`/`CHECK_FOR_INTERRUPTS`, which is not
 /// safe off-thread. See [`crate::postgres::customscan::mpp::mesh::ShmMqSender`]
 /// for the safety contract.
-pub(super) trait BatchChannelSender: Send + Sync {
+pub(crate) trait BatchChannelSender: Send + Sync {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError>;
 
     /// Non-blocking variant. Returns `Ok(true)` on success, `Ok(false)`
@@ -428,13 +470,13 @@ pub struct MppSender {
     /// `shm_mq` queue while tagging frames with different `(stage_id, partition)` headers, which
     /// is the multiplexed path's natural pattern. Clone the Arc, build a new `MppSender` with a
     /// different header, both write into the same queue.
-    channel: Arc<dyn BatchChannelSender>,
+    pub(super) channel: Arc<dyn BatchChannelSender>,
     cooperative_drain: Option<Arc<dyn CooperativeDrainSet>>,
     /// Frame header prepended to every outgoing batch. Identifies the logical
     /// `(stage_id, partition)` channel the receiver demultiplexes on. Per-sender rather than
     /// per-call: each partition gets its own `MppSender` via `clone_with_header`, all sharing
     /// the underlying `Arc<dyn BatchChannelSender>` of a single shm_mq queue.
-    header: MppFrameHeader,
+    pub(super) header: MppFrameHeader,
     /// Scratch buffer reused across every `encode_frame_into` on this sender. Sized by the
     /// first batch; subsequent batches clear and re-fill without reallocating. Interior
     /// mutability lets the caller keep the `&self` signature (each producer fragment holds
@@ -552,7 +594,12 @@ impl MppSender {
         scratch: &mut Vec<u8>,
         stats: &mut SendBatchStats,
     ) -> Result<(), DataFusionError> {
-        encode_eof_frame_into(self.header.stage_id, self.header.partition, scratch)?;
+        encode_eof_frame_into(
+            self.header.stage_id,
+            self.header.partition,
+            self.header.sender_proc(),
+            scratch,
+        )?;
         let Some(drain) = self.cooperative_drain.as_ref() else {
             return self.channel.send_bytes(scratch);
         };
@@ -562,9 +609,9 @@ impl MppSender {
         let mut first_try = true;
         let t_wait_start = Instant::now();
         loop {
-            #[cfg(not(test))]
-            pgrx::check_for_interrupts!();
-            if self.channel.try_send_bytes(scratch)? {
+            self.spin_check_for_interrupts().await?;
+            let send_ok = self.spin_try_send_bytes(scratch).await?;
+            if send_ok {
                 if !first_try {
                     stats.send_wait += t_wait_start.elapsed();
                 }
@@ -573,10 +620,31 @@ impl MppSender {
             first_try = false;
             stats.spin_iters += 1;
             let t_drain = Instant::now();
-            drain.try_drain_pass()?;
+            self.spin_try_drain_pass(drain).await?;
             stats.coop_drain_in_spin += t_drain.elapsed();
             tokio::task::yield_now().await;
         }
+    }
+
+    /// Spin-loop helper: call `check_for_interrupts`. Gated out of test builds because the
+    /// pgrx macro pulls in symbols the lib-test binary doesn't link.
+    async fn spin_check_for_interrupts(&self) -> Result<(), DataFusionError> {
+        #[cfg(not(test))]
+        pgrx::check_for_interrupts!();
+        Ok(())
+    }
+
+    /// Spin-loop helper: call `channel.try_send_bytes(scratch)`.
+    async fn spin_try_send_bytes(&self, scratch: &[u8]) -> Result<bool, DataFusionError> {
+        self.channel.try_send_bytes(scratch)
+    }
+
+    /// Spin-loop helper: call `drain.try_drain_pass()`.
+    async fn spin_try_drain_pass(
+        &self,
+        drain: &Arc<dyn CooperativeDrainSet>,
+    ) -> Result<(), DataFusionError> {
+        drain.try_drain_pass()
     }
 
     async fn send_with_scratch(
@@ -597,6 +665,13 @@ impl MppSender {
         // partial write through the shared shm_mq handle. See `BatchChannelSender::send_lock`.
         // Long-term, switching shm_mq for an async-friendly ring buffer (cf. #4184) drops the
         // partial-send invariant entirely and removes the need for this lock.
+        //
+        // Latent under the current-thread runtime: today every fragment owns its own
+        // `Arc<dyn BatchChannelSender>` (one sender per `Arc`), so the FIFO Mutex below
+        // is uncontended. A future multi-thread runtime that shares a sender across
+        // sibling fragment tasks (multi-partition fan-out) would let one task starve
+        // another for the duration of a large shuffle; the fix at that point is to move
+        // the entire spin off the compute thread.
         let _send_guard = self.channel.send_lock().lock().await;
         let mut first_try = true;
         let t_wait_start = Instant::now();
@@ -607,13 +682,9 @@ impl MppSender {
         // sends advance. `yield_now().await` between iterations hands the runtime back to
         // siblings if any are ready, mostly a no-op under today's linear MPP topology.
         loop {
-            // Gate the check out of test builds. `pgrx::check_for_interrupts!()` pulls in PG
-            // symbols (`ProcessInterrupts`, etc.) that the `--tests` / llvm-cov build can't
-            // link. `InProc` channels used in tests never block, so the loop returns on the
-            // first iteration anyway.
-            #[cfg(not(test))]
-            pgrx::check_for_interrupts!();
-            if self.channel.try_send_bytes(scratch)? {
+            self.spin_check_for_interrupts().await?;
+            let send_ok = self.spin_try_send_bytes(scratch).await?;
+            if send_ok {
                 if !first_try {
                     stats.send_wait += t_wait_start.elapsed();
                 }
@@ -626,7 +697,7 @@ impl MppSender {
             // propagate so a peer detaching mid-spin doesn't leave us spinning on a closed
             // mesh.
             let t_drain = Instant::now();
-            drain.try_drain_pass()?;
+            self.spin_try_drain_pass(drain).await?;
             stats.coop_drain_in_spin += t_drain.elapsed();
             tokio::task::yield_now().await;
         }
@@ -696,21 +767,22 @@ pub(super) enum RecvBatchOutcome {
     Error(DataFusionError),
 }
 
-/// Per-`(stage_id, partition)` channel buffer registry owned by a cooperative [`DrainHandle`]. The
-/// handle serves one sender_proc, whose shm_mq queue carries frames for many logical channels,
-/// each tagged by the [`MppFrameHeader`] prefix. `try_drain_pass` looks up the right channel buffer
-/// on every frame and pushes the payload into it. Consumers waiting on
-/// `(stage_id=s, partition=p)` only see frames matching that key.
+/// Per-`(sender_proc, stage_id, partition)` channel buffer registry owned by a cooperative
+/// [`DrainHandle`]. The handle may host several cooperative receivers (DSM MPSC inbox + self-loop
+/// in-proc), each demultiplexed by the [`MppFrameHeader`] prefix into the same `map`.
+/// `try_drain_pass` looks up the right channel buffer on every frame and pushes the payload into
+/// it. Consumers waiting on a given key only see frames matching that key.
 ///
-/// Each entry is a `DrainBuffer::new(1)` because exactly one source (the sender_proc this handle
-/// serves) emits frames for any given channel via this drain. When the sender_proc detaches
-/// (`Detached` outcome on the underlying receiver), `detached` flips to `true` and every existing
-/// channel buffer is notified, so any consumer blocked on `try_pop` unblocks with `DrainItem::Eof`.
-/// Channel buffers registered *after* detach come back already EOF'd so a late consumer doesn't hang.
+/// Each entry is a `DrainBuffer::new(1)`: exactly one sender_proc emits frames for any given
+/// channel. Per-channel EOF flows via the `Eof` frame demuxed onto the matching buffer; query-
+/// teardown unblock flows via [`DrainHandle::cancel_channel_buffers`] from the handle's `Drop`.
 #[derive(Default)]
 struct ChannelBufferRegistry {
-    map: HashMap<(u32, u32), Arc<DrainBuffer>>,
-    detached: bool,
+    /// Keyed by `(sender_proc, stage_id, partition)`. Under mesh-multiplexing the unified
+    /// inbox carries frames from every peer, so each `(stage, partition)` consumer gets
+    /// its own per-sender buffer. This preserves the implicit "one stream per sender"
+    /// semantics that `WorkerConnection::stream_partition` consumers rely on.
+    map: HashMap<(u32, u32, u32), Arc<DrainBuffer>>,
 }
 
 /// Per-sender-proc drain: stashes the receivers and polls them inline from the cooperative spin
@@ -752,63 +824,41 @@ impl DrainHandle {
         }
     }
 
-    /// Register (or look up) the channel buffer for `(stage_id, partition)`. The returned
-    /// `Arc<DrainBuffer>` is the canonical destination for frames matching that key:
-    /// `try_drain_pass` pushes into the same entry on every `Batch { header, .. }` whose header
-    /// matches.
-    ///
-    /// If the drain has already observed `Detached` from its underlying receiver, the
-    /// newly-created buffer comes back with `notify_source_done` already called so a consumer
-    /// registering after detach sees `Eof` on the first `try_pop` instead of hanging forever.
-    pub(super) fn register_channel(&self, stage_id: u32, partition: u32) -> Arc<DrainBuffer> {
+    /// Register (or look up) the channel buffer for `(sender_proc, stage_id, partition)`.
+    /// The returned `Arc<DrainBuffer>` is the canonical destination for frames matching
+    /// that key: `try_drain_pass` pushes into the same entry on every `Batch { header, .. }`
+    /// whose `header.sender_proc()` / `stage_id` / `partition` matches.
+    pub(super) fn register_channel(
+        &self,
+        sender_proc: u32,
+        stage_id: u32,
+        partition: u32,
+    ) -> Arc<DrainBuffer> {
         let mut guard = self
             .channel_buffers
             .lock()
             .expect("DrainHandle channel_buffers mutex poisoned");
-        let detached = guard.detached;
         guard
             .map
-            .entry((stage_id, partition))
+            .entry((sender_proc, stage_id, partition))
             .or_insert_with(|| {
-                let buf = DrainBuffer::new(1);
-                if detached {
-                    buf.notify_source_done();
-                }
-                buf
+                // num_sources stays 1: under mesh-multiplexing each
+                // (sender_proc, stage, partition) tuple has exactly one upstream (the
+                // named sender), even though the underlying inbox is shared across all
+                // senders.
+                DrainBuffer::new(1)
             })
             .clone()
     }
 
-    /// Mark the drain as detached and `notify_source_done` every registered channel buffer.
-    /// Idempotent. Used by `try_drain_pass` after `Detached` / `Error` outcomes; the
-    /// cooperative-path equivalent fires from `Drop` via [`Self::cancel_channel_buffers`] so any
-    /// consumer blocked on `try_pop` unblocks with `Eof` even if the query is torn down before
-    /// EOF frames flow.
-    ///
-    /// Collects buffer handles under the registry lock, then notifies after releasing it.
-    /// Notifying inline would block any concurrent [`Self::register_channel`] for as long as it
-    /// takes to acquire `DrainBuffer::inner` N times. Fine today (single backend thread), but
-    /// cheap insurance against the multi-thread variant landing later.
-    fn mark_detached(&self) {
-        let to_notify = {
-            let mut guard = self
-                .channel_buffers
-                .lock()
-                .expect("DrainHandle channel_buffers mutex poisoned");
-            if guard.detached {
-                return;
-            }
-            guard.detached = true;
-            guard.map.values().cloned().collect::<Vec<_>>()
-        };
-        for buf in to_notify {
-            buf.notify_source_done();
-        }
-    }
-
     /// Cancel every registered channel buffer. Called from `Drop` to unblock any consumer waiting on
-    /// a channel buffer when the handle goes away mid-query. Same collect-then-notify pattern as
-    /// [`Self::mark_detached`].
+    /// a channel buffer when the handle goes away mid-query.
+    ///
+    /// Collects buffer handles under the registry lock, then notifies after releasing
+    /// it. Notifying inline would block any concurrent [`Self::register_channel`] for
+    /// as long as it takes to acquire `DrainBuffer::inner` N times. Fine today (single
+    /// backend thread), but cheap insurance against the multi-thread variant landing
+    /// later.
     fn cancel_channel_buffers(&self) {
         let to_cancel = {
             let guard = self
@@ -860,24 +910,39 @@ impl DrainHandle {
             for _ in 0..MAX_BATCHES_PER_SOURCE_PER_PASS {
                 match rx.try_recv_batch() {
                     RecvBatchOutcome::Batch { header, batch } => {
-                        let buf = self.register_channel(header.stage_id, header.partition);
+                        let buf = self.register_channel(
+                            header.sender_proc(),
+                            header.stage_id,
+                            header.partition,
+                        );
                         buf.push_batch(batch);
                     }
                     RecvBatchOutcome::Eof { header } => {
-                        let buf = self.register_channel(header.stage_id, header.partition);
+                        let buf = self.register_channel(
+                            header.sender_proc(),
+                            header.stage_id,
+                            header.partition,
+                        );
                         buf.notify_source_done();
                         // Other channels may still flow on this queue, so the receiver slot
                         // stays live.
                     }
                     RecvBatchOutcome::Empty => break,
                     RecvBatchOutcome::Detached => {
+                        // Only THIS receiver is dead. Under mesh-multiplexing the drain holds
+                        // multiple receivers (own-inbox MPSC + self-loop in-proc); one going
+                        // away does not imply the others have. Do not fire a registry-wide
+                        // "all channels EOF" here. Channel buffers waiting on a still-live
+                        // sibling receiver would falsely terminate. Per-channel EOF flows via
+                        // the demuxed Eof frame above; query-teardown unblock flows via
+                        // `cancel_channel_buffers` from `DrainHandle::Drop`.
                         *slot = None;
-                        self.mark_detached();
                         break;
                     }
                     RecvBatchOutcome::Error(e) => {
+                        // Same reasoning as Detached: drop only this slot. The error itself
+                        // still propagates up; caller surfaces it as a query error.
                         *slot = None;
-                        self.mark_detached();
                         return Err(e);
                     }
                 }
@@ -1021,7 +1086,7 @@ mod tests {
         /// Construct a sender with the default `(stage_id=0, partition=0)` header. Used where
         /// the header carries no actionable routing info.
         fn new(channel: Arc<dyn BatchChannelSender>) -> Self {
-            Self::with_header(channel, MppFrameHeader::batch(0, 0))
+            Self::with_header(channel, MppFrameHeader::batch(0, 0, 0))
         }
 
         /// Stats-less wrapper around `send_batch_traced`. Production call sites
@@ -1176,7 +1241,7 @@ mod tests {
     #[test]
     fn frame_round_trips_a_batch_with_header() {
         let orig = sample_batch(64);
-        let header = MppFrameHeader::batch(7, 3);
+        let header = MppFrameHeader::batch(7, 3, 0);
         let mut buf = Vec::with_capacity(1024);
         encode_frame_into(header, &orig, &mut buf).expect("encode_frame");
 
@@ -1195,11 +1260,11 @@ mod tests {
     #[test]
     fn frame_round_trips_eof() {
         let mut buf = Vec::new();
-        encode_eof_frame_into(2, 5, &mut buf).expect("encode_eof");
+        encode_eof_frame_into(2, 5, 0, &mut buf).expect("encode_eof");
         assert_eq!(buf.len(), MPP_FRAME_HEADER_SIZE);
 
         let (header, batch_opt) = decode_frame(&buf).expect("decode_frame");
-        assert_eq!(header, MppFrameHeader::eof(2, 5));
+        assert_eq!(header, MppFrameHeader::eof(2, 5, 0));
         assert_eq!(header.kind().unwrap(), MppFrameKind::Eof);
         assert!(batch_opt.is_none());
     }
@@ -1240,24 +1305,66 @@ mod tests {
 
     #[test]
     fn frame_rejects_reserved_flag_bits() {
-        // Any bit above the low byte of `flags` is reserved-must-be-zero;
-        // setting one should trip `kind()` before the kind byte is consulted.
+        // Reserved range is bits 8..16. Bits 16..32 are sender_proc and must NOT trip the
+        // reserved check. Cover both boundaries of the reserved range.
+        for bit in [0x0000_0100u32, 0x0000_8000u32] {
+            let header = MppFrameHeader {
+                magic: MPP_FRAME_MAGIC,
+                flags: bit, // kind byte 0 (Batch), reserved bit set, no sender_proc
+                stage_id: 0,
+                partition: 0,
+            };
+            let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
+            header.write_to(&mut buf);
+            let err = decode_frame(&buf).expect_err(&format!("reserved bit {bit:#x} must fail"));
+            assert!(
+                format!("{err}").contains("reserved frame flag bits"),
+                "bit {bit:#x}: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn frame_kind_coexists_with_max_sender_proc() {
+        // Negative-space companion to frame_rejects_reserved_flag_bits: setting every bit in
+        // 16..32 (= max sender_proc) along with kind=Eof in bit 0 must parse cleanly without
+        // tripping the reserved-bits check, and sender_proc()/kind() must read both back.
         let header = MppFrameHeader {
             magic: MPP_FRAME_MAGIC,
-            flags: 0x0000_0100, // bit 8 set, kind byte 0 (would be Batch)
+            flags: 0xFFFF_0001, // Eof in low byte, max sender_proc in high half, reserved=0
             stage_id: 0,
             partition: 0,
         };
-        let mut buf = vec![0u8; MPP_FRAME_HEADER_SIZE];
-        header.write_to(&mut buf);
-        let err = decode_frame(&buf).expect_err("reserved bit must fail");
-        assert!(format!("{err}").contains("reserved frame flag bits"));
+        assert_eq!(header.kind().unwrap(), MppFrameKind::Eof);
+        assert_eq!(header.sender_proc(), MPP_MAX_SENDER_PROC);
+    }
+
+    #[test]
+    fn frame_sender_proc_round_trip() {
+        // sender_proc lives in flags bits 16..32 and shouldn't collide with kind or reserved.
+        for &sp in &[0u32, 1, 7, 255, 256, 1023, 65534, MPP_MAX_SENDER_PROC] {
+            let header = MppFrameHeader::batch(11, 5, sp);
+            assert_eq!(header.sender_proc(), sp, "batch round-trip sp={sp}");
+            assert_eq!(header.kind().unwrap(), MppFrameKind::Batch);
+
+            let mut buf = Vec::with_capacity(MPP_FRAME_HEADER_SIZE);
+            let payload = sample_batch(8);
+            encode_frame_into(header, &payload, &mut buf).expect("encode batch");
+            let (parsed, _) = decode_frame(&buf).expect("decode batch");
+            assert_eq!(parsed.sender_proc(), sp, "decoded batch sender_proc");
+
+            let mut eof_buf = Vec::new();
+            encode_eof_frame_into(11, 5, sp, &mut eof_buf).expect("encode eof");
+            let (parsed_eof, _) = decode_frame(&eof_buf).expect("decode eof");
+            assert_eq!(parsed_eof.sender_proc(), sp, "decoded eof sender_proc");
+            assert_eq!(parsed_eof.kind().unwrap(), MppFrameKind::Eof);
+        }
     }
 
     #[test]
     fn frame_eof_with_payload_is_rejected() {
         let mut buf = Vec::with_capacity(32);
-        encode_eof_frame_into(0, 0, &mut buf).expect("encode_eof");
+        encode_eof_frame_into(0, 0, 0, &mut buf).expect("encode_eof");
         buf.push(0xAB); // smuggle a payload byte after the Eof header
         let err = decode_frame(&buf).expect_err("Eof+payload must fail");
         assert!(format!("{err}").contains("Eof frame carries payload"));
@@ -1268,7 +1375,7 @@ mod tests {
         let mut buf = Vec::with_capacity(1024);
         for rows in [0, 1, 7, 64, 1024] {
             let orig = sample_batch(rows);
-            encode_frame_into(MppFrameHeader::batch(0, 0), &orig, &mut buf).expect("encode");
+            encode_frame_into(MppFrameHeader::batch(0, 0, 0), &orig, &mut buf).expect("encode");
             let (_header, decoded) = decode_frame(&buf).expect("decode");
             let decoded = decoded.expect("Batch frame must carry a payload");
             assert_eq!(orig.num_rows(), decoded.num_rows());
@@ -1543,7 +1650,7 @@ mod tests {
         let mut enc_bytes = 0usize;
         let mut enc_buf = Vec::with_capacity(1024);
         for _ in 0..batches {
-            encode_frame_into(MppFrameHeader::batch(0, 0), &template, &mut enc_buf)
+            encode_frame_into(MppFrameHeader::batch(0, 0, 0), &template, &mut enc_buf)
                 .expect("encode");
             enc_bytes += enc_buf.len();
         }
@@ -1643,20 +1750,20 @@ mod tests {
     fn drain_until_detached(handle: &DrainHandle) {
         for _ in 0..64 {
             handle.try_drain_pass().expect("try_drain_pass");
-            // After enough passes the in-proc backend reports `Detached`, which flips
-            // `mark_detached` and notifies every channel buffer. We keep polling so any queued
-            // frames flow through first.
         }
     }
 
     #[test]
     fn drain_handle_demuxes_frames_by_header() {
         // One queue carrying two channels: `(0, 0)` and `(0, 1)`. Each
-        // channel buffer receives only its own batches.
+        // channel buffer receives only its own batches. Per-channel EOF is out of scope
+        // here. See `drain_handle_eof_frame_closes_one_channel` for explicit-Eof routing
+        // and `drain_handle_drop_cancels_registered_channel_buffers` for the
+        // teardown-EOF contract.
         let (tx, rx) = in_proc_channel(8);
         let base = MppSender::new(Arc::new(tx));
-        let s00 = base.clone_with_header(MppFrameHeader::batch(0, 0));
-        let s01 = base.clone_with_header(MppFrameHeader::batch(0, 1));
+        let s00 = base.clone_with_header(MppFrameHeader::batch(0, 0, 0));
+        let s01 = base.clone_with_header(MppFrameHeader::batch(0, 1, 0));
         let receiver = MppReceiver::new(Box::new(rx));
         let handle = DrainHandle::cooperative(vec![receiver]);
 
@@ -1665,10 +1772,10 @@ mod tests {
         s00.send_batch(&sample_batch(3)).unwrap();
         drop(s00);
         drop(s01);
-        drop(base); // Last sender dropped. Receiver will report Detached.
+        drop(base);
 
-        let buf00 = handle.register_channel(0, 0);
-        let buf01 = handle.register_channel(0, 1);
+        let buf00 = handle.register_channel(0, 0, 0);
+        let buf01 = handle.register_channel(0, 0, 1);
 
         drain_until_detached(&handle);
 
@@ -1682,33 +1789,30 @@ mod tests {
         }
         assert_eq!(p0_rows, vec![2, 3]);
         assert_eq!(p1_rows, vec![7]);
-        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
-        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
     }
 
     #[test]
     fn drain_handle_eof_frame_closes_one_channel() {
         // An `Eof` frame on `(0, 0)` closes that channel buffer while frames on
-        // `(0, 1)` continue to flow on the same queue.
+        // `(0, 1)` continue to flow on the same queue. `Detached` doesn't broadcast a
+        // registry-wide EOF, so `(0, 1)` surfaces EOF only when the handle's `Drop`
+        // runs `cancel_channel_buffers`.
         let (tx, rx) = in_proc_channel(8);
         let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
-        let s00 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0));
-        let s01 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 1));
+        let s00 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0, 0));
+        let s01 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 1, 0));
         let receiver = MppReceiver::new(Box::new(rx));
         let handle = DrainHandle::cooperative(vec![receiver]);
 
         s00.send_batch(&sample_batch(4)).unwrap();
-        // Hand-roll an Eof frame for (0, 0) onto the same shared channel.
         let mut eof_buf = Vec::new();
-        encode_eof_frame_into(0, 0, &mut eof_buf).unwrap();
+        encode_eof_frame_into(0, 0, 0, &mut eof_buf).unwrap();
         tx_arc.send_bytes(&eof_buf).unwrap();
-        // (0, 1) is still live and ships another batch after the EOF.
         s01.send_batch(&sample_batch(6)).unwrap();
 
-        let buf00 = handle.register_channel(0, 0);
-        let buf01 = handle.register_channel(0, 1);
+        let buf00 = handle.register_channel(0, 0, 0);
+        let buf01 = handle.register_channel(0, 0, 1);
 
-        // Drop senders so the receiver eventually observes Detached.
         drop(s00);
         drop(s01);
         drop(tx_arc);
@@ -1718,50 +1822,15 @@ mod tests {
             Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 4),
             other => panic!("expected (0,0) batch, got {other:?}"),
         }
-        // The Eof frame closed (0, 0) before the queue detached.
         assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
 
         match buf01.try_pop() {
             Some(DrainItem::Batch(b)) => assert_eq!(b.num_rows(), 6),
             other => panic!("expected (0,1) batch, got {other:?}"),
         }
-        // (0, 1) sees EOF at receiver-detach time.
+        assert!(buf01.try_pop().is_none());
+        drop(handle);
         assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
-    }
-
-    #[test]
-    fn drain_handle_detach_eofs_all_registered_channel_buffers() {
-        // No frames flow; consumer pre-registers two channels. When the sender drops and
-        // `try_drain_pass` observes `Detached`, both channel buffers immediately surface `Eof`.
-        // Without that, a consumer blocked on `try_pop` would hang past the producer's death.
-        let (tx, rx) = in_proc_channel(8);
-        drop(tx); // detach immediately
-        let receiver = MppReceiver::new(Box::new(rx));
-        let handle = DrainHandle::cooperative(vec![receiver]);
-
-        let buf00 = handle.register_channel(0, 0);
-        let buf01 = handle.register_channel(0, 1);
-        // No frames ever land; the next poll observes Detached and notifies.
-        handle.try_drain_pass().unwrap();
-
-        assert!(matches!(buf00.try_pop(), Some(DrainItem::Eof)));
-        assert!(matches!(buf01.try_pop(), Some(DrainItem::Eof)));
-    }
-
-    #[test]
-    fn drain_handle_register_after_detach_returns_eof_buffer() {
-        // Detach first, then register. The returned buffer is already
-        // EOF'd so a late consumer doesn't block forever waiting on a
-        // channel whose source is gone.
-        let (tx, rx) = in_proc_channel(8);
-        drop(tx);
-        let receiver = MppReceiver::new(Box::new(rx));
-        let handle = DrainHandle::cooperative(vec![receiver]);
-
-        handle.try_drain_pass().unwrap(); // observes Detached, marks handle
-
-        let late_buf = handle.register_channel(5, 9);
-        assert!(matches!(late_buf.try_pop(), Some(DrainItem::Eof)));
     }
 
     #[test]
@@ -1772,8 +1841,8 @@ mod tests {
         let receiver = MppReceiver::new(Box::new(rx));
         let handle = DrainHandle::cooperative(vec![receiver]);
 
-        let first = handle.register_channel(2, 3);
-        let second = handle.register_channel(2, 3);
+        let first = handle.register_channel(0, 2, 3);
+        let second = handle.register_channel(0, 2, 3);
         assert!(Arc::ptr_eq(&first, &second));
     }
 
@@ -1783,8 +1852,8 @@ mod tests {
         // The registry's compound key keeps them on separate channel buffers.
         let (tx, rx) = in_proc_channel(8);
         let tx_arc: Arc<dyn BatchChannelSender> = Arc::new(tx);
-        let s_stage0 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0));
-        let s_stage1 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(1, 0));
+        let s_stage0 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(0, 0, 0));
+        let s_stage1 = MppSender::with_header(Arc::clone(&tx_arc), MppFrameHeader::batch(1, 0, 0));
         let receiver = MppReceiver::new(Box::new(rx));
         let handle = DrainHandle::cooperative(vec![receiver]);
 
@@ -1795,8 +1864,8 @@ mod tests {
         drop(s_stage1);
         drop(tx_arc);
 
-        let buf0 = handle.register_channel(0, 0);
-        let buf1 = handle.register_channel(1, 0);
+        let buf0 = handle.register_channel(0, 0, 0);
+        let buf1 = handle.register_channel(0, 1, 0);
 
         drain_until_detached(&handle);
 
@@ -1821,8 +1890,8 @@ mod tests {
         let receiver = MppReceiver::new(Box::new(rx));
         let handle = DrainHandle::cooperative(vec![receiver]);
 
-        let buf_a = handle.register_channel(0, 0);
-        let buf_b = handle.register_channel(7, 3);
+        let buf_a = handle.register_channel(0, 0, 0);
+        let buf_b = handle.register_channel(0, 7, 3);
         // No data ever flows; the handle is just dropped.
         drop(handle);
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -761,7 +761,7 @@ struct ChannelBufferRegistry {
     /// Keyed by `(sender_proc, stage_id, partition)`. The unified inbox carries frames
     /// from every peer, so each `(stage, partition)` consumer gets its own per-sender
     /// buffer. This preserves the implicit "one stream per sender" semantics that
-    /// `WorkerConnection::stream_partition` consumers rely on.
+    /// `WorkerConnection::execute` consumers rely on.
     map: HashMap<(u32, u32, u32), Arc<DrainBuffer>>,
 }
 

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -17,21 +17,14 @@
 
 //! Transport layer for MPP shuffle.
 //!
-//! Layout:
-//! - [`MppFrameHeader`] is a fixed 16-byte prefix every wire message carries. It tags the
-//!   payload with `(stage_id, partition)`, so one underlying queue can carry frames for many
-//!   logical channels at once. That's what the multi-stage natural-shape path needs.
-//! - [`encode_frame_into`] / [`decode_frame`] serialize a `RecordBatch` with a header prefix via
-//!   Arrow IPC. They're the only codec entry points; tests round-trip through the same path so
-//!   the wire format under test always matches production.
-//! - [`DrainBuffer`] is the local per-proc queue that the drain thread writes into and
-//!   the DataFusion consumer reads from. It decouples consumer-side backpressure from
-//!   producer-side backpressure: the drain thread always makes forward progress on the
-//!   inbound rings, so a stalled consumer cannot propagate backpressure to remote
-//!   producers and cause a peer-mesh stall cycle.
-//!
-//! The DSM-backed sender/receiver and drain spawn logic build on top of these
-//! primitives.
+//! - [`MppFrameHeader`]: fixed 16-byte prefix tagging each wire message with
+//!   `(stage_id, partition)`, so one queue carries frames for many logical channels.
+//! - [`encode_frame_into`] / [`decode_frame`]: Arrow IPC serialize/deserialize with
+//!   header prefix. Only codec entry points; tests round-trip through the same path.
+//! - [`DrainBuffer`]: per-proc queue the drain writes into and the DataFusion consumer
+//!   reads from. Decouples consumer-side from producer-side backpressure: the drain
+//!   always makes forward progress on the inbound rings, so a stalled consumer can't
+//!   propagate backpressure to remote producers and cause a peer-mesh stall.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -24,15 +24,14 @@
 //! - [`encode_frame_into`] / [`decode_frame`] serialize a `RecordBatch` with a header prefix via
 //!   Arrow IPC. They're the only codec entry points; tests round-trip through the same path so
 //!   the wire format under test always matches production.
-//! - [`DrainBuffer`] is the local per-proc queue that the drain thread
-//!   writes into and the DataFusion consumer reads from. It decouples
-//!   consumer-side backpressure from producer-side backpressure: the drain thread
-//!   always makes forward progress on the inbound shm_mqs, so a stalled consumer
-//!   cannot propagate backpressure to remote producers and cause an N×N
-//!   peer-stall cycle.
+//! - [`DrainBuffer`] is the local per-proc queue that the drain thread writes into and
+//!   the DataFusion consumer reads from. It decouples consumer-side backpressure from
+//!   producer-side backpressure: the drain thread always makes forward progress on the
+//!   inbound rings, so a stalled consumer cannot propagate backpressure to remote
+//!   producers and cause a peer-mesh stall cycle.
 //!
-//! The shm_mq-backed sender/receiver and drain thread spawn logic build on
-//! top of these primitives.
+//! The DSM-backed sender/receiver and drain spawn logic build on top of these
+//! primitives.
 
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Condvar, Mutex, MutexGuard};
@@ -394,35 +393,17 @@ pub(super) enum RecvOutcome {
     Detached,
 }
 
-/// Non-blocking byte channel receiver. Implementations: shm_mq (production),
-/// `std::sync::mpsc` (tests). Must be `Send` because the drain thread takes
-/// ownership.
+/// Non-blocking byte channel receiver. Implementations: `DsmInboxReceiver` (production),
+/// `std::sync::mpsc` (tests). Must be `Send` because the drain thread takes ownership.
 pub(super) trait BatchChannelReceiver: Send + Sync {
     fn try_recv(&self) -> RecvOutcome;
-
-    /// Tell producers to stop sending. Default no-op; concrete impls override when the
-    /// underlying transport doesn't get a "drop = detach" signal for free.
-    ///
-    /// `ShmMqReceiver` doesn't override: shm_mq's `MessageQueueReceiver::Drop` calls
-    /// `shm_mq_detach`, which is enough to make producers see Detached.
-    ///
-    /// `DsmInboxReceiver` overrides: the DSM MPSC ring's detach is mostly handled by
-    /// `DsmMpscSender::Drop` flipping `detached` when the last sender goes away, but
-    /// the consumer side can force-detach early (e.g., query teardown before producers
-    /// finish) via this method. `DrainHandle::Drop` calls it on teardown.
-    #[allow(dead_code)]
-    fn set_detached(&self) {}
 }
 
 /// Byte channel sender paired with [`BatchChannelReceiver`]. `send` blocks when
 /// the channel is full. Dropping the sender signals EOF to the receiver.
 ///
 /// `Send` is required because unit tests and future producer-pump threads move
-/// senders across thread boundaries. Production shm_mq senders, however, must
-/// only be *used* from the main backend thread — the blocking shm_mq send path
-/// (`nowait=false`) touches `WaitLatch`/`CHECK_FOR_INTERRUPTS`, which is not
-/// safe off-thread. See [`crate::postgres::customscan::mpp::mesh::ShmMqSender`]
-/// for the safety contract.
+/// senders across thread boundaries.
 pub(crate) trait BatchChannelSender: Send + Sync {
     fn send_bytes(&self, bytes: &[u8]) -> Result<(), DataFusionError>;
 
@@ -489,8 +470,7 @@ pub struct MppSender {
 // compose `send_*_traced` futures via `tokio::spawn` / `join_all`, which makes the compiler
 // require `&Self: Send` and therefore `Self: Sync`. At runtime those futures run on the
 // current-thread tokio runtime pinned to the PG backend thread, so the cell is never actually
-// observed from another thread. Same single-thread-by-construction contract as
-// `unsafe impl Send for ShmMqSender` in `mesh.rs`.
+// observed from another thread.
 unsafe impl Sync for MppSender {}
 
 impl MppSender {
@@ -778,10 +758,10 @@ pub(super) enum RecvBatchOutcome {
 /// teardown unblock flows via [`DrainHandle::cancel_channel_buffers`] from the handle's `Drop`.
 #[derive(Default)]
 struct ChannelBufferRegistry {
-    /// Keyed by `(sender_proc, stage_id, partition)`. Under mesh-multiplexing the unified
-    /// inbox carries frames from every peer, so each `(stage, partition)` consumer gets
-    /// its own per-sender buffer. This preserves the implicit "one stream per sender"
-    /// semantics that `WorkerConnection::stream_partition` consumers rely on.
+    /// Keyed by `(sender_proc, stage_id, partition)`. The unified inbox carries frames
+    /// from every peer, so each `(stage, partition)` consumer gets its own per-sender
+    /// buffer. This preserves the implicit "one stream per sender" semantics that
+    /// `WorkerConnection::stream_partition` consumers rely on.
     map: HashMap<(u32, u32, u32), Arc<DrainBuffer>>,
 }
 
@@ -842,10 +822,9 @@ impl DrainHandle {
             .map
             .entry((sender_proc, stage_id, partition))
             .or_insert_with(|| {
-                // num_sources stays 1: under mesh-multiplexing each
-                // (sender_proc, stage, partition) tuple has exactly one upstream (the
-                // named sender), even though the underlying inbox is shared across all
-                // senders.
+                // num_sources stays 1: each (sender_proc, stage, partition) tuple has
+                // exactly one upstream (the named sender), even though the underlying
+                // inbox is shared across all senders.
                 DrainBuffer::new(1)
             })
             .clone()
@@ -929,12 +908,12 @@ impl DrainHandle {
                     }
                     RecvBatchOutcome::Empty => break,
                     RecvBatchOutcome::Detached => {
-                        // Only THIS receiver is dead. Under mesh-multiplexing the drain holds
-                        // multiple receivers (own-inbox MPSC + self-loop in-proc); one going
-                        // away does not imply the others have. Do not fire a registry-wide
-                        // "all channels EOF" here. Channel buffers waiting on a still-live
-                        // sibling receiver would falsely terminate. Per-channel EOF flows via
-                        // the demuxed Eof frame above; query-teardown unblock flows via
+                        // Only THIS receiver is dead. The drain holds multiple receivers
+                        // (own-inbox MPSC + self-loop in-proc); one going away doesn't
+                        // imply the others have. Don't fire a registry-wide "all channels
+                        // EOF" here, or channel buffers waiting on a still-live sibling
+                        // receiver would falsely terminate. Per-channel EOF flows via the
+                        // demuxed Eof frame above; query-teardown unblock flows via
                         // `cancel_channel_buffers` from `DrainHandle::Drop`.
                         *slot = None;
                         break;
@@ -961,12 +940,13 @@ impl Drop for DrainHandle {
 }
 /// SPSC channel pair for two use cases:
 /// - Unit tests (bounded capacity, exercising backpressure).
-/// - Production self-loop slots: when a worker's fragment emits a partition destined for its OWN
-///   proc (e.g. peer-mesh hash routing where consumer task t lands on the same worker as
-///   producer task t), the shm_mq grid leaves the `slot(this_proc, this_proc)` diagonal
-///   unattached. The dispatcher routes those self-loops through this in-proc channel instead.
-///   It shares the same `BatchChannelSender`/`BatchChannelReceiver` abstraction as shm_mq, so the
-///   drain and channel buffer registry don't need a special case.
+/// - Production self-loop slots: when a worker's fragment emits a partition destined for
+///   its OWN proc (e.g. peer-mesh hash routing where consumer task t lands on the same
+///   worker as producer task t), the DSM layout has no self-pair inbox: a process is
+///   not its own peer. The dispatcher routes those self-loops through this in-proc
+///   channel, which exposes the same `BatchChannelSender` / `BatchChannelReceiver`
+///   surface as the DSM ring so the drain and channel-buffer registry don't need a
+///   special case.
 ///
 /// Production callers pass a very large `capacity` so the channel is effectively unbounded under
 /// steady state. The current-thread Tokio runtime interleaves producer and consumer fragments
@@ -988,8 +968,8 @@ pub(super) struct InProcSender {
     /// Per-instance lock so the [`BatchChannelSender::send_lock`] contract holds even when an
     /// in-proc channel ends up in a code path that would otherwise need serialization. In-proc
     /// `send_bytes` is already atomic (each call pushes a complete `Vec<u8>`), so the lock is
-    /// effectively a no-op here, but keeping it uniform with `ShmMqSender` avoids special-casing
-    /// the caller.
+    /// effectively a no-op here; keeping it uniform with `DsmInboxSender` avoids
+    /// special-casing the caller.
     send_lock: tokio::sync::Mutex<()>,
 }
 


### PR DESCRIPTION
## What

This PR collapses the MPP transport's `N × (N-1)` per-pair `shm_mq` grid into `N` per-receiver MPSC inboxes, and lets a single frame span multiple ring slots so payloads aren't capped at `slot_capacity`.

## Why

Join + groupby wall-time was tracking `N²` because mesh edges scaled with peer count.

The per-pair drain also treated any peer detach as registry-wide EOF. Once a single `HashJoinExec` probe input finalized, that fired on channels still expecting data and the upstream hung.

Capping a frame at one slot worked while frames were small headers. The moment a partition emitted a batch larger than `slot_capacity` it failed with `MessageTooLarge`. Bumping `slot_capacity` for every batch wastes DSM; fragmentation lets the existing ring stretch.

## How

`DsmMpscRing` is a Vyukov lock-free MPSC primitive over DSM, with `Latch` wake. Frames carry a `sender_proc` field so the receiver demuxes them into the same channel-buffer registry used by the prior `shm_mq` grid.

Multi-slot fragmentation lets a single frame span N consecutive ring slots. The producer reserves the slots via the same `tail` CAS, fragments the payload, and the consumer reassembles before handing the bytes up. Partial reads aren't visible to higher layers.

Per-channel EOF rides the demuxed `Eof` frame instead of peer detach. Teardown unblock comes from `DrainHandle::Drop` setting the shared `detached` flag.

Zero-copy in-proc shuffle still ships separately.

## Tests

Unit tests cover the ring's SPSC round trip, MPSC contention, per-producer ordering, attach-time magic/version checks, multi-slot wraparound, and a proptest that randomizes per-producer fragment-kind sequences under contention.