### PR TITLE
test: [test-on-plan-a, do-not-merge] proptest PR #5163 rebased on Plan A #5167

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -325,6 +325,44 @@ struct IndexComponents {
     schema: SearchIndexSchema,
 }
 
+/// Segment iterator backed by `ParallelScanState`'s single (partitioning-source) counter.
+/// Each `next()` claims one segment via `checkout_segment`; returns `None` when the pool
+/// is exhausted. Used by [`SearchIndexReader::search_lazy`].
+struct ParallelSegmentIterator {
+    parallel_state: *mut crate::postgres::ParallelScanState,
+}
+// SAFETY: `parallel_state` is a pointer to PG-managed shared memory that's valid for the
+// duration of the parallel scan and synchronized internally via the state's mutex. The
+// pointer can move across threads safely because every access reaches back into the
+// mutex-protected state.
+unsafe impl Send for ParallelSegmentIterator {}
+unsafe impl Sync for ParallelSegmentIterator {}
+impl Iterator for ParallelSegmentIterator {
+    type Item = tantivy::index::SegmentId;
+    fn next(&mut self) -> Option<Self::Item> {
+        pgrx::check_for_interrupts!();
+        unsafe { crate::postgres::customscan::parallel::checkout_segment(self.parallel_state) }
+    }
+}
+
+/// Source-aware segment iterator: claims segments from `source_idx`'s per-source pool in
+/// [`ParallelScanState`] instead of the partitioning source's pool. Used by MPP for
+/// non-partitioning sources so two sources don't race on the same counter.
+struct PerSourceSegmentIterator {
+    parallel_state: *mut crate::postgres::ParallelScanState,
+    source_idx: usize,
+}
+// SAFETY: same as `ParallelSegmentIterator`.
+unsafe impl Send for PerSourceSegmentIterator {}
+unsafe impl Sync for PerSourceSegmentIterator {}
+impl Iterator for PerSourceSegmentIterator {
+    type Item = tantivy::index::SegmentId;
+    fn next(&mut self) -> Option<Self::Item> {
+        pgrx::check_for_interrupts!();
+        unsafe { (*self.parallel_state).checkout_segment_for_source(self.source_idx) }
+    }
+}
+
 impl SearchIndexReader {
     fn open_index_components(
         index_relation: &PgSearchRelation,
@@ -671,23 +709,32 @@ impl SearchIndexReader {
         parallel_state: *mut crate::postgres::ParallelScanState,
         estimated_rows: u64,
     ) -> MultiSegmentSearchResults {
-        struct ParallelSegmentIterator {
-            parallel_state: *mut crate::postgres::ParallelScanState,
-        }
-        unsafe impl Send for ParallelSegmentIterator {}
-        unsafe impl Sync for ParallelSegmentIterator {}
-        impl Iterator for ParallelSegmentIterator {
-            type Item = tantivy::index::SegmentId;
-            fn next(&mut self) -> Option<Self::Item> {
-                pgrx::check_for_interrupts!();
-                unsafe {
-                    crate::postgres::customscan::parallel::checkout_segment(self.parallel_state)
-                }
-            }
-        }
+        self.search_lazy_with(estimated_rows, ParallelSegmentIterator { parallel_state })
+    }
 
-        let segment_ids = ParallelSegmentIterator { parallel_state };
+    /// Source-aware variant of [`Self::search_lazy`] used by MPP for non-partitioning sources.
+    /// Each worker claims segments from `source_idx`'s pool in [`ParallelScanState`] via
+    /// `checkout_segment_for_source` instead of the single partitioning-source counter that
+    /// `search_lazy` uses, so two scans of different sources don't race on the same counter.
+    pub fn search_lazy_for_source(
+        &self,
+        parallel_state: *mut crate::postgres::ParallelScanState,
+        source_idx: usize,
+        estimated_rows: u64,
+    ) -> MultiSegmentSearchResults {
+        self.search_lazy_with(
+            estimated_rows,
+            PerSourceSegmentIterator {
+                parallel_state,
+                source_idx,
+            },
+        )
+    }
 
+    fn search_lazy_with<I>(&self, estimated_rows: u64, segment_ids: I) -> MultiSegmentSearchResults
+    where
+        I: Iterator<Item = tantivy::index::SegmentId> + Send + Sync + 'static,
+    {
         let searcher = self.searcher.clone();
         let query = self.query.box_clone();
         let need_scores = self.need_scores;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -601,6 +601,13 @@ async fn build_source_df(
     let mut provider = PgSearchTableProvider::new(scan_info, fields, is_parallel);
     if let Some(idx) = np_idx {
         provider.set_non_partitioning_index(idx);
+        // Under MPP this source becomes its own pool in `ParallelScanState`: each worker
+        // claims this source's segments via `checkout_segment_for_source(plan_position)`
+        // rather than scanning the full data and relying on a downstream slice. Outside
+        // MPP the codec doesn't carry a `parallel_state` and this flag is a no-op.
+        if mpp_ctx.is_some() {
+            provider.set_mpp_source_idx(plan_position);
+        }
     }
     // HeapFilter queries (e.g. `=` on a column indexed via a
     // `pdb.literal(...)` cast) compile to runtime Postgres expressions

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1530,9 +1530,8 @@ impl AggregateScan {
                         if launched < expected {
                             pgrx::error!(
                                 "mpp aggregate: PG launched {launched} of {expected} requested \
-                                 parallel workers; missing slots would hang the query. Retry, or \
-                                 raise `max_parallel_workers` / `max_parallel_workers_per_gather` \
-                                 so PG can launch the full set. Long-term fix tracked in \
+                                 parallel workers because the machine is saturated; missing slots \
+                                 would hang the query. Please retry. Long-term fix tracked in \
                                  https://github.com/paradedb/paradedb/issues/5061."
                             );
                         }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1494,9 +1494,9 @@ impl CustomScan for JoinScan {
                             if launched < expected {
                                 pgrx::error!(
                                     "mpp join: PG launched {launched} of {expected} requested \
-                                     parallel workers; missing slots would hang the query. Retry, \
-                                     or raise `max_parallel_workers` / \
-                                     `max_parallel_workers_per_gather` so PG can launch the full set."
+                                     parallel workers because the machine is saturated; missing slots \
+                                     would hang the query. Please retry. Long-term fix tracked in \
+                                     https://github.com/paradedb/paradedb/issues/5061."
                                 );
                             }
                         }

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -595,7 +595,31 @@ unsafe fn collect_join_sources_join_rel(
 
         // Extract keys for this level
         let join_restrict_info = (*join_path).joinrestrictinfo;
-        let join_conditions = extract_join_conditions_from_list(join_restrict_info, &all_sources);
+        let mut join_conditions =
+            extract_join_conditions_from_list(join_restrict_info, &all_sources);
+
+        // PG drops a join clause from `joinrestrictinfo` when a parameterized
+        // inner index lookup already enforces it (the inner index's `ppi`
+        // clauses become the join condition for the `NestPath`). The clause
+        // still lives on `inner_path->param_info->ppi_clauses` for the base
+        // rel. Pull it in here so we can recover the equi-key. Without this
+        // the 3-way `JoinScan` declines whenever PG picks a parameterized
+        // inner bitmap-index plan.
+        if join_conditions.equi_keys.is_empty() {
+            let inner_param = (*inner_path).param_info;
+            if !inner_param.is_null() {
+                let ppi_clauses = (*inner_param).ppi_clauses;
+                if !ppi_clauses.is_null() {
+                    let extra = extract_join_conditions_from_list(ppi_clauses, &all_sources);
+                    join_conditions.equi_keys.extend(extra.equi_keys);
+                    join_conditions
+                        .other_conditions
+                        .extend(extra.other_conditions);
+                    join_conditions.has_search_predicate =
+                        join_conditions.has_search_predicate || extra.has_search_predicate;
+                }
+            }
+        }
 
         let jointype = (*join_path).jointype;
 

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -1058,6 +1058,16 @@ fn build_source_df<'a>(
         // canonical segment IDs during decode.
         if let Some(idx) = np_idx {
             provider.set_non_partitioning_index(idx);
+            // Under MPP this source becomes its own pool in `ParallelScanState`: each
+            // worker claims this source's segments via
+            // `checkout_segment_for_source(plan_position)`. Gate on `mpp_is_active()`
+            // because the joinscan EXEC site passes `parallel_state` to the codec on
+            // both MPP and PG-parallel runs, and PG-parallel hash join still wants the
+            // canonical-segment-ids replication path so every worker sees the full
+            // build side.
+            if crate::postgres::customscan::mpp::glue::mpp_is_active() {
+                provider.set_mpp_source_idx(plan_position);
+            }
         }
 
         if let Some(ref sort_order) = scan_info.sort_order {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -68,8 +68,19 @@ const MIN_TOTAL_WORKER_COUNT: i32 = 3;
 
 /// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >=
 /// MIN_TOTAL_WORKER_COUNT`. Customscan path-builders gate `parallel_workers` on this.
+/// Also requires that the system has enough `max_parallel_workers` and
+/// `max_parallel_workers_per_gather` to launch the requested number of producers.
 pub fn mpp_is_active() -> bool {
-    enable_mpp() && gucs_mpp_worker_count() >= MIN_TOTAL_WORKER_COUNT
+    let active = enable_mpp() && gucs_mpp_worker_count() >= MIN_TOTAL_WORKER_COUNT;
+    if !active {
+        return false;
+    }
+
+    let producer_count = gucs_mpp_worker_count() - 1;
+    let max_per_gather = unsafe { pg_sys::max_parallel_workers_per_gather };
+    let max_workers = unsafe { pg_sys::max_parallel_workers };
+
+    producer_count <= max_per_gather && producer_count <= max_workers
 }
 
 /// Total proc count: leader + producers. Equals the GUC value when [`mpp_is_active`] is

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -176,11 +176,17 @@ struct ParallelScanPayloadLayout {
     all_counts: Range<usize>,
     /// Concatenated 16-byte segment UUIDs for all sources, in ascending source-index order.
     all_ids: Range<usize>,
+    /// One `u32` per source: remaining unclaimed segments. Workers atomically decrement
+    /// the slot for the source they're scanning to claim its segments. Lets every source
+    /// in a multi-source MPP plan be partitioned across workers, not just the
+    /// planner-chosen partitioning source.
+    remaining_by_source: Range<usize>,
     /// One `u32` per segment in the partitioning source: deleted doc count.
     partitioning_deleted_docs: Range<usize>,
     /// One `u32` per segment in the partitioning source: max doc count.
     partitioning_max_docs: Range<usize>,
     /// One `i32` per segment in the partitioning source: which worker claimed it.
+    /// Non-partitioning sources don't track claims (used only by `EXPLAIN ANALYZE`).
     claims: Range<usize>,
     aggregates_header: Option<Range<usize>>,
     aggregates_data: Option<Range<usize>>,
@@ -215,6 +221,13 @@ impl ParallelScanPayloadLayout {
         let all_ids_layout = Layout::from_size_align(total_segs * SEGMENT_ID_SIZE, 1)?;
         let (layout, all_ids_offset) = layout.extend(all_ids_layout)?;
         let all_ids_range = all_ids_offset..(all_ids_offset + all_ids_layout.size());
+
+        // Per-source remaining-segments counter: [u32; n_sources]. One slot per source,
+        // initialized in `init()` to the source's segment count. `checkout_segment_for_source`
+        // decrements the slot to claim a segment for that source.
+        let remaining_layout = Layout::array::<u32>(n_sources)?;
+        let (layout, remaining_offset) = layout.extend(remaining_layout)?;
+        let remaining_range = remaining_offset..(remaining_offset + remaining_layout.size());
 
         // Deleted doc counts for the partitioning source only: [u32; partitioning_nsegments].
         let partitioning_del_layout = Layout::array::<u32>(partitioning_nsegments)?;
@@ -253,6 +266,7 @@ impl ParallelScanPayloadLayout {
             query: query_range,
             all_counts: all_counts_range,
             all_ids: all_ids_range,
+            remaining_by_source: remaining_range,
             partitioning_deleted_docs: partitioning_deleted_docs_range,
             partitioning_max_docs: partitioning_max_docs_range,
             claims: claims_range,
@@ -345,6 +359,22 @@ impl ParallelScanPayload {
         for claim in self.claims_mut().iter_mut() {
             *claim = SEGMENT_CLAIM_UNCLAIMED;
         }
+
+        // Initialize per-source remaining counters from each source's segment count.
+        // Workers running an MPP fragment for a non-partitioning source atomically
+        // decrement the slot for the source they're scanning via
+        // `checkout_segment_for_source`. Single-source scans (BaseScan parallel,
+        // single-table top-k / paging / count) never enter that path. They use the
+        // single `remaining_segments` counter via `checkout_segment`, so skip the slab
+        // init to keep the parallel non-MPP hot path free of per-source bookkeeping.
+        if all_sources.len() > 1 {
+            let remaining_range = self.layout.remaining_by_source.clone();
+            let remaining_slice: &mut [u32] =
+                bytemuck::try_cast_slice_mut(&mut self.data_mut()[remaining_range]).unwrap();
+            for (source, target) in all_sources.iter().zip(remaining_slice.iter_mut()) {
+                *target = source.len() as u32;
+            }
+        }
     }
 
     fn data(&self) -> &[u8] {
@@ -396,6 +426,11 @@ impl ParallelScanPayload {
 
     fn partitioning_max_docs(&self) -> &[u32] {
         bytemuck::try_cast_slice(&self.data()[self.layout.partitioning_max_docs.clone()]).unwrap()
+    }
+
+    fn remaining_by_source_mut(&mut self) -> &mut [u32] {
+        let range = self.layout.remaining_by_source.clone();
+        bytemuck::try_cast_slice_mut(&mut self.data_mut()[range]).unwrap()
     }
 
     /// An array of `i32` parallel worker numbers (as returned by pg_sys::ParallelWorkerNumber)
@@ -633,6 +668,15 @@ impl ParallelScanState {
     pub fn mark_initialized_empty(&mut self) {
         self.nsegments = 0;
         self.remaining_segments = 0;
+        // Zero the per-source slab only if it was actually populated (multi-source MPP
+        // scans). Single-source scans skip the slab init in `populate()`, so there's
+        // nothing to zero and walking the (empty) slice would still be cheap but
+        // pointless.
+        if self.payload.all_counts().len() > 1 {
+            for slot in self.payload.remaining_by_source_mut() {
+                *slot = 0;
+            }
+        }
         self.init_cv.broadcast();
     }
 
@@ -839,8 +883,40 @@ impl ParallelScanState {
             // this means we're purposely checking out segments from largest-to-smallest.
             let claimed_segment = self.decrement_remaining_segments();
             self.payload.claims_mut()[claimed_segment] = parallel_worker_number;
+            // The per-source slab tracks non-partitioning sources only. The partitioning
+            // source uses `remaining_segments` here, and `checkout_segment_for_source`
+            // never looks at the partitioning slot, so don't mirror this decrement onto
+            // `remaining_by_source[partitioning_idx]`.
             break Some(self.segment_id(claimed_segment));
         }
+    }
+
+    /// Source-aware variant of [`Self::checkout_segment`] used by MPP scans whose source
+    /// is not the planner-chosen partitioning source. Claims and returns one segment ID
+    /// from `source_idx`'s pool, or `None` when that pool is empty. Doesn't update the
+    /// partitioning source's `claims` array — those are reserved for `EXPLAIN ANALYZE`
+    /// output of the partitioning source.
+    pub fn checkout_segment_for_source(&mut self, source_idx: usize) -> Option<SegmentId> {
+        self.wait_for_initialization();
+        let _mutex = self.acquire_mutex();
+        let counts = self.payload.all_counts();
+        let count_for_source = *counts.get(source_idx)? as usize;
+        if count_for_source == 0 {
+            return None;
+        }
+        let by_source = self.payload.remaining_by_source_mut();
+        let slot = by_source.get_mut(source_idx)?;
+        if *slot == 0 {
+            return None;
+        }
+        *slot -= 1;
+        let claimed_idx = *slot as usize;
+        // Segment IDs for this source live in the concatenated `all_ids` slab. Look them
+        // up positionally; this gives the same largest-to-smallest claim order as the
+        // partitioning source (segments are sorted in `init()`).
+        Some(SegmentId::from_bytes(
+            self.payload.source_ids(source_idx)[claimed_idx],
+        ))
     }
 
     /// Returns a map of segment IDs to their deleted document counts.
@@ -940,8 +1016,43 @@ impl ParallelScanState {
     /// Reset remaining_segments for a rescan. Called by amparallelrescan.
     pub fn reset(&mut self) {
         self.remaining_segments = self.nsegments;
+        // Refill the per-source counters from each source's segment count so a rescan
+        // re-partitions the same way the initial scan did. Without this, the second
+        // scan would observe zero remaining for every source and emit nothing.
+        // Single-source scans never enter `checkout_segment_for_source` and the slab
+        // was never populated in `populate()`, so skip the refill.
+        if self.payload.all_counts().len() > 1 {
+            let counts: Vec<u32> = self.payload.all_counts().to_vec();
+            for (slot, count) in self
+                .payload
+                .remaining_by_source_mut()
+                .iter_mut()
+                .zip(counts.iter())
+            {
+                *slot = *count;
+            }
+        }
         // NOTE: We do not reset `queries_per_worker` here, so that it can be tracked across
         // rescans.
+    }
+
+    /// Return all segment IDs for `source_idx`. Used by MPP workers to open
+    /// `MvccSatisfies::ParallelWorker(ids)` on a per-source basis so each worker sees the
+    /// same frozen segment set even though only a subset will be claimed via
+    /// `checkout_segment_for_source`. The leader-snapshotted segment set lives in the
+    /// shared payload, so workers don't need a separate codec channel for it.
+    ///
+    /// Waits for leader initialization so a worker that races ahead of `populate()` reads
+    /// the post-init segment set rather than zero IDs. Matches the precondition every
+    /// other payload reader (`segments`, `checkout_segment*`) enforces.
+    pub fn segment_ids_for_source(&mut self, source_idx: usize) -> HashSet<SegmentId> {
+        self.wait_for_initialization();
+        let _mutex = self.acquire_mutex();
+        self.payload
+            .source_ids(source_idx)
+            .iter()
+            .map(|b| SegmentId::from_bytes(*b))
+            .collect()
     }
 }
 

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -219,7 +219,12 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         let mut provider: PgSearchTableProvider = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("Failed to deserialize PgSearchTableProvider: {e}"))
         })?;
-        if provider.is_parallel() {
+        // The partitioning source uses the legacy single-counter `checkout_segment` path.
+        // Under MPP every non-partitioning source also reaches into `parallel_state` —
+        // it calls `checkout_segment_for_source(mpp_source_idx)` for its own per-source
+        // pool. Inject the pointer in both cases so the runtime can route to the right
+        // counter at scan time.
+        if provider.is_parallel() || provider.mpp_source_idx().is_some() {
             provider.set_parallel_state(self.parallel_state);
         }
         if let Some(np_idx) = provider.non_partitioning_index() {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -93,9 +93,23 @@ pub enum ScanRecipe {
         segment_ids: Vec<SegmentId>,
         scanner_config: ScannerConfig,
     },
-    /// Lazy scan: segments are claimed dynamically from parallel state.
+    /// Lazy scan: segments are claimed dynamically from parallel state's single
+    /// (partitioning-source) counter via `checkout_segment`. Used by the basescan IAM
+    /// path, the MPP partitioning source, and non-MPP parallel hash join.
     Lazy {
         parallel_state: Option<*mut ParallelScanState>,
+        planner_estimated_rows: u64,
+        scanner_config: ScannerConfig,
+    },
+    /// Lazy scan for a specific source under MPP: claims segments from a per-source pool
+    /// via `checkout_segment_for_source(source_idx)`. Used by every non-partitioning source
+    /// in the multi-source MPP plan so each source's segments are split across workers
+    /// instead of replicated. The partitioning source keeps using `Lazy` because the
+    /// existing `checkout_segment` path also updates the per-segment `claims` array that
+    /// `EXPLAIN ANALYZE` displays.
+    LazyForSource {
+        parallel_state: *mut ParallelScanState,
+        source_idx: usize,
         planner_estimated_rows: u64,
         scanner_config: ScannerConfig,
     },
@@ -232,6 +246,10 @@ impl PgSearchScanPlan {
                         .reader
                         .estimated_docs_in_segments(segment_ids.iter().cloned()),
                     ScanRecipe::Lazy {
+                        planner_estimated_rows,
+                        ..
+                    }
+                    | ScanRecipe::LazyForSource {
                         planner_estimated_rows,
                         ..
                     } => *planner_estimated_rows,
@@ -496,6 +514,21 @@ impl ExecutionPlan for PgSearchScanPlan {
                             } else {
                                 reader.search()
                             };
+                            (res, scanner_config)
+                        }
+                        ScanRecipe::LazyForSource {
+                            parallel_state,
+                            source_idx,
+                            planner_estimated_rows,
+                            scanner_config,
+                        } => {
+                            // MPP non-partitioning source: each worker claims segments from
+                            // this source's per-source pool in `ParallelScanState`.
+                            let res = reader.search_lazy_for_source(
+                                parallel_state,
+                                source_idx,
+                                planner_estimated_rows,
+                            );
                             (res, scanner_config)
                         }
                         ScanRecipe::Prefetched { .. } => unreachable!(),

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -131,6 +131,17 @@ pub struct PgSearchTableProvider {
     /// and load (in get_schema) execute sequentially within the same single-threaded optimization pass.
     #[serde(with = "atomic_bool_serde")]
     late_materialization_active: AtomicBool,
+
+    /// Source index in the unified all-sources array, when this provider is participating in
+    /// the multi-source MPP path. Set by the customscans on every non-partitioning source.
+    /// Combined with the codec's `parallel_state`, lets each worker claim its own segments
+    /// for that source via `checkout_segment_for_source(source_idx)` so the source isn't
+    /// replicated across workers and the downstream `NetworkShuffleExec` doesn't receive
+    /// N copies of the source's output. `None` for serial scans, the partitioning source
+    /// (which uses the single-counter `checkout_segment` path), and non-MPP parallel hash
+    /// join (which has its own worker-aware scheduling).
+    #[serde(default)]
+    mpp_source_idx: Option<usize>,
 }
 
 mod atomic_bool_serde {
@@ -171,6 +182,7 @@ impl PgSearchTableProvider {
             canonical_segment_ids: None,
             visibility_mode: VisibilityMode::Eager,
             late_materialization_active: AtomicBool::new(false),
+            mpp_source_idx: None,
         }
     }
 
@@ -185,7 +197,11 @@ impl PgSearchTableProvider {
     }
 
     pub(crate) fn set_parallel_state(&mut self, parallel_state: Option<*mut ParallelScanState>) {
-        assert!(self.is_parallel);
+        // Non-partitioning sources also need the pointer under MPP so they can claim from
+        // their own per-source pool via `checkout_segment_for_source(mpp_source_idx)`.
+        // Leaving `is_parallel = false` for those sources keeps the logical-plan rules
+        // (e.g. partitioning-source-only segment ordering) working unchanged.
+        assert!(self.is_parallel || self.mpp_source_idx.is_some());
         self.parallel_state = parallel_state;
     }
 
@@ -212,6 +228,16 @@ impl PgSearchTableProvider {
 
     pub(crate) fn set_planstate(&mut self, planstate: Option<*mut pg_sys::PlanState>) {
         self.planstate = planstate;
+    }
+
+    /// Assign this provider's source position in the MPP unified-sources array. See
+    /// [`PgSearchTableProvider::mpp_source_idx`] for what it gates.
+    pub(crate) fn set_mpp_source_idx(&mut self, idx: usize) {
+        self.mpp_source_idx = Some(idx);
+    }
+
+    pub(crate) fn mpp_source_idx(&self) -> Option<usize> {
+        self.mpp_source_idx
     }
     fn enable_deferred_columns(&mut self, required_early_columns: &HashSet<String>) {
         for wff in self.fields.iter_mut() {
@@ -617,6 +643,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         query_for_display: SearchQueryInput,
         planner_estimated_rows: u64,
+        mpp_source_idx: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -624,12 +651,27 @@ impl PgSearchTableProvider {
             heap_relid: heap_relid.into(),
             batch_size_hint: None,
         };
-        let state = ScanState {
-            recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
+        // MPP non-partitioning source path: pull segments from this source's per-source
+        // pool in `ParallelScanState`. The partitioning source, serial scans, and non-MPP
+        // parallel hash join stay on the single-counter `Lazy` recipe, which claims via
+        // `checkout_segment` (the `partitioning_source_idx` slot).
+        let recipe = match (mpp_source_idx, parallel_state) {
+            (Some(source_idx), Some(ps)) => {
+                crate::scan::execution_plan::ScanRecipe::LazyForSource {
+                    parallel_state: ps,
+                    source_idx,
+                    planner_estimated_rows,
+                    scanner_config,
+                }
+            }
+            _ => crate::scan::execution_plan::ScanRecipe::Lazy {
                 parallel_state,
                 planner_estimated_rows,
                 scanner_config,
             },
+        };
+        let state = ScanState {
+            recipe,
             ffhelper: ffhelper.clone(),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader: reader.clone(),
@@ -761,20 +803,39 @@ impl PgSearchTableProvider {
 
         // Determine MVCC strategy based on whether we are running in parallel mode.
         //
-        // For the partitioning source (`parallel_state` is Some):
+        // For the partitioning source (`parallel_state` is Some, no `mpp_source_idx`):
         //   - Leader: Snapshot (claims segments dynamically; its own snapshot is the source
         //             of truth for which segments exist).
         //   - Workers: ParallelWorker(partitioning_segment_ids) – frozen set from leader.
         //
-        // For non-partitioning / replicated sources (`canonical_segment_ids` is Some):
-        //   - Both leader and workers use ParallelWorker(canonical_ids) so that every
-        //     participant opens exactly the same frozen segment set, preventing DocAddress
-        //     mismatches when late materialization stores (segment_ord, doc_id) pairs.
+        // For non-partitioning sources under MPP (`mpp_source_idx` is Some, `parallel_state`
+        // is Some): every participant opens the same frozen segment set for that source.
+        // The IDs come from the shared `ParallelScanState` rather than the codec-injected
+        // `canonical_segment_ids`, so the leader's snapshot remains the single source of
+        // truth for which segments exist. Each worker then claims a per-source slice via
+        // `checkout_segment_for_source`.
         //
-        // Serial scans (both fields None): Snapshot.
-        let mvcc_style = if let Some(ids) = canonical_segment_ids {
-            // Non-partitioning source in a parallel join scan: use the frozen segment list
-            // that the leader snapshotted and wrote to shared memory.
+        // For non-MPP parallel hash join (`canonical_segment_ids` Some, `mpp_source_idx`
+        // None): every worker opens the leader-snapshotted segment set, matching PG's
+        // own worker scheduling.
+        //
+        // Serial scans (all fields None): Snapshot.
+        let mvcc_style = if let Some(source_idx) = self.mpp_source_idx {
+            if let Some(parallel_state) = parallel_state {
+                unsafe {
+                    let ids = (*parallel_state).segment_ids_for_source(source_idx);
+                    MvccSatisfies::ParallelWorker(ids)
+                }
+            } else if let Some(ids) = canonical_segment_ids.clone() {
+                // Codec injected canonical IDs but no `parallel_state`. Belt-and-braces
+                // fallback: open the same frozen segment set the leader recorded.
+                MvccSatisfies::ParallelWorker(ids)
+            } else {
+                MvccSatisfies::Snapshot
+            }
+        } else if let Some(ids) = canonical_segment_ids {
+            // Non-partitioning source in a non-MPP parallel join scan: use the frozen
+            // segment list that the leader snapshotted and wrote to shared memory.
             MvccSatisfies::ParallelWorker(ids)
         } else if let Some(parallel_state) = parallel_state {
             unsafe {
@@ -851,6 +912,7 @@ impl PgSearchTableProvider {
                 projected_schema,
                 query,
                 total_estimated_rows,
+                self.mpp_source_idx,
             )
         }
     }

--- a/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
@@ -65,27 +65,27 @@ JOIN products ON users.age = products.age
 JOIN orders ON products.uuid = orders.uuid
 WHERE users.name @@@ 'bob'
 ORDER BY users.id, products.id, orders.id LIMIT 1;
-WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
-                                                                                                        QUERY PLAN                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: users.id, products.id, orders.id
-         ->  Nested Loop
-               ->  Nested Loop
-                     ->  Bitmap Heap Scan on users
-                           Recheck Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
-                           ->  Bitmap Index Scan on idxusers
-                                 Index Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
-                     ->  Bitmap Heap Scan on products
-                           Recheck Cond: (users.age = age)
-                           ->  Bitmap Index Scan on idxproducts_age
-                                 Index Cond: (age = users.age)
-               ->  Bitmap Heap Scan on orders
-                     Recheck Cond: (products.uuid = uuid)
-                     ->  Bitmap Index Scan on idxorders_uuid
-                           Index Cond: (uuid = products.uuid)
-(17 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: users INNER (products INNER orders)
+         Join Cond: users.age = products.age, products.uuid = orders.uuid
+         Limit: 1
+         Order By: users.id asc, products.id asc, orders.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, id@3 as col_3, id@5 as col_4, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
+           :   SortExec: TopK(fetch=1), expr=[id@1 ASC NULLS LAST, id@3 ASC NULLS LAST, id@5 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[users, products, orders]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(uuid@3, uuid@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4, ctid_2@5, id@7]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_0@0, id@2, ctid_1@3, uuid@5, id@6]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
 
 SELECT users.id, users.name
 FROM users
@@ -93,7 +93,6 @@ JOIN products ON users.age = products.age
 JOIN orders ON products.uuid = orders.uuid
 WHERE users.name @@@ 'bob'
 ORDER BY users.id, products.id, orders.id LIMIT 1;
-WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
  id | name 
 ----+------
   1 | bob

--- a/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
@@ -1,0 +1,104 @@
+-- Regression test: JoinScan declines on a 3-way INNER join when PG picks a
+-- parameterized `NestPath` for the inner sub-join.
+--
+-- This is a JoinScan-activation gap, not a correctness gap. PG's fallback
+-- nested-loop / bitmap plan returns the right rows; JoinScan just never
+-- fires, so the query loses the BM25 join acceleration.
+--
+-- With `enable_seqscan` and `enable_indexscan` off, PG plans the
+-- `(users JOIN products)` sub-join as a `NestPath` whose inner side is a
+-- parameterized bitmap-index lookup on `idxproducts_age`. The join clause
+-- `users.age = products.age` is enforced via that index condition, so PG
+-- leaves `JoinPath.joinrestrictinfo` empty. `collect_join_sources_join_rel`
+-- reads only `joinrestrictinfo` to recover equi-keys, finds nothing,
+-- returns `None`, and the 3-way JoinScan never gets registered.
+SET max_parallel_workers = 0;
+SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO users (name, age, uuid)
+SELECT (ARRAY['alice','bob','cloe']::text[])[((i % 3) + 1)],
+       ((i % 100) + 1),
+       md5(i::text)::uuid
+FROM generate_series(1, 100) AS i;
+CREATE INDEX idxusers ON users USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxusers_age ON users (age);
+CREATE INDEX idxusers_uuid ON users (uuid);
+ANALYZE users;
+CREATE TABLE products (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO products (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxproducts_age ON products (age);
+CREATE INDEX idxproducts_uuid ON products (uuid);
+ANALYZE products;
+CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO orders (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxorders ON orders USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxorders_age ON orders (age);
+CREATE INDEX idxorders_uuid ON orders (uuid);
+ANALYZE orders;
+SET paradedb.enable_aggregate_custom_scan = off;
+SET paradedb.enable_custom_scan = off;
+SET paradedb.enable_join_custom_scan = on;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: users.id, products.id, orders.id
+         ->  Nested Loop
+               ->  Nested Loop
+                     ->  Bitmap Heap Scan on users
+                           Recheck Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
+                           ->  Bitmap Index Scan on idxusers
+                                 Index Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
+                     ->  Bitmap Heap Scan on products
+                           Recheck Cond: (users.age = age)
+                           ->  Bitmap Index Scan on idxproducts_age
+                                 Index Cond: (age = users.age)
+               ->  Bitmap Heap Scan on orders
+                     Recheck Cond: (products.uuid = uuid)
+                     ->  Bitmap Index Scan on idxorders_uuid
+                           Index Cond: (uuid = products.uuid)
+(17 rows)
+
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
+ id | name 
+----+------
+  1 | bob
+(1 row)
+
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;

--- a/pg_search/tests/pg_regress/sql/joinscan_null_jri.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_null_jri.sql
@@ -1,0 +1,86 @@
+-- Regression test: JoinScan declines on a 3-way INNER join when PG picks a
+-- parameterized `NestPath` for the inner sub-join.
+--
+-- This is a JoinScan-activation gap, not a correctness gap. PG's fallback
+-- nested-loop / bitmap plan returns the right rows; JoinScan just never
+-- fires, so the query loses the BM25 join acceleration.
+--
+-- With `enable_seqscan` and `enable_indexscan` off, PG plans the
+-- `(users JOIN products)` sub-join as a `NestPath` whose inner side is a
+-- parameterized bitmap-index lookup on `idxproducts_age`. The join clause
+-- `users.age = products.age` is enforced via that index condition, so PG
+-- leaves `JoinPath.joinrestrictinfo` empty. `collect_join_sources_join_rel`
+-- reads only `joinrestrictinfo` to recover equi-keys, finds nothing,
+-- returns `None`, and the 3-way JoinScan never gets registered.
+
+SET max_parallel_workers = 0;
+SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+
+CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO users (name, age, uuid)
+SELECT (ARRAY['alice','bob','cloe']::text[])[((i % 3) + 1)],
+       ((i % 100) + 1),
+       md5(i::text)::uuid
+FROM generate_series(1, 100) AS i;
+CREATE INDEX idxusers ON users USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxusers_age ON users (age);
+CREATE INDEX idxusers_uuid ON users (uuid);
+ANALYZE users;
+
+CREATE TABLE products (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO products (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxproducts_age ON products (age);
+CREATE INDEX idxproducts_uuid ON products (uuid);
+ANALYZE products;
+
+CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO orders (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxorders ON orders USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxorders_age ON orders (age);
+CREATE INDEX idxorders_uuid ON orders (uuid);
+ANALYZE orders;
+
+SET paradedb.enable_aggregate_custom_scan = off;
+SET paradedb.enable_custom_scan = off;
+SET paradedb.enable_join_custom_scan = on;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -369,6 +369,7 @@ pub struct PgGucs {
     pub columnar_exec: bool,
     /// Enable sorted execution for ColumnarExecState.
     pub columnar_sort: bool,
+    pub enable_mpp: bool,
 }
 
 /// When `PARADEDB_FORCE_PARALLEL=1` (or `=true`), the proptest `Arbitrary` impl pins
@@ -402,9 +403,9 @@ impl Arbitrary for PgGucs {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any::<[bool; 11]>()
+        any::<[bool; 12]>()
             .prop_map(|b| {
-                let mut g = PgGucs {
+                let mut g = Self {
                     aggregate_custom_scan: b[0],
                     custom_scan: b[1],
                     custom_scan_without_operator: b[2],
@@ -413,9 +414,10 @@ impl Arbitrary for PgGucs {
                     seqscan: b[5],
                     indexscan: b[6],
                     parallel_workers: b[7],
-                    columnar_exec: b[8],
-                    columnar_sort: b[9],
-                    parallel_leader_participation: b[10],
+                    parallel_leader_participation: b[8],
+                    columnar_exec: b[9],
+                    columnar_sort: b[10],
+                    enable_mpp: b[11],
                 };
                 if force_parallel() {
                     g.parallel_workers = true;
@@ -426,8 +428,9 @@ impl Arbitrary for PgGucs {
     }
 }
 
-impl Default for PgGucs {
-    fn default() -> Self {
+impl PgGucs {
+    /// Creates an instance of PgGucs with all pg_search scans disabled.
+    pub fn pg_search_disabled() -> Self {
         Self {
             aggregate_custom_scan: false,
             custom_scan: false,
@@ -439,12 +442,11 @@ impl Default for PgGucs {
             parallel_workers: true,
             parallel_leader_participation: true,
             columnar_exec: false,
-            columnar_sort: true,
+            columnar_sort: false,
+            enable_mpp: false,
         }
     }
-}
 
-impl PgGucs {
     pub fn set(&self) -> String {
         let PgGucs {
             aggregate_custom_scan,
@@ -458,6 +460,7 @@ impl PgGucs {
             parallel_leader_participation,
             columnar_exec,
             columnar_sort,
+            enable_mpp,
         } = self;
 
         let max_parallel_workers = if *parallel_workers { 8 } else { 0 };
@@ -503,6 +506,7 @@ impl PgGucs {
             "SET paradedb.enable_columnar_sort TO {columnar_sort};"
         )
         .unwrap();
+        writeln!(gucs, "SET paradedb.enable_mpp TO {enable_mpp};").unwrap();
         writeln!(gucs, "SET statement_timeout TO {};", statement_timeout_ms()).unwrap();
         if force_parallel() {
             writeln!(gucs, "SET debug_parallel_query TO on;").unwrap();
@@ -565,7 +569,7 @@ where
     // the postgres query is always run with the paradedb custom scan turned off
     // this ensures we get the actual, known-to-be-correct result from Postgres'
     // plan, and not from ours where we did some kind of pushdown
-    PgGucs::default().set().execute(conn);
+    PgGucs::pg_search_disabled().set().execute(conn);
 
     conn.deallocate_all()?;
 
@@ -645,7 +649,7 @@ Original error:
 "#,
         failure_type = failure_type,
         setup_sql = setup_sql,
-        default_gucs = PgGucs::default().set(),
+        default_gucs = PgGucs::pg_search_disabled().set(),
         gucs_sql = gucs.set(),
         pg_query = pg_query,
         bm25_query = bm25_query,

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -663,6 +663,7 @@ async fn generated_joinscan(database: Db) {
         include_expr_ordering in proptest::bool::ANY,
         // Result limit
         limit in 1..=50usize,
+        mut gucs in any::<PgGucs>(),
     )| {
         // DISTINCT + expression ORDER BY requires projecting the expression in SELECT,
         // which JoinScan doesn't support yet. Skip this combination.
@@ -753,10 +754,7 @@ async fn generated_joinscan(database: Db) {
         let order_by = order_parts.join(", ");
 
         // GUCs with JoinScan enabled
-        let gucs = PgGucs {
-            join_custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.join_custom_scan = true;
 
         // PostgreSQL native join query
         let pg_query = format!(
@@ -872,6 +870,7 @@ async fn generated_aggregate_join(database: Db) {
                 "MAX(users.rating)",
             ],
         ),
+        mut gucs in any::<PgGucs>(),
     )| {
         // Build join with selected number of tables
         let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
@@ -910,12 +909,9 @@ async fn generated_aggregate_join(database: Db) {
         );
 
         // GUCs: enable both join and aggregate custom scans
-        let gucs = PgGucs {
-            aggregate_custom_scan: true,
-            join_custom_scan: true,
-            custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.aggregate_custom_scan = true;
+        gucs.join_custom_scan = true;
+        gucs.custom_scan = true;
 
         compare(
             &pg_query,
@@ -990,6 +986,7 @@ async fn generated_aggregate_join_distinct(database: Db) {
                 "AVG(DISTINCT users.age)",
             ],
         ),
+        mut gucs in any::<PgGucs>(),
     )| {
         let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
 
@@ -1020,12 +1017,9 @@ async fn generated_aggregate_join_distinct(database: Db) {
             "SELECT {select_list} {join_clause} WHERE {bm25_where} {group_by_clause}"
         );
 
-        let gucs = PgGucs {
-            aggregate_custom_scan: true,
-            join_custom_scan: true,
-            custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.aggregate_custom_scan = true;
+        gucs.join_custom_scan = true;
+        gucs.custom_scan = true;
 
         compare(
             &pg_query,
@@ -1225,6 +1219,7 @@ async fn generated_join_aggregates(database: Db) {
             grouping_columns.clone(),
             vec!["COUNT(*)", "SUM(users.age)", "AVG(users.age)", "MIN(users.rating)", "MAX(users.rating)"],
         ),
+        mut gucs in any::<PgGucs>(),
     )| {
         // Generate join expression (INNER JOIN only)
         let join = arb_joins(
@@ -1260,12 +1255,9 @@ async fn generated_join_aggregates(database: Db) {
         );
 
         // GUCs: enable both join and aggregate custom scans
-        let gucs = PgGucs {
-            aggregate_custom_scan: true,
-            join_custom_scan: true,
-            custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.aggregate_custom_scan = true;
+        gucs.join_custom_scan = true;
+        gucs.custom_scan = true;
 
         compare(
             &pg_query,
@@ -1432,6 +1424,7 @@ async fn generated_joinscan_semi_like(database: Db) {
         nested_join in proptest::option::of(arb_semi_joins(all_tables.clone(), join_key_columns.clone())),
         nested_term in proptest::sample::select(search_terms.clone()),
         nested_is_anti in proptest::bool::ANY,
+        mut gucs in any::<PgGucs>(),
     )| {
         let outer = semi_join.outer_table();
         let inner = semi_join.inner_table();
@@ -1518,10 +1511,7 @@ async fn generated_joinscan_semi_like(database: Db) {
         );
 
         for join_custom_scan in [false, true] {
-            let gucs = PgGucs {
-                join_custom_scan,
-                ..PgGucs::default()
-            };
+            gucs.join_custom_scan = join_custom_scan;
 
             compare(
                 &pg_query,


### PR DESCRIPTION
# Ticket(s) Closed

- (none — diagnostic PR, do not merge)

## What

Rebases #5163 (stuhood's MPP proptest enablement) onto #5167 (Plan A per-source segment coordination) to verify Plan A actually fixes the correctness issues the proptests are catching.

## Why

#5163 enables MPP in the qgen proptests and currently fails all 6 test jobs on main. If Plan A is the correct fix, the same proptests should pass with Plan A's per-source segment coordination underneath.

## How

Branch `moe/mpp-proptests-on-plan-a` = `moe/mpp-plan-a-per-source-segments` + cherry-pick of `9237aba64` + `b0172a707` from `stuhood.mpp-proptests`.

Four commits ahead of main:

```
19b5b4f89 Do not activate the mpp scan if there are not sufficient workers at planning time to execute it.
72e55286f Do not implement `Default` for `PgGucs`, as it is too likely to accidentally abuse in tests.
ed1c87b89 fix(mpp): per-source segment coordination in ParallelScanState
```

(plus origin/main as the fourth)

## Tests

CI is the test. If pg_search tests pass on this branch (where they currently fail on #5163), Plan A is confirmed to fix the correctness issues #5163's proptest is catching.