### PR TITLE
fix(joinscan): preserve cross-table OR pushed into sub-join joinrestrictinfo.

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -342,6 +342,7 @@ unsafe fn build_relnode_from_fromexpr(
             right,
             equi_keys: Vec::new(),
             filter: None,
+            absorbed_search_clauses: Vec::new(),
             subplan_id: None,
         }));
     }
@@ -560,6 +561,7 @@ unsafe fn build_join_node(
         equi_keys,
         filter: None,
         subplan_id: None,
+        absorbed_search_clauses: Vec::new(),
     })))
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -697,19 +697,16 @@ pub struct JoinNode {
     /// `wrap_with_semi_anti` and `wrap_with_mark_filter`; `None` for joins
     /// that come from the normal join-hook path or path reconstruction.
     pub subplan_id: Option<i32>,
-    /// PG files a `WHERE` clause at the lowest join with all its relations.
-    /// `collect_join_sources_join_rel` (the producer) parks `@@@`
-    /// `RestrictInfo`s here when no `JoinCSClause` exists yet to receive
-    /// interned `plan_position`s. `lower_absorbed_search_clauses` (the
-    /// consumer) drains the field once one does, leaving it empty everywhere
-    /// after the outer hook returns.
-    ///
-    /// Stored as `usize` so the public field signature doesn't leak a raw
-    /// pointer type that would force every downstream walker to be `unsafe`.
-    /// The field is `serde(skip)` so the pointers never reach a serialized
-    /// plan.
-    #[serde(skip, default)]
-    pub absorbed_search_clauses: Vec<usize>,
+    /// Cross-table `@@@` predicates that PG placed on this sub-join's
+    /// `joinrestrictinfo`. The reconstruction in
+    /// `collect_join_sources_join_rel` parks them here because no
+    /// `JoinCSClause` exists yet to receive interned `plan_position`s;
+    /// `lower_absorbed_search_clauses` drains the field once one does, so
+    /// the vector is empty by the time the outer hook returns.
+    /// `#[serde(skip)]` because the pointers are valid only within this
+    /// planning pass and never reach the serialized plan.
+    #[serde(skip)]
+    pub absorbed_search_clauses: Vec<*mut pg_sys::RestrictInfo>,
 }
 
 /// A filter node in the relational plan tree.

--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -697,6 +697,19 @@ pub struct JoinNode {
     /// `wrap_with_semi_anti` and `wrap_with_mark_filter`; `None` for joins
     /// that come from the normal join-hook path or path reconstruction.
     pub subplan_id: Option<i32>,
+    /// PG files a `WHERE` clause at the lowest join with all its relations.
+    /// `collect_join_sources_join_rel` (the producer) parks `@@@`
+    /// `RestrictInfo`s here when no `JoinCSClause` exists yet to receive
+    /// interned `plan_position`s. `lower_absorbed_search_clauses` (the
+    /// consumer) drains the field once one does, leaving it empty everywhere
+    /// after the outer hook returns.
+    ///
+    /// Stored as `usize` so the public field signature doesn't leak a raw
+    /// pointer type that would force every downstream walker to be `unsafe`.
+    /// The field is `serde(skip)` so the pointers never reach a serialized
+    /// plan.
+    #[serde(skip, default)]
+    pub absorbed_search_clauses: Vec<usize>,
 }
 
 /// A filter node in the relational plan tree.

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -2026,10 +2026,13 @@ impl JoinScan {
             let search_op = crate::api::operator::anyelement_query_input_opoid();
             for ri in join_conditions.other_conditions {
                 let clause = (*ri).clause;
-                // The disjunction absorber lowers via
-                // `PredicateTranslator::can_translate`, which doesn't recognize
-                // `@@@`. Pass these through to `extract_join_level_conditions`
-                // below; `transform_to_search_expr` handles them there.
+                // Skip `@@@` (and any of our search ops, all of which the
+                // simplifier has rewritten to `@@@` by now): the
+                // Semi/Anti absorption path lowers via
+                // `PredicateTranslator::can_translate`, which only
+                // recognizes non-search predicates. Search clauses pass
+                // through to `extract_join_level_conditions`, where
+                // `transform_to_search_expr` handles them.
                 if !clause.is_null() && expr_contains_any_operator(clause.cast(), &[search_op]) {
                     continue;
                 }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -160,6 +160,7 @@ use self::privdat::PrivateData;
 use crate::postgres::customscan::datafusion::explain::{format_join_level_expr, get_attname_safe};
 use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
 use crate::postgres::customscan::pullup::resolve_fast_field;
+use crate::postgres::utils::expr_contains_any_operator;
 
 use self::scan_state::{
     build_joinscan_logical_plan, build_physical_plan, build_task_context,
@@ -2022,8 +2023,16 @@ impl JoinScan {
             let mut absorbed_clauses: Vec<*mut pg_sys::Node> = Vec::new();
             let mut remaining: Vec<*mut pg_sys::RestrictInfo> =
                 Vec::with_capacity(join_conditions.other_conditions.len());
+            let search_op = crate::api::operator::anyelement_query_input_opoid();
             for ri in join_conditions.other_conditions {
                 let clause = (*ri).clause;
+                // The disjunction absorber lowers via
+                // `PredicateTranslator::can_translate`, which doesn't recognize
+                // `@@@`. Pass these through to `extract_join_level_conditions`
+                // below; `transform_to_search_expr` handles them there.
+                if !clause.is_null() && expr_contains_any_operator(clause.cast(), &[search_op]) {
+                    continue;
+                }
                 if clause.is_null()
                     || !all_vars_are_fast_fields_recursive(clause.cast(), &current_sources)
                     || !PredicateTranslator::can_translate(&current_sources, clause.cast())
@@ -2087,6 +2096,7 @@ impl JoinScan {
             equi_keys: join_conditions.equi_keys,
             filter: initial_filter,
             subplan_id: None,
+            absorbed_search_clauses: Vec::new(),
         }));
 
         let unsupported = plan.unsupported_join_types();

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -603,18 +603,24 @@ unsafe fn collect_join_sources_join_rel(
             return None;
         }
 
-        // PG files a `WHERE` clause at the lowest join with all its relations,
-        // so a cross-table `OR` over outer-side relations lands in *this*
-        // sub-join's `joinrestrictinfo`. Without a `JoinCSClause` we can't
-        // intern them yet; park the pointers and let
-        // `extract_join_level_conditions` lower them once one exists.
+        // PG places each `WHERE` predicate at the lowest join carrying all
+        // its rels, so a cross-table `OR` over the outer-side rels lands in
+        // *this* sub-join's `joinrestrictinfo`. We can't intern it yet (no
+        // `JoinCSClause` exists at reconstruction time); park the pointers
+        // and let `extract_join_level_conditions` lower them once one does.
+        //
+        // `@@@` is the only search op visible here: PG's
+        // `SupportRequestSimplify` has already rewritten `|||`/`&&&`/`===`/
+        // `###` to `@@@`, and `##`/`##>` appear as arguments inside an
+        // `@@@`, not as standalone predicates. Same convention as
+        // `transform_to_search_expr`.
         let search_op = anyelement_query_input_opoid();
-        let mut absorbed_search_clauses: Vec<usize> = Vec::new();
+        let mut absorbed_search_clauses: Vec<*mut pg_sys::RestrictInfo> = Vec::new();
         let mut has_non_search_leftover = false;
         for ri in &join_conditions.other_conditions {
             let clause = (**ri).clause;
             if !clause.is_null() && expr_contains_any_operator(clause.cast(), &[search_op]) {
-                absorbed_search_clauses.push(*ri as usize);
+                absorbed_search_clauses.push(*ri);
             } else {
                 has_non_search_leftover = true;
             }

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -113,8 +113,10 @@ pub(super) unsafe fn expr_uses_scores_from_source(
 pub(super) struct JoinConditions {
     /// Equi-join keys with type info for composite key extraction.
     pub equi_keys: Vec<JoinKeyPair>,
-    /// Other join conditions (non-equijoin) that need to be evaluated after join.
-    /// These are the RestrictInfo nodes themselves.
+    /// Every non-equijoin clause, `@@@` included. The producer keeps the two
+    /// kinds in one list so a future consumer can't silently lose `@@@`
+    /// clauses by forgetting they exist; each consumer decides explicitly
+    /// what it accepts.
     pub other_conditions: Vec<*mut pg_sys::RestrictInfo>,
     /// Whether any join-level condition contains our @@@ operator.
     pub has_search_predicate: bool,
@@ -456,6 +458,7 @@ pub unsafe fn wrap_with_semi_anti(
             equi_keys: equi_keys.clone(),
             filter: None,
             subplan_id: Some(plan_id),
+            absorbed_search_clauses: Vec::new(),
         };
 
         all_keys.extend(equi_keys);
@@ -506,6 +509,7 @@ unsafe fn wrap_with_mark_filter(
             equi_keys: equi_keys.clone(),
             filter: None,
             subplan_id: Some(plan_id),
+            absorbed_search_clauses: Vec::new(),
         };
 
         all_keys.extend(equi_keys);
@@ -599,8 +603,23 @@ unsafe fn collect_join_sources_join_rel(
             return None;
         }
 
-        // Reject if there are other conditions (filters) we can't handle yet
-        if !join_conditions.other_conditions.is_empty() {
+        // PG files a `WHERE` clause at the lowest join with all its relations,
+        // so a cross-table `OR` over outer-side relations lands in *this*
+        // sub-join's `joinrestrictinfo`. Without a `JoinCSClause` we can't
+        // intern them yet; park the pointers and let
+        // `extract_join_level_conditions` lower them once one exists.
+        let search_op = anyelement_query_input_opoid();
+        let mut absorbed_search_clauses: Vec<usize> = Vec::new();
+        let mut has_non_search_leftover = false;
+        for ri in &join_conditions.other_conditions {
+            let clause = (**ri).clause;
+            if !clause.is_null() && expr_contains_any_operator(clause.cast(), &[search_op]) {
+                absorbed_search_clauses.push(*ri as usize);
+            } else {
+                has_non_search_leftover = true;
+            }
+        }
+        if has_non_search_leftover {
             return None;
         }
 
@@ -647,6 +666,18 @@ unsafe fn collect_join_sources_join_rel(
                 return None;
             }
         };
+
+        // Inner is the only join type where wrapping the reconstructed join in
+        // a `RelNode::Filter` is semantically equivalent. Outer joins
+        // (Left/Right/Full) would drop outer-fill rows the post-Filter
+        // shouldn't see; pruned-side joins (Semi/Anti/Mark, both directions)
+        // would leave Vars unresolved against the pruned schema;
+        // UniqueOuter/UniqueInner aren't lowerable to DataFusion at all.
+        if !absorbed_search_clauses.is_empty() && !matches!(parsed_jointype, build::JoinType::Inner)
+        {
+            return None;
+        }
+
         let join_node = crate::postgres::customscan::joinscan::build::JoinNode {
             join_type: parsed_jointype,
             left: outer_node,
@@ -654,6 +685,7 @@ unsafe fn collect_join_sources_join_rel(
             equi_keys: join_conditions.equi_keys.clone(),
             filter: None,
             subplan_id: None,
+            absorbed_search_clauses,
         };
 
         keys.extend(join_conditions.equi_keys);
@@ -1059,7 +1091,7 @@ unsafe fn extract_join_conditions_from_list(
             is_equi_join = true;
         }
 
-        if !is_equi_join && !has_search_op {
+        if !is_equi_join {
             result.other_conditions.push(ri);
         }
     }

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -27,7 +27,9 @@
 //! - Cross-relation heap conditions (evaluated by PostgreSQL)
 //! - Boolean expression trees (AND/OR/NOT)
 
-use super::build::{JoinCSClause, JoinLevelExpr, JoinSource, ScanInfo};
+use super::build::{
+    FilterNode, JoinCSClause, JoinLevelExpr, JoinNode, JoinSource, RelNode, ScanInfo,
+};
 use crate::api::operator::anyelement_query_input_opoid;
 use crate::postgres::customscan::builders::custom_path::RestrictInfoType;
 use crate::postgres::customscan::datafusion::explain::format_expr_for_explain;
@@ -49,6 +51,11 @@ use pgrx::{pg_sys, PgList};
 /// - Cross-relation conditions: transformed into MultiTablePredicate nodes
 /// - Boolean expressions: recursively processed to preserve structure
 ///
+/// `JoinNode.absorbed_search_clauses` carries `@@@` `RestrictInfo`s parked
+/// during sub-join reconstruction. This is the first point a `JoinCSClause`
+/// exists to receive the interned predicates, so we drain them here before
+/// the regular `extra->restrictlist` walk.
+///
 /// Returns the updated JoinCSClause and a list of heap condition clause pointers
 /// (in the same order as multi_table_predicates in the clause) for adding to custom_exprs.
 pub unsafe fn extract_join_level_conditions(
@@ -60,7 +67,25 @@ pub unsafe fn extract_join_level_conditions(
 ) -> Result<(JoinCSClause, Vec<*mut pg_sys::Expr>), String> {
     let mut multi_table_predicate_clauses: Vec<*mut pg_sys::Expr> = Vec::new();
 
-    if extra.is_null() || sources.is_empty() {
+    if sources.is_empty() {
+        return Ok((join_clause, multi_table_predicate_clauses));
+    }
+
+    // The absorbed-clause walk is independent of `extra`: it mutates
+    // `join_clause.plan` and `join_clause.join_level_predicates` from each
+    // sub-join's `joinrestrictinfo`. PG files each clause at its lowest
+    // applicable join, and the absorbed path only runs on Inner sub-joins
+    // (the Inner-only gate in `collect_join_sources_join_rel`), so in
+    // practice the two passes process disjoint clause sets.
+    let new_plan = lower_absorbed_search_clauses(
+        root,
+        std::mem::take(&mut join_clause.plan),
+        &mut join_clause,
+        &mut multi_table_predicate_clauses,
+    )?;
+    join_clause.plan = new_plan;
+
+    if extra.is_null() {
         return Ok((join_clause, multi_table_predicate_clauses));
     }
 
@@ -349,6 +374,134 @@ pub unsafe fn extract_single_table_predicate(
 
     let idx = join_clause.add_join_level_predicate(rti, indexrelid, heaprelid, query, display_str);
     Some(idx)
+}
+
+/// Sub-join reconstruction stashes `@@@` `RestrictInfo`s onto
+/// `JoinNode.absorbed_search_clauses` without lowering them, because no
+/// `JoinCSClause` exists yet to receive interned `plan_position`s. Once one
+/// does, walking the tree converts each entry into a `RelNode::Filter`
+/// wrapping the absorbing `JoinNode`.
+pub(super) unsafe fn lower_absorbed_search_clauses(
+    root: *mut pg_sys::PlannerInfo,
+    node: RelNode,
+    join_clause: &mut JoinCSClause,
+    multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
+) -> Result<RelNode, String> {
+    match node {
+        RelNode::Scan(s) => Ok(RelNode::Scan(s)),
+        RelNode::Filter(mut f) => {
+            recurse_into(
+                root,
+                &mut f.input,
+                join_clause,
+                multi_table_predicate_clauses,
+            )?;
+            Ok(RelNode::Filter(f))
+        }
+        RelNode::Join(mut j) => {
+            recurse_into(
+                root,
+                &mut j.left,
+                join_clause,
+                multi_table_predicate_clauses,
+            )?;
+            recurse_into(
+                root,
+                &mut j.right,
+                join_clause,
+                multi_table_predicate_clauses,
+            )?;
+
+            // Drain before any fallible step: the field is `#[serde(skip)]`
+            // and an error path that left it populated would mean the
+            // pointers got dropped on the floor on the next plan walk.
+            let absorbed = std::mem::take(&mut j.absorbed_search_clauses);
+            if absorbed.is_empty() {
+                return Ok(RelNode::Join(j));
+            }
+
+            let predicate = build_absorbed_filter(
+                root,
+                &j,
+                &absorbed,
+                join_clause,
+                multi_table_predicate_clauses,
+            )?;
+            Ok(RelNode::Filter(Box::new(FilterNode {
+                input: RelNode::Join(j),
+                predicate,
+            })))
+        }
+    }
+}
+
+/// `RelNode` moves through this rewrite by value; an `&mut RelNode` slot needs
+/// a placeholder while the taken value transforms, and forgetting the reassign
+/// step would leave a `Default::default()` shard in the tree.
+unsafe fn recurse_into(
+    root: *mut pg_sys::PlannerInfo,
+    slot: &mut RelNode,
+    join_clause: &mut JoinCSClause,
+    multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
+) -> Result<(), String> {
+    let taken = std::mem::take(slot);
+    *slot = lower_absorbed_search_clauses(root, taken, join_clause, multi_table_predicate_clauses)?;
+    Ok(())
+}
+
+/// `absorbed` was populated from a live `joinrestrictinfo` minutes ago in the
+/// same planning pass; every entry should still translate. We error rather
+/// than skip so a future refactor that drops a clause on the floor blows up
+/// the test suite instead of producing wrong rows.
+unsafe fn build_absorbed_filter(
+    root: *mut pg_sys::PlannerInfo,
+    join: &JoinNode,
+    absorbed: &[usize],
+    join_clause: &mut JoinCSClause,
+    multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
+) -> Result<JoinLevelExpr, String> {
+    // PG files RestrictInfo clauses against RTIs in the sub-tree, so the
+    // sources we need to resolve them against are everything below.
+    let mut sub_sources = join.left.sources();
+    sub_sources.extend(join.right.sources());
+
+    let expr_trees: Vec<JoinLevelExpr> = absorbed
+        .iter()
+        .copied()
+        .map(|ri_usize| {
+            let ri = ri_usize as *mut pg_sys::RestrictInfo;
+            if ri.is_null() {
+                return Err("absorbed search clause is a null RestrictInfo".to_string());
+            }
+            let clause = (*ri).clause;
+            if clause.is_null() {
+                return Err("absorbed search clause has a null clause".to_string());
+            }
+            transform_to_search_expr(
+                root,
+                clause.cast(),
+                &sub_sources,
+                join_clause,
+                multi_table_predicate_clauses,
+            )
+            .ok_or_else(|| {
+                format!(
+                    "Failed to lower absorbed search clause: {}",
+                    format_expr_for_explain(clause.cast()).as_str()
+                )
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    // Caller guarantees `absorbed` is non-empty; collect either yielded N
+    // entries or short-circuited with `Err`. An empty result here would
+    // otherwise lower to `And(vec![])`, which evaluates to TRUE and silently
+    // wipes the WHERE.
+    match expr_trees.len() {
+        0 => Err("absorbed clause set lowered to empty expr tree".to_string()),
+        1 => Ok(expr_trees.into_iter().next().unwrap()),
+        _ => Ok(JoinLevelExpr::And(expr_trees)),
+    }
 }
 
 /// Check if all Var references in an expression are fast fields.

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -73,7 +73,7 @@ pub unsafe fn extract_join_level_conditions(
 
     // The absorbed-clause walk is independent of `extra`: it mutates
     // `join_clause.plan` and `join_clause.join_level_predicates` from each
-    // sub-join's `joinrestrictinfo`. PG files each clause at its lowest
+    // sub-join's `joinrestrictinfo`. PG places each clause at its lowest
     // applicable join, and the absorbed path only runs on Inner sub-joins
     // (the Inner-only gate in `collect_join_sources_join_rel`), so in
     // practice the two passes process disjoint clause sets.
@@ -389,87 +389,94 @@ pub(super) unsafe fn lower_absorbed_search_clauses(
 ) -> Result<RelNode, String> {
     match node {
         RelNode::Scan(s) => Ok(RelNode::Scan(s)),
-        RelNode::Filter(mut f) => {
-            recurse_into(
+        RelNode::Filter(f) => {
+            let FilterNode { input, predicate } = *f;
+            let input = lower_absorbed_search_clauses(
                 root,
-                &mut f.input,
+                input,
                 join_clause,
                 multi_table_predicate_clauses,
             )?;
-            Ok(RelNode::Filter(f))
+            Ok(RelNode::Filter(Box::new(FilterNode { input, predicate })))
         }
-        RelNode::Join(mut j) => {
-            recurse_into(
+        RelNode::Join(j) => {
+            let JoinNode {
+                join_type,
+                left,
+                right,
+                equi_keys,
+                filter,
+                subplan_id,
+                absorbed_search_clauses,
+            } = *j;
+            let left = lower_absorbed_search_clauses(
                 root,
-                &mut j.left,
+                left,
                 join_clause,
                 multi_table_predicate_clauses,
             )?;
-            recurse_into(
+            let right = lower_absorbed_search_clauses(
                 root,
-                &mut j.right,
+                right,
                 join_clause,
                 multi_table_predicate_clauses,
             )?;
 
-            // Drain before any fallible step: the field is `#[serde(skip)]`
-            // and an error path that left it populated would mean the
-            // pointers got dropped on the floor on the next plan walk.
-            let absorbed = std::mem::take(&mut j.absorbed_search_clauses);
-            if absorbed.is_empty() {
-                return Ok(RelNode::Join(j));
+            if absorbed_search_clauses.is_empty() {
+                return Ok(RelNode::Join(Box::new(JoinNode {
+                    join_type,
+                    left,
+                    right,
+                    equi_keys,
+                    filter,
+                    subplan_id,
+                    absorbed_search_clauses: Vec::new(),
+                })));
             }
+
+            // PG anchors `RestrictInfo`s against RTIs from the sub-tree, so
+            // resolve against everything reachable below this join.
+            let mut sub_sources = left.sources();
+            sub_sources.extend(right.sources());
 
             let predicate = build_absorbed_filter(
                 root,
-                &j,
-                &absorbed,
+                &sub_sources,
+                &absorbed_search_clauses,
                 join_clause,
                 multi_table_predicate_clauses,
             )?;
             Ok(RelNode::Filter(Box::new(FilterNode {
-                input: RelNode::Join(j),
+                input: RelNode::Join(Box::new(JoinNode {
+                    join_type,
+                    left,
+                    right,
+                    equi_keys,
+                    filter,
+                    subplan_id,
+                    absorbed_search_clauses: Vec::new(),
+                })),
                 predicate,
             })))
         }
     }
 }
 
-/// `RelNode` moves through this rewrite by value; an `&mut RelNode` slot needs
-/// a placeholder while the taken value transforms, and forgetting the reassign
-/// step would leave a `Default::default()` shard in the tree.
-unsafe fn recurse_into(
-    root: *mut pg_sys::PlannerInfo,
-    slot: &mut RelNode,
-    join_clause: &mut JoinCSClause,
-    multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
-) -> Result<(), String> {
-    let taken = std::mem::take(slot);
-    *slot = lower_absorbed_search_clauses(root, taken, join_clause, multi_table_predicate_clauses)?;
-    Ok(())
-}
-
-/// `absorbed` was populated from a live `joinrestrictinfo` minutes ago in the
-/// same planning pass; every entry should still translate. We error rather
-/// than skip so a future refactor that drops a clause on the floor blows up
-/// the test suite instead of producing wrong rows.
+/// `absorbed` was populated from a live `joinrestrictinfo` earlier in the
+/// same planning pass, so every entry should still translate. We error
+/// rather than skip so a future refactor that drops a clause on the floor
+/// blows up the test suite instead of producing wrong rows.
 unsafe fn build_absorbed_filter(
     root: *mut pg_sys::PlannerInfo,
-    join: &JoinNode,
-    absorbed: &[usize],
+    sub_sources: &[&JoinSource],
+    absorbed: &[*mut pg_sys::RestrictInfo],
     join_clause: &mut JoinCSClause,
     multi_table_predicate_clauses: &mut Vec<*mut pg_sys::Expr>,
 ) -> Result<JoinLevelExpr, String> {
-    // PG files RestrictInfo clauses against RTIs in the sub-tree, so the
-    // sources we need to resolve them against are everything below.
-    let mut sub_sources = join.left.sources();
-    sub_sources.extend(join.right.sources());
-
     let expr_trees: Vec<JoinLevelExpr> = absorbed
         .iter()
         .copied()
-        .map(|ri_usize| {
-            let ri = ri_usize as *mut pg_sys::RestrictInfo;
+        .map(|ri| {
             if ri.is_null() {
                 return Err("absorbed search clause is a null RestrictInfo".to_string());
             }
@@ -480,7 +487,7 @@ unsafe fn build_absorbed_filter(
             transform_to_search_expr(
                 root,
                 clause.cast(),
-                &sub_sources,
+                sub_sources,
                 join_clause,
                 multi_table_predicate_clauses,
             )
@@ -493,10 +500,10 @@ unsafe fn build_absorbed_filter(
         })
         .collect::<Result<_, _>>()?;
 
-    // Caller guarantees `absorbed` is non-empty; collect either yielded N
-    // entries or short-circuited with `Err`. An empty result here would
-    // otherwise lower to `And(vec![])`, which evaluates to TRUE and silently
-    // wipes the WHERE.
+    // Caller guarantees `absorbed` is non-empty; `collect` either yielded
+    // N entries or short-circuited with `Err`. An empty result here would
+    // otherwise lower to `And(vec![])`, which evaluates to TRUE and
+    // silently wipes the WHERE.
     match expr_trees.len() {
         0 => Err("absorbed clause set lowered to empty expr tree".to_string()),
         1 => Ok(expr_trees.into_iter().next().unwrap()),

--- a/pg_search/tests/pg_regress/expected/joinscan_cross_table_or.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_cross_table_or.out
@@ -64,8 +64,8 @@ SELECT 'PG' AS source, users.id AS uid, users.name AS uname,
        products.id AS pid, products.name AS pname, orders.id AS oid
 FROM orders JOIN (products JOIN users ON users.id = products.id)
        ON products.age = orders.age
-WHERE (users.name = 'bob') AND (users.name = 'bob')
-  AND (NOT (products.name = 'bob')) OR (products.name = 'bob')
+WHERE (users.name = 'bob') AND (NOT (products.name = 'bob'))
+   OR (products.name = 'bob')
 ORDER BY users.id, products.id, orders.id LIMIT 20;
  source | uid | uname | pid | pname | oid 
 --------+-----+-------+-----+-------+-----
@@ -81,11 +81,11 @@ SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
        products.id AS pid, products.name AS pname, orders.id AS oid
 FROM orders JOIN (products JOIN users ON users.id = products.id)
        ON products.age = orders.age
-WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
-  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+WHERE (users.name @@@ 'bob') AND (NOT (products.name @@@ 'bob'))
+   OR (products.name @@@ 'bob')
 ORDER BY users.id, products.id, orders.id LIMIT 20;
-                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                 
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                                                                                                        QUERY PLAN                                                                                                                                                                                                                                                                                                                                                                         
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Result
          ->  Custom Scan (ParadeDB Join Scan)
@@ -98,11 +98,11 @@ ORDER BY users.id, products.id, orders.id LIMIT 20;
                  :   SortExec: TopK(fetch=20), expr=[id@1 ASC NULLS LAST, id@5 ASC NULLS LAST], preserve_partitioning=[false]
                  :     VisibilityFilterExec: tables=[users, products, orders]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@3, age@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4, ctid_2@5, id@7]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@2)]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@2)], filter=pdb_search_predicate(ctid_0@0) AND pdb_search_predicate(ctid_1@1) OR pdb_search_predicate(ctid_1@1)
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"should":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"boolean":{"should":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"should":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}]}}
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (19 rows)
@@ -111,17 +111,14 @@ SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
        products.id AS pid, products.name AS pname, orders.id AS oid
 FROM orders JOIN (products JOIN users ON users.id = products.id)
        ON products.age = orders.age
-WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
-  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+WHERE (users.name @@@ 'bob') AND (NOT (products.name @@@ 'bob'))
+   OR (products.name @@@ 'bob')
 ORDER BY users.id, products.id, orders.id LIMIT 20;
- source | uid | uname  | pid |  pname  | oid 
---------+-----+--------+-----+---------+-----
- BM25   |   1 | bob    |   1 | cloe    | 101
- BM25   |   2 | alice  |   2 | alice   | 102
- BM25   |   3 | cloe   |   3 | sally   | 103
- BM25   |   4 | brandy |   4 | brisket | 104
- BM25   |   5 | sally  |   5 | bob     | 105
-(5 rows)
+ source | uid | uname | pid | pname | oid 
+--------+-----+-------+-----+-------+-----
+ BM25   |   1 | bob   |   1 | cloe  | 101
+ BM25   |   5 | sally |   5 | bob   | 105
+(2 rows)
 
 DROP TABLE users CASCADE;
 DROP TABLE products CASCADE;

--- a/pg_search/tests/pg_regress/expected/joinscan_cross_table_or.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_cross_table_or.out
@@ -1,0 +1,128 @@
+-- Regression test for issue 5177.
+-- When `WHERE` has a cross-table OR like `(u.name @@@ 'bob') OR (p.name @@@ 'bob')`
+-- and PG pushes that OR into an inner sub-join's `joinrestrictinfo`, the outer
+-- JoinScan's path reconstruction silently dropped `RestrictInfo` clauses that
+-- contain `@@@`. The cross-table OR was then lost and the WHERE was effectively
+-- dropped: BM25 returned join pairs where neither name matched 'bob'.
+-- Disable parallel to keep the plan deterministic.
+SET max_parallel_workers = 0;
+SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+CREATE INDEX idxusers ON users USING bm25 (id, name)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true}}');
+CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, age INTEGER);
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE TABLE orders (id INTEGER PRIMARY KEY, age INTEGER);
+CREATE INDEX idxorders ON orders USING bm25 (id, age)
+  WITH (key_field = 'id', numeric_fields = '{"age": {"fast": true}}');
+-- Joinable on users.id = products.id and products.age = orders.age.
+-- For each (u, p, o) triple, only some satisfy `u.name='bob' OR p.name='bob'`.
+INSERT INTO users (id, name) VALUES
+    (1, 'bob'),      -- satisfies via u.name
+    (2, 'alice'),    -- not 'bob'
+    (3, 'cloe'),     -- not 'bob'
+    (4, 'brandy'),   -- not 'bob'
+    (5, 'sally');    -- satisfies (because products.id=5 is 'bob')
+INSERT INTO products (id, name, age) VALUES
+    (1, 'cloe',   10),  -- name not 'bob', but pairs with u=1 ('bob') so OR holds
+    (2, 'alice',  20),  -- neither 'bob'
+    (3, 'sally',  30),  -- neither 'bob'
+    (4, 'brisket',40),  -- neither 'bob'
+    (5, 'bob',    50);  -- name='bob', satisfies OR
+INSERT INTO orders (id, age) VALUES
+    (101, 10),
+    (102, 20),
+    (103, 30),
+    (104, 40),
+    (105, 50);
+ANALYZE users;
+ANALYZE products;
+ANALYZE orders;
+SET paradedb.enable_aggregate_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.enable_fast_field_exec = on;
+SET paradedb.enable_columnar_sort = off;
+SET paradedb.enable_mpp = off;
+-- Force the (products INNER users) sub-join order so PG pushes the cross-table
+-- OR down into the sub-join's `joinrestrictinfo`. Without this nesting the
+-- planner places the OR on the outer join and the bug doesn't surface.
+SET join_collapse_limit = 1;
+SET from_collapse_limit = 1;
+-- Reference plan via vanilla PG.
+SET paradedb.enable_aggregate_custom_scan = off;
+SET paradedb.enable_join_custom_scan = off;
+SELECT 'PG' AS source, users.id AS uid, users.name AS uname,
+       products.id AS pid, products.name AS pname, orders.id AS oid
+FROM orders JOIN (products JOIN users ON users.id = products.id)
+       ON products.age = orders.age
+WHERE (users.name = 'bob') AND (users.name = 'bob')
+  AND (NOT (products.name = 'bob')) OR (products.name = 'bob')
+ORDER BY users.id, products.id, orders.id LIMIT 20;
+ source | uid | uname | pid | pname | oid 
+--------+-----+-------+-----+-------+-----
+ PG     |   1 | bob   |   1 | cloe  | 101
+ PG     |   5 | sally |   5 | bob   | 105
+(2 rows)
+
+-- BM25 path with JoinScan.
+SET paradedb.enable_aggregate_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
+       products.id AS pid, products.name AS pname, orders.id AS oid
+FROM orders JOIN (products JOIN users ON users.id = products.id)
+       ON products.age = orders.age
+WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
+  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+ORDER BY users.id, products.id, orders.id LIMIT 20;
+                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Result
+         ->  Custom Scan (ParadeDB Join Scan)
+               Relation Tree: (users INNER products) INNER orders
+               Join Cond: orders.age = products.age, products.id = users.id
+               Limit: 20
+               Order By: users.id asc, orders.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@5 as col_1, id@3 as col_2, NULL as col_3, id@1 as col_4, NULL as col_5, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
+                 :   SortExec: TopK(fetch=20), expr=[id@1 ASC NULLS LAST, id@5 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[users, products, orders]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@3, age@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4, ctid_2@5, id@7]
+                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@2)]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"should":[{"boolean":{"must":["all"],"must_not":[{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(19 rows)
+
+SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
+       products.id AS pid, products.name AS pname, orders.id AS oid
+FROM orders JOIN (products JOIN users ON users.id = products.id)
+       ON products.age = orders.age
+WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
+  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+ORDER BY users.id, products.id, orders.id LIMIT 20;
+ source | uid | uname  | pid |  pname  | oid 
+--------+-----+--------+-----+---------+-----
+ BM25   |   1 | bob    |   1 | cloe    | 101
+ BM25   |   2 | alice  |   2 | alice   | 102
+ BM25   |   3 | cloe   |   3 | sally   | 103
+ BM25   |   4 | brandy |   4 | brisket | 104
+ BM25   |   5 | sally  |   5 | bob     | 105
+(5 rows)
+
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;

--- a/pg_search/tests/pg_regress/sql/joinscan_cross_table_or.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_cross_table_or.sql
@@ -1,0 +1,107 @@
+-- Regression test for issue 5177.
+-- When `WHERE` has a cross-table OR like `(u.name @@@ 'bob') OR (p.name @@@ 'bob')`
+-- and PG pushes that OR into an inner sub-join's `joinrestrictinfo`, the outer
+-- JoinScan's path reconstruction silently dropped `RestrictInfo` clauses that
+-- contain `@@@`. The cross-table OR was then lost and the WHERE was effectively
+-- dropped: BM25 returned join pairs where neither name matched 'bob'.
+
+-- Disable parallel to keep the plan deterministic.
+SET max_parallel_workers = 0;
+SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+
+CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT);
+CREATE INDEX idxusers ON users USING bm25 (id, name)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true}}');
+
+CREATE TABLE products (id INTEGER PRIMARY KEY, name TEXT, age INTEGER);
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+
+CREATE TABLE orders (id INTEGER PRIMARY KEY, age INTEGER);
+CREATE INDEX idxorders ON orders USING bm25 (id, age)
+  WITH (key_field = 'id', numeric_fields = '{"age": {"fast": true}}');
+
+-- Joinable on users.id = products.id and products.age = orders.age.
+-- For each (u, p, o) triple, only some satisfy `u.name='bob' OR p.name='bob'`.
+INSERT INTO users (id, name) VALUES
+    (1, 'bob'),      -- satisfies via u.name
+    (2, 'alice'),    -- not 'bob'
+    (3, 'cloe'),     -- not 'bob'
+    (4, 'brandy'),   -- not 'bob'
+    (5, 'sally');    -- satisfies (because products.id=5 is 'bob')
+
+INSERT INTO products (id, name, age) VALUES
+    (1, 'cloe',   10),  -- name not 'bob', but pairs with u=1 ('bob') so OR holds
+    (2, 'alice',  20),  -- neither 'bob'
+    (3, 'sally',  30),  -- neither 'bob'
+    (4, 'brisket',40),  -- neither 'bob'
+    (5, 'bob',    50);  -- name='bob', satisfies OR
+
+INSERT INTO orders (id, age) VALUES
+    (101, 10),
+    (102, 20),
+    (103, 30),
+    (104, 40),
+    (105, 50);
+
+ANALYZE users;
+ANALYZE products;
+ANALYZE orders;
+
+SET paradedb.enable_aggregate_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.enable_fast_field_exec = on;
+SET paradedb.enable_columnar_sort = off;
+SET paradedb.enable_mpp = off;
+
+-- Force the (products INNER users) sub-join order so PG pushes the cross-table
+-- OR down into the sub-join's `joinrestrictinfo`. Without this nesting the
+-- planner places the OR on the outer join and the bug doesn't surface.
+SET join_collapse_limit = 1;
+SET from_collapse_limit = 1;
+
+-- Reference plan via vanilla PG.
+SET paradedb.enable_aggregate_custom_scan = off;
+SET paradedb.enable_join_custom_scan = off;
+SELECT 'PG' AS source, users.id AS uid, users.name AS uname,
+       products.id AS pid, products.name AS pname, orders.id AS oid
+FROM orders JOIN (products JOIN users ON users.id = products.id)
+       ON products.age = orders.age
+WHERE (users.name = 'bob') AND (users.name = 'bob')
+  AND (NOT (products.name = 'bob')) OR (products.name = 'bob')
+ORDER BY users.id, products.id, orders.id LIMIT 20;
+
+-- BM25 path with JoinScan.
+SET paradedb.enable_aggregate_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
+       products.id AS pid, products.name AS pname, orders.id AS oid
+FROM orders JOIN (products JOIN users ON users.id = products.id)
+       ON products.age = orders.age
+WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
+  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+ORDER BY users.id, products.id, orders.id LIMIT 20;
+
+SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
+       products.id AS pid, products.name AS pname, orders.id AS oid
+FROM orders JOIN (products JOIN users ON users.id = products.id)
+       ON products.age = orders.age
+WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
+  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+ORDER BY users.id, products.id, orders.id LIMIT 20;
+
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;

--- a/pg_search/tests/pg_regress/sql/joinscan_cross_table_or.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_cross_table_or.sql
@@ -77,8 +77,8 @@ SELECT 'PG' AS source, users.id AS uid, users.name AS uname,
        products.id AS pid, products.name AS pname, orders.id AS oid
 FROM orders JOIN (products JOIN users ON users.id = products.id)
        ON products.age = orders.age
-WHERE (users.name = 'bob') AND (users.name = 'bob')
-  AND (NOT (products.name = 'bob')) OR (products.name = 'bob')
+WHERE (users.name = 'bob') AND (NOT (products.name = 'bob'))
+   OR (products.name = 'bob')
 ORDER BY users.id, products.id, orders.id LIMIT 20;
 
 -- BM25 path with JoinScan.
@@ -90,16 +90,16 @@ SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
        products.id AS pid, products.name AS pname, orders.id AS oid
 FROM orders JOIN (products JOIN users ON users.id = products.id)
        ON products.age = orders.age
-WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
-  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+WHERE (users.name @@@ 'bob') AND (NOT (products.name @@@ 'bob'))
+   OR (products.name @@@ 'bob')
 ORDER BY users.id, products.id, orders.id LIMIT 20;
 
 SELECT 'BM25' AS source, users.id AS uid, users.name AS uname,
        products.id AS pid, products.name AS pname, orders.id AS oid
 FROM orders JOIN (products JOIN users ON users.id = products.id)
        ON products.age = orders.age
-WHERE (users.name @@@ 'bob') AND (users.name @@@ 'bob')
-  AND (NOT (products.name @@@ 'bob')) OR (products.name @@@ 'bob')
+WHERE (users.name @@@ 'bob') AND (NOT (products.name @@@ 'bob'))
+   OR (products.name @@@ 'bob')
 ORDER BY users.id, products.id, orders.id LIMIT 20;
 
 DROP TABLE users CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5177

## What

This PR fixes JoinScan dropping cross-table `OR` clauses when PG pushes them into an inner sub-join's `joinrestrictinfo`. Before this fix, BM25 returned join pairs that didn't satisfy the `WHERE`. See #5177 for the SQL repro and the PG vs BM25 row sets.

## Why

PG places a `WHERE` clause at the lowest join level that has all referenced relations. For `WHERE (a.x @@@ ...) OR (b.y @@@ ...)`, that's often an inner sub-join. The inner JoinScan can't fire there (no `LIMIT` on the sub-join), so the outer JoinScan's `collect_join_sources_join_rel` reconstructs that sub-join from PG's standard `JoinPath`. Reconstruction went through `extract_join_conditions_from_list`, which dropped any non-equi clause containing `@@@` (`!is_equi_join && !has_search_op`). The cross-table OR vanished and the WHERE was effectively gone.

The guard made sense when the function had one caller (the outer hook), because `extract_join_level_conditions` handles `@@@` clauses over the same `extra->restrictlist`. When #4039 split the function for multi-way reconstruction, the new caller had no such second pass and the assumption silently broke.

## How

- `extract_join_conditions_from_list` keeps every non-equi clause in `other_conditions`, `@@@` included. Consumers filter as needed.
- `collect_join_sources_join_rel`'s reconstruction partitions: non-search-op clauses still trip the reject gate, `@@@` clauses get stashed on a new `JoinNode.absorbed_search_clauses` field (planning-only, `#[serde(skip)]`).
- `extract_join_level_conditions` runs a pre-pass (`lower_absorbed_search_clauses_node`) that walks the `RelNode` tree, finds `JoinNode`s with absorbed clauses, lowers them into a `RelNode::Filter` via the existing `transform_to_search_expr` (interning predicates into `join_level_predicates`), and drains the field.
- The Semi/Anti disjunction absorber in `try_build_join_custom_path` skips `@@@` clauses so they don't get lowered as generic `PgExpression`s. `extract_join_level_conditions` picks them up.

## Tests

- Added `pg_search/tests/pg_regress/sql/joinscan_cross_table_or.sql`. It pins the join order via subquery nesting + `join_collapse_limit = 1` so PG pushes the OR into the inner sub-join. The first commit locks in the buggy output; the fix commit flips the expected to match PG.