### PR TITLE
ci: Bumped runner volume from 80GB to 100GB.

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -255,7 +255,7 @@ jobs:
       - cpu=16
       - ram=64
       - image=ubuntu24-full-x64
-      - volume=80gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
+      - volume=100gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -49,7 +49,7 @@ jobs:
       - cpu=4
       - ram=16
       - image=${{ matrix.runner_image }}
-      - volume=80gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
+      - volume=100gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -79,7 +79,7 @@ jobs:
       - cpu=8
       - ram=16
       - image=ubuntu24-full-arm64
-      - volume=80gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
+      - volume=100gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     strategy:
       fail-fast: false


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR bumps the `runs-on` runner `volume=` from `80gb` to `100gb` in `test-pg_search-docker.yml`, `test-pg_search-upgrade.yml`, and `antithesis-trigger-test-run.yml`.

## Why

Docker builds, Rust target dirs, system Postgres + extension installs, and `pg_search` segment data add up. We were already at the 80GB volume on these three workflows (the default `runs-on` linux image ships with 40GB), and recent runs have started bumping into that limit. Let's bump to 100GB to give us headroom.

## How

Single-line change in each of the three workflow files. The comment stays the same since the original 40GB default note is still useful context.

## Tests

CI will exercise the larger volume on this PR.