### PR TITLE
ci: Tune runner volume sizes for RunsOn v3

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -255,7 +255,7 @@ jobs:
       - cpu=16
       - ram=64
       - image=ubuntu24-full-x64
-      - volume=100gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
+      - volume=80gb # default runner ships with 30GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -49,7 +49,7 @@ jobs:
       - cpu=4
       - ram=16
       - image=${{ matrix.runner_image }}
-      - volume=100gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
+      - volume=80gb # default runner ships with 30GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -79,7 +79,7 @@ jobs:
       - cpu=8
       - ram=16
       - image=ubuntu24-full-arm64
-      - volume=100gb # default runner ships with 40GB — see https://runs-on.com/runners/linux/
+      - volume=80gb # default runner ships with 30GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     strategy:
       fail-fast: false

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -58,6 +58,7 @@ jobs:
       - cpu=${{ matrix.cpu }}
       - ram=${{ matrix.ram }}
       - image=${{ matrix.runner_image }}
+      - volume=40gb # default runner ships with 30GB — see https://runs-on.com/runners/linux/
       - extras=s3-cache
     if: ${{ !cancelled() }}
     needs: set-matrix


### PR DESCRIPTION
## What

- Add `volume=40gb` to `test-pg_search.yml` (the workflow hitting "No space left on device" on the system-amd64 matrix in [run 26567656910](https://github.com/paradedb/paradedb/actions/runs/26567656910/job/78275926171)).
- Revert the three workflows from #5179 (`test-pg_search-docker.yml`, `test-pg_search-upgrade.yml`, `antithesis-trigger-test-run.yml`) back to `volume=80gb` — 100GB was more headroom than they actually need.
- Refresh the inline comment to reference the new 30GB v3 default (was 40GB in v2).

## Why

The RunsOn v3 stack lowered the default runner root EBS volume from 40GB → 30GB (confirmed in the EC2 console: all runners without an explicit `volume=` label show `gp3 30 GiB`, while a job with `volume=100gb` correctly shows 100 GiB attached). The `volume=` label IS still being honored in v3; the failures were just from workflows that never set it, plus the now-stale comment claiming the default is 40GB.

Other RunsOn workflows (`lint-rust`, `publish-*`, `schemabot`, `test-docs`, `test-stressgres`, etc.) are left at the 30GB default for now and can be bumped individually if/when they start showing disk pressure.

## Tests

- CI on this PR exercises `test-pg_search.yml` with the new 40GB volume.