### PR TITLE
fix(joinscan): recover equi-key from parameterized inner index when joinrestrictinfo is empty.

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -595,7 +595,31 @@ unsafe fn collect_join_sources_join_rel(
 
         // Extract keys for this level
         let join_restrict_info = (*join_path).joinrestrictinfo;
-        let join_conditions = extract_join_conditions_from_list(join_restrict_info, &all_sources);
+        let mut join_conditions =
+            extract_join_conditions_from_list(join_restrict_info, &all_sources);
+
+        // PG drops a join clause from `joinrestrictinfo` when a parameterized
+        // inner index lookup already enforces it (the inner index's `ppi`
+        // clauses become the join condition for the `NestPath`). The clause
+        // still lives on `inner_path->param_info->ppi_clauses` for the base
+        // rel. Pull it in here so we can recover the equi-key. Without this
+        // the 3-way `JoinScan` declines whenever PG picks a parameterized
+        // inner bitmap-index plan.
+        if join_conditions.equi_keys.is_empty() {
+            let inner_param = (*inner_path).param_info;
+            if !inner_param.is_null() {
+                let ppi_clauses = (*inner_param).ppi_clauses;
+                if !ppi_clauses.is_null() {
+                    let extra = extract_join_conditions_from_list(ppi_clauses, &all_sources);
+                    join_conditions.equi_keys.extend(extra.equi_keys);
+                    join_conditions
+                        .other_conditions
+                        .extend(extra.other_conditions);
+                    join_conditions.has_search_predicate =
+                        join_conditions.has_search_predicate || extra.has_search_predicate;
+                }
+            }
+        }
 
         let jointype = (*join_path).jointype;
 

--- a/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
@@ -65,27 +65,27 @@ JOIN products ON users.age = products.age
 JOIN orders ON products.uuid = orders.uuid
 WHERE users.name @@@ 'bob'
 ORDER BY users.id, products.id, orders.id LIMIT 1;
-WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
-                                                                                                        QUERY PLAN                                                                                                         
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                               
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: users.id, products.id, orders.id
-         ->  Nested Loop
-               ->  Nested Loop
-                     ->  Bitmap Heap Scan on users
-                           Recheck Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
-                           ->  Bitmap Index Scan on idxusers
-                                 Index Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
-                     ->  Bitmap Heap Scan on products
-                           Recheck Cond: (users.age = age)
-                           ->  Bitmap Index Scan on idxproducts_age
-                                 Index Cond: (age = users.age)
-               ->  Bitmap Heap Scan on orders
-                     Recheck Cond: (products.uuid = uuid)
-                     ->  Bitmap Index Scan on idxorders_uuid
-                           Index Cond: (uuid = products.uuid)
-(17 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: users INNER (products INNER orders)
+         Join Cond: users.age = products.age, products.uuid = orders.uuid
+         Limit: 1
+         Order By: users.id asc, products.id asc, orders.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, NULL as col_2, id@3 as col_3, id@5 as col_4, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1, ctid_2@4 as ctid_2]
+           :   SortExec: TopK(fetch=1), expr=[id@1 ASC NULLS LAST, id@3 ASC NULLS LAST, id@5 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[users, products, orders]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(uuid@3, uuid@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4, ctid_2@5, id@7]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@1, age@1)], projection=[ctid_0@0, id@2, ctid_1@3, uuid@5, id@6]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
 
 SELECT users.id, users.name
 FROM users
@@ -93,7 +93,6 @@ JOIN products ON users.age = products.age
 JOIN orders ON products.uuid = orders.uuid
 WHERE users.name @@@ 'bob'
 ORDER BY users.id, products.id, orders.id LIMIT 1;
-WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
  id | name 
 ----+------
   1 | bob

--- a/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_null_jri.out
@@ -1,0 +1,104 @@
+-- Regression test: JoinScan declines on a 3-way INNER join when PG picks a
+-- parameterized `NestPath` for the inner sub-join.
+--
+-- This is a JoinScan-activation gap, not a correctness gap. PG's fallback
+-- nested-loop / bitmap plan returns the right rows; JoinScan just never
+-- fires, so the query loses the BM25 join acceleration.
+--
+-- With `enable_seqscan` and `enable_indexscan` off, PG plans the
+-- `(users JOIN products)` sub-join as a `NestPath` whose inner side is a
+-- parameterized bitmap-index lookup on `idxproducts_age`. The join clause
+-- `users.age = products.age` is enforced via that index condition, so PG
+-- leaves `JoinPath.joinrestrictinfo` empty. `collect_join_sources_join_rel`
+-- reads only `joinrestrictinfo` to recover equi-keys, finds nothing,
+-- returns `None`, and the 3-way JoinScan never gets registered.
+SET max_parallel_workers = 0;
+SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO users (name, age, uuid)
+SELECT (ARRAY['alice','bob','cloe']::text[])[((i % 3) + 1)],
+       ((i % 100) + 1),
+       md5(i::text)::uuid
+FROM generate_series(1, 100) AS i;
+CREATE INDEX idxusers ON users USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxusers_age ON users (age);
+CREATE INDEX idxusers_uuid ON users (uuid);
+ANALYZE users;
+CREATE TABLE products (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO products (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxproducts_age ON products (age);
+CREATE INDEX idxproducts_uuid ON products (uuid);
+ANALYZE products;
+CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO orders (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxorders ON orders USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxorders_age ON orders (age);
+CREATE INDEX idxorders_uuid ON orders (uuid);
+ANALYZE orders;
+SET paradedb.enable_aggregate_custom_scan = off;
+SET paradedb.enable_custom_scan = off;
+SET paradedb.enable_join_custom_scan = on;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
+                                                                                                        QUERY PLAN                                                                                                         
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: users.id, products.id, orders.id
+         ->  Nested Loop
+               ->  Nested Loop
+                     ->  Bitmap Heap Scan on users
+                           Recheck Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
+                           ->  Bitmap Index Scan on idxusers
+                                 Index Cond: (id @@@ '{"with_index":{"oid":976533,"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}'::paradedb.searchqueryinput)
+                     ->  Bitmap Heap Scan on products
+                           Recheck Cond: (users.age = age)
+                           ->  Bitmap Index Scan on idxproducts_age
+                                 Index Cond: (age = users.age)
+               ->  Bitmap Heap Scan on orders
+                     Recheck Cond: (products.uuid = uuid)
+                     ->  Bitmap Index Scan on idxorders_uuid
+                           Index Cond: (uuid = products.uuid)
+(17 rows)
+
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+WARNING:  JoinScan not used: LIMIT pushdown is unsafe due to un-absorbed relations (tables: products, users)
+ id | name 
+----+------
+  1 | bob
+(1 row)
+
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;

--- a/pg_search/tests/pg_regress/sql/joinscan_null_jri.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_null_jri.sql
@@ -1,0 +1,86 @@
+-- Regression test: JoinScan declines on a 3-way INNER join when PG picks a
+-- parameterized `NestPath` for the inner sub-join.
+--
+-- This is a JoinScan-activation gap, not a correctness gap. PG's fallback
+-- nested-loop / bitmap plan returns the right rows; JoinScan just never
+-- fires, so the query loses the BM25 join acceleration.
+--
+-- With `enable_seqscan` and `enable_indexscan` off, PG plans the
+-- `(users JOIN products)` sub-join as a `NestPath` whose inner side is a
+-- parameterized bitmap-index lookup on `idxproducts_age`. The join clause
+-- `users.age = products.age` is enforced via that index condition, so PG
+-- leaves `JoinPath.joinrestrictinfo` empty. `collect_join_sources_join_rel`
+-- reads only `joinrestrictinfo` to recover equi-keys, finds nothing,
+-- returns `None`, and the 3-way JoinScan never gets registered.
+
+SET max_parallel_workers = 0;
+SET max_parallel_workers_per_gather = 0;
+SET parallel_leader_participation = off;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS users CASCADE;
+DROP TABLE IF EXISTS products CASCADE;
+DROP TABLE IF EXISTS orders CASCADE;
+
+CREATE TABLE users (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO users (name, age, uuid)
+SELECT (ARRAY['alice','bob','cloe']::text[])[((i % 3) + 1)],
+       ((i % 100) + 1),
+       md5(i::text)::uuid
+FROM generate_series(1, 100) AS i;
+CREATE INDEX idxusers ON users USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxusers_age ON users (age);
+CREATE INDEX idxusers_uuid ON users (uuid);
+ANALYZE users;
+
+CREATE TABLE products (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO products (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxproducts ON products USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxproducts_age ON products (age);
+CREATE INDEX idxproducts_uuid ON products (uuid);
+ANALYZE products;
+
+CREATE TABLE orders (id BIGSERIAL PRIMARY KEY, name TEXT, age INTEGER, uuid UUID);
+INSERT INTO orders (name, age, uuid) SELECT name, age, uuid FROM users;
+CREATE INDEX idxorders ON orders USING bm25 (id, name, age, uuid)
+  WITH (key_field = 'id',
+        text_fields = '{"name": {"tokenizer": {"type": "keyword"}, "fast": true},
+                        "uuid": {"tokenizer": {"type": "keyword"}, "fast": true}}',
+        numeric_fields = '{"age": {"fast": true}}');
+CREATE INDEX idxorders_age ON orders (age);
+CREATE INDEX idxorders_uuid ON orders (uuid);
+ANALYZE orders;
+
+SET paradedb.enable_aggregate_custom_scan = off;
+SET paradedb.enable_custom_scan = off;
+SET paradedb.enable_join_custom_scan = on;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+
+SELECT users.id, users.name
+FROM users
+JOIN products ON users.age = products.age
+JOIN orders ON products.uuid = orders.uuid
+WHERE users.name @@@ 'bob'
+ORDER BY users.id, products.id, orders.id LIMIT 1;
+
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5186

## What

This PR adds a fallback to `inner_path->param_info->ppi_clauses` in `collect_join_sources_join_rel` for when `JoinPath.joinrestrictinfo` carries no equi-key.

## Why

PG drops a join clause from `joinrestrictinfo` when a parameterized inner index lookup already enforces it. For a `NestPath` whose inner side is a parameterized bitmap-index scan, the equi-key disappears from `joinrestrictinfo` and shows up only on `ppi_clauses` for the inner base rel.

`collect_join_sources_join_rel` read only `joinrestrictinfo`, saw no equi-key, returned `None`, and the 3-way `JoinScan` never got registered. PG fell back to its own nested-loop / bitmap plan. Rows were correct; BM25 acceleration was lost.

The shape comes up whenever `enable_seqscan = off` and `enable_indexscan = off` are both set with `paradedb.enable_join_custom_scan = on`. #5176's `de7eef6b` flipped the qgen test from forced-default GUCs to proptest-generated GUCs, which is how the failure showed up.

## How

When the `joinrestrictinfo` extraction yields no equi-key, walk `inner_path->param_info->ppi_clauses` and merge any equi-keys / `@@@` clauses into the in-progress `JoinConditions`. The rest of the reconstruction (fast-field checks, `absorbed_search_clauses` partition, `Inner`-only gate, `JoinNode` build) runs unchanged.

## Tests

- New regression test `joinscan_null_jri` captures the failing shape and pins the post-fix `EXPLAIN` showing `Custom Scan (ParadeDB Join Scan)`.
- `joinscan_*` and `aggregate_join_*` regression suites pass.
- `cargo test --package tests --test qgen generated_joinscan` passes.
