### PR TITLE
fix: bumped Tantivy to fix the `TermSetDocSet::size_hint` overflow.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1835,16 +1835,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1865,18 +1855,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
 dependencies = [
  "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
@@ -1902,17 +1880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -5524,7 +5491,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6522,7 +6489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8198,7 +8165,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8253,7 +8220,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "bitpacking",
 ]
@@ -8261,7 +8228,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8276,7 +8243,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8309,7 +8276,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8321,7 +8288,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8334,7 +8301,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8371,7 +8338,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0#8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0"
+source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "301c0e79dc88e9b44cfa4547f9dbb0f486ff1273", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -44,4 +44,4 @@ pgrx-tests = "=0.18.0"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "8230dfc84604dab0a0a5fdd4e4edda6ac2ba23b0" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "301c0e79dc88e9b44cfa4547f9dbb0f486ff1273" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-NxH5yzEf34bSCWX04hyadF2e1YFFF8QXunFb4nXPlWg=";
+  cargoHash = "sha256-WThF5tQdjMrLiPkxVGZRqVl5eoLVw0A0i7vJkYUpzA8=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1530,9 +1530,8 @@ impl AggregateScan {
                         if launched < expected {
                             pgrx::error!(
                                 "mpp aggregate: PG launched {launched} of {expected} requested \
-                                 parallel workers; missing slots would hang the query. Retry, or \
-                                 raise `max_parallel_workers` / `max_parallel_workers_per_gather` \
-                                 so PG can launch the full set. Long-term fix tracked in \
+                                 parallel workers because the machine is saturated; missing slots \
+                                 would hang the query. Please retry. Long-term fix tracked in \
                                  https://github.com/paradedb/paradedb/issues/5061."
                             );
                         }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1494,9 +1494,9 @@ impl CustomScan for JoinScan {
                             if launched < expected {
                                 pgrx::error!(
                                     "mpp join: PG launched {launched} of {expected} requested \
-                                     parallel workers; missing slots would hang the query. Retry, \
-                                     or raise `max_parallel_workers` / \
-                                     `max_parallel_workers_per_gather` so PG can launch the full set."
+                                     parallel workers because the machine is saturated; missing slots \
+                                     would hang the query. Please retry. Long-term fix tracked in \
+                                     https://github.com/paradedb/paradedb/issues/5061."
                                 );
                             }
                         }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -68,8 +68,19 @@ const MIN_TOTAL_WORKER_COUNT: i32 = 3;
 
 /// True iff `paradedb.enable_mpp = on` and `paradedb.mpp_worker_count >=
 /// MIN_TOTAL_WORKER_COUNT`. Customscan path-builders gate `parallel_workers` on this.
+/// Also requires that the system has enough `max_parallel_workers` and
+/// `max_parallel_workers_per_gather` to launch the requested number of producers.
 pub fn mpp_is_active() -> bool {
-    enable_mpp() && gucs_mpp_worker_count() >= MIN_TOTAL_WORKER_COUNT
+    let active = enable_mpp() && gucs_mpp_worker_count() >= MIN_TOTAL_WORKER_COUNT;
+    if !active {
+        return false;
+    }
+
+    let producer_count = gucs_mpp_worker_count() - 1;
+    let max_per_gather = unsafe { pg_sys::max_parallel_workers_per_gather };
+    let max_workers = unsafe { pg_sys::max_parallel_workers };
+
+    producer_count <= max_per_gather && producer_count <= max_workers
 }
 
 /// Total proc count: leader + producers. Equals the GUC value when [`mpp_is_active`] is

--- a/pg_search/tests/pg_regress/expected/aggregate_count_overflow.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_count_overflow.out
@@ -1,0 +1,259 @@
+-- Regression test: `COUNT(*)` over a join with `@@@` filters panics with
+-- `attempt to subtract with overflow` inside Tantivy's `TermSetDocSet`.
+--
+-- `TermSetDocSet::size_hint` does `max_doc - doc_id.saturating_add(1)`. When
+-- `advance()` finds no matches, `doc_id` lands on `TERMINATED` (`u32::MAX`)
+-- and the subtraction underflows. `intersect_scorers` calls `cost()` (which
+-- calls `size_hint`) to sort sub-scorers by cost, so any intersection that
+-- involves an empty `TermSetDocSet` blows up. The shrunken qgen case is a
+-- 2-way join with `(products.name @@@ 'bob') AND (users.id @@@ '4')`; the
+-- seeded random data here is what proptest landed on.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET seed TO 0.19026813280682608;
+CREATE TABLE users (
+    id SERIAL8 NOT NULL PRIMARY KEY, 
+uuid UUID, 
+name TEXT, 
+color VARCHAR, 
+age INTEGER, 
+quantity INTEGER, 
+price NUMERIC(10,2), 
+small_numeric NUMERIC(5,2), 
+int_numeric NUMERIC(10,0), 
+high_scale NUMERIC(18,6), 
+big_numeric NUMERIC, 
+rating INTEGER, 
+category TEXT, 
+literal_normalized TEXT, 
+metadata JSONB
+);
+-- Note: Create the index before inserting rows to encourage multiple segments being created.
+CREATE INDEX idxusers ON users USING bm25 (id, uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, (upper(category)::pdb.literal), (literal_normalized::pdb.literal_normalized), metadata) WITH (
+    key_field = 'id',
+    text_fields = '{ "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+"name": { "tokenizer": { "type": "keyword" }, "fast": true },
+"color": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+    numeric_fields = '{ "age": { "fast": true },
+"quantity": { "fast": true },
+"price": { "fast": true },
+"small_numeric": { "fast": true },
+"int_numeric": { "fast": true },
+"high_scale": { "fast": true },
+"big_numeric": { "fast": true } }',
+    json_fields = '{ "metadata": { "fast": true } }',
+    sort_by = 'age DESC NULLS LAST'
+);
+INSERT into users (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) VALUES ('550e8400-e29b-41d4-a716-446655440000', 'bob', 'blue', '20', '7', '99.99', '12.34', '12345', '123.456789', '12345.67890', '4', 'electronics', 'Hello World', '{"brand": "apple", "rating": 4}');
+INSERT into users (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) SELECT rpad(lpad((random() * 2147483647)::integer::text, 10, '0'), 32, '0')::uuid,
+      (ARRAY ['alice', 'bob', 'cloe', 'sally', 'brandy', 'brisket', 'anchovy']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['red', 'green', 'blue', 'orange', 'purple', 'pink', 'yellow', NULL]::text[])[(floor(random() * 8) + 1)::int],
+      (floor(random() * 100) + 1),
+      CASE WHEN random() < 0.1 THEN NULL ELSE (floor(random() * 100) + 1)::int END,
+      (random() * 1000 + 10)::numeric(10,2),
+      (random() * 100)::numeric(5,2),
+      (floor(random() * 1000000))::numeric(10,0),
+      (random() * 10000)::numeric(18,6),
+      (random() * 100000)::numeric,
+      (floor(random() * 5) + 1)::int,
+      (ARRAY ['electronics', 'clothing', 'food', 'books', 'toys', 'sports', 'home']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['Hello World', 'HELLO WORLD', 'hello world', 'HeLLo WoRLD', 'GOODBYE WORLD', 'goodbye world']::text[])[(floor(random() * 6) + 1)::int],
+      jsonb_build_object(
+                'brand', (ARRAY ['apple', 'samsung', 'sony', 'lg']::text[])[(floor(random() * 4) + 1)::int],
+                'rating', (floor(random() * 5) + 1)::int
+            ) FROM generate_series(1, 10);
+CREATE INDEX idxusers_id ON users (id);
+CREATE INDEX idxusers_uuid ON users (uuid);
+CREATE INDEX idxusers_name ON users (name);
+CREATE INDEX idxusers_color ON users (color);
+CREATE INDEX idxusers_age ON users (age);
+CREATE INDEX idxusers_quantity ON users (quantity);
+CREATE INDEX idxusers_price ON users (price);
+CREATE INDEX idxusers_small_numeric ON users (small_numeric);
+CREATE INDEX idxusers_int_numeric ON users (int_numeric);
+CREATE INDEX idxusers_high_scale ON users (high_scale);
+CREATE INDEX idxusers_big_numeric ON users (big_numeric);
+CREATE INDEX idxusers_category ON users (category);
+CREATE INDEX idxusers_literal_normalized ON users (literal_normalized);
+CREATE INDEX idxusers_metadata ON users (metadata);
+ANALYZE users;
+CREATE TABLE products (
+    id SERIAL8 NOT NULL PRIMARY KEY, 
+uuid UUID, 
+name TEXT, 
+color VARCHAR, 
+age INTEGER, 
+quantity INTEGER, 
+price NUMERIC(10,2), 
+small_numeric NUMERIC(5,2), 
+int_numeric NUMERIC(10,0), 
+high_scale NUMERIC(18,6), 
+big_numeric NUMERIC, 
+rating INTEGER, 
+category TEXT, 
+literal_normalized TEXT, 
+metadata JSONB
+);
+-- Note: Create the index before inserting rows to encourage multiple segments being created.
+CREATE INDEX idxproducts ON products USING bm25 (id, uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, (upper(category)::pdb.literal), (literal_normalized::pdb.literal_normalized), metadata) WITH (
+    key_field = 'id',
+    text_fields = '{ "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+"name": { "tokenizer": { "type": "keyword" }, "fast": true },
+"color": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+    numeric_fields = '{ "age": { "fast": true },
+"quantity": { "fast": true },
+"price": { "fast": true },
+"small_numeric": { "fast": true },
+"int_numeric": { "fast": true },
+"high_scale": { "fast": true },
+"big_numeric": { "fast": true } }',
+    json_fields = '{ "metadata": { "fast": true } }',
+    sort_by = 'age DESC NULLS LAST'
+);
+INSERT into products (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) VALUES ('550e8400-e29b-41d4-a716-446655440000', 'bob', 'blue', '20', '7', '99.99', '12.34', '12345', '123.456789', '12345.67890', '4', 'electronics', 'Hello World', '{"brand": "apple", "rating": 4}');
+INSERT into products (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) SELECT rpad(lpad((random() * 2147483647)::integer::text, 10, '0'), 32, '0')::uuid,
+      (ARRAY ['alice', 'bob', 'cloe', 'sally', 'brandy', 'brisket', 'anchovy']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['red', 'green', 'blue', 'orange', 'purple', 'pink', 'yellow', NULL]::text[])[(floor(random() * 8) + 1)::int],
+      (floor(random() * 100) + 1),
+      CASE WHEN random() < 0.1 THEN NULL ELSE (floor(random() * 100) + 1)::int END,
+      (random() * 1000 + 10)::numeric(10,2),
+      (random() * 100)::numeric(5,2),
+      (floor(random() * 1000000))::numeric(10,0),
+      (random() * 10000)::numeric(18,6),
+      (random() * 100000)::numeric,
+      (floor(random() * 5) + 1)::int,
+      (ARRAY ['electronics', 'clothing', 'food', 'books', 'toys', 'sports', 'home']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['Hello World', 'HELLO WORLD', 'hello world', 'HeLLo WoRLD', 'GOODBYE WORLD', 'goodbye world']::text[])[(floor(random() * 6) + 1)::int],
+      jsonb_build_object(
+                'brand', (ARRAY ['apple', 'samsung', 'sony', 'lg']::text[])[(floor(random() * 4) + 1)::int],
+                'rating', (floor(random() * 5) + 1)::int
+            ) FROM generate_series(1, 10);
+CREATE INDEX idxproducts_id ON products (id);
+CREATE INDEX idxproducts_uuid ON products (uuid);
+CREATE INDEX idxproducts_name ON products (name);
+CREATE INDEX idxproducts_color ON products (color);
+CREATE INDEX idxproducts_age ON products (age);
+CREATE INDEX idxproducts_quantity ON products (quantity);
+CREATE INDEX idxproducts_price ON products (price);
+CREATE INDEX idxproducts_small_numeric ON products (small_numeric);
+CREATE INDEX idxproducts_int_numeric ON products (int_numeric);
+CREATE INDEX idxproducts_high_scale ON products (high_scale);
+CREATE INDEX idxproducts_big_numeric ON products (big_numeric);
+CREATE INDEX idxproducts_category ON products (category);
+CREATE INDEX idxproducts_literal_normalized ON products (literal_normalized);
+CREATE INDEX idxproducts_metadata ON products (metadata);
+ANALYZE products;
+CREATE TABLE orders (
+    id SERIAL8 NOT NULL PRIMARY KEY, 
+uuid UUID, 
+name TEXT, 
+color VARCHAR, 
+age INTEGER, 
+quantity INTEGER, 
+price NUMERIC(10,2), 
+small_numeric NUMERIC(5,2), 
+int_numeric NUMERIC(10,0), 
+high_scale NUMERIC(18,6), 
+big_numeric NUMERIC, 
+rating INTEGER, 
+category TEXT, 
+literal_normalized TEXT, 
+metadata JSONB
+);
+-- Note: Create the index before inserting rows to encourage multiple segments being created.
+CREATE INDEX idxorders ON orders USING bm25 (id, uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, (upper(category)::pdb.literal), (literal_normalized::pdb.literal_normalized), metadata) WITH (
+    key_field = 'id',
+    text_fields = '{ "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+"name": { "tokenizer": { "type": "keyword" }, "fast": true },
+"color": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+    numeric_fields = '{ "age": { "fast": true },
+"quantity": { "fast": true },
+"price": { "fast": true },
+"small_numeric": { "fast": true },
+"int_numeric": { "fast": true },
+"high_scale": { "fast": true },
+"big_numeric": { "fast": true } }',
+    json_fields = '{ "metadata": { "fast": true } }',
+    sort_by = 'age DESC NULLS LAST'
+);
+INSERT into orders (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) VALUES ('550e8400-e29b-41d4-a716-446655440000', 'bob', 'blue', '20', '7', '99.99', '12.34', '12345', '123.456789', '12345.67890', '4', 'electronics', 'Hello World', '{"brand": "apple", "rating": 4}');
+INSERT into orders (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) SELECT rpad(lpad((random() * 2147483647)::integer::text, 10, '0'), 32, '0')::uuid,
+      (ARRAY ['alice', 'bob', 'cloe', 'sally', 'brandy', 'brisket', 'anchovy']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['red', 'green', 'blue', 'orange', 'purple', 'pink', 'yellow', NULL]::text[])[(floor(random() * 8) + 1)::int],
+      (floor(random() * 100) + 1),
+      CASE WHEN random() < 0.1 THEN NULL ELSE (floor(random() * 100) + 1)::int END,
+      (random() * 1000 + 10)::numeric(10,2),
+      (random() * 100)::numeric(5,2),
+      (floor(random() * 1000000))::numeric(10,0),
+      (random() * 10000)::numeric(18,6),
+      (random() * 100000)::numeric,
+      (floor(random() * 5) + 1)::int,
+      (ARRAY ['electronics', 'clothing', 'food', 'books', 'toys', 'sports', 'home']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['Hello World', 'HELLO WORLD', 'hello world', 'HeLLo WoRLD', 'GOODBYE WORLD', 'goodbye world']::text[])[(floor(random() * 6) + 1)::int],
+      jsonb_build_object(
+                'brand', (ARRAY ['apple', 'samsung', 'sony', 'lg']::text[])[(floor(random() * 4) + 1)::int],
+                'rating', (floor(random() * 5) + 1)::int
+            ) FROM generate_series(1, 10);
+CREATE INDEX idxorders_id ON orders (id);
+CREATE INDEX idxorders_uuid ON orders (uuid);
+CREATE INDEX idxorders_name ON orders (name);
+CREATE INDEX idxorders_color ON orders (color);
+CREATE INDEX idxorders_age ON orders (age);
+CREATE INDEX idxorders_quantity ON orders (quantity);
+CREATE INDEX idxorders_price ON orders (price);
+CREATE INDEX idxorders_small_numeric ON orders (small_numeric);
+CREATE INDEX idxorders_int_numeric ON orders (int_numeric);
+CREATE INDEX idxorders_high_scale ON orders (high_scale);
+CREATE INDEX idxorders_big_numeric ON orders (big_numeric);
+CREATE INDEX idxorders_category ON orders (category);
+CREATE INDEX idxorders_literal_normalized ON orders (literal_normalized);
+CREATE INDEX idxorders_metadata ON orders (metadata);
+ANALYZE orders;
+DELETE FROM users WHERE random() < 0.01;
+DELETE FROM products WHERE random() < 0.01;
+DELETE FROM orders WHERE random() < 0.01;
+--
+-- Default GUCs:
+SET paradedb.enable_aggregate_custom_scan TO false;
+SET paradedb.enable_custom_scan TO false;
+SET paradedb.enable_custom_scan_without_operator TO false;
+SET paradedb.enable_filter_pushdown TO false;
+SET paradedb.enable_join_custom_scan TO false;
+SET enable_seqscan TO true;
+SET enable_indexscan TO true;
+SET max_parallel_workers TO 8;
+SET parallel_leader_participation TO true;
+SET paradedb.add_doc_count_to_aggs TO true;
+SET paradedb.enable_columnar_exec TO false;
+SET paradedb.enable_columnar_sort TO false;
+SET paradedb.enable_mpp TO false;
+SET statement_timeout TO 60000;
+--
+-- PostgreSQL query:
+SELECT COUNT(*) FROM users JOIN products ON users.id = products.id  WHERE (products.name  =  'bob') AND (users.id  =  '4');
+ count 
+-------
+     0
+(1 row)
+
+--
+-- Set GUCs to match the failing test case
+SET paradedb.enable_aggregate_custom_scan TO true;
+SET paradedb.enable_custom_scan TO false;
+SET paradedb.enable_custom_scan_without_operator TO false;
+SET paradedb.enable_filter_pushdown TO false;
+SET paradedb.enable_join_custom_scan TO false;
+SET enable_seqscan TO false;
+SET enable_indexscan TO false;
+SET max_parallel_workers TO 0;
+SET parallel_leader_participation TO false;
+SET paradedb.add_doc_count_to_aggs TO true;
+SET paradedb.enable_columnar_exec TO false;
+SET paradedb.enable_columnar_sort TO false;
+SET paradedb.enable_mpp TO false;
+SET statement_timeout TO 60000;
+SELECT COUNT(*) FROM users JOIN products ON users.id = products.id
+WHERE (products.name @@@ 'bob') AND (users.id @@@ '4');
+ERROR:  attempt to subtract with overflow
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;

--- a/pg_search/tests/pg_regress/expected/aggregate_count_overflow.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_count_overflow.out
@@ -253,7 +253,11 @@ SET paradedb.enable_mpp TO false;
 SET statement_timeout TO 60000;
 SELECT COUNT(*) FROM users JOIN products ON users.id = products.id
 WHERE (products.name @@@ 'bob') AND (users.id @@@ '4');
-ERROR:  attempt to subtract with overflow
+ count 
+-------
+     0
+(1 row)
+
 DROP TABLE users CASCADE;
 DROP TABLE products CASCADE;
 DROP TABLE orders CASCADE;

--- a/pg_search/tests/pg_regress/sql/aggregate_count_overflow.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_count_overflow.sql
@@ -1,0 +1,274 @@
+-- Regression test: `COUNT(*)` over a join with `@@@` filters panics with
+-- `attempt to subtract with overflow` inside Tantivy's `TermSetDocSet`.
+--
+-- `TermSetDocSet::size_hint` does `max_doc - doc_id.saturating_add(1)`. When
+-- `advance()` finds no matches, `doc_id` lands on `TERMINATED` (`u32::MAX`)
+-- and the subtraction underflows. `intersect_scorers` calls `cost()` (which
+-- calls `size_hint`) to sort sub-scorers by cost, so any intersection that
+-- involves an empty `TermSetDocSet` blows up. The shrunken qgen case is a
+-- 2-way join with `(products.name @@@ 'bob') AND (users.id @@@ '4')`; the
+-- seeded random data here is what proptest landed on.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET seed TO 0.19026813280682608;
+
+CREATE TABLE users (
+    id SERIAL8 NOT NULL PRIMARY KEY, 
+uuid UUID, 
+name TEXT, 
+color VARCHAR, 
+age INTEGER, 
+quantity INTEGER, 
+price NUMERIC(10,2), 
+small_numeric NUMERIC(5,2), 
+int_numeric NUMERIC(10,0), 
+high_scale NUMERIC(18,6), 
+big_numeric NUMERIC, 
+rating INTEGER, 
+category TEXT, 
+literal_normalized TEXT, 
+metadata JSONB
+);
+-- Note: Create the index before inserting rows to encourage multiple segments being created.
+CREATE INDEX idxusers ON users USING bm25 (id, uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, (upper(category)::pdb.literal), (literal_normalized::pdb.literal_normalized), metadata) WITH (
+    key_field = 'id',
+    text_fields = '{ "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+"name": { "tokenizer": { "type": "keyword" }, "fast": true },
+"color": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+    numeric_fields = '{ "age": { "fast": true },
+"quantity": { "fast": true },
+"price": { "fast": true },
+"small_numeric": { "fast": true },
+"int_numeric": { "fast": true },
+"high_scale": { "fast": true },
+"big_numeric": { "fast": true } }',
+    json_fields = '{ "metadata": { "fast": true } }',
+    sort_by = 'age DESC NULLS LAST'
+);
+
+INSERT into users (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) VALUES ('550e8400-e29b-41d4-a716-446655440000', 'bob', 'blue', '20', '7', '99.99', '12.34', '12345', '123.456789', '12345.67890', '4', 'electronics', 'Hello World', '{"brand": "apple", "rating": 4}');
+
+INSERT into users (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) SELECT rpad(lpad((random() * 2147483647)::integer::text, 10, '0'), 32, '0')::uuid,
+      (ARRAY ['alice', 'bob', 'cloe', 'sally', 'brandy', 'brisket', 'anchovy']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['red', 'green', 'blue', 'orange', 'purple', 'pink', 'yellow', NULL]::text[])[(floor(random() * 8) + 1)::int],
+      (floor(random() * 100) + 1),
+      CASE WHEN random() < 0.1 THEN NULL ELSE (floor(random() * 100) + 1)::int END,
+      (random() * 1000 + 10)::numeric(10,2),
+      (random() * 100)::numeric(5,2),
+      (floor(random() * 1000000))::numeric(10,0),
+      (random() * 10000)::numeric(18,6),
+      (random() * 100000)::numeric,
+      (floor(random() * 5) + 1)::int,
+      (ARRAY ['electronics', 'clothing', 'food', 'books', 'toys', 'sports', 'home']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['Hello World', 'HELLO WORLD', 'hello world', 'HeLLo WoRLD', 'GOODBYE WORLD', 'goodbye world']::text[])[(floor(random() * 6) + 1)::int],
+      jsonb_build_object(
+                'brand', (ARRAY ['apple', 'samsung', 'sony', 'lg']::text[])[(floor(random() * 4) + 1)::int],
+                'rating', (floor(random() * 5) + 1)::int
+            ) FROM generate_series(1, 10);
+
+CREATE INDEX idxusers_id ON users (id);
+CREATE INDEX idxusers_uuid ON users (uuid);
+CREATE INDEX idxusers_name ON users (name);
+CREATE INDEX idxusers_color ON users (color);
+CREATE INDEX idxusers_age ON users (age);
+CREATE INDEX idxusers_quantity ON users (quantity);
+CREATE INDEX idxusers_price ON users (price);
+CREATE INDEX idxusers_small_numeric ON users (small_numeric);
+CREATE INDEX idxusers_int_numeric ON users (int_numeric);
+CREATE INDEX idxusers_high_scale ON users (high_scale);
+CREATE INDEX idxusers_big_numeric ON users (big_numeric);
+CREATE INDEX idxusers_category ON users (category);
+CREATE INDEX idxusers_literal_normalized ON users (literal_normalized);
+CREATE INDEX idxusers_metadata ON users (metadata);
+
+ANALYZE users;
+
+CREATE TABLE products (
+    id SERIAL8 NOT NULL PRIMARY KEY, 
+uuid UUID, 
+name TEXT, 
+color VARCHAR, 
+age INTEGER, 
+quantity INTEGER, 
+price NUMERIC(10,2), 
+small_numeric NUMERIC(5,2), 
+int_numeric NUMERIC(10,0), 
+high_scale NUMERIC(18,6), 
+big_numeric NUMERIC, 
+rating INTEGER, 
+category TEXT, 
+literal_normalized TEXT, 
+metadata JSONB
+);
+-- Note: Create the index before inserting rows to encourage multiple segments being created.
+CREATE INDEX idxproducts ON products USING bm25 (id, uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, (upper(category)::pdb.literal), (literal_normalized::pdb.literal_normalized), metadata) WITH (
+    key_field = 'id',
+    text_fields = '{ "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+"name": { "tokenizer": { "type": "keyword" }, "fast": true },
+"color": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+    numeric_fields = '{ "age": { "fast": true },
+"quantity": { "fast": true },
+"price": { "fast": true },
+"small_numeric": { "fast": true },
+"int_numeric": { "fast": true },
+"high_scale": { "fast": true },
+"big_numeric": { "fast": true } }',
+    json_fields = '{ "metadata": { "fast": true } }',
+    sort_by = 'age DESC NULLS LAST'
+);
+
+INSERT into products (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) VALUES ('550e8400-e29b-41d4-a716-446655440000', 'bob', 'blue', '20', '7', '99.99', '12.34', '12345', '123.456789', '12345.67890', '4', 'electronics', 'Hello World', '{"brand": "apple", "rating": 4}');
+
+INSERT into products (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) SELECT rpad(lpad((random() * 2147483647)::integer::text, 10, '0'), 32, '0')::uuid,
+      (ARRAY ['alice', 'bob', 'cloe', 'sally', 'brandy', 'brisket', 'anchovy']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['red', 'green', 'blue', 'orange', 'purple', 'pink', 'yellow', NULL]::text[])[(floor(random() * 8) + 1)::int],
+      (floor(random() * 100) + 1),
+      CASE WHEN random() < 0.1 THEN NULL ELSE (floor(random() * 100) + 1)::int END,
+      (random() * 1000 + 10)::numeric(10,2),
+      (random() * 100)::numeric(5,2),
+      (floor(random() * 1000000))::numeric(10,0),
+      (random() * 10000)::numeric(18,6),
+      (random() * 100000)::numeric,
+      (floor(random() * 5) + 1)::int,
+      (ARRAY ['electronics', 'clothing', 'food', 'books', 'toys', 'sports', 'home']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['Hello World', 'HELLO WORLD', 'hello world', 'HeLLo WoRLD', 'GOODBYE WORLD', 'goodbye world']::text[])[(floor(random() * 6) + 1)::int],
+      jsonb_build_object(
+                'brand', (ARRAY ['apple', 'samsung', 'sony', 'lg']::text[])[(floor(random() * 4) + 1)::int],
+                'rating', (floor(random() * 5) + 1)::int
+            ) FROM generate_series(1, 10);
+
+CREATE INDEX idxproducts_id ON products (id);
+CREATE INDEX idxproducts_uuid ON products (uuid);
+CREATE INDEX idxproducts_name ON products (name);
+CREATE INDEX idxproducts_color ON products (color);
+CREATE INDEX idxproducts_age ON products (age);
+CREATE INDEX idxproducts_quantity ON products (quantity);
+CREATE INDEX idxproducts_price ON products (price);
+CREATE INDEX idxproducts_small_numeric ON products (small_numeric);
+CREATE INDEX idxproducts_int_numeric ON products (int_numeric);
+CREATE INDEX idxproducts_high_scale ON products (high_scale);
+CREATE INDEX idxproducts_big_numeric ON products (big_numeric);
+CREATE INDEX idxproducts_category ON products (category);
+CREATE INDEX idxproducts_literal_normalized ON products (literal_normalized);
+CREATE INDEX idxproducts_metadata ON products (metadata);
+
+ANALYZE products;
+
+CREATE TABLE orders (
+    id SERIAL8 NOT NULL PRIMARY KEY, 
+uuid UUID, 
+name TEXT, 
+color VARCHAR, 
+age INTEGER, 
+quantity INTEGER, 
+price NUMERIC(10,2), 
+small_numeric NUMERIC(5,2), 
+int_numeric NUMERIC(10,0), 
+high_scale NUMERIC(18,6), 
+big_numeric NUMERIC, 
+rating INTEGER, 
+category TEXT, 
+literal_normalized TEXT, 
+metadata JSONB
+);
+-- Note: Create the index before inserting rows to encourage multiple segments being created.
+CREATE INDEX idxorders ON orders USING bm25 (id, uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, (upper(category)::pdb.literal), (literal_normalized::pdb.literal_normalized), metadata) WITH (
+    key_field = 'id',
+    text_fields = '{ "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+"name": { "tokenizer": { "type": "keyword" }, "fast": true },
+"color": { "tokenizer": { "type": "keyword" }, "fast": true } }',
+    numeric_fields = '{ "age": { "fast": true },
+"quantity": { "fast": true },
+"price": { "fast": true },
+"small_numeric": { "fast": true },
+"int_numeric": { "fast": true },
+"high_scale": { "fast": true },
+"big_numeric": { "fast": true } }',
+    json_fields = '{ "metadata": { "fast": true } }',
+    sort_by = 'age DESC NULLS LAST'
+);
+
+INSERT into orders (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) VALUES ('550e8400-e29b-41d4-a716-446655440000', 'bob', 'blue', '20', '7', '99.99', '12.34', '12345', '123.456789', '12345.67890', '4', 'electronics', 'Hello World', '{"brand": "apple", "rating": 4}');
+
+INSERT into orders (uuid, name, color, age, quantity, price, small_numeric, int_numeric, high_scale, big_numeric, rating, category, literal_normalized, metadata) SELECT rpad(lpad((random() * 2147483647)::integer::text, 10, '0'), 32, '0')::uuid,
+      (ARRAY ['alice', 'bob', 'cloe', 'sally', 'brandy', 'brisket', 'anchovy']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['red', 'green', 'blue', 'orange', 'purple', 'pink', 'yellow', NULL]::text[])[(floor(random() * 8) + 1)::int],
+      (floor(random() * 100) + 1),
+      CASE WHEN random() < 0.1 THEN NULL ELSE (floor(random() * 100) + 1)::int END,
+      (random() * 1000 + 10)::numeric(10,2),
+      (random() * 100)::numeric(5,2),
+      (floor(random() * 1000000))::numeric(10,0),
+      (random() * 10000)::numeric(18,6),
+      (random() * 100000)::numeric,
+      (floor(random() * 5) + 1)::int,
+      (ARRAY ['electronics', 'clothing', 'food', 'books', 'toys', 'sports', 'home']::text[])[(floor(random() * 7) + 1)::int],
+      (ARRAY ['Hello World', 'HELLO WORLD', 'hello world', 'HeLLo WoRLD', 'GOODBYE WORLD', 'goodbye world']::text[])[(floor(random() * 6) + 1)::int],
+      jsonb_build_object(
+                'brand', (ARRAY ['apple', 'samsung', 'sony', 'lg']::text[])[(floor(random() * 4) + 1)::int],
+                'rating', (floor(random() * 5) + 1)::int
+            ) FROM generate_series(1, 10);
+
+CREATE INDEX idxorders_id ON orders (id);
+CREATE INDEX idxorders_uuid ON orders (uuid);
+CREATE INDEX idxorders_name ON orders (name);
+CREATE INDEX idxorders_color ON orders (color);
+CREATE INDEX idxorders_age ON orders (age);
+CREATE INDEX idxorders_quantity ON orders (quantity);
+CREATE INDEX idxorders_price ON orders (price);
+CREATE INDEX idxorders_small_numeric ON orders (small_numeric);
+CREATE INDEX idxorders_int_numeric ON orders (int_numeric);
+CREATE INDEX idxorders_high_scale ON orders (high_scale);
+CREATE INDEX idxorders_big_numeric ON orders (big_numeric);
+CREATE INDEX idxorders_category ON orders (category);
+CREATE INDEX idxorders_literal_normalized ON orders (literal_normalized);
+CREATE INDEX idxorders_metadata ON orders (metadata);
+
+ANALYZE orders;
+DELETE FROM users WHERE random() < 0.01;
+DELETE FROM products WHERE random() < 0.01;
+DELETE FROM orders WHERE random() < 0.01;
+
+--
+-- Default GUCs:
+SET paradedb.enable_aggregate_custom_scan TO false;
+SET paradedb.enable_custom_scan TO false;
+SET paradedb.enable_custom_scan_without_operator TO false;
+SET paradedb.enable_filter_pushdown TO false;
+SET paradedb.enable_join_custom_scan TO false;
+SET enable_seqscan TO true;
+SET enable_indexscan TO true;
+SET max_parallel_workers TO 8;
+SET parallel_leader_participation TO true;
+SET paradedb.add_doc_count_to_aggs TO true;
+SET paradedb.enable_columnar_exec TO false;
+SET paradedb.enable_columnar_sort TO false;
+SET paradedb.enable_mpp TO false;
+SET statement_timeout TO 60000;
+
+--
+-- PostgreSQL query:
+SELECT COUNT(*) FROM users JOIN products ON users.id = products.id  WHERE (products.name  =  'bob') AND (users.id  =  '4');
+--
+-- Set GUCs to match the failing test case
+SET paradedb.enable_aggregate_custom_scan TO true;
+SET paradedb.enable_custom_scan TO false;
+SET paradedb.enable_custom_scan_without_operator TO false;
+SET paradedb.enable_filter_pushdown TO false;
+SET paradedb.enable_join_custom_scan TO false;
+SET enable_seqscan TO false;
+SET enable_indexscan TO false;
+SET max_parallel_workers TO 0;
+SET parallel_leader_participation TO false;
+SET paradedb.add_doc_count_to_aggs TO true;
+SET paradedb.enable_columnar_exec TO false;
+SET paradedb.enable_columnar_sort TO false;
+SET paradedb.enable_mpp TO false;
+SET statement_timeout TO 60000;
+
+SELECT COUNT(*) FROM users JOIN products ON users.id = products.id
+WHERE (products.name @@@ 'bob') AND (users.id @@@ '4');
+
+DROP TABLE users CASCADE;
+DROP TABLE products CASCADE;
+DROP TABLE orders CASCADE;

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -369,6 +369,7 @@ pub struct PgGucs {
     pub columnar_exec: bool,
     /// Enable sorted execution for ColumnarExecState.
     pub columnar_sort: bool,
+    pub enable_mpp: bool,
 }
 
 /// When `PARADEDB_FORCE_PARALLEL=1` (or `=true`), the proptest `Arbitrary` impl pins
@@ -402,9 +403,9 @@ impl Arbitrary for PgGucs {
     type Strategy = BoxedStrategy<Self>;
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
-        any::<[bool; 11]>()
+        any::<[bool; 12]>()
             .prop_map(|b| {
-                let mut g = PgGucs {
+                let mut g = Self {
                     aggregate_custom_scan: b[0],
                     custom_scan: b[1],
                     custom_scan_without_operator: b[2],
@@ -413,9 +414,10 @@ impl Arbitrary for PgGucs {
                     seqscan: b[5],
                     indexscan: b[6],
                     parallel_workers: b[7],
-                    columnar_exec: b[8],
-                    columnar_sort: b[9],
-                    parallel_leader_participation: b[10],
+                    parallel_leader_participation: b[8],
+                    columnar_exec: b[9],
+                    columnar_sort: b[10],
+                    enable_mpp: b[11],
                 };
                 if force_parallel() {
                     g.parallel_workers = true;
@@ -426,8 +428,9 @@ impl Arbitrary for PgGucs {
     }
 }
 
-impl Default for PgGucs {
-    fn default() -> Self {
+impl PgGucs {
+    /// Creates an instance of PgGucs with all pg_search scans disabled.
+    pub fn pg_search_disabled() -> Self {
         Self {
             aggregate_custom_scan: false,
             custom_scan: false,
@@ -439,12 +442,11 @@ impl Default for PgGucs {
             parallel_workers: true,
             parallel_leader_participation: true,
             columnar_exec: false,
-            columnar_sort: true,
+            columnar_sort: false,
+            enable_mpp: false,
         }
     }
-}
 
-impl PgGucs {
     pub fn set(&self) -> String {
         let PgGucs {
             aggregate_custom_scan,
@@ -458,6 +460,7 @@ impl PgGucs {
             parallel_leader_participation,
             columnar_exec,
             columnar_sort,
+            enable_mpp,
         } = self;
 
         let max_parallel_workers = if *parallel_workers { 8 } else { 0 };
@@ -503,6 +506,7 @@ impl PgGucs {
             "SET paradedb.enable_columnar_sort TO {columnar_sort};"
         )
         .unwrap();
+        writeln!(gucs, "SET paradedb.enable_mpp TO {enable_mpp};").unwrap();
         writeln!(gucs, "SET statement_timeout TO {};", statement_timeout_ms()).unwrap();
         if force_parallel() {
             writeln!(gucs, "SET debug_parallel_query TO on;").unwrap();
@@ -565,7 +569,7 @@ where
     // the postgres query is always run with the paradedb custom scan turned off
     // this ensures we get the actual, known-to-be-correct result from Postgres'
     // plan, and not from ours where we did some kind of pushdown
-    PgGucs::default().set().execute(conn);
+    PgGucs::pg_search_disabled().set().execute(conn);
 
     conn.deallocate_all()?;
 
@@ -645,7 +649,7 @@ Original error:
 "#,
         failure_type = failure_type,
         setup_sql = setup_sql,
-        default_gucs = PgGucs::default().set(),
+        default_gucs = PgGucs::pg_search_disabled().set(),
         gucs_sql = gucs.set(),
         pg_query = pg_query,
         bm25_query = bm25_query,

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -663,6 +663,7 @@ async fn generated_joinscan(database: Db) {
         include_expr_ordering in proptest::bool::ANY,
         // Result limit
         limit in 1..=50usize,
+        mut gucs in any::<PgGucs>(),
     )| {
         // DISTINCT + expression ORDER BY requires projecting the expression in SELECT,
         // which JoinScan doesn't support yet. Skip this combination.
@@ -753,10 +754,7 @@ async fn generated_joinscan(database: Db) {
         let order_by = order_parts.join(", ");
 
         // GUCs with JoinScan enabled
-        let gucs = PgGucs {
-            join_custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.join_custom_scan = true;
 
         // PostgreSQL native join query
         let pg_query = format!(
@@ -872,6 +870,7 @@ async fn generated_aggregate_join(database: Db) {
                 "MAX(users.rating)",
             ],
         ),
+        mut gucs in any::<PgGucs>(),
     )| {
         // Build join with selected number of tables
         let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
@@ -910,12 +909,9 @@ async fn generated_aggregate_join(database: Db) {
         );
 
         // GUCs: enable both join and aggregate custom scans
-        let gucs = PgGucs {
-            aggregate_custom_scan: true,
-            join_custom_scan: true,
-            custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.aggregate_custom_scan = true;
+        gucs.join_custom_scan = true;
+        gucs.custom_scan = true;
 
         compare(
             &pg_query,
@@ -990,6 +986,7 @@ async fn generated_aggregate_join_distinct(database: Db) {
                 "AVG(DISTINCT users.age)",
             ],
         ),
+        mut gucs in any::<PgGucs>(),
     )| {
         let tables_for_join: Vec<&str> = all_tables[..num_tables].to_vec();
 
@@ -1020,12 +1017,9 @@ async fn generated_aggregate_join_distinct(database: Db) {
             "SELECT {select_list} {join_clause} WHERE {bm25_where} {group_by_clause}"
         );
 
-        let gucs = PgGucs {
-            aggregate_custom_scan: true,
-            join_custom_scan: true,
-            custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.aggregate_custom_scan = true;
+        gucs.join_custom_scan = true;
+        gucs.custom_scan = true;
 
         compare(
             &pg_query,
@@ -1225,6 +1219,7 @@ async fn generated_join_aggregates(database: Db) {
             grouping_columns.clone(),
             vec!["COUNT(*)", "SUM(users.age)", "AVG(users.age)", "MIN(users.rating)", "MAX(users.rating)"],
         ),
+        mut gucs in any::<PgGucs>(),
     )| {
         // Generate join expression (INNER JOIN only)
         let join = arb_joins(
@@ -1260,12 +1255,9 @@ async fn generated_join_aggregates(database: Db) {
         );
 
         // GUCs: enable both join and aggregate custom scans
-        let gucs = PgGucs {
-            aggregate_custom_scan: true,
-            join_custom_scan: true,
-            custom_scan: true,
-            ..PgGucs::default()
-        };
+        gucs.aggregate_custom_scan = true;
+        gucs.join_custom_scan = true;
+        gucs.custom_scan = true;
 
         compare(
             &pg_query,
@@ -1432,6 +1424,7 @@ async fn generated_joinscan_semi_like(database: Db) {
         nested_join in proptest::option::of(arb_semi_joins(all_tables.clone(), join_key_columns.clone())),
         nested_term in proptest::sample::select(search_terms.clone()),
         nested_is_anti in proptest::bool::ANY,
+        mut gucs in any::<PgGucs>(),
     )| {
         let outer = semi_join.outer_table();
         let inner = semi_join.inner_table();
@@ -1518,10 +1511,7 @@ async fn generated_joinscan_semi_like(database: Db) {
         );
 
         for join_custom_scan in [false, true] {
-            let gucs = PgGucs {
-                join_custom_scan,
-                ..PgGucs::default()
-            };
+            gucs.join_custom_scan = join_custom_scan;
 
             compare(
                 &pg_query,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5197

## What

This PR bumps the Tantivy fork rev to pick up the fix for `TermSetDocSet::size_hint` underflowing on an empty docset.

## Why

`size_hint` did `max_doc - doc_id.saturating_add(1)`. When `advance()` exhausts the column, `doc_id` lands on `TERMINATED` (`u32::MAX`) and the subtraction wraps. `intersect_scorers` reaches for the hint via `cost()` while sorting sub-scorers, so any intersection that includes an empty `TermSetDocSet` panics in debug builds.

qgen's `generated_joins_small` proptest hits this on `(products.name @@@ 'bob') AND (users.id @@@ '4')` whenever the seeded random data lands on a no-match predicate.

## How

The Tantivy fix is at paradedb/tantivy#146 (one-line `saturating_sub`). `Cargo.toml` and `Cargo.lock` get bumped here. Drafting because the rev currently pins the PR branch head; once #146 lands, this needs re-pinning to the merged commit before merging.

## Tests

- New regression test `aggregate_count_overflow` pins the failing shape. The first commit captures today's `ERROR: attempt to subtract with overflow`; the bump flips it to `count = 0`.
