### PR TITLE
chore: port shared changes from enterprise (WAL ordering, replication deflake, field alias)

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -11,8 +11,6 @@ This README covers development of the `pg_search` extension. For installation, d
 
 ### Rust
 
-Install stable Rust:
-
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 rustup install stable

--- a/pg_search/sql/pg_search--0.23.5--0.23.6.sql
+++ b/pg_search/sql/pg_search--0.23.5--0.23.6.sql
@@ -1,1 +1,4 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.6'" to load this file. \quit
+
+DROP FUNCTION IF EXISTS field(name text, indexed bool, stored bool, fast bool, fieldnorms bool, record text, expand_dots bool, tokenizer jsonb, normalizer text);
+CREATE OR REPLACE FUNCTION field(name text, indexed bool DEFAULT NULL, stored bool DEFAULT NULL, fast bool DEFAULT NULL, fieldnorms bool DEFAULT NULL, record text DEFAULT NULL, expand_dots bool DEFAULT NULL, tokenizer jsonb DEFAULT NULL, normalizer text DEFAULT NULL, alias text DEFAULT NULL) RETURNS jsonb AS 'MODULE_PATHNAME', 'field_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;

--- a/pg_search/src/api/config.rs
+++ b/pg_search/src/api/config.rs
@@ -31,6 +31,7 @@ pub fn field(
     expand_dots: default!(Option<bool>, "NULL"),
     tokenizer: default!(Option<JsonB>, "NULL"),
     normalizer: default!(Option<String>, "NULL"),
+    alias: default!(Option<String>, "NULL"),
 ) -> JsonB {
     if let Some(true) = stored {
         ErrorReport::new(
@@ -53,7 +54,11 @@ pub fn field(
     tokenizer.map(|v| config.insert("tokenizer".to_string(), v.0));
     normalizer.map(|v| config.insert("normalizer".to_string(), Value::String(v)));
 
-    JsonB(json!({ name: config }))
+    if let Some(alias) = alias {
+        JsonB(json!({ alias: config }))
+    } else {
+        JsonB(json!({ name: config }))
+    }
 }
 
 #[pg_extern(name = "tokenizer", immutable, parallel_safe)]

--- a/pg_search/src/postgres/parallel.rs
+++ b/pg_search/src/postgres/parallel.rs
@@ -34,7 +34,7 @@ pub unsafe extern "C-unwind" fn aminitparallelscan(target: *mut ::core::ffi::c_v
 pub unsafe extern "C-unwind" fn amparallelrescan(scan: pg_sys::IndexScanDesc) {
     // PostgreSQL calls this before a rescan to reset the parallel scan state.
     // Mark as uninitialized so workers wait for leader to re-populate.
-    if let Some(state) = get_bm25_scan_state(&mut (scan as *mut _)) {
+    if let Some(state) = get_bm25_scan_state(scan) {
         let _mutex = state.acquire_mutex();
         state.mark_uninitialized();
     }
@@ -104,7 +104,7 @@ unsafe fn bm25_shared_state(
 /// use ParallelWorker visibility to see the same segments.
 /// Segments are NOT claimed here - they're claimed lazily in amgettuple/amgetbitmap.
 pub unsafe fn maybe_init_parallel_scan(
-    mut scan: pg_sys::IndexScanDesc,
+    scan: pg_sys::IndexScanDesc,
     searcher: &SearchIndexReader,
 ) -> Option<i32> {
     if unsafe { (*scan).parallel_scan.is_null() } {
@@ -115,7 +115,7 @@ pub unsafe fn maybe_init_parallel_scan(
     // Read indexRelation before mutable borrow of scan
     let rel = (*scan).indexRelation;
 
-    let state = get_bm25_scan_state(&mut scan)?;
+    let state = get_bm25_scan_state(scan)?;
 
     let _mutex = state.acquire_mutex();
 
@@ -141,11 +141,11 @@ pub unsafe fn maybe_init_parallel_scan(
 /// Claim a segment from the shared pool.
 /// Both leader and workers use this to get work.
 /// All participants wait for initialization before attempting to claim.
-pub unsafe fn maybe_claim_segment(mut scan: pg_sys::IndexScanDesc) -> Option<SegmentId> {
-    get_bm25_scan_state(&mut scan)?.checkout_segment()
+pub unsafe fn maybe_claim_segment(scan: pg_sys::IndexScanDesc) -> Option<SegmentId> {
+    get_bm25_scan_state(scan)?.checkout_segment()
 }
 
-fn get_bm25_scan_state(scan: &mut pg_sys::IndexScanDesc) -> Option<&mut ParallelScanState> {
+pub fn get_bm25_scan_state<'a>(scan: pg_sys::IndexScanDesc) -> Option<&'a mut ParallelScanState> {
     unsafe {
         assert!(!scan.is_null());
         let scan = scan.as_mut().unwrap_unchecked();

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -373,15 +373,46 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone> LinkedItemList<T> {
                     let next_blockno = page.next_blockno();
                     buffer = self.bman.get_buffer_mut(next_blockno);
                 } else {
-                    // need to create new block and link it to this one
-                    let mut new_page = self.bman.new_buffer();
-                    let new_blockno = new_page.number();
-                    new_page.init_page();
+                    // Extend the list with a new tail block.
+                    //
+                    // Ordering is load-bearing for physical replication:
+                    // we must emit the WAL record for the new block
+                    // (`log_newpage_buffer`) BEFORE the WAL record for the
+                    // previous tail's `next_blockno` update
+                    // (`GenericXLogFinish`), so that a standby replaying
+                    // serially always materializes the new block on disk
+                    // before any pointer references it.
+                    //
+                    // On the primary this ordering is already safe because
+                    // `new_buffer()` extends the relation file synchronously;
+                    // but on a standby, the file grows only when WAL replays.
+                    // If the pointer-update record lands in the log ahead of
+                    // the new-page record, a standby briefly sees
+                    // `prev.next_blockno = new_blockno` while the file is
+                    // still too short to contain `new_blockno`, and
+                    // concurrent readers walking the chain fail with
+                    // `XX001: could not read blocks N..N ... read only 0 of
+                    // 8192 bytes`.
+                    //
+                    // We achieve the correct order by allocating and
+                    // initializing the new page in an inner scope so its
+                    // `BufferMut` drops (and emits `log_newpage_buffer`)
+                    // before we touch the previous tail's `next_blockno`.
+                    // Re-opening the new block via `get_buffer_mut` then
+                    // makes the reassignment of `buffer` drop the old tail
+                    // (emitting `GenericXLogFinish` for the pointer update)
+                    // strictly after the new-page record.
+                    let new_blockno = {
+                        let mut new_page = self.bman.new_buffer();
+                        let bn = new_page.number();
+                        new_page.init_page();
+                        bn
+                    };
 
                     let special = page.special_mut::<BM25PageSpecialData>();
                     special.next_blockno = new_blockno;
 
-                    buffer = new_page;
+                    buffer = self.bman.get_buffer_mut(new_blockno);
                 }
             }
         }
@@ -920,6 +951,70 @@ mod tests {
         guard.commit();
         assert_eq!(linked_list_block_numbers(&list), duplicate_block_numbers);
         assert_eq!(list.list(None), duplicate_contents);
+    }
+
+    /// Extending the linked list with enough entries to span many pages must
+    /// keep the chain consistent: every `next_blockno` pointer on every page
+    /// must reference a block that is already part of the list, and reading
+    /// the list back must return every entry that was added, in order.
+    ///
+    /// The `add_items` extension path was historically vulnerable to a
+    /// WAL-ordering bug where the pointer-update WAL record could be emitted
+    /// before the new-page WAL record, causing standby replay to briefly
+    /// see a pointer to a not-yet-materialized block. On the primary the
+    /// file grows synchronously inside `new_buffer()`, so chain walks there
+    /// were always well-formed; this test asserts that invariant holds and
+    /// guards against future refactors that could regress it.
+    #[pg_test]
+    unsafe fn test_linked_items_extension_chain_is_walkable() {
+        let relation_oid = init_bm25_index();
+        let indexrel = PgSearchRelation::open(relation_oid);
+
+        // Force the list to span many pages by inserting enough entries
+        // that add_items must extend the chain several times.
+        let n = 5000usize;
+        let entries = (0..n)
+            .map(|_| {
+                SegmentMetaEntry::new_immutable(
+                    random_segment_id(),
+                    0,
+                    pg_sys::InvalidTransactionId,
+                    SegmentMetaEntryImmutable {
+                        postings: Some(make_fake_postings(&indexrel)),
+                        ..Default::default()
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let mut list = LinkedItemList::<SegmentMetaEntry>::create_with_fsm(&indexrel);
+        list.add_items(&entries, None);
+
+        // Every next_blockno pointer must reference a block that is itself
+        // part of the chain. `linked_list_block_numbers` walks the chain via
+        // `next_blockno` and collects block numbers; if any pointer led to
+        // a block that could not be opened, the walk would panic (on the
+        // primary) or short-read (on a standby). Completing the walk plus
+        // a read of every page's special area proves the chain is intact.
+        let chain_blocks = linked_list_block_numbers(&list);
+        assert!(
+            chain_blocks.len() > 1,
+            "expected multiple pages for {n} entries, got {} page(s)",
+            chain_blocks.len()
+        );
+
+        // Reading the list back must return exactly the entries we added,
+        // preserving insertion order. This also exercises every page on
+        // the chain (including the most recently-extended tail pages).
+        let read_back = list.list(None);
+        assert_eq!(read_back.len(), entries.len(), "entry count mismatch");
+        for (i, (got, expected)) in read_back.iter().zip(entries.iter()).enumerate() {
+            assert_eq!(
+                got.segment_id(),
+                expected.segment_id(),
+                "entry {i} segment_id mismatch after chain extension"
+            );
+        }
     }
 
     fn init_bm25_index() -> pg_sys::Oid {

--- a/tests/tests/fixtures/db.rs
+++ b/tests/tests/fixtures/db.rs
@@ -149,8 +149,6 @@ where
                         return result;
                     } else if attempt < retries - 1 {
                         block_on(async_std::task::sleep(Duration::from_millis(delay_ms)));
-                    } else {
-                        return vec![];
                     }
                 }
                 Err(_) if attempt < retries - 1 => {

--- a/tests/tests/replication.rs
+++ b/tests/tests/replication.rs
@@ -36,6 +36,9 @@ use tempfile::TempDir;
 static INIT: Once = Once::new();
 static LAST_PORT: AtomicUsize = AtomicUsize::new(49152);
 
+const RETRIES: u32 = 60;
+const RETRY_DELAY: u64 = 1000; // measured in milliseconds
+
 // Function to check if a port can be bound (i.e., is available)
 fn can_bind(port: u16) -> bool {
     std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
@@ -281,8 +284,8 @@ async fn test_logical_replication() -> Result<()> {
     let target_results: Vec<(String,)> =
         "SELECT description FROM mock_items WHERE id @@@ 'description:shoes'".fetch_retry(
             &mut target_conn,
-            5,
-            1000,
+            RETRIES,
+            RETRY_DELAY,
             |result| !result.is_empty(),
         );
 
@@ -321,8 +324,8 @@ async fn test_logical_replication() -> Result<()> {
     let target_results: Vec<(i32,)> =
         "SELECT rating FROM mock_items WHERE description = 'Red sports shoes'".fetch_retry(
             &mut target_conn,
-            5,
-            1000,
+            RETRIES,
+            RETRY_DELAY,
             |result| !result.is_empty(),
         );
 
@@ -341,9 +344,9 @@ async fn test_logical_replication() -> Result<()> {
     let target_results: Vec<(String,)> =
         "SELECT description FROM mock_items WHERE description = 'Red sports shoes'".fetch_retry(
             &mut target_conn,
-            5,
-            1000,
-            |result| !result.is_empty(),
+            RETRIES,
+            RETRY_DELAY,
+            |result| result.is_empty(),
         );
 
     assert_eq!(source_results.len(), 0);
@@ -367,7 +370,7 @@ async fn test_logical_replication() -> Result<()> {
     std::thread::sleep(std::time::Duration::from_secs(1)); // give a little time for the data to replicate
     let target_results: Vec<(String,)> =
         "SELECT description FROM mock_items WHERE description @@@ 'description:replicated1' OR description @@@ 'description:replicated2' OR description @@@ 'description:replicated3'"
-            .fetch_retry(&mut target_conn, 5, 1000, |result| !result.is_empty());
+            .fetch_retry(&mut target_conn, RETRIES, RETRY_DELAY, |result| result.len() == 3);
     assert_eq!(target_results.len(), 3);
 
     Ok(())


### PR DESCRIPTION
Closes #5202

## What & why

These changes already live in the `paradedb-enterprise` mirror but are **not enterprise-specific**. Porting them upstream shrinks the enterprise↔community divergence (so they stop reappearing in every rebase) and they stand on their own merits for community. Bundled into one PR per request; happy to split.

Each change was applied onto current `main` (the enterprise base for these files is identical to `main`, so they apply cleanly).

## Changes

| Type | Area | Description |
|------|------|-------------|
| `fix` | `storage/linked_items.rs` | In `LinkedItemList::add_items`, emit the **new-page** WAL record before the previous tail's `next_blockno` **pointer-update** record. A standby replaying WAL serially could otherwise briefly see a pointer to a block the file doesn't yet contain, and concurrent readers walking the chain fail with `XX001: could not read blocks … read only 0 of 8192 bytes`. The primary was always safe (the file grows synchronously in `new_buffer()`); this only bites on a replica. Includes a new `test_linked_items_extension_chain_is_walkable` regression test. |
| `test` | `tests/replication.rs` | Deflake `test_logical_replication`: introduce `RETRIES`/`RETRY_DELAY`, raise retries from 5→60, and **fix two incorrect validators** — the delete check waited for `!is_empty()` (which can never become true after a delete) and now waits for `is_empty()`; the COPY check now waits for exactly 3 rows instead of "non-empty". |
| `fix` | `tests/fixtures/db.rs` | `fetch_retry` no longer returns an empty `vec![]` on the final attempt — that silently masked failures. It now exhausts all retries and panics loudly on persistent failure. |
| `feat` | `api/config.rs` | Add an optional `alias` argument to `paradedb.field(...)` to key the field config under an alias instead of the column name. |
| `refactor` | `postgres/parallel.rs` | Take `IndexScanDesc` by value in `get_bm25_scan_state` and callers; removes pointless `&mut` indirection, no behavior change. |
| `docs` | `pg_search/README.md` | Remove a stray "Install stable Rust:" line. |

## Testing

CI