### PR TITLE
chore: Bump 0.23.5 to 0.23.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "approx",
@@ -5008,7 +5008,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5723,7 +5723,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -8029,7 +8029,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -8417,7 +8417,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "approx",
@@ -8596,7 +8596,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.23.5"
+version = "0.23.6"
 dependencies = [
  "anyhow",
  "emoji",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.5"
+version = "0.23.6"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-sWBPbf8vcychdEk9y6zTkYNZ/SsZdJ4dCk2MYnYS8ZM=";
+  cargoHash = "sha256-NxH5yzEf34bSCWX04hyadF2e1YFFF8QXunFb4nXPlWg=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.23.5--0.23.6.sql
+++ b/pg_search/sql/pg_search--0.23.5--0.23.6.sql
@@ -1,0 +1,1 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.23.6'" to load this file. \quit


### PR DESCRIPTION
# Description

Bumps the workspace version from `0.23.5` to `0.23.6` and adds an empty upgrade script (`pg_search--0.23.5--0.23.6.sql`).

- `Cargo.toml` / `Cargo.lock`: workspace version `0.23.5` → `0.23.6`
- `pg_search/sql/pg_search--0.23.5--0.23.6.sql`: empty upgrade script (just the `\echo ... \quit` header)

Docs are intentionally left untouched.