### PR TITLE
test: verify MPP vs non-MPP `num_results` parity in the benchmark suite.

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -49,6 +49,40 @@ runs:
 
         echo "ROWS_LABEL=${{ inputs.size }}" >> $GITHUB_ENV
 
+    # Each query file produces N variants ("base", "base - alternative 1",
+    # "base - alternative 2"). All variants of a file run the same logical
+    # query under different GUC combinations (PG default, DataFusion agg,
+    # MPP). If they don't agree on `num_results`, one of the custom-scan
+    # paths has a correctness regression.
+    - name: Verify alternative-vs-base num_results equality
+      working-directory: benchmarks/
+      shell: bash
+      run: |
+        python3 - <<'PY'
+        import json, re, sys
+        with open("results.json") as f:
+            results = json.load(f)
+        groups = {}
+        for r in results:
+            base = re.sub(r' - alternative \d+$', '', r["name"])
+            groups.setdefault(base, []).append((r["name"], r.get("num_results")))
+        mismatches = []
+        for base, members in groups.items():
+            if len(members) < 2:
+                continue
+            counts = {n for _, n in members}
+            if len(counts) > 1:
+                mismatches.append((base, members))
+        if mismatches:
+            print("MPP vs non-MPP num_results mismatch:")
+            for base, members in mismatches:
+                print(f"  {base}:")
+                for name, n in members:
+                    print(f"    {name}: {n}")
+            sys.exit(1)
+        print("All alternatives produced matching num_results.")
+        PY
+
     - name: Print the Postgres Logs
       if: failure()
       shell: bash

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -83,11 +83,18 @@ runs:
             return stmt.rsplit(";", 1)[-1].strip().lower()
 
         def hash_rows(stmt):
-            # Use raw `psql` so SET ... ; SELECT ... runs in a single session.
-            # `-At` gives unaligned, tuple-only output; rows sorted to absorb
-            # non-deterministic ordering in `ORDER BY`-less queries.
+            # `-q -X -P "tuples_only=on" -P "format=unaligned"` suppresses
+            # the "SET" command tags emitted by the GUC prefix so only the
+            # SELECT's rows reach stdout. Rows sorted to absorb queries
+            # that don't carry an `ORDER BY`.
             proc = subprocess.run(
-                ["psql", url, "-At", "-v", "ON_ERROR_STOP=1", "-c", stmt],
+                [
+                    "psql", url, "-q", "-X",
+                    "-P", "tuples_only=on",
+                    "-P", "format=unaligned",
+                    "-v", "ON_ERROR_STOP=1",
+                    "-c", stmt,
+                ],
                 capture_output=True, text=True
             )
             if proc.returncode != 0:

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -102,8 +102,18 @@ runs:
             rows = sorted(proc.stdout.splitlines())
             return hashlib.sha256("\n".join(rows).encode()).hexdigest(), None
 
+        # Only check files that have an MPP alternative. The other files
+        # are deliberately running shape-different variants (and many add
+        # `LIMIT N` over `ORDER BY` columns with ties, where SQL itself
+        # doesn't pin a unique row set so the hashes legitimately diverge).
+        def file_touches_mpp(path):
+            with open(path) as f:
+                return "enable_mpp" in f.read().lower()
+
         mismatches, errors = [], []
         for path in sorted(glob.glob(f"datasets/{dataset}/queries/*.sql")):
+            if not file_touches_mpp(path):
+                continue
             base = os.path.basename(path)
             alts = alternatives(path)
             by_select = {}

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -49,11 +49,11 @@ runs:
 
         echo "ROWS_LABEL=${{ inputs.size }}" >> $GITHUB_ENV
 
-    # Each query file produces N variants ("base", "base - alternative 1",
-    # "base - alternative 2"). All variants of a file run the same logical
-    # query under different GUC combinations (PG default, DataFusion agg,
-    # MPP). If they don't agree on `num_results`, one of the custom-scan
-    # paths has a correctness regression.
+    # Group alternatives that share the same trailing `SELECT` (only the
+    # `SET` prefix differs, e.g. PG default vs DataFusion agg vs MPP). If
+    # they don't agree on `num_results`, one of the custom-scan paths has a
+    # correctness regression. Alternatives with different `SELECT`s
+    # (different query shapes — see `cardinality.sql`) don't get compared.
     - name: Verify alternative-vs-base num_results equality
       working-directory: benchmarks/
       shell: bash
@@ -62,25 +62,37 @@ runs:
         import json, re, sys
         with open("results.json") as f:
             results = json.load(f)
+
+        def select_text(extra: str) -> str:
+            m = re.search(r'query=(.*)$', extra, re.S)
+            if not m:
+                return ""
+            full = m.group(1).strip()
+            return full.rsplit(";", 1)[-1].strip().lower()
+
         groups = {}
         for r in results:
-            base = re.sub(r' - alternative \d+$', '', r["name"])
-            groups.setdefault(base, []).append((r["name"], r.get("num_results")))
+            base_name = re.sub(r' - alternative \d+$', '', r["name"])
+            key = (base_name, select_text(r.get("extra", "")))
+            groups.setdefault(key, []).append((r["name"], r.get("num_results")))
+
         mismatches = []
-        for base, members in groups.items():
+        for key, members in groups.items():
             if len(members) < 2:
                 continue
             counts = {n for _, n in members}
             if len(counts) > 1:
-                mismatches.append((base, members))
+                mismatches.append((key, members))
+
         if mismatches:
-            print("MPP vs non-MPP num_results mismatch:")
-            for base, members in mismatches:
+            print("Alternatives sharing the same SELECT disagree on num_results:")
+            for (base, sel), members in mismatches:
                 print(f"  {base}:")
+                print(f"    SELECT: {sel[:120]}{'...' if len(sel) > 120 else ''}")
                 for name, n in members:
-                    print(f"    {name}: {n}")
+                    print(f"      {name}: {n}")
             sys.exit(1)
-        print("All alternatives produced matching num_results.")
+        print("All same-SELECT alternatives produced matching num_results.")
         PY
 
     - name: Print the Postgres Logs

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -82,7 +82,7 @@ runs:
         def select_text(stmt):
             return stmt.rsplit(";", 1)[-1].strip().lower()
 
-        def hash_rows(stmt):
+        def run_alt(stmt):
             # `-q -X -P "tuples_only=on" -P "format=unaligned"` suppresses
             # the "SET" command tags emitted by the GUC prefix so only the
             # SELECT's rows reach stdout. Rows sorted to absorb queries
@@ -98,9 +98,9 @@ runs:
                 capture_output=True, text=True
             )
             if proc.returncode != 0:
-                return None, (proc.stderr or proc.stdout).strip()
+                return None, None, (proc.stderr or proc.stdout).strip()
             rows = sorted(proc.stdout.splitlines())
-            return hashlib.sha256("\n".join(rows).encode()).hexdigest(), None
+            return rows, hashlib.sha256("\n".join(rows).encode()).hexdigest(), None
 
         # Only check files that have an MPP alternative. The other files
         # are deliberately running shape-different variants (and many add
@@ -109,6 +109,23 @@ runs:
         def file_touches_mpp(path):
             with open(path) as f:
                 return "enable_mpp" in f.read().lower()
+
+        def diff_snippet(rows_a, rows_b, label_a, label_b, limit=20):
+            set_a, set_b = set(rows_a), set(rows_b)
+            only_a = sorted(set_a - set_b)[:limit]
+            only_b = sorted(set_b - set_a)[:limit]
+            lines = [
+                f"      rowcounts: {label_a}={len(rows_a)} {label_b}={len(rows_b)}",
+                f"      symmetric-diff: {label_a}-only={len(set_a - set_b)}"
+                f" {label_b}-only={len(set_b - set_a)}",
+            ]
+            if only_a:
+                lines.append(f"      first {len(only_a)} {label_a}-only rows:")
+                lines.extend(f"        {r}" for r in only_a)
+            if only_b:
+                lines.append(f"      first {len(only_b)} {label_b}-only rows:")
+                lines.extend(f"        {r}" for r in only_b)
+            return "\n".join(lines)
 
         mismatches, errors = [], []
         for path in sorted(glob.glob(f"datasets/{dataset}/queries/*.sql")):
@@ -122,14 +139,14 @@ runs:
             for sel, members in by_select.items():
                 if len(members) < 2:
                     continue
-                results = []
+                runs = []
                 for idx, alt in members:
-                    h, err = hash_rows(alt)
+                    rows, h, err = run_alt(alt)
                     if err:
                         errors.append((base, idx, err))
-                    results.append((idx, h))
-                if len({h for _, h in results if h is not None}) > 1:
-                    mismatches.append((base, sel, results))
+                    runs.append((idx, rows, h))
+                if len({h for _, _, h in runs if h is not None}) > 1:
+                    mismatches.append((base, sel, runs))
 
         if errors:
             print("Query errors:")
@@ -137,11 +154,20 @@ runs:
                 print(f"  {f} alt {i}: {e}")
         if mismatches:
             print("\nAlternatives with the same SELECT but different result sets:")
-            for f, sel, results in mismatches:
+            for f, sel, runs in mismatches:
                 snip = sel[:120] + ("..." if len(sel) > 120 else "")
                 print(f"  {f}: {snip}")
-                for i, h in results:
+                for i, _rows, h in runs:
                     print(f"    alt {i}: {h}")
+                # Pin alt 0 as the reference and diff every other alt against it.
+                ref_idx, ref_rows, _ = runs[0]
+                for i, rows, h in runs[1:]:
+                    if h is None or rows is None:
+                        continue
+                    if h == runs[0][2]:
+                        continue
+                    print(f"    --- diff alt {ref_idx} vs alt {i} ---")
+                    print(diff_snippet(ref_rows, rows, f"alt{ref_idx}", f"alt{i}"))
         if errors or mismatches:
             sys.exit(1)
         print("All same-SELECT alternatives returned identical result sets.")

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -50,49 +50,84 @@ runs:
         echo "ROWS_LABEL=${{ inputs.size }}" >> $GITHUB_ENV
 
     # Group alternatives that share the same trailing `SELECT` (only the
-    # `SET` prefix differs, e.g. PG default vs DataFusion agg vs MPP). If
-    # they don't agree on `num_results`, one of the custom-scan paths has a
-    # correctness regression. Alternatives with different `SELECT`s
-    # (different query shapes — see `cardinality.sql`) don't get compared.
-    - name: Verify alternative-vs-base num_results equality
+    # `SET` prefix differs, e.g. PG default vs DataFusion agg vs MPP), run
+    # each variant and compare hashed result sets. `num_results` alone
+    # can't tell `COUNT(*) = 42` from `COUNT(*) = 99` (both have one row),
+    # so we hash the sorted rows and require an exact match. Alternatives
+    # with different `SELECT`s (different query shapes) don't get compared.
+    - name: Verify alternative-vs-base result equality
       working-directory: benchmarks/
       shell: bash
+      env:
+        DATASET: ${{ inputs.dataset }}
       run: |
         python3 - <<'PY'
-        import json, re, sys
-        with open("results.json") as f:
-            results = json.load(f)
+        import glob, hashlib, os, re, subprocess, sys
 
-        def select_text(extra: str) -> str:
-            m = re.search(r'query=(.*)$', extra, re.S)
-            if not m:
-                return ""
-            full = m.group(1).strip()
-            return full.rsplit(";", 1)[-1].strip().lower()
+        dataset = os.environ["DATASET"]
+        url = f"postgresql://localhost:288{os.environ['pg_version']}/postgres"
 
-        groups = {}
-        for r in results:
-            base_name = re.sub(r' - alternative \d+$', '', r["name"])
-            key = (base_name, select_text(r.get("extra", "")))
-            groups.setdefault(key, []).append((r["name"], r.get("num_results")))
+        def alternatives(path):
+            with open(path) as f:
+                content = f.read()
+            out = []
+            for raw in content.split(";\n"):
+                stripped = " ".join(
+                    line.split("--")[0].strip() for line in raw.splitlines()
+                ).strip()
+                if stripped:
+                    out.append(stripped)
+            return out
 
-        mismatches = []
-        for key, members in groups.items():
-            if len(members) < 2:
-                continue
-            counts = {n for _, n in members}
-            if len(counts) > 1:
-                mismatches.append((key, members))
+        def select_text(stmt):
+            return stmt.rsplit(";", 1)[-1].strip().lower()
 
+        def hash_rows(stmt):
+            # Use raw `psql` so SET ... ; SELECT ... runs in a single session.
+            # `-At` gives unaligned, tuple-only output; rows sorted to absorb
+            # non-deterministic ordering in `ORDER BY`-less queries.
+            proc = subprocess.run(
+                ["psql", url, "-At", "-v", "ON_ERROR_STOP=1", "-c", stmt],
+                capture_output=True, text=True
+            )
+            if proc.returncode != 0:
+                return None, (proc.stderr or proc.stdout).strip()
+            rows = sorted(proc.stdout.splitlines())
+            return hashlib.sha256("\n".join(rows).encode()).hexdigest(), None
+
+        mismatches, errors = [], []
+        for path in sorted(glob.glob(f"datasets/{dataset}/queries/*.sql")):
+            base = os.path.basename(path)
+            alts = alternatives(path)
+            by_select = {}
+            for idx, alt in enumerate(alts):
+                by_select.setdefault(select_text(alt), []).append((idx, alt))
+            for sel, members in by_select.items():
+                if len(members) < 2:
+                    continue
+                results = []
+                for idx, alt in members:
+                    h, err = hash_rows(alt)
+                    if err:
+                        errors.append((base, idx, err))
+                    results.append((idx, h))
+                if len({h for _, h in results if h is not None}) > 1:
+                    mismatches.append((base, sel, results))
+
+        if errors:
+            print("Query errors:")
+            for f, i, e in errors:
+                print(f"  {f} alt {i}: {e}")
         if mismatches:
-            print("Alternatives sharing the same SELECT disagree on num_results:")
-            for (base, sel), members in mismatches:
-                print(f"  {base}:")
-                print(f"    SELECT: {sel[:120]}{'...' if len(sel) > 120 else ''}")
-                for name, n in members:
-                    print(f"      {name}: {n}")
+            print("\nAlternatives with the same SELECT but different result sets:")
+            for f, sel, results in mismatches:
+                snip = sel[:120] + ("..." if len(sel) > 120 else "")
+                print(f"  {f}: {snip}")
+                for i, h in results:
+                    print(f"    alt {i}: {h}")
+        if errors or mismatches:
             sys.exit(1)
-        print("All same-SELECT alternatives produced matching num_results.")
+        print("All same-SELECT alternatives returned identical result sets.")
         PY
 
     - name: Print the Postgres Logs

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -154,6 +154,9 @@ struct JSONBenchmarkResult {
     value: f64,
     range: String,
     extra: String,
+    // Carried into the JSON output so a post-process step can verify
+    // alternative-vs-base equality (MPP vs non-MPP).
+    num_results: usize,
 }
 
 impl From<QueryResult> for JSONBenchmarkResult {
@@ -179,6 +182,7 @@ impl From<QueryResult> for JSONBenchmarkResult {
             value: mean,
             range: range_str,
             extra: cold_query_extra,
+            num_results: res.results.num_results,
         }
     }
 }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -325,6 +325,39 @@ struct IndexComponents {
     schema: SearchIndexSchema,
 }
 
+/// Single-counter iterator backing [`SearchIndexReader::search_lazy`].
+struct ParallelSegmentIterator {
+    parallel_state: *mut crate::postgres::ParallelScanState,
+}
+// SAFETY: PG-managed shared memory; every access goes through the state's mutex,
+// so the raw pointer can cross threads.
+unsafe impl Send for ParallelSegmentIterator {}
+unsafe impl Sync for ParallelSegmentIterator {}
+impl Iterator for ParallelSegmentIterator {
+    type Item = tantivy::index::SegmentId;
+    fn next(&mut self) -> Option<Self::Item> {
+        pgrx::check_for_interrupts!();
+        unsafe { crate::postgres::customscan::parallel::checkout_segment(self.parallel_state) }
+    }
+}
+
+/// Per-source iterator for MPP non-partitioning sources. Avoids racing two sources
+/// on the partitioning source's counter.
+struct PerSourceSegmentIterator {
+    parallel_state: *mut crate::postgres::ParallelScanState,
+    source_idx: usize,
+}
+// SAFETY: same as `ParallelSegmentIterator`.
+unsafe impl Send for PerSourceSegmentIterator {}
+unsafe impl Sync for PerSourceSegmentIterator {}
+impl Iterator for PerSourceSegmentIterator {
+    type Item = tantivy::index::SegmentId;
+    fn next(&mut self) -> Option<Self::Item> {
+        pgrx::check_for_interrupts!();
+        unsafe { (*self.parallel_state).checkout_segment_for_source(self.source_idx) }
+    }
+}
+
 impl SearchIndexReader {
     fn open_index_components(
         index_relation: &PgSearchRelation,
@@ -671,23 +704,30 @@ impl SearchIndexReader {
         parallel_state: *mut crate::postgres::ParallelScanState,
         estimated_rows: u64,
     ) -> MultiSegmentSearchResults {
-        struct ParallelSegmentIterator {
-            parallel_state: *mut crate::postgres::ParallelScanState,
-        }
-        unsafe impl Send for ParallelSegmentIterator {}
-        unsafe impl Sync for ParallelSegmentIterator {}
-        impl Iterator for ParallelSegmentIterator {
-            type Item = tantivy::index::SegmentId;
-            fn next(&mut self) -> Option<Self::Item> {
-                pgrx::check_for_interrupts!();
-                unsafe {
-                    crate::postgres::customscan::parallel::checkout_segment(self.parallel_state)
-                }
-            }
-        }
+        self.search_lazy_with(estimated_rows, ParallelSegmentIterator { parallel_state })
+    }
 
-        let segment_ids = ParallelSegmentIterator { parallel_state };
+    /// `search_lazy` variant for MPP non-partitioning sources. Each source claims from
+    /// its own counter, avoiding races between sources.
+    pub fn search_lazy_for_source(
+        &self,
+        parallel_state: *mut crate::postgres::ParallelScanState,
+        source_idx: usize,
+        estimated_rows: u64,
+    ) -> MultiSegmentSearchResults {
+        self.search_lazy_with(
+            estimated_rows,
+            PerSourceSegmentIterator {
+                parallel_state,
+                source_idx,
+            },
+        )
+    }
 
+    fn search_lazy_with<I>(&self, estimated_rows: u64, segment_ids: I) -> MultiSegmentSearchResults
+    where
+        I: Iterator<Item = tantivy::index::SegmentId> + Send + Sync + 'static,
+    {
         let searcher = self.searcher.clone();
         let query = self.query.box_clone();
         let need_scores = self.need_scores;

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_exec.rs
@@ -601,6 +601,11 @@ async fn build_source_df(
     let mut provider = PgSearchTableProvider::new(scan_info, fields, is_parallel);
     if let Some(idx) = np_idx {
         provider.set_non_partitioning_index(idx);
+        // MPP: this source claims via `checkout_segment_for_source(plan_position)`
+        // instead of scanning the full data. Non-MPP: no `parallel_state`, no-op.
+        if mpp_ctx.is_some() {
+            provider.set_mpp_source_idx(plan_position);
+        }
     }
     // HeapFilter queries (e.g. `=` on a column indexed via a
     // `pdb.literal(...)` cast) compile to runtime Postgres expressions

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -1058,6 +1058,13 @@ fn build_source_df<'a>(
         // canonical segment IDs during decode.
         if let Some(idx) = np_idx {
             provider.set_non_partitioning_index(idx);
+            // Gate on `mpp_is_active()`: joinscan EXEC passes `parallel_state` to the
+            // codec on both MPP and PG-parallel runs, but PG-parallel hash join still
+            // needs canonical-segment-ids replication so every worker sees the full
+            // build side.
+            if crate::postgres::customscan::mpp::glue::mpp_is_active() {
+                provider.set_mpp_source_idx(plan_position);
+            }
         }
 
         if let Some(ref sort_order) = scan_info.sort_order {

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -176,11 +176,17 @@ struct ParallelScanPayloadLayout {
     all_counts: Range<usize>,
     /// Concatenated 16-byte segment UUIDs for all sources, in ascending source-index order.
     all_ids: Range<usize>,
+    /// One `u32` per source: remaining unclaimed segments. Lets every source in a
+    /// multi-source MPP plan be partitioned across workers, not just the planner-chosen
+    /// partitioning source.
+    remaining_by_source: Range<usize>,
     /// One `u32` per segment in the partitioning source: deleted doc count.
     partitioning_deleted_docs: Range<usize>,
     /// One `u32` per segment in the partitioning source: max doc count.
     partitioning_max_docs: Range<usize>,
     /// One `i32` per segment in the partitioning source: which worker claimed it.
+    /// Non-partitioning sources skip claims tracking; `EXPLAIN ANALYZE` only reads the
+    /// partitioning source's claims.
     claims: Range<usize>,
     aggregates_header: Option<Range<usize>>,
     aggregates_data: Option<Range<usize>>,
@@ -215,6 +221,10 @@ impl ParallelScanPayloadLayout {
         let all_ids_layout = Layout::from_size_align(total_segs * SEGMENT_ID_SIZE, 1)?;
         let (layout, all_ids_offset) = layout.extend(all_ids_layout)?;
         let all_ids_range = all_ids_offset..(all_ids_offset + all_ids_layout.size());
+
+        let remaining_layout = Layout::array::<u32>(n_sources)?;
+        let (layout, remaining_offset) = layout.extend(remaining_layout)?;
+        let remaining_range = remaining_offset..(remaining_offset + remaining_layout.size());
 
         // Deleted doc counts for the partitioning source only: [u32; partitioning_nsegments].
         let partitioning_del_layout = Layout::array::<u32>(partitioning_nsegments)?;
@@ -253,6 +263,7 @@ impl ParallelScanPayloadLayout {
             query: query_range,
             all_counts: all_counts_range,
             all_ids: all_ids_range,
+            remaining_by_source: remaining_range,
             partitioning_deleted_docs: partitioning_deleted_docs_range,
             partitioning_max_docs: partitioning_max_docs_range,
             claims: claims_range,
@@ -345,6 +356,18 @@ impl ParallelScanPayload {
         for claim in self.claims_mut().iter_mut() {
             *claim = SEGMENT_CLAIM_UNCLAIMED;
         }
+
+        // Skip slab init on single-source scans. They use `remaining_segments` via
+        // `checkout_segment` and never touch the per-source slab, so don't pay
+        // bookkeeping on the non-MPP parallel hot path.
+        if all_sources.len() > 1 {
+            let remaining_range = self.layout.remaining_by_source.clone();
+            let remaining_slice: &mut [u32] =
+                bytemuck::try_cast_slice_mut(&mut self.data_mut()[remaining_range]).unwrap();
+            for (source, target) in all_sources.iter().zip(remaining_slice.iter_mut()) {
+                *target = source.len() as u32;
+            }
+        }
     }
 
     fn data(&self) -> &[u8] {
@@ -396,6 +419,11 @@ impl ParallelScanPayload {
 
     fn partitioning_max_docs(&self) -> &[u32] {
         bytemuck::try_cast_slice(&self.data()[self.layout.partitioning_max_docs.clone()]).unwrap()
+    }
+
+    fn remaining_by_source_mut(&mut self) -> &mut [u32] {
+        let range = self.layout.remaining_by_source.clone();
+        bytemuck::try_cast_slice_mut(&mut self.data_mut()[range]).unwrap()
     }
 
     /// An array of `i32` parallel worker numbers (as returned by pg_sys::ParallelWorkerNumber)
@@ -633,6 +661,12 @@ impl ParallelScanState {
     pub fn mark_initialized_empty(&mut self) {
         self.nsegments = 0;
         self.remaining_segments = 0;
+        // Mirror `populate()`'s gate: nothing to zero on single-source scans.
+        if self.payload.all_counts().len() > 1 {
+            for slot in self.payload.remaining_by_source_mut() {
+                *slot = 0;
+            }
+        }
         self.init_cv.broadcast();
     }
 
@@ -839,8 +873,35 @@ impl ParallelScanState {
             // this means we're purposely checking out segments from largest-to-smallest.
             let claimed_segment = self.decrement_remaining_segments();
             self.payload.claims_mut()[claimed_segment] = parallel_worker_number;
+            // `checkout_segment_for_source` never reads the partitioning slot, so
+            // don't mirror this decrement onto `remaining_by_source[partitioning_idx]`.
             break Some(self.segment_id(claimed_segment));
         }
+    }
+
+    /// Source-aware checkout for MPP non-partitioning sources. Skips the partitioning
+    /// source's `claims` array because `EXPLAIN ANALYZE` only reads that array on the
+    /// partitioning source.
+    pub fn checkout_segment_for_source(&mut self, source_idx: usize) -> Option<SegmentId> {
+        self.wait_for_initialization();
+        let _mutex = self.acquire_mutex();
+        let counts = self.payload.all_counts();
+        let count_for_source = *counts.get(source_idx)? as usize;
+        if count_for_source == 0 {
+            return None;
+        }
+        let by_source = self.payload.remaining_by_source_mut();
+        let slot = by_source.get_mut(source_idx)?;
+        if *slot == 0 {
+            return None;
+        }
+        *slot -= 1;
+        let claimed_idx = *slot as usize;
+        // Positional lookup gives the same largest-to-smallest claim order
+        // `checkout_segment` uses on the partitioning source.
+        Some(SegmentId::from_bytes(
+            self.payload.source_ids(source_idx)[claimed_idx],
+        ))
     }
 
     /// Returns a map of segment IDs to their deleted document counts.
@@ -940,8 +1001,35 @@ impl ParallelScanState {
     /// Reset remaining_segments for a rescan. Called by amparallelrescan.
     pub fn reset(&mut self) {
         self.remaining_segments = self.nsegments;
+        // Rescan must re-partition the same way as the initial scan; without this,
+        // every source observes zero remaining and emits nothing. Skip for
+        // single-source (slab never populated).
+        if self.payload.all_counts().len() > 1 {
+            let counts: Vec<u32> = self.payload.all_counts().to_vec();
+            for (slot, count) in self
+                .payload
+                .remaining_by_source_mut()
+                .iter_mut()
+                .zip(counts.iter())
+            {
+                *slot = *count;
+            }
+        }
         // NOTE: We do not reset `queries_per_worker` here, so that it can be tracked across
         // rescans.
+    }
+
+    /// Per-source frozen segment set for `MvccSatisfies::ParallelWorker(ids)`. Lives
+    /// in the shared payload so workers don't need a codec channel for it. Waits for
+    /// leader init; otherwise a racing worker reads zero IDs.
+    pub fn segment_ids_for_source(&mut self, source_idx: usize) -> HashSet<SegmentId> {
+        self.wait_for_initialization();
+        let _mutex = self.acquire_mutex();
+        self.payload
+            .source_ids(source_idx)
+            .iter()
+            .map(|b| SegmentId::from_bytes(*b))
+            .collect()
     }
 }
 

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -219,7 +219,10 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         let mut provider: PgSearchTableProvider = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("Failed to deserialize PgSearchTableProvider: {e}"))
         })?;
-        if provider.is_parallel() {
+        // Inject `parallel_state` for the partitioning source and every non-partitioning
+        // MPP source. The non-partitioning path calls
+        // `checkout_segment_for_source(mpp_source_idx)` against the same pointer.
+        if provider.is_parallel() || provider.mpp_source_idx().is_some() {
             provider.set_parallel_state(self.parallel_state);
         }
         if let Some(np_idx) = provider.non_partitioning_index() {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -93,9 +93,19 @@ pub enum ScanRecipe {
         segment_ids: Vec<SegmentId>,
         scanner_config: ScannerConfig,
     },
-    /// Lazy scan: segments are claimed dynamically from parallel state.
+    /// Single-counter claim via `checkout_segment`. Used by the basescan IAM, the MPP
+    /// partitioning source, and non-MPP parallel hash join.
     Lazy {
         parallel_state: Option<*mut ParallelScanState>,
+        planner_estimated_rows: u64,
+        scanner_config: ScannerConfig,
+    },
+    /// Per-source claim for MPP non-partitioning sources, splitting work across workers
+    /// instead of replicating. The partitioning source stays on `Lazy` because
+    /// `checkout_segment` updates the `claims` array `EXPLAIN ANALYZE` reads.
+    LazyForSource {
+        parallel_state: *mut ParallelScanState,
+        source_idx: usize,
         planner_estimated_rows: u64,
         scanner_config: ScannerConfig,
     },
@@ -232,6 +242,10 @@ impl PgSearchScanPlan {
                         .reader
                         .estimated_docs_in_segments(segment_ids.iter().cloned()),
                     ScanRecipe::Lazy {
+                        planner_estimated_rows,
+                        ..
+                    }
+                    | ScanRecipe::LazyForSource {
                         planner_estimated_rows,
                         ..
                     } => *planner_estimated_rows,
@@ -496,6 +510,19 @@ impl ExecutionPlan for PgSearchScanPlan {
                             } else {
                                 reader.search()
                             };
+                            (res, scanner_config)
+                        }
+                        ScanRecipe::LazyForSource {
+                            parallel_state,
+                            source_idx,
+                            planner_estimated_rows,
+                            scanner_config,
+                        } => {
+                            let res = reader.search_lazy_for_source(
+                                parallel_state,
+                                source_idx,
+                                planner_estimated_rows,
+                            );
                             (res, scanner_config)
                         }
                         ScanRecipe::Prefetched { .. } => unreachable!(),

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -131,6 +131,14 @@ pub struct PgSearchTableProvider {
     /// and load (in get_schema) execute sequentially within the same single-threaded optimization pass.
     #[serde(with = "atomic_bool_serde")]
     late_materialization_active: AtomicBool,
+
+    /// Source position in the MPP unified-sources array. When set, the codec's
+    /// `parallel_state` routes per-source claims via
+    /// `checkout_segment_for_source(source_idx)`, so `NetworkShuffleExec` doesn't
+    /// receive N copies. `None` for serial, the partitioning source, and non-MPP
+    /// parallel hash join.
+    #[serde(default)]
+    mpp_source_idx: Option<usize>,
 }
 
 mod atomic_bool_serde {
@@ -171,6 +179,7 @@ impl PgSearchTableProvider {
             canonical_segment_ids: None,
             visibility_mode: VisibilityMode::Eager,
             late_materialization_active: AtomicBool::new(false),
+            mpp_source_idx: None,
         }
     }
 
@@ -185,7 +194,10 @@ impl PgSearchTableProvider {
     }
 
     pub(crate) fn set_parallel_state(&mut self, parallel_state: Option<*mut ParallelScanState>) {
-        assert!(self.is_parallel);
+        // Non-partitioning MPP sources need `parallel_state` for
+        // `checkout_segment_for_source`, but `is_parallel` stays false so the
+        // logical-plan rules (partitioning-source-only segment ordering) keep working.
+        assert!(self.is_parallel || self.mpp_source_idx.is_some());
         self.parallel_state = parallel_state;
     }
 
@@ -212,6 +224,15 @@ impl PgSearchTableProvider {
 
     pub(crate) fn set_planstate(&mut self, planstate: Option<*mut pg_sys::PlanState>) {
         self.planstate = planstate;
+    }
+
+    /// See [`PgSearchTableProvider::mpp_source_idx`] for what this gates.
+    pub(crate) fn set_mpp_source_idx(&mut self, idx: usize) {
+        self.mpp_source_idx = Some(idx);
+    }
+
+    pub(crate) fn mpp_source_idx(&self) -> Option<usize> {
+        self.mpp_source_idx
     }
     fn enable_deferred_columns(&mut self, required_early_columns: &HashSet<String>) {
         for wff in self.fields.iter_mut() {
@@ -617,6 +638,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         query_for_display: SearchQueryInput,
         planner_estimated_rows: u64,
+        mpp_source_idx: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -624,12 +646,25 @@ impl PgSearchTableProvider {
             heap_relid: heap_relid.into(),
             batch_size_hint: None,
         };
-        let state = ScanState {
-            recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
+        // `LazyForSource` for MPP non-partitioning sources; `Lazy` for the partitioning
+        // source, serial scans, and non-MPP parallel hash join.
+        let recipe = match (mpp_source_idx, parallel_state) {
+            (Some(source_idx), Some(ps)) => {
+                crate::scan::execution_plan::ScanRecipe::LazyForSource {
+                    parallel_state: ps,
+                    source_idx,
+                    planner_estimated_rows,
+                    scanner_config,
+                }
+            }
+            _ => crate::scan::execution_plan::ScanRecipe::Lazy {
                 parallel_state,
                 planner_estimated_rows,
                 scanner_config,
             },
+        };
+        let state = ScanState {
+            recipe,
             ffhelper: ffhelper.clone(),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader: reader.clone(),
@@ -759,22 +794,35 @@ impl PgSearchTableProvider {
             query.solve_postgres_expressions(expr_context);
         }
 
-        // Determine MVCC strategy based on whether we are running in parallel mode.
+        // MVCC dispatch by (`mpp_source_idx`, `parallel_state`, `canonical_segment_ids`):
         //
-        // For the partitioning source (`parallel_state` is Some):
-        //   - Leader: Snapshot (claims segments dynamically; its own snapshot is the source
-        //             of truth for which segments exist).
-        //   - Workers: ParallelWorker(partitioning_segment_ids) – frozen set from leader.
+        // MPP non-partitioning (`mpp_source_idx` Some, `parallel_state` Some): every
+        // worker opens the leader's frozen segment set from `ParallelScanState`, then
+        // claims a slice via `checkout_segment_for_source`.
         //
-        // For non-partitioning / replicated sources (`canonical_segment_ids` is Some):
-        //   - Both leader and workers use ParallelWorker(canonical_ids) so that every
-        //     participant opens exactly the same frozen segment set, preventing DocAddress
-        //     mismatches when late materialization stores (segment_ord, doc_id) pairs.
+        // Non-MPP parallel hash join (`canonical_segment_ids` Some): every worker opens
+        // the leader-snapshotted set, matching PG's worker scheduling.
         //
-        // Serial scans (both fields None): Snapshot.
-        let mvcc_style = if let Some(ids) = canonical_segment_ids {
-            // Non-partitioning source in a parallel join scan: use the frozen segment list
-            // that the leader snapshotted and wrote to shared memory.
+        // Partitioning source (`parallel_state` Some): leader uses Snapshot, workers use
+        // `ParallelWorker(partitioning_segment_ids)`.
+        //
+        // Serial (all None): Snapshot.
+        let mvcc_style = if let Some(source_idx) = self.mpp_source_idx {
+            if let Some(parallel_state) = parallel_state {
+                unsafe {
+                    let ids = (*parallel_state).segment_ids_for_source(source_idx);
+                    MvccSatisfies::ParallelWorker(ids)
+                }
+            } else if let Some(ids) = canonical_segment_ids.clone() {
+                // Codec injected canonical IDs without `parallel_state`. Fallback to the
+                // frozen set the leader recorded.
+                MvccSatisfies::ParallelWorker(ids)
+            } else {
+                MvccSatisfies::Snapshot
+            }
+        } else if let Some(ids) = canonical_segment_ids {
+            // Non-MPP parallel join scan: open the leader's frozen segment list from
+            // shared memory.
             MvccSatisfies::ParallelWorker(ids)
         } else if let Some(parallel_state) = parallel_state {
             unsafe {
@@ -851,6 +899,7 @@ impl PgSearchTableProvider {
                 projected_schema,
                 query,
                 total_estimated_rows,
+                self.mpp_source_idx,
             )
         }
     }


### PR DESCRIPTION
# Ticket(s) Closed

(None — temporary verification PR.)

## What

This PR is a throwaway. It bumps the benchmark JSON output to include `num_results` per query and adds a post-process step that fails the action when alternatives within a query file disagree on row count.

## Why

The aggregate-on-join queries in `benchmarks/datasets/stackoverflow/queries/` each ship three variants: PG default, DataFusion aggregate scan, and MPP aggregate scan. They all run the same logical query under different GUC combinations. They have to agree on row count, otherwise a custom-scan path is silently wrong.

This branch piggybacks on the existing benchmark workflow so we can verify the contract on top of #5199's Tantivy bump without burning local AWS creds.

## How

`JSONBenchmarkResult` now carries `num_results`. The `benchmark-queries` action groups results by base name (`foo`, `foo - alternative 1`, ...) and asserts a single `num_results` per group.

## Tests

- Locally compiles. CI run kicked off by adding the `benchmark-queries` label.
