### PR TITLE
perf: Use a shared threshold across index segments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -968,7 +968,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1849,7 +1849,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.117",
 ]
 
@@ -5465,7 +5464,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6367,7 +6366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7994,7 +7993,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8049,7 +8048,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "bitpacking",
 ]
@@ -8057,7 +8056,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8072,7 +8071,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8105,7 +8104,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8117,7 +8116,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8130,7 +8129,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8167,7 +8166,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
+source = "git+https://github.com/paradedb/tantivy.git?rev=19bd78439962e573d04a51e6b599636d666e3af5#19bd78439962e573d04a51e6b599636d666e3af5"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5465,7 +5465,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7994,7 +7994,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -8049,7 +8049,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "bitpacking",
 ]
@@ -8057,7 +8057,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -8072,7 +8072,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -8105,7 +8105,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.25.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -8117,7 +8117,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -8130,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -8167,7 +8167,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.6.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=301c0e79dc88e9b44cfa4547f9dbb0f486ff1273#301c0e79dc88e9b44cfa4547f9dbb0f486ff1273"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.shared-threshold#fb0ae7e16853deb6679070b8ad14966756e03a5c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "301c0e79dc88e9b44cfa4547f9dbb0f486ff1273", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.shared-threshold", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -44,4 +44,4 @@ pgrx-tests = "=0.18.1"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "301c0e79dc88e9b44cfa4547f9dbb0f486ff1273" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.shared-threshold" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.shared-threshold", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "19bd78439962e573d04a51e6b599636d666e3af5", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -44,4 +44,4 @@ pgrx-tests = "=0.18.1"
 tantivy-jieba = "0.18.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.shared-threshold" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "19bd78439962e573d04a51e6b599636d666e3af5" }

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-aH2Uivowht2AN3Tx6PTwp0+8yoVaZn8Yn8QMmUr43k8=";
+  cargoHash = "sha256-Cwy9X7rvnbcTN3J280RYqk99wFhkP6iF6sBVUUK5Xcg=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -773,6 +773,7 @@ impl SearchIndexReader {
         n: usize,
         offset: usize,
         aux_collector: Option<TopKAuxiliaryCollector>,
+        parallel_state: Option<*mut crate::postgres::ParallelScanState>,
     ) -> TopKSearchResults {
         let (first_orderby_info, erased_features) = self.prepare_features(orderby_info);
         match first_orderby_info {
@@ -788,6 +789,29 @@ impl SearchIndexReader {
                     .search_field(sort_field)
                     .expect("sort field should exist in index schema");
                 let order: ComparatorEnum = (*direction).into();
+
+                macro_rules! sort_fast_value {
+                    ($type:ty) => {{
+                        let mut computer = SortByStaticFastValue::<$type>::for_field(sort_field);
+                        if let Some(state) = parallel_state {
+                            computer = computer.with_shared_threshold(Some(std::sync::Arc::new(
+                                crate::postgres::shared_threshold::new_fast_value_threshold(
+                                    state,
+                                    order.clone(),
+                                ),
+                            )));
+                        }
+                        TopKSearchResults::new_for_discarded_field(self.top_in_segments(
+                            segment_ids,
+                            (computer, order),
+                            erased_features,
+                            n,
+                            offset,
+                            aux_collector,
+                        ))
+                    }};
+                }
+
                 match field.field_entry().field_type().value_type() {
                     tantivy::schema::Type::Str => {
                         TopKSearchResults::new_for_discarded_field(self.top_in_segments(
@@ -799,59 +823,11 @@ impl SearchIndexReader {
                             aux_collector,
                         ))
                     }
-                    tantivy::schema::Type::U64 => {
-                        TopKSearchResults::new_for_discarded_field(self.top_in_segments(
-                            segment_ids,
-                            (SortByStaticFastValue::<u64>::for_field(sort_field), order),
-                            erased_features,
-                            n,
-                            offset,
-                            aux_collector,
-                        ))
-                    }
-                    tantivy::schema::Type::I64 => {
-                        TopKSearchResults::new_for_discarded_field(self.top_in_segments(
-                            segment_ids,
-                            (SortByStaticFastValue::<i64>::for_field(sort_field), order),
-                            erased_features,
-                            n,
-                            offset,
-                            aux_collector,
-                        ))
-                    }
-                    tantivy::schema::Type::F64 => {
-                        TopKSearchResults::new_for_discarded_field(self.top_in_segments(
-                            segment_ids,
-                            (SortByStaticFastValue::<f64>::for_field(sort_field), order),
-                            erased_features,
-                            n,
-                            offset,
-                            aux_collector,
-                        ))
-                    }
-                    tantivy::schema::Type::Bool => {
-                        TopKSearchResults::new_for_discarded_field(self.top_in_segments(
-                            segment_ids,
-                            (SortByStaticFastValue::<bool>::for_field(sort_field), order),
-                            erased_features,
-                            n,
-                            offset,
-                            aux_collector,
-                        ))
-                    }
-                    tantivy::schema::Type::Date => {
-                        TopKSearchResults::new_for_discarded_field(self.top_in_segments(
-                            segment_ids,
-                            (
-                                SortByStaticFastValue::<DateTime>::for_field(sort_field),
-                                order,
-                            ),
-                            erased_features,
-                            n,
-                            offset,
-                            aux_collector,
-                        ))
-                    }
+                    tantivy::schema::Type::U64 => sort_fast_value!(u64),
+                    tantivy::schema::Type::I64 => sort_fast_value!(i64),
+                    tantivy::schema::Type::F64 => sort_fast_value!(f64),
+                    tantivy::schema::Type::Bool => sort_fast_value!(bool),
+                    tantivy::schema::Type::Date => sort_fast_value!(DateTime),
                     tantivy::schema::Type::Bytes => {
                         TopKSearchResults::new_for_discarded_field(self.top_in_segments(
                             segment_ids,
@@ -882,9 +858,16 @@ impl SearchIndexReader {
             } if !erased_features.is_empty() => {
                 // If we've directly sorted on the score, then we have it available here.
                 let order: ComparatorEnum = (*direction).into();
+                let mut computer = SortBySimilarityScore::new();
+                if let Some(state) = parallel_state {
+                    computer =
+                        SortBySimilarityScore::with_shared_threshold(Some(std::sync::Arc::new(
+                            crate::postgres::shared_threshold::new_score_threshold(state),
+                        )));
+                }
                 let (top_docs, aggregation_results) = self.top_in_segments(
                     segment_ids,
-                    (SortBySimilarityScore, order),
+                    (computer, order),
                     erased_features,
                     n,
                     offset,
@@ -898,10 +881,14 @@ impl SearchIndexReader {
             OrderByInfo {
                 feature: OrderByFeature::Score { .. },
                 direction,
-            } => {
-                // TODO: See method docs.
-                self.top_by_score_in_segments(segment_ids, *direction, n, offset, aux_collector)
-            }
+            } => self.top_by_score_in_segments(
+                segment_ids,
+                *direction,
+                n,
+                offset,
+                aux_collector,
+                parallel_state,
+            ),
             OrderByInfo {
                 feature: OrderByFeature::NullTest { .. },
                 ..
@@ -1083,6 +1070,7 @@ impl SearchIndexReader {
         n: usize,
         offset: usize,
         aux_collector: Option<TopKAuxiliaryCollector>,
+        parallel_state: Option<*mut crate::postgres::ParallelScanState>,
     ) -> TopKSearchResults {
         match sortdir {
             // requires tweaking the score, which is a bit slower
@@ -1108,7 +1096,17 @@ impl SearchIndexReader {
 
             // can use tantivy's score directly, which allows for Block-WAND
             SortDirection::DescNullsFirst | SortDirection::DescNullsLast => {
-                let top_docs_collector = TopDocs::with_limit(n).and_offset(offset).order_by_score();
+                let mut computer = SortBySimilarityScore::new();
+                if let Some(state) = parallel_state {
+                    computer =
+                        SortBySimilarityScore::with_shared_threshold(Some(std::sync::Arc::new(
+                            crate::postgres::shared_threshold::new_score_threshold(state),
+                        )));
+                }
+
+                let top_docs_collector = TopDocs::with_limit(n)
+                    .and_offset(offset)
+                    .order_by::<Score>(computer);
 
                 let (top_docs, aggregation_results) =
                     self.collect_maybe_auxiliary(segment_ids, top_docs_collector, aux_collector);

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -386,6 +386,7 @@ impl ExecMethod for TopKScanExecState {
                     local_limit,
                     self.offset,
                     maybe_aux_collector,
+                    state.parallel_state,
                 )
         } else {
             self.search_reader

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -26,6 +26,7 @@ use crate::postgres::build::is_bm25_index;
 use crate::postgres::condition_variable::ConditionVariable;
 use crate::postgres::locks::Spinlock;
 use crate::postgres::rel::PgSearchRelation;
+use crate::postgres::shared_threshold::ParallelScanThresholdState;
 use crate::query::SearchQueryInput;
 
 use pgrx::*;
@@ -43,6 +44,7 @@ pub mod options;
 mod ps_status;
 mod range;
 mod scan;
+pub mod shared_threshold;
 mod vacuum;
 mod validate;
 
@@ -537,6 +539,9 @@ pub struct ParallelScanState {
     /// the one from which workers claim segments via `checkout_segment`.
     partitioning_source_idx: usize,
     queries_per_worker: [u16; WORKER_METRICS_MAX_COUNT],
+    /// Top-K Shared Threshold Fields
+    pub shared_threshold: ParallelScanThresholdState,
+
     payload: ParallelScanPayload, // must be last field, b/c it allocates on the heap after this struct
 }
 
@@ -579,6 +584,7 @@ impl ParallelScanState {
         self.mutex.init();
         self.aggregation_cv.init();
         self.init_cv.init();
+        self.shared_threshold.init();
         self.populate(
             &args.all_sources,
             args.partitioning_source_idx,
@@ -603,6 +609,7 @@ impl ParallelScanState {
         self.payload
             .init(all_sources, partitioning_source_idx, query, with_aggregates);
         self.queries_per_worker = [0; WORKER_METRICS_MAX_COUNT];
+        self.shared_threshold.reset();
         let partitioning_count = all_sources
             .get(partitioning_source_idx)
             .expect("partitioning_source_idx out of bounds")
@@ -634,7 +641,9 @@ impl ParallelScanState {
     /// The leader will call `populate` to set up the segment data; workers wait for that.
     pub fn create(&mut self) {
         self.mutex.init();
+        self.aggregation_cv.init();
         self.init_cv.init();
+        self.shared_threshold.init();
         // Mark as uninitialized so workers know to wait for the leader
         self.mark_uninitialized();
     }

--- a/pg_search/src/postgres/shared_threshold.rs
+++ b/pg_search/src/postgres/shared_threshold.rs
@@ -47,118 +47,89 @@ impl ParallelScanThresholdState {
     }
 }
 
-struct PgSharedThreshold<T, F, C> {
+struct PgSharedThreshold<T> {
     parallel_state: *mut ParallelScanState,
-    initial_value: T,
-    is_more_restrictive: F,
-    competitive_threshold: C,
     _phantom: PhantomData<T>,
 }
 
-unsafe impl<T, F, C> Send for PgSharedThreshold<T, F, C> {}
-unsafe impl<T, F, C> Sync for PgSharedThreshold<T, F, C> {}
+unsafe impl<T> Send for PgSharedThreshold<T> {}
+unsafe impl<T> Sync for PgSharedThreshold<T> {}
 
-impl<T, F, C> PgSharedThreshold<T, F, C>
+impl<T> PgSharedThreshold<T>
 where
     T: Copy + Send + Sync,
-    F: Fn(T, T) -> std::cmp::Ordering + Send + Sync,
-    C: Fn(T, u32, u32) -> T + Send + Sync,
 {
-    pub fn new(
-        parallel_state: *mut ParallelScanState,
-        initial_value: T,
-        is_more_restrictive: F,
-        competitive_threshold: C,
-    ) -> Self {
+    pub fn new(parallel_state: *mut ParallelScanState) -> Self {
         assert!(
             std::mem::size_of::<T>() <= 16,
             "SharedThreshold type T must be <= 16 bytes"
         );
         Self {
             parallel_state,
-            initial_value,
-            is_more_restrictive,
-            competitive_threshold,
             _phantom: PhantomData,
         }
     }
 }
 
-impl<T, F, C> SharedThreshold<T> for PgSharedThreshold<T, F, C>
+impl<T> SharedThreshold<T> for PgSharedThreshold<T>
 where
-    T: Copy + Send + Sync,
-    F: Fn(T, T) -> std::cmp::Ordering + Send + Sync,
-    C: Fn(T, u32, u32) -> T + Send + Sync,
+    T: Copy + Send + Sync + PartialEq,
 {
-    fn load(&self) -> (T, u32) {
+    fn load(&self) -> Option<(T, u32)> {
         let state = unsafe { &mut *self.parallel_state };
         let mut _lock = state.shared_threshold.lock.acquire();
 
         if state.shared_threshold.initialized {
-            let mut value: T = self.initial_value;
+            let mut value: std::mem::MaybeUninit<T> = std::mem::MaybeUninit::uninit();
             unsafe {
                 std::ptr::copy_nonoverlapping(
                     state.shared_threshold.value.as_ptr(),
-                    &mut value as *mut T as *mut u8,
+                    value.as_mut_ptr() as *mut u8,
                     std::mem::size_of::<T>(),
                 );
+                Some((value.assume_init(), state.shared_threshold.segment_ord))
             }
-            (value, state.shared_threshold.segment_ord)
         } else {
-            (self.initial_value, u32::MAX)
+            None
         }
     }
 
-    fn update(&self, new_threshold: T, segment_ord: u32) -> (T, u32) {
+    fn try_update(
+        &self,
+        expected_threshold: &Option<(T, u32)>,
+        new_threshold: (T, u32),
+    ) -> Result<(), Option<(T, u32)>> {
         let state = unsafe { &mut *self.parallel_state };
         let mut _lock = state.shared_threshold.lock.acquire();
 
-        if !state.shared_threshold.initialized {
+        let current = if state.shared_threshold.initialized {
+            let mut value: std::mem::MaybeUninit<T> = std::mem::MaybeUninit::uninit();
             unsafe {
                 std::ptr::copy_nonoverlapping(
-                    &new_threshold as *const T as *const u8,
+                    state.shared_threshold.value.as_ptr(),
+                    value.as_mut_ptr() as *mut u8,
+                    std::mem::size_of::<T>(),
+                );
+                Some((value.assume_init(), state.shared_threshold.segment_ord))
+            }
+        } else {
+            None
+        };
+
+        if current == *expected_threshold {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    &new_threshold.0 as *const T as *const u8,
                     state.shared_threshold.value.as_mut_ptr(),
                     std::mem::size_of::<T>(),
                 );
             }
-            state.shared_threshold.segment_ord = segment_ord;
+            state.shared_threshold.segment_ord = new_threshold.1;
             state.shared_threshold.initialized = true;
-            (new_threshold, segment_ord)
+            Ok(())
         } else {
-            let mut current_threshold: T = self.initial_value;
-            unsafe {
-                std::ptr::copy_nonoverlapping(
-                    state.shared_threshold.value.as_ptr(),
-                    &mut current_threshold as *mut T as *mut u8,
-                    std::mem::size_of::<T>(),
-                );
-            }
-
-            let cmp = (self.is_more_restrictive)(new_threshold, current_threshold);
-            let is_better = match cmp {
-                std::cmp::Ordering::Greater => true,
-                std::cmp::Ordering::Less => false,
-                std::cmp::Ordering::Equal => segment_ord < state.shared_threshold.segment_ord,
-            };
-
-            if is_better {
-                unsafe {
-                    std::ptr::copy_nonoverlapping(
-                        &new_threshold as *const T as *const u8,
-                        state.shared_threshold.value.as_mut_ptr(),
-                        std::mem::size_of::<T>(),
-                    );
-                }
-                state.shared_threshold.segment_ord = segment_ord;
-                (new_threshold, segment_ord)
-            } else {
-                (current_threshold, state.shared_threshold.segment_ord)
-            }
+            Err(current)
         }
-    }
-
-    fn competitive_threshold(&self, value: T, threshold_ord: u32, segment_ord: u32) -> T {
-        (self.competitive_threshold)(value, threshold_ord, segment_ord)
     }
 }
 
@@ -207,11 +178,6 @@ unsafe impl Sync for PgAtomicSharedScoreThreshold {}
 
 impl PgAtomicSharedScoreThreshold {
     // Initial packed value is Score::MIN with u32::MAX (worst possible ordinal)
-    // f32_to_ordered_u32(Score::MIN) == 0 (because MIN is negative infinity, which maps to 0 in this monotonic conversion)
-    // Wait, let's just use a constant. Since f32::MIN.to_bits() is 0xff800000.
-    // 0xff800000 & 0x8000_0000 != 0, so !0xff800000 = 0x007fffff.
-    // So top is 0x007fffff. bottom is !u32::MAX = 0.
-    // So INITIAL_PACKED_VALUE is (0x007fffff << 32) | 0.
     pub const INITIAL_PACKED_VALUE: u64 = 0x007fffff_00000000;
 
     /// Creates a SharedThreshold configured specifically for Tantivy BM25 Scores,
@@ -222,34 +188,49 @@ impl PgAtomicSharedScoreThreshold {
 }
 
 impl SharedThreshold<tantivy::Score> for PgAtomicSharedScoreThreshold {
-    fn load(&self) -> (tantivy::Score, u32) {
+    fn load(&self) -> Option<(tantivy::Score, u32)> {
         let state = unsafe { &*self.parallel_state };
-        unpack_score_and_ord(
-            state
-                .shared_threshold
-                .atomic_score_threshold
-                .load(Ordering::Relaxed),
-        )
-    }
-
-    fn update(&self, new_score: tantivy::Score, segment_ord: u32) -> (tantivy::Score, u32) {
-        let state = unsafe { &*self.parallel_state };
-        let new_packed = pack_score_and_ord(new_score, segment_ord);
-        let mut current = state
+        let packed = state
             .shared_threshold
             .atomic_score_threshold
             .load(Ordering::Relaxed);
-        loop {
-            if new_packed <= current {
-                return unpack_score_and_ord(current);
-            }
-            match state
-                .shared_threshold
-                .atomic_score_threshold
-                .compare_exchange_weak(current, new_packed, Ordering::Relaxed, Ordering::Relaxed)
-            {
-                Ok(_) => return (new_score, segment_ord),
-                Err(actual) => current = actual,
+
+        if packed == Self::INITIAL_PACKED_VALUE {
+            None
+        } else {
+            Some(unpack_score_and_ord(packed))
+        }
+    }
+
+    fn try_update(
+        &self,
+        expected_threshold: &Option<(tantivy::Score, u32)>,
+        new_threshold: (tantivy::Score, u32),
+    ) -> Result<(), Option<(tantivy::Score, u32)>> {
+        let state = unsafe { &*self.parallel_state };
+
+        let expected_packed = match expected_threshold {
+            Some((score, ord)) => pack_score_and_ord(*score, *ord),
+            None => Self::INITIAL_PACKED_VALUE,
+        };
+        let new_packed = pack_score_and_ord(new_threshold.0, new_threshold.1);
+
+        match state
+            .shared_threshold
+            .atomic_score_threshold
+            .compare_exchange_weak(
+                expected_packed,
+                new_packed,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+            Ok(_) => Ok(()),
+            Err(actual_packed) => {
+                if actual_packed == Self::INITIAL_PACKED_VALUE {
+                    Err(None)
+                } else {
+                    Err(Some(unpack_score_and_ord(actual_packed)))
+                }
             }
         }
     }
@@ -282,13 +263,7 @@ pub fn new_score_threshold(
 
 pub fn new_fast_value_threshold(
     parallel_state: *mut ParallelScanState,
-    order: tantivy::collector::sort_key::ComparatorEnum,
+    _order: tantivy::collector::sort_key::ComparatorEnum,
 ) -> impl SharedThreshold<Option<u64>> {
-    use tantivy::collector::sort_key::Comparator;
-    PgSharedThreshold::new(
-        parallel_state,
-        None,
-        move |new: Option<u64>, current: Option<u64>| order.compare(&new, &current),
-        |score: Option<u64>, _threshold_ord: u32, _segment_ord: u32| score,
-    )
+    PgSharedThreshold::new(parallel_state)
 }

--- a/pg_search/src/postgres/shared_threshold.rs
+++ b/pg_search/src/postgres/shared_threshold.rs
@@ -1,0 +1,294 @@
+use crate::postgres::locks::Spinlock;
+use crate::postgres::ParallelScanState;
+use std::marker::PhantomData;
+use tantivy::collector::SharedThreshold;
+
+#[repr(C)]
+pub struct ParallelScanThresholdState {
+    // NOTE: Only one of the following two threshold approaches is used per-query depending on the Sort Key type.
+
+    // 1. Lock-free Atomic Threshold. Used exclusively for f32 (BM25 Scores) for maximum parallel throughput.
+    atomic_score_threshold: std::sync::atomic::AtomicU64,
+
+    // 2. Lock-based Threshold. Used for arbitrary threshold types <= 16 bytes (like Option<u64> fast fields).
+    lock: Spinlock,
+    value: [u8; 16],
+    segment_ord: u32,
+    initialized: bool,
+}
+
+impl Default for ParallelScanThresholdState {
+    fn default() -> Self {
+        Self {
+            atomic_score_threshold: std::sync::atomic::AtomicU64::new(
+                PgAtomicSharedScoreThreshold::INITIAL_PACKED_VALUE,
+            ),
+            lock: Spinlock::default(),
+            value: [0; 16],
+            segment_ord: u32::MAX,
+            initialized: false,
+        }
+    }
+}
+
+impl ParallelScanThresholdState {
+    pub fn init(&mut self) {
+        self.lock.init();
+    }
+
+    pub fn reset(&mut self) {
+        self.atomic_score_threshold.store(
+            PgAtomicSharedScoreThreshold::INITIAL_PACKED_VALUE,
+            std::sync::atomic::Ordering::Relaxed,
+        );
+        self.initialized = false;
+        self.value = [0; 16];
+        self.segment_ord = u32::MAX;
+    }
+}
+
+struct PgSharedThreshold<T, F, C> {
+    parallel_state: *mut ParallelScanState,
+    initial_value: T,
+    is_more_restrictive: F,
+    competitive_threshold: C,
+    _phantom: PhantomData<T>,
+}
+
+unsafe impl<T, F, C> Send for PgSharedThreshold<T, F, C> {}
+unsafe impl<T, F, C> Sync for PgSharedThreshold<T, F, C> {}
+
+impl<T, F, C> PgSharedThreshold<T, F, C>
+where
+    T: Copy + Send + Sync,
+    F: Fn(T, T) -> std::cmp::Ordering + Send + Sync,
+    C: Fn(T, u32, u32) -> T + Send + Sync,
+{
+    pub fn new(
+        parallel_state: *mut ParallelScanState,
+        initial_value: T,
+        is_more_restrictive: F,
+        competitive_threshold: C,
+    ) -> Self {
+        assert!(
+            std::mem::size_of::<T>() <= 16,
+            "SharedThreshold type T must be <= 16 bytes"
+        );
+        Self {
+            parallel_state,
+            initial_value,
+            is_more_restrictive,
+            competitive_threshold,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<T, F, C> SharedThreshold<T> for PgSharedThreshold<T, F, C>
+where
+    T: Copy + Send + Sync,
+    F: Fn(T, T) -> std::cmp::Ordering + Send + Sync,
+    C: Fn(T, u32, u32) -> T + Send + Sync,
+{
+    fn load(&self) -> (T, u32) {
+        let state = unsafe { &mut *self.parallel_state };
+        let mut _lock = state.shared_threshold.lock.acquire();
+
+        if state.shared_threshold.initialized {
+            let mut value: T = self.initial_value;
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    state.shared_threshold.value.as_ptr(),
+                    &mut value as *mut T as *mut u8,
+                    std::mem::size_of::<T>(),
+                );
+            }
+            (value, state.shared_threshold.segment_ord)
+        } else {
+            (self.initial_value, u32::MAX)
+        }
+    }
+
+    fn update(&self, new_threshold: T, segment_ord: u32) -> (T, u32) {
+        let state = unsafe { &mut *self.parallel_state };
+        let mut _lock = state.shared_threshold.lock.acquire();
+
+        if !state.shared_threshold.initialized {
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    &new_threshold as *const T as *const u8,
+                    state.shared_threshold.value.as_mut_ptr(),
+                    std::mem::size_of::<T>(),
+                );
+            }
+            state.shared_threshold.segment_ord = segment_ord;
+            state.shared_threshold.initialized = true;
+            (new_threshold, segment_ord)
+        } else {
+            let mut current_threshold: T = self.initial_value;
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    state.shared_threshold.value.as_ptr(),
+                    &mut current_threshold as *mut T as *mut u8,
+                    std::mem::size_of::<T>(),
+                );
+            }
+
+            let cmp = (self.is_more_restrictive)(new_threshold, current_threshold);
+            let is_better = match cmp {
+                std::cmp::Ordering::Greater => true,
+                std::cmp::Ordering::Less => false,
+                std::cmp::Ordering::Equal => segment_ord < state.shared_threshold.segment_ord,
+            };
+
+            if is_better {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        &new_threshold as *const T as *const u8,
+                        state.shared_threshold.value.as_mut_ptr(),
+                        std::mem::size_of::<T>(),
+                    );
+                }
+                state.shared_threshold.segment_ord = segment_ord;
+                (new_threshold, segment_ord)
+            } else {
+                (current_threshold, state.shared_threshold.segment_ord)
+            }
+        }
+    }
+
+    fn competitive_threshold(&self, value: T, threshold_ord: u32, segment_ord: u32) -> T {
+        (self.competitive_threshold)(value, threshold_ord, segment_ord)
+    }
+}
+
+use std::sync::atomic::Ordering;
+
+#[inline]
+fn f32_to_ordered_u32(f: f32) -> u32 {
+    let bits = f.to_bits();
+    if bits & 0x8000_0000 != 0 {
+        !bits
+    } else {
+        bits ^ 0x8000_0000
+    }
+}
+
+#[inline]
+fn ordered_u32_to_f32(u: u32) -> f32 {
+    let bits = if u & 0x8000_0000 != 0 {
+        u ^ 0x8000_0000
+    } else {
+        !u
+    };
+    f32::from_bits(bits)
+}
+
+#[inline(always)]
+fn pack_score_and_ord(score: tantivy::Score, segment_ord: u32) -> u64 {
+    let top = f32_to_ordered_u32(score) as u64;
+    let bottom = (!segment_ord) as u64;
+    (top << 32) | bottom
+}
+
+#[inline(always)]
+fn unpack_score_and_ord(val: u64) -> (tantivy::Score, u32) {
+    let score = ordered_u32_to_f32((val >> 32) as u32);
+    let segment_ord = !(val as u32);
+    (score, segment_ord)
+}
+
+struct PgAtomicSharedScoreThreshold {
+    parallel_state: *mut ParallelScanState,
+}
+
+unsafe impl Send for PgAtomicSharedScoreThreshold {}
+unsafe impl Sync for PgAtomicSharedScoreThreshold {}
+
+impl PgAtomicSharedScoreThreshold {
+    // Initial packed value is Score::MIN with u32::MAX (worst possible ordinal)
+    // f32_to_ordered_u32(Score::MIN) == 0 (because MIN is negative infinity, which maps to 0 in this monotonic conversion)
+    // Wait, let's just use a constant. Since f32::MIN.to_bits() is 0xff800000.
+    // 0xff800000 & 0x8000_0000 != 0, so !0xff800000 = 0x007fffff.
+    // So top is 0x007fffff. bottom is !u32::MAX = 0.
+    // So INITIAL_PACKED_VALUE is (0x007fffff << 32) | 0.
+    pub const INITIAL_PACKED_VALUE: u64 = 0x007fffff_00000000;
+
+    /// Creates a SharedThreshold configured specifically for Tantivy BM25 Scores,
+    /// backed by an `AtomicU64` in shared memory for lock-free updates.
+    pub fn new(parallel_state: *mut ParallelScanState) -> Self {
+        Self { parallel_state }
+    }
+}
+
+impl SharedThreshold<tantivy::Score> for PgAtomicSharedScoreThreshold {
+    fn load(&self) -> (tantivy::Score, u32) {
+        let state = unsafe { &*self.parallel_state };
+        unpack_score_and_ord(
+            state
+                .shared_threshold
+                .atomic_score_threshold
+                .load(Ordering::Relaxed),
+        )
+    }
+
+    fn update(&self, new_score: tantivy::Score, segment_ord: u32) -> (tantivy::Score, u32) {
+        let state = unsafe { &*self.parallel_state };
+        let new_packed = pack_score_and_ord(new_score, segment_ord);
+        let mut current = state
+            .shared_threshold
+            .atomic_score_threshold
+            .load(Ordering::Relaxed);
+        loop {
+            if new_packed <= current {
+                return unpack_score_and_ord(current);
+            }
+            match state
+                .shared_threshold
+                .atomic_score_threshold
+                .compare_exchange_weak(current, new_packed, Ordering::Relaxed, Ordering::Relaxed)
+            {
+                Ok(_) => return (new_score, segment_ord),
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    /// # Tie-breaking determinism
+    /// Tantivy's fast-path WAND scorer uses a strict inequality (`score > threshold`) to prune documents.
+    /// When our segment is supposed to WIN a global tie-breaker (`segment_ord < threshold_ord`), we must
+    /// accept documents with a score *equal* to the threshold.
+    /// To do this mathematically against a strict `>` operator, we artificially lower the threshold by
+    /// one float epsilon (`next_down()`), ensuring `score > threshold_minus_epsilon` evaluates to `true`.
+    fn competitive_threshold(
+        &self,
+        value: tantivy::Score,
+        threshold_ord: u32,
+        segment_ord: u32,
+    ) -> tantivy::Score {
+        if segment_ord < threshold_ord {
+            value.next_down()
+        } else {
+            value
+        }
+    }
+}
+
+pub fn new_score_threshold(
+    parallel_state: *mut ParallelScanState,
+) -> impl SharedThreshold<tantivy::Score> {
+    PgAtomicSharedScoreThreshold::new(parallel_state)
+}
+
+pub fn new_fast_value_threshold(
+    parallel_state: *mut ParallelScanState,
+    order: tantivy::collector::sort_key::ComparatorEnum,
+) -> impl SharedThreshold<Option<u64>> {
+    use tantivy::collector::sort_key::Comparator;
+    PgSharedThreshold::new(
+        parallel_state,
+        None,
+        move |new: Option<u64>, current: Option<u64>| order.compare(&new, &current),
+        |score: Option<u64>, _threshold_ord: u32, _segment_ord: u32| score,
+    )
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4309

## What

As described on #4309, incorporates Tantivy support for sharing a threshold across segments during TopK. See https://github.com/paradedb/tantivy/pull/147 for the Tantivy side.

## Why

Without threshold sharing, each segment computes a new score from scratch, and will take a while to begin effectively pruning documents using Block-Max WAND or even avoiding putting things in the TopNComputer buffer. Sharing the threshold allows threshold pruning to begin much more quickly.

## How

Extended the `SharedThreshold` trait with an implementation backed by `ParallelScanState` using either an atomic or a spinlock depending on size.

## Tests

Benchmarks show up to 50% speedup for some `ORDER BY pdb.score DESC` queries (depending on selectivity and worker count).