### PR TITLE
chore: bump pgvector to 0.8.2

### DIFF
--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -124,7 +124,7 @@ jobs:
       # Needed for hybrid search unit tests
       - name: Install pgvector
         run: |
-          git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
           cd pgvector/
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -176,7 +176,7 @@ jobs:
       - name: Install pgvector (system)
         if: matrix.pg_impl == 'system'
         run: |
-          git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
           cd pgvector/
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j
@@ -184,7 +184,7 @@ jobs:
       - name: Install pgvector (pgrx)
         if: matrix.pg_impl == 'pgrx'
         run: |
-          git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
           cd pgvector/
           PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make -j
           PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make install -j

--- a/docker/Dockerfile.antithesis-18
+++ b/docker/Dockerfile.antithesis-18
@@ -38,7 +38,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-18-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-18-cron=1.6.7-2.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-15
+++ b/docker/Dockerfile.official-15
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-15-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-15-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-15-cron=1.6.7-2.pgdg13+1 \
     postgresql-15-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-16
+++ b/docker/Dockerfile.official-16
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-16-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-16-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-16-cron=1.6.7-2.pgdg13+1 \
     postgresql-16-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-17
+++ b/docker/Dockerfile.official-17
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-17-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-17-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-17-cron=1.6.7-2.pgdg13+1 \
     postgresql-17-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-18
+++ b/docker/Dockerfile.official-18
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-18-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-18-cron=1.6.7-2.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-15
+++ b/docker/Dockerfile.paradedb-15
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-15-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-15-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-15-cron=1.6.7-2.pgdg13+1 \
     postgresql-15-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-16
+++ b/docker/Dockerfile.paradedb-16
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-16-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-16-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-16-cron=1.6.7-2.pgdg13+1 \
     postgresql-16-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-17
+++ b/docker/Dockerfile.paradedb-17
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-17-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-17-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-17-cron=1.6.7-2.pgdg13+1 \
     postgresql-17-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-18
+++ b/docker/Dockerfile.paradedb-18
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-18-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-18-cron=1.6.7-2.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -58,7 +58,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.1-2.pgdg13+1 \
+    postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.2-1.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-cron=1.6.7-2.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-postgis-$POSTGIS_VERSION_MAJOR \

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -47,7 +47,7 @@ cargo pgrx init
 `pgvector` is needed for hybrid search integration tests. To build it against the pgrx-managed Postgres install (replace `18.3` with the version under `~/.pgrx/`):
 
 ```bash
-git clone --branch v0.8.1 https://github.com/pgvector/pgvector.git
+git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
 cd pgvector/
 
 PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make


### PR DESCRIPTION
## What

Closes #5198

Upgrades the bundled pgvector extension from `0.8.1` to `0.8.2`, the latest release.

- **Dockerfiles** (`docker/Dockerfile.{paradedb,official}-{15,16,17,18}`, `Dockerfile.antithesis-18`, `Dockerfile.template`): Debian package pin `pgvector=0.8.1-2.pgdg13+1` → `pgvector=0.8.2-1.pgdg13+1`.
- **Source builds** (`test-pg_search.yml`, `test-pg_search-upgrade.yml`, `pg_search/README.md`): git tag `v0.8.1` → `v0.8.2`.

## Other extensions

Checked the rest against the PGDG `trixie` apt repo — already at the latest packaged versions, so no changes needed:

| Extension | Version | Status |
|---|---|---|
| pg_cron | 1.6.7 | latest |
| pg_ivm | 1.13 | latest |
| PostGIS | 3.6.3 (pinned by major `3`) | latest |