### PR TITLE
chore: shift antithesis cron schedule and annotate env docs with languages

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -12,7 +12,7 @@ on:
   # (community) the job-level `if` below short-circuits the schedule trigger. The cron
   # entry stays here so the same workflow file can be synced between the two repos.
   schedule:
-    - cron: "0 2 * * 2,4" # At 02:00 UTC on Tuesday and Thursday (Monday night and Wednesday night)
+    - cron: "0 2 * * 1,4" # At 02:00 UTC on Monday and Thursday (Sunday night and Wednesday night)
   pull_request:
     types: [labeled]
   workflow_dispatch:

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -59,7 +59,7 @@ You're all set! Try [running some queries](/documentation/getting-started/querie
 
 </Accordion>
 
-<Accordion title="Drizzle">
+<Accordion title="Drizzle (JavaScript)">
 To get started, create a TypeScript project with [Drizzle](https://orm.drizzle.team/), [postgres.js](https://github.com/porsager/postgres), and [@paradedb/drizzle-paradedb](https://www.npmjs.com/package/@paradedb/drizzle-paradedb) installed.
 
 ```bash
@@ -201,7 +201,7 @@ You're all set! Try [running some queries](/documentation/getting-started/querie
 
 </Accordion>
 
-<Accordion title="Django">
+<Accordion title="Django (Python)">
 To start you'll need a [Django](https://www.djangoproject.com/) project with [Psycopg](https://www.psycopg.org/) and [django-paradedb](https://pypi.org/project/django-paradedb/) installed. Run the following to create one:
 
 ```bash
@@ -319,7 +319,7 @@ You're all set! Try [running some queries](/documentation/getting-started/querie
 
 </Accordion>
 
-<Accordion title="SQLAlchemy">
+<Accordion title="SQLAlchemy (Python)">
 To get started, install [SQLAlchemy](https://www.sqlalchemy.org/), [Alembic](https://alembic.sqlalchemy.org/en/latest/), [Psycopg](https://www.psycopg.org/), and [sqlalchemy-paradedb](https://pypi.org/project/sqlalchemy-paradedb/).
 
 ```bash
@@ -572,7 +572,7 @@ You're all set! Try [running some queries](/documentation/getting-started/querie
 
 </Accordion>
 
-<Accordion title="Rails">
+<Accordion title="Rails (Ruby)">
 To get started, create a [Rails](https://rubyonrails.org/) app that uses PostgreSQL.
 
 ```bash


### PR DESCRIPTION
## What

Two unrelated small changes:

1. **Antithesis schedule** — move the antithesis suite cron from Monday/Wednesday nights to **Sunday/Wednesday nights**:
   - `0 2 * * 2,4` (Tue & Thu 02:00 UTC = Mon night & Wed night) → `0 2 * * 1,4` (Mon & Thu 02:00 UTC = Sun night & Wed night)
2. **Env docs** — in *Configure your Environment*, annotate each ORM/framework accordion with its host language: Drizzle (JavaScript), Django (Python), SQLAlchemy (Python), Rails (Ruby).

## Why

- Spreads the scheduled runs differently across the week (Sun night instead of Mon night).
- Makes it clearer at a glance which language each integration targets.