### PR TITLE
chore: upgrade Rust toolchain to 1.96

### DIFF
--- a/docker/Dockerfile.proptests
+++ b/docker/Dockerfile.proptests
@@ -7,7 +7,7 @@
 # the in-cluster ParadeDB primary by the driver script (see
 # tests/antithesis/singleton_driver_property-tests.sh).
 
-FROM rust:1.95-slim
+FROM rust:1.96-slim
 
 # Required for the piped RUN below (hadolint DL4006).
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -11,7 +11,7 @@
 #       memory: "4Gi"
 #       cpu: "2000m"
 
-FROM rust:1.95-slim-trixie
+FROM rust:1.96-slim-trixie
 
 # Install build and runtime dependencies. Upgrade existing OS packages first so
 # we pick up the latest Debian security fixes regardless of the base layer's age.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.95.0"
+channel = "1.96.0"


### PR DESCRIPTION
## What

Upgrades the Rust toolchain from 1.95 to 1.96 everywhere it was pinned:

- `rust-toolchain.toml` — `channel = "1.96.0"`
- `docker/Dockerfile.proptests` — `FROM rust:1.96-slim`
- `docker/Dockerfile.stressgres` — `FROM rust:1.96-slim-trixie`

## Why

Keep the toolchain current.

## Notes

The GitHub workflows use `actions-rust-lang/setup-rust-toolchain@v1`, which reads the version from `rust-toolchain.toml`, so they pick up 1.96 automatically — no workflow changes needed.