### PR TITLE
ci: Remove noisy caching

### DIFF
--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -54,10 +54,6 @@ jobs:
       - name: Install Determinate Nix
         uses: DeterminateSystems/determinate-nix-action@main
 
-      # This Action uses GitHub Actions' built-in cache to speed up Nix-related CI workflows
-      - name: Use Magic Nix Cache Action
-        uses: DeterminateSystems/magic-nix-cache-action@main
-
       # Build only cargo deps to surface cargoHash mismatches quickly, without
       # compiling pg_search for every Postgres variant. If the hash is stale,
       # compute the correct one and push a fix commit to the PR branch.


### PR DESCRIPTION
# Ticket(s) Closed

The Nix cache step is creating a new cache entry on every PR, it is responsible for the vast majority of the entries. There's probably a better way to set things up in the future, but I'm just removing it for now.

The uv caching also creates a decent number of entries, so I'm disabling it too.

## What

## Why

## How

## Tests
