### PR TITLE
ci: include LICENSE/copyright in all hand-rolled packages

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -292,6 +292,26 @@ jobs:
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Postgres for Search and Analytics' >> $CONTROL_FILE
 
+          # Copyright file (Debian Policy §12.5). Also consumed by the
+          # CloudNativePG postgres-extensions-containers Dockerfiles, which
+          # COPY /usr/share/doc/<pkg>/copyright into the extension image's
+          # /licenses/ tree.
+          doc_dir=${package_dir}/usr/share/doc/postgresql-${{ matrix.pg_version }}-pg-search
+          mkdir -p ${doc_dir}
+          cat > ${doc_dir}/copyright <<'EOF'
+          Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+          Upstream-Name: pg_search
+          Upstream-Contact: ParadeDB <support@paradedb.com>
+          Source: https://github.com/paradedb/paradedb
+
+          Files: *
+          Copyright: ParadeDB <support@paradedb.com>
+          License: AGPL-3.0-or-later
+           The full license text is in this package at LICENSE,
+           and online at https://www.gnu.org/licenses/agpl-3.0.txt
+          EOF
+          cp LICENSE ${doc_dir}/LICENSE
+
           # Create .deb package
           sudo chown -R root:root ${package_dir}
           sudo chmod -R 755 ${package_dir}

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -167,6 +167,10 @@ jobs:
           cp archive/*.control ${package_dir}/${share_path}
           cp archive/*.sql ${package_dir}/${share_path}
 
+          # Bundle the LICENSE so it lands at /opt/homebrew/opt/paradedb/LICENSE
+          # alongside the Homebrew install prefix.
+          cp LICENSE ${package_dir}/LICENSE
+
           # Create postinstall script
           mkdir -p ~/tmp/pg_search_postinstall_script/
           postinstall_file=~/tmp/pg_search_postinstall_script/postinstall

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -328,11 +328,14 @@ jobs:
           %{__rm} -rf %{buildroot}
           install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
           install -d %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -d %{buildroot}/usr/share/licenses/%{name}/
           install -m 755 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/lib/
           install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*.sql %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
           install -m 644 %{_sourcedir}/pg_search_${{ matrix.pg_version }}/usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control %{buildroot}/usr/pgsql-${{ matrix.pg_version }}/share/extension/
+          install -m 644 %{_sourcedir}/LICENSE %{buildroot}/usr/share/licenses/%{name}/LICENSE
 
           %files
+          %license /usr/share/licenses/%{name}/LICENSE
           /usr/pgsql-${{ matrix.pg_version }}/lib/pg_search.so
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search.control
           /usr/pgsql-${{ matrix.pg_version }}/share/extension/pg_search*sql
@@ -346,6 +349,7 @@ jobs:
 
           echo "Copying pg_search binaries to RPM build directory..."
           cp -r target/release/pg_search-pg${{ matrix.pg_version }}/ ~/rpmbuild/SOURCES/pg_search_${{ matrix.pg_version }}
+          cp LICENSE ~/rpmbuild/SOURCES/LICENSE
 
           echo "Building RPM package..."
           rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_search.spec

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -271,6 +271,26 @@ jobs:
           echo 'Maintainer: ParadeDB <support@paradedb.com>' >> $CONTROL_FILE
           echo 'Description: Postgres for Search and Analytics' >> $CONTROL_FILE
 
+          # Copyright file (Debian Policy §12.5). Also consumed by the
+          # CloudNativePG postgres-extensions-containers Dockerfiles, which
+          # COPY /usr/share/doc/<pkg>/copyright into the extension image's
+          # /licenses/ tree.
+          doc_dir=${package_dir}/usr/share/doc/postgresql-${{ matrix.pg_version }}-pg-search
+          mkdir -p ${doc_dir}
+          cat > ${doc_dir}/copyright <<'EOF'
+          Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+          Upstream-Name: pg_search
+          Upstream-Contact: ParadeDB <support@paradedb.com>
+          Source: https://github.com/paradedb/paradedb
+
+          Files: *
+          Copyright: ParadeDB <support@paradedb.com>
+          License: AGPL-3.0-or-later
+           The full license text is in this package at LICENSE,
+           and online at https://www.gnu.org/licenses/agpl-3.0.txt
+          EOF
+          cp LICENSE ${doc_dir}/LICENSE
+
           # Create .deb package
           sudo chown -R root:root ${package_dir}
           sudo chmod -R 755 ${package_dir}


### PR DESCRIPTION
Our hand-rolled .deb and .rpm packaging in the publish-pg_search-* workflows skipped the standard license payload. Adds:

- /usr/share/doc/postgresql-${PG_MAJOR}-pg-search/copyright (Debian Policy §12.5, machine-readable format) plus a verbatim LICENSE alongside it, in both publish-pg_search-debian.yml and -ubuntu.yml
- /usr/share/licenses/%{name}/LICENSE in publish-pg_search-rhel.yml's rpm SPEC, marked with %license in %files

This aligns pg_search with the CloudNativePG postgres-extensions- containers pattern: pgvector, timescaledb, and wal2json all install via apt-get and COPY /usr/share/doc/<pkg>/copyright into the extension image's /licenses/ tree. A pg_search-cnpg image can now follow the same canonical pattern with no special-casing.
