### PR TITLE
ci(docker): publish paradedb extension image

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -4,10 +4,11 @@
 # Publish ParadeDB as Docker images for all of our supported PostgreSQL versions to Docker Hub after
 # the pg_search .deb has been published to GitHub Releases. Stable releases publish Docker images for
 # all of our supported PostgreSQL versions, while beta releases only publish the default PostgreSQL
-# version we run as default (currently 18). Once all Docker images are published, notify ORM wrapper
-# repositories via repository_dispatch so they can run compatibility checks against the new version.
-# This is done in `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker
-# image.
+# version we run as default (currently 18). This workflow also publishes the non-runnable
+# paradedb/paradedb-extension image for Postgres 18+ deployments that mount Postgres extension images.
+# Once the runnable Docker images are published, notify ORM wrapper repositories via repository_dispatch
+# so they can run compatibility checks against the new version. This is done in
+# `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
 
 name: Publish ParadeDB (Docker)
 
@@ -239,6 +240,98 @@ jobs:
           subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
 
+  publish-extension-image:
+    name: Publish ParadeDB Extension Image for PostgreSQL ${{ matrix.pg_version }}
+    runs-on: ubuntu-latest
+    needs:
+      - generate-dockerfiles
+      - test-generated-dockerfiles
+    strategy:
+      matrix:
+        # Mounted extension images require PostgreSQL 18+ because
+        # extension_control_path was introduced in PG 18. Older PG majors cannot
+        # see a mounted /share/extension directory.
+        pg_version: [18]
+    env:
+      image_name: paradedb/paradedb-extension
+      image_os: trixie
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.generate-dockerfiles.outputs.branch }}
+
+      - name: Resolve pg_search .deb Checksums
+        id: checksums
+        env:
+          PG_VERSION: ${{ matrix.pg_version }}
+          PG_SEARCH_VERSION: ${{ needs.generate-dockerfiles.outputs.version }}
+        run: |
+          tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$tmp_dir"' EXIT
+
+          fetch_checksum() {
+            local arch="$1"
+            local release_asset_name="postgresql-${PG_VERSION}-pg-search_${PG_SEARCH_VERSION}-1PARADEDB-trixie_${arch}.deb"
+            local deb="${tmp_dir}/${release_asset_name}"
+
+            echo "Fetching ${release_asset_name}" >&2
+            curl -fsSL -o "$deb" "https://github.com/paradedb/paradedb/releases/download/v${PG_SEARCH_VERSION}/${release_asset_name}"
+            sha256sum "$deb" | awk '{ print $1 }'
+          }
+
+          echo "amd64=$(fetch_checksum amd64)" >> "$GITHUB_OUTPUT"
+          echo "arm64=$(fetch_checksum arm64)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Setup Docker Image tags
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.image_name }}
+          # Extension payloads are version-pinned to a Postgres major, mirroring the
+          # cloudnative-pg/postgres-extensions-containers `<version>-<pg-major>-<distro>`
+          # convention.
+          tags: |
+            type=raw,value=${{ needs.generate-dockerfiles.outputs.version }}-${{ matrix.pg_version }}-${{ env.image_os }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
+
+      - name: Build and Push Docker Image to Docker Hub
+        id: build-push
+        uses: docker/build-push-action@v7
+        with:
+          context: docker
+          platforms: linux/amd64,linux/arm64
+          file: docker/Dockerfile.extension
+          build-args: |
+            BASE=ghcr.io/cloudnative-pg/postgresql:${{ matrix.pg_version }}-minimal-trixie
+            PG_VERSION_MAJOR=${{ matrix.pg_version }}
+            PG_SEARCH_VERSION=${{ needs.generate-dockerfiles.outputs.version }}
+            PG_SEARCH_DEB_AMD64_SHA256=${{ steps.checksums.outputs.amd64 }}
+            PG_SEARCH_DEB_ARM64_SHA256=${{ steps.checksums.outputs.arm64 }}
+          push: true
+          sbom: true
+          provenance: mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Sign and Attest Build Provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-name: index.docker.io/${{ env.image_name }}
+          subject-digest: ${{ steps.build-push.outputs.digest }}
+          push-to-registry: true
+
   open-dockerfile-prs:
     name: Open Dockerfile Update PRs
     runs-on: ubuntu-latest
@@ -347,8 +440,8 @@ jobs:
         run: |
           # Attempt every repo even if one fails (e.g. the ParadeDB GitHub App is
           # not installed on it), so a single misconfigured repo doesn't block the
-          # rest. Collect failures and fail the step at the end to trigger the Slack
-          # alert below.
+          # rest. Collect failures and fail the step at the end, which trips the
+          # notify-slack-on-failure job.
           failed=()
           while IFS= read -r repo; do
             repo=$(echo "$repo" | xargs)
@@ -367,9 +460,24 @@ jobs:
             exit 1
           fi
 
+  # Single failure sink for the whole workflow: if any publishing job (including
+  # the regular image, the extension image, Dockerfile generation/testing, or the
+  # ORM dispatch) fails, alert Slack once with a link to the run.
+  notify-slack-on-failure:
+    name: Notify Slack on Failure
+    runs-on: ubuntu-latest
+    needs:
+      - set-matrix
+      - generate-dockerfiles
+      - test-generated-dockerfiles
+      - publish-paradedb-docker-image
+      - publish-extension-image
+      - open-dockerfile-prs
+      - notify-orm-repos
+    if: ${{ always() && (needs.set-matrix.result == 'failure' || needs.generate-dockerfiles.result == 'failure' || needs.test-generated-dockerfiles.result == 'failure' || needs.publish-paradedb-docker-image.result == 'failure' || needs.publish-extension-image.result == 'failure' || needs.open-dockerfile-prs.result == 'failure' || needs.notify-orm-repos.result == 'failure') }}
+    steps:
       - name: Notify Slack on Failure
-        if: failure()
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> Failed to notify ORM repos of the new \`pg_search\` release in \`${{ github.repository }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!here> \`publish-paradedb-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -406,3 +406,116 @@ jobs:
         run: |
           docker run --name temp-inspect-paradedb --entrypoint /bin/bash paradedb/paradedb:latest -c "ls -la /var/lib/postgresql"
           docker rm temp-inspect-paradedb
+
+  # Smoke-test that docker/Dockerfile.extension (the non-runnable, FROM scratch
+  # paradedb/paradedb-extension payload) builds for PostgreSQL 18 on each arch.
+  # This image is only built at release time in publish-paradedb-docker.yml, so
+  # without this job a break in the .deb layout or the COPY paths would not surface
+  # until a publish fails. Building per arch natively keeps it consistent with the
+  # runnable-image job above.
+  test-extension-image:
+    name: Test Extension Image Build (${{ matrix.arch }})
+    # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - family=${{ matrix.runner_family }}
+      - cpu=4
+      - ram=16
+      - image=${{ matrix.runner_image }}
+      - volume=40gb
+      - extras=s3-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        arch:
+          - amd64
+          - arm64
+        include:
+          - arch: amd64
+            runner_family: m7a+m7i
+            runner_image: ubuntu24-full-x64
+            platform: linux/amd64
+            deb_sha_arg: PG_SEARCH_DEB_AMD64_SHA256
+          - arch: arm64
+            runner_family: m7g+m8g
+            runner_image: ubuntu24-full-arm64
+            platform: linux/arm64
+            deb_sha_arg: PG_SEARCH_DEB_ARM64_SHA256
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      # The extension image installs pg_search from the same GitHub Release .deb as
+      # the runnable images. Resolve that version from the committed Dockerfile and
+      # skip if the release isn't published yet — same pre-release gate as the
+      # runnable-image job above (matters for the enterprise rebase).
+      - name: Check whether the referenced pg_search release is published
+        id: release_gate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          dockerfile="docker/Dockerfile.paradedb-${{ env.PG_VERSION }}"
+          url="$(grep -oE 'https://(api\.)?github\.com/[^"]*releases/(download|tags)/v[0-9][^"/]*' "$dockerfile" | head -1)"
+          if [[ -z "$url" ]]; then
+            echo "No pg_search release URL found in ${dockerfile}; building the extension image."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          repo="$(sed -E 's#https://(api\.)?github\.com/(repos/)?([^/]+/[^/]+)/releases/.*#\3#' <<< "$url")"
+          tag="$(grep -oE 'v[0-9][^"/]*' <<< "$url" | head -1)"
+          echo "Dockerfile ${dockerfile} installs pg_search from ${repo}@${tag}"
+          echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
+          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
+            echo "Release ${repo}@${tag} is published — building the extension image."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "::notice::Release ${repo}@${tag} is not published yet — skipping the extension image build. It will run once the release exists."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve pg_search .deb Checksum
+        id: checksum
+        if: steps.release_gate.outputs.skip != 'true'
+        run: |
+          asset="postgresql-${{ env.PG_VERSION }}-pg-search_${{ steps.release_gate.outputs.version }}-1PARADEDB-trixie_${{ matrix.arch }}.deb"
+          url="https://github.com/paradedb/paradedb/releases/download/v${{ steps.release_gate.outputs.version }}/${asset}"
+          echo "Fetching ${asset}"
+          curl -fsSL -o /tmp/pg_search.deb "$url"
+          echo "sha256=$(sha256sum /tmp/pg_search.deb | awk '{ print $1 }')" >> "$GITHUB_OUTPUT"
+
+      # A successful `FROM scratch` build already proves the .deb installs and every
+      # COPY glob (library, control file, SQL, license) matched at least one file —
+      # an empty glob fails the build. We export the payload and additionally assert
+      # the key files are present. Scoped per-arch so amd64 and arm64 don't evict
+      # each other in the BuildKit gha/S3 cache.
+      - name: Build and Verify the Extension Image
+        if: steps.release_gate.outputs.skip != 'true'
+        run: |
+          docker buildx build \
+            --platform ${{ matrix.platform }} \
+            --file docker/Dockerfile.extension \
+            --build-arg BASE=ghcr.io/cloudnative-pg/postgresql:${{ env.PG_VERSION }}-minimal-trixie \
+            --build-arg PG_VERSION_MAJOR=${{ env.PG_VERSION }} \
+            --build-arg PG_SEARCH_VERSION=${{ steps.release_gate.outputs.version }} \
+            --build-arg ${{ matrix.deb_sha_arg }}=${{ steps.checksum.outputs.sha256 }} \
+            --cache-from type=gha,scope=paradedb-extension-${{ matrix.arch }} \
+            --cache-to type=gha,mode=max,scope=paradedb-extension-${{ matrix.arch }} \
+            --output type=local,dest=/tmp/extension-payload \
+            docker
+
+          echo "Payload contents:"
+          find /tmp/extension-payload -type f | sort
+
+          for required in lib/pg_search.so share/extension/pg_search.control; do
+            if [[ ! -f "/tmp/extension-payload/${required}" ]]; then
+              echo "Error: extension payload is missing ${required}"
+              exit 1
+            fi
+          done
+          echo "Extension payload built successfully and contains the expected library and control file."

--- a/docker/Dockerfile.extension
+++ b/docker/Dockerfile.extension
@@ -1,0 +1,55 @@
+# Postgres extension image payload for pg_search.
+#
+# Unlike Dockerfile.paradedb-N / Dockerfile.official-N, this image is not a
+# runnable Postgres. It is a `FROM scratch` artifact containing only
+# pg_search's shared library, control file, SQL scripts, and license. The
+# CloudNativePG Postgres base image is used in the builder stage so the .deb's
+# ABI matches the common extension-image runtime used by Postgres operators.
+#
+ARG BASE=ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+FROM $BASE AS builder
+
+ARG PG_VERSION_MAJOR=18
+ARG PG_SEARCH_VERSION
+ARG PG_SEARCH_DEB_AMD64_SHA256
+ARG PG_SEARCH_DEB_ARM64_SHA256
+
+USER 0
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c", "-e"]
+
+# Install pg_search from GitHub Releases (same .deb as the runnable images).
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    : "${PG_SEARCH_VERSION:?PG_SEARCH_VERSION is required}" && \
+    arch="$(dpkg --print-architecture)" && \
+    case "$arch" in \
+        amd64) checksum="$PG_SEARCH_DEB_AMD64_SHA256" ;; \
+        arm64) checksum="$PG_SEARCH_DEB_ARM64_SHA256" ;; \
+        *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac && \
+    if [ -z "$checksum" ]; then echo "checksum is required for $arch" >&2; exit 1; fi && \
+    curl -fsSL -o /tmp/pg_search.deb "https://github.com/paradedb/paradedb/releases/download/v${PG_SEARCH_VERSION}/postgresql-${PG_VERSION_MAJOR}-pg-search_${PG_SEARCH_VERSION}-1PARADEDB-trixie_${arch}.deb" && \
+    echo "${checksum}  /tmp/pg_search.deb" | sha256sum -c - && \
+    apt-get install -y --no-install-recommends /tmp/pg_search.deb && \
+    rm /tmp/pg_search.deb && \
+    rm -rf /var/lib/apt/lists/*
+
+USER 65532:65532
+
+# Final extension payload. Postgres 18+ can load this mounted /lib and
+# /share/extension content through extension_control_path.
+FROM scratch
+
+ARG PG_VERSION_MAJOR=18
+
+# Licenses
+COPY --from=builder /usr/share/doc/postgresql-${PG_VERSION_MAJOR}-pg-search/copyright /licenses/postgresql-${PG_VERSION_MAJOR}-pg-search/
+
+# Library: pg_search.so
+COPY --from=builder /usr/lib/postgresql/${PG_VERSION_MAJOR}/lib/pg_search* /lib/
+
+# Control + SQL scripts
+COPY --from=builder /usr/share/postgresql/${PG_VERSION_MAJOR}/extension/pg_search* /share/extension/
+
+USER 65532:65532

--- a/docker/generate-dockerfiles.sh
+++ b/docker/generate-dockerfiles.sh
@@ -5,7 +5,7 @@
 # Postgres version we support. Our normal Dockerfile includes Barman cloud which is specific to our deployment approach
 # and thus cannot be included in the official images. We also have a version of the file for use in Antithesis.
 #
-# This script downloads the .debs for the specified version from GitHub Releases in order to compute checksusm and embed
+# This script downloads the .debs for the specified version from GitHub Releases in order to compute checksums and embed
 # them in the Dockerfiles.
 #
 # To make a change, update the template, rerun the script with the desired version, and commit the generated Dockerfiles.
@@ -14,7 +14,7 @@ set -euo pipefail
 
 if [[ $# -ne 1 ]]; then
   echo "Error: PG_SEARCH_VERSION is required"
-  echo "Usage: $0 0.23.4"
+  echo "Usage: $0 0.24.0"
   exit 1
 fi
 

--- a/docs/deploy/self-hosted/kubernetes.mdx
+++ b/docs/deploy/self-hosted/kubernetes.mdx
@@ -108,6 +108,61 @@ helm upgrade --atomic --install paradedb \
 paradedb/paradedb
 ```
 
+## Use the Extension Image with CloudNativePG
+
+If you already run a CloudNativePG cluster and want to add ParadeDB to an
+existing Postgres image, use the ParadeDB extension image instead of the full
+`paradedb/paradedb` image. Extension images require Postgres 18+ because they
+depend on `extension_control_path`.
+
+Add the `pg_search` extension image to the `postgresql.extensions` section of
+your CloudNativePG `Cluster` resource:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: paradedb
+spec:
+  imageName: ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie
+  instances: 1
+
+  storage:
+    size: 1Gi
+
+  postgresql:
+    shared_preload_libraries:
+      - "pg_search"
+    extensions:
+      - name: pg_search
+        image:
+          reference: docker.io/paradedb/paradedb-extension:0.24.0-18-trixie
+        extension_control_path:
+          - /share
+        dynamic_library_path:
+          - /lib
+```
+
+Then enable the extension in a database:
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: paradedb-app
+spec:
+  name: app
+  owner: app
+  cluster:
+    name: paradedb
+  extensions:
+    - name: pg_search
+      version: "0.24.0"
+```
+
+The extension image tag format is `<paradedb-version>-<postgres-major>-trixie`.
+For example, use `0.24.0-18-trixie` for ParadeDB `0.24.0` on Postgres 18.
+
 ## Connect to the Cluster
 
 The command to connect to the primary instance of the cluster will be printed in your terminal. If you do not modify any settings, it will be:


### PR DESCRIPTION
## Summary

Publishes a dedicated ParadeDB extension image to Docker Hub as `paradedb/paradedb-extension`.

This is not a runnable Postgres image. It is a `FROM scratch` payload image intended for operators that can mount extension images into an existing Postgres pod, including CloudNativePG. The payload contains only:

- `/lib/pg_search.so`
- `/share/extension/pg_search.control` and `pg_search--*.sql`
- `/licenses/postgresql-18-pg-search/copyright`

The extension image is PG 18+ only because mounted extension images need Postgres `extension_control_path` support.

## What Changed

- Adds `docker/Dockerfile.extension`, a parameterized scratch payload Dockerfile built from the same `postgresql-N-pg-search` release `.deb` as the runnable images.
- Publishes `paradedb/paradedb-extension` from the existing `.github/workflows/publish-paradedb-docker.yml` workflow after generated Dockerfiles pass tests.
- Reuses the main Docker workflow's release metadata, latest-release decision, Docker Hub login, SBOM/provenance, and attestation path instead of adding a separate workflow/action.
- Removes the old generated `docker/Dockerfile.cnpg-extension-*` approach and the old `publish-pg_search-cnpg-extension-container` workflow.
- Documents CloudNativePG usage with `docker.io/paradedb/paradedb-extension:0.24.0-18-trixie`.

The extension publish job resolves amd64/arm64 `.deb` checksums, builds `linux/amd64` and `linux/arm64`, pushes SBOM/provenance, and signs the pushed image digest.

Primary tag format:

```text
<pg_search-version>-<postgres-major>-trixie
```

For example:

```text
0.24.0-18-trixie
```

## CloudNativePG Notes

The CNPG extension config must use:

```yaml
extension_control_path:
  - /share
dynamic_library_path:
  - /lib
```

`/share` is intentional. Postgres expects `extension_control_path` entries to point at a root containing an `extension/` subdirectory, so `/share/extension` is one level too deep.

## Local Validation

Tested locally against `pg_search 0.24.0` in kind with CloudNativePG 1.29.1:

- Verified the 0.24.0 PG18 `.deb` SHA-256 from the GitHub release asset metadata.
- Confirmed the `.deb` includes `/usr/share/doc/postgresql-18-pg-search/copyright`, `pg_search.so`, `pg_search.control`, and SQL migration files.
- Built a local `paradedb-extension-local:0.24.0-18-trixie-amd64` payload image with the same final layout as `docker/Dockerfile.extension`.
- Loaded the image into kind and created a CNPG cluster using `ghcr.io/cloudnative-pg/postgresql:18-minimal-trixie` plus the extension image volume.
- CNPG cluster reached Ready.
- `SHOW extension_control_path` returned `$system:/extensions/pg_search/share`.
- `pg_available_extensions` listed `pg_search | 0.24.0`.
- A CNPG `Database` resource applied successfully, and `pg_extension` reported `pg_search | 0.24.0`.

Also checked:

- `actionlint -ignore 'missing input "app-id"' -ignore 'input "client-id" is not defined' .github/workflows/publish-paradedb-docker.yml`
- `prettier --check .github/workflows/publish-paradedb-docker.yml docs/deploy/self-hosted/kubernetes.mdx`
- `git diff --check`

## Notes

`main` already contains the generated runnable/official Dockerfile bump to `0.24.0`, so this PR no longer carries those generated Dockerfile changes.

The unignored `actionlint` warnings are existing `actions/create-github-app-token@v3` schema warnings in this workflow: the action now expects `app-id`, while the workflow still uses the existing `client-id` input pattern.
