### PR TITLE
chore(mpp): bump datafusion-distributed to the rebased fork tip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2171,7 +2171,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=340ceb5#340ceb52a10415ea5c81ba0de2541326faccedca"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=e5a498e#e5a498e7212a69efa395953a0ed36d7839258d6d"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-HFxiS0aBRdTlc8h8Kb7FPaseOuKVnNrKivtjpqp2cUk=";
+  cargoHash = "sha256-TvthlUfLVUmqSO85ZxfHQEghylSYiWLBZqSc6ZH8Ar0=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -78,7 +78,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "340ceb5" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "e5a498e" }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -404,7 +404,7 @@ pub(crate) fn run_mpp_worker(
         // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue /
         // in-proc channel are the per-partition clones owned by the spawned fragments. Without
         // this, the originals would outlive the futures, the consumer-side drains would never
-        // observe `Detached`, and `stream_partition`'s pull loop would spin forever.
+        // observe `Detached`, and `execute`'s pull loop would spin forever.
         drop(outbound_senders);
         crate::mpp_log!(
             "mpp worker dispatch this_proc={this_proc} starting join_all on {} fragments",

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -266,7 +266,7 @@ pub unsafe fn leader_setup(
 
     // Each `DrainHandle` owns a per-`(stage_id, partition)` channel buffer registry, so one shm_mq
     // queue can carry frames from many logical channels. Channel buffers are created lazily on first
-    // frame, or up-front by `WorkerConnection::stream_partition`.
+    // frame, or up-front by `WorkerConnection::execute`.
     let inbound_receivers = build_inbound_receivers(0, total_procs, attach.inbound_receivers);
 
     let mesh = Arc::new(MppMesh::new(0, total_procs, inbound_receivers));

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -34,12 +34,12 @@
 use std::ops::Range;
 use std::sync::Arc;
 
+use datafusion::arrow::array::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
-use datafusion_distributed::{
-    RemoteStage, WorkerConnection, WorkerPartitionStream, WorkerTransport,
-};
+use datafusion_distributed::{RemoteStage, WorkerConnection, WorkerTransport};
+use futures::stream::BoxStream;
 
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, DrainHandle, DrainItem};
 
@@ -210,7 +210,7 @@ struct ShmMqWorkerConnection {
 }
 
 impl WorkerConnection for ShmMqWorkerConnection {
-    fn stream_partition(&self, partition: usize) -> Result<WorkerPartitionStream> {
+    fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>> {
         let partition_u32 = u32::try_from(partition).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerConnection: partition={partition} > u32::MAX"
@@ -232,7 +232,7 @@ impl WorkerConnection for ShmMqWorkerConnection {
         // their own channel buffers, so this consumer only sees its slice.
         let buffer = drain.register_channel(self.stage_id, partition_u32);
         crate::mpp_log!(
-            "mpp transport::stream_partition this_proc={} sender_proc={} stage_id={} \
+            "mpp transport::execute this_proc={} sender_proc={} stage_id={} \
              partition={partition_u32} (register_channel)",
             self.mesh.this_proc,
             self.sender_proc,

--- a/pg_search/src/postgres/customscan/mpp/transport.rs
+++ b/pg_search/src/postgres/customscan/mpp/transport.rs
@@ -725,7 +725,7 @@ struct ChannelBufferRegistry {
 /// with `Eof` — the drain can therefore never outlive its query, even on a panicked teardown.
 pub struct DrainHandle {
     /// Per-(stage_id, partition) channel buffer registry. Populated lazily on first frame for a
-    /// channel, or up-front by callers (e.g. `WorkerConnection::stream_partition`) that need a
+    /// channel, or up-front by callers (e.g. `WorkerConnection::execute`) that need a
     /// buffer to wait on before any frame arrives.
     channel_buffers: Mutex<ChannelBufferRegistry>,
     /// Receivers owned by the handle and polled inline from `DrainGatherStream::poll_next` via

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -43,7 +43,9 @@ use std::sync::Arc;
 use datafusion::physical_plan::ExecutionPlan;
 #[cfg(not(test))]
 use datafusion::physical_plan::ExecutionPlanProperties;
-use datafusion_distributed::{NetworkBoundaryExt, NetworkBoundaryKind};
+use datafusion_distributed::{
+    NetworkBoundaryExt, NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec,
+};
 
 use crate::postgres::customscan::mpp::runtime::proc_for_task;
 
@@ -73,7 +75,7 @@ pub enum FragmentRouting {
     /// All output partitions go to one destination proc (`NetworkCoalesceExec`
     /// or the top-level gather case). Frame header carries
     /// `(stage_id, partition)` directly; consumer reads
-    /// `stream_partition(partition)`.
+    /// `execute(partition)`.
     Coalesce {
         /// Destination proc index. `0` for the leader (top-level gather),
         /// or an `assignment.proc_for(parent_stage_id, 0)` lookup for a
@@ -84,7 +86,7 @@ pub enum FragmentRouting {
     /// goes to consumer task `q / partitions_per_consumer_task`, hosted on
     /// `proc_for_task(n_workers, consumer_task_idx)`. Frame header is
     /// `(stage_id, q)` so the consumer's
-    /// `stream_partition(P_c * task_index + p_local)` finds it via the
+    /// `execute(P_c * task_index + p_local)` finds it via the
     /// per-`(stage_id, partition)` channel buffer registry.
     ///
     /// [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
@@ -178,79 +180,85 @@ fn collect(
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
         let stage_id = stage.num() as u32;
-        let kind = nb.kind();
         // Per-consumer-task partition count from upstream's `NetworkShuffleExec::execute`
         // receive-side formula `off = P_c * task_index`.
         let p_c = plan.properties().partitioning.partition_count();
+        let plan_any = plan.as_ref().as_any();
 
-        // Classify by `(boundary_kind, top_level)` and pick a destination proc for every
-        // output partition. The fork's gRPC path keys dispatch on resolver URLs and never
-        // has to decide this; our shm_mq peers are push-driven without URLs, so the
-        // dispatcher has to. Shuffle and Broadcast share the receive-side math but Broadcast
-        // caps to task 0; Coalesce collapses to one consumer task; top-level (`nested ==
-        // false`) routes to the leader.
-        //
-        // `NetworkBoundaryKind` is `#[non_exhaustive]`, so the catch-all `_ =>` arm is
-        // required. It also surfaces any future fork variant we haven't reasoned about.
-        let routing = match (kind, nested) {
-            // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan
-            // plan produces; broadcast always sits nested inside the HashJoin build subtree.
-            // Falling through to `Coalesce { dest_proc: 0 }` would send every input task's
-            // full canonical replica to the leader and `select_all` would over-count by
-            // `input_task_count`. Fail loudly so a future planner change that hits this
-            // shape can't silently produce wrong answers.
-            (NetworkBoundaryKind::Broadcast, false) => {
-                crate::postgres::customscan::mpp::fail_loud(format!(
-                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
-                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
-                     produce this shape; route via a NetworkCoalesceExec gather instead."
-                ))
+        // Classify the boundary by downcasting to its concrete `Network*Exec` type, then pick a
+        // destination proc for every output partition from `(type, top_level)`. The fork's gRPC
+        // path keys dispatch on resolver URLs and never has to decide this; our shm_mq peers are
+        // push-driven without URLs, so the dispatcher has to. Shuffle and Broadcast share the
+        // receive-side math but Broadcast caps to task 0; Coalesce collapses to one consumer task;
+        // top-level (`nested == false`) routes to the leader.
+        let routing = if plan_any.is::<NetworkCoalesceExec>() {
+            if nested {
+                // Nested NetworkCoalesceExec: consumer is a single task in the parent stage. The
+                // receive math collapses to task 0 of the parent group, so the destination proc
+                // is `proc_for_task(n_workers, 0)`.
+                FragmentRouting::Coalesce {
+                    dest_proc: proc_for_task(n_workers, 0),
+                }
+            } else {
+                // Top-level NetworkCoalesceExec (gather to leader): consumer is leader proc 0.
+                FragmentRouting::Coalesce { dest_proc: 0 }
             }
-            // Top-level NetworkShuffleExec isn't a shape our customscan plans produce
-            // either. Shuffles emit hash-partitioned output into a parent consumer stage,
-            // not directly into the leader. Coalescing the partitions to proc 0 would
-            // technically work (each batch reaches `select_all` exactly once) but it would
-            // mask a planner anomaly by silently treating hash-partitioned output as one
-            // logical stream. Same stance as the Broadcast case above.
-            (NetworkBoundaryKind::Shuffle, false) => {
+        } else if plan_any.is::<NetworkShuffleExec>() {
+            if nested {
+                // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps
+                // to consumer task q / p_c.
+                FragmentRouting::Shuffle {
+                    partitions_per_consumer_task: p_c,
+                }
+            } else {
+                // Top-level NetworkShuffleExec isn't a shape our customscan plans produce.
+                // Shuffles emit hash-partitioned output into a parent consumer stage, not directly
+                // into the leader. Coalescing the partitions to proc 0 would technically work (each
+                // batch reaches `select_all` exactly once) but it would mask a planner anomaly by
+                // silently treating hash-partitioned output as one logical stream.
                 crate::postgres::customscan::mpp::fail_loud(format!(
                     "mpp worker_fragments: top-level NetworkShuffleExec is unsupported \
                      (stage_id={stage_id}). Shuffles emit hash-partitioned output into a \
                      parent consumer stage; a top-level shuffle is a planner anomaly."
                 ))
             }
-            // Top-level NetworkCoalesceExec (gather to leader): consumer is leader proc 0.
-            (NetworkBoundaryKind::Coalesce, false) => FragmentRouting::Coalesce { dest_proc: 0 },
-            // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps
-            // to consumer task q / p_c.
-            (NetworkBoundaryKind::Shuffle, true) => FragmentRouting::Shuffle {
-                partitions_per_consumer_task: p_c,
-            },
-            // Nested NetworkBroadcastExec: same wire-level math as Shuffle, but the
-            // dispatcher only runs the producer plan on task 0 to avoid the canonical-replica
-            // duplication described on `FragmentRouting::Broadcast`.
-            (NetworkBoundaryKind::Broadcast, true) => FragmentRouting::Broadcast {
-                partitions_per_consumer_task: p_c,
-            },
-            // Nested NetworkCoalesceExec: consumer is a single task in the parent stage. The
-            // receive math collapses to task 0 of the parent group, so the destination proc is
-            // `proc_for_task(n_workers, 0)`.
-            (NetworkBoundaryKind::Coalesce, true) => FragmentRouting::Coalesce {
-                dest_proc: proc_for_task(n_workers, 0),
-            },
-            // Catch-all for `#[non_exhaustive]` future variants. Fail loudly rather than
-            // guess routing; a default destination would silently produce wrong answers
-            // under a shape we haven't seen.
-            _ => crate::postgres::customscan::mpp::fail_loud(format!(
-                "mpp worker_fragments: unrecognized NetworkBoundaryKind {kind:?} \
-                 (stage_id={stage_id}). Add a routing arm before bumping the fork rev."
-            )),
+        } else if plan_any.is::<NetworkBroadcastExec>() {
+            if nested {
+                // Nested NetworkBroadcastExec: same wire-level math as Shuffle, but the dispatcher
+                // only runs the producer plan on task 0 to avoid the canonical-replica duplication
+                // described on `FragmentRouting::Broadcast`.
+                FragmentRouting::Broadcast {
+                    partitions_per_consumer_task: p_c,
+                }
+            } else {
+                // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan
+                // plan produces; broadcast always sits nested inside the HashJoin build subtree.
+                // Falling through to `Coalesce { dest_proc: 0 }` would send every input task's full
+                // canonical replica to the leader and `select_all` would over-count by
+                // `input_task_count`. Fail loudly so a future planner change that hits this shape
+                // can't silently produce wrong answers.
+                crate::postgres::customscan::mpp::fail_loud(format!(
+                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
+                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
+                     produce this shape; route via a NetworkCoalesceExec gather instead."
+                ))
+            }
+        } else {
+            // `as_network_boundary()` matched, but the node isn't one of the three concrete
+            // boundary types we route. Fail loudly rather than guess; a default destination would
+            // silently produce wrong answers under a shape we haven't seen.
+            crate::postgres::customscan::mpp::fail_loud(format!(
+                "mpp worker_fragments: unrecognized network boundary {} (stage_id={stage_id}). \
+                 Add a routing arm before bumping the fork rev.",
+                plan.name()
+            ))
         };
         #[cfg(not(test))]
         {
             crate::mpp_log!(
-                "mpp worker_fragments::collect boundary kind={kind:?} stage_id={stage_id} \
-                 p_c={p_c} nested={nested}"
+                "mpp worker_fragments::collect boundary={} stage_id={stage_id} \
+                 p_c={p_c} nested={nested}",
+                plan.name()
             );
         }
 

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -143,21 +143,22 @@ LIMIT 10;
                  : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
                  : └──────────────────────────────────────────────────
                  :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
-                 :   │ TantivyLookupExec: decode=[title]
-                 :   │   SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
-                 :   │     VisibilityFilterExec: tables=[p, f]
-                 :   │       ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
-                 :   │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
-                 :   │           CoalescePartitionsExec
-                 :   │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-                 :   │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :   │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :   │ LocalLimitExec: fetch=10
+                 :   │   TantivyLookupExec: decode=[title]
+                 :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+                 :   │       VisibilityFilterExec: tables=[p, f]
+                 :   │         ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
+                 :   │           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
+                 :   │             CoalescePartitionsExec
+                 :   │               [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                 :   │             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :   │               PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :   └──────────────────────────────────────────────────
                  :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
                  :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
                  :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :     └──────────────────────────────────────────────────
-(32 rows)
+(33 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id


### PR DESCRIPTION
This PR bumps `datafusion-distributed` from `340ceb5` to `e5a498e`.

The fork's `main` was rebased onto current `upstream/main` (DF-D `14b3b56`) and the fork commits were restructured into two upstreamable ones (a pluggable `WorkerTransport` and `in_process_mode`) plus a fork-only docs-delete. DataFusion stays at `53.0.0`, so there's no version cascade into `pg_search`.

## Code changes

Two DF-D API adaptations in the MPP module:

- **`WorkerConnection` method rename.** Upstream PR #427 introduced the `WorkerConnection` trait with `fn execute(partition) -> BoxStream`, where our fork previously had `fn stream_partition(partition) -> WorkerPartitionStream`. The reconciled fork adopts the upstream signature, so `ShmMqWorkerConnection` in `mpp/runtime.rs` renames its method to `execute` and returns `BoxStream<'static, Result<RecordBatch>>` (the type the old `WorkerPartitionStream` alias resolved to).

- **Downcast instead of `kind()`.** The fork dropped the `NetworkBoundary::kind()` accessor and the `NetworkBoundaryKind` enum; consumers classify boundaries by downcasting, like elsewhere in df-d and DataFusion. `worker_fragments::collect` now branches on `plan.as_any().is::<NetworkShuffleExec>()` / `NetworkBroadcastExec` / `NetworkCoalesceExec` instead of matching on `nb.kind()`, with a fail-loud arm for any unrecognized boundary type. The routing for each `(type, top_level)` case is unchanged.

The rest of what `pg_search` uses is unchanged: `WorkerTransport`, `in_process_mode`, `prepare_in_process_plan`, and `with_distributed_worker_transport`.
