### PR TITLE
test: add `order by ... limit ...offset` coverage to `group by`

### DIFF
--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -18,7 +18,7 @@
 mod fixtures;
 
 use crate::fixtures::querygen::crossrelgen::arb_cross_rel_expr;
-use crate::fixtures::querygen::groupbygen::arb_group_by;
+use crate::fixtures::querygen::groupbygen::{arb_group_by, SelectItem};
 use crate::fixtures::querygen::joingen::{arb_joins, arb_semi_joins, JoinType};
 use crate::fixtures::querygen::numericgen::arb_numeric_expr;
 use crate::fixtures::querygen::pagegen::arb_paging_exprs;
@@ -353,7 +353,8 @@ async fn generated_single_relation(database: Db) {
 }
 
 ///
-/// Property test for GROUP BY aggregates - ensures equivalence between PostgreSQL and bm25 behavior
+/// Property test for GROUP BY aggregates with ORDER BY and LIMIT/OFFSET
+/// - ensures equivalence between PostgreSQL and bm25 behavior
 ///
 #[rstest]
 #[tokio::test]
@@ -391,10 +392,24 @@ async fn generated_group_by_aggregates(database: Db) {
             &columns_named(vec!["age", "price", "rating"]),
         ),
         group_by_expr in arb_group_by(grouping_columns.to_vec(), vec!["COUNT(*)", "SUM(price)", "AVG(price)", "MIN(rating)", "MAX(rating)", "SUM(age)", "AVG(age)"]),
+        limit in 5..21_usize,
+        offset in 0..4_usize,
         gucs in any::<PgGucs>(),
     )| {
         let select_list = group_by_expr.to_select_list();
         let group_by_clause = group_by_expr.to_sql();
+
+        // use every item in GROUP BY target list for ORDER BY sorting
+        // to ensure deterministic tie-breaking and prevent flaky tests
+        // if multiple targets are used in GROUP BY
+        let order_by_items: Vec<String> = group_by_expr.target_list
+            .iter()
+            .map(|item| match item {
+                SelectItem::Column(col) => format!("{col} ASC NULLS LAST"),
+                SelectItem::Aggregate(agg) => format!("{agg} ASC NULLS LAST"),
+            })
+            .collect();
+        let order_by_clause = format!("ORDER BY {}", order_by_items.join(", "));
 
         // Create combined WHERE clause for PostgreSQL using = operator
         let pg_where_clause = format!(
@@ -411,18 +426,18 @@ async fn generated_group_by_aggregates(database: Db) {
         );
 
         let pg_query = format!(
-            "SELECT {select_list} FROM {table_name} WHERE {pg_where_clause} {group_by_clause}",
+            "SELECT {select_list} FROM {table_name} WHERE {pg_where_clause} {group_by_clause} {order_by_clause} LIMIT {limit} OFFSET {offset}",
         );
 
         let bm25_query = format!(
-            "SELECT {select_list} FROM {table_name} WHERE {bm25_where_clause} {group_by_clause}",
+            "SELECT {select_list} FROM {table_name} WHERE {bm25_where_clause} {group_by_clause} {order_by_clause} LIMIT {limit} OFFSET {offset}",
         );
 
         // Custom result comparator for GROUP BY results
         let compare_results = |query: &str, conn: &mut PgConnection| -> Vec<String> {
             // Fetch all rows as dynamic results and convert to string representation
             let rows = query.fetch_dynamic(conn);
-            let mut string_rows: Vec<String> = rows
+            let string_rows: Vec<String> = rows
                 .into_iter()
                 .map(|row| {
                     // Convert entire row to a string representation for comparison
@@ -449,8 +464,6 @@ async fn generated_group_by_aggregates(database: Db) {
                 })
                 .collect();
 
-            // Sort for consistent comparison
-            string_rows.sort();
             string_rows
         };
 

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -412,7 +412,7 @@ async fn generated_group_by_aggregates(database: Db) {
             .iter()
             .map(|item| {format!("{item} ASC NULLS LAST")})
             .collect()
-    };
+        };
         let order_by_clause = format!("ORDER BY {}", order_by_items.join(", "));
 
         // Create combined WHERE clause for PostgreSQL using = operator

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -399,16 +399,20 @@ async fn generated_group_by_aggregates(database: Db) {
         let select_list = group_by_expr.to_select_list();
         let group_by_clause = group_by_expr.to_sql();
 
-        // use every item in GROUP BY target list for ORDER BY sorting
-        // to ensure deterministic tie-breaking and prevent flaky tests
-        // if multiple targets are used in GROUP BY
-        let order_by_items: Vec<String> = group_by_expr.target_list
+        let order_by_items: Vec<String> = if group_by_expr.group_by_columns.is_empty() {
+            group_by_expr.target_list
             .iter()
             .map(|item| match item {
                 SelectItem::Column(col) => format!("{col} ASC NULLS LAST"),
                 SelectItem::Aggregate(agg) => format!("{agg} ASC NULLS LAST"),
             })
-            .collect();
+            .collect()
+        } else {
+            group_by_expr.group_by_columns
+            .iter()
+            .map(|item| {format!("{item} ASC NULLS LAST")})
+            .collect()
+    };
         let order_by_clause = format!("ORDER BY {}", order_by_items.join(", "));
 
         // Create combined WHERE clause for PostgreSQL using = operator

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -18,7 +18,7 @@
 mod fixtures;
 
 use crate::fixtures::querygen::crossrelgen::arb_cross_rel_expr;
-use crate::fixtures::querygen::groupbygen::{arb_group_by, SelectItem};
+use crate::fixtures::querygen::groupbygen::arb_group_by;
 use crate::fixtures::querygen::joingen::{arb_joins, arb_semi_joins, JoinType};
 use crate::fixtures::querygen::numericgen::arb_numeric_expr;
 use crate::fixtures::querygen::pagegen::arb_paging_exprs;
@@ -399,21 +399,15 @@ async fn generated_group_by_aggregates(database: Db) {
         let select_list = group_by_expr.to_select_list();
         let group_by_clause = group_by_expr.to_sql();
 
-        let order_by_items: Vec<String> = if group_by_expr.group_by_columns.is_empty() {
-            group_by_expr.target_list
-            .iter()
-            .map(|item| match item {
-                SelectItem::Column(col) => format!("{col} ASC NULLS LAST"),
-                SelectItem::Aggregate(agg) => format!("{agg} ASC NULLS LAST"),
-            })
-            .collect()
+        let order_by_and_offset_clause: String = if group_by_expr.group_by_columns.is_empty() {
+            String::new()
         } else {
-            group_by_expr.group_by_columns
-            .iter()
-            .map(|item| {format!("{item} ASC NULLS LAST")})
-            .collect()
+            let order_by_items: Vec<String> = group_by_expr.group_by_columns
+                .iter()
+                .map(|item| {format!("{item} ASC NULLS LAST")})
+                .collect();
+            format!("ORDER BY {} OFFSET {offset}", order_by_items.join(", "))
         };
-        let order_by_clause = format!("ORDER BY {}", order_by_items.join(", "));
 
         // Create combined WHERE clause for PostgreSQL using = operator
         let pg_where_clause = format!(
@@ -430,11 +424,11 @@ async fn generated_group_by_aggregates(database: Db) {
         );
 
         let pg_query = format!(
-            "SELECT {select_list} FROM {table_name} WHERE {pg_where_clause} {group_by_clause} {order_by_clause} LIMIT {limit} OFFSET {offset}",
+            "SELECT {select_list} FROM {table_name} WHERE {pg_where_clause} {group_by_clause} {order_by_and_offset_clause} LIMIT {limit}",
         );
 
         let bm25_query = format!(
-            "SELECT {select_list} FROM {table_name} WHERE {bm25_where_clause} {group_by_clause} {order_by_clause} LIMIT {limit} OFFSET {offset}",
+            "SELECT {select_list} FROM {table_name} WHERE {bm25_where_clause} {group_by_clause} {order_by_and_offset_clause} LIMIT {limit}",
         );
 
         // Custom result comparator for GROUP BY results


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3156

## What

Adds test coverage for `GROUP BY...ORDER BY...LIMIT/OFFSET` in the `GROUP BY` prop tests.

## Why

Currently missing test coverage for #3134 

## How

in `qgen.rs` -> `generated_group_by_aggregates()` test
- added limit and offset ranges in the proptest params for random generation
- removed manual result sorting in `compare_results`, as we now use `ORDER BY` for sorting
- added building of `ORDER BY ... OFFSET` clause (details below)

how `ORDER BY ... OFFSET` clause is built within the proptest (`order_by_and_offset_clause`):

A limitation to follow when testing `ORDER BY` here is that we can only use fields in `group_by_expr.group_by_columns`, instead of generating arbitrary `ORDER BY` queries

`ORDER BY` uses all fields in `group_by_columns` to ensure no ties after sorting, since each group is unique

If `group_by_columns` is empty, we return a empty clause, since an aggregate operation without `GROUP BY` returns only 1 row

`OFFSET` is only added when `group_by_columns` is non-empty, since offsetting any >0 value over 1 row returns 0 rows (not sure if asserting empty outputs is relevant for this test)

## Question

Do we want to include coverage for ordering by aggregate? for example, this would look like
```
aggregate = [count, sum]
group_by_columns = [name, age]

query = "... ORDER BY COUNT, SUM, NAME, AGE ..."
```

instead of right now which looks like
```
query = "... ORDER BY NAME, AGE ..."
```
