### PR TITLE
fix: clean up stale merge-list entries in ambulkdelete instead of asserting

### DIFF
--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -135,17 +135,35 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     // take the MergeLock
     let merge_lock = metadata.acquire_merge_lock();
 
-    // garbage collecting the MergeList is necessary to remove any stale entries that may have
-    // been leftover from a cancelled merge or crash during merge
-    merge_lock
-        .merge_list()
-        .garbage_collect(pg_sys::ReadNextFullTransactionId());
+    // We hold the CLEANUP_LOCK exclusively (see above), so no merge is running for this index
+    // right now: a live merge holds the CLEANUP_LOCK shared for its whole duration and removes
+    // its MergeEntry before releasing it.
+    //
+    // `garbage_collect` reclaims entries whose backend has exited or whose transaction has
+    // ended. Any entry still present is therefore a stale leftover from a merge that errored or
+    // crashed after writing its MergeEntry but before removing it: a panic or ERROR on the merge
+    // path cannot reliably remove it mid-unwind. No live merge depends on these, so we remove
+    // them here (logging as we go) rather than failing VACUUM.
+    let mut merge_list = merge_lock.merge_list();
+    merge_list.garbage_collect(pg_sys::ReadNextFullTransactionId());
 
-    // and now we should not have any merges happening, and cannot
-    assert!(
-        merge_lock.merge_list().is_empty(),
-        "ambulkdelete cannot run concurrently with an active merge operation"
-    );
+    let stale_entries = merge_list.list();
+    if !stale_entries.is_empty() {
+        pgrx::log!(
+            "ambulkdelete: cleaning up {} stale merge list {} left behind by a cancelled or crashed merge",
+            stale_entries.len(),
+            if stale_entries.len() == 1 {
+                "entry"
+            } else {
+                "entries"
+            },
+        );
+        for entry in stale_entries {
+            merge_list
+                .remove_entry(entry)
+                .expect("should be able to remove a stale MergeEntry while holding the merge lock");
+        }
+    }
     drop(cleanup_lock);
 
     let reader = SearchIndexReader::empty(&index_relation, MvccSatisfies::Vacuum)

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -135,35 +135,18 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
     // take the MergeLock
     let merge_lock = metadata.acquire_merge_lock();
 
-    // We hold the CLEANUP_LOCK exclusively (see above), so no merge is running for this index
-    // right now: a live merge holds the CLEANUP_LOCK shared for its whole duration and removes
-    // its MergeEntry before releasing it.
+    // garbage_collect reclaims stale entries (owning backend exited or transaction ended) left
+    // behind by a cancelled or crashed merge.
     //
-    // `garbage_collect` reclaims entries whose backend has exited or whose transaction has
-    // ended. Any entry still present is therefore a stale leftover from a merge that errored or
-    // crashed after writing its MergeEntry but before removing it: a panic or ERROR on the merge
-    // path cannot reliably remove it mid-unwind. No live merge depends on these, so we remove
-    // them here (logging as we go) rather than failing VACUUM.
-    let mut merge_list = merge_lock.merge_list();
-    merge_list.garbage_collect(pg_sys::ReadNextFullTransactionId());
+    // We don't assert the list is empty afterwards. A merge that errored between writing its
+    // MergeEntry and removing it leaves a not-yet-recyclable entry (backend alive, xmin in
+    // progress) that survives garbage_collect. Such an entry is a harmless leftover, not a
+    // concurrent merge -- we hold the CLEANUP_LOCK exclusively, and a live merge holds it shared
+    // for its whole duration -- and a later garbage_collect reclaims it.
+    merge_lock
+        .merge_list()
+        .garbage_collect(pg_sys::ReadNextFullTransactionId());
 
-    let stale_entries = merge_list.list();
-    if !stale_entries.is_empty() {
-        pgrx::log!(
-            "ambulkdelete: cleaning up {} stale merge list {} left behind by a cancelled or crashed merge",
-            stale_entries.len(),
-            if stale_entries.len() == 1 {
-                "entry"
-            } else {
-                "entries"
-            },
-        );
-        for entry in stale_entries {
-            merge_list
-                .remove_entry(entry)
-                .expect("should be able to remove a stale MergeEntry while holding the merge lock");
-        }
-    }
     drop(cleanup_lock);
 
     let reader = SearchIndexReader::empty(&index_relation, MvccSatisfies::Vacuum)

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -284,10 +284,6 @@ impl MergeList {
         Self { entries, bman }
     }
 
-    pub unsafe fn is_empty(&self) -> bool {
-        self.entries.is_empty()
-    }
-
     pub unsafe fn list(&self) -> Vec<MergeEntry> {
         self.entries.list(None)
     }


### PR DESCRIPTION
## What

`ambulkdelete` no longer crashes when a leftover entry remains in the merge
list after garbage collection. The faulty assertion is removed; `garbage_collect`
stays the sole remover of merge-list entries, and the stale leftover is tolerated
(it is reclaimed by a later `garbage_collect`).

## Why

An autovacuum worker can crash with:

```
ERROR: ambulkdelete cannot run concurrently with an active merge operation
context: while vacuuming index "idxtest" of relation "public.test"
         automatic vacuum of table "public.test"

  9: core::panicking::panic_fmt
 10: pg_search::postgres::delete::ambulkdelete::ambulkdelete_inner
       at pg_search/src/postgres/delete.rs:145:5
 18: pg_search::postgres::delete::ambulkdelete
 19: vac_bulkdel_one_index
 21: heap_vacuum_rel
 23: vacuum
 25: AutoVacWorkerMain
```

The panic is the `assert!` at `delete.rs:145`.

### Root cause

The assertion treated a non-empty merge list as proof that a merge is running.
That is not true. `garbage_collect` (called just above the assert) only reclaims
entries that are *recyclable* — `xmin_done || pid_dead`:

```rust
let xmin_done = self.xmin != InvalidTransactionId && !TransactionIdIsInProgress(self.xmin);
let pid_dead  = !IsBackendPid(self.pid);
xmin_done || pid_dead
```

A merge that errored after writing its `MergeEntry` but before removing it
(an ERROR/panic cannot reliably remove it mid-unwind — that requires buffer
locks, which Postgres refuses while unwinding) leaves an entry that is **not
yet recyclable** while its backend is still alive and its `xmin` still in
progress. Such an entry survives `garbage_collect` and trips the assertion,
crashing VACUUM.

### Why the leftover is harmless

`ambulkdelete` holds the **CLEANUP_LOCK exclusively**, and a live merge holds
it *shared* for its whole duration (removing its `MergeEntry` before releasing).
So a surviving entry is provably **not** a concurrent merge — it is stale debris.
It does not affect the vacuum, and a later `garbage_collect` reclaims it once
its backend exits or its transaction ends.

### Fix

Remove the assertion and tolerate the leftover; `garbage_collect` remains the
only place that removes merge-list entries. Also drops the now-unused
`MergeList::is_empty`, whose only caller was the deleted assertion.

## Verification

Reproduced on a local PG17 cluster:

- Injected the exact crash condition — a non-recyclable merge entry
  (alive pid + in-progress xmin, no cleanup lock held), which survives
  `garbage_collect` — then ran `VACUUM` with dead tuples so `ambulkdelete` runs.
- **Before:** `assert!` fires -> `ERROR: ambulkdelete cannot run concurrently
  with an active merge operation`.
- **After:** VACUUM succeeds; the stale entry is left in place and reclaimed by
  a subsequent `garbage_collect` once it becomes recyclable.