### PR TITLE
feat: Remove json5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,17 +4512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "json5"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
-dependencies = [
- "pest",
- "pest_derive",
- "serde",
-]
-
-[[package]]
 name = "kanaria"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5660,49 +5649,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df202b0b0f5b8e389955afd5f27b007b00fb948162953f1db9c70d2c7e3157d7"
 
 [[package]]
-name = "pest"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
-dependencies = [
- "memchr",
- "ucd-trie",
-]
-
-[[package]]
-name = "pest_derive"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
-dependencies = [
- "pest",
- "pest_generator",
-]
-
-[[package]]
-name = "pest_generator"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
-dependencies = [
- "pest",
- "pest_meta",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "pest_meta"
-version = "2.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
-dependencies = [
- "pest",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5738,7 +5684,6 @@ dependencies = [
  "env_logger 0.11.10",
  "futures",
  "half 2.7.1",
- "json5",
  "lazy_static",
  "macros",
  "memoffset",
@@ -8894,12 +8839,6 @@ checksum = "c06ff81122fcbf4df4c1660b15f7e3336058e7aec14437c9f85c6b31a0f279b9"
 dependencies = [
  "regex-lite",
 ]
-
-[[package]]
-name = "ucd-trie"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unarray"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-TvthlUfLVUmqSO85ZxfHQEghylSYiWLBZqSc6ZH8Ar0=";
+  cargoHash = "sha256-rLoTpUg/jf3dZGGiyBVLhhCrcEmFcmuJBbDAxbMuTlE=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -35,7 +35,6 @@ chrono = "0.4.44"
 time = "0.3.47"
 derive_more = { version = "2.1.1", features = ["full"] }
 env_logger = { version = "0.11.10", optional = true }
-json5 = "0.4.1"
 memoffset = "0.9.1"
 once_cell = "1.21.4"
 parking_lot = "0.12.5"

--- a/pg_search/src/api/builder_fns/mlt.rs
+++ b/pg_search/src/api/builder_fns/mlt.rs
@@ -42,7 +42,7 @@ mod pdb {
         stopwords: default!(Option<Vec<String>>, "NULL"),
     ) -> SearchQueryInput {
         let document: HashMap<String, tantivy::schema::OwnedValue> =
-            json5::from_str(&document).expect("could not parse document_fields");
+            serde_json::from_str(&document).expect("could not parse document_fields");
 
         SearchQueryInput::MoreLikeThis {
             min_doc_frequency: min_doc_frequency.map(|n| n as u64),

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -137,18 +137,6 @@ extern "C-unwind" fn validate_datetime_fields(value: *const std::os::raw::c_char
 }
 
 #[pg_guard]
-extern "C-unwind" fn validate_fields(value: *const std::os::raw::c_char) {
-    let json_str = cstr_to_rust_str(value);
-    if json_str.is_empty() {
-        return;
-    }
-
-    // Just ensure the config can be deserialized as json.
-    let _: HashMap<String, serde_json::Value> = json5::from_str(&json_str)
-        .unwrap_or_else(|err| panic!("failed to deserialize field config: {err:?}"));
-}
-
-#[pg_guard]
 extern "C-unwind" fn validate_key_field(value: *const std::os::raw::c_char) {
     cstr_to_rust_str(value);
 }


### PR DESCRIPTION
# Ticket(s) Closed

Removes the `json5` crate. Currently this is only used to parse the document for more like this queries. Removing this is a breaking change as now more_like_this only accepts normal json rather than json5. I think this is the right change to make. The docs don't mention anything about MLT supporting this and I don't see a reason that we need to support it. Looking at the commit history I see that json5 was added originally to parse all json arguments and then was removed later down the line. It seems best to be consistent and accept normal JSON everywhere.

## What

## Why

## How

## Tests
