### PR TITLE
chore: Remove memoffset and derive_more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5017,15 +5017,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5686,7 +5677,6 @@ dependencies = [
  "half 2.7.1",
  "lazy_static",
  "macros",
- "memoffset",
  "once_cell",
  "ordered-float 5.3.0",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1490,15 +1490,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
-name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
@@ -2711,29 +2702,6 @@ checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case 0.10.0",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn 2.0.117",
- "unicode-xid",
 ]
 
 [[package]]
@@ -5671,7 +5639,6 @@ dependencies = [
  "datafusion-distributed",
  "datafusion-proto",
  "decimal-bytes",
- "derive_more",
  "env_logger 0.11.10",
  "futures",
  "half 2.7.1",
@@ -5816,7 +5783,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82169b961269f7436bfba3b9464f4d6be6b500f0ace1de694be77398b58c09a7"
 dependencies = [
- "convert_case 0.11.0",
+ "convert_case",
  "eyre",
  "petgraph",
  "proc-macro2",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-rLoTpUg/jf3dZGGiyBVLhhCrcEmFcmuJBbDAxbMuTlE=";
+  cargoHash = "sha256-RgQt3f9oDIEqbue77/PKt53G2DoaTMHx3lj/T3C5Cak=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -35,7 +35,6 @@ chrono = "0.4.44"
 time = "0.3.47"
 derive_more = { version = "2.1.1", features = ["full"] }
 env_logger = { version = "0.11.10", optional = true }
-memoffset = "0.9.1"
 once_cell = "1.21.4"
 parking_lot = "0.12.5"
 tokenizers = { path = "../tokenizers" }

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -33,7 +33,6 @@ arrow-select = "58.1.0"
 bitpacking = "0.9.3"
 chrono = "0.4.44"
 time = "0.3.47"
-derive_more = { version = "2.1.1", features = ["full"] }
 env_logger = { version = "0.11.10", optional = true }
 once_cell = "1.21.4"
 parking_lot = "0.12.5"

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -29,7 +29,6 @@ use crate::schema::{SearchFieldConfig, SearchFieldType};
 use crate::api::tokenizers::search_field_config_from_type;
 use crate::gucs::{global_enable_background_merging, global_target_segment_count};
 use anyhow::Result;
-use memoffset::*;
 use pgrx::pg_sys::AsPgCStr;
 use pgrx::*;
 use serde::{Deserialize, Serialize};
@@ -210,98 +209,99 @@ pub unsafe extern "C-unwind" fn amoptions(
         pg_sys::relopt_parse_elt {
             optname: "text_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, text_fields_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, text_fields_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "inet_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, inet_fields_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, inet_fields_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "numeric_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, numeric_fields_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, numeric_fields_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "boolean_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, boolean_fields_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, boolean_fields_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "json_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, json_fields_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, json_fields_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "range_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, range_fields_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, range_fields_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "datetime_fields".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, datetime_fields_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, datetime_fields_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "key_field".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, key_field_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, key_field_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "layer_sizes".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, layer_sizes_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, layer_sizes_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "target_segment_count".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
-            offset: offset_of!(BM25IndexOptionsData, target_segment_count) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, target_segment_count) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "background_layer_sizes".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, background_layer_sizes_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, background_layer_sizes_offset)
+                as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "mutable_segment_rows".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_INT,
-            offset: offset_of!(BM25IndexOptionsData, mutable_segment_rows) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, mutable_segment_rows) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "sort_by".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, sort_by_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, sort_by_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },
         pg_sys::relopt_parse_elt {
             optname: "search_tokenizer".as_pg_cstr(),
             opttype: pg_sys::relopt_type::RELOPT_TYPE_STRING,
-            offset: offset_of!(BM25IndexOptionsData, search_tokenizer_offset) as i32,
+            offset: std::mem::offset_of!(BM25IndexOptionsData, search_tokenizer_offset) as i32,
             #[cfg(feature = "pg18")]
             isset_offset: 0,
         },

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -41,7 +41,6 @@ use crate::postgres::utils::extract_numeric_precision_scale;
 use crate::query::QueryError;
 use anyhow::Result;
 use decimal_bytes::MAX_DECIMAL64_NO_SCALE_PRECISION;
-use derive_more::Into;
 use pgrx::{pg_sys, PgBuiltInOids, PgOid};
 use serde::{Deserialize, Serialize};
 use tantivy::schema::{Field, FieldEntry, FieldType, OwnedValue, Schema};
@@ -348,12 +347,17 @@ pub struct CategorizedFieldData {
     pub is_json: bool,
 }
 
-#[derive(Clone, Into)]
+#[derive(Clone)]
 pub struct SearchIndexSchema {
-    #[into]
     schema: Schema,
     bm25_options: BM25IndexOptions,
     categorized: Rc<RefCell<Vec<(SearchField, CategorizedFieldData)>>>,
+}
+
+impl From<SearchIndexSchema> for Schema {
+    fn from(search_index_schema: SearchIndexSchema) -> Self {
+        search_index_schema.schema
+    }
 }
 
 impl SearchIndexSchema {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "1.96.0"
+components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
# Ticket(s) Closed

Found easy ways to remove both of these crates.

## What

## Why

## How

## Tests
