### PR TITLE
ci: Add volume=80gb to Antithesis pg_search .deb build job

### DIFF
--- a/.github/workflows/antithesis-trigger-test-run.yml
+++ b/.github/workflows/antithesis-trigger-test-run.yml
@@ -113,6 +113,7 @@ jobs:
       - ram=64
       - image=ubuntu24-full-x64
       - extras=s3-cache
+      - volume=80gb # default runner ships with 30GB — see https://runs-on.com/runners/linux/
     container:
       image: debian:13-slim
     if: |


### PR DESCRIPTION
## What

Adds `volume=80gb` to the `build-antithesis-pg_search-deb` job's `runs-on` configuration in the Antithesis trigger workflow.

## Why

The default runs-on runner ships with only 30GB of disk. The pgrx package build (with sanitizer coverage instrumentation + debug symbols) plus the `.deb` packaging can exceed that, causing the job to fail — as seen on a recent PR.

The downstream `antithesis-trigger-test-run` job already specifies `volume=80gb`; this brings the `.deb` build job in line with it (and with `test-pg_search-docker.yml` / `test-pg_search-upgrade.yml`).

This was already fixed in paradedb-enterprise; this ports the same fix to community.