### PR TITLE
feat: simplified the MPP transport using the new WorkerTransport abstractions.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=e5a498e#e5a498e7212a69efa395953a0ed36d7839258d6d"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=6e6e19f#6e6e19f23c134e0ab797331df9499f7f82477452"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -5685,6 +5685,7 @@ dependencies = [
  "tokenizers",
  "tokio",
  "typetag",
+ "url",
  "uuid",
 ]
 
@@ -6381,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7098,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7156,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7585,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8222,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9239,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=3f454b5#3f454b5cfc9d7fb550664a4f5aaa547311593740"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=10d90b1#10d90b19842ef69e11a338717b58af5993fcbf11"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=aaa29e15a9835c587edc4e48e636ea4e61c9bbf3#aaa29e15a9835c587edc4e48e636ea4e61c9bbf3"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=602c6a03f7347bd2c6009f3f10bca2ee1a58dd84#602c6a03f7347bd2c6009f3f10bca2ee1a58dd84"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=6e6e19f#6e6e19f23c134e0ab797331df9499f7f82477452"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=227059f#227059fb8756400ae07fa0ee832393ef3bb1f49d"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=193e7eb13157ce68e433d96494309b258c00ab1b#193e7eb13157ce68e433d96494309b258c00ab1b"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=c36483dfac0436c0f9ae3d2b0f7a38018ae6baf4#c36483dfac0436c0f9ae3d2b0f7a38018ae6baf4"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=227059f#227059fb8756400ae07fa0ee832393ef3bb1f49d"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=3f454b5#3f454b5cfc9d7fb550664a4f5aaa547311593740"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=0a4de67cd1c3c0d770ed197d8035cc4e62c45154#0a4de67cd1c3c0d770ed197d8035cc4e62c45154"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=aaa29e15a9835c587edc4e48e636ea4e61c9bbf3#aaa29e15a9835c587edc4e48e636ea4e61c9bbf3"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=10d90b1#10d90b19842ef69e11a338717b58af5993fcbf11"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=cf7842d#cf7842d9e013491f3f52351a2053275f2c98b39d"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=936571971f5cece4a3ffcbbc03d9c625e77c9d64#936571971f5cece4a3ffcbbc03d9c625e77c9d64"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=0a4de67cd1c3c0d770ed197d8035cc4e62c45154#0a4de67cd1c3c0d770ed197d8035cc4e62c45154"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=2a9d3acfb4a111a3d04c88bc3002c4a3328e043e#2a9d3acfb4a111a3d04c88bc3002c4a3328e043e"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=936571971f5cece4a3ffcbbc03d9c625e77c9d64#936571971f5cece4a3ffcbbc03d9c625e77c9d64"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=cf7842d#cf7842d9e013491f3f52351a2053275f2c98b39d"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=193e7eb13157ce68e433d96494309b258c00ab1b#193e7eb13157ce68e433d96494309b258c00ab1b"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,7 +142,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -153,7 +153,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2177,7 +2177,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "1.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=c36483dfac0436c0f9ae3d2b0f7a38018ae6baf4#c36483dfac0436c0f9ae3d2b0f7a38018ae6baf4"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=2a9d3acfb4a111a3d04c88bc3002c4a3328e043e#2a9d3acfb4a111a3d04c88bc3002c4a3328e043e"
 dependencies = [
  "arrow-flight",
  "arrow-ipc",
@@ -2773,7 +2773,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3093,7 +3093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3940,7 +3940,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4312,7 +4312,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5474,7 +5474,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7099,7 +7099,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7157,7 +7157,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7586,7 +7586,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8223,7 +8223,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9240,7 +9240,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-/2kETwPcNNDoo2AJa/yhfld+XtaC3dnL69/dFfmmaxc=";
+  cargoHash = "sha256-KzjuPvxeF0DdPfdutLl/Opl1xLeTKhtlXDOk0FxaWIQ=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-32gKDbxdeR5t1IYwxnw0No0OLgqeW46wrrAhOegLV9o=";
+  cargoHash = "sha256-/2kETwPcNNDoo2AJa/yhfld+XtaC3dnL69/dFfmmaxc=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,8 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "e5a498e" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "6e6e19f" }
+url = "2"
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "3f454b5" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "10d90b1" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "0a4de67cd1c3c0d770ed197d8035cc4e62c45154" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "aaa29e15a9835c587edc4e48e636ea4e61c9bbf3" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "aaa29e15a9835c587edc4e48e636ea4e61c9bbf3" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "602c6a03f7347bd2c6009f3f10bca2ee1a58dd84" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "c36483dfac0436c0f9ae3d2b0f7a38018ae6baf4" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "2a9d3acfb4a111a3d04c88bc3002c4a3328e043e" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "10d90b1" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "cf7842d" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "6e6e19f" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "227059f" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "2a9d3acfb4a111a3d04c88bc3002c4a3328e043e" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "936571971f5cece4a3ffcbbc03d9c625e77c9d64" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "cf7842d" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "193e7eb13157ce68e433d96494309b258c00ab1b" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "193e7eb13157ce68e433d96494309b258c00ab1b" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "c36483dfac0436c0f9ae3d2b0f7a38018ae6baf4" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "227059f" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "3f454b5" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -75,7 +75,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "53", default-features = false }
 datafusion-proto = { version = "53", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "936571971f5cece4a3ffcbbc03d9c625e77c9d64" }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "0a4de67cd1c3c0d770ed197d8035cc4e62c45154" }
 url = "2"
 futures = "0.3"
 async-stream = "0.3.6"

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -404,10 +404,9 @@ unsafe fn build_scan_node(
         )
     })?;
 
-    // Under MPP a pre-sorted scan lowers to a multi-partition scan that coordinator dispatch
-    // can't encode (it only ships a single-partition lazy leaf), so the leader's
-    // `build_dispatch_blob` fails and the query falls back to serial. Results stay correct; the
-    // trade-off is losing MPP for sorted-source queries.
+    // Under MPP a pre-sorted scan lowers to a multi-partition scan the dispatch codec
+    // declines (it ships only the single-partition lazy leaf), so the query falls back to
+    // serial. Correct, just slower for sorted sources.
     let sort_order = if crate::gucs::is_columnar_sort_enabled() {
         bm25_index.options().sort_by().into_iter().next()
     } else {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -404,7 +404,12 @@ unsafe fn build_scan_node(
         )
     })?;
 
-    let sort_order = if crate::gucs::is_columnar_sort_enabled() {
+    // Suppressed under MPP: a pre-sorted scan lowers to a throttled scan (runtime-variable
+    // partition count) that can't be coordinator-dispatched; without the hint the scan stays
+    // single-partition lazy and DataFusion handles ordering, which dispatches.
+    let sort_order = if crate::gucs::is_columnar_sort_enabled()
+        && !crate::postgres::customscan::mpp::glue::mpp_is_active()
+    {
         bm25_index.options().sort_by().into_iter().next()
     } else {
         None

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -404,12 +404,11 @@ unsafe fn build_scan_node(
         )
     })?;
 
-    // Suppressed under MPP: a pre-sorted scan lowers to a throttled scan (runtime-variable
-    // partition count) that can't be coordinator-dispatched; without the hint the scan stays
-    // single-partition lazy and DataFusion handles ordering, which dispatches.
-    let sort_order = if crate::gucs::is_columnar_sort_enabled()
-        && !crate::postgres::customscan::mpp::glue::mpp_is_active()
-    {
+    // Under MPP a pre-sorted scan lowers to a multi-partition scan that coordinator dispatch
+    // can't encode (it only ships a single-partition lazy leaf), so the leader's
+    // `build_dispatch_blob` fails and the query falls back to serial. Results stay correct; the
+    // trade-off is losing MPP for sorted-source queries.
+    let sort_order = if crate::gucs::is_columnar_sort_enabled() {
         bm25_index.options().sort_by().into_iter().next()
     } else {
         None

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -50,7 +50,6 @@ use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
     read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
-    MPP_DISABLED_OFFSET,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 
@@ -705,20 +704,6 @@ impl ParallelQueryCapable for AggregateScan {
             )
         };
 
-        // On any failure past this point the leader falls back to serial, but the parallel
-        // workers are already planned and will still launch. Stamp the disabled marker so they
-        // emit nothing instead of attaching to an uninitialized region and each re-running the
-        // whole aggregate.
-        let write_disabled_header = || unsafe {
-            write_custom_scan_header(
-                coordinate,
-                CustomScanMppHeader {
-                    mpp_offset: MPP_DISABLED_OFFSET,
-                    partitioning_source_idx: partitioning_idx as u64,
-                },
-            )
-        };
-
         // Init the ParallelScanState at `pscan_offset`.
         let pscan_state =
             unsafe { (coordinate as *mut u8).add(pscan_offset) as *mut ParallelScanState };
@@ -743,8 +728,10 @@ impl ParallelQueryCapable for AggregateScan {
         state.custom_state_mut().mpp_partitioning_source_idx = Some(partitioning_idx);
 
         // Build the leader dispatch payload: per-stage physical subplans, serialized once
-        // so workers run their fragments without re-planning. Any failure falls back to serial,
-        // correct but slower.
+        // so workers run their fragments without re-planning. This runs before
+        // `LaunchParallelWorkers`, so erroring here fails the query without launching a single
+        // worker; surviving a serialization gap with a silent serial fallback would hide codec
+        // bugs behind a correct-but-slow plan.
         let payload = match build_dispatch_payload(
             &plan_bytes,
             create_aggregate_session_context(),
@@ -752,11 +739,7 @@ impl ParallelQueryCapable for AggregateScan {
             &state.custom_state().non_partitioning_segments,
         ) {
             Ok(p) => p,
-            Err(e) => {
-                pgrx::warning!("mpp: dispatch payload build failed: {e}; falling back to serial");
-                write_disabled_header();
-                return;
-            }
+            Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
         };
 
         // Init the MPP region.
@@ -764,11 +747,7 @@ impl ParallelQueryCapable for AggregateScan {
             unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut std::os::raw::c_void };
         let leader = match unsafe { leader_setup(mpp_coordinate, pcxt, payload) } {
             Ok(l) => l,
-            Err(e) => {
-                pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");
-                write_disabled_header();
-                return;
-            }
+            Err(e) => pgrx::error!("mpp: leader_setup failed: {e}"),
         };
         let df_state = state
             .custom_state_mut()
@@ -802,19 +781,10 @@ impl ParallelQueryCapable for AggregateScan {
         }
 
         // Read the MPP-region offset + partitioning-source index from the
-        // DSM header.
+        // DSM header. The leader errors out of `initialize_dsm_custom_scan` on any setup
+        // failure, before `LaunchParallelWorkers`, so a launched worker always finds an
+        // initialized region.
         let header = unsafe { read_custom_scan_header(coordinate) };
-        if header.mpp_offset == MPP_DISABLED_OFFSET {
-            // The leader fell back to serial before initializing the region; emit nothing
-            // (see [`scan_state::MppExecState::Disabled`]).
-            let df_state = state
-                .custom_state_mut()
-                .datafusion_state
-                .as_mut()
-                .expect("checked above");
-            df_state.mpp = Some(scan_state::MppExecState::Disabled);
-            return;
-        }
         let mpp_offset = header.mpp_offset as usize;
         let pscan_offset = pscan_offset();
         state.custom_state_mut().mpp_partitioning_source_idx =
@@ -1555,12 +1525,6 @@ impl AggregateScan {
         // PG; the leader assembles the result via the consumer plan.
         if let Some(scan_state::MppExecState::Worker(_)) = &df_state.mpp {
             return crate::postgres::customscan::mpp::host::exec_mpp_worker(state);
-        }
-
-        // MPP disabled by the leader before setup: this parallel worker emits nothing; the
-        // leader computes the whole aggregate serially.
-        if let Some(scan_state::MppExecState::Disabled) = &df_state.mpp {
-            return std::ptr::null_mut();
         }
 
         // First call: build and execute the DataFusion plan

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -752,11 +752,6 @@ impl ParallelQueryCapable for AggregateScan {
                 &plan_bytes,
                 create_aggregate_session_context(),
                 producer_worker_count(),
-                Some(pscan_state),
-                // The leader build is structure-only; the per-source segment sets are injected on
-                // the workers at decode, so empty here.
-                Vec::new(),
-                Vec::new(),
                 &runtime,
             ) {
                 Ok(b) => b,

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -45,9 +45,7 @@ use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTaskContext};
 
-use crate::postgres::customscan::mpp::dispatch::{
-    build_dispatch_blob, dispatch_plan_capacity, frame_dispatch_payload,
-};
+use crate::postgres::customscan::mpp::dispatch::{build_dispatch_payload, dispatch_plan_capacity};
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
@@ -751,42 +749,17 @@ impl ParallelQueryCapable for AggregateScan {
         // generously at estimate time; the payload is the blob behind a length prefix, padded to
         // capacity. Any failure (build error, or blob over capacity) falls back to serial, which
         // is correct, just slower.
-        let capacity = dispatch_plan_capacity(plan_bytes.len());
-        let payload = {
-            let runtime = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(rt) => rt,
-                Err(e) => {
-                    pgrx::warning!(
-                        "mpp: dispatch runtime build failed: {e}; falling back to serial"
-                    );
-                    write_disabled_header();
-                    return;
-                }
-            };
-            let blob = match build_dispatch_blob(
-                &plan_bytes,
-                create_aggregate_session_context(),
-                producer_worker_count(),
-                &runtime,
-                &state.custom_state().non_partitioning_segments,
-            ) {
-                Ok(b) => b,
-                Err(e) => {
-                    pgrx::warning!("mpp: build_dispatch_blob failed: {e}; falling back to serial");
-                    write_disabled_header();
-                    return;
-                }
-            };
-            match frame_dispatch_payload(&blob, capacity) {
-                Ok(p) => p,
-                Err(e) => {
-                    pgrx::warning!("mpp: {e}; falling back to serial");
-                    write_disabled_header();
-                    return;
-                }
+        let payload = match build_dispatch_payload(
+            &plan_bytes,
+            create_aggregate_session_context(),
+            producer_worker_count(),
+            &state.custom_state().non_partitioning_segments,
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                pgrx::warning!("mpp: dispatch payload build failed: {e}; falling back to serial");
+                write_disabled_header();
+                return;
             }
         };
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -755,6 +755,7 @@ impl ParallelQueryCapable for AggregateScan {
                 create_aggregate_session_context(),
                 producer_worker_count(),
                 &runtime,
+                &state.custom_state().non_partitioning_segments,
             ) {
                 Ok(b) => b,
                 Err(e) => {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -742,7 +742,7 @@ impl ParallelQueryCapable for AggregateScan {
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
         state.custom_state_mut().mpp_partitioning_source_idx = Some(partitioning_idx);
 
-        // Build the coordinator dispatch payload: per-stage physical subplans, serialized once
+        // Build the leader dispatch payload: per-stage physical subplans, serialized once
         // so workers run their fragments without re-planning. Any failure falls back to serial,
         // correct but slower.
         let payload = match build_dispatch_payload(

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -45,6 +45,9 @@ use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTaskContext};
 
+use crate::postgres::customscan::mpp::dispatch::{
+    build_dispatch_blob, dispatch_plan_capacity, frame_dispatch_payload,
+};
 use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
@@ -651,7 +654,12 @@ impl ParallelQueryCapable for AggregateScan {
         let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
         let mpp_offset = mpp_align(pscan_offset() + pscan_size);
 
-        let mpp_size = match estimate_dsm_size(plan_bytes_len) {
+        // Size the plan region for the worst-case dispatch payload: the physical plan (and so
+        // the real blob size) can't be built until `ParallelScanState` exists at init time, so
+        // size generously here from the logical-plan length. `initialize_dsm` uses the same
+        // `dispatch_plan_capacity(plan_bytes_len)` so the DSM layout matches; an oversized blob
+        // falls back to serial there.
+        let mpp_size = match estimate_dsm_size(dispatch_plan_capacity(plan_bytes_len)) {
             Ok(sz) => sz,
             Err(e) => {
                 pgrx::warning!("mpp: estimate_dsm failed: {e}; falling back to serial");
@@ -723,10 +731,53 @@ impl ParallelQueryCapable for AggregateScan {
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
         state.custom_state_mut().mpp_partitioning_source_idx = Some(partitioning_idx);
 
+        // Build the coordinator dispatch payload. The leader serializes the distributed physical
+        // plan once so workers run their fragments without re-planning. The region was sized
+        // generously at estimate time; the payload is the blob behind a length prefix, padded to
+        // capacity. Any failure (build error, or blob over capacity) falls back to serial, which
+        // is correct, just slower.
+        let capacity = dispatch_plan_capacity(plan_bytes.len());
+        let payload = {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    pgrx::warning!("mpp: dispatch runtime build failed: {e}; falling back to serial");
+                    return;
+                }
+            };
+            let blob = match build_dispatch_blob(
+                &plan_bytes,
+                create_aggregate_session_context(),
+                producer_worker_count(),
+                Some(pscan_state),
+                // The leader build is structure-only; the per-source segment sets are injected on
+                // the workers at decode, so empty here.
+                Vec::new(),
+                Vec::new(),
+                &runtime,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    pgrx::warning!("mpp: build_dispatch_blob failed: {e}; falling back to serial");
+                    return;
+                }
+            };
+            match frame_dispatch_payload(&blob, capacity) {
+                Ok(p) => p,
+                Err(e) => {
+                    pgrx::warning!("mpp: {e}; falling back to serial");
+                    return;
+                }
+            }
+        };
+
         // Init the MPP region.
         let mpp_coordinate =
             unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut std::os::raw::c_void };
-        let leader = match unsafe { leader_setup(mpp_coordinate, pcxt, plan_bytes) } {
+        let leader = match unsafe { leader_setup(mpp_coordinate, pcxt, payload) } {
             Ok(l) => l,
             Err(e) => {
                 pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -52,6 +52,7 @@ use crate::postgres::customscan::mpp::dsm::MppDsmHeader;
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
     read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
+    MPP_DISABLED_OFFSET,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 
@@ -708,6 +709,20 @@ impl ParallelQueryCapable for AggregateScan {
             )
         };
 
+        // On any failure past this point the leader falls back to serial, but the parallel
+        // workers are already planned and will still launch. Stamp the disabled marker so they
+        // emit nothing instead of attaching to an uninitialized region and each re-running the
+        // whole aggregate.
+        let write_disabled_header = || unsafe {
+            write_custom_scan_header(
+                coordinate,
+                CustomScanMppHeader {
+                    mpp_offset: MPP_DISABLED_OFFSET,
+                    partitioning_source_idx: partitioning_idx as u64,
+                },
+            )
+        };
+
         // Init the ParallelScanState at `pscan_offset`.
         let pscan_state =
             unsafe { (coordinate as *mut u8).add(pscan_offset) as *mut ParallelScanState };
@@ -747,6 +762,7 @@ impl ParallelQueryCapable for AggregateScan {
                     pgrx::warning!(
                         "mpp: dispatch runtime build failed: {e}; falling back to serial"
                     );
+                    write_disabled_header();
                     return;
                 }
             };
@@ -760,6 +776,7 @@ impl ParallelQueryCapable for AggregateScan {
                 Ok(b) => b,
                 Err(e) => {
                     pgrx::warning!("mpp: build_dispatch_blob failed: {e}; falling back to serial");
+                    write_disabled_header();
                     return;
                 }
             };
@@ -767,6 +784,7 @@ impl ParallelQueryCapable for AggregateScan {
                 Ok(p) => p,
                 Err(e) => {
                     pgrx::warning!("mpp: {e}; falling back to serial");
+                    write_disabled_header();
                     return;
                 }
             }
@@ -779,6 +797,7 @@ impl ParallelQueryCapable for AggregateScan {
             Ok(l) => l,
             Err(e) => {
                 pgrx::warning!("mpp: leader_setup failed: {e}; falling back to serial");
+                write_disabled_header();
                 return;
             }
         };
@@ -816,6 +835,18 @@ impl ParallelQueryCapable for AggregateScan {
         // Read the MPP-region offset + partitioning-source index from the
         // DSM header.
         let header = unsafe { read_custom_scan_header(coordinate) };
+        if header.mpp_offset == MPP_DISABLED_OFFSET {
+            // The leader disabled MPP before initializing the region (serial fallback) and
+            // computes the whole aggregate itself. A parallel aggregate worker has no
+            // partitioned non-MPP path, so emit nothing rather than a duplicate result set.
+            let df_state = state
+                .custom_state_mut()
+                .datafusion_state
+                .as_mut()
+                .expect("checked above");
+            df_state.mpp = Some(scan_state::MppExecState::Disabled);
+            return;
+        }
         let mpp_offset = header.mpp_offset as usize;
         let pscan_offset = pscan_offset();
         state.custom_state_mut().mpp_partitioning_source_idx =
@@ -839,8 +870,10 @@ impl ParallelQueryCapable for AggregateScan {
         let worker = match unsafe { worker_setup(mpp_coordinate, region_total, worker_number) } {
             Ok(w) => w,
             Err(e) => {
-                pgrx::warning!("mpp: worker_setup failed: {e}; falling back to serial");
-                return;
+                // No disabled marker, so the leader initialized the region and will wait for
+                // this worker's EOFs. Falling back here would either duplicate the aggregate
+                // or hang the leader; fail the query instead.
+                pgrx::error!("mpp: worker_setup failed: {e}");
             }
         };
         let df_state = state
@@ -1554,6 +1587,12 @@ impl AggregateScan {
         // PG; the leader assembles the result via the consumer plan.
         if let Some(scan_state::MppExecState::Worker(_)) = &df_state.mpp {
             return crate::postgres::customscan::mpp::host::exec_mpp_worker(state);
+        }
+
+        // MPP disabled by the leader before setup: this parallel worker emits nothing; the
+        // leader computes the whole aggregate serially.
+        if let Some(scan_state::MppExecState::Disabled) = &df_state.mpp {
+            return std::ptr::null_mut();
         }
 
         // First call: build and execute the DataFusion plan

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -744,7 +744,9 @@ impl ParallelQueryCapable for AggregateScan {
             {
                 Ok(rt) => rt,
                 Err(e) => {
-                    pgrx::warning!("mpp: dispatch runtime build failed: {e}; falling back to serial");
+                    pgrx::warning!(
+                        "mpp: dispatch runtime build failed: {e}; falling back to serial"
+                    );
                     return;
                 }
             };

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -653,11 +653,9 @@ impl ParallelQueryCapable for AggregateScan {
         let pscan_size = ParallelScanState::size_of(&all_nsegments, partitioning_idx, &[], false);
         let mpp_offset = mpp_align(pscan_offset() + pscan_size);
 
-        // Size the plan region for the worst-case dispatch payload: the physical plan (and so
-        // the real blob size) can't be built until `ParallelScanState` exists at init time, so
-        // size generously here from the logical-plan length. `initialize_dsm` uses the same
-        // `dispatch_plan_capacity(plan_bytes_len)` so the DSM layout matches; an oversized blob
-        // falls back to serial there.
+        // Size the plan region before the physical plan (and so the real blob size) can exist;
+        // `initialize_dsm` derives the same capacity from the same length, and an oversized
+        // blob falls back to serial there.
         let mpp_size = match estimate_dsm_size(dispatch_plan_capacity(plan_bytes_len)) {
             Ok(sz) => sz,
             Err(e) => {
@@ -744,11 +742,9 @@ impl ParallelQueryCapable for AggregateScan {
         state.custom_state_mut().non_partitioning_segments = non_partitioning_segments;
         state.custom_state_mut().mpp_partitioning_source_idx = Some(partitioning_idx);
 
-        // Build the coordinator dispatch payload. The leader serializes the distributed physical
-        // plan once so workers run their fragments without re-planning. The region was sized
-        // generously at estimate time; the payload is the blob behind a length prefix, padded to
-        // capacity. Any failure (build error, or blob over capacity) falls back to serial, which
-        // is correct, just slower.
+        // Build the coordinator dispatch payload: per-stage physical subplans, serialized once
+        // so workers run their fragments without re-planning. Any failure falls back to serial,
+        // correct but slower.
         let payload = match build_dispatch_payload(
             &plan_bytes,
             create_aggregate_session_context(),
@@ -809,9 +805,8 @@ impl ParallelQueryCapable for AggregateScan {
         // DSM header.
         let header = unsafe { read_custom_scan_header(coordinate) };
         if header.mpp_offset == MPP_DISABLED_OFFSET {
-            // The leader disabled MPP before initializing the region (serial fallback) and
-            // computes the whole aggregate itself. A parallel aggregate worker has no
-            // partitioned non-MPP path, so emit nothing rather than a duplicate result set.
+            // The leader fell back to serial before initializing the region; emit nothing
+            // (see [`scan_state::MppExecState::Disabled`]).
             let df_state = state
                 .custom_state_mut()
                 .datafusion_state

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -91,6 +91,10 @@ pub struct DataFusionAggState {
 pub enum MppExecState {
     Leader(crate::postgres::customscan::mpp::glue::MppLeaderState),
     Worker(crate::postgres::customscan::mpp::glue::MppWorkerState),
+    /// The leader disabled MPP before setup (serial fallback). A parallel worker must emit
+    /// nothing: the leader computes the whole result, and a parallel aggregate worker has no
+    /// partitioned non-MPP path to fall into.
+    Disabled,
 }
 
 /// State for projecting wrapped aggregate expressions through Postgres' own

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -91,10 +91,6 @@ pub struct DataFusionAggState {
 pub enum MppExecState {
     Leader(crate::postgres::customscan::mpp::glue::MppLeaderState),
     Worker(crate::postgres::customscan::mpp::glue::MppWorkerState),
-    /// The leader disabled MPP before setup (serial fallback). A parallel worker must emit
-    /// nothing: the leader computes the whole result, and a parallel aggregate worker has no
-    /// partitioned non-MPP path to fall into.
-    Disabled,
 }
 
 /// State for projecting wrapped aggregate expressions through Postgres' own

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -417,6 +417,8 @@ impl ColumnarExecState {
             recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
                 parallel_state: state.parallel_state,
                 source_idx: None,
+                // Basescan is never an MPP source, so there is no non-partitioning position.
+                non_partitioning_index: None,
                 planner_estimated_rows: 0,
                 scanner_config,
             },

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -405,6 +405,11 @@ impl ColumnarExecState {
             which_fast_fields: self.scanner_fast_fields.clone(),
             heap_relid: heap_rel.oid().to_u32(),
             batch_size_hint: self.batch_size_hint,
+            // Basescan is never coordinator-dispatched; mirror the reader's scoring from the fields.
+            score_needed: self
+                .scanner_fast_fields
+                .iter()
+                .any(|f| matches!(f, crate::index::fast_fields_helper::WhichFastField::Score)),
         };
 
         // Create PgSearchScanPlan and execute via DataFusion
@@ -537,6 +542,10 @@ impl ColumnarExecState {
                         which_fast_fields: self.scanner_fast_fields.clone(),
                         heap_relid: heaprel.oid().to_u32(),
                         batch_size_hint: self.batch_size_hint,
+                        // Basescan is never coordinator-dispatched.
+                        score_needed: self.scanner_fast_fields.iter().any(|f| {
+                            matches!(f, crate::index::fast_fields_helper::WhichFastField::Score)
+                        }),
                     };
                     ScanState {
                         recipe: crate::scan::execution_plan::ScanRecipe::Eager {

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -405,7 +405,7 @@ impl ColumnarExecState {
             which_fast_fields: self.scanner_fast_fields.clone(),
             heap_relid: heap_rel.oid().to_u32(),
             batch_size_hint: self.batch_size_hint,
-            // Basescan is never coordinator-dispatched; mirror the reader's scoring from the fields.
+            // Basescan is never leader-dispatched; mirror the reader's scoring from the fields.
             score_needed: self
                 .scanner_fast_fields
                 .iter()
@@ -544,7 +544,7 @@ impl ColumnarExecState {
                         which_fast_fields: self.scanner_fast_fields.clone(),
                         heap_relid: heaprel.oid().to_u32(),
                         batch_size_hint: self.batch_size_hint,
-                        // Basescan is never coordinator-dispatched.
+                        // Basescan is never leader-dispatched.
                         score_needed: self.scanner_fast_fields.iter().any(|f| {
                             matches!(f, crate::index::fast_fields_helper::WhichFastField::Score)
                         }),

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -180,9 +180,7 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::joinscan::scan_state::MppExecState;
 use crate::postgres::customscan::limit_offset::LimitOffset;
-use crate::postgres::customscan::mpp::dispatch::{
-    build_dispatch_blob, dispatch_plan_capacity, frame_dispatch_payload,
-};
+use crate::postgres::customscan::mpp::dispatch::{build_dispatch_payload, dispatch_plan_capacity};
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
     read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
@@ -918,44 +916,19 @@ impl ParallelQueryCapable for JoinScan {
         // Build the coordinator dispatch payload (Tier 2): the leader slices the physical plan and
         // ships the per-stage subplans. Any failure (codec gap, oversized blob) falls back to
         // serial, which is correct, just slower.
-        let capacity = dispatch_plan_capacity(plan_bytes.len());
-        let payload = {
-            let runtime = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(rt) => rt,
-                Err(e) => {
-                    pgrx::warning!(
-                        "mpp join: dispatch runtime build failed: {e}; falling back to serial"
-                    );
-                    write_disabled_header();
-                    return;
-                }
-            };
-            let blob = match build_dispatch_blob(
-                &plan_bytes,
-                create_datafusion_session_context(SessionContextProfile::Join),
-                producer_worker_count(),
-                &runtime,
-                &state.custom_state().non_partitioning_segments,
-            ) {
-                Ok(b) => b,
-                Err(e) => {
-                    pgrx::warning!(
-                        "mpp join: build_dispatch_blob failed: {e}; falling back to serial"
-                    );
-                    write_disabled_header();
-                    return;
-                }
-            };
-            match frame_dispatch_payload(&blob, capacity) {
-                Ok(p) => p,
-                Err(e) => {
-                    pgrx::warning!("mpp join: {e}; falling back to serial");
-                    write_disabled_header();
-                    return;
-                }
+        let payload = match build_dispatch_payload(
+            &plan_bytes,
+            create_datafusion_session_context(SessionContextProfile::Join),
+            producer_worker_count(),
+            &state.custom_state().non_partitioning_segments,
+        ) {
+            Ok(p) => p,
+            Err(e) => {
+                pgrx::warning!(
+                    "mpp join: dispatch payload build failed: {e}; falling back to serial"
+                );
+                write_disabled_header();
+                return;
             }
         };
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -922,9 +922,6 @@ impl ParallelQueryCapable for JoinScan {
                 &plan_bytes,
                 create_datafusion_session_context(SessionContextProfile::Join),
                 producer_worker_count(),
-                Some(pscan_state),
-                Vec::new(),
-                Vec::new(),
                 &runtime,
             ) {
                 Ok(b) => b,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -180,6 +180,7 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::joinscan::scan_state::MppExecState;
 use crate::postgres::customscan::limit_offset::LimitOffset;
+use crate::postgres::customscan::mpp::dispatch::{frame_logical_payload, logical_plan_capacity};
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
     read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
@@ -819,7 +820,9 @@ impl ParallelQueryCapable for JoinScan {
             return pscan_size as pg_sys::Size;
         };
         let mpp_offset = mpp_align(pscan_offset() + pscan_size);
-        let mpp_size = match estimate_dsm_size(plan_bytes_len) {
+        // The join path re-plans on the workers (Tier 1), so the DSM ships the logical plan behind
+        // the mode tag, not a dispatch blob.
+        let mpp_size = match estimate_dsm_size(logical_plan_capacity(plan_bytes_len)) {
             Ok(sz) => sz,
             Err(e) => {
                 pgrx::warning!("mpp join: estimate_dsm failed: {e}; falling back to serial");
@@ -897,7 +900,7 @@ impl ParallelQueryCapable for JoinScan {
         };
 
         let mpp_coordinate = unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut c_void };
-        match unsafe { leader_setup(mpp_coordinate, pcxt, plan_bytes) } {
+        match unsafe { leader_setup(mpp_coordinate, pcxt, frame_logical_payload(plan_bytes)) } {
             Ok(leader) => {
                 state.custom_state_mut().mpp = Some(MppExecState::Leader(leader));
             }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -180,7 +180,9 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::joinscan::scan_state::MppExecState;
 use crate::postgres::customscan::limit_offset::LimitOffset;
-use crate::postgres::customscan::mpp::dispatch::{frame_logical_payload, logical_plan_capacity};
+use crate::postgres::customscan::mpp::dispatch::{
+    build_dispatch_blob, dispatch_plan_capacity, frame_dispatch_payload,
+};
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
     read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
@@ -820,9 +822,9 @@ impl ParallelQueryCapable for JoinScan {
             return pscan_size as pg_sys::Size;
         };
         let mpp_offset = mpp_align(pscan_offset() + pscan_size);
-        // The join path re-plans on the workers (Tier 1), so the DSM ships the logical plan behind
-        // the mode tag, not a dispatch blob.
-        let mpp_size = match estimate_dsm_size(logical_plan_capacity(plan_bytes_len)) {
+        // Sized for the worst-case dispatch payload (see the aggregate path); an oversized blob or
+        // a codec gap falls back to serial at init time.
+        let mpp_size = match estimate_dsm_size(dispatch_plan_capacity(plan_bytes_len)) {
             Ok(sz) => sz,
             Err(e) => {
                 pgrx::warning!("mpp join: estimate_dsm failed: {e}; falling back to serial");
@@ -899,8 +901,49 @@ impl ParallelQueryCapable for JoinScan {
             )
         };
 
+        // Build the coordinator dispatch payload (Tier 2): the leader slices the physical plan and
+        // ships the per-stage subplans. Any failure (codec gap, oversized blob) falls back to
+        // serial, which is correct, just slower.
+        let capacity = dispatch_plan_capacity(plan_bytes.len());
+        let payload = {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(rt) => rt,
+                Err(e) => {
+                    pgrx::warning!(
+                        "mpp join: dispatch runtime build failed: {e}; falling back to serial"
+                    );
+                    return;
+                }
+            };
+            let blob = match build_dispatch_blob(
+                &plan_bytes,
+                create_datafusion_session_context(SessionContextProfile::Join),
+                producer_worker_count(),
+                Some(pscan_state),
+                Vec::new(),
+                Vec::new(),
+                &runtime,
+            ) {
+                Ok(b) => b,
+                Err(e) => {
+                    pgrx::warning!("mpp join: build_dispatch_blob failed: {e}; falling back to serial");
+                    return;
+                }
+            };
+            match frame_dispatch_payload(&blob, capacity) {
+                Ok(p) => p,
+                Err(e) => {
+                    pgrx::warning!("mpp join: {e}; falling back to serial");
+                    return;
+                }
+            }
+        };
+
         let mpp_coordinate = unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut c_void };
-        match unsafe { leader_setup(mpp_coordinate, pcxt, frame_logical_payload(plan_bytes)) } {
+        match unsafe { leader_setup(mpp_coordinate, pcxt, payload) } {
             Ok(leader) => {
                 state.custom_state_mut().mpp = Some(MppExecState::Leader(leader));
             }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -186,6 +186,7 @@ use crate::postgres::customscan::mpp::dispatch::{
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
     read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
+    MPP_DISABLED_OFFSET,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::parallel::compute_nworkers;
@@ -901,6 +902,19 @@ impl ParallelQueryCapable for JoinScan {
             )
         };
 
+        // On any failure past this point the leader falls back to serial, but the parallel
+        // workers are already planned and will still launch. Stamp the disabled marker so they
+        // skip the MPP region instead of attaching to one that was never initialized.
+        let write_disabled_header = || unsafe {
+            write_custom_scan_header(
+                coordinate,
+                CustomScanMppHeader {
+                    mpp_offset: MPP_DISABLED_OFFSET,
+                    partitioning_source_idx: partitioning_idx as u64,
+                },
+            )
+        };
+
         // Build the coordinator dispatch payload (Tier 2): the leader slices the physical plan and
         // ships the per-stage subplans. Any failure (codec gap, oversized blob) falls back to
         // serial, which is correct, just slower.
@@ -915,6 +929,7 @@ impl ParallelQueryCapable for JoinScan {
                     pgrx::warning!(
                         "mpp join: dispatch runtime build failed: {e}; falling back to serial"
                     );
+                    write_disabled_header();
                     return;
                 }
             };
@@ -930,6 +945,7 @@ impl ParallelQueryCapable for JoinScan {
                     pgrx::warning!(
                         "mpp join: build_dispatch_blob failed: {e}; falling back to serial"
                     );
+                    write_disabled_header();
                     return;
                 }
             };
@@ -937,6 +953,7 @@ impl ParallelQueryCapable for JoinScan {
                 Ok(p) => p,
                 Err(e) => {
                     pgrx::warning!("mpp join: {e}; falling back to serial");
+                    write_disabled_header();
                     return;
                 }
             }
@@ -949,6 +966,7 @@ impl ParallelQueryCapable for JoinScan {
             }
             Err(e) => {
                 pgrx::warning!("mpp join: leader_setup failed: {e}; falling back to serial");
+                write_disabled_header();
             }
         }
     }
@@ -994,6 +1012,12 @@ impl ParallelQueryCapable for JoinScan {
         // MPP worker: read the header to find where the MPP region starts + which source we're
         // partitioning over. Hand the MPP region to `worker_setup`.
         let header = unsafe { read_custom_scan_header(coordinate) };
+        if header.mpp_offset == MPP_DISABLED_OFFSET {
+            // The leader disabled MPP before initializing the region (serial fallback). With
+            // `mpp` unset this worker runs the plain parallel join path, which claims segments
+            // from the shared pool like any non-MPP parallel scan.
+            return;
+        }
         let mpp_offset = header.mpp_offset as usize;
         state.custom_state_mut().mpp_partitioning_source_idx =
             Some(header.partitioning_source_idx as usize);
@@ -1008,7 +1032,10 @@ impl ParallelQueryCapable for JoinScan {
                 state.custom_state_mut().mpp = Some(MppExecState::Worker(worker));
             }
             Err(e) => {
-                pgrx::warning!("mpp join: worker_setup failed: {e}; falling back to serial");
+                // No disabled marker, so the leader initialized the region and will wait for
+                // this worker's EOFs. Producing rows through the plain parallel path here
+                // would mix protocols; fail the query instead.
+                pgrx::error!("mpp join: worker_setup failed: {e}");
             }
         }
     }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -913,7 +913,7 @@ impl ParallelQueryCapable for JoinScan {
             )
         };
 
-        // Build the coordinator dispatch payload: per-stage physical subplans, serialized once
+        // Build the leader dispatch payload: per-stage physical subplans, serialized once
         // so workers run their fragments without re-planning. Any failure falls back to serial,
         // correct but slower.
         let payload = match build_dispatch_payload(

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -184,7 +184,6 @@ use crate::postgres::customscan::mpp::dispatch::{build_dispatch_payload, dispatc
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, mpp_align, mpp_is_active, producer_worker_count, pscan_offset,
     read_custom_scan_header, worker_setup, write_custom_scan_header, CustomScanMppHeader,
-    MPP_DISABLED_OFFSET,
 };
 use crate::postgres::customscan::mpp::runtime::MppMesh;
 use crate::postgres::customscan::parallel::compute_nworkers;
@@ -900,22 +899,11 @@ impl ParallelQueryCapable for JoinScan {
             )
         };
 
-        // On any failure past this point the leader falls back to serial, but the parallel
-        // workers are already planned and will still launch. Stamp the disabled marker so they
-        // skip the MPP region instead of attaching to one that was never initialized.
-        let write_disabled_header = || unsafe {
-            write_custom_scan_header(
-                coordinate,
-                CustomScanMppHeader {
-                    mpp_offset: MPP_DISABLED_OFFSET,
-                    partitioning_source_idx: partitioning_idx as u64,
-                },
-            )
-        };
-
         // Build the leader dispatch payload: per-stage physical subplans, serialized once
-        // so workers run their fragments without re-planning. Any failure falls back to serial,
-        // correct but slower.
+        // so workers run their fragments without re-planning. This runs before
+        // `LaunchParallelWorkers`, so erroring here fails the query without launching a single
+        // worker; surviving a serialization gap with a silent serial fallback would hide codec
+        // bugs behind a correct-but-slow plan.
         let payload = match build_dispatch_payload(
             &plan_bytes,
             create_datafusion_session_context(SessionContextProfile::Join),
@@ -923,13 +911,7 @@ impl ParallelQueryCapable for JoinScan {
             &state.custom_state().non_partitioning_segments,
         ) {
             Ok(p) => p,
-            Err(e) => {
-                pgrx::warning!(
-                    "mpp join: dispatch payload build failed: {e}; falling back to serial"
-                );
-                write_disabled_header();
-                return;
-            }
+            Err(e) => pgrx::error!("mpp join: dispatch payload build failed: {e}"),
         };
 
         let mpp_coordinate = unsafe { (coordinate as *mut u8).add(mpp_offset) as *mut c_void };
@@ -937,10 +919,7 @@ impl ParallelQueryCapable for JoinScan {
             Ok(leader) => {
                 state.custom_state_mut().mpp = Some(MppExecState::Leader(leader));
             }
-            Err(e) => {
-                pgrx::warning!("mpp join: leader_setup failed: {e}; falling back to serial");
-                write_disabled_header();
-            }
+            Err(e) => pgrx::error!("mpp join: leader_setup failed: {e}"),
         }
     }
 
@@ -983,14 +962,10 @@ impl ParallelQueryCapable for JoinScan {
         }
 
         // MPP worker: read the header to find where the MPP region starts + which source we're
-        // partitioning over. Hand the MPP region to `worker_setup`.
+        // partitioning over. Hand the MPP region to `worker_setup`. The leader errors out of
+        // `initialize_dsm_custom_scan` on any setup failure, before `LaunchParallelWorkers`, so
+        // a launched worker always finds an initialized region.
         let header = unsafe { read_custom_scan_header(coordinate) };
-        if header.mpp_offset == MPP_DISABLED_OFFSET {
-            // The leader disabled MPP before initializing the region (serial fallback). With
-            // `mpp` unset this worker runs the plain parallel join path, which claims segments
-            // from the shared pool like any non-MPP parallel scan.
-            return;
-        }
         let mpp_offset = header.mpp_offset as usize;
         state.custom_state_mut().mpp_partitioning_source_idx =
             Some(header.partitioning_source_idx as usize);
@@ -1005,9 +980,9 @@ impl ParallelQueryCapable for JoinScan {
                 state.custom_state_mut().mpp = Some(MppExecState::Worker(worker));
             }
             Err(e) => {
-                // No disabled marker, so the leader initialized the region and will wait for
-                // this worker's EOFs. Producing rows through the plain parallel path here
-                // would mix protocols; fail the query instead.
+                // The leader initialized the region and will wait for this worker's EOFs.
+                // Producing rows through the plain parallel path here would mix protocols;
+                // fail the query instead.
                 pgrx::error!("mpp join: worker_setup failed: {e}");
             }
         }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -923,6 +923,7 @@ impl ParallelQueryCapable for JoinScan {
                 create_datafusion_session_context(SessionContextProfile::Join),
                 producer_worker_count(),
                 &runtime,
+                &state.custom_state().non_partitioning_segments,
             ) {
                 Ok(b) => b,
                 Err(e) => {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -926,7 +926,9 @@ impl ParallelQueryCapable for JoinScan {
             ) {
                 Ok(b) => b,
                 Err(e) => {
-                    pgrx::warning!("mpp join: build_dispatch_blob failed: {e}; falling back to serial");
+                    pgrx::warning!(
+                        "mpp join: build_dispatch_blob failed: {e}; falling back to serial"
+                    );
                     return;
                 }
             };

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -913,9 +913,9 @@ impl ParallelQueryCapable for JoinScan {
             )
         };
 
-        // Build the coordinator dispatch payload (Tier 2): the leader slices the physical plan and
-        // ships the per-stage subplans. Any failure (codec gap, oversized blob) falls back to
-        // serial, which is correct, just slower.
+        // Build the coordinator dispatch payload: per-stage physical subplans, serialized once
+        // so workers run their fragments without re-planning. Any failure falls back to serial,
+        // correct but slower.
         let payload = match build_dispatch_payload(
             &plan_bytes,
             create_datafusion_session_context(SessionContextProfile::Join),

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -224,7 +224,15 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         // Read the sort order from the index's relation options.
         // This allows DataFusion-based execution to leverage physical sort order
         // for optimizations like SortPreservingMergeExec and sort-merge joins.
-        let sort_order = if crate::gucs::is_columnar_sort_enabled() {
+        //
+        // Suppressed under MPP: a pre-sorted scan lowers to a throttled scan whose partition
+        // count is decided at runtime by how many segments each worker claims, which can't be
+        // coordinator-dispatched (the leader builds a fixed-shape plan to slice). Without the
+        // hint the scan stays single-partition lazy and DataFusion's SortExec / SegmentedTopK
+        // handles ordering, which dispatches.
+        let sort_order = if crate::gucs::is_columnar_sort_enabled()
+            && !crate::postgres::customscan::mpp::glue::mpp_is_active()
+        {
             let sort_by = bm25_index.options().sort_by();
             sort_by.into_iter().next()
         } else {

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -224,10 +224,9 @@ pub(super) unsafe fn collect_join_sources_base_rel(
         // Read the sort order from the index's relation options so DataFusion can use the
         // physical sort order (SortPreservingMergeExec, sort-merge joins).
         //
-        // Under MPP a pre-sorted scan lowers to a multi-partition scan that coordinator dispatch
-        // can't encode (it only ships a single-partition lazy leaf), so the leader's
-        // `build_dispatch_blob` fails and the query falls back to serial. Results stay correct;
-        // the trade-off is losing MPP for sorted-source queries.
+        // Under MPP a pre-sorted scan lowers to a multi-partition scan the dispatch codec
+        // declines (it ships only the single-partition lazy leaf), so the query falls back to
+        // serial. Correct, just slower for sorted sources.
         let sort_order = if crate::gucs::is_columnar_sort_enabled() {
             let sort_by = bm25_index.options().sort_by();
             sort_by.into_iter().next()

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -221,18 +221,14 @@ pub(super) unsafe fn collect_join_sources_base_rel(
     if let Some((_, bm25_index)) = rel_get_bm25_index(relid) {
         side_info = side_info.with_indexrelid(bm25_index.oid());
 
-        // Read the sort order from the index's relation options.
-        // This allows DataFusion-based execution to leverage physical sort order
-        // for optimizations like SortPreservingMergeExec and sort-merge joins.
+        // Read the sort order from the index's relation options so DataFusion can use the
+        // physical sort order (SortPreservingMergeExec, sort-merge joins).
         //
-        // Suppressed under MPP: a pre-sorted scan lowers to a throttled scan whose partition
-        // count is decided at runtime by how many segments each worker claims, which can't be
-        // coordinator-dispatched (the leader builds a fixed-shape plan to slice). Without the
-        // hint the scan stays single-partition lazy and DataFusion's SortExec / SegmentedTopK
-        // handles ordering, which dispatches.
-        let sort_order = if crate::gucs::is_columnar_sort_enabled()
-            && !crate::postgres::customscan::mpp::glue::mpp_is_active()
-        {
+        // Under MPP a pre-sorted scan lowers to a multi-partition scan that coordinator dispatch
+        // can't encode (it only ships a single-partition lazy leaf), so the leader's
+        // `build_dispatch_blob` fails and the query falls back to serial. Results stay correct;
+        // the trade-off is losing MPP for sorted-source queries.
+        let sort_order = if crate::gucs::is_columnar_sort_enabled() {
             let sort_by = bm25_index.options().sort_by();
             sort_by.into_iter().next()
         } else {

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -770,6 +770,35 @@ impl VisibilityFilterExec {
     pub fn plan_pos_oids(&self) -> &[(usize, pg_sys::Oid)] {
         &self.plan_pos_oids
     }
+
+    /// Serialize for coordinator dispatch. The `ctid_resolvers` are live `FFHelper`s wired by an
+    /// optimizer rule, so they don't travel; the receiving worker re-wires them from the scans in
+    /// its decoded subtree.
+    pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
+        let payload: (&[(usize, pg_sys::Oid)], &[String]) =
+            (&self.plan_pos_oids, &self.table_names);
+        serde_json::to_vec(&payload).map_err(|e| {
+            DataFusionError::Internal(format!("VisibilityFilterExec dispatch: serialize: {e}"))
+        })
+    }
+
+    /// Rebuild from a dispatch descriptor, re-wiring the per-plan_position ctid resolvers from the
+    /// scans the worker decoded below this node.
+    pub(crate) fn decode_for_dispatch(
+        buf: &[u8],
+        input: Arc<dyn ExecutionPlan>,
+        ctid_resolvers: Vec<(usize, Arc<FFHelper>)>,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let (plan_pos_oids, table_names): (Vec<(usize, pg_sys::Oid)>, Vec<String>) =
+            serde_json::from_slice(buf).map_err(|e| {
+                DataFusionError::Internal(format!("VisibilityFilterExec dispatch: deserialize: {e}"))
+            })?;
+        let exec = VisibilityFilterExec::new(input, plan_pos_oids, table_names)?;
+        for (plan_pos, ffhelper) in ctid_resolvers {
+            exec.set_ctid_resolver(plan_pos, ffhelper);
+        }
+        Ok(Arc::new(exec))
+    }
 }
 
 impl DisplayAs for VisibilityFilterExec {

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -771,7 +771,7 @@ impl VisibilityFilterExec {
         &self.plan_pos_oids
     }
 
-    /// Serialize for coordinator dispatch. The `ctid_resolvers` are live `FFHelper`s wired by an
+    /// Serialize for leader dispatch. The `ctid_resolvers` are live `FFHelper`s wired by an
     /// optimizer rule, so they don't travel; the receiving worker re-wires them from the scans in
     /// its decoded subtree.
     pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -791,7 +791,9 @@ impl VisibilityFilterExec {
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let (plan_pos_oids, table_names): (Vec<(usize, pg_sys::Oid)>, Vec<String>) =
             serde_json::from_slice(buf).map_err(|e| {
-                DataFusionError::Internal(format!("VisibilityFilterExec dispatch: deserialize: {e}"))
+                DataFusionError::Internal(format!(
+                    "VisibilityFilterExec dispatch: deserialize: {e}"
+                ))
             })?;
         let exec = VisibilityFilterExec::new(input, plan_pos_oids, table_names)?;
         for (plan_pos, ffhelper) in ctid_resolvers {

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -155,12 +155,10 @@ pub fn build_dispatch_blob(
         let plan_proto = serialize_physical_plan(stage.plan)?;
         // Encode can succeed while decode fails (a codec gap). The first decode otherwise
         // happens in a worker, where failure is a hard query error instead of the serial
-        // fallback this Result feeds. One extra decode per stage at init buys the fallback
-        // (it re-opens the scans' readers, on top of the ones the physical planning above
-        // already opened; both are released with the init context). With no ParallelScanState
-        // here, a non-partitioning scan resolves its MVCC view from these canonical sets (by
-        // its compacted `non_partitioning_index`); `index_segment_ids` stays empty, which
-        // skips the UDF segment injection without failing it.
+        // fallback this Result feeds; one extra decode per stage (readers released with the
+        // init context) buys the fallback. With no ParallelScanState, a non-partitioning scan
+        // resolves its MVCC view from these canonical sets by its `non_partitioning_index`;
+        // `index_segment_ids` stays empty, which skips the UDF injection without failing it.
         deserialize_physical_plan_with_runtime(
             &plan_proto,
             &decode_ctx,

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -133,6 +133,7 @@ pub fn build_dispatch_blob(
     seed: SessionContext,
     n_workers: u32,
     runtime: &tokio::runtime::Runtime,
+    non_partitioning_segments: &[HashSet<SegmentId>],
 ) -> Result<Vec<u8>> {
     let logical = deserialize_logical_plan_with_runtime(
         logical_bytes,
@@ -154,12 +155,17 @@ pub fn build_dispatch_blob(
         let plan_proto = serialize_physical_plan(stage.plan)?;
         // Encode can succeed while decode fails (a codec gap). The first decode otherwise
         // happens in a worker, where failure is a hard query error instead of the serial
-        // fallback this Result feeds. One extra decode per stage at init buys the fallback.
+        // fallback this Result feeds. One extra decode per stage at init buys the fallback
+        // (it re-opens the scans' readers, on top of the ones the physical planning above
+        // already opened; both are released with the init context). The canonical
+        // non-partitioning sets are the same ones DSM hands the workers, so a lazy scan with
+        // `source_idx` decodes here exactly as it will there; `index_segment_ids` stays empty,
+        // which skips the UDF segment injection without failing it.
         deserialize_physical_plan_with_runtime(
             &plan_proto,
             &decode_ctx,
             None,
-            Vec::new(),
+            non_partitioning_segments.to_vec(),
             Vec::new(),
         )?;
         dispatched.push(DispatchedStage {

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -33,7 +33,7 @@ use crate::api::HashSet;
 use crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context;
 use crate::postgres::customscan::mpp::runtime::{proc_for_task, MppMesh};
 use crate::postgres::customscan::mpp::worker_fragments::{
-    collect_dispatched_stages, FragmentAssignment, FragmentRouting, StageEntry,
+    collect_dispatched_stages, FragmentAssignment, FragmentRouting,
 };
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::deserialize_logical_plan_with_runtime;
@@ -50,10 +50,9 @@ struct DispatchedStage {
     plan_proto: Vec<u8>,
 }
 
-/// First byte of the DSM plan region: a re-planned worker reads a logical plan (Tier 1, join);
-/// a dispatched worker reads the framed per-stage blob (Tier 2, aggregate). The customscans opt
-/// in per scan, so the shared worker path branches on this.
-pub const TAG_LOGICAL: u8 = 0;
+/// First byte of the DSM plan region. Only the dispatch blob is shipped today (every MPP
+/// customscan dispatches); the tag is kept so a future re-plan fallback can be distinguished
+/// without a wire-format change.
 pub const TAG_BLOB: u8 = 1;
 
 /// bincode config for the dispatch blob. Pinned so leader and worker agree.
@@ -69,11 +68,6 @@ fn blob_config() -> impl bincode::config::Config {
 /// `initialize_dsm` MUST call this with the same `logical_len` so the DSM layout matches.
 pub fn dispatch_plan_capacity(logical_len: usize) -> usize {
     1 + 8 + logical_len.saturating_mul(64).max(1 << 20)
-}
-
-/// DSM plan-region size for a re-planned (logical) worker: the logical plan behind the mode tag.
-pub fn logical_plan_capacity(logical_len: usize) -> usize {
-    1 + logical_len
 }
 
 /// Frame the blob into a fixed-capacity dispatch payload:
@@ -92,14 +86,6 @@ pub fn frame_dispatch_payload(blob: &[u8], capacity: usize) -> Result<Vec<u8>> {
     payload.extend_from_slice(blob);
     payload.resize(capacity, 0);
     Ok(payload)
-}
-
-/// Frame a logical plan into the re-plan payload: `[TAG_LOGICAL][logical plan bytes]`.
-pub fn frame_logical_payload(logical_bytes: Vec<u8>) -> Vec<u8> {
-    let mut payload = Vec::with_capacity(1 + logical_bytes.len());
-    payload.push(TAG_LOGICAL);
-    payload.extend_from_slice(&logical_bytes);
-    payload
 }
 
 /// Extract the blob from a framed dispatch payload body (the bytes after the mode tag).
@@ -230,31 +216,9 @@ fn expand_to_assignments(
     Ok(out)
 }
 
-/// Re-plan path (Tier 1): expand in-memory stages from a freshly built physical plan.
-fn assignments_from_stages(
-    stages: Vec<StageEntry>,
-    this_proc: u32,
-    n_workers: u32,
-) -> Vec<FragmentAssignment> {
-    let mut out = Vec::new();
-    for stage in stages {
-        push_owned_tasks(
-            &mut out,
-            stage.stage_num,
-            stage.task_count,
-            &stage.routing,
-            &stage.plan,
-            this_proc,
-            n_workers,
-        );
-    }
-    out
-}
-
-/// Build this worker's fragment assignments from the DSM plan payload, branching on the mode tag:
-/// a dispatched blob runs the leader's sliced subplans directly (Tier 2); a logical plan is
-/// re-planned and walked locally (Tier 1, for customscans whose execs aren't dispatchable yet).
-/// Returns the distributed session context too, since the caller needs it to run the fragments.
+/// Build this worker's fragment assignments from the DSM dispatch payload: run the leader's
+/// sliced per-stage subplans directly, without re-planning. Returns the distributed session
+/// context too, since the caller needs it to run the fragments.
 #[allow(clippy::too_many_arguments)]
 pub fn fragments_for_worker(
     plan_bytes: &[u8],
@@ -265,48 +229,28 @@ pub fn fragments_for_worker(
     parallel_state: Option<*mut ParallelScanState>,
     non_partitioning_segments: &[HashSet<SegmentId>],
     index_segment_ids: &[HashSet<SegmentId>],
-    runtime: &tokio::runtime::Runtime,
 ) -> Result<(Vec<FragmentAssignment>, SessionContext)> {
     let Some((&tag, body)) = plan_bytes.split_first() else {
         return Err(DataFusionError::Internal(
             "mpp dispatch: empty worker plan bytes".into(),
         ));
     };
-    match tag {
-        TAG_BLOB => {
-            let session = build_mpp_session_context(seed, Some(mesh));
-            // Decode against the full session task context so functions resolve through the
-            // registry (the composed physical codec can shadow UDF/UDAF decode at position 0).
-            let fragments = expand_to_assignments(
-                body,
-                this_proc,
-                n_workers,
-                &session.task_ctx(),
-                parallel_state,
-                non_partitioning_segments,
-                index_segment_ids,
-            )?;
-            Ok((fragments, session))
-        }
-        TAG_LOGICAL => {
-            let logical = deserialize_logical_plan_with_runtime(
-                body,
-                &seed.task_ctx(),
-                parallel_state,
-                None, // expr_context: bm25 search predicates don't need runtime params
-                None, // planstate: same
-                non_partitioning_segments.to_vec(),
-                index_segment_ids.to_vec(),
-            )?;
-            let session = build_mpp_session_context(seed, Some(mesh));
-            let physical =
-                runtime.block_on(async { session.state().create_physical_plan(&logical).await })?;
-            let fragments =
-                assignments_from_stages(collect_dispatched_stages(&physical, n_workers), this_proc, n_workers);
-            Ok((fragments, session))
-        }
-        other => Err(DataFusionError::Internal(format!(
-            "mpp dispatch: unknown worker plan tag {other}"
-        ))),
+    if tag != TAG_BLOB {
+        return Err(DataFusionError::Internal(format!(
+            "mpp dispatch: unexpected worker plan tag {tag}"
+        )));
     }
+    let session = build_mpp_session_context(seed, Some(mesh));
+    // Decode against the full session task context so functions resolve through the registry
+    // (the composed physical codec can shadow UDF/UDAF decode at position 0 otherwise).
+    let fragments = expand_to_assignments(
+        body,
+        this_proc,
+        n_workers,
+        &session.task_ctx(),
+        parallel_state,
+        non_partitioning_segments,
+        index_segment_ids,
+    )?;
+    Ok((fragments, session))
 }

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -153,8 +153,7 @@ fn read_dispatch_blob(payload: &[u8]) -> Result<Vec<DispatchedStage>> {
     Ok(stages)
 }
 
-/// Fan a stage out to the `task_idx` slots `this_proc` owns under `proc_for_task`. Shared by the
-/// dispatch (decoded) and re-plan (in-memory) paths.
+/// Fan a stage out to the `task_idx` slots `this_proc` owns under `proc_for_task`.
 fn push_owned_tasks(
     out: &mut Vec<FragmentAssignment>,
     stage_num: u32,

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -62,6 +62,14 @@ fn blob_config() -> impl bincode::config::Config {
     bincode::config::standard()
 }
 
+/// Physical-plan blobs grow with the logical plan but with a different constant: the physical
+/// encoding repeats schemas per node and carries the dispatch descriptors. The factor is
+/// deliberately generous because the region lives only for the query and an overflowing blob
+/// falls back to serial, while an undersized region costs the MPP path.
+const DISPATCH_BLOAT_FACTOR: usize = 64;
+/// Floor for tiny logical plans, whose physical expansion is dominated by fixed overhead.
+const DISPATCH_MIN_CAPACITY: usize = 1 << 20;
+
 /// DSM plan-region capacity for the dispatch payload (`[tag][u64 len][blob][pad]`).
 ///
 /// The region is sized at `estimate_dsm` time, before the physical plan (and so the real blob
@@ -69,7 +77,10 @@ fn blob_config() -> impl bincode::config::Config {
 /// logical-plan length; an overflowing blob falls back to serial. `estimate_dsm` and
 /// `initialize_dsm` MUST call this with the same `logical_len` so the DSM layout matches.
 pub fn dispatch_plan_capacity(logical_len: usize) -> usize {
-    1 + 8 + logical_len.saturating_mul(64).max(1 << 20)
+    1 + 8
+        + logical_len
+            .saturating_mul(DISPATCH_BLOAT_FACTOR)
+            .max(DISPATCH_MIN_CAPACITY)
 }
 
 /// Frame the blob into a fixed-capacity dispatch payload:
@@ -113,6 +124,10 @@ fn unframe_dispatch_payload(body: &[u8]) -> Result<&[u8]> {
 /// dropping the query to serial with the real state intact). Lazy scans ship source indices, and
 /// each worker injects its own `ParallelScanState` + segments on decode. `mesh = None` keeps the
 /// build off the transport; the stage numbering matches the consumer plan the leader builds at exec.
+///
+/// The logical bytes predate exec-time rewrites: joinscan injects a runtime `Limit` for
+/// parameterized LIMIT/OFFSET only at exec, after this build. Workers re-planned from these same
+/// bytes before dispatch existed, so the producer-stage shapes here match that precedent.
 pub fn build_dispatch_blob(
     logical_bytes: &[u8],
     seed: SessionContext,
@@ -132,10 +147,21 @@ pub fn build_dispatch_blob(
     let physical =
         runtime.block_on(async { session.state().create_physical_plan(&logical).await })?;
 
-    let stages = collect_dispatched_stages(&physical, n_workers);
+    let stages = collect_dispatched_stages(&physical, n_workers)?;
     let mut dispatched = Vec::with_capacity(stages.len());
+    let decode_ctx = session.task_ctx();
     for stage in stages {
         let plan_proto = serialize_physical_plan(stage.plan)?;
+        // Encode can succeed while decode fails (a codec gap). The first decode otherwise
+        // happens in a worker, where failure is a hard query error instead of the serial
+        // fallback this Result feeds. One extra decode per stage at init buys the fallback.
+        deserialize_physical_plan_with_runtime(
+            &plan_proto,
+            &decode_ctx,
+            None,
+            Vec::new(),
+            Vec::new(),
+        )?;
         dispatched.push(DispatchedStage {
             stage_num: stage.stage_num,
             task_count: stage.task_count,
@@ -194,6 +220,13 @@ fn expand_to_assignments(
     let stages = read_dispatch_blob(body)?;
     let mut out = Vec::new();
     for stage in stages {
+        // Decode opens index readers, so skip stages this proc owns no tasks of (broadcast
+        // stages put all work on task 0, leaving the other procs with nothing).
+        let owns_any = (0..stage.task_count)
+            .any(|task_idx| proc_for_task(n_workers, task_idx as u32) == this_proc);
+        if !owns_any {
+            continue;
+        }
         let plan = deserialize_physical_plan_with_runtime(
             &stage.plan_proto,
             decode_ctx,
@@ -239,8 +272,9 @@ pub fn fragments_for_worker(
         )));
     }
     let session = build_mpp_session_context(seed, Some(mesh));
-    // Decode against the full session task context so functions resolve through the registry
-    // (the composed physical codec can shadow UDF/UDAF decode at position 0 otherwise).
+    // Decode against the full session task context: by-name functions (DataFusion built-ins)
+    // resolve through its registry, while pg_search UDFs travel with their definition and
+    // decode through the codec.
     let fragments = expand_to_assignments(
         body,
         this_proc,

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -1,0 +1,188 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Coordinator-dispatch blob: the leader serializes the distributed physical plan once and ships
+//! per-stage subplans to the workers, so workers run their fragments without re-planning.
+//!
+//! The blob is one shared buffer in DSM. Every worker reads it and selects the `(stage, task)`
+//! slots it owns under [`proc_for_task`]. The fork's `DistributedCodec` serializes the
+//! `Network*Exec` boundaries; [`crate::scan::physical_codec`] serializes the `pg_search` execs.
+
+use std::sync::Arc;
+
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::prelude::SessionContext;
+use tantivy::index::SegmentId;
+
+use crate::api::HashSet;
+use crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context;
+use crate::postgres::customscan::mpp::runtime::proc_for_task;
+use crate::postgres::customscan::mpp::worker_fragments::{
+    collect_dispatched_stages, FragmentAssignment, FragmentRouting,
+};
+use crate::postgres::ParallelScanState;
+use crate::scan::codec::deserialize_logical_plan_with_runtime;
+use crate::scan::physical_codec::{deserialize_physical_plan_with_runtime, serialize_physical_plan};
+
+/// One stage of the dispatch blob: a serialized producer subplan plus the metadata a worker needs
+/// to run and route it. Shared by all workers; each selects the `task_idx` slots it owns.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct DispatchedStage {
+    stage_num: u32,
+    task_count: usize,
+    routing: FragmentRouting,
+    /// `PhysicalPlanNode`-encoded `stage.local_plan()` (via the combined codec).
+    plan_proto: Vec<u8>,
+}
+
+/// bincode config for the dispatch blob. Pinned so leader and worker agree.
+fn blob_config() -> impl bincode::config::Config {
+    bincode::config::standard()
+}
+
+/// DSM plan-region capacity for the dispatch payload, including the 8-byte length prefix.
+///
+/// The region is sized at `estimate_dsm` time, before the physical plan (and so the real blob
+/// size) can be known, because `ParallelScanState` doesn't exist yet. Size generously from the
+/// logical-plan length; an overflowing blob falls back to serial. `estimate_dsm` and
+/// `initialize_dsm` MUST call this with the same `logical_len` so the DSM layout matches.
+pub fn dispatch_plan_capacity(logical_len: usize) -> usize {
+    8 + logical_len.saturating_mul(64).max(1 << 20)
+}
+
+/// Frame the blob into a fixed-capacity DSM payload: `[u64 len LE][blob][zero pad to capacity]`.
+/// Errors if the blob plus prefix exceeds `capacity` so the caller can fall back to serial.
+pub fn frame_dispatch_payload(blob: &[u8], capacity: usize) -> Result<Vec<u8>> {
+    let needed = 8 + blob.len();
+    if needed > capacity {
+        return Err(DataFusionError::Internal(format!(
+            "mpp dispatch: blob {needed} bytes exceeds DSM plan capacity {capacity}"
+        )));
+    }
+    let mut payload = Vec::with_capacity(capacity);
+    payload.extend_from_slice(&(blob.len() as u64).to_le_bytes());
+    payload.extend_from_slice(blob);
+    payload.resize(capacity, 0);
+    Ok(payload)
+}
+
+/// Extract the blob from a framed DSM payload (inverse of [`frame_dispatch_payload`]).
+fn unframe_dispatch_payload(payload: &[u8]) -> Result<&[u8]> {
+    let len_bytes = payload.get(0..8).ok_or_else(|| {
+        DataFusionError::Internal("mpp dispatch: payload too short for length prefix".into())
+    })?;
+    let len = u64::from_le_bytes(len_bytes.try_into().unwrap()) as usize;
+    payload.get(8..8 + len).ok_or_else(|| {
+        DataFusionError::Internal(format!(
+            "mpp dispatch: payload length prefix {len} exceeds payload {}",
+            payload.len()
+        ))
+    })
+}
+
+/// Build the dispatch blob on the leader at DSM-init, after `ParallelScanState` is populated:
+/// deserialize the leader's logical plan, build the distributed physical plan once, and serialize
+/// each producer stage's subplan.
+///
+/// The runtime state (`parallel_state` + per-source segment sets) is only needed to deserialize
+/// the logical plan; serialization ships source indices, and each worker injects its own segments
+/// on decode. `mesh = None` keeps the build structure-only -- the leader never opens a
+/// `WorkerConnection` here, and the stage numbering matches the consumer plan it builds at exec.
+#[allow(clippy::too_many_arguments)]
+pub fn build_dispatch_blob(
+    logical_bytes: &[u8],
+    seed: SessionContext,
+    n_workers: u32,
+    parallel_state: Option<*mut ParallelScanState>,
+    non_partitioning_segments: Vec<HashSet<SegmentId>>,
+    index_segment_ids: Vec<HashSet<SegmentId>>,
+    runtime: &tokio::runtime::Runtime,
+) -> Result<Vec<u8>> {
+    let logical = deserialize_logical_plan_with_runtime(
+        logical_bytes,
+        &seed.task_ctx(),
+        parallel_state,
+        None,
+        None,
+        non_partitioning_segments,
+        index_segment_ids,
+    )?;
+    let session = build_mpp_session_context(seed, None);
+    let physical =
+        runtime.block_on(async { session.state().create_physical_plan(&logical).await })?;
+
+    let stages = collect_dispatched_stages(&physical, n_workers);
+    let mut dispatched = Vec::with_capacity(stages.len());
+    for stage in stages {
+        let plan_proto = serialize_physical_plan(stage.plan)?;
+        dispatched.push(DispatchedStage {
+            stage_num: stage.stage_num,
+            task_count: stage.task_count,
+            routing: stage.routing,
+            plan_proto,
+        });
+    }
+    bincode::serde::encode_to_vec(&dispatched, blob_config())
+        .map_err(|e| DataFusionError::Internal(format!("mpp dispatch: blob encode: {e}")))
+}
+
+/// Decode the dispatch blob from the framed DSM payload a worker copied out of DSM.
+fn read_dispatch_blob(payload: &[u8]) -> Result<Vec<DispatchedStage>> {
+    let blob = unframe_dispatch_payload(payload)?;
+    let (stages, _) = bincode::serde::decode_from_slice(blob, blob_config())
+        .map_err(|e| DataFusionError::Internal(format!("mpp dispatch: blob decode: {e}")))?;
+    Ok(stages)
+}
+
+/// Expand the dispatch blob into this worker's fragment assignments. Each stage's subplan is
+/// decoded once (injecting the worker's runtime context) and fanned out to the `task_idx` slots
+/// this proc owns. Mirrors what the worker re-plan + `find_worker_assignments` produced before.
+#[allow(clippy::too_many_arguments)]
+pub fn expand_to_assignments(
+    payload: &[u8],
+    this_proc: u32,
+    n_workers: u32,
+    decode_ctx: &TaskContext,
+    parallel_state: Option<*mut ParallelScanState>,
+    non_partitioning_segments: &[HashSet<SegmentId>],
+    index_segment_ids: &[HashSet<SegmentId>],
+) -> Result<Vec<FragmentAssignment>> {
+    let stages = read_dispatch_blob(payload)?;
+    let mut out = Vec::new();
+    for stage in stages {
+        let plan = deserialize_physical_plan_with_runtime(
+            &stage.plan_proto,
+            decode_ctx,
+            parallel_state,
+            non_partitioning_segments.to_vec(),
+            index_segment_ids.to_vec(),
+        )?;
+        for task_idx in 0..stage.task_count {
+            if proc_for_task(n_workers, task_idx as u32) == this_proc {
+                out.push(FragmentAssignment {
+                    stage_id: stage.stage_num,
+                    task_idx,
+                    task_count: stage.task_count,
+                    plan: Arc::clone(&plan),
+                    routing: stage.routing.clone(),
+                });
+            }
+        }
+    }
+    Ok(out)
+}

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -15,12 +15,16 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Coordinator-dispatch blob: the leader serializes the distributed physical plan once and ships
+//! Leader-dispatch blob: the leader serializes the distributed physical plan once and ships
 //! per-stage subplans to the workers, so workers run their fragments without re-planning.
 //!
 //! The blob is one shared buffer in DSM. Every worker reads it and selects the `(stage, task)`
 //! slots it owns under [`proc_for_task`]. The fork's `DistributedCodec` serializes the
 //! `Network*Exec` boundaries; [`crate::scan::physical_codec`] serializes the `pg_search` execs.
+//!
+//! The blob rides DSM rather than the mesh rings: workers read it while setting up, before they
+//! attach to the mesh, so startup needs no receive loop; one read-only copy serves every worker;
+//! and the rings stay sized for row traffic (`paradedb.mpp_queue_size`), not plan payloads.
 
 use std::sync::Arc;
 

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -210,6 +210,30 @@ fn push_owned_tasks(
     }
 }
 
+/// Builds and frames the dispatch payload for the DSM plan region: a single-thread runtime for
+/// the planning pass, the per-stage blob, then the fixed-capacity frame. One `Err` covers the
+/// whole pipeline so a caller warns once and falls back to serial. Capacity is derived from
+/// `logical_bytes.len()`, the same input `estimate_dsm` sized the region with.
+pub fn build_dispatch_payload(
+    logical_bytes: &[u8],
+    seed: SessionContext,
+    n_workers: u32,
+    non_partitioning_segments: &[HashSet<SegmentId>],
+) -> Result<Vec<u8>> {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| DataFusionError::Internal(format!("mpp dispatch: runtime build: {e}")))?;
+    let blob = build_dispatch_blob(
+        logical_bytes,
+        seed,
+        n_workers,
+        &runtime,
+        non_partitioning_segments,
+    )?;
+    frame_dispatch_payload(&blob, dispatch_plan_capacity(logical_bytes.len()))
+}
+
 /// Expand the dispatch blob body into this worker's fragment assignments. Each stage's subplan is
 /// decoded once (injecting the worker's runtime context) and fanned out to the `task_idx` slots
 /// this proc owns.

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -157,10 +157,10 @@ pub fn build_dispatch_blob(
         // happens in a worker, where failure is a hard query error instead of the serial
         // fallback this Result feeds. One extra decode per stage at init buys the fallback
         // (it re-opens the scans' readers, on top of the ones the physical planning above
-        // already opened; both are released with the init context). The canonical
-        // non-partitioning sets are the same ones DSM hands the workers, so a lazy scan with
-        // `source_idx` decodes here exactly as it will there; `index_segment_ids` stays empty,
-        // which skips the UDF segment injection without failing it.
+        // already opened; both are released with the init context). With no ParallelScanState
+        // here, a non-partitioning scan resolves its MVCC view from these canonical sets (by
+        // its compacted `non_partitioning_index`); `index_segment_ids` stays empty, which
+        // skips the UDF segment injection without failing it.
         deserialize_physical_plan_with_runtime(
             &plan_proto,
             &decode_ctx,

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -31,9 +31,9 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context;
-use crate::postgres::customscan::mpp::runtime::proc_for_task;
+use crate::postgres::customscan::mpp::runtime::{proc_for_task, MppMesh};
 use crate::postgres::customscan::mpp::worker_fragments::{
-    collect_dispatched_stages, FragmentAssignment, FragmentRouting,
+    collect_dispatched_stages, FragmentAssignment, FragmentRouting, StageEntry,
 };
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::deserialize_logical_plan_with_runtime;
@@ -50,47 +50,68 @@ struct DispatchedStage {
     plan_proto: Vec<u8>,
 }
 
+/// First byte of the DSM plan region: a re-planned worker reads a logical plan (Tier 1, join);
+/// a dispatched worker reads the framed per-stage blob (Tier 2, aggregate). The customscans opt
+/// in per scan, so the shared worker path branches on this.
+pub const TAG_LOGICAL: u8 = 0;
+pub const TAG_BLOB: u8 = 1;
+
 /// bincode config for the dispatch blob. Pinned so leader and worker agree.
 fn blob_config() -> impl bincode::config::Config {
     bincode::config::standard()
 }
 
-/// DSM plan-region capacity for the dispatch payload, including the 8-byte length prefix.
+/// DSM plan-region capacity for the dispatch payload (`[tag][u64 len][blob][pad]`).
 ///
 /// The region is sized at `estimate_dsm` time, before the physical plan (and so the real blob
 /// size) can be known, because `ParallelScanState` doesn't exist yet. Size generously from the
 /// logical-plan length; an overflowing blob falls back to serial. `estimate_dsm` and
 /// `initialize_dsm` MUST call this with the same `logical_len` so the DSM layout matches.
 pub fn dispatch_plan_capacity(logical_len: usize) -> usize {
-    8 + logical_len.saturating_mul(64).max(1 << 20)
+    1 + 8 + logical_len.saturating_mul(64).max(1 << 20)
 }
 
-/// Frame the blob into a fixed-capacity DSM payload: `[u64 len LE][blob][zero pad to capacity]`.
-/// Errors if the blob plus prefix exceeds `capacity` so the caller can fall back to serial.
+/// DSM plan-region size for a re-planned (logical) worker: the logical plan behind the mode tag.
+pub fn logical_plan_capacity(logical_len: usize) -> usize {
+    1 + logical_len
+}
+
+/// Frame the blob into a fixed-capacity dispatch payload:
+/// `[TAG_BLOB][u64 len LE][blob][zero pad to capacity]`. Errors if it doesn't fit `capacity` so
+/// the caller can fall back to serial.
 pub fn frame_dispatch_payload(blob: &[u8], capacity: usize) -> Result<Vec<u8>> {
-    let needed = 8 + blob.len();
+    let needed = 1 + 8 + blob.len();
     if needed > capacity {
         return Err(DataFusionError::Internal(format!(
             "mpp dispatch: blob {needed} bytes exceeds DSM plan capacity {capacity}"
         )));
     }
     let mut payload = Vec::with_capacity(capacity);
+    payload.push(TAG_BLOB);
     payload.extend_from_slice(&(blob.len() as u64).to_le_bytes());
     payload.extend_from_slice(blob);
     payload.resize(capacity, 0);
     Ok(payload)
 }
 
-/// Extract the blob from a framed DSM payload (inverse of [`frame_dispatch_payload`]).
-fn unframe_dispatch_payload(payload: &[u8]) -> Result<&[u8]> {
-    let len_bytes = payload.get(0..8).ok_or_else(|| {
+/// Frame a logical plan into the re-plan payload: `[TAG_LOGICAL][logical plan bytes]`.
+pub fn frame_logical_payload(logical_bytes: Vec<u8>) -> Vec<u8> {
+    let mut payload = Vec::with_capacity(1 + logical_bytes.len());
+    payload.push(TAG_LOGICAL);
+    payload.extend_from_slice(&logical_bytes);
+    payload
+}
+
+/// Extract the blob from a framed dispatch payload body (the bytes after the mode tag).
+fn unframe_dispatch_payload(body: &[u8]) -> Result<&[u8]> {
+    let len_bytes = body.get(0..8).ok_or_else(|| {
         DataFusionError::Internal("mpp dispatch: payload too short for length prefix".into())
     })?;
     let len = u64::from_le_bytes(len_bytes.try_into().unwrap()) as usize;
-    payload.get(8..8 + len).ok_or_else(|| {
+    body.get(8..8 + len).ok_or_else(|| {
         DataFusionError::Internal(format!(
             "mpp dispatch: payload length prefix {len} exceeds payload {}",
-            payload.len()
+            body.len()
         ))
     })
 }
@@ -149,12 +170,36 @@ fn read_dispatch_blob(payload: &[u8]) -> Result<Vec<DispatchedStage>> {
     Ok(stages)
 }
 
-/// Expand the dispatch blob into this worker's fragment assignments. Each stage's subplan is
+/// Fan a stage out to the `task_idx` slots `this_proc` owns under `proc_for_task`. Shared by the
+/// dispatch (decoded) and re-plan (in-memory) paths.
+fn push_owned_tasks(
+    out: &mut Vec<FragmentAssignment>,
+    stage_num: u32,
+    task_count: usize,
+    routing: &FragmentRouting,
+    plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    this_proc: u32,
+    n_workers: u32,
+) {
+    for task_idx in 0..task_count {
+        if proc_for_task(n_workers, task_idx as u32) == this_proc {
+            out.push(FragmentAssignment {
+                stage_id: stage_num,
+                task_idx,
+                task_count,
+                plan: Arc::clone(plan),
+                routing: routing.clone(),
+            });
+        }
+    }
+}
+
+/// Expand the dispatch blob body into this worker's fragment assignments. Each stage's subplan is
 /// decoded once (injecting the worker's runtime context) and fanned out to the `task_idx` slots
-/// this proc owns. Mirrors what the worker re-plan + `find_worker_assignments` produced before.
+/// this proc owns.
 #[allow(clippy::too_many_arguments)]
-pub fn expand_to_assignments(
-    payload: &[u8],
+fn expand_to_assignments(
+    body: &[u8],
     this_proc: u32,
     n_workers: u32,
     decode_ctx: &TaskContext,
@@ -162,7 +207,7 @@ pub fn expand_to_assignments(
     non_partitioning_segments: &[HashSet<SegmentId>],
     index_segment_ids: &[HashSet<SegmentId>],
 ) -> Result<Vec<FragmentAssignment>> {
-    let stages = read_dispatch_blob(payload)?;
+    let stages = read_dispatch_blob(body)?;
     let mut out = Vec::new();
     for stage in stages {
         let plan = deserialize_physical_plan_with_runtime(
@@ -172,17 +217,96 @@ pub fn expand_to_assignments(
             non_partitioning_segments.to_vec(),
             index_segment_ids.to_vec(),
         )?;
-        for task_idx in 0..stage.task_count {
-            if proc_for_task(n_workers, task_idx as u32) == this_proc {
-                out.push(FragmentAssignment {
-                    stage_id: stage.stage_num,
-                    task_idx,
-                    task_count: stage.task_count,
-                    plan: Arc::clone(&plan),
-                    routing: stage.routing.clone(),
-                });
-            }
-        }
+        push_owned_tasks(
+            &mut out,
+            stage.stage_num,
+            stage.task_count,
+            &stage.routing,
+            &plan,
+            this_proc,
+            n_workers,
+        );
     }
     Ok(out)
+}
+
+/// Re-plan path (Tier 1): expand in-memory stages from a freshly built physical plan.
+fn assignments_from_stages(
+    stages: Vec<StageEntry>,
+    this_proc: u32,
+    n_workers: u32,
+) -> Vec<FragmentAssignment> {
+    let mut out = Vec::new();
+    for stage in stages {
+        push_owned_tasks(
+            &mut out,
+            stage.stage_num,
+            stage.task_count,
+            &stage.routing,
+            &stage.plan,
+            this_proc,
+            n_workers,
+        );
+    }
+    out
+}
+
+/// Build this worker's fragment assignments from the DSM plan payload, branching on the mode tag:
+/// a dispatched blob runs the leader's sliced subplans directly (Tier 2); a logical plan is
+/// re-planned and walked locally (Tier 1, for customscans whose execs aren't dispatchable yet).
+/// Returns the distributed session context too, since the caller needs it to run the fragments.
+#[allow(clippy::too_many_arguments)]
+pub fn fragments_for_worker(
+    plan_bytes: &[u8],
+    seed: SessionContext,
+    mesh: Arc<MppMesh>,
+    this_proc: u32,
+    n_workers: u32,
+    parallel_state: Option<*mut ParallelScanState>,
+    non_partitioning_segments: &[HashSet<SegmentId>],
+    index_segment_ids: &[HashSet<SegmentId>],
+    runtime: &tokio::runtime::Runtime,
+) -> Result<(Vec<FragmentAssignment>, SessionContext)> {
+    let Some((&tag, body)) = plan_bytes.split_first() else {
+        return Err(DataFusionError::Internal(
+            "mpp dispatch: empty worker plan bytes".into(),
+        ));
+    };
+    match tag {
+        TAG_BLOB => {
+            let session = build_mpp_session_context(seed, Some(mesh));
+            // Decode against the full session task context so functions resolve through the
+            // registry (the composed physical codec can shadow UDF/UDAF decode at position 0).
+            let fragments = expand_to_assignments(
+                body,
+                this_proc,
+                n_workers,
+                &session.task_ctx(),
+                parallel_state,
+                non_partitioning_segments,
+                index_segment_ids,
+            )?;
+            Ok((fragments, session))
+        }
+        TAG_LOGICAL => {
+            let logical = deserialize_logical_plan_with_runtime(
+                body,
+                &seed.task_ctx(),
+                parallel_state,
+                None, // expr_context: bm25 search predicates don't need runtime params
+                None, // planstate: same
+                non_partitioning_segments.to_vec(),
+                index_segment_ids.to_vec(),
+            )?;
+            let session = build_mpp_session_context(seed, Some(mesh));
+            let physical =
+                runtime.block_on(async { session.state().create_physical_plan(&logical).await })?;
+            let fragments =
+                assignments_from_stages(collect_dispatched_stages(&physical, n_workers), this_proc, n_workers);
+            Ok((fragments, session))
+        }
+        other => Err(DataFusionError::Internal(format!(
+            "mpp dispatch: unknown worker plan tag {other}"
+        ))),
+    }
 }

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -37,7 +37,9 @@ use crate::postgres::customscan::mpp::worker_fragments::{
 };
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::deserialize_logical_plan_with_runtime;
-use crate::scan::physical_codec::{deserialize_physical_plan_with_runtime, serialize_physical_plan};
+use crate::scan::physical_codec::{
+    deserialize_physical_plan_with_runtime, serialize_physical_plan,
+};
 
 /// One stage of the dispatch blob: a serialized producer subplan plus the metadata a worker needs
 /// to run and route it. Shared by all workers; each selects the `task_idx` slots it owns.

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -102,32 +102,29 @@ fn unframe_dispatch_payload(body: &[u8]) -> Result<&[u8]> {
     })
 }
 
-/// Build the dispatch blob on the leader at DSM-init, after `ParallelScanState` is populated:
-/// deserialize the leader's logical plan, build the distributed physical plan once, and serialize
-/// each producer stage's subplan.
+/// Build the dispatch blob on the leader at DSM-init: deserialize the leader's logical plan, build
+/// the distributed physical plan once, and serialize each producer stage's subplan.
 ///
-/// The runtime state (`parallel_state` + per-source segment sets) is only needed to deserialize
-/// the logical plan; serialization ships source indices, and each worker injects its own segments
-/// on decode. `mesh = None` keeps the build structure-only -- the leader never opens a
-/// `WorkerConnection` here, and the stage numbering matches the consumer plan it builds at exec.
-#[allow(clippy::too_many_arguments)]
+/// This is a structure-only build: no `parallel_state` is injected, so the leader never claims
+/// segments while planning (a throttled sorted scan would otherwise checkout the workers' segments
+/// against the shared state here; with no state it falls to an eager scan that the codec declines,
+/// dropping the query to serial with the real state intact). Lazy scans ship source indices, and
+/// each worker injects its own `ParallelScanState` + segments on decode. `mesh = None` keeps the
+/// build off the transport; the stage numbering matches the consumer plan the leader builds at exec.
 pub fn build_dispatch_blob(
     logical_bytes: &[u8],
     seed: SessionContext,
     n_workers: u32,
-    parallel_state: Option<*mut ParallelScanState>,
-    non_partitioning_segments: Vec<HashSet<SegmentId>>,
-    index_segment_ids: Vec<HashSet<SegmentId>>,
     runtime: &tokio::runtime::Runtime,
 ) -> Result<Vec<u8>> {
     let logical = deserialize_logical_plan_with_runtime(
         logical_bytes,
         &seed.task_ctx(),
-        parallel_state,
         None,
         None,
-        non_partitioning_segments,
-        index_segment_ids,
+        None,
+        Vec::new(),
+        Vec::new(),
     )?;
     let session = build_mpp_session_context(seed, None);
     let physical =

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -111,9 +111,6 @@ pub(crate) fn build_mpp_session_context(
     //      `_distribute_plan` elides every shuffle.
     //   3. distributed_broadcast_joins(true): otherwise CollectLeft HashJoins cap their
     //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
-    // The old `in_process_mode` knob is gone: the registered `ShmMqWorkerTransport` carries a
-    // no-op dispatcher (coordinator dispatch rides DSM, not gRPC), so there is no gRPC
-    // plan-send / metrics / work-unit-feed to skip.
     let cfg = seed
         .copied_config()
         .with_target_partitions(n_workers.max(2));
@@ -128,8 +125,8 @@ pub(crate) fn build_mpp_session_context(
     // Both seeds ship without a `DistributedConfig` extension. The bootstrap below would
     // clobber one if a future change started adding `with_distributed_*` calls on the
     // seed, so guard explicitly. Debug-only; release builds silently let the bootstrap
-    // win, which would surface as missing `in_process_mode` / `broadcast_joins` knobs at
-    // execute time and trip the regress suite.
+    // win, which would surface as missing distributed knobs at execute time and trip the
+    // regress suite.
     debug_assert!(
         seed.state()
             .config()
@@ -143,16 +140,12 @@ pub(crate) fn build_mpp_session_context(
     let mut state_builder = SessionStateBuilder::new_from_existing(seed.state())
         .with_config(cfg)
         // Explicit `DistributedConfig` bootstrap so the downstream `with_distributed_*`
-        // setters have something to mutate. `with_distributed_worker_transport` used to
-        // bootstrap this implicitly when it was first in the chain; with the transport
-        // now optional (EXPLAIN passes mesh = None) we install the extension explicitly
-        // so order doesn't matter.
+        // setters have something to mutate regardless of order; the transport setter is
+        // optional (EXPLAIN passes mesh = None), so nothing else is guaranteed to run first.
         .with_distributed_option_extension(DistributedConfig::default())
         // Placeholder resolver. Our "workers" are PG parallel workers in the same backend tree,
         // not URL-addressed nodes, so the shm_mq transport routes by task index and never dials a
-        // URL; the planner only needs `n_workers` of them to size stages. There is no
-        // `in_process_mode` flag anymore: the transport's no-op dispatcher is what skips the
-        // wire plan-send / metrics / work-unit-feed (see `ShmMqWorkerTransport::dispatch`).
+        // URL; the planner only needs `n_workers` of them to size stages.
         .with_distributed_worker_resolver(InProcessWorkerResolver::new(n_workers));
     // Install the shm_mq transport only for actual execution (mesh = Some). mesh = None is the
     // structure-only path: EXPLAIN, and the leader serializing the plan for dispatch. Neither
@@ -170,10 +163,8 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
         // No `with_distributed_user_codec(...)`: the leader serializes per-stage subplans through
-        // a combined codec built explicitly in `scan::physical_codec` (the fork's `DistributedCodec`
-        // plus the pg_search codec), and each worker decodes the same way. Nothing drives the
-        // session's user-codec slot, and the transport's dispatcher stays a no-op since
-        // coordinator dispatch rides DSM, not the wire.
+        // a combined codec built explicitly in `scan::physical_codec`, and each worker decodes
+        // the same way. Nothing drives the session's user-codec slot.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }
@@ -273,11 +264,9 @@ pub(crate) fn run_mpp_worker(
             for q in 0..n_out {
                 let dest_proc = match &fragment.routing {
                     FragmentRouting::Coalesce { dest_proc } => *dest_proc,
-                    // Output partition q routes to the consumer task the crate's
-                    // `route_partition` picked (precomputed in `worker_fragments`), hosted on
-                    // `proc_for_task`. A partition outside the table means the decoded plan's
-                    // partitioning drifted from the blob the leader routed; name it instead of
-                    // panicking on the index.
+                    // A partition outside the table means the decoded plan's partitioning
+                    // drifted from the blob the leader routed; name it instead of panicking
+                    // on the index.
                     FragmentRouting::Hashed { consumer_task, .. } => {
                         let Some(&task) = consumer_task.get(q) else {
                             return Err(datafusion::common::DataFusionError::Internal(format!(

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -222,6 +222,11 @@ pub(crate) fn run_mpp_worker(
         }
     }
 
+    // Clones for the Tier 2 round-trip probe; the originals are consumed by the logical
+    // deserialize below. Drop these once leader-side physical dispatch replaces the probe.
+    let np_segments_probe = non_partitioning_segments.clone();
+    let index_segment_ids_probe = index_segment_ids.clone();
+
     let logical = match deserialize_logical_plan_with_runtime(
         &plan_bytes,
         &seed_ctx.task_ctx(),
@@ -389,8 +394,58 @@ pub(crate) fn run_mpp_worker(
             // `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task count
             // exceeds 1; with the conversion, those boundaries dispatch through
             // `ShmMqWorkerTransport` exactly like outer boundaries.
+            // Tier 2 round-trip probe: serialize this fragment's subplan through the physical
+            // codec and run the decoded copy, exercising coordinator-dispatch serialization on
+            // the real plan before the slice step moves to the leader. Any codec gap falls back
+            // to the original plan so it surfaces as a warning, not a failed query.
+            let probe_plan =
+                match crate::scan::physical_codec::serialize_physical_plan(Arc::clone(
+                    &fragment.plan,
+                )) {
+                    Ok(bytes) => {
+                        // Decode against the full session task context so built-in aggregates
+                        // (count/sum/...) and any custom UDFs resolve via the function registry.
+                        // datafusion-proto consults the registry before the codec, which sidesteps
+                        // the composed codec shadowing UDAF decode at position 0.
+                        let decode_ctx = session_arc.task_ctx();
+                        match crate::scan::physical_codec::deserialize_physical_plan_with_runtime(
+                            &bytes,
+                            &decode_ctx,
+                            parallel_state,
+                            np_segments_probe.clone(),
+                            index_segment_ids_probe.clone(),
+                        ) {
+                            Ok(p) => {
+                                crate::mpp_log!(
+                                    "tier2 probe (proc={this_proc}) stage_id={} round-tripped OK \
+                                     ({} bytes)",
+                                    fragment.stage_id,
+                                    bytes.len()
+                                );
+                                p
+                            }
+                            Err(e) => {
+                                pgrx::warning!(
+                                    "tier2 probe (proc={this_proc}) stage_id={} decode failed: \
+                                     {e}; using original",
+                                    fragment.stage_id
+                                );
+                                Arc::clone(&fragment.plan)
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        pgrx::warning!(
+                            "tier2 probe (proc={this_proc}) stage_id={} encode failed: {e}; using \
+                             original",
+                            fragment.stage_id
+                        );
+                        Arc::clone(&fragment.plan)
+                    }
+                };
+
             let plan = {
-                let dist = Arc::new(DistributedExec::new(Arc::clone(&fragment.plan)));
+                let dist = Arc::new(DistributedExec::new(probe_plan));
                 match dist.prepare_in_process_plan(&task_ctx) {
                     Ok(p) => p,
                     Err(e) => {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -275,9 +275,19 @@ pub(crate) fn run_mpp_worker(
                     FragmentRouting::Coalesce { dest_proc } => *dest_proc,
                     // Output partition q routes to the consumer task the crate's
                     // `route_partition` picked (precomputed in `worker_fragments`), hosted on
-                    // `proc_for_task`.
+                    // `proc_for_task`. A partition outside the table means the decoded plan's
+                    // partitioning drifted from the blob the leader routed; name it instead of
+                    // panicking on the index.
                     FragmentRouting::Hashed { consumer_task, .. } => {
-                        proc_for_task(n_workers, consumer_task[q])
+                        let Some(&task) = consumer_task.get(q) else {
+                            return Err(datafusion::common::DataFusionError::Internal(format!(
+                                "mpp worker dispatch: partition {q} outside routing table of                                  len {} (stage_id={} task_idx={})",
+                                consumer_task.len(),
+                                fragment.stage_id,
+                                fragment.task_idx,
+                            )));
+                        };
+                        proc_for_task(n_workers, task)
                     }
                 };
                 let base = match outbound_senders

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -235,7 +235,6 @@ pub(crate) fn run_mpp_worker(
         parallel_state,
         &non_partitioning_segments,
         &index_segment_ids,
-        runtime,
     ) {
         Ok(v) => v,
         Err(e) => pgrx::error!("mpp worker: build fragment assignments failed: {e}"),

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -330,7 +330,10 @@ pub(crate) fn run_mpp_worker(
             // EOF-only-ing the fragment.
             if matches!(
                 fragment.routing,
-                FragmentRouting::Hashed { broadcast: true, .. }
+                FragmentRouting::Hashed {
+                    broadcast: true,
+                    ..
+                }
             ) {
                 debug_assert!(
                     fragment.task_idx == 0,

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -45,7 +45,7 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
-use crate::postgres::customscan::mpp::dispatch::expand_to_assignments;
+use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
 use crate::postgres::customscan::mpp::glue::producer_worker_count;
 use crate::postgres::customscan::mpp::runtime::{
     proc_for_task, InProcessWorkerResolver, MppMesh, ShmMqWorkerTransport,
@@ -220,27 +220,25 @@ pub(crate) fn run_mpp_worker(
         }
     }
 
-    let session = build_mpp_session_context(seed_ctx, Some(Arc::clone(&worker_mesh)));
-
-    // Decode the leader's dispatched per-stage subplans into this proc's fragment assignments,
-    // instead of re-planning from a logical plan. The decode runs against the full session task
-    // context so functions resolve through the registry (the composed physical codec can shadow
-    // UDF/UDAF decode at position 0 otherwise). The dispatcher then runs each fragment exactly as
-    // before. `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before
-    // reaching this), so `n_workers() = n_procs - 1` is safe.
+    // Build this worker's fragment assignments from the DSM plan payload. The aggregate path
+    // runs the leader's dispatched per-stage subplans directly; the join path still re-plans
+    // locally (its custom execs aren't dispatchable yet). Both land at the same dispatcher loop.
+    // `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before reaching
+    // this), so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();
-    let decode_ctx = session.task_ctx();
-    let fragments = match expand_to_assignments(
+    let (fragments, session) = match fragments_for_worker(
         &plan_bytes,
+        seed_ctx,
+        Arc::clone(&worker_mesh),
         this_proc,
         n_workers,
-        &decode_ctx,
         parallel_state,
         &non_partitioning_segments,
         &index_segment_ids,
+        runtime,
     ) {
-        Ok(f) => f,
-        Err(e) => pgrx::error!("mpp worker: expand dispatch blob failed: {e}"),
+        Ok(v) => v,
+        Err(e) => pgrx::error!("mpp worker: build fragment assignments failed: {e}"),
     };
     if fragments.is_empty() {
         pgrx::warning!(

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -47,7 +47,9 @@ use tantivy::index::SegmentId;
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
 use crate::postgres::customscan::mpp::glue::producer_worker_count;
-use crate::postgres::customscan::mpp::runtime::{proc_for_task, MppMesh, ShmMqWorkerTransport};
+use crate::postgres::customscan::mpp::runtime::{
+    proc_for_task, InProcessWorkerResolver, MppMesh, ShmMqWorkerTransport,
+};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
 use crate::postgres::customscan::mpp::worker::run_worker_fragment;
@@ -103,15 +105,16 @@ pub(crate) fn build_mpp_session_context(
         Some(m) => m.n_workers() as usize,
         None => producer_worker_count() as usize,
     };
-    // Four knobs that have to be set for the planner to actually emit `NetworkShuffleExec`:
+    // Three knobs that have to be set for the planner to actually emit `NetworkShuffleExec`:
     //   1. target_partitions(N): without it, EnforceDistribution skips every
     //      RepartitionExec so the annotator never sees a Shuffle.
     //   2. distributed_task_estimator(N): without it, leaves default to Maximum(1) and
     //      `_distribute_plan` elides every shuffle.
     //   3. distributed_broadcast_joins(true): otherwise CollectLeft HashJoins cap their
     //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
-    //   4. distributed_in_process_mode(true): skips the gRPC plan-send / metrics /
-    //      work-unit-feed tasks. Workers re-plan from the logical plan in DSM.
+    // The old `in_process_mode` knob is gone: the registered `ShmMqWorkerTransport` carries a
+    // no-op `dispatch()`, so there is no gRPC plan-send / metrics / work-unit-feed to skip.
+    // Workers still re-plan from the logical plan in DSM.
     let cfg = seed
         .copied_config()
         .with_target_partitions(n_workers.max(2));
@@ -146,12 +149,12 @@ pub(crate) fn build_mpp_session_context(
         // now optional (EXPLAIN passes mesh = None) we install the extension explicitly
         // so order doesn't matter.
         .with_distributed_option_extension(DistributedConfig::default())
-        // No `with_distributed_worker_resolver(...)`: under `in_process_mode = true`, the
-        // fork gates the resolver lookup and substitutes a single placeholder URL. Our
-        // "workers" are PG parallel workers in the same backend tree, not URL-addressed
-        // nodes, so we have nothing meaningful to resolve.
-        .with_distributed_in_process_mode(true)
-        .expect("with_distributed_in_process_mode");
+        // Placeholder resolver. Our "workers" are PG parallel workers in the same backend tree,
+        // not URL-addressed nodes, so the shm_mq transport routes by task index and never dials a
+        // URL; the planner only needs `n_workers` of them to size stages. There is no
+        // `in_process_mode` flag anymore: the transport's no-op `dispatch()` is what skips the
+        // wire plan-send / metrics / work-unit-feed (see `ShmMqWorkerTransport::dispatch`).
+        .with_distributed_worker_resolver(InProcessWorkerResolver::new(n_workers));
     // Install the shm_mq transport only when running for actual execution (mesh = Some).
     // EXPLAIN passes mesh = None and the fork's default (FlightWorkerTransport) sits
     // unused. The planner never calls WorkerConnection::open() outside streaming, so the
@@ -168,12 +171,11 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)`: under `in_process_mode = true`, the fork
-        // skips constructing `CoordinatorToWorkerTaskSpawner`, so its eager codec encode
-        // never runs. Workers re-plan from the logical plan we ship via DSM and never
-        // decode a physical subplan over the wire. If `in_process_mode = false` ever gets
-        // exercised, restore a codec here for our custom execs or `try_encode` will reject
-        // the first one it meets.
+        // No `with_distributed_user_codec(...)`: the transport's no-op `dispatch()` never
+        // constructs the gRPC task spawner, so its eager codec encode never runs. Workers
+        // re-plan from the logical plan we ship via DSM and never decode a physical subplan over
+        // the wire. A transport whose `dispatch()` did ship plans would need a codec here for our
+        // custom execs, or `try_encode` would reject the first one it meets.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -282,14 +282,11 @@ pub(crate) fn run_mpp_worker(
             for q in 0..n_out {
                 let dest_proc = match &fragment.routing {
                     FragmentRouting::Coalesce { dest_proc } => *dest_proc,
-                    FragmentRouting::Shuffle {
-                        partitions_per_consumer_task,
-                    }
-                    | FragmentRouting::Broadcast {
-                        partitions_per_consumer_task,
-                    } => {
-                        let t_c = (q / partitions_per_consumer_task) as u32;
-                        proc_for_task(n_workers, t_c)
+                    // Output partition q routes to the consumer task the crate's
+                    // `route_partition` picked (precomputed in `worker_fragments`), hosted on
+                    // `proc_for_task`.
+                    FragmentRouting::Hashed { consumer_task, .. } => {
+                        proc_for_task(n_workers, consumer_task[q])
                     }
                 };
                 let base = match outbound_senders
@@ -340,7 +337,10 @@ pub(crate) fn run_mpp_worker(
             // wasn't installed, the chain order is wrong, or a future planner pass re-expanded
             // the build subtree. We surface this as a hard error rather than silently
             // EOF-only-ing the fragment.
-            if matches!(fragment.routing, FragmentRouting::Broadcast { .. }) {
+            if matches!(
+                fragment.routing,
+                FragmentRouting::Hashed { broadcast: true, .. }
+            ) {
                 debug_assert!(
                     fragment.task_idx == 0,
                     "mpp dispatcher: Broadcast fragment with task_idx={} but \

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -17,9 +17,9 @@
 
 //! Shape-agnostic MPP worker exec dispatcher.
 //!
-//! The natural-shape MPP path is the same flow for every customscan that opts in: deserialize
-//! the leader's logical plan from DSM, build a distributed physical plan with the same session
-//! config the leader ran, walk it to find this proc's fragments, and dispatch them via
+//! The natural-shape MPP path is the same flow for every customscan that opts in: read the
+//! leader's dispatch blob from DSM, decode this proc's per-stage physical subplans (the leader
+//! built and sliced the plan once, so workers don't re-plan), and run each fragment via
 //! [`run_worker_fragment`] + `join_all`. The only customscan-specific pieces are the seed
 //! `SessionContext` (different `SessionContextProfile`) and where the inputs come from in
 //! per-scan state.
@@ -35,7 +35,6 @@ use std::sync::Arc;
 
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
-use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
     DistributedConfig, DistributedExec, DistributedExt, DistributedTaskContext,
@@ -46,6 +45,7 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use crate::postgres::customscan::mpp::dispatch::expand_to_assignments;
 use crate::postgres::customscan::mpp::glue::producer_worker_count;
 use crate::postgres::customscan::mpp::runtime::{
     proc_for_task, InProcessWorkerResolver, MppMesh, ShmMqWorkerTransport,
@@ -53,12 +53,9 @@ use crate::postgres::customscan::mpp::runtime::{
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, MppFrameHeader, MppSender};
 use crate::postgres::customscan::mpp::worker::run_worker_fragment;
-use crate::postgres::customscan::mpp::worker_fragments::{
-    find_worker_assignments, FragmentRouting,
-};
+use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::customscan::parallel::list_segment_ids;
 use crate::postgres::ParallelScanState;
-use crate::scan::codec::deserialize_logical_plan_with_runtime;
 
 /// Bundle of inputs the worker dispatcher needs. Per-scan
 /// [`crate::postgres::customscan::mpp::host::MppWorkerHost`] impls populate this from their
@@ -72,7 +69,8 @@ pub(crate) struct MppWorkerInputs {
     pub partitioning_source_idx: usize,
     /// Total number of sources in the plan. Used to size the codec's per-source segment-ID Vec.
     pub plan_sources_count: usize,
-    /// Leader's serialized logical plan, copied out of DSM during `worker_setup`.
+    /// Leader's dispatch payload (framed per-stage physical subplans), copied out of DSM during
+    /// `worker_setup`.
     pub plan_bytes: Vec<u8>,
     /// This worker's `MppMesh` handle.
     pub worker_mesh: Arc<MppMesh>,
@@ -81,10 +79,11 @@ pub(crate) struct MppWorkerInputs {
     pub outbound_senders: Vec<Option<MppSender>>,
 }
 
-/// Build the worker/leader distributed session context. Same builder both procs run so they
-/// agree on stage shape, task estimator chain, target_partitions, and codec. Without that,
-/// `find_worker_assignments` returns no fragments because the worker's plan numbers stages
-/// differently from the leader's.
+/// Build the distributed session context. The leader runs this (mesh = None) to build and slice
+/// the plan for dispatch, and again at exec (mesh = Some) for its consumer side; workers run it
+/// (mesh = Some) to host the decoded fragments. Both procs must agree on stage shape, task
+/// estimator chain, and target_partitions so the dispatched stage numbers line up with the
+/// leader's consumer plan.
 ///
 /// `seed` is the customscan's serial session context (`create_aggregate_session_context()` for
 /// AggregateScan, `create_datafusion_session_context(SessionContextProfile::Join)` for JoinScan).
@@ -113,8 +112,8 @@ pub(crate) fn build_mpp_session_context(
     //   3. distributed_broadcast_joins(true): otherwise CollectLeft HashJoins cap their
     //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
     // The old `in_process_mode` knob is gone: the registered `ShmMqWorkerTransport` carries a
-    // no-op `dispatch()`, so there is no gRPC plan-send / metrics / work-unit-feed to skip.
-    // Workers still re-plan from the logical plan in DSM.
+    // no-op `dispatch()` (coordinator dispatch rides DSM, not gRPC), so there is no gRPC
+    // plan-send / metrics / work-unit-feed to skip.
     let cfg = seed
         .copied_config()
         .with_target_partitions(n_workers.max(2));
@@ -155,10 +154,9 @@ pub(crate) fn build_mpp_session_context(
         // `in_process_mode` flag anymore: the transport's no-op `dispatch()` is what skips the
         // wire plan-send / metrics / work-unit-feed (see `ShmMqWorkerTransport::dispatch`).
         .with_distributed_worker_resolver(InProcessWorkerResolver::new(n_workers));
-    // Install the shm_mq transport only when running for actual execution (mesh = Some).
-    // EXPLAIN passes mesh = None and the fork's default (FlightWorkerTransport) sits
-    // unused. The planner never calls WorkerConnection::open() outside streaming, so the
-    // default is fine for read-only plan introspection.
+    // Install the shm_mq transport only for actual execution (mesh = Some). mesh = None is the
+    // structure-only path: EXPLAIN, and the leader serializing the plan for dispatch. Neither
+    // opens a WorkerConnection, so the fork's default transport sits unused.
     if let Some(mesh) = mesh {
         state_builder =
             state_builder.with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh));
@@ -171,11 +169,11 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)`: the transport's no-op `dispatch()` never
-        // constructs the gRPC task spawner, so its eager codec encode never runs. Workers
-        // re-plan from the logical plan we ship via DSM and never decode a physical subplan over
-        // the wire. A transport whose `dispatch()` did ship plans would need a codec here for our
-        // custom execs, or `try_encode` would reject the first one it meets.
+        // No `with_distributed_user_codec(...)`: the leader serializes per-stage subplans through
+        // a combined codec built explicitly in `scan::physical_codec` (the fork's `DistributedCodec`
+        // plus the pg_search codec), and each worker decodes the same way. Nothing drives the
+        // session's user-codec slot, and the transport's `dispatch()` stays a no-op since
+        // coordinator dispatch rides DSM, not the wire.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }
@@ -222,40 +220,28 @@ pub(crate) fn run_mpp_worker(
         }
     }
 
-    // Clones for the Tier 2 round-trip probe; the originals are consumed by the logical
-    // deserialize below. Drop these once leader-side physical dispatch replaces the probe.
-    let np_segments_probe = non_partitioning_segments.clone();
-    let index_segment_ids_probe = index_segment_ids.clone();
-
-    let logical = match deserialize_logical_plan_with_runtime(
-        &plan_bytes,
-        &seed_ctx.task_ctx(),
-        parallel_state,
-        None, // expr_context: bm25 search predicates don't need runtime params
-        None, // planstate: same
-        non_partitioning_segments,
-        index_segment_ids,
-    ) {
-        Ok(lp) => lp,
-        Err(e) => pgrx::error!("mpp worker: deserialize_logical_plan failed: {e}"),
-    };
-
     let session = build_mpp_session_context(seed_ctx, Some(Arc::clone(&worker_mesh)));
 
-    let physical_plan =
-        runtime.block_on(async { session.state().create_physical_plan(&logical).await });
-    let physical_plan = match physical_plan {
-        Ok(p) => p,
-        Err(e) => pgrx::error!("mpp worker: create_physical_plan failed: {e}"),
-    };
-
-    // Walk the plan and collect every `(stage_id, task_idx)` slot owned by this proc under
-    // the `proc_for_task` round-robin policy. The dispatcher spawns one async task per
-    // fragment; together they form the worker's complete contribution to the distributed
-    // plan. `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate
-    // before reaching this), so `n_workers() = n_procs - 1` is safe.
+    // Decode the leader's dispatched per-stage subplans into this proc's fragment assignments,
+    // instead of re-planning from a logical plan. The decode runs against the full session task
+    // context so functions resolve through the registry (the composed physical codec can shadow
+    // UDF/UDAF decode at position 0 otherwise). The dispatcher then runs each fragment exactly as
+    // before. `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before
+    // reaching this), so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();
-    let fragments = find_worker_assignments(&physical_plan, this_proc, n_workers);
+    let decode_ctx = session.task_ctx();
+    let fragments = match expand_to_assignments(
+        &plan_bytes,
+        this_proc,
+        n_workers,
+        &decode_ctx,
+        parallel_state,
+        &non_partitioning_segments,
+        &index_segment_ids,
+    ) {
+        Ok(f) => f,
+        Err(e) => pgrx::error!("mpp worker: expand dispatch blob failed: {e}"),
+    };
     if fragments.is_empty() {
         pgrx::warning!(
             "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
@@ -279,7 +265,11 @@ pub(crate) fn run_mpp_worker(
     let result = runtime.block_on(async move {
         let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
         for fragment in &fragments {
-            let n_out = fragment.plan.output_partitioning().partition_count();
+            let n_out = fragment
+                .plan
+                .properties()
+                .output_partitioning()
+                .partition_count();
             // Build per-output-partition senders. For each partition `q` emitted by this
             // fragment, look up the destination proc via `fragment.routing` and clone the right
             // outbound sender.
@@ -394,58 +384,8 @@ pub(crate) fn run_mpp_worker(
             // `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task count
             // exceeds 1; with the conversion, those boundaries dispatch through
             // `ShmMqWorkerTransport` exactly like outer boundaries.
-            // Tier 2 round-trip probe: serialize this fragment's subplan through the physical
-            // codec and run the decoded copy, exercising coordinator-dispatch serialization on
-            // the real plan before the slice step moves to the leader. Any codec gap falls back
-            // to the original plan so it surfaces as a warning, not a failed query.
-            let probe_plan =
-                match crate::scan::physical_codec::serialize_physical_plan(Arc::clone(
-                    &fragment.plan,
-                )) {
-                    Ok(bytes) => {
-                        // Decode against the full session task context so built-in aggregates
-                        // (count/sum/...) and any custom UDFs resolve via the function registry.
-                        // datafusion-proto consults the registry before the codec, which sidesteps
-                        // the composed codec shadowing UDAF decode at position 0.
-                        let decode_ctx = session_arc.task_ctx();
-                        match crate::scan::physical_codec::deserialize_physical_plan_with_runtime(
-                            &bytes,
-                            &decode_ctx,
-                            parallel_state,
-                            np_segments_probe.clone(),
-                            index_segment_ids_probe.clone(),
-                        ) {
-                            Ok(p) => {
-                                crate::mpp_log!(
-                                    "tier2 probe (proc={this_proc}) stage_id={} round-tripped OK \
-                                     ({} bytes)",
-                                    fragment.stage_id,
-                                    bytes.len()
-                                );
-                                p
-                            }
-                            Err(e) => {
-                                pgrx::warning!(
-                                    "tier2 probe (proc={this_proc}) stage_id={} decode failed: \
-                                     {e}; using original",
-                                    fragment.stage_id
-                                );
-                                Arc::clone(&fragment.plan)
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        pgrx::warning!(
-                            "tier2 probe (proc={this_proc}) stage_id={} encode failed: {e}; using \
-                             original",
-                            fragment.stage_id
-                        );
-                        Arc::clone(&fragment.plan)
-                    }
-                };
-
             let plan = {
-                let dist = Arc::new(DistributedExec::new(probe_plan));
+                let dist = Arc::new(DistributedExec::new(Arc::clone(&fragment.plan)));
                 match dist.prepare_in_process_plan(&task_ctx) {
                     Ok(p) => p,
                     Err(e) => {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -112,7 +112,7 @@ pub(crate) fn build_mpp_session_context(
     //   3. distributed_broadcast_joins(true): otherwise CollectLeft HashJoins cap their
     //      stage at Maximum(1) and propagate the cap upward, eliding shuffles above the join.
     // The old `in_process_mode` knob is gone: the registered `ShmMqWorkerTransport` carries a
-    // no-op `dispatch()` (coordinator dispatch rides DSM, not gRPC), so there is no gRPC
+    // no-op dispatcher (coordinator dispatch rides DSM, not gRPC), so there is no gRPC
     // plan-send / metrics / work-unit-feed to skip.
     let cfg = seed
         .copied_config()
@@ -151,7 +151,7 @@ pub(crate) fn build_mpp_session_context(
         // Placeholder resolver. Our "workers" are PG parallel workers in the same backend tree,
         // not URL-addressed nodes, so the shm_mq transport routes by task index and never dials a
         // URL; the planner only needs `n_workers` of them to size stages. There is no
-        // `in_process_mode` flag anymore: the transport's no-op `dispatch()` is what skips the
+        // `in_process_mode` flag anymore: the transport's no-op dispatcher is what skips the
         // wire plan-send / metrics / work-unit-feed (see `ShmMqWorkerTransport::dispatch`).
         .with_distributed_worker_resolver(InProcessWorkerResolver::new(n_workers));
     // Install the shm_mq transport only for actual execution (mesh = Some). mesh = None is the
@@ -172,7 +172,7 @@ pub(crate) fn build_mpp_session_context(
         // No `with_distributed_user_codec(...)`: the leader serializes per-stage subplans through
         // a combined codec built explicitly in `scan::physical_codec` (the fork's `DistributedCodec`
         // plus the pg_search codec), and each worker decodes the same way. Nothing drives the
-        // session's user-codec slot, and the transport's `dispatch()` stays a no-op since
+        // session's user-codec slot, and the transport's dispatcher stays a no-op since
         // coordinator dispatch rides DSM, not the wire.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
@@ -281,7 +281,8 @@ pub(crate) fn run_mpp_worker(
                     FragmentRouting::Hashed { consumer_task, .. } => {
                         let Some(&task) = consumer_task.get(q) else {
                             return Err(datafusion::common::DataFusionError::Internal(format!(
-                                "mpp worker dispatch: partition {q} outside routing table of                                  len {} (stage_id={} task_idx={})",
+                                "mpp worker dispatch: partition {q} outside routing table of len {} \
+                                 (stage_id={} task_idx={})",
                                 consumer_task.len(),
                                 fragment.stage_id,
                                 fragment.task_idx,

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -220,9 +220,8 @@ pub(crate) fn run_mpp_worker(
         }
     }
 
-    // Build this worker's fragment assignments from the DSM plan payload. The aggregate path
-    // runs the leader's dispatched per-stage subplans directly; the join path still re-plans
-    // locally (its custom execs aren't dispatchable yet). Both land at the same dispatcher loop.
+    // Build this worker's fragment assignments by decoding the leader's dispatched per-stage
+    // subplans from the DSM payload (no re-planning), then run them on the dispatcher loop below.
     // `worker_mesh.n_procs >= 3` is guaranteed by `mpp_is_active()` (callers gate before reaching
     // this), so `n_workers() = n_procs - 1` is safe.
     let n_workers = worker_mesh.n_workers();

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -16,7 +16,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! High-level glue between PostgreSQL parallel-query callbacks and the
-//! coordinator/worker MPP architecture.
+//! leader/worker MPP architecture.
 //!
 //! Customscan code calls into this module from four hooks; everything else
 //! (DSM math, shm_mq FFI, DF-D fork's `WorkerTransport` plumbing) is hidden

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -115,16 +115,12 @@ pub fn mpp_worker_count() -> u32 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CustomScanMppHeader {
-    /// Byte offset of the MPP region within the coordinate, or [`MPP_DISABLED_OFFSET`].
+    /// Byte offset of the MPP region within the coordinate. Always a real, initialized region:
+    /// the leader errors out of `initialize_dsm_custom_scan` on any setup failure, before
+    /// `LaunchParallelWorkers`, so no worker ever reads a half-written header.
     pub mpp_offset: u64,
     pub partitioning_source_idx: u64,
 }
-
-/// `mpp_offset` value marking MPP as disabled for this query: the leader hit a pre-setup
-/// failure (dispatch blob, capacity, runtime) and fell back to serial. Workers must not attach
-/// to the MPP region (it was never initialized) and must not produce rows of their own. A real
-/// region offset is always non-zero because this header occupies the start of the coordinate.
-pub const MPP_DISABLED_OFFSET: u64 = 0;
 
 const CUSTOM_SCAN_MPP_HEADER_SIZE: usize = std::mem::size_of::<CustomScanMppHeader>();
 

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -115,9 +115,16 @@ pub fn mpp_worker_count() -> u32 {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct CustomScanMppHeader {
+    /// Byte offset of the MPP region within the coordinate, or [`MPP_DISABLED_OFFSET`].
     pub mpp_offset: u64,
     pub partitioning_source_idx: u64,
 }
+
+/// `mpp_offset` value marking MPP as disabled for this query: the leader hit a pre-setup
+/// failure (dispatch blob, capacity, runtime) and fell back to serial. Workers must not attach
+/// to the MPP region (it was never initialized) and must not produce rows of their own. A real
+/// region offset is always non-zero because this header occupies the start of the coordinate.
+pub const MPP_DISABLED_OFFSET: u64 = 0;
 
 const CUSTOM_SCAN_MPP_HEADER_SIZE: usize = std::mem::size_of::<CustomScanMppHeader>();
 

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -302,8 +302,8 @@ pub struct MppWorkerState {
     /// `Arc<dyn BatchChannelSender>` so callers can `clone_with_header` to multiplex
     /// `(stage_id, partition)` channels onto one inbox.
     pub outbound_senders: Vec<Option<MppSender>>,
-    /// Worker fragment plan bytes, copied out of DSM. Caller deserializes via the
-    /// `PgSearchExtensionCodec` to get an `Arc<dyn ExecutionPlan>`.
+    /// Leader's dispatch payload (framed per-stage physical subplans), copied out of DSM. The
+    /// worker decodes it into its fragment assignments via `mpp::dispatch::expand_to_assignments`.
     pub plan_bytes: Vec<u8>,
     /// Worker's MppMesh. The single `inbound_receiver` pulls frames addressed to this
     /// proc from both the DSM MPSC inbox and the in-proc self-loop channel; demux by

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -25,6 +25,7 @@
 //! that reads all inbound queues into a spillable local buffer — this decouples
 //! consumer-side backpressure from producer-side backpressure.
 
+pub mod dispatch;
 pub mod dsm;
 pub mod dsm_mpsc_ring;
 pub mod exec_worker;

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -40,7 +40,7 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
 use datafusion_distributed::{
-    ChannelKey, CooperativeScheduler, RemoteStage, WorkerConnection, WorkerDispatch,
+    CooperativeScheduler, RemoteStage, WorkerConnection, WorkerDispatch,
     WorkerDispatchRequest, WorkerResolver, WorkerSink, WorkerTransport,
 };
 use futures::stream::BoxStream;
@@ -273,8 +273,7 @@ struct ShmMqWorkerConnection {
 }
 
 impl WorkerConnection for ShmMqWorkerConnection {
-    fn execute(&self, key: ChannelKey) -> Result<BoxStream<'static, Result<RecordBatch>>> {
-        let partition = key.partition;
+    fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>> {
         let partition_u32 = u32::try_from(partition).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerConnection: partition={partition} > u32::MAX"

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -40,8 +40,8 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
 use datafusion_distributed::{
-    CooperativeScheduler, RemoteStage, WorkerConnection, WorkerDispatch,
-    WorkerDispatchRequest, WorkerResolver, WorkerSink, WorkerTransport,
+    CooperativeScheduler, RemoteStage, WorkerConnection, WorkerDispatch, WorkerDispatchRequest,
+    WorkerResolver, WorkerTransport,
 };
 use futures::stream::BoxStream;
 use url::Url;
@@ -205,17 +205,6 @@ impl WorkerTransport for ShmMqWorkerTransport {
     /// the old `in_process_mode` flag.
     fn dispatch(&self) -> &dyn WorkerDispatch {
         self
-    }
-
-    /// MPP produces inside `run_worker_fragment` on each PG worker, pushing through the shm_mq
-    /// senders, so there is no free-standing sink to hand back. Same shape as Flight, which
-    /// produces inside its gRPC worker service and also declines `sink()`.
-    fn sink(&self, _ctx: &Arc<TaskContext>) -> Result<Arc<dyn WorkerSink>> {
-        Err(DataFusionError::Internal(
-            "ShmMqWorkerTransport has no free-standing WorkerSink; MPP produces inside \
-             run_worker_fragment via shm_mq senders"
-                .to_string(),
-        ))
     }
 
     /// The mesh drains its inbound queues cooperatively. Advertise it so the crate can pump

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -29,8 +29,7 @@
 //!
 //! [`InProcessWorkerResolver`] hands the planner `n_workers` placeholder URLs. The transport
 //! routes by task index, not URL, so the URLs are never dialed; the resolver exists only because
-//! the planner sizes stages from the URL count. It replaces the placeholder URL the fork used to
-//! substitute internally under the old `in_process_mode` flag.
+//! the planner sizes stages from the URL count.
 
 use std::ops::Range;
 use std::sync::Arc;
@@ -192,8 +191,7 @@ impl WorkerTransport for ShmMqWorkerTransport {
 
     /// The plan rides DSM at parallel-context init: the leader writes per-stage physical
     /// subplans, and workers decode their fragments before the leader's plan reaches dispatch.
-    /// Nothing is left to deliver here, so the dispatcher is a no-op. This is what replaces the
-    /// old `in_process_mode` flag.
+    /// Nothing is left to deliver here, so the dispatcher is a no-op.
     fn dispatcher(&self) -> Box<dyn WorkerDispatch> {
         Box::new(NoOpDispatch)
     }
@@ -202,19 +200,15 @@ impl WorkerTransport for ShmMqWorkerTransport {
 struct NoOpDispatch;
 
 impl WorkerDispatch for NoOpDispatch {
-    /// No-op, see [`ShmMqWorkerTransport::dispatcher`]. The workers already hold their decoded
-    /// fragments, so there is nothing to deliver.
+    /// No-op, see [`ShmMqWorkerTransport::dispatcher`].
     fn dispatch(&self, _request: WorkerDispatchRequest<'_>) -> Result<()> {
         Ok(())
     }
 }
 
-/// Placeholder worker resolver for the in-process MPP transport.
-///
-/// The shm_mq transport routes by `target_task` (proc index), never by URL, so these URLs are
-/// never dialed. The distributed planner still needs a resolver: it sizes stages and assigns
-/// tasks from the URL count. `n_workers` placeholder URLs is exactly what the planner needs. This
-/// replaces the placeholder URL the fork used to substitute internally under `in_process_mode`.
+/// Placeholder worker resolver for the in-process MPP transport: the planner sizes stages from
+/// the URL count, and the shm_mq transport routes by `target_task`, so the URLs are never
+/// dialed.
 pub struct InProcessWorkerResolver {
     n_workers: usize,
 }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -40,8 +40,8 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
 use datafusion_distributed::{
-    CooperativeScheduler, RemoteStage, WorkerConnection, WorkerDispatch, WorkerDispatchRequest,
-    WorkerResolver, WorkerTransport,
+    RemoteStage, WorkerConnection, WorkerDispatch, WorkerDispatchRequest, WorkerResolver,
+    WorkerTransport,
 };
 use futures::stream::BoxStream;
 use url::Url;
@@ -134,15 +134,6 @@ impl CooperativeDrainSet for MppMesh {
     }
 }
 
-/// The mesh is also the fork's [`CooperativeScheduler`], advertised via
-/// [`WorkerTransport::scheduler`]. One `poll_progress` pulls every inbound drain, which is how a
-/// producer stalled on a full outbound queue makes room without blocking the backend thread.
-impl CooperativeScheduler for MppMesh {
-    fn poll_progress(&self) -> Result<(), DataFusionError> {
-        self.drain_all_inbound()
-    }
-}
-
 /// Implements the DF-D fork's [`WorkerTransport`] over the leader's [`MppMesh`].
 ///
 /// `open(input_stage, target_task)` translates the DF-D `(stage, task)`
@@ -167,7 +158,7 @@ impl WorkerTransport for ShmMqWorkerTransport {
         target_task: usize,
         _ctx: &Arc<TaskContext>,
         _metrics: &ExecutionPlanMetricsSet,
-    ) -> Result<Box<dyn WorkerConnection + Send + Sync>> {
+    ) -> Result<Box<dyn WorkerConnection>> {
         let target_task_u32 = u32::try_from(target_task).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerTransport: target_task={target_task} > u32::MAX"
@@ -199,24 +190,20 @@ impl WorkerTransport for ShmMqWorkerTransport {
         }))
     }
 
-    /// The leader never pushes plans to workers: PG parallel workers self-plan from the DSM
-    /// logical plan and run their own fragments. By the time the leader's DataFusion plan reaches
-    /// dispatch, the workers are already producing, so dispatch is a no-op. This is what replaces
-    /// the old `in_process_mode` flag.
-    fn dispatch(&self) -> &dyn WorkerDispatch {
-        self
-    }
-
-    /// The mesh drains its inbound queues cooperatively. Advertise it so the crate can pump
-    /// progress at its own block points, instead of ParadeDB threading the drain by hand.
-    fn scheduler(&self) -> Option<Arc<dyn CooperativeScheduler>> {
-        Some(Arc::clone(&self.mesh) as Arc<dyn CooperativeScheduler>)
+    /// The plan rides DSM at parallel-context init: the leader writes per-stage physical
+    /// subplans, and workers decode their fragments before the leader's plan reaches dispatch.
+    /// Nothing is left to deliver here, so the dispatcher is a no-op. This is what replaces the
+    /// old `in_process_mode` flag.
+    fn dispatcher(&self) -> Box<dyn WorkerDispatch> {
+        Box::new(NoOpDispatch)
     }
 }
 
-impl WorkerDispatch for ShmMqWorkerTransport {
-    /// No-op, see [`ShmMqWorkerTransport::dispatch`]. The workers already hold the plan (shipped
-    /// via DSM) and run their fragments, so there is nothing to deliver.
+struct NoOpDispatch;
+
+impl WorkerDispatch for NoOpDispatch {
+    /// No-op, see [`ShmMqWorkerTransport::dispatcher`]. The workers already hold their decoded
+    /// fragments, so there is nothing to deliver.
     fn dispatch(&self, _request: WorkerDispatchRequest<'_>) -> Result<()> {
         Ok(())
     }

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -27,8 +27,10 @@
 //! time. `open(target_task=worker)` returns a [`ShmMqWorkerConnection`] that yields one
 //! stream per consumer partition from the shared `inbound_receiver`.
 //!
-//! No `WorkerResolver` impl: under `in_process_mode = true` the fork makes the resolver
-//! optional and substitutes a placeholder URL; nothing here resolves anything by URL.
+//! [`InProcessWorkerResolver`] hands the planner `n_workers` placeholder URLs. The transport
+//! routes by task index, not URL, so the URLs are never dialed; the resolver exists only because
+//! the planner sizes stages from the URL count. It replaces the placeholder URL the fork used to
+//! substitute internally under the old `in_process_mode` flag.
 
 use std::ops::Range;
 use std::sync::Arc;
@@ -37,8 +39,12 @@ use datafusion::arrow::array::RecordBatch;
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
-use datafusion_distributed::{RemoteStage, WorkerConnection, WorkerTransport};
+use datafusion_distributed::{
+    ChannelKey, RemoteStage, WorkerConnection, WorkerDispatch, WorkerDispatchRequest,
+    WorkerResolver, WorkerSink, WorkerTransport,
+};
 use futures::stream::BoxStream;
+use url::Url;
 
 use crate::postgres::customscan::mpp::transport::{CooperativeDrainSet, DrainHandle, DrainItem};
 
@@ -183,6 +189,63 @@ impl WorkerTransport for ShmMqWorkerTransport {
             stage_id,
         }))
     }
+
+    /// The leader never pushes plans to workers: PG parallel workers self-plan from the DSM
+    /// logical plan and run their own fragments. By the time the leader's DataFusion plan reaches
+    /// dispatch, the workers are already producing, so dispatch is a no-op. This is what replaces
+    /// the old `in_process_mode` flag.
+    fn dispatch(&self) -> &dyn WorkerDispatch {
+        self
+    }
+
+    /// MPP produces inside `run_worker_fragment` on each PG worker, pushing through the shm_mq
+    /// senders, so there is no free-standing sink to hand back. Same shape as Flight, which
+    /// produces inside its gRPC worker service and also declines `sink()`.
+    fn sink(&self, _ctx: &Arc<TaskContext>) -> Result<Arc<dyn WorkerSink>> {
+        Err(DataFusionError::Internal(
+            "ShmMqWorkerTransport has no free-standing WorkerSink; MPP produces inside \
+             run_worker_fragment via shm_mq senders"
+                .to_string(),
+        ))
+    }
+}
+
+impl WorkerDispatch for ShmMqWorkerTransport {
+    /// No-op, see [`ShmMqWorkerTransport::dispatch`]. The workers already hold the plan (shipped
+    /// via DSM) and run their fragments, so there is nothing to deliver.
+    fn dispatch(&self, _request: WorkerDispatchRequest<'_>) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Placeholder worker resolver for the in-process MPP transport.
+///
+/// The shm_mq transport routes by `target_task` (proc index), never by URL, so these URLs are
+/// never dialed. The distributed planner still needs a resolver: it sizes stages and assigns
+/// tasks from the URL count. `n_workers` placeholder URLs is exactly what the planner needs. This
+/// replaces the placeholder URL the fork used to substitute internally under `in_process_mode`.
+pub struct InProcessWorkerResolver {
+    n_workers: usize,
+}
+
+impl InProcessWorkerResolver {
+    pub fn new(n_workers: usize) -> Self {
+        Self { n_workers }
+    }
+}
+
+impl WorkerResolver for InProcessWorkerResolver {
+    fn get_urls(&self) -> Result<Vec<Url>, DataFusionError> {
+        (0..self.n_workers.max(1))
+            .map(|i| {
+                Url::parse(&format!("inprocess://worker/{i}")).map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "InProcessWorkerResolver: invalid placeholder url: {e}"
+                    ))
+                })
+            })
+            .collect()
+    }
 }
 
 struct ShmMqWorkerConnection {
@@ -195,7 +258,8 @@ struct ShmMqWorkerConnection {
 }
 
 impl WorkerConnection for ShmMqWorkerConnection {
-    fn execute(&self, partition: usize) -> Result<BoxStream<'static, Result<RecordBatch>>> {
+    fn execute(&self, key: ChannelKey) -> Result<BoxStream<'static, Result<RecordBatch>>> {
+        let partition = key.partition;
         let partition_u32 = u32::try_from(partition).map_err(|_| {
             DataFusionError::Internal(format!(
                 "ShmMqWorkerConnection: partition={partition} > u32::MAX"

--- a/pg_search/src/postgres/customscan/mpp/runtime.rs
+++ b/pg_search/src/postgres/customscan/mpp/runtime.rs
@@ -40,8 +40,8 @@ use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::physical_expr_common::metrics::ExecutionPlanMetricsSet;
 use datafusion_distributed::{
-    ChannelKey, RemoteStage, WorkerConnection, WorkerDispatch, WorkerDispatchRequest,
-    WorkerResolver, WorkerSink, WorkerTransport,
+    ChannelKey, CooperativeScheduler, RemoteStage, WorkerConnection, WorkerDispatch,
+    WorkerDispatchRequest, WorkerResolver, WorkerSink, WorkerTransport,
 };
 use futures::stream::BoxStream;
 use url::Url;
@@ -134,6 +134,15 @@ impl CooperativeDrainSet for MppMesh {
     }
 }
 
+/// The mesh is also the fork's [`CooperativeScheduler`], advertised via
+/// [`WorkerTransport::scheduler`]. One `poll_progress` pulls every inbound drain, which is how a
+/// producer stalled on a full outbound queue makes room without blocking the backend thread.
+impl CooperativeScheduler for MppMesh {
+    fn poll_progress(&self) -> Result<(), DataFusionError> {
+        self.drain_all_inbound()
+    }
+}
+
 /// Implements the DF-D fork's [`WorkerTransport`] over the leader's [`MppMesh`].
 ///
 /// `open(input_stage, target_task)` translates the DF-D `(stage, task)`
@@ -207,6 +216,12 @@ impl WorkerTransport for ShmMqWorkerTransport {
              run_worker_fragment via shm_mq senders"
                 .to_string(),
         ))
+    }
+
+    /// The mesh drains its inbound queues cooperatively. Advertise it so the crate can pump
+    /// progress at its own block points, instead of ParadeDB threading the drain by hand.
+    fn scheduler(&self) -> Option<Arc<dyn CooperativeScheduler>> {
+        Some(Arc::clone(&self.mesh) as Arc<dyn CooperativeScheduler>)
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -136,10 +136,8 @@ fn collect_stages(
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
         let stage_id = stage.num() as u32;
-        // Per-consumer-task partition count, kept for the trace below. Routing itself reads the
-        // crate's `route_partition` so the producer side follows the receive-side formula the
-        // crate owns, rather than re-deriving `q / P_c`. Only the `mpp_log!` trace reads it, so it
-        // is gated to non-test builds to avoid an unused-variable warning under the test cfg.
+        // Only the `mpp_log!` trace reads `p_c` (routing reads the crate's `route_partition`),
+        // so it's gated to non-test builds to avoid the unused-variable warning.
         #[cfg(not(test))]
         let p_c = nb.partitions_per_consumer_task();
         // `route_partition(q).consumer_task` for every producer output partition. Used by the

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -38,6 +38,7 @@
 
 use std::sync::Arc;
 
+use datafusion::common::DataFusionError;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{
     NetworkBoundaryExt, NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec,
@@ -117,10 +118,13 @@ pub struct StageEntry {
 /// leader runs this (replacing the worker-side re-plan): it classifies routing from the boundary
 /// type and captures each stage's `local_plan` for serialization. Not filtered by proc; the blob
 /// is shared and each worker selects its own `(stage, task)` slots.
-pub fn collect_dispatched_stages(root: &Arc<dyn ExecutionPlan>, n_workers: u32) -> Vec<StageEntry> {
+pub fn collect_dispatched_stages(
+    root: &Arc<dyn ExecutionPlan>,
+    n_workers: u32,
+) -> Result<Vec<StageEntry>, DataFusionError> {
     let mut out = Vec::new();
-    collect_stages(root, n_workers, /* nested = */ false, &mut out);
-    out
+    collect_stages(root, n_workers, /* nested = */ false, &mut out)?;
+    Ok(out)
 }
 
 fn collect_stages(
@@ -128,7 +132,7 @@ fn collect_stages(
     n_workers: u32,
     nested: bool,
     out: &mut Vec<StageEntry>,
-) {
+) -> Result<(), DataFusionError> {
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
         let stage_id = stage.num() as u32;
@@ -140,13 +144,13 @@ fn collect_stages(
         let p_c = nb.partitions_per_consumer_task();
         // `route_partition(q).consumer_task` for every producer output partition. Used by the
         // hash-partitioned boundaries (Shuffle / Broadcast) only; Coalesce routes by task instead.
-        let route_consumer_tasks = || {
+        let route_consumer_tasks = || -> Result<Vec<u32>, DataFusionError> {
             let n_out = stage
                 .local_plan()
                 .map_or(0, |p| p.properties().partitioning.partition_count());
             (0..n_out)
-                .map(|q| nb.route_partition(q).consumer_task as u32)
-                .collect::<Vec<u32>>()
+                .map(|q| Ok(nb.route_partition(q)?.consumer_task as u32))
+                .collect()
         };
         let plan_any = plan.as_ref().as_any();
 
@@ -173,7 +177,7 @@ fn collect_stages(
                 // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps
                 // to the consumer task `route_partition(q)` selects.
                 FragmentRouting::Hashed {
-                    consumer_task: route_consumer_tasks(),
+                    consumer_task: route_consumer_tasks()?,
                     broadcast: false,
                 }
             } else {
@@ -194,7 +198,7 @@ fn collect_stages(
                 // `route_partition`), but the dispatcher only runs the producer plan on task 0 to
                 // avoid the canonical-replica duplication described on `FragmentRouting::Hashed`.
                 FragmentRouting::Hashed {
-                    consumer_task: route_consumer_tasks(),
+                    consumer_task: route_consumer_tasks()?,
                     broadcast: true,
                 }
             } else {
@@ -240,14 +244,15 @@ fn collect_stages(
             // Recurse into the stage's plan with `nested = true`. The boundary's `children()`
             // returns `[stage.plan]`, so descending through it would double-process every nested
             // stage. Return here to keep visit counts exact.
-            collect_stages(stage_plan, n_workers, true, out);
+            collect_stages(stage_plan, n_workers, true, out)?;
         }
-        return;
+        return Ok(());
     }
     // Non-boundary nodes recurse through plan children.
     for child in plan.children() {
-        collect_stages(child, n_workers, nested, out);
+        collect_stages(child, n_workers, nested, out)?;
     }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -260,7 +265,7 @@ mod tests {
     fn boundary_free_plan_yields_no_stages() {
         let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
-        let out = collect_dispatched_stages(&plan, 3);
+        let out = collect_dispatched_stages(&plan, 3).unwrap();
         assert!(out.is_empty());
     }
 

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -15,13 +15,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Leader-side producer-stage discovery for coordinator dispatch.
+//! Leader-side producer-stage discovery for dispatch. "Fragment" here means a plan fragment
+//! (one task of a producer stage), not the frame fragmentation the ring does for oversized
+//! messages.
 //!
 //! [`collect_dispatched_stages`] walks the distributed physical plan, visits every
 //! [`datafusion_distributed::NetworkBoundary`], and collects one [`StageEntry`]
 //! (`input_stage.num`, `task_count`, `routing`, `plan`) per boundary. The leader serializes each
 //! stage's plan and ships it; each worker later expands a stage into one [`FragmentAssignment`]
 //! per `task_idx` it owns under `proc_for_task`.
+//!
+//! The fork's coordinator has no equivalent of this walk: it dispatches one boundary at a time,
+//! when the consumer's `execute` opens connections, so routing is implicit in who pulls. These
+//! workers launch exactly once and the mesh is push-driven, so the leader enumerates every
+//! producer stage and precomputes destinations before any worker exists.
 //!
 //! Routing classification (which proc an output partition `q` is sent to) depends on the
 //! boundary's position:

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -180,9 +180,10 @@ fn collect(
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
         let stage_id = stage.num() as u32;
-        // Per-consumer-task partition count from upstream's `NetworkShuffleExec::execute`
-        // receive-side formula `off = P_c * task_index`.
-        let p_c = plan.properties().partitioning.partition_count();
+        // Per-consumer-task partition count, read from the boundary's own routing contract
+        // instead of re-deriving the receive-side formula. The crate owns `route_partition`
+        // now, so producer-side routing follows it automatically.
+        let p_c = nb.partitions_per_consumer_task();
         let plan_any = plan.as_ref().as_any();
 
         // Classify the boundary by downcasting to its concrete `Network*Exec` type, then pick a

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -73,44 +73,32 @@ pub struct FragmentAssignment {
 #[derive(Clone, Debug)]
 pub enum FragmentRouting {
     /// All output partitions go to one destination proc (`NetworkCoalesceExec`
-    /// or the top-level gather case). Frame header carries
-    /// `(stage_id, partition)` directly; consumer reads
-    /// `execute(partition)`.
+    /// or the top-level gather case). Coalesce routes by producer task, not by
+    /// output partition, so the crate's `route_partition` does not describe it;
+    /// the dispatcher sends every partition to `dest_proc`.
     Coalesce {
-        /// Destination proc index. `0` for the leader (top-level gather),
-        /// or an `assignment.proc_for(parent_stage_id, 0)` lookup for a
-        /// nested coalesce that lands on a single consumer task.
+        /// Destination proc index. `0` for the leader (top-level gather), or a
+        /// `proc_for_task(n_workers, 0)` lookup for a nested coalesce that lands
+        /// on a single consumer task.
         dest_proc: u32,
     },
-    /// Hash-partitioned mesh ([`NetworkShuffleExec`]). Output partition `q`
-    /// goes to consumer task `q / partitions_per_consumer_task`, hosted on
-    /// `proc_for_task(n_workers, consumer_task_idx)`. Frame header is
-    /// `(stage_id, q)` so the consumer's
-    /// `execute(P_c * task_index + p_local)` finds it via the
-    /// per-`(stage_id, partition)` channel buffer registry.
+    /// Hash-partitioned mesh ([`NetworkShuffleExec`] / [`NetworkBroadcastExec`]). Output
+    /// partition `q` goes to the consumer task the crate's `route_partition(q)` selects,
+    /// hosted on `proc_for_task(n_workers, consumer_task)`. Precomputed per output partition:
+    /// the crate owns the receive-side formula, so the producer side reads it from
+    /// `route_partition` rather than re-deriving `q / P_c`.
     ///
     /// [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
-    Shuffle {
-        /// `B.properties().output_partitioning().partition_count()`. Equal to
-        /// `P_c` in the receive-side formula `off = P_c * task_index`.
-        partitions_per_consumer_task: usize,
-    },
-    /// Broadcast mesh ([`NetworkBroadcastExec`]). Wire-level math matches [`Self::Shuffle`]
-    /// (`q → q / P_c`).
-    ///
-    /// Delta from upstream: we cap the build subtree at `task_count = 1` via
-    /// [`BroadcastBuildSideOneTaskEstimator`], so the dispatcher only ever sees `task_idx == 0`
-    /// fragments here. The estimator relies on the AggregateScan all-gather step canonical-
-    /// replicating the build side; a future planner that emits `NetworkBroadcastExec` over a
-    /// sharded child would silently drop shards under this rule and needs a new routing variant.
-    ///
     /// [`NetworkBroadcastExec`]: datafusion_distributed::NetworkBroadcastExec
-    /// [`BroadcastBuildSideOneTaskEstimator`]: crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator
-    Broadcast {
-        /// `B.properties().output_partitioning().partition_count()`. Same
-        /// semantics as
-        /// [`Self::Shuffle::partitions_per_consumer_task`].
-        partitions_per_consumer_task: usize,
+    Hashed {
+        /// `route_partition(q).consumer_task` for each producer output partition `q`.
+        consumer_task: Vec<u32>,
+        /// `true` for broadcast. The build subtree is capped at `task_count = 1` via
+        /// [`BroadcastBuildSideOneTaskEstimator`], so the dispatcher only ever sees
+        /// `task_idx == 0` broadcast fragments; the cap is asserted at dispatch.
+        ///
+        /// [`BroadcastBuildSideOneTaskEstimator`]: crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator
+        broadcast: bool,
     },
 }
 
@@ -144,22 +132,13 @@ pub fn find_worker_assignments(
                     f.task_idx,
                     f.task_count,
                 ),
-                FragmentRouting::Shuffle {
-                    partitions_per_consumer_task,
+                FragmentRouting::Hashed {
+                    consumer_task,
+                    broadcast,
                 } => crate::mpp_log!(
                     "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
-                     n_out={n_out} routing=Shuffle \
-                     partitions_per_consumer_task={partitions_per_consumer_task}",
-                    f.stage_id,
-                    f.task_idx,
-                    f.task_count,
-                ),
-                FragmentRouting::Broadcast {
-                    partitions_per_consumer_task,
-                } => crate::mpp_log!(
-                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
-                     n_out={n_out} routing=Broadcast \
-                     partitions_per_consumer_task={partitions_per_consumer_task}",
+                     n_out={n_out} routing=Hashed broadcast={broadcast} \
+                     consumer_task={consumer_task:?}",
                     f.stage_id,
                     f.task_idx,
                     f.task_count,
@@ -180,10 +159,20 @@ fn collect(
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
         let stage_id = stage.num() as u32;
-        // Per-consumer-task partition count, read from the boundary's own routing contract
-        // instead of re-deriving the receive-side formula. The crate owns `route_partition`
-        // now, so producer-side routing follows it automatically.
+        // Per-consumer-task partition count, kept for the trace below. Routing itself reads the
+        // crate's `route_partition` so the producer side follows the receive-side formula the
+        // crate owns, rather than re-deriving `q / P_c`.
         let p_c = nb.partitions_per_consumer_task();
+        // `route_partition(q).consumer_task` for every producer output partition. Used by the
+        // hash-partitioned boundaries (Shuffle / Broadcast) only; Coalesce routes by task instead.
+        let route_consumer_tasks = || {
+            let n_out = stage
+                .local_plan()
+                .map_or(0, |p| p.properties().partitioning.partition_count());
+            (0..n_out)
+                .map(|q| nb.route_partition(q).consumer_task as u32)
+                .collect::<Vec<u32>>()
+        };
         let plan_any = plan.as_ref().as_any();
 
         // Classify the boundary by downcasting to its concrete `Network*Exec` type, then pick a
@@ -207,9 +196,10 @@ fn collect(
         } else if plan_any.is::<NetworkShuffleExec>() {
             if nested {
                 // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps
-                // to consumer task q / p_c.
-                FragmentRouting::Shuffle {
-                    partitions_per_consumer_task: p_c,
+                // to the consumer task `route_partition(q)` selects.
+                FragmentRouting::Hashed {
+                    consumer_task: route_consumer_tasks(),
+                    broadcast: false,
                 }
             } else {
                 // Top-level NetworkShuffleExec isn't a shape our customscan plans produce.
@@ -225,11 +215,12 @@ fn collect(
             }
         } else if plan_any.is::<NetworkBroadcastExec>() {
             if nested {
-                // Nested NetworkBroadcastExec: same wire-level math as Shuffle, but the dispatcher
-                // only runs the producer plan on task 0 to avoid the canonical-replica duplication
-                // described on `FragmentRouting::Broadcast`.
-                FragmentRouting::Broadcast {
-                    partitions_per_consumer_task: p_c,
+                // Nested NetworkBroadcastExec: same receive-side routing as Shuffle (via
+                // `route_partition`), but the dispatcher only runs the producer plan on task 0 to
+                // avoid the canonical-replica duplication described on `FragmentRouting::Hashed`.
+                FragmentRouting::Hashed {
+                    consumer_task: route_consumer_tasks(),
+                    broadcast: true,
                 }
             } else {
                 // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan
@@ -316,15 +307,20 @@ mod tests {
     }
 
     #[test]
-    fn routing_shuffle_carries_pc() {
-        let r = FragmentRouting::Shuffle {
-            partitions_per_consumer_task: 3,
+    fn routing_hashed_carries_consumer_tasks() {
+        let r = FragmentRouting::Hashed {
+            consumer_task: vec![0, 0, 1],
+            broadcast: false,
         };
         match r {
-            FragmentRouting::Shuffle {
-                partitions_per_consumer_task,
-            } => assert_eq!(partitions_per_consumer_task, 3),
-            _ => panic!("expected Shuffle"),
+            FragmentRouting::Hashed {
+                consumer_task,
+                broadcast,
+            } => {
+                assert_eq!(consumer_task, vec![0, 0, 1]);
+                assert!(!broadcast);
+            }
+            _ => panic!("expected Hashed"),
         }
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -134,7 +134,9 @@ fn collect_stages(
         let stage_id = stage.num() as u32;
         // Per-consumer-task partition count, kept for the trace below. Routing itself reads the
         // crate's `route_partition` so the producer side follows the receive-side formula the
-        // crate owns, rather than re-deriving `q / P_c`.
+        // crate owns, rather than re-deriving `q / P_c`. Only the `mpp_log!` trace reads it, so it
+        // is gated to non-test builds to avoid an unused-variable warning under the test cfg.
+        #[cfg(not(test))]
         let p_c = nb.partitions_per_consumer_task();
         // `route_partition(q).consumer_task` for every producer output partition. Used by the
         // hash-partitioned boundaries (Shuffle / Broadcast) only; Coalesce routes by task instead.

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -41,8 +41,6 @@
 use std::sync::Arc;
 
 use datafusion::physical_plan::ExecutionPlan;
-#[cfg(not(test))]
-use datafusion::physical_plan::ExecutionPlanProperties;
 use datafusion_distributed::{
     NetworkBoundaryExt, NetworkBroadcastExec, NetworkCoalesceExec, NetworkShuffleExec,
 };
@@ -70,7 +68,7 @@ pub struct FragmentAssignment {
 }
 
 /// Routing rule for a fragment's output partitions.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub enum FragmentRouting {
     /// All output partitions go to one destination proc (`NetworkCoalesceExec`
     /// or the top-level gather case). Coalesce routes by producer task, not by
@@ -102,59 +100,36 @@ pub enum FragmentRouting {
     },
 }
 
-/// Walk `root` (the worker's physical plan) and collect every fragment
-/// assigned to `this_proc` under the `proc_for_task` round-robin policy.
-/// Returns one [`FragmentAssignment`] per `(stage_id, task_idx)` pair
-/// hosted by this proc; the dispatcher spawns one async task per entry.
-pub fn find_worker_assignments(
-    root: &Arc<dyn ExecutionPlan>,
-    this_proc: u32,
-    n_workers: u32,
-) -> Vec<FragmentAssignment> {
+/// One producer stage to dispatch. The leader serializes `plan` once per stage and ships it with
+/// its `task_count` and `routing`; each worker expands a stage into one [`FragmentAssignment`] per
+/// `task_idx` it owns under `proc_for_task`.
+pub struct StageEntry {
+    /// `input_stage.num` of the boundary whose producer side this stage belongs to.
+    pub stage_num: u32,
+    /// Total task count for the stage (= `input_stage.tasks.len()`).
+    pub task_count: usize,
+    /// How to route each output partition to a destination proc.
+    pub routing: FragmentRouting,
+    /// The stage's `input_stage.plan` (nested boundaries left `Local`; the worker converts them
+    /// at run time via `prepare_in_process_plan`, same as before).
+    pub plan: Arc<dyn ExecutionPlan>,
+}
+
+/// Walk the distributed physical plan and collect every producer stage, once per boundary. The
+/// leader runs this (replacing the worker-side re-plan): it classifies routing from the boundary
+/// type and captures each stage's `local_plan` for serialization. Not filtered by proc; the blob
+/// is shared and each worker selects its own `(stage, task)` slots.
+pub fn collect_dispatched_stages(root: &Arc<dyn ExecutionPlan>, n_workers: u32) -> Vec<StageEntry> {
     let mut out = Vec::new();
-    collect(
-        root, this_proc, n_workers, /* nested = */ false, &mut out,
-    );
-    #[cfg(not(test))]
-    {
-        crate::mpp_log!(
-            "mpp worker_fragments::find_worker_assignments this_proc={} fragments={}",
-            this_proc,
-            out.len()
-        );
-        for f in &out {
-            let n_out = f.plan.output_partitioning().partition_count();
-            match &f.routing {
-                FragmentRouting::Coalesce { dest_proc } => crate::mpp_log!(
-                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
-                     n_out={n_out} routing=Coalesce dest_proc={dest_proc}",
-                    f.stage_id,
-                    f.task_idx,
-                    f.task_count,
-                ),
-                FragmentRouting::Hashed {
-                    consumer_task,
-                    broadcast,
-                } => crate::mpp_log!(
-                    "mpp worker_fragments fragment stage_id={} task_idx={} task_count={} \
-                     n_out={n_out} routing=Hashed broadcast={broadcast} \
-                     consumer_task={consumer_task:?}",
-                    f.stage_id,
-                    f.task_idx,
-                    f.task_count,
-                ),
-            }
-        }
-    }
+    collect_stages(root, n_workers, /* nested = */ false, &mut out);
     out
 }
 
-fn collect(
+fn collect_stages(
     plan: &Arc<dyn ExecutionPlan>,
-    this_proc: u32,
     n_workers: u32,
     nested: bool,
-    out: &mut Vec<FragmentAssignment>,
+    out: &mut Vec<StageEntry>,
 ) {
     if let Some(nb) = plan.as_ref().as_network_boundary() {
         let stage = nb.input_stage();
@@ -248,7 +223,7 @@ fn collect(
         #[cfg(not(test))]
         {
             crate::mpp_log!(
-                "mpp worker_fragments::collect boundary={} stage_id={stage_id} \
+                "mpp worker_fragments::collect_stages boundary={} stage_id={stage_id} \
                  p_c={p_c} nested={nested}",
                 plan.name()
             );
@@ -256,28 +231,22 @@ fn collect(
 
         let task_count = stage.task_count();
         if let Some(stage_plan) = stage.local_plan() {
-            for task_idx in 0..task_count {
-                let owner = proc_for_task(n_workers, task_idx as u32);
-                if owner == this_proc {
-                    out.push(FragmentAssignment {
-                        stage_id,
-                        task_idx,
-                        task_count,
-                        plan: Arc::clone(stage_plan),
-                        routing: routing.clone(),
-                    });
-                }
-            }
+            out.push(StageEntry {
+                stage_num: stage_id,
+                task_count,
+                routing,
+                plan: Arc::clone(stage_plan),
+            });
             // Recurse into the stage's plan with `nested = true`. The boundary's `children()`
             // returns `[stage.plan]`, so descending through it would double-process every nested
-            // fragment. Return here to keep visit counts exact.
-            collect(stage_plan, this_proc, n_workers, true, out);
+            // stage. Return here to keep visit counts exact.
+            collect_stages(stage_plan, n_workers, true, out);
         }
         return;
     }
     // Non-boundary nodes recurse through plan children.
     for child in plan.children() {
-        collect(child, this_proc, n_workers, nested, out);
+        collect_stages(child, n_workers, nested, out);
     }
 }
 
@@ -288,10 +257,10 @@ mod tests {
     use datafusion::physical_plan::empty::EmptyExec;
 
     #[test]
-    fn boundary_free_plan_returns_no_assignments() {
+    fn boundary_free_plan_yields_no_stages() {
         let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
         let plan: Arc<dyn ExecutionPlan> = Arc::new(EmptyExec::new(schema));
-        let out = find_worker_assignments(&plan, 1, 3);
+        let out = collect_dispatched_stages(&plan, 3);
         assert!(out.is_empty());
     }
 

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -15,25 +15,23 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Worker-side fragment discovery for the multi-fragment runner.
+//! Leader-side producer-stage discovery for coordinator dispatch.
 //!
-//! [`find_worker_assignments`] walks a worker's physical plan, visits every
-//! [`datafusion_distributed::NetworkBoundary`], and collects the
-//! `(input_stage.num, task_idx, plan, routing)` tuples assigned to a given
-//! `this_proc`. The dispatcher driven by [`mpp::host::exec_mpp_worker`] runs one
-//! fragment per returned [`FragmentAssignment`].
+//! [`collect_dispatched_stages`] walks the distributed physical plan, visits every
+//! [`datafusion_distributed::NetworkBoundary`], and collects one [`StageEntry`]
+//! (`input_stage.num`, `task_count`, `routing`, `plan`) per boundary. The leader serializes each
+//! stage's plan and ships it; each worker later expands a stage into one [`FragmentAssignment`]
+//! per `task_idx` it owns under `proc_for_task`.
 //!
-//! The walker tracks a `ParentContext` per recursion level so nested
-//! boundaries know which OUTER stage's tasks consume their output. The
-//! routing math (which proc to send partition `q` to) depends on this:
+//! Routing classification (which proc an output partition `q` is sent to) depends on the
+//! boundary's position:
 //!
-//! - **Top-level boundary** (`parent = None`): the consumer is the leader at
+//! - **Top-level boundary** (`nested = false`): the consumer is the leader at
 //!   proc 0. Every output partition goes there.
-//! - **Nested boundary inside outer stage `S_outer.plan`**: the consumer is
-//!   one of `S_outer`'s tasks. For [`NetworkShuffleExec`] the routing is
-//!   hash-partitioned (partition `q` → consumer task `q / P_c` where `P_c`
-//!   is the per-consumer-task output count); for [`NetworkCoalesceExec`]
-//!   the routing collapses to a single consumer task.
+//! - **Nested boundary inside an outer stage**: the consumer is one of that stage's
+//!   tasks. For [`NetworkShuffleExec`] the routing is hash-partitioned (partition `q` →
+//!   the consumer task `route_partition(q)` picks); for [`NetworkCoalesceExec`] the
+//!   routing collapses to a single consumer task.
 //!
 //! [`NetworkShuffleExec`]: datafusion_distributed::NetworkShuffleExec
 //! [`NetworkCoalesceExec`]: datafusion_distributed::NetworkCoalesceExec

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -89,7 +89,7 @@ pub struct ScannerConfig {
     pub which_fast_fields: Vec<WhichFastField>,
     pub heap_relid: u32,
     pub batch_size_hint: Option<usize>,
-    /// `need_scores` the index reader was opened with. Carried so a coordinator-dispatched worker
+    /// `need_scores` the index reader was opened with. Carried so a leader-dispatched worker
     /// re-opens its reader with the same scoring behavior (the reader itself can't travel).
     pub score_needed: bool,
 }
@@ -112,7 +112,8 @@ pub enum ScanRecipe {
         /// Position in the compacted non-partitioning source list, the index space of the
         /// codec-injected canonical segment sets. Sibling of `source_idx`, which is the
         /// all-sources position; the two diverge for any source after the partitioning one.
-        /// Only consulted when decoding without a `ParallelScanState`.
+        /// Only consulted when decoding without a `ParallelScanState`, i.e. the leader's
+        /// build-time validation round-trip of the dispatch blob.
         non_partitioning_index: Option<usize>,
         planner_estimated_rows: u64,
         scanner_config: ScannerConfig,
@@ -161,7 +162,7 @@ pub struct PgSearchScanPlan {
     /// the states have been consumed.
     partition_row_counts: Vec<u64>,
     properties: Arc<PlanProperties>,
-    query_for_display: SearchQueryInput,
+    resolved_query: SearchQueryInput,
     /// Dynamic filters pushed down from parent operators (e.g. Top K threshold
     /// from SortExec, join-key bounds from HashJoinExec). Each batch produced
     /// by the scanner is filtered against all of these expressions so that rows
@@ -210,13 +211,14 @@ impl PgSearchScanPlan {
     ///
     /// * `states` - The list of pre-opened segments (one per partition)
     /// * `schema` - Arrow schema for the output
-    /// * `query_for_display` - Search query for EXPLAIN
+    /// * `resolved_query` - The filter-combined, param-solved query the readers were opened
+    ///   with. Used for EXPLAIN and shipped on dispatch.
     /// * `sort_order` - Optional sort order declaration for equivalence properties
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         states: Vec<ScanState>,
         schema: SchemaRef,
-        query_for_display: SearchQueryInput,
+        resolved_query: SearchQueryInput,
         sort_order: Option<&SortByField>,
         deferred_fields: Vec<DeferredField>,
         ffhelper: Option<Arc<FFHelper>>,
@@ -267,7 +269,7 @@ impl PgSearchScanPlan {
             states: Mutex::new(wrapped_states),
             partition_row_counts,
             properties,
-            query_for_display,
+            resolved_query,
             dynamic_filters: Vec::new(),
             metrics: ExecutionPlanMetricsSet::new(),
             deferred_fields,
@@ -292,11 +294,11 @@ impl PgSearchScanPlan {
         self.deferred_ctid_plan_position
     }
 
-    /// Serialize this scan into a transport-neutral descriptor for coordinator dispatch.
+    /// Serialize this scan into a transport-neutral descriptor for leader dispatch.
     ///
     /// Only the recipe and the reader-rebuild inputs travel; the live `ScanState` (tantivy
     /// readers, visibility checkers) is process-local and gets rebuilt on the receiving worker
-    /// from its own `ParallelScanState`. `query_for_display` is the filter-combined,
+    /// from its own `ParallelScanState`. `resolved_query` is the filter-combined,
     /// param-solved query the reader was opened with, so the receiver needs no `ExprContext`.
     pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
         let states = self
@@ -345,7 +347,7 @@ impl PgSearchScanPlan {
 
         let descriptor = ScanDispatchDescriptor {
             schema_proto: prost::Message::encode_to_vec(&schema_proto),
-            query: self.query_for_display.clone(),
+            query: self.resolved_query.clone(),
             score_needed: scanner_config.score_needed,
             sort_order: self.sort_order.clone(),
             indexrelid: self.indexrelid,
@@ -481,7 +483,7 @@ impl PgSearchScanPlan {
     }
 }
 
-/// Transport-neutral description of a `PgSearchScanPlan` for coordinator dispatch. Carries the
+/// Transport-neutral description of a `PgSearchScanPlan` for leader dispatch. Carries the
 /// recipe plus the inputs needed to re-open the reader on the receiving worker; the live tantivy
 /// state is rebuilt there from the worker's own `ParallelScanState`.
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -587,7 +589,7 @@ impl DisplayAs for PgSearchScanPlan {
                 write!(f, ", dynamic_filter_pushdown={}", strategy_name(strategy))?;
             }
         }
-        write!(f, ", query={}", self.query_for_display.explain_format())
+        write!(f, ", query={}", self.resolved_query.explain_format())
     }
 }
 
@@ -845,13 +847,13 @@ impl ExecutionPlan for PgSearchScanPlan {
                 .drain(..)
                 .collect();
 
-            let query_for_display = self.query_for_display.clone();
+            let resolved_query = self.resolved_query.clone();
 
             let new_plan = Arc::new(PgSearchScanPlan {
                 states: Mutex::new(states),
                 partition_row_counts: self.partition_row_counts.clone(),
                 properties: self.properties.clone(),
-                query_for_display,
+                resolved_query,
                 dynamic_filters,
                 metrics: self.metrics.clone(),
                 deferred_fields: self.deferred_fields.clone(),
@@ -947,7 +949,7 @@ impl<T: Stream<Item = Result<RecordBatch>>> RecordBatchStream for UnsafeSendStre
 pub fn create_sorted_scan(
     states: Vec<ScanState>,
     schema: SchemaRef,
-    query_for_display: SearchQueryInput,
+    resolved_query: SearchQueryInput,
     sort_order: &SortByField,
     indexrelid: u32,
 ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -968,7 +970,7 @@ pub fn create_sorted_scan(
     let segment_scan = Arc::new(PgSearchScanPlan::new(
         states,
         schema.clone(),
-        query_for_display,
+        resolved_query,
         Some(sort_order),
         Vec::new(),
         None,

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -384,11 +384,14 @@ impl PgSearchScanPlan {
                 MvccSatisfies::ParallelWorker(unsafe { (*ps).segment_ids_for_source(idx) })
             }
             (Some(idx), None) => {
-                let ids = non_partitioning_segment_ids.get(idx).cloned().ok_or_else(|| {
-                    DataFusionError::Internal(format!(
-                        "PgSearchScan dispatch: missing canonical segment ids for source {idx}"
-                    ))
-                })?;
+                let ids = non_partitioning_segment_ids
+                    .get(idx)
+                    .cloned()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "PgSearchScan dispatch: missing canonical segment ids for source {idx}"
+                        ))
+                    })?;
                 MvccSatisfies::ParallelWorker(ids)
             }
             (None, None) => MvccSatisfies::Snapshot,
@@ -409,7 +412,10 @@ impl PgSearchScanPlan {
             DataFusionError::Internal(format!("PgSearchScan dispatch: open reader: {e}"))
         })?;
 
-        let ffhelper = Arc::new(FFHelper::with_fields(&reader, &descriptor.which_fast_fields));
+        let ffhelper = Arc::new(FFHelper::with_fields(
+            &reader,
+            &descriptor.which_fast_fields,
+        ));
         let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
         let visibility = VisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
 

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -109,6 +109,11 @@ pub enum ScanRecipe {
     Lazy {
         parallel_state: Option<*mut ParallelScanState>,
         source_idx: Option<usize>,
+        /// Position in the compacted non-partitioning source list, the index space of the
+        /// codec-injected canonical segment sets. Sibling of `source_idx`, which is the
+        /// all-sources position; the two diverge for any source after the partitioning one.
+        /// Only consulted when decoding without a `ParallelScanState`.
+        non_partitioning_index: Option<usize>,
         planner_estimated_rows: u64,
         scanner_config: ScannerConfig,
     },
@@ -309,20 +314,28 @@ impl PgSearchScanPlan {
         let state = states[0].as_ref().ok_or_else(|| {
             DataFusionError::Internal("PgSearchScan dispatch: partition already consumed".into())
         })?;
-        let (source_idx, planner_estimated_rows, scanner_config) = match &state.0.recipe {
-            ScanRecipe::Lazy {
-                source_idx,
-                planner_estimated_rows,
-                scanner_config,
-                ..
-            } => (*source_idx, *planner_estimated_rows, scanner_config.clone()),
-            _ => {
-                return Err(DataFusionError::NotImplemented(
-                    "PgSearchScan dispatch: only the lazy single-partition recipe is supported"
-                        .into(),
-                ))
-            }
-        };
+        let (source_idx, non_partitioning_index, planner_estimated_rows, scanner_config) =
+            match &state.0.recipe {
+                ScanRecipe::Lazy {
+                    source_idx,
+                    non_partitioning_index,
+                    planner_estimated_rows,
+                    scanner_config,
+                    ..
+                } => (
+                    *source_idx,
+                    *non_partitioning_index,
+                    *planner_estimated_rows,
+                    scanner_config.clone(),
+                ),
+                _ => {
+                    return Err(DataFusionError::NotImplemented(
+                        "PgSearchScan dispatch: only the lazy single-partition recipe is \
+                         supported"
+                            .into(),
+                    ))
+                }
+            };
 
         let schema = self.properties.eq_properties.schema().clone();
         let schema_proto: datafusion_proto::protobuf::Schema =
@@ -342,6 +355,7 @@ impl PgSearchScanPlan {
             heap_relid: scanner_config.heap_relid,
             batch_size_hint: scanner_config.batch_size_hint,
             source_idx,
+            non_partitioning_index,
             planner_estimated_rows,
         };
         serde_json::to_vec(&descriptor).map_err(|e| {
@@ -384,12 +398,20 @@ impl PgSearchScanPlan {
                 MvccSatisfies::ParallelWorker(unsafe { (*ps).segment_ids_for_source(idx) })
             }
             (Some(idx), None) => {
+                // `idx` is the all-sources position, but the canonical sets are indexed by the
+                // compacted non-partitioning list; the descriptor carries that index separately.
+                let np_idx = descriptor.non_partitioning_index.ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "PgSearchScan dispatch: source {idx} has no non-partitioning index"
+                    ))
+                })?;
                 let ids = non_partitioning_segment_ids
-                    .get(idx)
+                    .get(np_idx)
                     .cloned()
                     .ok_or_else(|| {
                         DataFusionError::Internal(format!(
-                            "PgSearchScan dispatch: missing canonical segment ids for source {idx}"
+                            "PgSearchScan dispatch: missing canonical segment ids for \
+                             non-partitioning source {np_idx} (all-sources {idx})"
                         ))
                     })?;
                 MvccSatisfies::ParallelWorker(ids)
@@ -429,6 +451,7 @@ impl PgSearchScanPlan {
             recipe: ScanRecipe::Lazy {
                 parallel_state,
                 source_idx: descriptor.source_idx,
+                non_partitioning_index: descriptor.non_partitioning_index,
                 planner_estimated_rows: descriptor.planner_estimated_rows,
                 scanner_config,
             },
@@ -475,8 +498,11 @@ struct ScanDispatchDescriptor {
     heap_relid: u32,
     batch_size_hint: Option<usize>,
     /// `Some(i)` for an MPP non-partitioning source (claims from source `i`'s pool); `None` for
-    /// the partitioning source / single-counter checkout.
+    /// the partitioning source / single-counter checkout. All-sources position.
     source_idx: Option<usize>,
+    /// Position in the compacted non-partitioning source list, the index space of the canonical
+    /// segment sets a decode without `ParallelScanState` looks up.
+    non_partitioning_index: Option<usize>,
     planner_estimated_rows: u64,
 }
 
@@ -694,6 +720,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                         ScanRecipe::Lazy {
                             parallel_state,
                             source_idx,
+                            non_partitioning_index: _,
                             planner_estimated_rows,
                             scanner_config,
                         } => {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -57,17 +57,22 @@ use datafusion::physical_plan::{
 use futures::Stream;
 use tantivy::index::SegmentId;
 
+use crate::api::HashSet;
 use crate::index::fast_fields_helper::FFHelper;
 use crate::index::fast_fields_helper::WhichFastField;
+use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::customscan::explain::ExplainFormat;
+use crate::postgres::customscan::parallel::list_segment_ids;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::{SortByDirection, SortByField};
+use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::ParallelScanState;
 use crate::query::SearchQueryInput;
 use crate::scan::late_materialization::DeferredField;
 use crate::scan::pre_filter::{collect_filters, try_dynamic_filter_pushdown, PreFilter};
 use crate::scan::Scanner;
+use pgrx::pg_sys;
 
 /// A wrapper that implements Send + Sync unconditionally.
 /// UNSAFE: Only use this when you guarantee single-threaded access or manual synchronization.
@@ -278,6 +283,193 @@ impl PgSearchScanPlan {
     pub fn deferred_ctid_plan_position(&self) -> Option<usize> {
         self.deferred_ctid_plan_position
     }
+
+    /// Serialize this scan into a transport-neutral descriptor for coordinator dispatch.
+    ///
+    /// Only the recipe and the reader-rebuild inputs travel; the live `ScanState` (tantivy
+    /// readers, visibility checkers) is process-local and gets rebuilt on the receiving worker
+    /// from its own `ParallelScanState`. `query_for_display` is the filter-combined,
+    /// param-solved query the reader was opened with, so the receiver needs no `ExprContext`.
+    pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
+        let states = self
+            .states
+            .lock()
+            .map_err(|e| DataFusionError::Internal(format!("lock PgSearchScanPlan states: {e}")))?;
+        // The dispatch path only ships the single-partition lazy scan (the MPP natural-shape
+        // leaf). Sorted/eager multi-partition scans aren't dispatched yet.
+        if states.len() != 1 {
+            return Err(DataFusionError::NotImplemented(format!(
+                "PgSearchScan dispatch: expected 1 partition, found {}",
+                states.len()
+            )));
+        }
+        let state = states[0].as_ref().ok_or_else(|| {
+            DataFusionError::Internal("PgSearchScan dispatch: partition already consumed".into())
+        })?;
+        let (source_idx, planner_estimated_rows, scanner_config) = match &state.0.recipe {
+            ScanRecipe::Lazy {
+                source_idx,
+                planner_estimated_rows,
+                scanner_config,
+                ..
+            } => (*source_idx, *planner_estimated_rows, scanner_config.clone()),
+            _ => {
+                return Err(DataFusionError::NotImplemented(
+                    "PgSearchScan dispatch: only the lazy single-partition recipe is supported"
+                        .into(),
+                ))
+            }
+        };
+
+        let schema = self.properties.eq_properties.schema().clone();
+        let schema_proto: datafusion_proto::protobuf::Schema =
+            schema.as_ref().try_into().map_err(|e| {
+                DataFusionError::Internal(format!("PgSearchScan dispatch: schema encode: {e}"))
+            })?;
+
+        let descriptor = ScanDispatchDescriptor {
+            schema_proto: prost::Message::encode_to_vec(&schema_proto),
+            query: self.query_for_display.clone(),
+            // Scored scans aren't on the aggregate dispatch path yet; thread this through when
+            // the topk/scored paths land.
+            score_needed: false,
+            sort_order: self.sort_order.clone(),
+            indexrelid: self.indexrelid,
+            deferred_fields: self.deferred_fields.clone(),
+            deferred_ctid_plan_position: self.deferred_ctid_plan_position,
+            which_fast_fields: scanner_config.which_fast_fields,
+            heap_relid: scanner_config.heap_relid,
+            batch_size_hint: scanner_config.batch_size_hint,
+            source_idx,
+            planner_estimated_rows,
+        };
+        serde_json::to_vec(&descriptor).map_err(|e| {
+            DataFusionError::Internal(format!("PgSearchScan dispatch: serialize: {e}"))
+        })
+    }
+
+    /// Rebuild a scan from a dispatch descriptor, injecting the receiving worker's runtime
+    /// state. Mirrors the tail of `PgSearchTableProvider::scan_inner`: open the index reader
+    /// under the worker's MVCC view, build the fast-field helper + visibility checker, and wrap
+    /// a single lazy partition that claims segments at runtime from `parallel_state`.
+    pub(crate) fn decode_for_dispatch(
+        buf: &[u8],
+        parallel_state: Option<*mut ParallelScanState>,
+        non_partitioning_segment_ids: &[HashSet<SegmentId>],
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let descriptor: ScanDispatchDescriptor = serde_json::from_slice(buf).map_err(|e| {
+            DataFusionError::Internal(format!("PgSearchScan dispatch: deserialize: {e}"))
+        })?;
+
+        let schema_proto = <datafusion_proto::protobuf::Schema as prost::Message>::decode(
+            descriptor.schema_proto.as_slice(),
+        )
+        .map_err(|e| {
+            DataFusionError::Internal(format!("PgSearchScan dispatch: schema decode: {e}"))
+        })?;
+        let schema: SchemaRef = Arc::new((&schema_proto).try_into().map_err(|e| {
+            DataFusionError::Internal(format!("PgSearchScan dispatch: schema parse: {e}"))
+        })?);
+
+        let index_rel = PgSearchRelation::open(pg_sys::Oid::from(descriptor.indexrelid));
+        let heap_rel = PgSearchRelation::open(pg_sys::Oid::from(descriptor.heap_relid));
+
+        // MVCC view: the partitioning source (source_idx None) reads the worker's full segment
+        // list from `ParallelScanState`; a non-partitioning source reads its frozen per-source
+        // set. Mirrors the MVCC dispatch in `scan_inner`.
+        let mvcc = match (descriptor.source_idx, parallel_state) {
+            (None, Some(ps)) => MvccSatisfies::ParallelWorker(unsafe { list_segment_ids(ps) }),
+            (Some(idx), Some(ps)) => {
+                MvccSatisfies::ParallelWorker(unsafe { (*ps).segment_ids_for_source(idx) })
+            }
+            (Some(idx), None) => {
+                let ids = non_partitioning_segment_ids.get(idx).cloned().ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "PgSearchScan dispatch: missing canonical segment ids for source {idx}"
+                    ))
+                })?;
+                MvccSatisfies::ParallelWorker(ids)
+            }
+            (None, None) => MvccSatisfies::Snapshot,
+        };
+
+        let query = descriptor.query;
+        let needs_tokenizer = query.needs_tokenizer();
+        let reader = SearchIndexReader::open_with_context(
+            &index_rel,
+            query.clone(),
+            descriptor.score_needed,
+            mvcc,
+            None, // expr_context: the query ships pre-solved
+            None, // planstate: same
+            needs_tokenizer,
+        )
+        .map_err(|e| {
+            DataFusionError::Internal(format!("PgSearchScan dispatch: open reader: {e}"))
+        })?;
+
+        let ffhelper = Arc::new(FFHelper::with_fields(&reader, &descriptor.which_fast_fields));
+        let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
+        let visibility = VisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
+
+        let scanner_config = ScannerConfig {
+            which_fast_fields: descriptor.which_fast_fields,
+            heap_relid: descriptor.heap_relid,
+            batch_size_hint: descriptor.batch_size_hint,
+        };
+        let state = ScanState {
+            recipe: ScanRecipe::Lazy {
+                parallel_state,
+                source_idx: descriptor.source_idx,
+                planner_estimated_rows: descriptor.planner_estimated_rows,
+                scanner_config,
+            },
+            ffhelper: Arc::clone(&ffhelper),
+            visibility: Box::new(visibility) as Box<VisibilityChecker>,
+            reader,
+        };
+
+        let deferred = descriptor.deferred_fields;
+        let deferred_ctid_plan_position = descriptor.deferred_ctid_plan_position;
+        let ffhelper_arg = if deferred.is_empty() && deferred_ctid_plan_position.is_none() {
+            None
+        } else {
+            Some(ffhelper)
+        };
+
+        Ok(Arc::new(PgSearchScanPlan::new(
+            vec![state],
+            schema,
+            query,
+            descriptor.sort_order.as_ref(),
+            deferred,
+            ffhelper_arg,
+            descriptor.indexrelid,
+            deferred_ctid_plan_position,
+        )))
+    }
+}
+
+/// Transport-neutral description of a `PgSearchScanPlan` for coordinator dispatch. Carries the
+/// recipe plus the inputs needed to re-open the reader on the receiving worker; the live tantivy
+/// state is rebuilt there from the worker's own `ParallelScanState`.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ScanDispatchDescriptor {
+    /// Arrow schema, `datafusion_proto::protobuf::Schema`-encoded (arrow schema isn't serde).
+    schema_proto: Vec<u8>,
+    query: SearchQueryInput,
+    score_needed: bool,
+    sort_order: Option<SortByField>,
+    indexrelid: u32,
+    deferred_fields: Vec<DeferredField>,
+    deferred_ctid_plan_position: Option<usize>,
+    which_fast_fields: Vec<WhichFastField>,
+    heap_relid: u32,
+    batch_size_hint: Option<usize>,
+    /// `Some(i)` for an MPP non-partitioning source (claims from source `i`'s pool); `None` for
+    /// the partitioning source / single-counter checkout.
+    source_idx: Option<usize>,
+    planner_estimated_rows: u64,
 }
 
 /// Build `EquivalenceProperties` with the specified sort ordering.

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -89,6 +89,9 @@ pub struct ScannerConfig {
     pub which_fast_fields: Vec<WhichFastField>,
     pub heap_relid: u32,
     pub batch_size_hint: Option<usize>,
+    /// `need_scores` the index reader was opened with. Carried so a coordinator-dispatched worker
+    /// re-opens its reader with the same scoring behavior (the reader itself can't travel).
+    pub score_needed: bool,
 }
 
 /// Recipe for a scan partition.
@@ -330,9 +333,7 @@ impl PgSearchScanPlan {
         let descriptor = ScanDispatchDescriptor {
             schema_proto: prost::Message::encode_to_vec(&schema_proto),
             query: self.query_for_display.clone(),
-            // Scored scans aren't on the aggregate dispatch path yet; thread this through when
-            // the topk/scored paths land.
-            score_needed: false,
+            score_needed: scanner_config.score_needed,
             sort_order: self.sort_order.clone(),
             indexrelid: self.indexrelid,
             deferred_fields: self.deferred_fields.clone(),
@@ -416,6 +417,7 @@ impl PgSearchScanPlan {
             which_fast_fields: descriptor.which_fast_fields,
             heap_relid: descriptor.heap_relid,
             batch_size_hint: descriptor.batch_size_hint,
+            score_needed: descriptor.score_needed,
         };
         let state = ScanState {
             recipe: ScanRecipe::Lazy {

--- a/pg_search/src/scan/filter_passthrough_exec.rs
+++ b/pg_search/src/scan/filter_passthrough_exec.rs
@@ -44,6 +44,13 @@ impl FilterPassthroughExec {
     pub fn new(inner: Arc<dyn ExecutionPlan>) -> Self {
         Self { inner }
     }
+
+    /// The wrapped node. The passthrough only matters during filter-pushdown optimization; once
+    /// the plan is finalized it delegates everything to `inner`, so coordinator dispatch strips
+    /// the wrapper and ships `inner` directly.
+    pub(crate) fn inner(&self) -> &Arc<dyn ExecutionPlan> {
+        &self.inner
+    }
 }
 
 impl DisplayAs for FilterPassthroughExec {

--- a/pg_search/src/scan/filter_passthrough_exec.rs
+++ b/pg_search/src/scan/filter_passthrough_exec.rs
@@ -46,7 +46,7 @@ impl FilterPassthroughExec {
     }
 
     /// The wrapped node. The passthrough only matters during filter-pushdown optimization; once
-    /// the plan is finalized it delegates everything to `inner`, so coordinator dispatch strips
+    /// the plan is finalized it delegates everything to `inner`, so leader dispatch strips
     /// the wrapper and ships `inner` directly.
     pub(crate) fn inner(&self) -> &Arc<dyn ExecutionPlan> {
         &self.inner

--- a/pg_search/src/scan/mod.rs
+++ b/pg_search/src/scan/mod.rs
@@ -23,6 +23,7 @@ pub mod filter_passthrough_exec;
 pub mod filter_pushdown;
 pub mod info;
 pub mod late_materialization;
+pub mod physical_codec;
 pub mod pre_filter;
 pub mod search_predicate_udf;
 pub mod segmented_topk_exec;

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -29,8 +29,7 @@ use std::sync::Arc;
 use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
-use datafusion::functions_aggregate as dfa;
-use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
+use datafusion::logical_expr::ScalarUDF;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::DistributedCodec;
 use datafusion_proto::physical_plan::{
@@ -151,24 +150,6 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         )))
     }
 
-    fn try_decode_udaf(&self, name: &str, _buf: &[u8]) -> Result<Arc<AggregateUDF>> {
-        match name {
-            "min" => Ok(dfa::min_max::min_udaf()),
-            "max" => Ok(dfa::min_max::max_udaf()),
-            "count" => Ok(dfa::count::count_udaf()),
-            "sum" => Ok(dfa::sum::sum_udaf()),
-            "avg" => Ok(dfa::average::avg_udaf()),
-            _ => Err(DataFusionError::NotImplemented(format!(
-                "PhysicalExtensionCodec is not provided for aggregate function {name}"
-            ))),
-        }
-    }
-
-    fn try_encode_udaf(&self, node: &AggregateUDF, buf: &mut Vec<u8>) -> Result<()> {
-        buf.extend_from_slice(node.name().as_bytes());
-        Ok(())
-    }
-
     fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
         if name == "pdb_search_predicate" {
             let mut udf: SearchPredicateUDF = serde_json::from_slice(buf).map_err(|e| {
@@ -180,7 +161,11 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                         .index_segment_ids
                         .get(plan_position)
                         .cloned()
-                        .expect("missing canonical segment IDs for plan_position");
+                        .ok_or_else(|| {
+                            DataFusionError::Internal(format!(
+                                "missing canonical segment IDs for plan_position {plan_position}"
+                            ))
+                        })?;
                     udf.set_canonical_segment_ids(ids);
                 }
             }
@@ -230,9 +215,9 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
             return Ok(());
         }
 
-        Err(DataFusionError::NotImplemented(format!(
-            "UDF '{name}' serialization not implemented"
-        )))
+        // Not ours: encode nothing so the expression travels by name and the decoding session
+        // resolves it from its registry (DataFusion built-ins are registered there).
+        Ok(())
     }
 }
 
@@ -243,8 +228,9 @@ struct ScanRuntime {
     ctid_plan_position: Option<usize>,
 }
 
-/// Walk a decoded subtree collecting each `PgSearchScanPlan`'s runtime handles. Stops naturally at
-/// network boundaries (a Remote stage has no children).
+/// Walk a decoded subtree collecting each `PgSearchScanPlan`'s runtime handles. Nested stages are
+/// still `Local` at decode time, so the walk descends into them. Binding a resolver to any reader
+/// it finds is fine: canonical segment sets give every proc the same `segment_ord` layout.
 fn collect_scan_runtime(plan: &Arc<dyn ExecutionPlan>, out: &mut Vec<ScanRuntime>) {
     if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
         out.push(ScanRuntime {
@@ -301,11 +287,63 @@ fn first_scan_ffhelper(input: &Arc<dyn ExecutionPlan>) -> Option<Arc<FFHelper>> 
     scans.into_iter().find_map(|s| s.ffhelper)
 }
 
+/// [`DistributedCodec`] with the pg_search UDF names carved out of its UDF/UDAF handling.
+///
+/// The composed codec takes the first `Ok` per call, and the trait's default `try_encode_udf`
+/// returns `Ok` writing nothing, so a bare `DistributedCodec` at position 0 would shadow the
+/// pg_search UDF serialization: no `fun_definition` would ever travel, and a dispatched stage
+/// retaining a `pdb_search_predicate` / `pg_expr_*` expression would fail decode on the worker
+/// (their registry has no such functions). Position 0 still matters for everything else:
+/// `prost` skips default values, so only position 0 with an empty blob encodes to zero bytes,
+/// which is what keeps registry-resolved built-ins travelling by name. So this wrapper accepts
+/// (encodes nothing for) every name except ours, and declines ours so composition falls through
+/// to [`PgSearchPhysicalExtensionCodec`], which ships the real definition.
+#[derive(Debug)]
+struct DistributedCodecHostingPgSearchUdfs(DistributedCodec);
+
+fn is_pg_search_udf(name: &str) -> bool {
+    name == "pdb_search_predicate" || name.starts_with(PG_EXPR_UDF_PREFIX)
+}
+
+impl PhysicalExtensionCodec for DistributedCodecHostingPgSearchUdfs {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        inputs: &[Arc<dyn ExecutionPlan>],
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        self.0.try_decode(buf, inputs, ctx)
+    }
+
+    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
+        self.0.try_encode(node, buf)
+    }
+
+    fn try_encode_udf(&self, node: &ScalarUDF, _buf: &mut Vec<u8>) -> Result<()> {
+        if is_pg_search_udf(node.name()) {
+            return Err(DataFusionError::NotImplemented(format!(
+                "UDF '{}' is encoded by the pg_search codec",
+                node.name()
+            )));
+        }
+        Ok(())
+    }
+
+    fn try_decode_udf(&self, name: &str, _buf: &[u8]) -> Result<Arc<ScalarUDF>> {
+        Err(DataFusionError::NotImplemented(format!(
+            "UDF '{name}' is not registered on the decoding session and carries no definition"
+        )))
+    }
+}
+
 /// Compose the fork's [`DistributedCodec`] (handles `Network*Exec` / `StageExec`) with the
 /// `pg_search` codec. Encode and decode MUST build the same list in the same order: the composed
 /// codec records each node's codec index on the wire.
 fn combined_codec(user: PgSearchPhysicalExtensionCodec) -> ComposedPhysicalExtensionCodec {
-    ComposedPhysicalExtensionCodec::new(vec![Arc::new(DistributedCodec {}), Arc::new(user)])
+    ComposedPhysicalExtensionCodec::new(vec![
+        Arc::new(DistributedCodecHostingPgSearchUdfs(DistributedCodec {})),
+        Arc::new(user),
+    ])
 }
 
 /// Serialize one stage's physical subplan for dispatch. Context-free: only the recipe travels,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -207,7 +207,9 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                 .inner()
                 .as_any()
                 .downcast_ref::<SearchPredicateUDF>()
-                .ok_or_else(|| DataFusionError::Internal("UDF is not a SearchPredicateUDF".into()))?;
+                .ok_or_else(|| {
+                    DataFusionError::Internal("UDF is not a SearchPredicateUDF".into())
+                })?;
             let bytes = serde_json::to_vec(udf).map_err(|e| {
                 DataFusionError::Internal(format!("Failed to serialize SearchPredicateUDF: {e}"))
             })?;

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Physical-plan codec for coordinator-dispatched MPP fragments.
+//! Physical-plan codec for leader-dispatched MPP fragments.
 //!
 //! The leader builds the distributed physical plan once and ships each stage's subplan to the
 //! workers; the workers run their fragments without re-planning. DataFusion's `Network*Exec`

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -26,6 +26,7 @@
 
 use std::sync::Arc;
 
+use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::functions_aggregate as dfa;
@@ -38,16 +39,23 @@ use datafusion_proto::physical_plan::{
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use tantivy::index::SegmentId;
 
-use crate::api::HashSet;
+use crate::api::{HashMap, HashSet};
+use crate::index::fast_fields_helper::FFHelper;
+use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
 use crate::postgres::customscan::pg_expr_udf::{PgExprUdf, PG_EXPR_UDF_PREFIX};
 use crate::postgres::ParallelScanState;
 use crate::scan::execution_plan::PgSearchScanPlan;
+use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
 use crate::scan::search_predicate_udf::SearchPredicateUDF;
+use crate::scan::segmented_topk_exec::SegmentedTopKExec;
+use crate::scan::tantivy_lookup_exec::TantivyLookupExec;
 
-/// Byte tag for `PgSearchScanPlan` in the extension payload. Kept even though the composed
-/// codec already records which codec decoded a node, so a future second custom exec
-/// (`FilterPassthroughExec`, `VisibilityFilterExec`, ...) can share this codec by tag.
+/// Byte tags identifying each custom exec in the extension payload. The composed codec already
+/// records which codec decoded a node; the tag picks the exec within this codec.
 const TAG_PG_SEARCH_SCAN: u8 = 2;
+const TAG_VISIBILITY_FILTER: u8 = 4;
+const TAG_TANTIVY_LOOKUP: u8 = 5;
+const TAG_SEGMENTED_TOPK: u8 = 6;
 
 /// [`PhysicalExtensionCodec`] for the `pg_search` custom execs, carrying the runtime context a
 /// worker needs to rebuild them. Encode is context-free (the leader serializes the recipe);
@@ -74,8 +82,8 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
     fn try_decode(
         &self,
         buf: &[u8],
-        _inputs: &[Arc<dyn ExecutionPlan>],
-        _ctx: &TaskContext,
+        inputs: &[Arc<dyn ExecutionPlan>],
+        ctx: &TaskContext,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let Some((&tag, payload)) = buf.split_first() else {
             return Err(DataFusionError::Internal(
@@ -88,6 +96,28 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                 self.parallel_state,
                 &self.non_partitioning_segment_ids,
             ),
+            // The deferred execs (visibility ctid resolvers, tantivy lookup, segmented top-k)
+            // carry live `FFHelper`s that can't travel. Decode is bottom-up, so the scans below
+            // are already rebuilt; pull their helpers out of the decoded subtree.
+            TAG_VISIBILITY_FILTER => {
+                let input = single_input(inputs)?;
+                let resolvers = collect_ctid_resolvers(&input);
+                VisibilityFilterExec::decode_for_dispatch(payload, input, resolvers)
+            }
+            TAG_TANTIVY_LOOKUP => {
+                let input = single_input(inputs)?;
+                let ffhelpers = collect_ffhelpers_by_indexrelid(&input);
+                TantivyLookupExec::decode_for_dispatch(payload, input, ffhelpers)
+            }
+            TAG_SEGMENTED_TOPK => {
+                let input = single_input(inputs)?;
+                let ffhelper = first_scan_ffhelper(&input).ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "SegmentedTopKExec dispatch: no scan ffhelper in subtree".into(),
+                    )
+                })?;
+                SegmentedTopKExec::decode_for_dispatch(payload, input, ffhelper, ctx)
+            }
             other => Err(DataFusionError::NotImplemented(format!(
                 "PgSearchPhysicalExtensionCodec: unknown physical node tag {other}"
             ))),
@@ -98,6 +128,21 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         if let Some(scan) = node.as_any().downcast_ref::<PgSearchScanPlan>() {
             buf.push(TAG_PG_SEARCH_SCAN);
             buf.extend_from_slice(&scan.encode_for_dispatch()?);
+            return Ok(());
+        }
+        if let Some(vis) = node.as_any().downcast_ref::<VisibilityFilterExec>() {
+            buf.push(TAG_VISIBILITY_FILTER);
+            buf.extend_from_slice(&vis.encode_for_dispatch()?);
+            return Ok(());
+        }
+        if let Some(lookup) = node.as_any().downcast_ref::<TantivyLookupExec>() {
+            buf.push(TAG_TANTIVY_LOOKUP);
+            buf.extend_from_slice(&lookup.encode_for_dispatch()?);
+            return Ok(());
+        }
+        if let Some(topk) = node.as_any().downcast_ref::<SegmentedTopKExec>() {
+            buf.push(TAG_SEGMENTED_TOPK);
+            buf.extend_from_slice(&topk.encode_for_dispatch()?);
             return Ok(());
         }
         Err(DataFusionError::NotImplemented(format!(
@@ -189,6 +234,71 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
     }
 }
 
+/// Per-scan runtime handles pulled from a decoded subtree, used to re-wire the deferred execs.
+struct ScanRuntime {
+    indexrelid: u32,
+    ffhelper: Option<Arc<FFHelper>>,
+    ctid_plan_position: Option<usize>,
+}
+
+/// Walk a decoded subtree collecting each `PgSearchScanPlan`'s runtime handles. Stops naturally at
+/// network boundaries (a Remote stage has no children).
+fn collect_scan_runtime(plan: &Arc<dyn ExecutionPlan>, out: &mut Vec<ScanRuntime>) {
+    if let Some(scan) = plan.as_any().downcast_ref::<PgSearchScanPlan>() {
+        out.push(ScanRuntime {
+            indexrelid: scan.indexrelid,
+            ffhelper: scan.ffhelper(),
+            ctid_plan_position: scan.deferred_ctid_plan_position(),
+        });
+    }
+    for child in plan.children() {
+        collect_scan_runtime(child, out);
+    }
+}
+
+fn single_input(inputs: &[Arc<dyn ExecutionPlan>]) -> Result<Arc<dyn ExecutionPlan>> {
+    match inputs {
+        [one] => Ok(Arc::clone(one)),
+        _ => Err(DataFusionError::Internal(format!(
+            "PgSearchPhysicalExtensionCodec: expected one input, got {}",
+            inputs.len()
+        ))),
+    }
+}
+
+/// `(plan_position, ffhelper)` for each scan that resolves deferred ctids, for the visibility exec.
+fn collect_ctid_resolvers(input: &Arc<dyn ExecutionPlan>) -> Vec<(usize, Arc<FFHelper>)> {
+    let mut scans = Vec::new();
+    collect_scan_runtime(input, &mut scans);
+    scans
+        .into_iter()
+        .filter_map(|s| match (s.ctid_plan_position, s.ffhelper) {
+            (Some(pos), Some(ff)) => Some((pos, ff)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// `indexrelid -> ffhelper` for the tantivy lookup exec.
+fn collect_ffhelpers_by_indexrelid(input: &Arc<dyn ExecutionPlan>) -> HashMap<u32, Arc<FFHelper>> {
+    let mut scans = Vec::new();
+    collect_scan_runtime(input, &mut scans);
+    let mut map = HashMap::default();
+    for s in scans {
+        if let Some(ff) = s.ffhelper {
+            map.insert(s.indexrelid, ff);
+        }
+    }
+    map
+}
+
+/// The first scan ffhelper below this node, for the segmented top-k exec (single source).
+fn first_scan_ffhelper(input: &Arc<dyn ExecutionPlan>) -> Option<Arc<FFHelper>> {
+    let mut scans = Vec::new();
+    collect_scan_runtime(input, &mut scans);
+    scans.into_iter().find_map(|s| s.ffhelper)
+}
+
 /// Compose the fork's [`DistributedCodec`] (handles `Network*Exec` / `StageExec`) with the
 /// `pg_search` codec. Encode and decode MUST build the same list in the same order: the composed
 /// codec records each node's codec index on the wire.
@@ -199,6 +309,17 @@ fn combined_codec(user: PgSearchPhysicalExtensionCodec) -> ComposedPhysicalExten
 /// Serialize one stage's physical subplan for dispatch. Context-free: only the recipe travels,
 /// the receiving worker injects its own runtime state on decode.
 pub fn serialize_physical_plan(plan: Arc<dyn ExecutionPlan>) -> Result<Vec<u8>> {
+    // FilterPassthroughExec only matters during filter-pushdown optimization; once the plan is
+    // finalized it delegates to its inner node, so strip it and ship the inner directly.
+    let plan = plan
+        .transform_down(|node| {
+            if let Some(fp) = node.as_any().downcast_ref::<FilterPassthroughExec>() {
+                Ok(Transformed::yes(Arc::clone(fp.inner())))
+            } else {
+                Ok(Transformed::no(node))
+            }
+        })?
+        .data;
     let codec = combined_codec(PgSearchPhysicalExtensionCodec::default());
     let proto = PhysicalPlanNode::try_from_physical_plan(plan, &codec)?;
     Ok(prost::Message::encode_to_vec(&proto))

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -1,0 +1,225 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Physical-plan codec for coordinator-dispatched MPP fragments.
+//!
+//! The leader builds the distributed physical plan once and ships each stage's subplan to the
+//! workers; the workers run their fragments without re-planning. DataFusion's `Network*Exec`
+//! boundaries are serialized by the fork's [`DistributedCodec`]; this codec handles the
+//! `pg_search` custom execs that sit inside a stage. It mirrors the LOGICAL
+//! [`crate::scan::codec`] (same UDF/UDAF handling, same per-source segment-ID injection) but
+//! travels post-optimization physical nodes instead of a logical plan.
+
+use std::sync::Arc;
+
+use datafusion::common::{DataFusionError, Result};
+use datafusion::execution::TaskContext;
+use datafusion::functions_aggregate as dfa;
+use datafusion::logical_expr::{AggregateUDF, ScalarUDF};
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_distributed::DistributedCodec;
+use datafusion_proto::physical_plan::{
+    AsExecutionPlan, ComposedPhysicalExtensionCodec, PhysicalExtensionCodec,
+};
+use datafusion_proto::protobuf::PhysicalPlanNode;
+use tantivy::index::SegmentId;
+
+use crate::api::HashSet;
+use crate::postgres::customscan::pg_expr_udf::{PgExprUdf, PG_EXPR_UDF_PREFIX};
+use crate::postgres::ParallelScanState;
+use crate::scan::execution_plan::PgSearchScanPlan;
+use crate::scan::search_predicate_udf::SearchPredicateUDF;
+
+/// Byte tag for `PgSearchScanPlan` in the extension payload. Kept even though the composed
+/// codec already records which codec decoded a node, so a future second custom exec
+/// (`FilterPassthroughExec`, `VisibilityFilterExec`, ...) can share this codec by tag.
+const TAG_PG_SEARCH_SCAN: u8 = 2;
+
+/// [`PhysicalExtensionCodec`] for the `pg_search` custom execs, carrying the runtime context a
+/// worker needs to rebuild them. Encode is context-free (the leader serializes the recipe);
+/// decode injects the worker's own `ParallelScanState` and frozen per-source segment sets.
+#[derive(Debug, Default)]
+pub struct PgSearchPhysicalExtensionCodec {
+    /// Worker's `ParallelScanState`, used to resolve the scan's MVCC segment set and to claim
+    /// segments at runtime.
+    parallel_state: Option<*mut ParallelScanState>,
+    /// Canonical segment ID sets for non-partitioning sources, indexed by position in the
+    /// non-partitioning source list. Mirrors the logical codec.
+    non_partitioning_segment_ids: Vec<HashSet<SegmentId>>,
+    /// Canonical segment ID sets for all join sources, indexed by `plan_position`. Injected into
+    /// `SearchPredicateUDF` on decode, same as the logical codec.
+    index_segment_ids: Vec<HashSet<SegmentId>>,
+}
+
+// Same justification as the logical `PgSearchExtensionCodec`: Postgres extensions run
+// single-threaded, so the raw `ParallelScanState` pointer never crosses a real thread boundary.
+unsafe impl Send for PgSearchPhysicalExtensionCodec {}
+unsafe impl Sync for PgSearchPhysicalExtensionCodec {}
+
+impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
+    fn try_decode(
+        &self,
+        buf: &[u8],
+        _inputs: &[Arc<dyn ExecutionPlan>],
+        _ctx: &TaskContext,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let Some((&tag, payload)) = buf.split_first() else {
+            return Err(DataFusionError::Internal(
+                "PgSearchPhysicalExtensionCodec: empty buffer".into(),
+            ));
+        };
+        match tag {
+            TAG_PG_SEARCH_SCAN => PgSearchScanPlan::decode_for_dispatch(
+                payload,
+                self.parallel_state,
+                &self.non_partitioning_segment_ids,
+            ),
+            other => Err(DataFusionError::NotImplemented(format!(
+                "PgSearchPhysicalExtensionCodec: unknown physical node tag {other}"
+            ))),
+        }
+    }
+
+    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
+        if let Some(scan) = node.as_any().downcast_ref::<PgSearchScanPlan>() {
+            buf.push(TAG_PG_SEARCH_SCAN);
+            buf.extend_from_slice(&scan.encode_for_dispatch()?);
+            return Ok(());
+        }
+        Err(DataFusionError::NotImplemented(format!(
+            "PgSearchPhysicalExtensionCodec: no physical encoding for {}",
+            node.name()
+        )))
+    }
+
+    fn try_decode_udaf(&self, name: &str, _buf: &[u8]) -> Result<Arc<AggregateUDF>> {
+        match name {
+            "min" => Ok(dfa::min_max::min_udaf()),
+            "max" => Ok(dfa::min_max::max_udaf()),
+            "count" => Ok(dfa::count::count_udaf()),
+            "sum" => Ok(dfa::sum::sum_udaf()),
+            "avg" => Ok(dfa::average::avg_udaf()),
+            _ => Err(DataFusionError::NotImplemented(format!(
+                "PhysicalExtensionCodec is not provided for aggregate function {name}"
+            ))),
+        }
+    }
+
+    fn try_encode_udaf(&self, node: &AggregateUDF, buf: &mut Vec<u8>) -> Result<()> {
+        buf.extend_from_slice(node.name().as_bytes());
+        Ok(())
+    }
+
+    fn try_decode_udf(&self, name: &str, buf: &[u8]) -> Result<Arc<ScalarUDF>> {
+        if name == "pdb_search_predicate" {
+            let mut udf: SearchPredicateUDF = serde_json::from_slice(buf).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to deserialize SearchPredicateUDF: {e}"))
+            })?;
+            if let Some(plan_position) = udf.plan_position() {
+                if !self.index_segment_ids.is_empty() {
+                    let ids = self
+                        .index_segment_ids
+                        .get(plan_position)
+                        .cloned()
+                        .expect("missing canonical segment IDs for plan_position");
+                    udf.set_canonical_segment_ids(ids);
+                }
+            }
+            return Ok(Arc::new(ScalarUDF::new_from_impl(udf)));
+        }
+
+        if name.starts_with(PG_EXPR_UDF_PREFIX) {
+            let mut udf: PgExprUdf = serde_json::from_slice(buf).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to deserialize PgExprUdf: {e}"))
+            })?;
+            udf.fixup_after_deserialize();
+            return Ok(Arc::new(ScalarUDF::new_from_impl(udf)));
+        }
+
+        Err(DataFusionError::NotImplemented(format!(
+            "UDF '{name}' deserialization not implemented"
+        )))
+    }
+
+    fn try_encode_udf(&self, node: &ScalarUDF, buf: &mut Vec<u8>) -> Result<()> {
+        let name = node.name();
+        if name == "pdb_search_predicate" {
+            let udf = node
+                .inner()
+                .as_any()
+                .downcast_ref::<SearchPredicateUDF>()
+                .ok_or_else(|| DataFusionError::Internal("UDF is not a SearchPredicateUDF".into()))?;
+            let bytes = serde_json::to_vec(udf).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to serialize SearchPredicateUDF: {e}"))
+            })?;
+            buf.extend_from_slice(&bytes);
+            return Ok(());
+        }
+
+        if name.starts_with(PG_EXPR_UDF_PREFIX) {
+            let udf = node
+                .inner()
+                .as_any()
+                .downcast_ref::<PgExprUdf>()
+                .ok_or_else(|| DataFusionError::Internal("UDF is not a PgExprUdf".into()))?;
+            let bytes = serde_json::to_vec(udf).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to serialize PgExprUdf: {e}"))
+            })?;
+            buf.extend_from_slice(&bytes);
+            return Ok(());
+        }
+
+        Err(DataFusionError::NotImplemented(format!(
+            "UDF '{name}' serialization not implemented"
+        )))
+    }
+}
+
+/// Compose the fork's [`DistributedCodec`] (handles `Network*Exec` / `StageExec`) with the
+/// `pg_search` codec. Encode and decode MUST build the same list in the same order: the composed
+/// codec records each node's codec index on the wire.
+fn combined_codec(user: PgSearchPhysicalExtensionCodec) -> ComposedPhysicalExtensionCodec {
+    ComposedPhysicalExtensionCodec::new(vec![Arc::new(DistributedCodec {}), Arc::new(user)])
+}
+
+/// Serialize one stage's physical subplan for dispatch. Context-free: only the recipe travels,
+/// the receiving worker injects its own runtime state on decode.
+pub fn serialize_physical_plan(plan: Arc<dyn ExecutionPlan>) -> Result<Vec<u8>> {
+    let codec = combined_codec(PgSearchPhysicalExtensionCodec::default());
+    let proto = PhysicalPlanNode::try_from_physical_plan(plan, &codec)?;
+    Ok(prost::Message::encode_to_vec(&proto))
+}
+
+/// Deserialize a dispatched physical subplan, injecting the worker's runtime context so the
+/// `PgSearchScanPlan` leaves rebuild their readers under this worker's MVCC view.
+pub fn deserialize_physical_plan_with_runtime(
+    bytes: &[u8],
+    ctx: &TaskContext,
+    parallel_state: Option<*mut ParallelScanState>,
+    non_partitioning_segment_ids: Vec<HashSet<SegmentId>>,
+    index_segment_ids: Vec<HashSet<SegmentId>>,
+) -> Result<Arc<dyn ExecutionPlan>> {
+    let codec = combined_codec(PgSearchPhysicalExtensionCodec {
+        parallel_state,
+        non_partitioning_segment_ids,
+        index_segment_ids,
+    });
+    let proto = <PhysicalPlanNode as prost::Message>::decode(bytes).map_err(|e| {
+        DataFusionError::Internal(format!("Failed to decode dispatched PhysicalPlanNode: {e}"))
+    })?;
+    proto.try_into_physical_plan(ctx, &codec)
+}

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -220,7 +220,7 @@ impl SegmentedTopKExec {
         Ok(RowConverter::new(materialized_sort_fields)?)
     }
 
-    /// Serialize for coordinator dispatch. The `ffhelper` is live and doesn't travel; the worker
+    /// Serialize for leader dispatch. The `ffhelper` is live and doesn't travel; the worker
     /// pulls it from the scan in its decoded subtree. The `dynamic_filter` is internal and is
     /// recreated fresh by `new` on decode; the leader-side `FilterPushdown` wiring of that filter
     /// into the scans' `PreFilter` does not travel, so a dispatched fragment scans without the

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -222,7 +222,10 @@ impl SegmentedTopKExec {
 
     /// Serialize for coordinator dispatch. The `ffhelper` is live and doesn't travel; the worker
     /// pulls it from the scan in its decoded subtree. The `dynamic_filter` is internal and is
-    /// recreated fresh by `new` on decode. `decoders`/`properties` are derived.
+    /// recreated fresh by `new` on decode; the leader-side `FilterPushdown` wiring of that filter
+    /// into the scans' `PreFilter` does not travel, so a dispatched fragment scans without the
+    /// runtime top-k pruning (correct, just slower). Rewiring on decode is an open follow-up.
+    /// `decoders`/`properties` are derived.
     pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
         let codec = datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
         let proto_conv = datafusion_proto::physical_plan::DefaultPhysicalProtoConverter {};

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -104,7 +104,7 @@ use std::sync::Arc;
 use tantivy::termdict::TermOrdinal;
 use tantivy::{DocId, SegmentOrdinal};
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct DeferredSortColumn {
     pub sort_col_idx: usize,
     pub canonical: CanonicalColumn,
@@ -218,6 +218,70 @@ impl SegmentedTopKExec {
             .collect();
 
         Ok(RowConverter::new(materialized_sort_fields)?)
+    }
+
+    /// Serialize for coordinator dispatch. The `ffhelper` is live and doesn't travel; the worker
+    /// pulls it from the scan in its decoded subtree. The `dynamic_filter` is internal and is
+    /// recreated fresh by `new` on decode. `decoders`/`properties` are derived.
+    pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
+        let codec = datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
+        let proto_conv = datafusion_proto::physical_plan::DefaultPhysicalProtoConverter {};
+        let sort_proto = datafusion_proto::physical_plan::to_proto::serialize_physical_sort_exprs(
+            self.sort_exprs.iter().cloned(),
+            &codec,
+            &proto_conv,
+        )?;
+        let sort_bytes: Vec<Vec<u8>> = sort_proto
+            .iter()
+            .map(prost::Message::encode_to_vec)
+            .collect();
+        let payload = (sort_bytes, self.deferred_columns.clone(), self.k);
+        serde_json::to_vec(&payload).map_err(|e| {
+            DataFusionError::Internal(format!("SegmentedTopKExec dispatch: serialize: {e}"))
+        })
+    }
+
+    pub(crate) fn decode_for_dispatch(
+        buf: &[u8],
+        input: Arc<dyn ExecutionPlan>,
+        ffhelper: Arc<FFHelper>,
+        ctx: &TaskContext,
+    ) -> Result<Arc<dyn ExecutionPlan>> {
+        let (sort_bytes, deferred_columns, k): (Vec<Vec<u8>>, Vec<DeferredSortColumn>, usize) =
+            serde_json::from_slice(buf).map_err(|e| {
+                DataFusionError::Internal(format!("SegmentedTopKExec dispatch: deserialize: {e}"))
+            })?;
+        let sort_proto = sort_bytes
+            .iter()
+            .map(|b| {
+                <datafusion_proto::protobuf::PhysicalSortExprNode as prost::Message>::decode(
+                    b.as_slice(),
+                )
+            })
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .map_err(|e| {
+                DataFusionError::Internal(format!("SegmentedTopKExec dispatch: sort decode: {e}"))
+            })?;
+        let codec = datafusion_proto::physical_plan::DefaultPhysicalExtensionCodec {};
+        let proto_conv = datafusion_proto::physical_plan::DefaultPhysicalProtoConverter {};
+        let input_schema = input.schema();
+        let exprs = datafusion_proto::physical_plan::from_proto::parse_physical_sort_exprs(
+            &sort_proto,
+            ctx,
+            input_schema.as_ref(),
+            &codec,
+            &proto_conv,
+        )?;
+        let sort_exprs = LexOrdering::new(exprs).ok_or_else(|| {
+            DataFusionError::Internal("SegmentedTopKExec dispatch: empty sort order".into())
+        })?;
+        Ok(Arc::new(SegmentedTopKExec::new(
+            input,
+            sort_exprs,
+            deferred_columns,
+            ffhelper,
+            k,
+        )))
     }
 }
 

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -651,6 +651,7 @@ impl PgSearchTableProvider {
         let recipe = crate::scan::execution_plan::ScanRecipe::Lazy {
             parallel_state,
             source_idx: mpp_source_idx,
+            non_partitioning_index: self.non_partitioning_index,
             planner_estimated_rows,
             scanner_config,
         };

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -466,7 +466,7 @@ impl PgSearchTableProvider {
         &self,
         segments: Vec<ScanState>,
         schema: SchemaRef,
-        query_for_display: SearchQueryInput,
+        resolved_query: SearchQueryInput,
         sort_order: Option<&crate::postgres::options::SortByField>,
         ffhelper: Arc<FFHelper>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -495,7 +495,7 @@ impl PgSearchTableProvider {
         Ok(Arc::new(PgSearchScanPlan::new(
             segments,
             schema,
-            query_for_display,
+            resolved_query,
             actual_sort_order,
             deferred,
             ffhelper_arg,
@@ -527,7 +527,7 @@ impl PgSearchTableProvider {
         visibility: VisibilityChecker,
         heap_relid: pg_sys::Oid,
         schema: SchemaRef,
-        query_for_display: SearchQueryInput,
+        resolved_query: SearchQueryInput,
         sort_order: Option<&crate::postgres::options::SortByField>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let mut segments = Vec::new();
@@ -562,7 +562,7 @@ impl PgSearchTableProvider {
             segments.push(partition);
         }
 
-        self.create_scan(segments, schema, query_for_display, sort_order, ffhelper)
+        self.create_scan(segments, schema, resolved_query, sort_order, ffhelper)
     }
 
     /// Creates a multi-partition `PgSearchScanPlan` for eager scans.
@@ -585,7 +585,7 @@ impl PgSearchTableProvider {
         visibility: VisibilityChecker,
         heap_relid: pg_sys::Oid,
         schema: SchemaRef,
-        query_for_display: SearchQueryInput,
+        resolved_query: SearchQueryInput,
         sort_order: Option<&crate::postgres::options::SortByField>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
@@ -609,7 +609,7 @@ impl PgSearchTableProvider {
             })
             .collect();
 
-        self.create_scan(segments, schema, query_for_display, sort_order, ffhelper)
+        self.create_scan(segments, schema, resolved_query, sort_order, ffhelper)
     }
 
     /// Creates a single-partition `PgSearchScanPlan` for lazy scans.
@@ -637,7 +637,7 @@ impl PgSearchTableProvider {
         visibility: VisibilityChecker,
         heap_relid: pg_sys::Oid,
         schema: SchemaRef,
-        query_for_display: SearchQueryInput,
+        resolved_query: SearchQueryInput,
         planner_estimated_rows: u64,
         mpp_source_idx: Option<usize>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
@@ -665,7 +665,7 @@ impl PgSearchTableProvider {
         self.create_scan(
             vec![state],
             schema,
-            query_for_display,
+            resolved_query,
             None, // no sort order
             ffhelper,
         )

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -593,6 +593,7 @@ impl PgSearchTableProvider {
             which_fast_fields: which_fast_fields.clone(),
             heap_relid: heap_relid.into(),
             batch_size_hint: None,
+            score_needed: self.scan_info.score_needed,
         };
         let segments: Vec<ScanState> = reader
             .segment_readers()
@@ -645,6 +646,7 @@ impl PgSearchTableProvider {
             which_fast_fields: which_fast_fields.clone(),
             heap_relid: heap_relid.into(),
             batch_size_hint: None,
+            score_needed: self.scan_info.score_needed,
         };
         let recipe = crate::scan::execution_plan::ScanRecipe::Lazy {
             parallel_state,

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -139,7 +139,7 @@ impl TantivyLookupExec {
         self.ffhelpers.get(&indexrelid)
     }
 
-    /// Serialize for coordinator dispatch. The `ffhelpers` are live and don't travel; the worker
+    /// Serialize for leader dispatch. The `ffhelpers` are live and don't travel; the worker
     /// pulls them from the scans in its decoded subtree, keyed by index relid. `decoders` is
     /// derived from `deferred_fields`, so it's recomputed on decode.
     pub(crate) fn encode_for_dispatch(&self) -> datafusion::common::Result<Vec<u8>> {

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -34,7 +34,9 @@ use tantivy::{DocId, SegmentOrdinal};
 ///
 /// The `display_name` is preserved purely for `EXPLAIN` rendering and debugging; it should
 /// never be used for matching columns in the physical plan.
-#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(
+    Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize,
+)]
 pub struct PhysicalDeferredField {
     /// The positional index of the column in the physical Arrow schema
     pub col_idx: usize,
@@ -135,6 +137,35 @@ impl TantivyLookupExec {
 
     pub fn ffhelper(&self, indexrelid: u32) -> Option<&Arc<FFHelper>> {
         self.ffhelpers.get(&indexrelid)
+    }
+
+    /// Serialize for coordinator dispatch. The `ffhelpers` are live and don't travel; the worker
+    /// pulls them from the scans in its decoded subtree, keyed by index relid. `decoders` is
+    /// derived from `deferred_fields`, so it's recomputed on decode.
+    pub(crate) fn encode_for_dispatch(&self) -> datafusion::common::Result<Vec<u8>> {
+        serde_json::to_vec(&self.deferred_fields).map_err(|e| {
+            datafusion::common::DataFusionError::Internal(format!(
+                "TantivyLookupExec dispatch: serialize: {e}"
+            ))
+        })
+    }
+
+    pub(crate) fn decode_for_dispatch(
+        buf: &[u8],
+        input: Arc<dyn ExecutionPlan>,
+        ffhelpers: HashMap<u32, Arc<FFHelper>>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+        let deferred_fields: Vec<PhysicalDeferredField> =
+            serde_json::from_slice(buf).map_err(|e| {
+                datafusion::common::DataFusionError::Internal(format!(
+                    "TantivyLookupExec dispatch: deserialize: {e}"
+                ))
+            })?;
+        Ok(Arc::new(TantivyLookupExec::new(
+            input,
+            deferred_fields,
+            ffhelpers,
+        )?))
     }
 }
 


### PR DESCRIPTION
## What

This PR rewires `pg_search`'s MPP onto the `datafusion-distributed` fork's `WorkerTransport` abstractions and adds coordinator dispatch: the leader ships per-stage physical subplans through DSM, and workers stop re-planning.

## Why

The MPP transport carried its own copies of decisions the fork now owns: how connections open, how plans reach workers, and how a produced partition is routed. Every fork rebase had to re-derive them by hand. With the abstractions in place (fork PRs 1 through 5), `pg_search` implements the traits instead, and the worker-side re-plan (a whole logical planning pass per worker, per query) goes away. Stacks on #5171.

## How

- **Consume half.** `ShmMqWorkerTransport` / `ShmMqWorkerConnection` implement the fork's `WorkerTransport` / `WorkerConnection` over the existing shm_mq mesh. The dispatcher is a no-op: the plan rides DSM at parallel-context init, so nothing is left to deliver. `InProcessWorkerResolver` hands the planner placeholder URLs it never dials. The old `in_process_mode` flag is gone, and producer-side routing reads the crate's `route_partition` instead of re-deriving the receive math.
- **Coordinator dispatch.** The leader builds the distributed physical plan once at DSM init and serializes each producer stage. `ScanDispatchDescriptor` is the transport-neutral scan recipe: the worker re-opens its reader from it (`score_needed` keeps score-ordered queries ranking like the leader; `non_partitioning_index` keys the canonical segment sets). Readers, `FFHelper`s, and `ParallelScanState` never travel. UDF definitions travel through the composed codec: a wrapper at position `0` declines the `pg_search` names so their `fun_definition` ships, while built-ins keep resolving by registry name.
- **Failure policy is serial fallback, decided by the leader.** Build, capacity, encode, and routing problems return `Err` into the existing fallback, and the leader round-trips each stage blob at build time so a codec gap falls back instead of erroring in a worker. On any pre-setup failure the leader stamps `MPP_DISABLED_OFFSET` into the DSM header: joinscan workers return to the plain parallel path, aggregate workers emit nothing (a parallel aggregate worker has no partitioned non-MPP path), and a `worker_setup` failure without the marker fails the query rather than mixing protocols. Sorted-source queries fall back by design, same line as #5268.

## Tests

The property tests and MPP regress suites (`mpp_smoke`, `mpp_joinscan`, `mpp_aggregate`, `mpp_aggregate_postagg`) pass.