### PR TITLE
feat: Enable aggregate and join scans by default

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/aggregate_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/aggregate_sort.sql
@@ -5,7 +5,7 @@
 -- Query Info (statistics from 100k dataset; larger datasets may have different values):
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT
     p.id,
     p.title,
     MAX(c.creation_date) as last_activity
@@ -19,7 +19,7 @@ ORDER BY
     last_activity DESC            -- Single Feature Sort (Computed Aggregate)
 LIMIT 10;
 
-SET paradedb.enable_join_custom_scan TO on; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT
     p.id,
     p.title,
     MAX(c.creation_date) as last_activity

--- a/benchmarks/datasets/stackoverflow/queries/aggregate_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/aggregate_sort.sql
@@ -5,7 +5,7 @@
 -- Query Info (statistics from 100k dataset; larger datasets may have different values):
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT
     p.id,
     p.title,
     MAX(c.creation_date) as last_activity

--- a/benchmarks/datasets/stackoverflow/queries/bucket-expr-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/bucket-expr-filter.sql
@@ -1,4 +1,4 @@
-SELECT date_trunc('year', creation_date) as year, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY year ORDER BY year;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT date_trunc('year', creation_date) as year, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY year ORDER BY year;
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT date_trunc('year', creation_date) as year, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY year ORDER BY year;

--- a/benchmarks/datasets/stackoverflow/queries/bucket-numeric-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/bucket-numeric-filter.sql
@@ -1,5 +1,5 @@
 -- numeric ff
-SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id ORDER BY post_type_id;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id ORDER BY post_type_id;
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
@@ -8,4 +8,4 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) F
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
-SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id;

--- a/benchmarks/datasets/stackoverflow/queries/bucket-numeric-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/bucket-numeric-nofilter.sql
@@ -1,5 +1,5 @@
 -- numeric ff
-SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id ORDER BY post_type_id;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id ORDER BY post_type_id;
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
@@ -8,4 +8,4 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(*) F
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT post_type_id, COUNT(post_type_id) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
-SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT post_type_id, pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all() GROUP BY post_type_id;

--- a/benchmarks/datasets/stackoverflow/queries/bucket-string-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/bucket-string-filter.sql
@@ -1,5 +1,5 @@
 -- string ff
-SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name ORDER BY name;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name ORDER BY name;
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE name ||| 'Question' GROUP BY name;
@@ -8,4 +8,4 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badg
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(name) FROM badges WHERE name ||| 'Question' GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' GROUP BY name;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE name ||| 'Question' GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/bucket-string-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/bucket-string-nofilter.sql
@@ -1,5 +1,5 @@
 -- string ff
-SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name ORDER BY name;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name ORDER BY name;
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
@@ -8,4 +8,4 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(*) FROM badg
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT name, COUNT(name) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
 
 -- pdb.agg with GROUP BY (mvcc disabled)
-SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE id @@@ pdb.all() GROUP BY name;
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT name, pdb.agg('{"value_count": {"field": "name"}}', false) FROM badges WHERE id @@@ pdb.all() GROUP BY name;

--- a/benchmarks/datasets/stackoverflow/queries/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/cardinality.sql
@@ -1,8 +1,8 @@
 -- numeric ff
-SELECT COUNT(DISTINCT post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(DISTINCT post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- better numeric ff
-SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id ORDER BY post_type_id);
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id ORDER BY post_type_id);
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id);
@@ -11,13 +11,13 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT po
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- pdb.agg without GROUP BY (mvcc disabled)
-SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- high-cardinality aggregate scan
-SET work_mem TO '4GB'; SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET paradedb.enable_aggregate_custom_scan TO off; SET work_mem TO '4GB'; SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg
 SET paradedb.enable_aggregate_custom_scan TO on; SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
 
 -- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
-SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET paradedb.enable_aggregate_custom_scan TO off; SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;

--- a/benchmarks/datasets/stackoverflow/queries/count-filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/count-filter.sql
@@ -1,5 +1,5 @@
 -- numeric fast field
-SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverflow_posts WHERE body ||| 'error';
@@ -8,4 +8,4 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverf
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(ctid) FROM stackoverflow_posts WHERE body ||| 'error';
 
 -- pdb.agg without GROUP BY (mvcc disabled)
-SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE body ||| 'error';
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE body ||| 'error';

--- a/benchmarks/datasets/stackoverflow/queries/count-nofilter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/count-nofilter.sql
@@ -1,5 +1,5 @@
 -- numeric fast field
-SELECT COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all();
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 
 -- aggregate custom scan
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverflow_posts WHERE id @@@ pdb.all();
@@ -8,4 +8,4 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM stackoverf
 SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(ctid) FROM stackoverflow_posts WHERE id @@@ pdb.all();
 
 -- pdb.agg without GROUP BY (mvcc disabled)
-SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all();
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT pdb.agg('{"value_count": {"field": "ctid"}}', false) FROM stackoverflow_posts WHERE id @@@ pdb.all();

--- a/benchmarks/datasets/stackoverflow/queries/hierarchical_content-scores-large.sql
+++ b/benchmarks/datasets/stackoverflow/queries/hierarchical_content-scores-large.sql
@@ -17,7 +17,7 @@ ORDER BY pdb_score DESC
 LIMIT 1000;
 
 -- CTE to execute a smaller join before Top K and then fetch the rest of the content after Top K.
-WITH topk AS (
+SET paradedb.enable_join_custom_scan TO off; WITH topk AS (
   SELECT
     users.id AS user_id,
     stackoverflow_posts.id AS post_id,

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -30,13 +30,13 @@ use crate::postgres::options::MAX_MUTABLE_SEGMENT_ROWS;
 static ENABLE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Allows the user to toggle the use of our "ParadeDB Aggregate Scan".
-static ENABLE_AGGREGATE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false);
+static ENABLE_AGGREGATE_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Validate aggregate scan eligibility
 static CHECK_AGGREGATE_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Allows the user to toggle the use of our "ParadeDB Join Scan".
-static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(false);
+static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Allows the user to toggle the use of the custom scan without use of the `@@@` operator. The
 /// default is `false`.

--- a/pg_search/src/postgres/catalog.rs
+++ b/pg_search/src/postgres/catalog.rs
@@ -91,24 +91,21 @@ pub fn lookup_typoid(namespace: &CStr, typename: &CStr) -> Option<pg_sys::Oid> {
     }
 }
 
-/// Helper function to lookup a function's name by its OID
-pub fn lookup_func_name(funcid: pg_sys::Oid) -> Option<String> {
+/// Helper function to lookup a function's name by its OID as a CStr
+pub fn lookup_func_name_cstr<'a>(funcid: pg_sys::Oid) -> Option<&'a std::ffi::CStr> {
     unsafe {
         let name_ptr = pg_sys::get_func_name(funcid);
         if !name_ptr.is_null() {
-            std::ffi::CStr::from_ptr(name_ptr)
-                .to_str()
-                .ok()
-                .map(|s| s.to_string())
+            Some(std::ffi::CStr::from_ptr(name_ptr))
         } else {
             None
         }
     }
 }
 
-/// Helper function to lookup a function's namespace by its OID
-pub fn lookup_func_namespace(funcid: pg_sys::Oid) -> pg_sys::Oid {
-    unsafe { pg_sys::get_func_namespace(funcid) }
+/// Helper function to lookup a function's name by its OID
+pub fn lookup_func_name(funcid: pg_sys::Oid) -> Option<String> {
+    lookup_func_name_cstr(funcid).and_then(|cstr| cstr.to_str().ok().map(|s| s.to_string()))
 }
 
 /// Helper function to lookup a namespace's name by its OID
@@ -129,7 +126,7 @@ pub fn lookup_namespace_name(namespace_oid: pg_sys::Oid) -> Option<String> {
 /// Helper function to lookup a function's fully qualified name (schema.name) by its OID
 pub fn lookup_fully_qualified_func_name(funcid: pg_sys::Oid) -> Option<String> {
     let name = lookup_func_name(funcid)?;
-    let namespace_oid = lookup_func_namespace(funcid);
+    let namespace_oid = unsafe { pg_sys::get_func_namespace(funcid) };
     if namespace_oid != pg_sys::InvalidOid {
         if let Some(namespace) = lookup_namespace_name(namespace_oid) {
             if namespace != "pg_catalog" {

--- a/pg_search/src/postgres/catalog.rs
+++ b/pg_search/src/postgres/catalog.rs
@@ -91,6 +91,55 @@ pub fn lookup_typoid(namespace: &CStr, typename: &CStr) -> Option<pg_sys::Oid> {
     }
 }
 
+/// Helper function to lookup a function's name by its OID
+pub fn lookup_func_name(funcid: pg_sys::Oid) -> Option<String> {
+    unsafe {
+        let name_ptr = pg_sys::get_func_name(funcid);
+        if !name_ptr.is_null() {
+            std::ffi::CStr::from_ptr(name_ptr)
+                .to_str()
+                .ok()
+                .map(|s| s.to_string())
+        } else {
+            None
+        }
+    }
+}
+
+/// Helper function to lookup a function's namespace by its OID
+pub fn lookup_func_namespace(funcid: pg_sys::Oid) -> pg_sys::Oid {
+    unsafe { pg_sys::get_func_namespace(funcid) }
+}
+
+/// Helper function to lookup a namespace's name by its OID
+pub fn lookup_namespace_name(namespace_oid: pg_sys::Oid) -> Option<String> {
+    unsafe {
+        let name_ptr = pg_sys::get_namespace_name(namespace_oid);
+        if !name_ptr.is_null() {
+            std::ffi::CStr::from_ptr(name_ptr)
+                .to_str()
+                .ok()
+                .map(|s| s.to_string())
+        } else {
+            None
+        }
+    }
+}
+
+/// Helper function to lookup a function's fully qualified name (schema.name) by its OID
+pub fn lookup_fully_qualified_func_name(funcid: pg_sys::Oid) -> Option<String> {
+    let name = lookup_func_name(funcid)?;
+    let namespace_oid = lookup_func_namespace(funcid);
+    if namespace_oid != pg_sys::InvalidOid {
+        if let Some(namespace) = lookup_namespace_name(namespace_oid) {
+            if namespace != "pg_catalog" {
+                return Some(format!("{}.{}", namespace, name));
+            }
+        }
+    }
+    Some(name)
+}
+
 /// Returns `true` if `oid` is the OID of the `citext` type.
 pub fn is_citext_oid(oid: pg_sys::Oid) -> bool {
     static CITEXT_OID: OnceLock<pg_sys::Oid> = OnceLock::new();

--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -236,7 +236,15 @@ impl AggregateType {
 
         let agg_type =
             create_aggregate_from_oid(aggfnoid, field, missing, filter_query, bm25_index.oid())
-                .ok_or_else(|| format!("unsupported aggregate function OID: {}", aggfnoid))?;
+                .ok_or_else(|| {
+                    if let Some(n) = crate::postgres::catalog::lookup_fully_qualified_func_name(
+                        pg_sys::Oid::from(aggfnoid),
+                    ) {
+                        format!("unsupported aggregate function: {}", n)
+                    } else {
+                        format!("unsupported aggregate function OID: {}", aggfnoid)
+                    }
+                })?;
 
         Ok(agg_type)
     }

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -1082,11 +1082,7 @@ unsafe fn require_fast_field(
             source.scan_info.add_field(attno, field);
             Ok(())
         }
-        None => Err(format!(
-            "{} is not a fast field on table {}",
-            describe(),
-            source.scan_info.heaprelid.to_u32()
-        )),
+        None => Err(format!("{} is not a fast field", describe())),
     }
 }
 
@@ -1178,10 +1174,8 @@ pub unsafe fn populate_required_fields(
 
             if resolved_field.is_none() {
                 return Err(format!(
-                    "GROUP BY column '{}' (attno={}) is not a fast field on table {}",
-                    gc.field_name,
-                    gc.attno,
-                    source.scan_info.heaprelid.to_u32()
+                    "GROUP BY column '{}' (attno={}) is not a fast field",
+                    gc.field_name, gc.attno,
                 ));
             }
         }

--- a/pg_search/src/postgres/customscan/aggregatescan/groupby.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/groupby.rs
@@ -31,6 +31,7 @@ use pgrx::PgList;
 pub struct GroupingColumn {
     pub field_name: String,
     pub attno: pg_sys::AttrNumber,
+    pub original_type_oid: pg_sys::Oid,
 }
 
 #[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -157,7 +158,21 @@ impl CustomScanClause<AggregateScan> for GroupByClause {
                                 );
                             }
 
-                            grouping_columns.push(GroupingColumn { field_name, attno });
+                            // We capture the original type OID of the fast field here.
+                            // Because AggregateScan bypasses Postgres's ExecProject for grouping columns
+                            // and maps them directly to INDEX_VARs pointing at the final scan slot,
+                            // Postgres expects the slot to contain the Datum of the *cast* type (e.g. TEXTOID),
+                            // not the base column type.
+                            // This approach is only valid for known-safe casts (handled in `group_key_to_datum`),
+                            // where the grouping and comparison semantics of the internal fast field value
+                            // are strictly equivalent to the semantics of the projected value. If they were
+                            // different, we would need to evaluate grouping expressions natively via ExecProject.
+                            let original_type_oid = search_field.field_type().typeoid().value();
+                            grouping_columns.push(GroupingColumn {
+                                field_name,
+                                attno,
+                                original_type_oid,
+                            });
                             found_valid_column = true;
                             break; // Found a valid grouping column for this pathkey
                         } else {

--- a/pg_search/src/postgres/customscan/aggregatescan/groupby.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/groupby.rs
@@ -158,7 +158,6 @@ impl CustomScanClause<AggregateScan> for GroupByClause {
                                 );
                             }
 
-                            // We capture the original type OID of the fast field here.
                             // Because AggregateScan bypasses Postgres's ExecProject for grouping columns
                             // and maps them directly to INDEX_VARs pointing at the final scan slot,
                             // Postgres expects the slot to contain the Datum of the *cast* type (e.g. TEXTOID),

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -209,13 +209,7 @@ fn classify_aggregate_oid(aggfnoid: u32, aggstar: bool, has_distinct: bool) -> O
 /// Handles aggregate functions whose OIDs aren't exposed as constants in pg_sys
 /// (e.g., STDDEV, VARIANCE and their variants).
 fn classify_aggregate_by_name(aggfnoid: u32) -> Option<AggKind> {
-    let name = unsafe {
-        let name_ptr = pg_sys::get_func_name(pg_sys::Oid::from(aggfnoid));
-        if name_ptr.is_null() {
-            return None;
-        }
-        std::ffi::CStr::from_ptr(name_ptr).to_str().ok()?.to_owned()
-    };
+    let name = crate::postgres::catalog::lookup_func_name(pg_sys::Oid::from(aggfnoid))?;
     match name.as_str() {
         "stddev" | "stddev_samp" => Some(AggKind::StddevSamp),
         "stddev_pop" => Some(AggKind::StddevPop),
@@ -359,7 +353,15 @@ pub unsafe fn extract_aggregate_targetlist(
             }
 
             let mut agg_kind = classify_aggregate_oid(aggfnoid, (*aggref).aggstar, has_distinct)
-                .ok_or_else(|| format!("unsupported aggregate function OID: {}", aggfnoid))?;
+                .ok_or_else(|| {
+                    if let Some(n) = crate::postgres::catalog::lookup_fully_qualified_func_name(
+                        pg_sys::Oid::from(aggfnoid),
+                    ) {
+                        format!("unsupported aggregate function: {}", n)
+                    } else {
+                        format!("unsupported aggregate function OID: {}", aggfnoid)
+                    }
+                })?;
 
             // For STRING_AGG, extract the separator from the second argument
             let is_string_agg = matches!(agg_kind, AggKind::StringAgg(_));

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -2129,29 +2129,18 @@ unsafe fn make_placeholder_func_expr_internal(
 
 /// Get a human-readable name for the aggregate function
 unsafe fn get_aggregate_name(aggref: *mut pg_sys::Aggref) -> String {
-    // Try to get the function name from the catalog
     let funcid = (*aggref).aggfnoid;
     if funcid == agg_funcoid() {
         return "pdb.agg".to_string();
     }
-    let proc_tuple =
-        pg_sys::SearchSysCache1(pg_sys::SysCacheIdentifier::PROCOID as _, funcid.into());
 
-    if !proc_tuple.is_null() {
-        let proc_form = pg_sys::GETSTRUCT(proc_tuple) as *mut pg_sys::FormData_pg_proc;
-        let name_data = &(*proc_form).proname;
+    let name_str =
+        crate::postgres::catalog::lookup_func_name(funcid).unwrap_or_else(|| "UNKNOWN".to_string());
 
-        let name_str = pgrx::name_data_to_str(name_data);
-
-        pg_sys::ReleaseSysCache(proc_tuple);
-
-        // Add (*) for COUNT(*) or star aggregates
-        if (*aggref).aggstar {
-            format!("{}(*)", name_str.to_uppercase())
-        } else {
-            name_str.to_uppercase()
-        }
+    // Add (*) for COUNT(*) or star aggregates
+    if (*aggref).aggstar {
+        format!("{}(*)", name_str.to_uppercase())
     } else {
-        "UNKNOWN".to_string()
+        name_str.to_uppercase()
     }
 }

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1116,6 +1116,12 @@ impl AggregateScan {
         // If it's not a plain relation (e.g. it's a partitioned table), we can't do Tantivy agg directly.
         // Parent partitioned tables are not yet supported for aggregate pushdown.
         let Some(heap_relid) = (unsafe { range_table::get_plain_relation_relid(heap_rte) }) else {
+            if has_paradedb_agg {
+                Self::add_planner_warning(
+                    "Aggregate Scan not used: unsupported relation type (e.g., partitioned table or view)",
+                    unsafe { rte_alias_or_unknown(heap_rte) },
+                );
+            }
             return Vec::new();
         };
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1110,7 +1110,14 @@ impl AggregateScan {
         let Some(heap_rte) = heap_rte else {
             return Vec::new();
         };
-        let Some((_table, index)) = rel_get_bm25_index(unsafe { (*heap_rte).relid }) else {
+
+        // If it's not a plain relation (e.g. it's a partitioned table), we can't do Tantivy agg directly.
+        // Parent partitioned tables are not yet supported for aggregate pushdown.
+        let Some(heap_relid) = (unsafe { range_table::get_plain_relation_relid(heap_rte) }) else {
+            return Vec::new();
+        };
+
+        let Some((_table, index)) = rel_get_bm25_index(heap_relid) else {
             if has_paradedb_agg {
                 Self::add_planner_warning(
                     "Aggregate Scan not used: table must have a BM25 index",

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -39,6 +39,8 @@ pub use targetlist::TargetListEntry;
 
 use std::sync::Arc;
 
+use crate::postgres::catalog::is_ltree_oid;
+
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTaskContext};
@@ -1733,6 +1735,8 @@ unsafe fn fill_slot_from_row(
     let mut aggregates = row.aggregates.clone().into_iter();
     let mut natts_processed = 0;
 
+    let grouping_columns = aggregate_clause.grouping_columns();
+
     // Fill in values according to the target list
     for (i, entry) in aggregate_clause.entries().enumerate() {
         let attr = tupdesc.get(i).expect("missing attribute");
@@ -1743,7 +1747,11 @@ unsafe fn fill_slot_from_row(
                 if row.is_empty() {
                     None
                 } else {
-                    group_key_to_datum(row.group_keys[*gc_idx].clone(), expected_typoid)
+                    group_key_to_datum(
+                        row.group_keys[*gc_idx].clone(),
+                        expected_typoid,
+                        grouping_columns[*gc_idx].original_type_oid,
+                    )
                 }
             }
             TargetListEntry::Aggregate(agg_type) => {
@@ -1787,6 +1795,44 @@ unsafe fn fill_slot_from_row(
     (*slot).tts_nvalid = natts as i16;
 }
 
+/// Decodes internal binary fast-field representations for known-safe type casts.
+///
+/// Because `AggregateScan` maps grouping columns directly to `INDEX_VAR`s pointing at
+/// the final scan slot, Postgres expects the slot to contain the Datum of the
+/// *cast* type (e.g., `TEXTOID`), not the base column type. `try_into_datum` will
+/// use this cast type to decode the `TantivyValue`.
+///
+/// For types that use an internal binary encoding in Tantivy (like `ltree` using `\0`
+/// separators), casting directly to `TEXTOID` would expose the binary encoding.
+/// This function intercepts known-safe conversions and decodes the internal
+/// representation back into a standard `TantivyValue` string before it is cast.
+///
+/// This approach is only valid when the grouping and comparison semantics of the
+/// binary-encoded fast field value are strictly equivalent to the semantics of
+/// the projected value.
+fn decode_safe_cast(
+    mut key: TantivyValue,
+    original_typoid: pg_sys::Oid,
+    expected_typoid: pg_sys::Oid,
+) -> TantivyValue {
+    if original_typoid == expected_typoid {
+        return key;
+    }
+
+    match (original_typoid, expected_typoid) {
+        (orig, pg_sys::TEXTOID) if is_ltree_oid(orig) => {
+            if let PdbOwnedValue::Str(ref s) = key.0 {
+                key = TantivyValue(PdbOwnedValue::Str(
+                    crate::postgres::catalog::facet_encoded_str_to_ltree_text(s),
+                ));
+            }
+            key
+        }
+        // Add other safe `original_typoid` -> `expected_typoid` conversions here
+        _ => key,
+    }
+}
+
 /// Convert a Tantivy group key to a Postgres datum, handling NULL sentinels
 /// (used for I64/U64/F64/Bool when the aggregator omits a row) and the
 /// datetime decoding path (Tantivy returns ISO-8601 strings; we parse them
@@ -1797,6 +1843,7 @@ unsafe fn fill_slot_from_row(
 unsafe fn group_key_to_datum(
     key: TantivyValue,
     expected_typoid: pg_sys::Oid,
+    original_typoid: pg_sys::Oid,
 ) -> Option<pg_sys::Datum> {
     // Check if this is a NULL sentinel (handles both MIN and MAX sentinels).
     // U64 uses string sentinel for MIN (since 0 is valid); u64::MAX for MAX.
@@ -1812,6 +1859,8 @@ unsafe fn group_key_to_datum(
     if is_null_sentinel {
         return None;
     }
+
+    let key = decode_safe_cast(key, original_typoid, expected_typoid);
 
     if !is_datetime_type(expected_typoid) {
         return key

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -79,7 +79,7 @@ impl<'a> PredicateTranslator<'a> {
         let df_args = df_args?;
 
         let funcid = (*func).funcid;
-        let namespace_oid = crate::postgres::catalog::lookup_func_namespace(funcid);
+        let namespace_oid = pg_sys::get_func_namespace(funcid);
         let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
         let func_name = crate::postgres::catalog::lookup_func_name(funcid);
 
@@ -511,8 +511,7 @@ impl<'a> PredicateTranslator<'a> {
         // implementing function (`get_opcode` → `get_func_namespace`).
         let opno = (*op_expr).opno;
         let op_name_ptr = pg_sys::get_opname(opno);
-        let namespace_oid =
-            crate::postgres::catalog::lookup_func_namespace(pg_sys::get_opcode(opno));
+        let namespace_oid = pg_sys::get_func_namespace(pg_sys::get_opcode(opno));
         let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
         if op_name_ptr.is_null() || namespace_ptr.is_null() {
             pgrx::debug1!(

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -79,10 +79,11 @@ impl<'a> PredicateTranslator<'a> {
         let df_args = df_args?;
 
         let funcid = (*func).funcid;
-        let namespace_oid = pg_sys::get_func_namespace(funcid);
+        let namespace_oid = crate::postgres::catalog::lookup_func_namespace(funcid);
         let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
-        let func_name_ptr = pg_sys::get_func_name(funcid);
-        if namespace_ptr.is_null() || func_name_ptr.is_null() {
+        let func_name = crate::postgres::catalog::lookup_func_name(funcid);
+
+        if namespace_ptr.is_null() || func_name.is_none() {
             pgrx::debug1!(
                 "PredicateTranslator: could not resolve function identity [FuncExpr] funcid={}",
                 funcid.to_u32()
@@ -91,10 +92,10 @@ impl<'a> PredicateTranslator<'a> {
         }
 
         let schema = CStr::from_ptr(namespace_ptr).to_str().ok()?;
-        let name = CStr::from_ptr(func_name_ptr).to_str().ok()?;
+        let name = func_name?;
 
         let arity = df_args.len();
-        let result = Self::translate_known_func(schema, name, df_args);
+        let result = Self::translate_known_func(schema, &name, df_args);
         if result.is_none() {
             pgrx::debug1!(
                 "PredicateTranslator: no native mapping [FuncExpr] func={}.{}, arity={} | {}",
@@ -510,7 +511,8 @@ impl<'a> PredicateTranslator<'a> {
         // implementing function (`get_opcode` → `get_func_namespace`).
         let opno = (*op_expr).opno;
         let op_name_ptr = pg_sys::get_opname(opno);
-        let namespace_oid = pg_sys::get_func_namespace(pg_sys::get_opcode(opno));
+        let namespace_oid =
+            crate::postgres::catalog::lookup_func_namespace(pg_sys::get_opcode(opno));
         let namespace_ptr = pg_sys::get_namespace_name(namespace_oid);
         if op_name_ptr.is_null() || namespace_ptr.is_null() {
             pgrx::debug1!(

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -229,29 +229,53 @@ enum JoinPathDecline {
 /// Specific reason a `JoinPathDecline::Warn` was raised. Wraps a specific
 /// warning message and any optional details (e.g., unsupported join types)
 /// to be emitted as a planner warning.
-pub struct JoinDeclineReason {
-    message: String,
-    details: Option<Vec<String>>,
+pub enum JoinDeclineReason {
+    ContainsAggregate,
+    Message {
+        message: String,
+        details: Option<Vec<String>>,
+    },
 }
 
 impl JoinDeclineReason {
     pub fn new(message: impl Into<String>) -> Self {
-        Self {
+        Self::Message {
             message: message.into(),
             details: None,
         }
     }
 
-    pub fn with_details(mut self, details: Vec<String>) -> Self {
-        self.details = Some(details);
-        self
+    pub fn with_details(self, new_details: Vec<String>) -> Self {
+        match self {
+            Self::ContainsAggregate => self,
+            Self::Message {
+                message,
+                details: _,
+            } => Self::Message {
+                message,
+                details: Some(new_details),
+            },
+        }
     }
 
     fn emit(&self, aliases: &[String]) {
-        if let Some(details) = &self.details {
-            JoinScan::add_detailed_planner_warning(&self.message, aliases, details.clone());
-        } else {
-            JoinScan::add_planner_warning(&self.message, aliases);
+        match self {
+            Self::ContainsAggregate => {
+                if crate::gucs::enable_aggregate_custom_scan() {
+                    return;
+                }
+                JoinScan::add_planner_warning(
+                    "JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query.",
+                    aliases,
+                );
+            }
+            Self::Message { message, details } => {
+                if let Some(details) = details {
+                    JoinScan::add_detailed_planner_warning(message, aliases, details.clone());
+                } else {
+                    JoinScan::add_planner_warning(message, aliases);
+                }
+            }
         }
     }
 }
@@ -513,9 +537,7 @@ impl JoinScan {
         }
 
         if (*(*root).parse).hasAggs {
-            return Err(JoinDeclineReason::new(
-                "JoinScan not used: aggregates are not supported",
-            ));
+            return Err(JoinDeclineReason::ContainsAggregate);
         }
 
         // Require LIMIT for top-level queries (without it, JoinScan's TopK

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -247,7 +247,10 @@ impl JoinDeclineReason {
 
     pub fn with_details(self, new_details: Vec<String>) -> Self {
         match self {
-            Self::ContainsAggregate => self,
+            Self::ContainsAggregate => {
+                debug_assert!(false, "Cannot add details to ContainsAggregate");
+                self
+            }
             Self::Message {
                 message,
                 details: _,
@@ -262,6 +265,11 @@ impl JoinDeclineReason {
         match self {
             Self::ContainsAggregate => {
                 if crate::gucs::enable_aggregate_custom_scan() {
+                    // We currently suppress this warning if the aggregate scan is enabled, assuming
+                    // it will handle the query. If the aggregate scan later declines it, the user
+                    // won't see a JoinScan warning.
+                    // TODO: https://github.com/paradedb/paradedb/issues/5285 will fix this by allowing
+                    // the joinscan to propose itself even when aggregates are present.
                     return;
                 }
                 JoinScan::add_planner_warning(

--- a/pg_search/src/postgres/customscan/opexpr.rs
+++ b/pg_search/src/postgres/customscan/opexpr.rs
@@ -376,13 +376,13 @@ unsafe fn is_type_cast_function(funcid: pg_sys::Oid) -> bool {
         return false;
     }
 
-    let func_name = pg_sys::get_func_name(funcid);
-    if func_name.is_null() {
-        return false;
+    if let Some(func_name) = crate::postgres::catalog::lookup_func_name(funcid) {
+        if let Ok(cname) = std::ffi::CString::new(func_name) {
+            return pg_sys::TypenameGetTypid(cname.as_ptr()) != pg_sys::Oid::INVALID;
+        }
     }
 
-    // A function is a type cast if there's a type with the same name
-    pg_sys::TypenameGetTypid(func_name) != pg_sys::Oid::INVALID
+    false
 }
 
 /// Compare two PgList argument lists for semantic equality.
@@ -454,14 +454,14 @@ unsafe fn funcs_are_equivalent(funcid1: pg_sys::Oid, funcid2: pg_sys::Oid) -> bo
         return false;
     }
 
-    let name1 = pg_sys::get_func_name(funcid1);
-    let name2 = pg_sys::get_func_name(funcid2);
-    if name1.is_null() || name2.is_null() {
+    let name1 = crate::postgres::catalog::lookup_func_name(funcid1);
+    let name2 = crate::postgres::catalog::lookup_func_name(funcid2);
+    if name1.is_none() || name2.is_none() {
         return false;
     }
 
-    let name1_str = std::ffi::CStr::from_ptr(name1).to_string_lossy();
-    let name2_str = std::ffi::CStr::from_ptr(name2).to_string_lossy();
+    let name1_str = name1.unwrap();
+    let name2_str = name2.unwrap();
 
     // Check if both are arithmetic operations that normalize to the same op
     match (

--- a/pg_search/src/postgres/customscan/opexpr.rs
+++ b/pg_search/src/postgres/customscan/opexpr.rs
@@ -376,10 +376,8 @@ unsafe fn is_type_cast_function(funcid: pg_sys::Oid) -> bool {
         return false;
     }
 
-    if let Some(func_name) = crate::postgres::catalog::lookup_func_name(funcid) {
-        if let Ok(cname) = std::ffi::CString::new(func_name) {
-            return pg_sys::TypenameGetTypid(cname.as_ptr()) != pg_sys::Oid::INVALID;
-        }
+    if let Some(func_name_cstr) = crate::postgres::catalog::lookup_func_name_cstr(funcid) {
+        return pg_sys::TypenameGetTypid(func_name_cstr.as_ptr()) != pg_sys::Oid::INVALID;
     }
 
     false
@@ -454,19 +452,19 @@ unsafe fn funcs_are_equivalent(funcid1: pg_sys::Oid, funcid2: pg_sys::Oid) -> bo
         return false;
     }
 
-    let name1 = crate::postgres::catalog::lookup_func_name(funcid1);
-    let name2 = crate::postgres::catalog::lookup_func_name(funcid2);
+    let name1 = crate::postgres::catalog::lookup_func_name_cstr(funcid1);
+    let name2 = crate::postgres::catalog::lookup_func_name_cstr(funcid2);
     if name1.is_none() || name2.is_none() {
         return false;
     }
 
-    let name1_str = name1.unwrap();
-    let name2_str = name2.unwrap();
+    let name1_str = name1.unwrap().to_str().unwrap_or("");
+    let name2_str = name2.unwrap().to_str().unwrap_or("");
 
     // Check if both are arithmetic operations that normalize to the same op
     match (
-        normalize_arithmetic_op(&name1_str),
-        normalize_arithmetic_op(&name2_str),
+        normalize_arithmetic_op(name1_str),
+        normalize_arithmetic_op(name2_str),
     ) {
         (Some(op1), Some(op2)) => op1 == op2,
         _ => false,

--- a/pg_search/tests/pg_regress/expected/agg-score.out
+++ b/pg_search/tests/pg_regress/expected/agg-score.out
@@ -21,6 +21,7 @@ SET min_parallel_table_scan_size = 0;
 -- Test case 1: Basic max(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -40,6 +41,7 @@ SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 (14 rows)
 
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
      max     
 -------------
  0.057158466
@@ -48,6 +50,7 @@ SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 -- Test case 2: min(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT min(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -67,6 +70,7 @@ SELECT min(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 (14 rows)
 
 SELECT min(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
      min     
 -------------
  0.057158466
@@ -75,6 +79,7 @@ SELECT min(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 -- Test case 3: avg(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT avg(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -94,6 +99,7 @@ SELECT avg(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 (14 rows)
 
 SELECT avg(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
          avg          
 ----------------------
  0.057158466428518295
@@ -103,22 +109,15 @@ SELECT avg(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 -- This can still use parallelism because score is evaluated in the WHERE clause
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT count(*) FROM mock_items WHERE description @@@ 'keyboard' AND paradedb.score(id) > 0;
-                                                                                                                              QUERY PLAN                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
-   Output: count(*)
-   ->  Gather
-         Output: (PARTIAL count(*))
-         Workers Planned: 1
-         ->  Partial Aggregate
-               Output: PARTIAL count(*)
-               ->  Parallel Custom Scan (ParadeDB Base Scan) on public.mock_items
-                     Table: mock_items
-                     Index: search_idx
-                     Exec Method: NormalScanExecState
-                     Scores: true
-                     Tantivy Query: {"score_filter":{"bounds":[[{"Excluded":0.0},"Unbounded"]],"query":{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}]}}}}
-(13 rows)
+                                                                                                                     QUERY PLAN                                                                                                                      
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.mock_items
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: search_idx
+   Tantivy Query: {"score_filter":{"bounds":[[{"Excluded":0.0},"Unbounded"]],"query":{"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}}]}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
 
 SELECT count(*) FROM mock_items WHERE description @@@ 'keyboard' AND paradedb.score(id) > 0;
  count 
@@ -129,6 +128,7 @@ SELECT count(*) FROM mock_items WHERE description @@@ 'keyboard' AND paradedb.sc
 -- Test case 5: sum(score) - should work with parallel execution
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT sum(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -148,6 +148,7 @@ SELECT sum(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 (14 rows)
 
 SELECT sum(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
     sum     
 ------------
  0.45726773
@@ -158,6 +159,7 @@ SET debug_parallel_query = off;
 SET max_parallel_workers_per_gather = 0;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                                                                           QUERY PLAN                                                                           
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -172,6 +174,7 @@ SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
 (9 rows)
 
 SELECT max(paradedb.score(id)) FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
      max     
 -------------
  0.057158466
@@ -183,6 +186,7 @@ SET max_parallel_workers_per_gather = 2;
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT min(paradedb.score(id)), max(paradedb.score(id)), avg(paradedb.score(id)) 
 FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
                                                                                 QUERY PLAN                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Finalize Aggregate
@@ -203,6 +207,7 @@ FROM mock_items WHERE description @@@ 'keyboard';
 
 SELECT min(paradedb.score(id)), max(paradedb.score(id)), avg(paradedb.score(id)) 
 FROM mock_items WHERE description @@@ 'keyboard';
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: mock_items)
      min     |     max     |         avg          
 -------------+-------------+----------------------
  0.057158466 | 0.057158466 | 0.057158466428518295

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -55,6 +55,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                     QUERY PLAN                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -74,6 +75,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      6
@@ -85,6 +87,7 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                     QUERY PLAN                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -104,6 +107,7 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |        sum         | avg 
 -------+--------------------+-----
      6 | 5599.9400000000005 |   4
@@ -115,6 +119,7 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                     QUERY PLAN                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -134,6 +139,7 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   min   |   max   
 --------+---------
  499.99 | 1299.99
@@ -144,6 +150,7 @@ SELECT COUNT(*), SUM(p.price), AVG(p.price), MIN(p.rating), MAX(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |        sum         |        avg        | min | max 
 -------+--------------------+-------------------+-----+-----
      6 | 5599.9400000000005 | 933.3233333333334 |   2 |   5
@@ -157,6 +164,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'nonexistent_term_xyz';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      0
@@ -167,6 +175,7 @@ SELECT SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'nonexistent_term_xyz';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  sum | avg 
 -----+-----
      |    
@@ -177,6 +186,7 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'nonexistent_term_xyz';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  min | max 
 -----+-----
      |    
@@ -190,6 +200,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR toy';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      9
@@ -200,6 +211,7 @@ SELECT COUNT(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      6
@@ -210,6 +222,7 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |   sum   
 -------+---------
      4 | 4599.96
@@ -226,6 +239,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -252,6 +266,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -266,6 +281,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   | avg |  min   |   max   
 -------------+-------+---------+-----+--------+---------
  Electronics |     4 | 4599.96 |   5 | 999.99 | 1299.99
@@ -280,6 +296,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category, t.tag_name
 ORDER BY p.category, t.tag_name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | tag_name | count 
 -------------+----------+-------
  Electronics | computer |     1
@@ -299,6 +316,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -313,6 +331,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -332,6 +351,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR orphan';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      6
@@ -342,6 +362,7 @@ SELECT SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR orphan';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
         sum         | avg 
 --------------------+-----
  5599.9400000000005 |   4
@@ -360,6 +381,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -384,6 +406,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     3
@@ -399,6 +422,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     3
@@ -415,6 +439,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -439,6 +464,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  tag_name | count 
 ----------+-------
  computer |     1
@@ -457,6 +483,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  tag_name | count 
 ----------+-------
  computer |     1
@@ -478,6 +505,7 @@ FROM agg_join_products p
 LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -499,6 +527,7 @@ FROM agg_join_products p
 LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -514,6 +543,7 @@ LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -528,6 +558,7 @@ LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -544,6 +575,7 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -568,6 +600,7 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   tag_name  | count 
 ------------+-------
  orphan_tag |     0
@@ -582,6 +615,7 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   tag_name  | count 
 ------------+-------
  orphan_tag |     0
@@ -595,6 +629,7 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   tag_name  | count 
 ------------+-------
  orphan_tag |     0
@@ -620,6 +655,7 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
                                                                                                   QUERY PLAN                                                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -639,6 +675,7 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
  count 
 -------
      3
@@ -650,6 +687,7 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
  count 
 -------
      3
@@ -688,6 +726,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      6
@@ -697,6 +736,7 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating), MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |   sum   |        avg         |  min   |   max   
 -------+---------+--------------------+--------+---------
      6 | 5599.94 | 4.0000000000000000 | 499.99 | 1299.99
@@ -712,6 +752,7 @@ SELECT STDDEV(p.price), VARIANCE(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
        stddev       |      variance      
 --------------------+--------------------
  495.71737339507706 | 245735.71428571426
@@ -724,6 +765,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | stddev_pop | var_pop 
 -------------+------------+---------
  Electronics |        150 |   22500
@@ -737,6 +779,7 @@ SELECT STDDEV(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
       stddev       
 -------------------
  495.7173733950771
@@ -747,6 +790,7 @@ SELECT STDDEV(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
        stddev       
 --------------------
  495.71737339507706
@@ -793,6 +837,7 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
            min            |           max            
 --------------------------+--------------------------
  Mon Jan 15 10:30:00 2024 | Mon Jun 10 08:15:00 2024
@@ -804,6 +849,7 @@ FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |           min            |           max            
 -------------+--------------------------+--------------------------
  Electronics | Mon Jan 15 10:30:00 2024 | Wed Mar 20 14:45:00 2024
@@ -817,6 +863,7 @@ FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |           min            |           max            
 -------------+--------------------------+--------------------------
  Electronics | Mon Jan 15 10:30:00 2024 | Wed Mar 20 14:45:00 2024
@@ -829,6 +876,7 @@ FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |           min            |           max            
 -------------+--------------------------+--------------------------
  Electronics | Mon Jan 15 10:30:00 2024 | Wed Mar 20 14:45:00 2024
@@ -880,6 +928,7 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
              min              |             max              
 ------------------------------+------------------------------
  Sun Jan 14 21:00:00 2024 PST | Tue Dec 24 07:00:00 2024 PST
@@ -891,6 +940,7 @@ FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |             min              |             max              
 -------------+------------------------------+------------------------------
  Electronics | Sun Jan 14 21:00:00 2024 PST | Thu Jul 04 09:00:00 2024 PDT
@@ -903,6 +953,7 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
              min              |             max              
 ------------------------------+------------------------------
  Sun Jan 14 21:00:00 2024 PST | Tue Dec 24 07:00:00 2024 PST
@@ -913,6 +964,7 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
              min              |             max              
 ------------------------------+------------------------------
  Sun Jan 14 21:00:00 2024 PST | Tue Dec 24 07:00:00 2024 PST
@@ -928,6 +980,7 @@ JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category
 ORDER BY o.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |             min              |             max              
 -------------+------------------------------+------------------------------
  Electronics | Sun Jan 14 21:00:00 2024 PST | Thu Jul 04 09:00:00 2024 PDT
@@ -941,6 +994,7 @@ JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category
 ORDER BY o.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |             min              |             max              
 -------------+------------------------------+------------------------------
  Electronics | Sun Jan 14 21:00:00 2024 PST | Thu Jul 04 09:00:00 2024 PDT
@@ -979,6 +1033,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC NULLS LAST
 LIMIT 2;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortB | 19804
@@ -994,6 +1049,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC NULLS LAST
 LIMIT 2;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortB | 19804
@@ -1009,6 +1065,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) ASC NULLS FIRST
 LIMIT 2;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1024,6 +1081,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) ASC NULLS FIRST
 LIMIT 2;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1040,6 +1098,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC
 LIMIT 2;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1055,6 +1114,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC
 LIMIT 2;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1076,6 +1136,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1099,6 +1160,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1122,6 +1184,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1149,6 +1212,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id = 1 OR p.id = 1) AND p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      2
@@ -1159,6 +1223,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id = 1 OR p.id = 1) AND p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      2
@@ -1170,6 +1235,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id @@@ '1' OR p.id @@@ '1') AND p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      2
@@ -1180,6 +1246,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id @@@ '1' OR p.id @@@ '1') AND p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      2
@@ -1197,6 +1264,7 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                                        QUERY PLAN                                                                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1217,6 +1285,7 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |   sum   
 -------+---------
      4 | 4599.96
@@ -1228,6 +1297,7 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |   sum   
 -------+---------
      4 | 4599.96
@@ -1245,6 +1315,7 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING COUNT(*) > 1
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -1261,6 +1332,7 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING COUNT(*) > 1
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -1277,6 +1349,7 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING SUM(p.price) > 100
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1293,6 +1366,7 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING SUM(p.price) > 100
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1324,6 +1398,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                             QUERY PLAN                                                                                            
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1347,6 +1422,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | bool_and 
 -------------+----------
  Electronics | t
@@ -1361,6 +1437,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | bool_or 
 -------------+---------
  Electronics | t
@@ -1375,6 +1452,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1398,6 +1476,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | tech, computer, tech, gaming
@@ -1413,6 +1492,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | bool_and | bool_or 
 -------------+----------+---------
  Electronics | t        | t
@@ -1427,6 +1507,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | bool_and | bool_or 
 -------------+----------+---------
  Electronics | t        | t
@@ -1441,6 +1522,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {tech,computer,tech,gaming}
@@ -1456,6 +1538,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {tech,computer,tech,gaming}
@@ -1483,6 +1566,7 @@ SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
 FROM agg_join_products p
 FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1503,6 +1587,7 @@ SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
 FROM agg_join_products p
 FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  count | count | count 
 -------+-------+-------
      8 |     8 |     8
@@ -1515,6 +1600,7 @@ FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1530,6 +1616,7 @@ FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1544,6 +1631,7 @@ FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1561,6 +1649,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1585,6 +1674,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | computer, gaming, tech, tech
@@ -1600,6 +1690,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | computer, gaming, tech, tech
@@ -1615,6 +1706,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | tech, tech, gaming, computer
@@ -1629,6 +1721,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1653,6 +1746,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {computer,gaming,tech,tech}
@@ -1668,6 +1762,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {computer,gaming,tech,tech}
@@ -1683,6 +1778,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {tech,tech,gaming,computer}
@@ -1727,6 +1823,7 @@ FROM agg_json_items i
 JOIN agg_json_orders o ON i.id = o.item_id
 WHERE i.id @@@ paradedb.all()
 GROUP BY i.metadata->>'category';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1751,6 +1848,7 @@ JOIN agg_json_orders o ON i.id = o.item_id
 WHERE i.id @@@ paradedb.all()
 GROUP BY i.metadata->>'category'
 ORDER BY category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   | count | sum 
 -------------+-------+-----
  Electronics |     3 |  18
@@ -1765,6 +1863,7 @@ JOIN agg_json_orders o ON i.id = o.item_id
 WHERE i.id @@@ paradedb.all()
 GROUP BY i.metadata->>'category'
 ORDER BY category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   | count | sum 
 -------------+-------+-----
  Electronics |     3 |  18
@@ -1786,6 +1885,7 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                              QUERY PLAN                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1812,6 +1912,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | total | expensive 
 -------------+-------+-----------
  Clothing    |     1 |         1
@@ -1830,6 +1931,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | total | expensive 
 -------------+-------+-----------
  Clothing    |     1 |         1
@@ -1848,6 +1950,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | total_price | high_rated_price 
 -------------+-------------+------------------
  Clothing    |      129.99 |                 
@@ -1866,6 +1969,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | total_price | high_rated_price 
 -------------+-------------+------------------
  Clothing    |      129.99 |                 

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -55,7 +55,6 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                     QUERY PLAN                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -75,7 +74,6 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      6
@@ -87,7 +85,6 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                     QUERY PLAN                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -107,7 +104,6 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |        sum         | avg 
 -------+--------------------+-----
      6 | 5599.9400000000005 |   4
@@ -119,7 +115,6 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                     QUERY PLAN                                                                                    
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -139,7 +134,6 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   min   |   max   
 --------+---------
  499.99 | 1299.99
@@ -150,7 +144,6 @@ SELECT COUNT(*), SUM(p.price), AVG(p.price), MIN(p.rating), MAX(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |        sum         |        avg        | min | max 
 -------+--------------------+-------------------+-----+-----
      6 | 5599.9400000000005 | 933.3233333333334 |   2 |   5
@@ -164,7 +157,6 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'nonexistent_term_xyz';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      0
@@ -175,7 +167,6 @@ SELECT SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'nonexistent_term_xyz';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  sum | avg 
 -----+-----
      |    
@@ -186,7 +177,6 @@ SELECT MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'nonexistent_term_xyz';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  min | max 
 -----+-----
      |    
@@ -200,7 +190,6 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR toy';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      9
@@ -211,7 +200,6 @@ SELECT COUNT(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      6
@@ -222,7 +210,6 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |   sum   
 -------+---------
      4 | 4599.96
@@ -239,7 +226,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -266,7 +252,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -281,7 +266,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   | avg |  min   |   max   
 -------------+-------+---------+-----+--------+---------
  Electronics |     4 | 4599.96 |   5 | 999.99 | 1299.99
@@ -296,7 +280,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category, t.tag_name
 ORDER BY p.category, t.tag_name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | tag_name | count 
 -------------+----------+-------
  Electronics | computer |     1
@@ -316,7 +299,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -331,7 +314,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -351,7 +333,6 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR orphan';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      6
@@ -362,7 +343,6 @@ SELECT SUM(p.price), AVG(p.rating)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR orphan';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
         sum         | avg 
 --------------------+-----
  5599.9400000000005 |   4
@@ -381,7 +361,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -406,7 +385,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     3
@@ -422,7 +400,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     3
@@ -439,7 +417,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -464,7 +441,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  tag_name | count 
 ----------+-------
  computer |     1
@@ -483,7 +459,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  tag_name | count 
 ----------+-------
  computer |     1
@@ -655,7 +631,6 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
                                                                                                   QUERY PLAN                                                                                                  
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -675,7 +650,6 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
  count 
 -------
      3
@@ -687,7 +661,7 @@ SELECT COUNT(*)
 FROM comp_a a
 JOIN comp_b b ON a.x = b.x AND a.y = b.y
 WHERE a.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: a, b)
  count 
 -------
      3
@@ -726,7 +700,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  count 
 -------
      6
@@ -736,7 +710,7 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating), MIN(p.price), MAX(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  count |   sum   |        avg         |  min   |   max   
 -------+---------+--------------------+--------+---------
      6 | 5599.94 | 4.0000000000000000 | 499.99 | 1299.99
@@ -752,7 +726,6 @@ SELECT STDDEV(p.price), VARIANCE(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
        stddev       |      variance      
 --------------------+--------------------
  495.71737339507706 | 245735.71428571426
@@ -765,7 +738,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | stddev_pop | var_pop 
 -------------+------------+---------
  Electronics |        150 |   22500
@@ -779,7 +751,7 @@ SELECT STDDEV(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
       stddev       
 -------------------
  495.7173733950771
@@ -790,7 +762,6 @@ SELECT STDDEV(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
        stddev       
 --------------------
  495.71737339507706
@@ -837,7 +808,6 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
            min            |           max            
 --------------------------+--------------------------
  Mon Jan 15 10:30:00 2024 | Mon Jun 10 08:15:00 2024
@@ -849,7 +819,6 @@ FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |           min            |           max            
 -------------+--------------------------+--------------------------
  Electronics | Mon Jan 15 10:30:00 2024 | Wed Mar 20 14:45:00 2024
@@ -863,7 +832,7 @@ FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: i, o)
   category   |           min            |           max            
 -------------+--------------------------+--------------------------
  Electronics | Mon Jan 15 10:30:00 2024 | Wed Mar 20 14:45:00 2024
@@ -876,7 +845,6 @@ FROM ts_orders o
 JOIN ts_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |           min            |           max            
 -------------+--------------------------+--------------------------
  Electronics | Mon Jan 15 10:30:00 2024 | Wed Mar 20 14:45:00 2024
@@ -928,7 +896,6 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
              min              |             max              
 ------------------------------+------------------------------
  Sun Jan 14 21:00:00 2024 PST | Tue Dec 24 07:00:00 2024 PST
@@ -940,7 +907,6 @@ FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |             min              |             max              
 -------------+------------------------------+------------------------------
  Electronics | Sun Jan 14 21:00:00 2024 PST | Thu Jul 04 09:00:00 2024 PDT
@@ -953,7 +919,7 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: i, o)
              min              |             max              
 ------------------------------+------------------------------
  Sun Jan 14 21:00:00 2024 PST | Tue Dec 24 07:00:00 2024 PST
@@ -964,7 +930,6 @@ SELECT MIN(o.created_at), MAX(o.created_at)
 FROM tstz_orders o
 JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
              min              |             max              
 ------------------------------+------------------------------
  Sun Jan 14 21:00:00 2024 PST | Tue Dec 24 07:00:00 2024 PST
@@ -980,7 +945,7 @@ JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category
 ORDER BY o.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: i, o)
   category   |             min              |             max              
 -------------+------------------------------+------------------------------
  Electronics | Sun Jan 14 21:00:00 2024 PST | Thu Jul 04 09:00:00 2024 PDT
@@ -994,7 +959,6 @@ JOIN tstz_items i ON o.id = i.order_id
 WHERE o.description @@@ 'order'
 GROUP BY o.category
 ORDER BY o.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   |             min              |             max              
 -------------+------------------------------+------------------------------
  Electronics | Sun Jan 14 21:00:00 2024 PST | Thu Jul 04 09:00:00 2024 PDT
@@ -1136,7 +1100,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1160,7 +1123,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1184,7 +1146,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1212,7 +1173,6 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id = 1 OR p.id = 1) AND p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      2
@@ -1223,7 +1183,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id = 1 OR p.id = 1) AND p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  count 
 -------
      2
@@ -1235,7 +1195,6 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id @@@ '1' OR p.id @@@ '1') AND p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count 
 -------
      2
@@ -1246,7 +1205,7 @@ SELECT COUNT(*)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE (t.id @@@ '1' OR p.id @@@ '1') AND p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  count 
 -------
      2
@@ -1264,7 +1223,6 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                                        QUERY PLAN                                                                                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1285,7 +1243,6 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |   sum   
 -------+---------
      4 | 4599.96
@@ -1297,7 +1254,7 @@ SELECT COUNT(*), SUM(p.price)
 FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop' AND p.price > 500;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  count |   sum   
 -------+---------
      4 | 4599.96
@@ -1315,7 +1272,6 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING COUNT(*) > 1
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -1332,7 +1288,7 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING COUNT(*) > 1
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -1349,7 +1305,6 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING SUM(p.price) > 100
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1366,7 +1321,7 @@ WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 HAVING SUM(p.price) > 100
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1398,7 +1353,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                             QUERY PLAN                                                                                            
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1422,7 +1376,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | bool_and 
 -------------+----------
  Electronics | t
@@ -1437,7 +1390,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | bool_or 
 -------------+---------
  Electronics | t
@@ -1452,7 +1404,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1476,7 +1427,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | tech, computer, tech, gaming
@@ -1492,7 +1442,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | bool_and | bool_or 
 -------------+----------+---------
  Electronics | t        | t
@@ -1507,7 +1457,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR toy'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | bool_and | bool_or 
 -------------+----------+---------
  Electronics | t        | t
@@ -1522,7 +1471,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {tech,computer,tech,gaming}
@@ -1538,7 +1486,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {tech,computer,tech,gaming}
@@ -1649,7 +1597,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1674,7 +1621,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | computer, gaming, tech, tech
@@ -1690,7 +1636,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | computer, gaming, tech, tech
@@ -1706,7 +1652,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          string_agg          
 -------------+------------------------------
  Electronics | tech, tech, gaming, computer
@@ -1721,7 +1666,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                          QUERY PLAN                                                                                          
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1746,7 +1690,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {computer,gaming,tech,tech}
@@ -1762,7 +1705,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {computer,gaming,tech,tech}
@@ -1778,7 +1721,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |          array_agg          
 -------------+-----------------------------
  Electronics | {tech,tech,gaming,computer}
@@ -1823,7 +1765,6 @@ FROM agg_json_items i
 JOIN agg_json_orders o ON i.id = o.item_id
 WHERE i.id @@@ paradedb.all()
 GROUP BY i.metadata->>'category';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
                                                         QUERY PLAN                                                        
 --------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1848,7 +1789,6 @@ JOIN agg_json_orders o ON i.id = o.item_id
 WHERE i.id @@@ paradedb.all()
 GROUP BY i.metadata->>'category'
 ORDER BY category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   category   | count | sum 
 -------------+-------+-----
  Electronics |     3 |  18
@@ -1863,7 +1803,7 @@ JOIN agg_json_orders o ON i.id = o.item_id
 WHERE i.id @@@ paradedb.all()
 GROUP BY i.metadata->>'category'
 ORDER BY category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: i, o)
   category   | count | sum 
 -------------+-------+-----
  Electronics |     3 |  18
@@ -1885,7 +1825,6 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                              QUERY PLAN                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1912,7 +1851,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | total | expensive 
 -------------+-------+-----------
  Clothing    |     1 |         1
@@ -1931,7 +1869,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | total | expensive 
 -------------+-------+-----------
  Clothing    |     1 |         1
@@ -1950,7 +1888,6 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | total_price | high_rated_price 
 -------------+-------------+------------------
  Clothing    |      129.99 |                 
@@ -1969,7 +1906,7 @@ JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | total_price | high_rated_price 
 -------------+-------------+------------------
  Clothing    |      129.99 |                 

--- a/pg_search/tests/pg_regress/expected/aggregate_join_coverage.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_coverage.out
@@ -59,6 +59,7 @@ SELECT SUM(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  sum 
 -----
   21
@@ -69,6 +70,7 @@ SELECT SUM(o.amount)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   sum  
 -------
  20997
@@ -81,6 +83,7 @@ SELECT COUNT(i.unit_price)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  count 
 -------
      3
@@ -93,6 +96,7 @@ SELECT MIN(o.quantity), MAX(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  min | max 
 -----+-----
    1 |  50
@@ -103,6 +107,7 @@ SELECT MIN(i.unit_price), MAX(i.unit_price)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  min | max 
 -----+-----
   49 | 999
@@ -116,6 +121,7 @@ SELECT AVG(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  avg  
 ------
  24.2
@@ -150,6 +156,7 @@ SELECT COUNT(*), SUM(o.quantity), AVG(o.quantity), MIN(o.quantity), MAX(o.quanti
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'nonexistent_product_xyz';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  count | sum | avg | min | max 
 -------+-----+-----+-----+-----
      0 |     |     |     |    
@@ -181,6 +188,7 @@ JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes OR jacket OR tablet'
 GROUP BY o.customer
 ORDER BY o.customer;
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  customer  | count | sum | min | max 
 -----------+-------+-----+-----+-----
  Acme Corp |     3 |  21 |  49 | 999
@@ -214,6 +222,7 @@ SELECT COUNT(*), SUM(o.quantity), SUM(o.amount), AVG(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  count | sum |  sum  |         avg         
 -------+-----+-------+---------------------
      5 | 121 | 29995 | 24.2000000000000000
@@ -224,6 +233,7 @@ SELECT COUNT(*), SUM(o.quantity), SUM(o.amount), AVG(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  count | sum |  sum  | avg  
 -------+-----+-------+------
      5 | 121 | 29995 | 24.2
@@ -288,6 +298,7 @@ SELECT COUNT(*), SUM(s.reading), AVG(s.reading), MIN(s.reading), MAX(s.reading)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'sensor';
+WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
  count |  sum  |        avg         | min  | max  
 -------+-------+--------------------+------+------
      7 | 328.8 | 46.971428571428575 | 14.7 | 98.6
@@ -298,6 +309,7 @@ SELECT SUM(s.priority), MIN(s.priority), MAX(s.priority)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'sensor';
+WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
  sum | min | max 
 -----+-----+-----
   10 |   1 |   3
@@ -309,6 +321,7 @@ SELECT COUNT(*), SUM(s.reading), MIN(s.reading), MAX(s.reading)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'temperature';
+WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
  count |  sum  | min | max  
 -------+-------+-----+------
      3 | 229.2 |  32 | 98.6
@@ -319,6 +332,7 @@ SELECT COUNT(*), SUM(s.reading), MIN(s.reading), MAX(s.reading)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'temperature';
+WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
  count |  sum  | min | max  
 -------+-------+-----+------
      3 | 229.2 |  32 | 98.6
@@ -368,6 +382,7 @@ SELECT SUM(b.qty)
 FROM cov_big b
 JOIN cov_big_tags t ON b.id = t.big_id
 WHERE b.description @@@ 'laptop OR phone';
+WARNING:  JoinScan not used: aggregates are not supported (tables: b, t)
  sum 
 -----
  300
@@ -379,6 +394,7 @@ SELECT SUM(b.qty)
 FROM cov_big b
 JOIN cov_big_tags t ON b.id = t.big_id
 WHERE b.description @@@ 'laptop OR phone';
+WARNING:  JoinScan not used: aggregates are not supported (tables: b, t)
  sum 
 -----
  300

--- a/pg_search/tests/pg_regress/expected/aggregate_join_coverage.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_coverage.out
@@ -59,7 +59,6 @@ SELECT SUM(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  sum 
 -----
   21
@@ -70,7 +69,6 @@ SELECT SUM(o.amount)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
   sum  
 -------
  20997
@@ -83,7 +81,6 @@ SELECT COUNT(i.unit_price)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  count 
 -------
      3
@@ -96,7 +93,6 @@ SELECT MIN(o.quantity), MAX(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  min | max 
 -----+-----
    1 |  50
@@ -107,7 +103,6 @@ SELECT MIN(i.unit_price), MAX(i.unit_price)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  min | max 
 -----+-----
   49 | 999
@@ -121,7 +116,6 @@ SELECT AVG(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  avg  
 ------
  24.2
@@ -156,7 +150,6 @@ SELECT COUNT(*), SUM(o.quantity), AVG(o.quantity), MIN(o.quantity), MAX(o.quanti
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'nonexistent_product_xyz';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  count | sum | avg | min | max 
 -------+-----+-----+-----+-----
      0 |     |     |     |    
@@ -188,7 +181,7 @@ JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes OR jacket OR tablet'
 GROUP BY o.customer
 ORDER BY o.customer;
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: i, o)
  customer  | count | sum | min | max 
 -----------+-------+-----+-----+-----
  Acme Corp |     3 |  21 |  49 | 999
@@ -222,7 +215,7 @@ SELECT COUNT(*), SUM(o.quantity), SUM(o.amount), AVG(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: i, o)
  count | sum |  sum  |         avg         
 -------+-----+-------+---------------------
      5 | 121 | 29995 | 24.2000000000000000
@@ -233,7 +226,6 @@ SELECT COUNT(*), SUM(o.quantity), SUM(o.amount), AVG(o.quantity)
 FROM cov_orders o
 JOIN cov_items i ON o.id = i.order_id
 WHERE o.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: i, o)
  count | sum |  sum  | avg  
 -------+-----+-------+------
      5 | 121 | 29995 | 24.2
@@ -298,7 +290,6 @@ SELECT COUNT(*), SUM(s.reading), AVG(s.reading), MIN(s.reading), MAX(s.reading)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'sensor';
-WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
  count |  sum  |        avg         | min  | max  
 -------+-------+--------------------+------+------
      7 | 328.8 | 46.971428571428575 | 14.7 | 98.6
@@ -309,7 +300,6 @@ SELECT SUM(s.priority), MIN(s.priority), MAX(s.priority)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'sensor';
-WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
  sum | min | max 
 -----+-----+-----
   10 |   1 |   3
@@ -321,7 +311,7 @@ SELECT COUNT(*), SUM(s.reading), MIN(s.reading), MAX(s.reading)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'temperature';
-WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: l, s)
  count |  sum  | min | max  
 -------+-------+-----+------
      3 | 229.2 |  32 | 98.6
@@ -332,7 +322,6 @@ SELECT COUNT(*), SUM(s.reading), MIN(s.reading), MAX(s.reading)
 FROM cov_sensors s
 JOIN cov_logs l ON s.id = l.sensor_id
 WHERE s.description @@@ 'temperature';
-WARNING:  JoinScan not used: aggregates are not supported (tables: l, s)
  count |  sum  | min | max  
 -------+-------+-----+------
      3 | 229.2 |  32 | 98.6
@@ -382,7 +371,6 @@ SELECT SUM(b.qty)
 FROM cov_big b
 JOIN cov_big_tags t ON b.id = t.big_id
 WHERE b.description @@@ 'laptop OR phone';
-WARNING:  JoinScan not used: aggregates are not supported (tables: b, t)
  sum 
 -----
  300
@@ -394,7 +382,7 @@ SELECT SUM(b.qty)
 FROM cov_big b
 JOIN cov_big_tags t ON b.id = t.big_id
 WHERE b.description @@@ 'laptop OR phone';
-WARNING:  JoinScan not used: aggregates are not supported (tables: b, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: b, t)
  sum 
 -----
  300

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -79,6 +79,7 @@ SELECT COUNT(*)
 FROM ec_products p
 JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
                                                                                                         QUERY PLAN                                                                                                        
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -99,6 +100,7 @@ SELECT COUNT(*)
 FROM ec_products p
 JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
  count 
 -------
     12
@@ -112,6 +114,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
                                                                                                            QUERY PLAN                                                                                                           
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -138,6 +141,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
   category   | count | sum | avg 
 -------------+-------+-----+-----
  Clothing    |     2 |   7 | 3.5
@@ -153,6 +157,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
   category   | count | sum |        avg         
 -------------+-------+-----+--------------------
  Clothing    |     2 |   7 | 3.5000000000000000
@@ -168,6 +173,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
   category   | min | max |  min   |  max   
 -------------+-----+-----+--------+--------
  Clothing    |   3 |   4 | 129.99 | 129.99
@@ -187,6 +193,7 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
                                                                                                                QUERY PLAN                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -213,6 +220,7 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -229,6 +237,7 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -251,6 +260,7 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s)
                                                                                                             QUERY PLAN                                                                                                            
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -279,6 +289,7 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     4 |  14
@@ -295,6 +306,7 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     4 |  14
@@ -314,6 +326,7 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
                                                                                                                 QUERY PLAN                                                                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -342,6 +355,7 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
   category   | count | count | count 
 -------------+-------+-------+-------
  Books       |     1 |     0 |     0
@@ -359,6 +373,7 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
   category   | count | count | count 
 -------------+-------+-------+-------
  Books       |     1 |     0 |     0
@@ -377,6 +392,7 @@ FULL JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -393,6 +409,7 @@ FULL JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -412,6 +429,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY 1
 ORDER BY 1;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r)
                                                                                                                QUERY PLAN                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -437,6 +455,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY 1
 ORDER BY 1;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r)
   ?column?   
 -------------
  "Smash"
@@ -454,6 +473,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY 1
 ORDER BY 1;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r)
   ?column?   
 -------------
  "Smash"
@@ -476,6 +496,7 @@ LEFT JOIN ec_suppliers s ON r.category = s.category
 WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
                                                                                         QUERY PLAN                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -505,6 +526,7 @@ LEFT JOIN ec_suppliers s ON r.category = s.category
 WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
  brand_text | brand_json 
 ------------+------------
  TechCorp   | "TechCorp"
@@ -519,6 +541,7 @@ LEFT JOIN ec_suppliers s ON r.category = s.category
 WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
  brand_text | brand_json 
 ------------+------------
  TechCorp   | "TechCorp"

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -79,7 +79,6 @@ SELECT COUNT(*)
 FROM ec_products p
 JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
                                                                                                         QUERY PLAN                                                                                                        
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -100,7 +99,6 @@ SELECT COUNT(*)
 FROM ec_products p
 JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
  count 
 -------
     12
@@ -114,7 +112,6 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
                                                                                                            QUERY PLAN                                                                                                           
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -141,7 +138,6 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
   category   | count | sum | avg 
 -------------+-------+-----+-----
  Clothing    |     2 |   7 | 3.5
@@ -157,7 +153,7 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r)
   category   | count | sum |        avg         
 -------------+-------+-----+--------------------
  Clothing    |     2 |   7 | 3.5000000000000000
@@ -173,7 +169,6 @@ JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r)
   category   | min | max |  min   |  max   
 -------------+-----+-----+--------+--------
  Clothing    |   3 |   4 | 129.99 | 129.99
@@ -260,7 +255,6 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s)
                                                                                                             QUERY PLAN                                                                                                            
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -289,7 +283,6 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     4 |  14
@@ -306,7 +299,7 @@ JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r, s)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     4 |  14

--- a/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
@@ -60,7 +60,6 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -85,7 +84,6 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  count 
 -------
      2
@@ -99,7 +97,6 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   4
@@ -116,7 +113,7 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   4
@@ -133,7 +130,6 @@ JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -161,7 +157,6 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum | avg | min | max 
 -------------+-------+-----+-----+-----+-----
  Clothing    |     1 |   4 |   4 |   4 |   4
@@ -175,7 +170,6 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  count 
 -------
      2
@@ -191,7 +185,6 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  tag_name | count | sum 
 ----------+-------+-----
  fitness  |     1 |   3
@@ -286,7 +279,6 @@ JOIN fb_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -311,7 +303,6 @@ JOIN fb_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     1
@@ -328,7 +319,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count 
 -------------+-------
  Clothing    |     1
@@ -344,7 +335,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Clothing    |     1

--- a/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
@@ -60,6 +60,7 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -84,6 +85,7 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  count 
 -------
      2
@@ -97,6 +99,7 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   4
@@ -113,6 +116,7 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   4
@@ -129,6 +133,7 @@ JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -156,6 +161,7 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum | avg | min | max 
 -------------+-------+-----+-----+-----+-----
  Clothing    |     1 |   4 |   4 |   4 |   4
@@ -169,6 +175,7 @@ FROM fb_products p
 JOIN fb_tags t ON p.id = t.product_id
 JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  count 
 -------
      2
@@ -184,6 +191,7 @@ JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  tag_name | count | sum 
 ----------+-------+-----
  fitness  |     1 |   3
@@ -199,6 +207,7 @@ LEFT JOIN fb_tags t ON p.id = t.product_id
 LEFT JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -225,6 +234,7 @@ LEFT JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, t)
   category   | count | count 
 -------------+-------+-------
  Clothing    |     1 |     1
@@ -241,6 +251,7 @@ FROM fb_products p
 CROSS JOIN fb_tags t
 WHERE p.description @@@ 'laptop';
 WARNING:  Aggregate Scan (DataFusion) not used: CROSS JOINs are not supported (no equi-join keys) (table: join)
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: p, t)
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Aggregate
@@ -259,6 +270,7 @@ FROM fb_products p
 CROSS JOIN fb_tags t
 WHERE p.description @@@ 'laptop';
 WARNING:  Aggregate Scan (DataFusion) not used: CROSS JOINs are not supported (no equi-join keys) (table: join)
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: p, t)
  count 
 -------
      3
@@ -274,6 +286,7 @@ JOIN fb_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -298,6 +311,7 @@ JOIN fb_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     1
@@ -314,6 +328,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Clothing    |     1
@@ -329,6 +344,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 0
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Clothing    |     1

--- a/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
@@ -84,6 +84,7 @@ JOIN mt_tags t ON p.id = t.product_id
 JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -110,6 +111,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum | avg 
 -------------+-------+-----+-----
  Clothing    |     1 |   3 |   3
@@ -126,6 +128,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum |        avg         
 -------------+-------+-----+--------------------
  Clothing    |     1 |   3 | 3.0000000000000000
@@ -145,6 +148,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s, t)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -175,6 +179,7 @@ JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   3
@@ -192,6 +197,7 @@ JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   3
@@ -208,6 +214,7 @@ FROM mt_products p
 JOIN mt_tags t ON p.id = t.product_id
 JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  count | sum | min | max 
 -------+-----+-----+-----
      6 |  24 |   3 |   5
@@ -223,6 +230,8 @@ LEFT JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR kids'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, t)
   category   | count | count 
 -------------+-------+-------
  Clothing    |     1 |     1
@@ -241,6 +250,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop'
 GROUP BY p.category, t.tag_name
 ORDER BY p.category, t.tag_name;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | tag_name | count | sum 
 -------------+----------+-------+-----
  Electronics | computer |     2 |   9
@@ -259,6 +269,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 2
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum 
 -------------+-------+-----
  Electronics |     6 |  24
@@ -275,6 +286,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY cnt DESC
 LIMIT 2;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | cnt | total 
 -------------+-----+-------
  Electronics |   6 |    24
@@ -291,6 +303,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | sum 
 -------------+-----
  Clothing    |   3
@@ -307,6 +320,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | sum 
 -------------+-----
  Clothing    |   3
@@ -326,6 +340,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count 
 -------------+-------
  Electronics |     3
@@ -341,6 +356,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | bool_and | bool_or 
 -------------+----------+---------
  Clothing    | f        | f

--- a/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
@@ -84,7 +84,6 @@ JOIN mt_tags t ON p.id = t.product_id
 JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -111,7 +110,6 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum | avg 
 -------------+-------+-----+-----
  Clothing    |     1 |   3 |   3
@@ -128,7 +126,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r, t)
   category   | count | sum |        avg         
 -------------+-------+-----+--------------------
  Clothing    |     1 |   3 | 3.0000000000000000
@@ -148,7 +146,6 @@ JOIN mt_reviews r ON p.id = r.product_id
 JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s, t)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -179,7 +176,6 @@ JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   3
@@ -197,7 +193,7 @@ JOIN mt_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, s, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r, s, t)
   category   | count | sum 
 -------------+-------+-----
  Clothing    |     1 |   3
@@ -214,7 +210,6 @@ FROM mt_products p
 JOIN mt_tags t ON p.id = t.product_id
 JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
  count | sum | min | max 
 -------+-----+-----+-----
      6 |  24 |   3 |   5
@@ -230,7 +225,6 @@ LEFT JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR kids'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, t)
   category   | count | count 
 -------------+-------+-------
@@ -250,7 +244,6 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop'
 GROUP BY p.category, t.tag_name
 ORDER BY p.category, t.tag_name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | tag_name | count | sum 
 -------------+----------+-------+-----
  Electronics | computer |     2 |   9
@@ -269,7 +262,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 HAVING COUNT(*) > 2
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count | sum 
 -------------+-------+-----
  Electronics |     6 |  24
@@ -286,7 +278,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY cnt DESC
 LIMIT 2;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | cnt | total 
 -------------+-----+-------
  Electronics |   6 |    24
@@ -303,7 +294,6 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | sum 
 -------------+-----
  Clothing    |   3
@@ -320,7 +310,7 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r, t)
   category   | sum 
 -------------+-----
  Clothing    |   3
@@ -340,7 +330,6 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | count 
 -------------+-------
  Electronics |     3
@@ -356,7 +345,6 @@ JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, r, t)
   category   | bool_and | bool_or 
 -------------+----------+---------
  Clothing    | f        | f

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -70,7 +70,6 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                       QUERY PLAN                                                                                      
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -96,7 +95,6 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
@@ -116,7 +114,6 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, cl)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -146,7 +143,6 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, cl)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
      job_title     | doc_count 
 -------------------+-----------
@@ -171,7 +167,6 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -201,7 +196,6 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
@@ -221,8 +215,8 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -401,7 +395,6 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -431,7 +424,6 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
@@ -447,8 +439,8 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
 (0 rows)
@@ -467,7 +459,6 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
        label       | doc_count 
 -------------------+-----------
@@ -597,7 +588,6 @@ WHERE l.fk IN (
   AND r.body @@@ 'doc'
 GROUP BY l.label ORDER BY l.label;
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: l, r, z)
  label | c 
 -------+---
  A     | 1
@@ -612,7 +602,7 @@ WHERE l.fk IN (
 )
   AND r.body @@@ 'doc'
 GROUP BY l.label ORDER BY l.label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: l, r, z)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: l, r, z)
  label | c 
 -------+---
  A     | 1
@@ -659,7 +649,6 @@ WHERE a.id NOT IN (
     )
   AND a.body @@@ 'outermatch'
   AND b.val > a.threshold;
-WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -691,7 +680,6 @@ WHERE a.id NOT IN (
     )
   AND a.body @@@ 'outermatch'
   AND b.val > a.threshold;
-WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
  count | sum 
 -------+-----
      1 |  60
@@ -706,7 +694,7 @@ WHERE a.id NOT IN (
     )
   AND a.body @@@ 'outermatch'
   AND b.val > a.threshold;
-WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: a, b)
  count | sum 
 -------+-----
      1 |  60
@@ -739,7 +727,6 @@ WHERE id IN (
 )
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n9_outer, i, m)
  label | c 
 -------+---
  A     | 1
@@ -753,7 +740,7 @@ WHERE id IN (
 )
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n9_outer, i, m)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_n9_outer, i, m)
  label | c 
 -------+---
  A     | 1
@@ -790,7 +777,6 @@ WHERE id IN (SELECT id FROM asa_n10_in1)
   AND id NOT IN (SELECT id FROM asa_n10_in3)
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n10_in1, asa_n10_in2, asa_n10_in3, asa_n10_outer)
  label | c 
 -------+---
  A     | 3
@@ -803,7 +789,7 @@ WHERE id IN (SELECT id FROM asa_n10_in1)
   AND id NOT IN (SELECT id FROM asa_n10_in3)
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
-WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n10_in1, asa_n10_in2, asa_n10_in3, asa_n10_outer)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_n10_in1, asa_n10_in2, asa_n10_in3, asa_n10_outer)
  label | c 
 -------+---
  A     | 3

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -70,6 +70,8 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                       QUERY PLAN                                                                                      
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -94,6 +96,8 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |        10
@@ -112,6 +116,8 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, cl)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -140,6 +146,8 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, cl)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -163,6 +171,8 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                        QUERY PLAN                                                                                       
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -191,6 +201,8 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -209,6 +221,8 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -387,6 +401,8 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -415,6 +431,8 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
 (0 rows)
@@ -429,6 +447,8 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
 (0 rows)
@@ -447,6 +467,8 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
        label       | doc_count 
 -------------------+-----------
  Senior Programmer |         4
@@ -575,6 +597,7 @@ WHERE l.fk IN (
   AND r.body @@@ 'doc'
 GROUP BY l.label ORDER BY l.label;
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: l, r, z)
  label | c 
 -------+---
  A     | 1
@@ -589,6 +612,7 @@ WHERE l.fk IN (
 )
   AND r.body @@@ 'doc'
 GROUP BY l.label ORDER BY l.label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: l, r, z)
  label | c 
 -------+---
  A     | 1
@@ -635,6 +659,7 @@ WHERE a.id NOT IN (
     )
   AND a.body @@@ 'outermatch'
   AND b.val > a.threshold;
+WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
                                                                                                                                                                                                                                 QUERY PLAN                                                                                                                                                                                                                                 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -666,6 +691,7 @@ WHERE a.id NOT IN (
     )
   AND a.body @@@ 'outermatch'
   AND b.val > a.threshold;
+WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
  count | sum 
 -------+-----
      1 |  60
@@ -680,6 +706,7 @@ WHERE a.id NOT IN (
     )
   AND a.body @@@ 'outermatch'
   AND b.val > a.threshold;
+WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
  count | sum 
 -------+-----
      1 |  60
@@ -712,6 +739,7 @@ WHERE id IN (
 )
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n9_outer, i, m)
  label | c 
 -------+---
  A     | 1
@@ -725,6 +753,7 @@ WHERE id IN (
 )
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n9_outer, i, m)
  label | c 
 -------+---
  A     | 1
@@ -761,6 +790,7 @@ WHERE id IN (SELECT id FROM asa_n10_in1)
   AND id NOT IN (SELECT id FROM asa_n10_in3)
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n10_in1, asa_n10_in2, asa_n10_in3, asa_n10_outer)
  label | c 
 -------+---
  A     | 3
@@ -773,6 +803,7 @@ WHERE id IN (SELECT id FROM asa_n10_in1)
   AND id NOT IN (SELECT id FROM asa_n10_in3)
   AND label @@@ 'A'
 GROUP BY label ORDER BY label;
+WARNING:  JoinScan not used: aggregates are not supported (tables: asa_n10_in1, asa_n10_in2, asa_n10_in3, asa_n10_outer)
  label | c 
 -------+---
  A     | 3

--- a/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
@@ -66,7 +66,6 @@ FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                 QUERY PLAN                                                                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -89,7 +88,6 @@ FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -110,7 +108,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -141,7 +138,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Sports      |     4
@@ -160,7 +156,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 2;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -191,7 +186,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 2;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |   sum   
 -------------+---------
  Electronics | 4599.96
@@ -208,7 +202,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) ASC
 LIMIT 2;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category | count 
 ----------+-------
  Books    |     1
@@ -225,7 +218,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   | min | max 
 -------------+-------+---------+-----+-----
  Electronics |     4 | 4599.96 |   5 |   5
@@ -243,7 +235,7 @@ JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category
 ORDER BY COUNT(*) DESC;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count |        sum         
 -------------+-------+--------------------
  Electronics |     4 |            4599.96
@@ -261,7 +253,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Sports      |     4 |  419.96
@@ -276,7 +267,6 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |  sum   | avg 
 -------+--------+-----
     10 | 6019.9 | 3.8
@@ -293,7 +283,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 1;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -324,7 +313,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 1;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -340,7 +328,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 100;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Sports      |     4
@@ -360,7 +347,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 2 OFFSET 1;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -378,7 +364,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -394,7 +380,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Sports      |     4
@@ -412,7 +397,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) ASC
 LIMIT 2;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category |        sum         
 ----------+--------------------
  Books    |              24.99
@@ -432,7 +416,6 @@ JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR mouse'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     6
@@ -448,7 +431,6 @@ JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR mouse'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -476,7 +458,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                                  QUERY PLAN                                                                                                                                 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -504,7 +485,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Books       |     1
@@ -521,7 +501,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count 
 -------------+-------
  Books       |     1
@@ -540,7 +520,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category DESC
 LIMIT 2;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category | count 
 ----------+-------
  Toys     |     4
@@ -556,7 +535,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category DESC
 LIMIT 2;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  category | count 
 ----------+-------
  Toys     |     4
@@ -581,7 +560,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -609,7 +587,6 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category |  min  |  max   
 ----------+-------+--------
  Toys     | 19.99 | 499.99
@@ -626,7 +603,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  category |  min  |  max   
 ----------+-------+--------
  Toys     | 19.99 | 499.99

--- a/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
@@ -66,6 +66,7 @@ FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                 QUERY PLAN                                                                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -88,6 +89,7 @@ FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -108,6 +110,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -138,6 +141,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Sports      |     4
@@ -156,6 +160,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 2;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -186,6 +191,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 2;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   |   sum   
 -------------+---------
  Electronics | 4599.96
@@ -202,6 +208,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) ASC
 LIMIT 2;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category | count 
 ----------+-------
  Books    |     1
@@ -218,6 +225,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) DESC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   | min | max 
 -------------+-------+---------+-----+-----
  Electronics |     4 | 4599.96 |   5 |   5
@@ -235,6 +243,7 @@ JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook'
 GROUP BY p.category
 ORDER BY COUNT(*) DESC;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |        sum         
 -------------+-------+--------------------
  Electronics |     4 |            4599.96
@@ -252,6 +261,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Sports      |     4 |  419.96
@@ -266,6 +276,7 @@ SELECT COUNT(*), SUM(p.price), AVG(p.rating)
 FROM topk_products p
 JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  count |  sum   | avg 
 -------+--------+-----
     10 | 6019.9 | 3.8
@@ -282,6 +293,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 1;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -312,6 +324,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 1;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -327,6 +340,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 100;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Sports      |     4
@@ -346,6 +360,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 2 OFFSET 1;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -363,6 +378,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -378,6 +394,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY COUNT(*) DESC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Sports      |     4
@@ -395,6 +412,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY SUM(p.price) ASC
 LIMIT 2;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category |        sum         
 ----------+--------------------
  Books    |              24.99
@@ -414,6 +432,7 @@ JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR mouse'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     6
@@ -429,6 +448,7 @@ JOIN topk_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR mouse'
 GROUP BY p.category
 ORDER BY p.category;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -456,6 +476,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                                  QUERY PLAN                                                                                                                                 
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -483,6 +504,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Books       |     1
@@ -499,6 +521,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
   category   | count 
 -------------+-------
  Books       |     1
@@ -517,6 +540,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category DESC
 LIMIT 2;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category | count 
 ----------+-------
  Toys     |     4
@@ -532,6 +556,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY p.category DESC
 LIMIT 2;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category | count 
 ----------+-------
  Toys     |     4
@@ -556,6 +581,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
                                                                                                                        QUERY PLAN                                                                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -583,6 +609,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category |  min  |  max   
 ----------+-------+--------
  Toys     | 19.99 | 499.99
@@ -599,6 +626,7 @@ WHERE p.description @@@ 'laptop OR shoes OR jacket OR dress OR toy OR puzzle OR 
 GROUP BY p.category
 ORDER BY MIN(p.price) ASC
 LIMIT 3;
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, t)
  category |  min  |  max   
 ----------+-------+--------
  Toys     | 19.99 | 499.99

--- a/pg_search/tests/pg_regress/expected/citext.out
+++ b/pg_search/tests/pg_regress/expected/citext.out
@@ -375,6 +375,7 @@ SELECT category, COUNT(*) FROM citext_agg
 WHERE category ||| 'alpha beta gamma'
 GROUP BY category
 ORDER BY category;
+WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: citext_agg)
  category | count 
 ----------+-------
  Alpha    |     2
@@ -386,6 +387,7 @@ SELECT category, SUM(value) FROM citext_agg
 WHERE category ||| 'alpha beta'
 GROUP BY category
 ORDER BY category;
+WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: citext_agg)
  category | sum 
 ----------+-----
  Alpha    |  40

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_05_union_window_functions.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_05_union_window_functions.out
@@ -876,26 +876,23 @@ FROM union_test_a
 WHERE author @@@ 'Author'
 GROUP BY author
 ORDER BY avg_rating DESC;
-                                                                                   QUERY PLAN                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  WindowAgg
-   Window: w2 AS (ORDER BY (avg(rating)) ROWS UNBOUNDED PRECEDING)
+   Window: w2 AS (ORDER BY (pdb.agg_fn('AVG'::text)) ROWS UNBOUNDED PRECEDING)
    ->  Sort
-         Sort Key: (avg(rating)) DESC
+         Sort Key: (pdb.agg_fn('AVG'::text)) DESC
          ->  WindowAgg
-               Window: w1 AS (ORDER BY (avg(price)) ROWS UNBOUNDED PRECEDING)
+               Window: w1 AS (ORDER BY (pdb.agg_fn('AVG'::text)) ROWS UNBOUNDED PRECEDING)
                ->  Sort
-                     Sort Key: (avg(price))
-                     ->  HashAggregate
-                           Group Key: author
-                           ->  Custom Scan (ParadeDB Base Scan) on union_test_a
-                                 Table: union_test_a
-                                 Index: union_test_a_idx
-                                 Exec Method: ColumnarExecState
-                                 Fast Fields: author, price, rating
-                                 Scores: false
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author","lenient":null,"conjunction_mode":null}}}}
-(17 rows)
+                     Sort Key: (pdb.agg_fn('AVG'::text))
+                     ->  Custom Scan (ParadeDB Aggregate Scan) on union_test_a
+                           Index: union_test_a_idx
+                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"author","query_string":"Author","lenient":null,"conjunction_mode":null}}}}
+                             Applies to Aggregates: AVG(rating), AVG(price), COUNT(*)
+                             Group By: author
+                             Aggregate Definition: {"grouped":{"aggs":{"0":{"avg":{"field":"rating","missing":null}},"1":{"avg":{"field":"price","missing":null}}},"terms":{"field":"author","segment_size":65000,"size":65000}}}
+(14 rows)
 
 SELECT author, 
        AVG(rating) as avg_rating,

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
@@ -660,6 +660,8 @@ JOIN (
     WHERE author IN (SELECT author FROM score_test WHERE content @@@ 'technology')
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -704,6 +706,8 @@ JOIN (
     WHERE author IN (SELECT author FROM score_test WHERE content @@@ 'technology')
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
            title            |    author     | rating |    score    |       related_title        
 ----------------------------+---------------+--------+-------------+----------------------------
  Post 1                     | Author 2      |      2 | 0.019852143 | Post 11

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_09_multi_index_search.out
@@ -491,6 +491,7 @@ JOIN reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'product' AND r.rating >= 4
 ORDER BY r.helpful_votes DESC
 LIMIT 5;
+WARNING:  JoinScan not used: join keys must be fast fields (tables: p, r)
                                                                                    QUERY PLAN                                                                                   
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -516,6 +517,7 @@ JOIN reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'product' AND r.rating >= 4
 ORDER BY r.helpful_votes DESC
 LIMIT 5;
+WARNING:  JoinScan not used: join keys must be fast fields (tables: p, r)
     name    | rating |                  content                   
 ------------+--------+--------------------------------------------
  Product 10 |      5 | Terrible product, complete waste of money!
@@ -572,6 +574,7 @@ JOIN product_categories pc ON tp.id = pc.product_id
 JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -629,6 +632,7 @@ JOIN product_categories pc ON tp.id = pc.product_id
 JOIN categories c ON pc.category_id = c.id
 WHERE c.is_active = true
 ORDER BY pr.avg_rating DESC, pdb.score(tp.id), tp.price DESC;
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5: Union of results from different tables
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -809,6 +813,7 @@ ORDER BY
     END DESC,
     pdb.score(p.id),
     p.price;
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -852,6 +857,7 @@ ORDER BY
     END DESC,
     pdb.score(p.id),
     p.price;
+WARNING:  Aggregate Scan not used: grouping column product_id is missing from index. To disable this warning: SET paradedb.check_aggregate_scan = false (table: reviews)
     name    | price |  review_status  
 ------------+-------+-----------------
  Product 19 |   240 | Great reviews
@@ -900,6 +906,7 @@ WHERE p.name @@@ 'Product'
   AND c.name = 'Electronics'
   AND p.is_available = true
 ORDER BY r.rating DESC, p.price DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r)
                                                                                                                      QUERY PLAN                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -938,6 +945,7 @@ WHERE p.name @@@ 'Product'
   AND c.name = 'Electronics'
   AND p.is_available = true
 ORDER BY r.rating DESC, p.price DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r)
  name | price | content | rating 
 ------+-------+---------+--------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/columnar_queries_01_complex_join.out
+++ b/pg_search/tests/pg_regress/expected/columnar_queries_01_complex_join.out
@@ -115,6 +115,7 @@ JOIN files f ON d.id = f.documentId
 JOIN pages p ON p.fileId = f.id
 WHERE d.parents @@@ 'Factures' AND f.title @@@ 'Receipt' AND p.content @@@ 'Socienty'
 ORDER BY d.id, f.id, p.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, f, p)
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -154,6 +155,7 @@ JOIN files f ON d.id = f.documentId
 JOIN pages p ON p.fileId = f.id
 WHERE d.parents @@@ 'Factures' AND f.title @@@ 'Receipt' AND p.content @@@ 'Socienty'
 ORDER BY d.id, f.id, p.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, f, p)
   id  | parents  |  title  |     file_path      | fileid | page_number 
 ------+----------+---------+--------------------+--------+-------------
  doc2 | Factures | Receipt | /receipts/2023.pdf | file3  |           1
@@ -180,42 +182,27 @@ JOIN pages ON pages.fileId = files.id
 WHERE documents.parents @@@ 'Factures' AND files.title @@@ 'Receipt' AND pages.content @@@ 'Socienty'
 ORDER BY pages.fileId, pages.page_number
 LIMIT 10;
-                                                                                    QUERY PLAN                                                                                     
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Sort
-         Sort Key: pages.fileid, pages.page_number
-         ->  Hash Join
-               Hash Cond: (files.documentid = documents.id)
-               ->  Merge Join
-                     Merge Cond: (files.id = pages.fileid)
-                     ->  Sort
-                           Sort Key: files.id
-                           ->  Custom Scan (ParadeDB Base Scan) on files
-                                 Table: files
-                                 Index: files_search
-                                 Exec Method: ColumnarExecState
-                                 Fast Fields: documentid, id
-                                 Scores: false
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
-                     ->  Sort
-                           Sort Key: pages.fileid
-                           ->  Custom Scan (ParadeDB Base Scan) on pages
-                                 Table: pages
-                                 Index: pages_search
-                                 Exec Method: ColumnarExecState
-                                 Fast Fields: content, fileid, page_number
-                                 Scores: false
-                                 Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
-               ->  Hash
-                     ->  Custom Scan (ParadeDB Base Scan) on documents
-                           Table: documents
-                           Index: documents_search
-                           Exec Method: ColumnarExecState
-                           Fast Fields: id
-                           Scores: false
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
-(33 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: documents INNER (files INNER pages)
+         Join Cond: documents.id = files.documentid, files.id = pages.fileid
+         Limit: 10
+         Order By: pages.fileid asc, pages.page_number asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[fileid@3 as col_1, page_number@4 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@2 as ctid_2]
+           :   SortExec: TopK(fetch=10), expr=[fileid@3 ASC NULLS LAST, page_number@4 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[documents, files, pages]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@2, fileid@1)], projection=[ctid_0@0, ctid_1@1, ctid_2@3, fileid@4, page_number@5]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, documentid@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"parents","query_string":"Factures","lenient":null,"conjunction_mode":null}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
 
 \i common/columnar_queries_cleanup.sql
 -- Cleanup for relational query tests (07-10)

--- a/pg_search/tests/pg_regress/expected/columnar_queries_05_join2.out
+++ b/pg_search/tests/pg_regress/expected/columnar_queries_05_join2.out
@@ -209,21 +209,24 @@ SELECT users.color FROM users JOIN orders ON users.id = orders.id  WHERE (users.
 vacuum;
 SET paradedb.enable_columnar_exec = false;
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT users.color FROM users JOIN orders ON users.id = orders.id  WHERE (users.color @@@ 'blue') AND (users.name @@@ 'bob') LIMIT 10;
-                                                                                                                                                 QUERY PLAN                                                                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                               QUERY PLAN                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Nested Loop
-         ->  Custom Scan (ParadeDB Base Scan) on users
-               Table: users
-               Index: idxusers
-               Exec Method: NormalScanExecState
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
-         ->  Bitmap Heap Scan on orders
-               Recheck Cond: (users.id = id)
-               ->  Bitmap Index Scan on orders_pkey
-                     Index Cond: (id = users.id)
-(12 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: orders INNER users
+         Join Cond: users.id = orders.id
+         Limit: 10
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   GlobalLimitExec: skip=0, fetch=10
+           :     VisibilityFilterExec: tables=[orders, users]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT users.color FROM users JOIN orders ON users.id = orders.id  WHERE (users.color @@@ 'blue') AND (users.name @@@ 'bob') LIMIT 10;
  color 
@@ -233,22 +236,24 @@ SELECT users.color FROM users JOIN orders ON users.id = orders.id  WHERE (users.
 
 SET paradedb.enable_columnar_exec = true;
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) SELECT users.color FROM users JOIN orders ON users.id = orders.id  WHERE (users.color @@@ 'blue') AND (users.name @@@ 'bob') LIMIT 10;
-                                                                                                                                                 QUERY PLAN                                                                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                               QUERY PLAN                                                                                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Nested Loop
-         ->  Custom Scan (ParadeDB Base Scan) on users
-               Table: users
-               Index: idxusers
-               Exec Method: ColumnarExecState
-               Fast Fields: color, id
-               Scores: false
-               Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
-         ->  Bitmap Heap Scan on orders
-               Recheck Cond: (users.id = id)
-               ->  Bitmap Index Scan on orders_pkey
-                     Index Cond: (id = users.id)
-(13 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: orders INNER users
+         Join Cond: users.id = orders.id
+         Limit: 10
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[NULL as col_1, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   GlobalLimitExec: skip=0, fetch=10
+           :     VisibilityFilterExec: tables=[orders, users]
+           :       ProjectionExec: expr=[ctid_0@2 as ctid_0, id@3 as id, ctid_1@0 as ctid_1, id@1 as id]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"color","query_string":"blue","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}]}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(15 rows)
 
 SELECT users.color FROM users JOIN orders ON users.id = orders.id  WHERE (users.color @@@ 'blue') AND (users.name @@@ 'bob') LIMIT 10;
  color 

--- a/pg_search/tests/pg_regress/expected/composite.out
+++ b/pg_search/tests/pg_regress/expected/composite.out
@@ -37,16 +37,14 @@ INSERT INTO products (name, description, price) VALUES ('Gizmo', 'A fantastic gi
 -- Query on composite field - search by name
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM products WHERE id @@@ pdb.parse('name:Widget');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on products
-         Table: products
-         Index: idx_products
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Widget","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on products
+   Index: idx_products
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Widget","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM products WHERE id @@@ pdb.parse('name:Widget');
  count 
@@ -57,16 +55,14 @@ SELECT COUNT(*) FROM products WHERE id @@@ pdb.parse('name:Widget');
 -- Query on composite field - search by description
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM products WHERE id @@@ pdb.parse('description:amazing');
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on products
-         Table: products
-         Index: idx_products
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:amazing","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on products
+   Index: idx_products
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:amazing","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM products WHERE id @@@ pdb.parse('description:amazing');
  count 
@@ -173,16 +169,14 @@ CREATE INDEX idx_large ON large_table USING bm25 (id, (ROW(
 INSERT INTO large_table (field_1, field_20, field_35) VALUES ('alpha', 'beta', 'gamma');
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM large_table WHERE id @@@ pdb.parse('field_1:alpha');
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on large_table
-         Table: large_table
-         Index: idx_large
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"field_1:alpha","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on large_table
+   Index: idx_large
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"field_1:alpha","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM large_table WHERE id @@@ pdb.parse('field_1:alpha');
  count 
@@ -192,16 +186,14 @@ SELECT COUNT(*) FROM large_table WHERE id @@@ pdb.parse('field_1:alpha');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM large_table WHERE id @@@ pdb.parse('field_35:gamma');
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on large_table
-         Table: large_table
-         Index: idx_large
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"field_35:gamma","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on large_table
+   Index: idx_large
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"field_35:gamma","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM large_table WHERE id @@@ pdb.parse('field_35:gamma');
  count 
@@ -238,16 +230,14 @@ END $$;
 INSERT INTO huge_table (f001, f050, f100) VALUES ('first_field', 'middle_field', 'last_field');
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f001:first_field');
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on huge_table
-         Table: huge_table
-         Index: idx_huge
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f001:first_field","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on huge_table
+   Index: idx_huge
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f001:first_field","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f001:first_field');
  count 
@@ -257,16 +247,14 @@ SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f001:first_field');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f050:middle_field');
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on huge_table
-         Table: huge_table
-         Index: idx_huge
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f050:middle_field","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on huge_table
+   Index: idx_huge
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f050:middle_field","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f050:middle_field');
  count 
@@ -276,16 +264,14 @@ SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f050:middle_field');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f100:last_field');
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on huge_table
-         Table: huge_table
-         Index: idx_huge
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f100:last_field","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on huge_table
+   Index: idx_huge
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f100:last_field","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM huge_table WHERE id @@@ pdb.parse('f100:last_field');
  count 
@@ -433,16 +419,14 @@ INSERT INTO nullable_test (name, description, price) VALUES ('Product C', 'Anoth
 -- Should find non-NULL fields
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM nullable_test WHERE id @@@ pdb.parse('name:"Product C"');
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on nullable_test
-         Table: nullable_test
-         Index: idx_nullable
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:\"Product C\"","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on nullable_test
+   Index: idx_nullable
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:\"Product C\"","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM nullable_test WHERE id @@@ pdb.parse('name:"Product C"');
  count 
@@ -469,16 +453,14 @@ REINDEX INDEX idx_reindex;
 -- Verify data is still searchable after REINDEX
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM reindex_test WHERE id @@@ pdb.parse('name:Widget');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on reindex_test
-         Table: reindex_test
-         Index: idx_reindex
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Widget","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on reindex_test
+   Index: idx_reindex
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Widget","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM reindex_test WHERE id @@@ pdb.parse('name:Widget');
  count 
@@ -507,16 +489,14 @@ INSERT INTO large_val_test (title, content, metadata) VALUES (
 );
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM large_val_test WHERE id @@@ pdb.parse('title:Large');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on large_val_test
-         Table: large_val_test
-         Index: idx_large_val
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:Large","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on large_val_test
+   Index: idx_large_val
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:Large","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM large_val_test WHERE id @@@ pdb.parse('title:Large');
  count 
@@ -553,16 +533,14 @@ INSERT INTO full_pipeline_test (name, description, category, tags) VALUES
 -- Test search on each field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('name:Laptop');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on full_pipeline_test
-         Table: full_pipeline_test
-         Index: idx_full_pipeline
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Laptop","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on full_pipeline_test
+   Index: idx_full_pipeline
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Laptop","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('name:Laptop');
  count 
@@ -572,16 +550,14 @@ SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('name:Laptop');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('description:Wireless');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on full_pipeline_test
-         Table: full_pipeline_test
-         Index: idx_full_pipeline
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:Wireless","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on full_pipeline_test
+   Index: idx_full_pipeline
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:Wireless","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('description:Wireless');
  count 
@@ -591,16 +567,14 @@ SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('description:Wire
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:Electronics');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on full_pipeline_test
-         Table: full_pipeline_test
-         Index: idx_full_pipeline
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on full_pipeline_test
+   Index: idx_full_pipeline
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:Electronics');
  count 
@@ -610,16 +584,14 @@ SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:Electro
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('tags:office');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on full_pipeline_test
-         Table: full_pipeline_test
-         Index: idx_full_pipeline
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"tags:office","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on full_pipeline_test
+   Index: idx_full_pipeline
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"tags:office","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('tags:office');
  count 
@@ -630,16 +602,14 @@ SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('tags:office');
 -- Test complex queries with OR and AND using pdb.parse with tantivy syntax
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:books OR tags:computer');
-                                                                     QUERY PLAN                                                                      
------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on full_pipeline_test
-         Table: full_pipeline_test
-         Index: idx_full_pipeline
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:books OR tags:computer","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                  QUERY PLAN                                                                   
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on full_pipeline_test
+   Index: idx_full_pipeline
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:books OR tags:computer","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:books OR tags:computer');
  count 
@@ -649,16 +619,14 @@ SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:books O
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:electronics AND tags:accessories');
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on full_pipeline_test
-         Table: full_pipeline_test
-         Index: idx_full_pipeline
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:electronics AND tags:accessories","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                       QUERY PLAN                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on full_pipeline_test
+   Index: idx_full_pipeline
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:electronics AND tags:accessories","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM full_pipeline_test WHERE id @@@ pdb.parse('category:electronics AND tags:accessories');
  count 
@@ -696,16 +664,14 @@ INSERT INTO multi_comp_test (title, body, author, category) VALUES
 -- Search works on fields from BOTH composites
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('title:PostgreSQL');
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on multi_comp_test
-         Table: multi_comp_test
-         Index: idx_multi_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:PostgreSQL","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on multi_comp_test
+   Index: idx_multi_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:PostgreSQL","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('title:PostgreSQL');
  count 
@@ -715,16 +681,14 @@ SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('title:PostgreSQL');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('body:pasta');
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on multi_comp_test
-         Table: multi_comp_test
-         Index: idx_multi_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"body:pasta","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on multi_comp_test
+   Index: idx_multi_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"body:pasta","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('body:pasta');
  count 
@@ -734,16 +698,14 @@ SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('body:pasta');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('author:Alice');
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on multi_comp_test
-         Table: multi_comp_test
-         Index: idx_multi_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"author:Alice","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on multi_comp_test
+   Index: idx_multi_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"author:Alice","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('author:Alice');
  count 
@@ -753,16 +715,14 @@ SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('author:Alice');
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('category:food');
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on multi_comp_test
-         Table: multi_comp_test
-         Index: idx_multi_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:food","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on multi_comp_test
+   Index: idx_multi_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:food","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('category:food');
  count 
@@ -773,16 +733,14 @@ SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('category:food');
 -- Cross-composite search using pdb.parse with AND
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('title:guide AND author:alice');
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on multi_comp_test
-         Table: multi_comp_test
-         Index: idx_multi_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:guide AND author:alice","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on multi_comp_test
+   Index: idx_multi_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:guide AND author:alice","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM multi_comp_test WHERE id @@@ pdb.parse('title:guide AND author:alice');
  count 
@@ -817,16 +775,14 @@ INSERT INTO hybrid_test (name, description, notes, category, tags, keywords) VAL
 -- Test regular column
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('name:Widget');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on hybrid_test
-         Table: hybrid_test
-         Index: idx_hybrid
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Widget","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on hybrid_test
+   Index: idx_hybrid
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:Widget","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('name:Widget');
  count 
@@ -837,16 +793,14 @@ SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('name:Widget');
 -- Test first composite field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('description:amazing');
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on hybrid_test
-         Table: hybrid_test
-         Index: idx_hybrid
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:amazing","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on hybrid_test
+   Index: idx_hybrid
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:amazing","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('description:amazing');
  count 
@@ -857,16 +811,14 @@ SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('description:amazing');
 -- Test second regular column
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('category:tools');
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on hybrid_test
-         Table: hybrid_test
-         Index: idx_hybrid
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:tools","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on hybrid_test
+   Index: idx_hybrid
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:tools","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('category:tools');
  count 
@@ -877,16 +829,14 @@ SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('category:tools');
 -- Test second composite field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('tags:tech');
-                                                          QUERY PLAN                                                           
--------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on hybrid_test
-         Table: hybrid_test
-         Index: idx_hybrid
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"tags:tech","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                       QUERY PLAN                                                        
+-------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on hybrid_test
+   Index: idx_hybrid
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"tags:tech","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('tags:tech');
  count 
@@ -897,16 +847,14 @@ SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('tags:tech');
 -- Test cross-type query using pdb.parse with AND
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('name:widget AND description:useful');
-                                                                       QUERY PLAN                                                                       
---------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on hybrid_test
-         Table: hybrid_test
-         Index: idx_hybrid
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:widget AND description:useful","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                    QUERY PLAN                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on hybrid_test
+   Index: idx_hybrid
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"name:widget AND description:useful","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) FROM hybrid_test WHERE id @@@ pdb.parse('name:widget AND description:useful');
  count 
@@ -942,16 +890,14 @@ INSERT INTO articles (title, body, created_at) VALUES
 -- Search by title (simple column)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS title_search FROM articles WHERE id @@@ pdb.parse('title:First');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on articles
-         Table: articles
-         Index: idx_articles
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:First","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on articles
+   Index: idx_articles
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:First","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS title_search FROM articles WHERE id @@@ pdb.parse('title:First');
  title_search 
@@ -962,16 +908,14 @@ SELECT COUNT(*) AS title_search FROM articles WHERE id @@@ pdb.parse('title:Firs
 -- Search by title_upper (expression result - uppercase)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS title_upper_search FROM articles WHERE id @@@ pdb.parse('title_upper:FIRST');
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on articles
-         Table: articles
-         Index: idx_articles
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title_upper:FIRST","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on articles
+   Index: idx_articles
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title_upper:FIRST","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS title_upper_search FROM articles WHERE id @@@ pdb.parse('title_upper:FIRST');
  title_upper_search 
@@ -1012,16 +956,14 @@ SELECT COUNT(*) AS mixed_total FROM mixed_data;
 -- Verify searchable non-NULL values
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS found_medium FROM mixed_data WHERE id @@@ pdb.parse('medium:medium');
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mixed_data
-         Table: mixed_data
-         Index: idx_mixed
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"medium:medium","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mixed_data
+   Index: idx_mixed
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"medium:medium","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS found_medium FROM mixed_data WHERE id @@@ pdb.parse('medium:medium');
  found_medium 
@@ -1031,16 +973,14 @@ SELECT COUNT(*) AS found_medium FROM mixed_data WHERE id @@@ pdb.parse('medium:m
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS found_tiny FROM mixed_data WHERE id @@@ pdb.parse('small:tiny');
-                                                           QUERY PLAN                                                           
---------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mixed_data
-         Table: mixed_data
-         Index: idx_mixed
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"small:tiny","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mixed_data
+   Index: idx_mixed
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"small:tiny","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS found_tiny FROM mixed_data WHERE id @@@ pdb.parse('small:tiny');
  found_tiny 
@@ -1081,16 +1021,14 @@ SELECT EXISTS (SELECT 1 FROM paradedb.schema('verify_idx') WHERE name = 'second_
 INSERT INTO verify_table (first_field, second_field) VALUES ('hello', 'world');
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS first_field_search FROM verify_table WHERE id @@@ pdb.parse('first_field:hello');
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on verify_table
-         Table: verify_table
-         Index: verify_idx
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"first_field:hello","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on verify_table
+   Index: verify_idx
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"first_field:hello","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS first_field_search FROM verify_table WHERE id @@@ pdb.parse('first_field:hello');
  first_field_search 
@@ -1100,16 +1038,14 @@ SELECT COUNT(*) AS first_field_search FROM verify_table WHERE id @@@ pdb.parse('
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS second_field_search FROM verify_table WHERE id @@@ pdb.parse('second_field:world');
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on verify_table
-         Table: verify_table
-         Index: verify_idx
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"second_field:world","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on verify_table
+   Index: verify_idx
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"second_field:world","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS second_field_search FROM verify_table WHERE id @@@ pdb.parse('second_field:world');
  second_field_search 
@@ -1158,16 +1094,14 @@ INSERT INTO products_schema (product_name, product_desc, product_price) VALUES (
 -- Search each field to prove it was indexed
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS name_search FROM products_schema WHERE id @@@ pdb.parse('product_name:TestProduct');
-                                                                  QUERY PLAN                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on products_schema
-         Table: products_schema
-         Index: idx_products_schema
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"product_name:TestProduct","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on products_schema
+   Index: idx_products_schema
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"product_name:TestProduct","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS name_search FROM products_schema WHERE id @@@ pdb.parse('product_name:TestProduct');
  name_search 
@@ -1177,16 +1111,14 @@ SELECT COUNT(*) AS name_search FROM products_schema WHERE id @@@ pdb.parse('prod
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS desc_search FROM products_schema WHERE id @@@ pdb.parse('product_desc:TestDescription');
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on products_schema
-         Table: products_schema
-         Index: idx_products_schema
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"product_desc:TestDescription","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on products_schema
+   Index: idx_products_schema
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"product_desc:TestDescription","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS desc_search FROM products_schema WHERE id @@@ pdb.parse('product_desc:TestDescription');
  desc_search 
@@ -1223,16 +1155,14 @@ INSERT INTO tokenized_test (title) VALUES ('Running and Jumping');
 -- Search on the simple tokenizer field (lowercased)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS simple_tokenizer_search FROM tokenized_test WHERE id @@@ pdb.parse('title_simple:running');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on tokenized_test
-         Table: tokenized_test
-         Index: idx_tokenized
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title_simple:running","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on tokenized_test
+   Index: idx_tokenized
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title_simple:running","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS simple_tokenizer_search FROM tokenized_test WHERE id @@@ pdb.parse('title_simple:running');
  simple_tokenizer_search 
@@ -1243,16 +1173,14 @@ SELECT COUNT(*) AS simple_tokenizer_search FROM tokenized_test WHERE id @@@ pdb.
 -- Search on the default text field (should also find it)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS default_text_search FROM tokenized_test WHERE id @@@ pdb.parse('title:running');
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on tokenized_test
-         Table: tokenized_test
-         Index: idx_tokenized
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:running","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on tokenized_test
+   Index: idx_tokenized
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"title:running","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS default_text_search FROM tokenized_test WHERE id @@@ pdb.parse('title:running');
  default_text_search 
@@ -1289,16 +1217,14 @@ INSERT INTO ngram_test (content) VALUES ('PostgreSQL database');
 -- Search with partial match via ngram - 'gres' should match 'PostgreSQL'
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS ngram_partial_search FROM ngram_test WHERE id @@@ pdb.parse('content_ngram:gres');
-                                                               QUERY PLAN                                                               
-----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on ngram_test
-         Table: ngram_test
-         Index: idx_ngram
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content_ngram:gres","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                            QUERY PLAN                                                            
+----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on ngram_test
+   Index: idx_ngram
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content_ngram:gres","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS ngram_partial_search FROM ngram_test WHERE id @@@ pdb.parse('content_ngram:gres');
  ngram_partial_search 
@@ -1309,16 +1235,14 @@ SELECT COUNT(*) AS ngram_partial_search FROM ngram_test WHERE id @@@ pdb.parse('
 -- Default text field should NOT match partial 'gres' (no ngram)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS default_no_partial FROM ngram_test WHERE id @@@ pdb.parse('content:gres');
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on ngram_test
-         Table: ngram_test
-         Index: idx_ngram
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:gres","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on ngram_test
+   Index: idx_ngram
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:gres","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS default_no_partial FROM ngram_test WHERE id @@@ pdb.parse('content:gres');
  default_no_partial 
@@ -1357,16 +1281,14 @@ INSERT INTO stemmer_test (content) VALUES
 -- Stemmed search: 'run' should match 'running' and 'runs' (both stem to 'run')
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS stemmer_search FROM stemmer_test WHERE id @@@ pdb.parse('content_stemmed:run');
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on stemmer_test
-         Table: stemmer_test
-         Index: idx_stemmer
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content_stemmed:run","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                            QUERY PLAN                                                             
+-----------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on stemmer_test
+   Index: idx_stemmer
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content_stemmed:run","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS stemmer_search FROM stemmer_test WHERE id @@@ pdb.parse('content_stemmed:run');
  stemmer_search 
@@ -1377,16 +1299,14 @@ SELECT COUNT(*) AS stemmer_search FROM stemmer_test WHERE id @@@ pdb.parse('cont
 -- Default text field should NOT match 'run' (no stemming)
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS default_no_stem FROM stemmer_test WHERE id @@@ pdb.parse('content:run');
-                                                           QUERY PLAN                                                            
----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on stemmer_test
-         Table: stemmer_test
-         Index: idx_stemmer
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:run","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                        QUERY PLAN                                                         
+---------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on stemmer_test
+   Index: idx_stemmer
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:run","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS default_no_stem FROM stemmer_test WHERE id @@@ pdb.parse('content:run');
  default_no_stem 
@@ -1705,16 +1625,14 @@ LIMIT 2;
 -- COUNT
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) as total FROM smoke_test WHERE id @@@ pdb.parse('category:Electronics');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on smoke_test
-         Table: smoke_test
-         Index: smoke_idx
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on smoke_test
+   Index: smoke_idx
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) as total FROM smoke_test WHERE id @@@ pdb.parse('category:Electronics');
  total 
@@ -1725,17 +1643,14 @@ SELECT COUNT(*) as total FROM smoke_test WHERE id @@@ pdb.parse('category:Electr
 -- SUM
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT SUM(price) as total_price FROM smoke_test WHERE id @@@ pdb.parse('category:Electronics');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on smoke_test
-         Table: smoke_test
-         Index: smoke_idx
-         Exec Method: ColumnarExecState
-         Fast Fields: price
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
-(8 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on smoke_test
+   Index: smoke_idx
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: SUM(price)
+     Aggregate Definition: {"0":{"sum":{"field":"price","missing":null}}}
+(5 rows)
 
 SELECT SUM(price) as total_price FROM smoke_test WHERE id @@@ pdb.parse('category:Electronics');
  total_price 
@@ -1746,17 +1661,14 @@ SELECT SUM(price) as total_price FROM smoke_test WHERE id @@@ pdb.parse('categor
 -- AVG
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT AVG(rating) as avg_rating FROM smoke_test WHERE id @@@ pdb.parse('description:shoes OR description:boots');
-                                                                         QUERY PLAN                                                                         
-------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on smoke_test
-         Table: smoke_test
-         Index: smoke_idx
-         Exec Method: ColumnarExecState
-         Fast Fields: rating
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:shoes OR description:boots","lenient":null,"conjunction_mode":null}}}}
-(8 rows)
+                                                                      QUERY PLAN                                                                      
+------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on smoke_test
+   Index: smoke_idx
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"description:shoes OR description:boots","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: AVG(rating)
+     Aggregate Definition: {"0":{"avg":{"field":"rating","missing":null}}}
+(5 rows)
 
 SELECT AVG(rating) as avg_rating FROM smoke_test WHERE id @@@ pdb.parse('description:shoes OR description:boots');
  avg_rating 
@@ -1769,24 +1681,21 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) as count, SUM(price) as total, AVG(rating) as avg_rating, MIN(price) as min_price, MAX(price) as max_price
 FROM smoke_test
 WHERE id @@@ pdb.parse('category:Electronics OR category:Footwear');
-                                                                          QUERY PLAN                                                                           
----------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on smoke_test
-         Table: smoke_test
-         Index: smoke_idx
-         Exec Method: ColumnarExecState
-         Fast Fields: price, rating
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics OR category:Footwear","lenient":null,"conjunction_mode":null}}}}
-(8 rows)
+                                                                                                                              QUERY PLAN                                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on smoke_test
+   Index: smoke_idx
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics OR category:Footwear","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}},"1":{"sum":{"field":"price","missing":null}},"2":{"avg":{"field":"rating","missing":null}},"3":{"min":{"field":"price","missing":null}},"4":{"max":{"field":"price","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) as count, SUM(price) as total, AVG(rating) as avg_rating, MIN(price) as min_price, MAX(price) as max_price
 FROM smoke_test
 WHERE id @@@ pdb.parse('category:Electronics OR category:Footwear');
- count |       total        | avg_rating | min_price | max_price 
--------+--------------------+------------+-----------+-----------
-     5 | 399.95000000000005 |       4.48 |     39.99 |    129.99
+ count | total  |     avg_rating     | min_price | max_price 
+-------+--------+--------------------+-----------+-----------
+     5 | 399.95 | 4.4799999999999995 |     39.99 |    129.99
 (1 row)
 
 ------------------------------------------------------------
@@ -1801,20 +1710,17 @@ FROM smoke_test
 WHERE id @@@ pdb.all()
 GROUP BY category
 ORDER BY count DESC, category;
-                                  QUERY PLAN                                  
-------------------------------------------------------------------------------
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: (count(*)) DESC, category
-   ->  HashAggregate
-         Group Key: category
-         ->  Custom Scan (ParadeDB Base Scan) on smoke_test
-               Table: smoke_test
-               Index: smoke_idx
-               Exec Method: ColumnarExecState
-               Fast Fields: category, rating
-               Scores: false
-               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
-(11 rows)
+   Sort Key: (pdb.agg_fn('COUNT(*)'::text)) DESC, category
+   ->  Custom Scan (ParadeDB Aggregate Scan) on smoke_test
+         Index: smoke_idx
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+           Applies to Aggregates: COUNT(*), AVG(rating)
+           Group By: category
+           Aggregate Definition: {"grouped":{"aggs":{"0":{"avg":{"field":"rating","missing":null}}},"terms":{"field":"category","segment_size":65000,"size":65000}}}
+(8 rows)
 
 SELECT category, COUNT(*) as count, AVG(rating) as avg_rating
 FROM smoke_test
@@ -2258,16 +2164,14 @@ LIMIT 3;
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) FROM smoke_test
 WHERE id @@@ pdb.parse('category:Electronics');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on smoke_test
-         Table: smoke_test
-         Index: smoke_idx
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on smoke_test
+   Index: smoke_idx
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"category:Electronics","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 -- Verify Top K with pdb.agg window function
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/expected/composite_advanced.out
+++ b/pg_search/tests/pg_regress/expected/composite_advanced.out
@@ -116,16 +116,14 @@ INSERT INTO mvcc_test (content) VALUES ('unique_epsilon_new');
 -- Test 1: Deleted row's content should NOT be visible
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS deleted_not_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_beta_two');
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_beta_two","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                              QUERY PLAN                                                               
+---------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_beta_two","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS deleted_not_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_beta_two');
  deleted_not_visible 
@@ -136,16 +134,14 @@ SELECT COUNT(*) AS deleted_not_visible FROM mvcc_test WHERE id @@@ pdb.parse('co
 -- Test 2: Updated row's OLD content should NOT be visible
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS old_content_not_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_alpha_one');
-                                                                  QUERY PLAN                                                                  
-----------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_alpha_one","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                               QUERY PLAN                                                               
+----------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_alpha_one","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS old_content_not_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_alpha_one');
  old_content_not_visible 
@@ -156,16 +152,14 @@ SELECT COUNT(*) AS old_content_not_visible FROM mvcc_test WHERE id @@@ pdb.parse
 -- Test 3: Updated row's NEW content SHOULD be visible
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS new_content_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_delta_updated');
-                                                                    QUERY PLAN                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_delta_updated","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                 QUERY PLAN                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_delta_updated","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS new_content_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_delta_updated');
  new_content_visible 
@@ -176,16 +170,14 @@ SELECT COUNT(*) AS new_content_visible FROM mvcc_test WHERE id @@@ pdb.parse('co
 -- Test 4: Unchanged row SHOULD still be visible
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS unchanged_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_gamma_three');
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_gamma_three","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_gamma_three","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS unchanged_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_gamma_three');
  unchanged_visible 
@@ -196,16 +188,14 @@ SELECT COUNT(*) AS unchanged_visible FROM mvcc_test WHERE id @@@ pdb.parse('cont
 -- Test 5: Newly inserted row SHOULD be visible
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS new_row_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_epsilon_new');
-                                                                   QUERY PLAN                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_epsilon_new","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                QUERY PLAN                                                                
+------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:unique_epsilon_new","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS new_row_visible FROM mvcc_test WHERE id @@@ pdb.parse('content:unique_epsilon_new');
  new_row_visible 
@@ -268,16 +258,14 @@ SELECT COUNT(*) AS segment_count FROM paradedb.index_info('idx_catchup');
 -- Modified row should have new content indexed
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS modified_found FROM catchup_test WHERE id @@@ pdb.parse('content:modified_one');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on catchup_test
-         Table: catchup_test
-         Index: idx_catchup
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:modified_one","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on catchup_test
+   Index: idx_catchup
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:modified_one","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS modified_found FROM catchup_test WHERE id @@@ pdb.parse('content:modified_one');
  modified_found 
@@ -288,16 +276,14 @@ SELECT COUNT(*) AS modified_found FROM catchup_test WHERE id @@@ pdb.parse('cont
 -- Original content should NOT be found
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS original_not_found FROM catchup_test WHERE id @@@ pdb.parse('content:original_one');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on catchup_test
-         Table: catchup_test
-         Index: idx_catchup
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:original_one","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on catchup_test
+   Index: idx_catchup
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:original_one","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS original_not_found FROM catchup_test WHERE id @@@ pdb.parse('content:original_one');
  original_not_found 
@@ -308,16 +294,14 @@ SELECT COUNT(*) AS original_not_found FROM catchup_test WHERE id @@@ pdb.parse('
 -- Deleted row should not be in index
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS deleted_not_found FROM catchup_test WHERE id @@@ pdb.parse('content:original_two');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on catchup_test
-         Table: catchup_test
-         Index: idx_catchup
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:original_two","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on catchup_test
+   Index: idx_catchup
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:original_two","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS deleted_not_found FROM catchup_test WHERE id @@@ pdb.parse('content:original_two');
  deleted_not_found 
@@ -328,16 +312,14 @@ SELECT COUNT(*) AS deleted_not_found FROM catchup_test WHERE id @@@ pdb.parse('c
 -- Newly inserted row should be in index
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS inserted_found FROM catchup_test WHERE id @@@ pdb.parse('content:inserted_six');
-                                                                QUERY PLAN                                                                
-------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on catchup_test
-         Table: catchup_test
-         Index: idx_catchup
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:inserted_six","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                             QUERY PLAN                                                             
+------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on catchup_test
+   Index: idx_catchup
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:inserted_six","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS inserted_found FROM catchup_test WHERE id @@@ pdb.parse('content:inserted_six');
  inserted_found 
@@ -348,16 +330,14 @@ SELECT COUNT(*) AS inserted_found FROM catchup_test WHERE id @@@ pdb.parse('cont
 -- Unchanged rows should be in index
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS unchanged_found FROM catchup_test WHERE id @@@ pdb.parse('content:original_three');
-                                                                 QUERY PLAN                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on catchup_test
-         Table: catchup_test
-         Index: idx_catchup
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:original_three","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                              QUERY PLAN                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on catchup_test
+   Index: idx_catchup
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"content:original_three","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS unchanged_found FROM catchup_test WHERE id @@@ pdb.parse('content:original_three');
  unchanged_found 
@@ -412,16 +392,14 @@ INSERT INTO fast_test_50 (t01, t20, t40, n01, n05, n10) VALUES
 -- Verify search works on first text field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS t01_count FROM fast_test_50 WHERE id @@@ pdb.parse('t01:first_text');
-                                                             QUERY PLAN                                                             
-------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on fast_test_50
-         Table: fast_test_50
-         Index: idx_fast_50
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"t01:first_text","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on fast_test_50
+   Index: idx_fast_50
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"t01:first_text","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS t01_count FROM fast_test_50 WHERE id @@@ pdb.parse('t01:first_text');
  t01_count 
@@ -432,16 +410,14 @@ SELECT COUNT(*) AS t01_count FROM fast_test_50 WHERE id @@@ pdb.parse('t01:first
 -- Verify search works on middle text field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS t20_count FROM fast_test_50 WHERE id @@@ pdb.parse('t20:middle_text');
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on fast_test_50
-         Table: fast_test_50
-         Index: idx_fast_50
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"t20:middle_text","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on fast_test_50
+   Index: idx_fast_50
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"t20:middle_text","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS t20_count FROM fast_test_50 WHERE id @@@ pdb.parse('t20:middle_text');
  t20_count 
@@ -452,16 +428,14 @@ SELECT COUNT(*) AS t20_count FROM fast_test_50 WHERE id @@@ pdb.parse('t20:middl
 -- Verify search works on last text field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS t40_count FROM fast_test_50 WHERE id @@@ pdb.parse('t40:last_text');
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on fast_test_50
-         Table: fast_test_50
-         Index: idx_fast_50
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"t40:last_text","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on fast_test_50
+   Index: idx_fast_50
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"t40:last_text","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS t40_count FROM fast_test_50 WHERE id @@@ pdb.parse('t40:last_text');
  t40_count 
@@ -583,16 +557,14 @@ END $$;
 -- Verify search works on first, middle, and last fields
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS first_field_found FROM max_fields_test WHERE id @@@ pdb.parse('f001:first_field');
-                                                              QUERY PLAN                                                              
---------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on max_fields_test
-         Table: max_fields_test
-         Index: idx_max_fields
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f001:first_field","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on max_fields_test
+   Index: idx_max_fields
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f001:first_field","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS first_field_found FROM max_fields_test WHERE id @@@ pdb.parse('f001:first_field');
  first_field_found 
@@ -602,16 +574,14 @@ SELECT COUNT(*) AS first_field_found FROM max_fields_test WHERE id @@@ pdb.parse
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS middle_field_found FROM max_fields_test WHERE id @@@ pdb.parse('f250:middle_field');
-                                                              QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on max_fields_test
-         Table: max_fields_test
-         Index: idx_max_fields
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f250:middle_field","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                           QUERY PLAN                                                            
+---------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on max_fields_test
+   Index: idx_max_fields
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f250:middle_field","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS middle_field_found FROM max_fields_test WHERE id @@@ pdb.parse('f250:middle_field');
  middle_field_found 
@@ -621,16 +591,14 @@ SELECT COUNT(*) AS middle_field_found FROM max_fields_test WHERE id @@@ pdb.pars
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS last_field_found FROM max_fields_test WHERE id @@@ pdb.parse('f500:last_field');
-                                                             QUERY PLAN                                                              
--------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on max_fields_test
-         Table: max_fields_test
-         Index: idx_max_fields
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f500:last_field","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                          QUERY PLAN                                                           
+-------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on max_fields_test
+   Index: idx_max_fields
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"f500:last_field","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS last_field_found FROM max_fields_test WHERE id @@@ pdb.parse('f500:last_field');
  last_field_found 
@@ -722,16 +690,14 @@ VALUES ('first_a', 'mid_a', 'last_a', 'first_b', 'mid_b', 'last_b');
 -- Test search on both composite types using pdb.parse
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS a_first FROM dual_comp_test WHERE id @@@ pdb.parse('a0001:first_a');
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"a0001:first_a","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"a0001:first_a","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS a_first FROM dual_comp_test WHERE id @@@ pdb.parse('a0001:first_a');
  a_first 
@@ -741,16 +707,14 @@ SELECT COUNT(*) AS a_first FROM dual_comp_test WHERE id @@@ pdb.parse('a0001:fir
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS a_last FROM dual_comp_test WHERE id @@@ pdb.parse('a0400:last_a');
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"a0400:last_a","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"a0400:last_a","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS a_last FROM dual_comp_test WHERE id @@@ pdb.parse('a0400:last_a');
  a_last 
@@ -760,16 +724,14 @@ SELECT COUNT(*) AS a_last FROM dual_comp_test WHERE id @@@ pdb.parse('a0400:last
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS b_first FROM dual_comp_test WHERE id @@@ pdb.parse('b0001:first_b');
-                                                            QUERY PLAN                                                             
------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"b0001:first_b","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                          
+-----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"b0001:first_b","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS b_first FROM dual_comp_test WHERE id @@@ pdb.parse('b0001:first_b');
  b_first 
@@ -779,16 +741,14 @@ SELECT COUNT(*) AS b_first FROM dual_comp_test WHERE id @@@ pdb.parse('b0001:fir
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS b_last FROM dual_comp_test WHERE id @@@ pdb.parse('b0400:last_b');
-                                                            QUERY PLAN                                                            
-----------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"b0400:last_b","lenient":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"parse":{"query_string":"b0400:last_b","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS b_last FROM dual_comp_test WHERE id @@@ pdb.parse('b0400:last_b');
  b_last 
@@ -802,16 +762,14 @@ SELECT COUNT(*) AS b_last FROM dual_comp_test WHERE id @@@ pdb.parse('b0400:last
 -- pdb.term() on composite field from type A
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS term_a FROM dual_comp_test WHERE a0001 @@@ pdb.term('first_a');
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"term":{"field":"a0001","value":"first_a"}}}}
-(7 rows)
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"term":{"field":"a0001","value":"first_a"}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS term_a FROM dual_comp_test WHERE a0001 @@@ pdb.term('first_a');
  term_a 
@@ -822,16 +780,14 @@ SELECT COUNT(*) AS term_a FROM dual_comp_test WHERE a0001 @@@ pdb.term('first_a'
 -- pdb.term() on composite field from type B
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS term_b FROM dual_comp_test WHERE b0001 @@@ pdb.term('first_b');
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"term":{"field":"b0001","value":"first_b"}}}}
-(7 rows)
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"term":{"field":"b0001","value":"first_b"}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS term_b FROM dual_comp_test WHERE b0001 @@@ pdb.term('first_b');
  term_b 
@@ -842,16 +798,14 @@ SELECT COUNT(*) AS term_b FROM dual_comp_test WHERE b0001 @@@ pdb.term('first_b'
 -- pdb.match() on composite field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS match_a FROM dual_comp_test WHERE a0200 @@@ pdb.match('mid_a');
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"match":{"field":"a0200","value":"mid_a","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                                         QUERY PLAN                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"match":{"field":"a0200","value":"mid_a","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS match_a FROM dual_comp_test WHERE a0200 @@@ pdb.match('mid_a');
  match_a 
@@ -862,16 +816,14 @@ SELECT COUNT(*) AS match_a FROM dual_comp_test WHERE a0200 @@@ pdb.match('mid_a'
 -- pdb.regex() on composite field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS regex_b FROM dual_comp_test WHERE b0400 @@@ pdb.regex('last.*');
-                                           QUERY PLAN                                           
-------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on dual_comp_test
-         Table: dual_comp_test
-         Index: idx_dual_comp
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"regex":{"field":"b0400","pattern":"last.*"}}}}
-(7 rows)
+                                        QUERY PLAN                                        
+------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on dual_comp_test
+   Index: idx_dual_comp
+   Tantivy Query: {"with_index":{"query":{"regex":{"field":"b0400","pattern":"last.*"}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS regex_b FROM dual_comp_test WHERE b0400 @@@ pdb.regex('last.*');
  regex_b 
@@ -882,16 +834,14 @@ SELECT COUNT(*) AS regex_b FROM dual_comp_test WHERE b0400 @@@ pdb.regex('last.*
 -- Test pdb functions on MVCC test table composite field
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS mvcc_term FROM mvcc_test WHERE content @@@ pdb.term('unique_gamma_three');
-                                                QUERY PLAN                                                 
------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"term":{"field":"content","value":"unique_gamma_three"}}}}
-(7 rows)
+                                             QUERY PLAN                                              
+-----------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"term":{"field":"content","value":"unique_gamma_three"}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS mvcc_term FROM mvcc_test WHERE content @@@ pdb.term('unique_gamma_three');
  mvcc_term 
@@ -901,16 +851,14 @@ SELECT COUNT(*) AS mvcc_term FROM mvcc_test WHERE content @@@ pdb.term('unique_g
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS mvcc_match FROM mvcc_test WHERE content @@@ pdb.match('unique_delta_updated');
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"match":{"field":"content","value":"unique_delta_updated","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"match":{"field":"content","value":"unique_delta_updated","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS mvcc_match FROM mvcc_test WHERE content @@@ pdb.match('unique_delta_updated');
  mvcc_match 
@@ -920,16 +868,14 @@ SELECT COUNT(*) AS mvcc_match FROM mvcc_test WHERE content @@@ pdb.match('unique
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS mvcc_regex FROM mvcc_test WHERE content @@@ pdb.regex('unique_.*_new');
-                                               QUERY PLAN                                                
----------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on mvcc_test
-         Table: mvcc_test
-         Index: idx_mvcc
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"regex":{"field":"content","pattern":"unique_.*_new"}}}}
-(7 rows)
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on mvcc_test
+   Index: idx_mvcc
+   Tantivy Query: {"with_index":{"query":{"regex":{"field":"content","pattern":"unique_.*_new"}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS mvcc_regex FROM mvcc_test WHERE content @@@ pdb.regex('unique_.*_new');
  mvcc_regex 
@@ -940,16 +886,14 @@ SELECT COUNT(*) AS mvcc_regex FROM mvcc_test WHERE content @@@ pdb.regex('unique
 -- Test pdb functions on parallel test table composite fields
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS parallel_term FROM parallel_test WHERE f1 @@@ pdb.term('field1_100');
-                                          QUERY PLAN                                          
-----------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on parallel_test
-         Table: parallel_test
-         Index: idx_parallel
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"term":{"field":"f1","value":"field1_100"}}}}
-(7 rows)
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on parallel_test
+   Index: idx_parallel
+   Tantivy Query: {"with_index":{"query":{"term":{"field":"f1","value":"field1_100"}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS parallel_term FROM parallel_test WHERE f1 @@@ pdb.term('field1_100');
  parallel_term 
@@ -959,16 +903,14 @@ SELECT COUNT(*) AS parallel_term FROM parallel_test WHERE f1 @@@ pdb.term('field
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS parallel_match FROM parallel_test WHERE f2 @@@ pdb.match('field2_500');
-                                                                                             QUERY PLAN                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on parallel_test
-         Table: parallel_test
-         Index: idx_parallel
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"match":{"field":"f2","value":"field2_500","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on parallel_test
+   Index: idx_parallel
+   Tantivy Query: {"with_index":{"query":{"match":{"field":"f2","value":"field2_500","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS parallel_match FROM parallel_test WHERE f2 @@@ pdb.match('field2_500');
  parallel_match 
@@ -979,16 +921,14 @@ SELECT COUNT(*) AS parallel_match FROM parallel_test WHERE f2 @@@ pdb.match('fie
 -- Test pdb functions on fast fields table
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS fast_term FROM fast_test_50 WHERE t01 @@@ pdb.term('first_text');
-                                          QUERY PLAN                                           
------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on fast_test_50
-         Table: fast_test_50
-         Index: idx_fast_50
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"term":{"field":"t01","value":"first_text"}}}}
-(7 rows)
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on fast_test_50
+   Index: idx_fast_50
+   Tantivy Query: {"with_index":{"query":{"term":{"field":"t01","value":"first_text"}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS fast_term FROM fast_test_50 WHERE t01 @@@ pdb.term('first_text');
  fast_term 
@@ -998,16 +938,14 @@ SELECT COUNT(*) AS fast_term FROM fast_test_50 WHERE t01 @@@ pdb.term('first_tex
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT COUNT(*) AS fast_match FROM fast_test_50 WHERE t20 @@@ pdb.match('middle_text');
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Aggregate
-   ->  Custom Scan (ParadeDB Base Scan) on fast_test_50
-         Table: fast_test_50
-         Index: idx_fast_50
-         Exec Method: NormalScanExecState
-         Scores: false
-         Tantivy Query: {"with_index":{"query":{"match":{"field":"t20","value":"middle_text","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
-(7 rows)
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on fast_test_50
+   Index: idx_fast_50
+   Tantivy Query: {"with_index":{"query":{"match":{"field":"t20","value":"middle_text","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(5 rows)
 
 SELECT COUNT(*) AS fast_match FROM fast_test_50 WHERE t20 @@@ pdb.match('middle_text');
  fast_match 

--- a/pg_search/tests/pg_regress/expected/deprecated_score.out
+++ b/pg_search/tests/pg_regress/expected/deprecated_score.out
@@ -54,6 +54,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score | book_score 
 ---------+-----------------+--------------+------------
        1 | J.K. Rowling    |     2.540445 |          0
@@ -105,6 +106,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE a.name @@@ 'Rowling' AND b.content @@@ 'test'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  | author_score | book_score 
 ---------+--------------+--------------+------------
        3 | J.K. Rowling |    1.5404451 |  0.4624617
@@ -121,6 +123,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
@@ -131,6 +134,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  | author_score | book_score 
 ---------+--------------+--------------+------------
        1 | Stephen King |    1.5404451 |          0
@@ -146,6 +150,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
@@ -156,6 +161,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') OR a.age > 60
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score | book_score 
 ---------+-----------------+--------------+------------
        1 | Stephen King    |     2.540445 |          0
@@ -190,6 +196,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE a.name @@@ 'Rowling'
 ORDER BY a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  query_type | author_id | author_name  | author_score 
 ------------+-----------+--------------+--------------
  Join Query |         1 | J.K. Rowling |    1.5404451
@@ -207,6 +214,7 @@ FROM books b
 LEFT JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score | book_score 
 ---------+-----------------+--------------+------------
        1 | J.K. Rowling    |     2.540445 |          0
@@ -227,6 +235,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
@@ -241,6 +250,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'function' OR a.name @@@ 'King') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  | author_score_1 | author_score_2 | book_score_1 | book_score_2 
 ---------+--------------+----------------+----------------+--------------+--------------
        1 | J.K. Rowling |              1 |              1 |   0.35745716 |   0.35745716
@@ -276,6 +286,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score |   author_snippet    | book_score |                                                                       book_snippet                                                                       
 ---------+-----------------+--------------+---------------------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------
        1 | J.K. Rowling    |     2.540445 | J.K. <b>Rowling</b> |          0 | 
@@ -292,6 +303,7 @@ FROM books b
 LEFT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0
@@ -304,6 +316,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY a.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0

--- a/pg_search/tests/pg_regress/expected/generated_subquery_proptest_failure.out
+++ b/pg_search/tests/pg_regress/expected/generated_subquery_proptest_failure.out
@@ -82,12 +82,14 @@ ANALYZE;
 --
 -- these two queries should return the same count:  3
 SELECT COUNT(*) FROM products WHERE products.color IN (SELECT color FROM orders WHERE NOT (orders.age  =  '20') ORDER BY orders.id LIMIT 9) AND (products.name  =  'bob') AND (products.name  =  'bob');
+WARNING:  Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans (table: join)
  count 
 -------
      3
 (1 row)
 
 SELECT COUNT(*) FROM products WHERE products.color IN (SELECT color FROM orders WHERE NOT (orders.age @@@ '20') ORDER BY orders.id LIMIT 9) AND (products.name @@@ 'bob') AND (products.name @@@ 'bob');
+WARNING:  Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans (table: join)
  count 
 -------
      3

--- a/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
+++ b/pg_search/tests/pg_regress/expected/groupby-agg-filter.out
@@ -491,7 +491,7 @@ SELECT
     STDDEV(price) FILTER (WHERE category @@@ 'electronics') AS price_stddev,
     COUNT(*) FILTER (WHERE brand @@@ 'Apple') AS apple_count
 FROM filter_agg_test;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2158. To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: stddev. To disable this warning: SET paradedb.check_aggregate_scan = false (table: filter_agg_test)
  total |   price_stddev   | apple_count 
 -------+------------------+-------------
     20 | 901.871070925012 |           3

--- a/pg_search/tests/pg_regress/expected/issue-3750-repro.out
+++ b/pg_search/tests/pg_regress/expected/issue-3750-repro.out
@@ -57,22 +57,15 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*) as count
 FROM places 
 WHERE name &&& 'assist wireless';
-                                                                                                      QUERY PLAN                                                                                                       
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
-   Output: count(*)
-   ->  Gather
-         Output: (PARTIAL count(*))
-         Workers Planned: 1
-         ->  Partial Aggregate
-               Output: PARTIAL count(*)
-               ->  Parallel Custom Scan (ParadeDB Base Scan) on public.places
-                     Table: places
-                     Index: places_parade_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"with_index":{"query":{"match":{"field":"name","value":"assist wireless","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}
-(13 rows)
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.places
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: places_parade_idx
+   Tantivy Query: {"with_index":{"query":{"match":{"field":"name","value":"assist wireless","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
 
 SELECT COUNT(*) as count
 FROM places 
@@ -90,22 +83,15 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*) as count
 FROM places 
 WHERE name &&& 'assist wireless' AND country_code = 'us';
-                                                                                                                                                                              QUERY PLAN                                                                                                                                                                               
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
-   Output: count(*)
-   ->  Gather
-         Output: (PARTIAL count(*))
-         Workers Planned: 1
-         ->  Partial Aggregate
-               Output: PARTIAL count(*)
-               ->  Parallel Custom Scan (ParadeDB Base Scan) on public.places
-                     Table: places
-                     Index: places_parade_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"match":{"field":"name","value":"assist wireless","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}}]}},"field_filters":[{"heap_filter":"(country_code = 'us'::text)"}]}}]}}
-(13 rows)
+                                                                                                                                                             QUERY PLAN                                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.places
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: places_parade_idx
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"match":{"field":"name","value":"assist wireless","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(country_code = 'us'::text)"}]}}]}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
 
 SELECT COUNT(*) as count
 FROM places 
@@ -153,22 +139,15 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*) as count
 FROM places 
 WHERE name &&& 'assist wireless' AND country_code = 'us' AND id @@@ paradedb.all();
-                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Finalize Aggregate
-   Output: count(*)
-   ->  Gather
-         Output: (PARTIAL count(*))
-         Workers Planned: 1
-         ->  Partial Aggregate
-               Output: PARTIAL count(*)
-               ->  Parallel Custom Scan (ParadeDB Base Scan) on public.places
-                     Table: places
-                     Index: places_parade_idx
-                     Exec Method: NormalScanExecState
-                     Scores: false
-                     Tantivy Query: {"boolean":{"must":[{"heap_filter":{"indexed_query":{"boolean":{"must":[{"with_index":{"query":{"match":{"field":"name","value":"assist wireless","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":"all"}}]}},"field_filters":[{"heap_filter":"(country_code = 'us'::text)"}]}}]}}
-(13 rows)
+                                                                                                                                                                            QUERY PLAN                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.places
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: places_parade_idx
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"match":{"field":"name","value":"assist wireless","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":true}}}},{"with_index":{"query":"all"}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(country_code = 'us'::text)"}]}}]}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
 
 SELECT COUNT(*) as count
 FROM places 

--- a/pg_search/tests/pg_regress/expected/issue_2533.out
+++ b/pg_search/tests/pg_regress/expected/issue_2533.out
@@ -1,4 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- TODO: See https://github.com/paradedb/paradedb/issues/5266.
+SET paradedb.enable_aggregate_custom_scan TO off;
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS products;
 DROP TABLE IF EXISTS orders;
@@ -149,8 +151,12 @@ SELECT (SELECT COUNT(*)
            OR (NOT (products.age @@@ '20')) AND (users.name @@@ 'bob')
            OR ((users.color @@@ 'blue') AND (users.name @@@ 'bob')) AND (products.color @@@ 'blue')
            OR (NOT (products.name @@@ 'bob')));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: products, users)
+ count | count 
+-------+-------
+    13 |    13
+(1 row)
+
 ---- idx=4 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -169,8 +175,12 @@ SELECT (SELECT COUNT(*)
            OR (orders.age @@@ '20') AND NOT (users.name @@@ 'bob')
            OR ((users.color @@@ 'blue') OR (NOT (users.name @@@ 'bob'))) AND
               NOT ((orders.name @@@ 'bob') OR (orders.age @@@ '20')) AND (orders.name @@@ 'bob'));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: orders, users)
+ count | count 
+-------+-------
+     0 |     0
+(1 row)
+
 ---- idx=37 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -189,8 +199,12 @@ SELECT (SELECT COUNT(*)
            OR ((products.color @@@ 'blue') AND (products.color @@@ 'blue')) AND NOT (users.color @@@ 'blue')
            OR ((users.name @@@ 'bob') OR (NOT (users.color @@@ 'blue'))) AND NOT (products.color @@@ 'blue') AND
               ((products.color @@@ 'blue') OR (products.color @@@ 'blue')));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: products, users)
+ count | count 
+-------+-------
+     2 |     2
+(1 row)
+
 ---- idx=46 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -209,8 +223,12 @@ SELECT (SELECT COUNT(*)
            OR ((products.age @@@ '20') OR (products.age @@@ '20')) AND NOT (users.color @@@ 'blue')
            OR ((users.age @@@ '20') OR (NOT (users.color @@@ 'blue'))) AND NOT (products.age @@@ '20') AND
               (NOT (NOT (products.name @@@ 'bob'))));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: products, users)
+ count | count 
+-------+-------
+     3 |     3
+(1 row)
+
 ---- idx=55 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -229,8 +247,12 @@ SELECT (SELECT COUNT(*)
            OR ((products.name @@@ 'bob') OR (products.age @@@ '20')) AND NOT (users.color @@@ 'blue')
            OR ((NOT (users.color @@@ 'blue')) OR (users.color @@@ 'blue')) AND NOT (products.age @@@ '20') AND
               ((products.color @@@ 'blue') AND (products.name @@@ 'bob')));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: products, users)
+ count | count 
+-------+-------
+     2 |     2
+(1 row)
+
 ---- idx=83 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -247,8 +269,12 @@ SELECT (SELECT COUNT(*)
            OR ((users.age @@@ '20') OR (NOT (users.name @@@ 'bob'))) AND
               NOT NOT (NOT ((NOT (orders.name @@@ 'bob')) OR (orders.name @@@ 'bob'))) AND NOT (users.age @@@ '20')
            OR ((users.age @@@ '20') AND (NOT (users.color @@@ 'blue'))));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: orders, users)
+ count | count 
+-------+-------
+    13 |    13
+(1 row)
+
 ---- idx=92 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -266,8 +292,11 @@ SELECT (SELECT COUNT(*)
               NOT NOT ((NOT (orders.color @@@ 'blue')) OR (NOT (orders.color @@@ 'blue'))) AND NOT (users.age @@@ '20')
            OR ((NOT (users.color @@@ 'blue')) AND (users.color @@@ 'blue')));
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: orders, users)
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+ count | count 
+-------+-------
+    13 |    13
+(1 row)
+
 ---- idx=74 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -286,8 +315,12 @@ SELECT (SELECT COUNT(*)
               NOT ((orders.age @@@ '20') AND (orders.age @@@ '20'))
            OR (orders.color @@@ 'blue') AND NOT (users.age @@@ '20')
            OR ((users.name @@@ 'bob') AND (NOT (users.color @@@ 'blue'))));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: orders, users)
+ count | count 
+-------+-------
+    14 |    14
+(1 row)
+
 --
 -- removing the `uses_tantivy_to_query` code so that we always push down quals if we can exposed
 -- a bug where we'd confuse vars by their names if different tables in the query contain fields
@@ -303,5 +336,9 @@ SELECT (SELECT COUNT(*)
                  JOIN orders ON products.name = orders.name
         WHERE (NOT (products.id @@@ '3'))
            OR ((products.name @@@ 'bob') AND (orders.id @@@ '3')));
-ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
-This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: orders, products)
+ count | count 
+-------+-------
+    19 |    19
+(1 row)
+

--- a/pg_search/tests/pg_regress/expected/issue_2533.out
+++ b/pg_search/tests/pg_regress/expected/issue_2533.out
@@ -149,7 +149,6 @@ SELECT (SELECT COUNT(*)
            OR (NOT (products.age @@@ '20')) AND (users.name @@@ 'bob')
            OR ((users.color @@@ 'blue') AND (users.name @@@ 'bob')) AND (products.color @@@ 'blue')
            OR (NOT (products.name @@@ 'bob')));
-WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=4 ----
@@ -170,7 +169,6 @@ SELECT (SELECT COUNT(*)
            OR (orders.age @@@ '20') AND NOT (users.name @@@ 'bob')
            OR ((users.color @@@ 'blue') OR (NOT (users.name @@@ 'bob'))) AND
               NOT ((orders.name @@@ 'bob') OR (orders.age @@@ '20')) AND (orders.name @@@ 'bob'));
-WARNING:  JoinScan not used: aggregates are not supported (tables: orders, users)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=37 ----
@@ -191,7 +189,6 @@ SELECT (SELECT COUNT(*)
            OR ((products.color @@@ 'blue') AND (products.color @@@ 'blue')) AND NOT (users.color @@@ 'blue')
            OR ((users.name @@@ 'bob') OR (NOT (users.color @@@ 'blue'))) AND NOT (products.color @@@ 'blue') AND
               ((products.color @@@ 'blue') OR (products.color @@@ 'blue')));
-WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=46 ----
@@ -212,7 +209,6 @@ SELECT (SELECT COUNT(*)
            OR ((products.age @@@ '20') OR (products.age @@@ '20')) AND NOT (users.color @@@ 'blue')
            OR ((users.age @@@ '20') OR (NOT (users.color @@@ 'blue'))) AND NOT (products.age @@@ '20') AND
               (NOT (NOT (products.name @@@ 'bob'))));
-WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=55 ----
@@ -233,7 +229,6 @@ SELECT (SELECT COUNT(*)
            OR ((products.name @@@ 'bob') OR (products.age @@@ '20')) AND NOT (users.color @@@ 'blue')
            OR ((NOT (users.color @@@ 'blue')) OR (users.color @@@ 'blue')) AND NOT (products.age @@@ '20') AND
               ((products.color @@@ 'blue') AND (products.name @@@ 'bob')));
-WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=83 ----
@@ -252,7 +247,6 @@ SELECT (SELECT COUNT(*)
            OR ((users.age @@@ '20') OR (NOT (users.name @@@ 'bob'))) AND
               NOT NOT (NOT ((NOT (orders.name @@@ 'bob')) OR (orders.name @@@ 'bob'))) AND NOT (users.age @@@ '20')
            OR ((users.age @@@ '20') AND (NOT (users.color @@@ 'blue'))));
-WARNING:  JoinScan not used: aggregates are not supported (tables: orders, users)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=92 ----
@@ -292,7 +286,6 @@ SELECT (SELECT COUNT(*)
               NOT ((orders.age @@@ '20') AND (orders.age @@@ '20'))
            OR (orders.color @@@ 'blue') AND NOT (users.age @@@ '20')
            OR ((users.name @@@ 'bob') AND (NOT (users.color @@@ 'blue'))));
-WARNING:  JoinScan not used: aggregates are not supported (tables: orders, users)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 --
@@ -310,6 +303,5 @@ SELECT (SELECT COUNT(*)
                  JOIN orders ON products.name = orders.name
         WHERE (NOT (products.id @@@ '3'))
            OR ((products.name @@@ 'bob') AND (orders.id @@@ '3')));
-WARNING:  JoinScan not used: aggregates are not supported (tables: orders, products)
 ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
 This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues

--- a/pg_search/tests/pg_regress/expected/issue_2533.out
+++ b/pg_search/tests/pg_regress/expected/issue_2533.out
@@ -149,11 +149,9 @@ SELECT (SELECT COUNT(*)
            OR (NOT (products.age @@@ '20')) AND (users.name @@@ 'bob')
            OR ((users.color @@@ 'blue') AND (users.name @@@ 'bob')) AND (products.color @@@ 'blue')
            OR (NOT (products.name @@@ 'bob')));
- count | count 
--------+-------
-    13 |    13
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=4 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -172,11 +170,9 @@ SELECT (SELECT COUNT(*)
            OR (orders.age @@@ '20') AND NOT (users.name @@@ 'bob')
            OR ((users.color @@@ 'blue') OR (NOT (users.name @@@ 'bob'))) AND
               NOT ((orders.name @@@ 'bob') OR (orders.age @@@ '20')) AND (orders.name @@@ 'bob'));
- count | count 
--------+-------
-     0 |     0
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: orders, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=37 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -195,11 +191,9 @@ SELECT (SELECT COUNT(*)
            OR ((products.color @@@ 'blue') AND (products.color @@@ 'blue')) AND NOT (users.color @@@ 'blue')
            OR ((users.name @@@ 'bob') OR (NOT (users.color @@@ 'blue'))) AND NOT (products.color @@@ 'blue') AND
               ((products.color @@@ 'blue') OR (products.color @@@ 'blue')));
- count | count 
--------+-------
-     2 |     2
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=46 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -218,11 +212,9 @@ SELECT (SELECT COUNT(*)
            OR ((products.age @@@ '20') OR (products.age @@@ '20')) AND NOT (users.color @@@ 'blue')
            OR ((users.age @@@ '20') OR (NOT (users.color @@@ 'blue'))) AND NOT (products.age @@@ '20') AND
               (NOT (NOT (products.name @@@ 'bob'))));
- count | count 
--------+-------
-     3 |     3
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=55 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -241,11 +233,9 @@ SELECT (SELECT COUNT(*)
            OR ((products.name @@@ 'bob') OR (products.age @@@ '20')) AND NOT (users.color @@@ 'blue')
            OR ((NOT (users.color @@@ 'blue')) OR (users.color @@@ 'blue')) AND NOT (products.age @@@ '20') AND
               ((products.color @@@ 'blue') AND (products.name @@@ 'bob')));
- count | count 
--------+-------
-     2 |     2
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: products, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=83 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -262,11 +252,9 @@ SELECT (SELECT COUNT(*)
            OR ((users.age @@@ '20') OR (NOT (users.name @@@ 'bob'))) AND
               NOT NOT (NOT ((NOT (orders.name @@@ 'bob')) OR (orders.name @@@ 'bob'))) AND NOT (users.age @@@ '20')
            OR ((users.age @@@ '20') AND (NOT (users.color @@@ 'blue'))));
- count | count 
--------+-------
-    13 |    13
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: orders, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=92 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -283,11 +271,9 @@ SELECT (SELECT COUNT(*)
            OR ((NOT (users.color @@@ 'blue')) OR (users.name @@@ 'bob')) AND
               NOT NOT ((NOT (orders.color @@@ 'blue')) OR (NOT (orders.color @@@ 'blue'))) AND NOT (users.age @@@ '20')
            OR ((NOT (users.color @@@ 'blue')) AND (users.color @@@ 'blue')));
- count | count 
--------+-------
-    13 |    13
-(1 row)
-
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: orders, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 ---- idx=74 ----
 ---- connector=AND NOT ----
 SELECT (SELECT COUNT(*)
@@ -306,11 +292,9 @@ SELECT (SELECT COUNT(*)
               NOT ((orders.age @@@ '20') AND (orders.age @@@ '20'))
            OR (orders.color @@@ 'blue') AND NOT (users.age @@@ '20')
            OR ((users.name @@@ 'bob') AND (NOT (users.color @@@ 'blue'))));
- count | count 
--------+-------
-    14 |    14
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: orders, users)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
 --
 -- removing the `uses_tantivy_to_query` code so that we always push down quals if we can exposed
 -- a bug where we'd confuse vars by their names if different tables in the query contain fields
@@ -326,8 +310,6 @@ SELECT (SELECT COUNT(*)
                  JOIN orders ON products.name = orders.name
         WHERE (NOT (products.id @@@ '3'))
            OR ((products.name @@@ 'bob') AND (orders.id @@@ '3')));
- count | count 
--------+-------
-    19 |    19
-(1 row)
-
+WARNING:  JoinScan not used: aggregates are not supported (tables: orders, products)
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues

--- a/pg_search/tests/pg_regress/expected/issue_2533.out
+++ b/pg_search/tests/pg_regress/expected/issue_2533.out
@@ -1,6 +1,4 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
--- TODO: See https://github.com/paradedb/paradedb/issues/5266.
-SET paradedb.enable_aggregate_custom_scan TO off;
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS products;
 DROP TABLE IF EXISTS orders;
@@ -131,6 +129,19 @@ VALUES (10, 'cloe', 'red', '53');
 INSERT INTO orders
 VALUES (11, 'brandy', 'green', '92');
 ANALYZE;
+-- TODO: See https://github.com/paradedb/paradedb/issues/5266.
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT (SELECT COUNT(*)
+        FROM users
+                 LEFT JOIN products ON users.color = products.color
+        WHERE (users.name = 'bob') AND ((users.color = 'blue') AND (users.name = 'bob')) AND (products.name = 'bob')
+           OR (NOT (products.age = '20')) AND (users.name = 'bob')
+           OR ((users.color = 'blue') AND (users.name = 'bob')) AND (products.color = 'blue')
+           OR (NOT (products.name = 'bob')));
+ERROR:  Failed to build DataFusion aggregate plan: Internal error: Failed to translate aggregate custom expression at index 0.
+This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report in our issue tracker: https://github.com/apache/datafusion/issues
+-- TODO: See https://github.com/paradedb/paradedb/issues/5266.
+SET paradedb.enable_aggregate_custom_scan TO off;
 --
 -- each pair of queries should produce the same number of results
 --

--- a/pg_search/tests/pg_regress/expected/issue_2564-parallel.out
+++ b/pg_search/tests/pg_regress/expected/issue_2564-parallel.out
@@ -118,6 +118,7 @@ WHERE d.parents @@@ 'Factures'
   AND f.title @@@ 'Receipt'
   AND p.content @@@ 'Socienty'
 ORDER BY d.id, f.id, p.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, f, p)
                                                                                    QUERY PLAN                                                                                   
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Merge
@@ -158,6 +159,7 @@ WHERE d.parents @@@ 'Factures'
   AND f.title @@@ 'Receipt'
   AND p.content @@@ 'Socienty'
 ORDER BY d.id, f.id, p.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, f, p)
   id  | parents  |  title  |     file_path      | fileid | page_number 
 ------+----------+---------+--------------------+--------+-------------
  doc2 | Factures | Receipt | /receipts/2023.pdf | file3  |           1

--- a/pg_search/tests/pg_regress/expected/issue_2564.out
+++ b/pg_search/tests/pg_regress/expected/issue_2564.out
@@ -117,6 +117,7 @@ WHERE d.parents @@@ 'Factures'
   AND f.title @@@ 'Receipt'
   AND p.content @@@ 'Socienty'
 ORDER BY d.id, f.id, p.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, f, p)
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -154,6 +155,7 @@ WHERE d.parents @@@ 'Factures'
   AND f.title @@@ 'Receipt'
   AND p.content @@@ 'Socienty'
 ORDER BY d.id, f.id, p.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, f, p)
   id  | parents  |  title  |     file_path      | fileid | page_number 
 ------+----------+---------+--------------------+--------+-------------
  doc2 | Factures | Receipt | /receipts/2023.pdf | file3  |           1

--- a/pg_search/tests/pg_regress/expected/issue_3678.out
+++ b/pg_search/tests/pg_regress/expected/issue_3678.out
@@ -86,6 +86,7 @@ WHERE company_name &&& 'Jarvi'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                      
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -116,6 +117,7 @@ WHERE company_name &&& 'Jarvi'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
               profile_id              | best_score 
 --------------------------------------+------------
  a0000000-0000-0000-0000-000000000001 |  11.528142
@@ -135,6 +137,7 @@ WHERE title &&& 'developer'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
               profile_id              | best_score 
 --------------------------------------+------------
  a0000000-0000-0000-0000-000000000001 |  2.5257165
@@ -153,6 +156,7 @@ WHERE company_name &&& 'Jarvi'
 GROUP BY profile_id
 ORDER BY best_score DESC, profile_id
 LIMIT 5;
+WARNING:  Aggregate Scan not used: argument to aggregate function is neither a direct column reference nor a COALESCE expression. To disable this warning: SET paradedb.check_aggregate_scan = false (table: nhfs_big)
               profile_id              | best_score 
 --------------------------------------+------------
  a0000000-0000-0000-0000-000000000001 |  11.528142

--- a/pg_search/tests/pg_regress/expected/issue_3998.out
+++ b/pg_search/tests/pg_regress/expected/issue_3998.out
@@ -33,6 +33,7 @@ WITH scores AS (
     WHERE content @@@ 'test'
 )
 SELECT (MAX(s) - MIN(s)) < 0.00001 as scores_are_identical FROM scores;
+WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.check_aggregate_scan = false (table: fieldnorms_test)
  scores_are_identical 
 ----------------------
  t

--- a/pg_search/tests/pg_regress/expected/issue_4906_ltree_desc_op_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/issue_4906_ltree_desc_op_pushdown.out
@@ -165,7 +165,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top_science
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  descendant_ids_top_science 
 ----------------------------
  {2,3,4,5,6,14,15,16,17,18}
@@ -184,7 +184,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top.Science'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top_science;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top_science 
 ----------------------------------------------------
  t
@@ -204,7 +204,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category @@@ 'Top.Science'
     ) AS ltree_descendant_pushdown_matches_facet_query_top_science;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  ltree_descendant_pushdown_matches_facet_query_top_science 
 -----------------------------------------------------------
  t
@@ -217,7 +217,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top_science_astronomy
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science.Astronomy'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  descendant_ids_top_science_astronomy 
 --------------------------------------
  {3,4,5,15,16,17}
@@ -234,7 +234,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top.Science.Astronomy'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top_science_astronomy;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top_science_astronomy 
 --------------------------------------------------------------
  t
@@ -251,7 +251,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category @@@ 'Top.Science.Astronomy'
     ) AS ltree_desc_pushdown_matches_facet_query_top_science_astron;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  ltree_desc_pushdown_matches_facet_query_top_science_astron 
 ------------------------------------------------------------
  t
@@ -264,7 +264,7 @@ FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND category = 'Top.Science'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  equality_is_included 
 ----------------------
  {2}
@@ -289,7 +289,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top
 FROM issue_4906_ltree
 WHERE category <@ 'Top'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
             descendant_ids_top            
 ------------------------------------------
  {1,2,3,4,5,6,7,8,9,10,11,14,15,16,17,18}
@@ -306,7 +306,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top 
 --------------------------------------------
  t
@@ -318,7 +318,7 @@ SELECT coalesce(array_agg(id ORDER BY id), ARRAY[]::bigint[]) AS no_match_ids
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science.Astronomy.Deep'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  no_match_ids 
 --------------
  {}
@@ -336,7 +336,7 @@ FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND (id + 0) >= 15
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  combined_predicate_ids 
 ------------------------
  {15,16,17,18}
@@ -446,7 +446,7 @@ FROM issue_4906_ltree_partial
 WHERE is_indexed
   AND category <@ 'Top.Science'::ltree
   AND id @@@ pdb.all();
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
  partial_index_descendant_ids 
 ------------------------------
  {1,2,3,4}
@@ -468,7 +468,7 @@ SELECT
         WHERE is_indexed
           AND category ^<@ 'Top.Science'::ltree
     ) AS partial_index_matches_ltree_noindex_semantics;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
  partial_index_matches_ltree_noindex_semantics 
 -----------------------------------------------
  t
@@ -556,7 +556,7 @@ WHERE p.is_indexed
         ),
         false
       );
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
  partial_qual_subplan_ids 
 --------------------------
  {1,3,4}

--- a/pg_search/tests/pg_regress/expected/issue_4906_ltree_desc_op_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/issue_4906_ltree_desc_op_pushdown.out
@@ -165,6 +165,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top_science
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND id @@@ pdb.all();
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  descendant_ids_top_science 
 ----------------------------
  {2,3,4,5,6,14,15,16,17,18}
@@ -183,6 +184,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top.Science'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top_science;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top_science 
 ----------------------------------------------------
  t
@@ -202,6 +204,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category @@@ 'Top.Science'
     ) AS ltree_descendant_pushdown_matches_facet_query_top_science;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  ltree_descendant_pushdown_matches_facet_query_top_science 
 -----------------------------------------------------------
  t
@@ -214,6 +217,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top_science_astronomy
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science.Astronomy'::ltree
   AND id @@@ pdb.all();
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  descendant_ids_top_science_astronomy 
 --------------------------------------
  {3,4,5,15,16,17}
@@ -230,6 +234,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top.Science.Astronomy'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top_science_astronomy;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top_science_astronomy 
 --------------------------------------------------------------
  t
@@ -246,6 +251,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category @@@ 'Top.Science.Astronomy'
     ) AS ltree_desc_pushdown_matches_facet_query_top_science_astron;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  ltree_desc_pushdown_matches_facet_query_top_science_astron 
 ------------------------------------------------------------
  t
@@ -258,6 +264,7 @@ FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND category = 'Top.Science'::ltree
   AND id @@@ pdb.all();
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  equality_is_included 
 ----------------------
  {2}
@@ -282,6 +289,7 @@ SELECT array_agg(id ORDER BY id) AS descendant_ids_top
 FROM issue_4906_ltree
 WHERE category <@ 'Top'::ltree
   AND id @@@ pdb.all();
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
             descendant_ids_top            
 ------------------------------------------
  {1,2,3,4,5,6,7,8,9,10,11,14,15,16,17,18}
@@ -298,6 +306,7 @@ SELECT
         FROM issue_4906_ltree
         WHERE category ^<@ 'Top'::ltree
     ) AS pushed_matches_ltree_noindex_semantics_top;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  pushed_matches_ltree_noindex_semantics_top 
 --------------------------------------------
  t
@@ -309,6 +318,7 @@ SELECT coalesce(array_agg(id ORDER BY id), ARRAY[]::bigint[]) AS no_match_ids
 FROM issue_4906_ltree
 WHERE category <@ 'Top.Science.Astronomy.Deep'::ltree
   AND id @@@ pdb.all();
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  no_match_ids 
 --------------
  {}
@@ -326,6 +336,7 @@ FROM issue_4906_ltree
 WHERE category <@ 'Top.Science'::ltree
   AND (id + 0) >= 15
   AND id @@@ pdb.all();
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree)
  combined_predicate_ids 
 ------------------------
  {15,16,17,18}
@@ -435,6 +446,7 @@ FROM issue_4906_ltree_partial
 WHERE is_indexed
   AND category <@ 'Top.Science'::ltree
   AND id @@@ pdb.all();
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
  partial_index_descendant_ids 
 ------------------------------
  {1,2,3,4}
@@ -456,6 +468,7 @@ SELECT
         WHERE is_indexed
           AND category ^<@ 'Top.Science'::ltree
     ) AS partial_index_matches_ltree_noindex_semantics;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
  partial_index_matches_ltree_noindex_semantics 
 -----------------------------------------------
  t
@@ -543,6 +556,7 @@ WHERE p.is_indexed
         ),
         false
       );
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_ltree_partial)
  partial_qual_subplan_ids 
 --------------------------
  {1,3,4}

--- a/pg_search/tests/pg_regress/expected/issue_4906_ltree_op_absent.out
+++ b/pg_search/tests/pg_regress/expected/issue_4906_ltree_op_absent.out
@@ -96,6 +96,7 @@ SELECT array_agg(id ORDER BY id) AS non_ltree_query_result_ids
 FROM issue_4906_without_ltree
 WHERE body @@@ 'document'
   AND rating > 1;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_without_ltree)
  non_ltree_query_result_ids 
 ----------------------------
  {2,3}

--- a/pg_search/tests/pg_regress/expected/issue_4906_ltree_op_absent.out
+++ b/pg_search/tests/pg_regress/expected/issue_4906_ltree_op_absent.out
@@ -96,7 +96,7 @@ SELECT array_agg(id ORDER BY id) AS non_ltree_query_result_ids
 FROM issue_4906_without_ltree
 WHERE body @@@ 'document'
   AND rating > 1;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 2335. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_without_ltree)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: array_agg. To disable this warning: SET paradedb.check_aggregate_scan = false (table: issue_4906_without_ltree)
  non_ltree_query_result_ids 
 ----------------------------
  {2,3}

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -575,27 +575,23 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
     LIMIT 10;
 WARNING:  JoinScan not used: aggregates are not supported (tables: p, s)
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   Output: (count(*))
-   ->  Aggregate
-         Output: count(*)
-         ->  Hash Join
-               Hash Cond: (s.id = p.supplier_id)
-               ->  Seq Scan on public.dist_suppliers s
-                     Output: s.id, s.name, s.contact_info, s.country
-               ->  Hash
-                     Output: p.supplier_id
-                     ->  Custom Scan (ParadeDB Base Scan) on public.dist_products p
-                           Output: p.supplier_id
-                           Table: dist_products
-                           Index: dist_products_bm25_idx
-                           Exec Method: ColumnarExecState
-                           Fast Fields: supplier_id
-                           Scores: false
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+   Output: (pdb.agg_fn('COUNT(*)'::text))
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Output: pdb.agg_fn('COUNT(*)'::text)
+         Backend: DataFusion
+         Indexes: dist_products_bm25_idx (p), dist_suppliers_bm25_idx (s)
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : AggregateExec: mode=Single, gby=[], aggr=[agg_0]
+           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, supplier_id@0)], projection=[]
+           :     CooperativeExec
+           :       PgSearchScan: segments=1, query="all"
+           :     CooperativeExec
+           :       PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(14 rows)
 
 -- =============================================================================
 -- TEST 12: Aggregate correctness — COUNT not capped by LIMIT

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -574,7 +574,6 @@ FROM dist_products p
          JOIN dist_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
     LIMIT 10;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, s)
                                                                                                  QUERY PLAN                                                                                                  
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -604,7 +603,6 @@ FROM dist_products p
          JOIN dist_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
     LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, s)
  count 
 -------
      5

--- a/pg_search/tests/pg_regress/expected/join_execution_limits.out
+++ b/pg_search/tests/pg_regress/expected/join_execution_limits.out
@@ -125,7 +125,6 @@ FROM mem_test_products p
 JOIN mem_test_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 LIMIT 100;
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, s)
  match_count 
 -------------
          166
@@ -183,7 +182,6 @@ FROM large_items li
 JOIN large_categories lc ON li.category_id = lc.id
 WHERE li.content @@@ 'wireless'
 LIMIT 500;
-WARNING:  JoinScan not used: aggregates are not supported (tables: lc, li)
  wireless_count 
 ----------------
             200
@@ -453,7 +451,6 @@ SELECT COUNT(*) AS wireless_count
 FROM hint_test_products hp
 JOIN hint_test_categories hc ON hp.category_id = hc.id
 WHERE hp.description @@@ 'wireless';
-WARNING:  JoinScan not used: aggregates are not supported (tables: hc, hp)
  wireless_count 
 ----------------
              66

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -585,7 +585,6 @@ JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'story')
   AND (a.is_active = true OR b.is_published = true);
 WARNING:  Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 6.3: Unsafe conditions that cannot be pushed down
 SELECT 

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -130,6 +130,7 @@ FROM authors a
 INNER JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'science' OR b.content @@@ 'technology')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
   author_name  |      book_title      | author_score | book_score 
 ---------------+----------------------+--------------+------------
  J.K. Rowling  | Harry Potter Magic   |            0 |    0.98641
@@ -149,6 +150,7 @@ FROM authors a
 LEFT JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'mystery' OR b.content @@@ 'romance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
    author_name   |     book_title      | author_score | book_score 
 -----------------+---------------------+--------------+------------
  Agatha Christie | Murder Mystery Case |    1.5552412 |          0
@@ -164,6 +166,7 @@ FROM authors a
 RIGHT JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'fiction' OR b.content @@@ 'magic')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
  author_name  |      book_title      | author_score | book_score 
 --------------+----------------------+--------------+------------
  J.K. Rowling | Harry Potter Magic   |            0 |  1.3025584
@@ -184,6 +187,7 @@ FROM authors a
 INNER JOIN books b ON a.id = b.author_id AND a.birth_year < 2000
 WHERE (a.bio @@@ 'writer' OR b.content @@@ 'mystery')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 2: Non-equi joins and problematic conditions
@@ -199,6 +203,7 @@ CROSS JOIN books b
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'mystery')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC
 LIMIT 10;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, b)
  author_name  |      book_title      | author_score | book_score 
 --------------+----------------------+--------------+------------
  J.K. Rowling | Harry Potter Horrors |   0.66167223 |          0
@@ -223,6 +228,7 @@ FROM authors a
 INNER JOIN books b ON a.birth_year < b.publication_year
 WHERE (a.bio @@@ 'fiction' OR b.content @@@ 'love')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, b)
  author_name  |      book_title      | author_score | book_score 
 --------------+----------------------+--------------+------------
  Stephen King | Harry Potter Magic   |   0.66167223 |          0
@@ -259,6 +265,7 @@ FROM authors a
 INNER JOIN books b ON a.birth_year + 50 > b.publication_year
 WHERE (a.bio @@@ 'writer' OR b.content @@@ 'programming')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, b)
    author_name   |     book_title      | author_score | book_score 
 -----------------+---------------------+--------------+------------
  Agatha Christie | Murder Mystery Case |    1.0395092 |          0
@@ -278,6 +285,7 @@ FROM authors a
 INNER JOIN books b ON b.price BETWEEN 20.00 AND 30.00 AND a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'romance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- =============================================================================
 -- SECTION 3: CROSS-TABLE OR TESTS
@@ -293,6 +301,7 @@ CROSS JOIN books b
 WHERE (a.bio @@@ 'smartphone' OR b.content @@@ 'performance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC
 LIMIT 10;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, b)
    author_name   |                        book_content                         | author_score | book_score 
 -----------------+-------------------------------------------------------------+--------------+------------
  J.K. Rowling    | A horror story about supernatural terror events performance |            0 |  1.3702781
@@ -347,6 +356,7 @@ CROSS JOIN books b
 WHERE (a.bio @@@ 'smartphone' OR a.country @@@ 'British' OR b.content @@@ 'performance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC
 LIMIT 10;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, b)
    author_name   | author_country |                        book_content                         | author_score | book_score 
 -----------------+----------------+-------------------------------------------------------------+--------------+------------
  J.K. Rowling    | UK             | A horror story about supernatural terror events performance |            0 |  1.3702781
@@ -374,6 +384,7 @@ FROM authors a
 INNER JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'science' OR b.content @@@ 'mystery' OR b.price > 25.00)
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
    author_name   |      book_title      | author_score | book_score 
 -----------------+----------------------+--------------+------------
  J.K. Rowling    | Harry Potter Magic   |            0 |          0
@@ -396,6 +407,7 @@ INNER JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'smartphone' AND a.birth_year > 1950) 
    OR (b.content @@@ 'magic' AND b.publication_year > 1980)
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  author_name  |      book_title      | author_score | book_score 
 --------------+----------------------+--------------+------------
  J.K. Rowling | Harry Potter Magic   |            0 |  1.3025584
@@ -418,6 +430,7 @@ JOIN reviews r ON b.id = r.book_id
 WHERE (a.bio @@@ 'British' AND b.is_published = true) 
    OR (b.content @@@ 'horror' AND r.score >= 4)
 ORDER BY a.id, b.id, r.id, author_score DESC, book_score DESC, review_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 4.4: Intelligent partial salvage of AND expressions
 SELECT 
@@ -429,6 +442,7 @@ WHERE (a.bio @@@ 'laptop')
   AND (a.birth_year > 1000)
   AND (c.name @@@ 'Electronics')
 ORDER BY a.id, author_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, c)
  author_name | author_score 
 -------------+--------------
 (0 rows)
@@ -446,6 +460,7 @@ FROM authors a1
 INNER JOIN authors a2 ON a1.birth_year = a2.birth_year AND a1.id != a2.id
 WHERE (a1.bio @@@ 'fiction' OR a2.bio @@@ 'mystery')
 ORDER BY a1.id, a2.id, author1_score DESC, author2_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a1, a2)
  author1_name | author2_name | author1_score | author2_score 
 --------------+--------------+---------------+---------------
 (0 rows)
@@ -460,6 +475,7 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author' AND b.category_id = 1
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 5.3: LEFT JOIN semantics test
 SELECT 
@@ -471,6 +487,7 @@ FROM authors a
 LEFT JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author' OR b.content @@@ 'story'
 ORDER BY a.id, b.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
    author_name   |      book_title      | author_score | book_score 
 -----------------+----------------------+--------------+------------
  J.K. Rowling    | Harry Potter Magic   |   0.66167223 | 0.27030534
@@ -547,6 +564,7 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author'
 ORDER BY a.id, author_score DESC;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  author_name  | author_score 
 --------------+--------------
  J.K. Rowling |   0.66167223
@@ -566,6 +584,8 @@ FROM authors a
 JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'author' OR b.content @@@ 'story')
   AND (a.is_active = true OR b.is_published = true);
+WARNING:  Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test 6.3: Unsafe conditions that cannot be pushed down
 SELECT 
@@ -578,6 +598,7 @@ CROSS JOIN books b
 WHERE (a.bio @@@ 'smartphone' OR a.birth_year = b.publication_year)
 ORDER BY a.id, b.id, author_score DESC, book_score DESC
 LIMIT 5;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, b)
  author_name |      book_title      | author_score | book_score 
 -------------+----------------------+--------------+------------
  John Smith  | Harry Potter Magic   |    1.6503524 |          0
@@ -623,6 +644,7 @@ JOIN categories c ON b.category_id = c.id
 WHERE (a.bio @@@ 'smartphone')    -- Safe condition on authors
    OR (c.description @@@ 'electronic')    -- External condition on categories
 ORDER BY a.id, c.id, author_score DESC, category_score DESC;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, c)
  author_name | category_name | author_score | category_score 
 -------------+---------------+--------------+----------------
  John Smith  | Technology    |    1.6503524 |              0

--- a/pg_search/tests/pg_regress/expected/lateral-join.out
+++ b/pg_search/tests/pg_regress/expected/lateral-join.out
@@ -247,6 +247,7 @@ WHERE a.content @@@ 'database'
   AND c.comment_count > 5
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
                                                                               QUERY PLAN                                                                               
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -281,6 +282,7 @@ WHERE a.content @@@ 'database'
   AND c.comment_count > 5
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: HAVING clause is not supported (see https://github.com/paradedb/paradedb/issues/4206). To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
  id |              title               |   score   | comment_count 
 ----+----------------------------------+-----------+---------------
   4 | Database Security Best Practices | 1.4766761 |             7
@@ -302,6 +304,7 @@ LEFT JOIN authors au ON a.author_id = au.id
 WHERE a.content @@@ 'technology'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, au)
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -329,6 +332,7 @@ LEFT JOIN authors au ON a.author_id = au.id
 WHERE a.content @@@ 'technology'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, au)
  id |            title             |   score   | author_name 
 ----+------------------------------+-----------+-------------
  11 | Computer Vision Applications | 2.2999182 | Jane Smith
@@ -357,6 +361,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'machine learning'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 10;
+WARNING:  Aggregate Scan not used: field 'rating' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -391,6 +396,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'machine learning'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 10;
+WARNING:  Aggregate Scan not used: field 'rating' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
  id |          title          | total_comments | avg_rating 
 ----+-------------------------+----------------+------------
   2 | Machine Learning Basics |              7 |       2.00
@@ -415,6 +421,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'cloud'
 ORDER BY a.created_at DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
                                                                           QUERY PLAN                                                                          
 --------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -447,6 +454,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'cloud'
 ORDER BY a.created_at DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
  id |           title           |        created_at        |       comment_time       
 ----+---------------------------+--------------------------+--------------------------
   3 | Cloud Native Applications | Wed Jan 03 00:00:00 2024 | Thu Jan 04 20:00:00 2024
@@ -544,6 +552,7 @@ WHERE a.content @@@ 'machine learning'
   AND a.author_id IN (1, 2)
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
                                                                                                                                                              QUERY PLAN                                                                                                                                                             
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -578,6 +587,7 @@ WHERE a.content @@@ 'machine learning'
   AND a.author_id IN (1, 2)
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: field 'created_at' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
  id |          title          | score_value |   score   |       last_comment       
 ----+-------------------------+-------------+-----------+--------------------------
   2 | Machine Learning Basics |       82.30 | 4.5998363 | Thu Jan 04 19:00:00 2024
@@ -606,6 +616,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'encryption'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
                                                                             QUERY PLAN                                                                             
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -642,6 +653,7 @@ LEFT JOIN LATERAL (
 WHERE a.content @@@ 'encryption'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan not used: Expression is neither a grouping column nor a single Aggref. To disable this warning: SET paradedb.check_aggregate_scan = false (table: comments)
  id |          title          | has_comments | comment_count 
 ----+-------------------------+--------------+---------------
  14 | Encryption Fundamentals | t            |             6
@@ -732,6 +744,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8827127 (table: join)
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -778,6 +791,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8827127 (table: join)
  id |              title               | author_name | comment_count 
 ----+----------------------------------+-------------+---------------
   4 | Database Security Best Practices | Alice Brown |            20

--- a/pg_search/tests/pg_regress/expected/lateral-join.out
+++ b/pg_search/tests/pg_regress/expected/lateral-join.out
@@ -744,7 +744,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8827127 (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8052361 (table: join)
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -791,7 +791,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8827127 (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8052361 (table: join)
  id |              title               | author_name | comment_count 
 ----+----------------------------------+-------------+---------------
   4 | Database Security Best Practices | Alice Brown |            20

--- a/pg_search/tests/pg_regress/expected/lateral-join.out
+++ b/pg_search/tests/pg_regress/expected/lateral-join.out
@@ -744,7 +744,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8098419 (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field (table: join)
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -791,7 +791,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8098419 (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field (table: join)
  id |              title               | author_name | comment_count 
 ----+----------------------------------+-------------+---------------
   4 | Database Security Best Practices | Alice Brown |            20

--- a/pg_search/tests/pg_regress/expected/lateral-join.out
+++ b/pg_search/tests/pg_regress/expected/lateral-join.out
@@ -744,7 +744,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8052361 (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8098419 (table: join)
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -791,7 +791,7 @@ LEFT JOIN (
 WHERE a.content @@@ 'database'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8052361 (table: join)
+WARNING:  Aggregate Scan (DataFusion) not used: join key (plan_position=0, attno=2) is not a fast field on table 8098419 (table: join)
  id |              title               | author_name | comment_count 
 ----+----------------------------------+-------------+---------------
   4 | Database Security Best Practices | Alice Brown |            20

--- a/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
+++ b/pg_search/tests/pg_regress/expected/limit_pushdown_basescan.out
@@ -128,6 +128,7 @@ SELECT count(*) FROM (
                SELECT id FROM lp_categories
                WHERE name = 'rare_category'))
 ) sub;
+WARNING:  Aggregate Scan not used: could not extract search query from quals. To disable this warning: SET paradedb.check_aggregate_scan = false (table: lp_items)
  count 
 -------
    150

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -65,7 +65,6 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -85,7 +84,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  count 
 -------
   1000
@@ -99,7 +97,6 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                                    QUERY PLAN                                                                                                   
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -129,7 +126,6 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
   title   | count |  sum  
 ----------+-------+-------
  file-1   |     5 | 10040
@@ -153,7 +149,6 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -184,7 +179,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  count 
 -------
   1000
@@ -197,7 +191,6 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                                        QUERY PLAN                                                                                                       
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -245,7 +238,6 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
   title   | count |  sum  
 ----------+-------+-------
  file-1   |     5 | 10040

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -72,7 +72,6 @@ FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 GROUP BY f.category
 ORDER BY f.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  category | row_count | total_bytes | min_bytes | max_bytes 
 ----------+-----------+-------------+-----------+-----------
  cat-0    |       200 |      394380 |         4 |      4063
@@ -93,7 +92,6 @@ FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 GROUP BY f.category
 ORDER BY f.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                           QUERY PLAN                                                                                           
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Merge
@@ -141,7 +139,6 @@ FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 GROUP BY f.category
 ORDER BY f.category;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  category | row_count | total_bytes | min_bytes | max_bytes 
 ----------+-----------+-------------+-----------+-----------
  cat-0    |       200 |      394380 |         4 |      4063
@@ -161,7 +158,6 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.category, f.title
 ORDER BY f.category, f.title
 LIMIT 10;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  category |  title   | pages_per_file 
 ----------+----------+----------------
  cat-0    | file-10  |              5
@@ -184,7 +180,6 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.category, f.title
 ORDER BY f.category, f.title
 LIMIT 10;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                              QUERY PLAN                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -231,7 +226,6 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.category, f.title
 ORDER BY f.category, f.title
 LIMIT 10;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  category |  title   | pages_per_file 
 ----------+----------+----------------
  cat-0    | file-10  |              5
@@ -257,7 +251,6 @@ GROUP BY f.category
 HAVING COUNT(*) > 100
 ORDER BY s DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  category |  c  |   s    
 ----------+-----+--------
  cat-1    | 200 | 397780
@@ -274,7 +267,6 @@ GROUP BY f.category
 HAVING COUNT(*) > 100
 ORDER BY s DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                              QUERY PLAN                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -324,7 +316,6 @@ GROUP BY f.category
 HAVING COUNT(*) > 100
 ORDER BY s DESC
 LIMIT 3;
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  category |  c  |   s    
 ----------+-----+--------
  cat-1    | 200 | 397780
@@ -342,7 +333,6 @@ SET paradedb.enable_mpp TO off;
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  count 
 -------
   1000
@@ -353,7 +343,6 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
                                                                                    QUERY PLAN                                                                                    
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -384,7 +373,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-WARNING:  JoinScan not used: aggregates are not supported (tables: f, p)
  count 
 -------
   1000
@@ -422,7 +410,6 @@ JOIN mpp_postagg_categories c ON f.category = c.name
 WHERE f.content @@@ 'Section'
 GROUP BY c.name
 ORDER BY c.name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
  name  | row_count | total_bytes 
 -------+-----------+-------------
  cat-0 |       200 |      394380
@@ -441,7 +428,6 @@ JOIN mpp_postagg_categories c ON f.category = c.name
 WHERE f.content @@@ 'Section'
 GROUP BY c.name
 ORDER BY c.name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
                                                                                                     QUERY PLAN                                                                                                    
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Gather Merge
@@ -495,7 +481,6 @@ JOIN mpp_postagg_categories c ON f.category = c.name
 WHERE f.content @@@ 'Section'
 GROUP BY c.name
 ORDER BY c.name;
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, f, p)
  name  | row_count | total_bytes 
 -------+-----------+-------------
  cat-0 |       200 |      394380

--- a/pg_search/tests/pg_regress/expected/not-paradedb_all.out
+++ b/pg_search/tests/pg_regress/expected/not-paradedb_all.out
@@ -67,6 +67,7 @@ FROM notpdball a,
 WHERE a.id = b.id AND NOT a.id @@@ paradedb.all()
    OR b.id @@@ paradedb.all()
 ORDER BY a.id, b.id;
+WARNING:  JoinScan not used: at least one equi-join key (e.g., a.id = b.id) is required (tables: a, b)
  id | id 
 ----+----
   1 |  1

--- a/pg_search/tests/pg_regress/expected/numeric_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/numeric_pushdown.out
@@ -1658,6 +1658,7 @@ FROM numeric_unbounded_agg_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 ORDER BY category;
+WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_unbounded_agg_test)
                                     QUERY PLAN                                     
 -----------------------------------------------------------------------------------
  GroupAggregate
@@ -1681,6 +1682,7 @@ FROM numeric_unbounded_agg_test
 WHERE id @@@ paradedb.all()
 GROUP BY category
 ORDER BY category;
+WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_unbounded_agg_test)
  category |               total                
 ----------+------------------------------------
  A        | 301.111111110111111111011111111100
@@ -1692,6 +1694,7 @@ SELECT category, SUM(amount) as total
 FROM numeric_unbounded_agg_test
 GROUP BY category
 ORDER BY category;
+WARNING:  Aggregate Scan not used: grouping column category exists, but is not a fast field. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_unbounded_agg_test)
  category |               total                
 ----------+------------------------------------
  A        | 301.111111110111111111011111111100
@@ -2142,6 +2145,7 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM max_scale_test
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: max_scale_test)
                            QUERY PLAN                            
 -----------------------------------------------------------------
  Aggregate
@@ -2160,6 +2164,7 @@ WHERE id @@@ paradedb.all();
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM max_scale_test
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: max_scale_test)
          sum          |          avg           |          min          |         max          
 ----------------------+------------------------+-----------------------+----------------------
  0.623456789012345678 | 0.12469135780246913560 | -0.500000000000000000 | 0.999999999999999999
@@ -2265,6 +2270,7 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM negative_scale_test
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: negative_scale_test)
                               QUERY PLAN                              
 ----------------------------------------------------------------------
  Aggregate
@@ -2283,6 +2289,7 @@ WHERE id @@@ paradedb.all();
 SELECT SUM(val), AVG(val), MIN(val), MAX(val)
 FROM negative_scale_test
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'val' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: negative_scale_test)
   sum   |        avg         |  min   |  max  
 --------+--------------------+--------+-------
  132000 | 22000.000000000000 | -12000 | 99000
@@ -3169,6 +3176,7 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT SUM(val_small), AVG(val_small), MIN(val_small), MAX(val_small)
 FROM numeric_precision_only_test
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'val_small' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_precision_only_test)
                                   QUERY PLAN                                  
 ------------------------------------------------------------------------------
  Aggregate
@@ -3187,6 +3195,7 @@ WHERE id @@@ paradedb.all();
 SELECT SUM(val_small), AVG(val_small), MIN(val_small), MAX(val_small)
 FROM numeric_precision_only_test
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'val_small' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_precision_only_test)
   sum  |          avg          | min  |  max  
 -------+-----------------------+------+-------
  12368 | 1766.8571428571428571 | -500 | 12345
@@ -3195,6 +3204,7 @@ WHERE id @@@ paradedb.all();
 SELECT SUM(val_large), AVG(val_large), MIN(val_large), MAX(val_large)
 FROM numeric_precision_only_test
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'val_large' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_precision_only_test)
        sum       |         avg         |      min      |       max       
 -----------------+---------------------+---------------+-----------------
  126956789024690 | 18136684146384.2857 | -500000000000 | 123456789012345
@@ -3256,6 +3266,7 @@ ORDER BY id;
 SELECT SUM(implicit_scale), SUM(explicit_scale)
 FROM numeric_explicit_scale_zero
 WHERE id @@@ paradedb.all();
+WARNING:  Aggregate Scan not used: field 'implicit_scale' does not support aggregate pushdown. To disable this warning: SET paradedb.check_aggregate_scan = false (table: numeric_explicit_scale_zero)
   sum  |  sum  
 -------+-------
  69124 | 69124

--- a/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
+++ b/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
@@ -84,6 +84,8 @@ AND EXISTS(
     AND t.id @@@ paradedb.term('status', 'completed')
 )
 ORDER BY u.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: t, u)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: t, u)
  id | name  
 ----+-------
   1 | Alice
@@ -109,6 +111,8 @@ AND EXISTS(
     )
 )
 ORDER BY u.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, id, t, ti)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: d, id, t, ti, u)
  id | name 
 ----+------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
+++ b/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
@@ -129,7 +129,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -145,7 +144,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -161,7 +159,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -177,7 +174,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -193,7 +189,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -209,7 +204,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -225,7 +219,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -243,7 +236,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -259,7 +251,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -275,7 +266,6 @@ WHERE dt.full_text @@@ 'ea'
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -295,7 +285,6 @@ WHERE dt.full_text @@@ $1
 -- Execute multiple times to trigger generic plan after 5 executions
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -303,7 +292,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -311,7 +299,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -319,7 +306,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -327,7 +313,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -336,7 +321,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 -- 6th execution uses generic plan
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -369,7 +353,6 @@ WHERE dt.full_text @@@ $1
   AND DATE(c.date_time_combined) <= $6;
 EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20

--- a/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
+++ b/pg_search/tests/pg_regress/expected/parallel_hash_join_race.out
@@ -128,6 +128,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -142,6 +144,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -156,6 +160,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -170,6 +176,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -184,6 +192,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -198,6 +208,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -212,6 +224,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -228,6 +242,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -242,6 +258,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -256,6 +274,8 @@ WHERE dt.full_text @@@ 'ea'
        OR c.author @@@ paradedb.match('author', 'bonnie swanson'))
   AND DATE(c.date_time_combined) >= DATE('2001-01-01')
   AND DATE(c.date_time_combined) <= DATE('2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -274,30 +294,40 @@ WHERE dt.full_text @@@ $1
   AND DATE(c.date_time_combined) <= $6;
 -- Execute multiple times to trigger generic plan after 5 executions
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
 (1 row)
 
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -305,6 +335,8 @@ EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt'
 
 -- 6th execution uses generic plan
 EXECUTE parallel_hash_join_query('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20
@@ -336,6 +368,8 @@ WHERE dt.full_text @@@ $1
   AND DATE(c.date_time_combined) >= $5
   AND DATE(c.date_time_combined) <= $6;
 EXECUTE parallel_hash_join_query_generic('ea', 'brian griffin', 'barabara pewterschmidt', 'bonnie swanson', '2001-01-01', '2025-12-31');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
     20

--- a/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
+++ b/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
@@ -56,7 +56,6 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
 -- All executions should return consistent results
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -64,7 +63,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -72,7 +70,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -80,7 +77,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -88,7 +84,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -97,7 +92,6 @@ WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
 -- 6th execution should use generic plan and return same result
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -124,7 +118,6 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
 -- These should all return consistent results
 EXECUTE test_parallel_join_generic('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122

--- a/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
+++ b/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
@@ -55,30 +55,40 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
 -- Execute multiple times to trigger generic plan
 -- All executions should return consistent results
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
 (1 row)
 
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -86,6 +96,8 @@ EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 
 -- 6th execution should use generic plan and return same result
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122
@@ -111,6 +123,8 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
   AND c.created_at::date <= $3::date;
 -- These should all return consistent results
 EXECUTE test_parallel_join_generic('ea', '2024-01-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: c, dt)
  count 
 -------
    122

--- a/pg_search/tests/pg_regress/expected/score_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_join_predicates.out
@@ -68,6 +68,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score | book_score 
 ---------+-----------------+--------------+------------
        1 | J.K. Rowling    |     2.540445 |          0
@@ -119,6 +120,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE a.name @@@ 'Rowling' AND b.content @@@ 'test'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  | author_score | book_score 
 ---------+--------------+--------------+------------
        3 | J.K. Rowling |    1.5404451 |  0.4624617
@@ -135,6 +137,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 70
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
@@ -145,6 +148,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  | author_score | book_score 
 ---------+--------------+--------------+------------
        1 | Stephen King |    1.5404451 |          0
@@ -160,6 +164,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') AND a.age > 60
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 SELECT
     b.id as book_id,
@@ -170,6 +175,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring') OR a.age > 60
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score | book_score 
 ---------+-----------------+--------------+------------
        1 | Stephen King    |     2.540445 |          0
@@ -204,6 +210,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE a.name @@@ 'Rowling'
 ORDER BY a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  query_type | author_id | author_name  | author_score 
 ------------+-----------+--------------+--------------
  Join Query |         1 | J.K. Rowling |    1.5404451
@@ -221,6 +228,7 @@ FROM books b
 LEFT JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score | book_score 
 ---------+-----------------+--------------+------------
        1 | J.K. Rowling    |     2.540445 |          0
@@ -241,6 +249,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
@@ -255,6 +264,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'function' OR a.name @@@ 'King') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  | author_score_1 | author_score_2 | book_score_1 | book_score_2 
 ---------+--------------+----------------+----------------+--------------+--------------
        1 | J.K. Rowling |              1 |              1 |   0.35745716 |   0.35745716
@@ -290,6 +300,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_name   | author_score |   author_snippet    | book_score |                                                                       book_snippet                                                                       
 ---------+-----------------+--------------+---------------------+------------+----------------------------------------------------------------------------------------------------------------------------------------------------------
        1 | J.K. Rowling    |     2.540445 | J.K. <b>Rowling</b> |          0 | 
@@ -306,6 +317,7 @@ FROM books b
 LEFT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0
@@ -318,6 +330,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY a.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0

--- a/pg_search/tests/pg_regress/expected/self-join.out
+++ b/pg_search/tests/pg_regress/expected/self-join.out
@@ -187,6 +187,7 @@ SELECT i.id,
 FROM test_items i
 INNER JOIN test_orders o ON i.id = o.item_id
 WHERE i.description @@@ 'teddy bear' AND o.customer @@@ 'alice';
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: i, o)
                                                                            QUERY PLAN                                                                            
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------
  Hash Join
@@ -217,6 +218,7 @@ SELECT i.id,
 FROM test_items i
 INNER JOIN test_orders o ON i.id = o.item_id
 WHERE i.description @@@ 'teddy bear' AND o.customer @@@ 'alice';
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: i, o)
  id | item_score | order_id | order_score 
 ----+------------+----------+-------------
   1 |   1.112579 |        1 |   0.9808292

--- a/pg_search/tests/pg_regress/expected/snippet_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/snippet_join_predicates.out
@@ -65,6 +65,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id |   author_snippet    | author_positions | author_score | book_score 
 ---------+---------------------+------------------+--------------+------------
        1 | J.K. <b>Rowling</b> | {{5,12}}         |    2.3862944 | 0.20342469
@@ -130,6 +131,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  |   author_snippet    |                                      content_snippet                                      | author_positions |     content_positions     | author_score | book_score 
 ---------+--------------+---------------------+-------------------------------------------------------------------------------------------+------------------+---------------------------+--------------+------------
        1 | J.K. Rowling | J.K. <b>Rowling</b> | This is a <b>test</b> <b>test</b> of the snippet function with multiple <b>test</b> words | {{5,12}}         | {{10,14},{15,19},{58,62}} |    2.3862944 | 0.20342469
@@ -149,6 +151,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  |   author_snippet    | author_score | book_score 
 ---------+--------------+---------------------+--------------+------------
        1 | J.K. Rowling | J.K. <b>Rowling</b> |    2.3862944 | 0.20342469
@@ -168,6 +171,7 @@ FROM books b
 LEFT JOIN authors a ON b.author_id = a.id
 WHERE (b.content @@@ 'test' OR a.name @@@ 'Rowling') AND a.age @@@ '>50'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_name  |   author_snippet    | author_score | book_score 
 ---------+--------------+---------------------+--------------+------------
        1 | J.K. Rowling | J.K. <b>Rowling</b> |    2.3862944 | 0.20342469

--- a/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
@@ -74,6 +74,7 @@ FROM book_snippets bs
 LEFT JOIN reviews r ON r.book_id = bs.book_id
 WHERE r.id @@@ paradedb.parse('metadata.review:test') AND r.id @@@ paradedb.parse('metadata.review:snippet')
 ORDER BY bs.book_id, r.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
  book_id |                            author_snippet                            | author_positions |                                   book_content_snippet                                    |  book_content_positions   | book_score | author_score |                                   review_text                                   |                                               review_snippet                                                |         review_positions         | review_score 
 ---------+----------------------------------------------------------------------+------------------+-------------------------------------------------------------------------------------------+---------------------------+------------+--------------+---------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------+----------------------------------+--------------
        1 |                                                                      |                  | This is a <b>test</b> <b>test</b> of the snippet function with multiple <b>test</b> words | {{10,14},{15,19},{58,62}} | 0.21010332 |            0 | This is a test review of the snippet function with multiple test words          | This is a <b>test</b> review of the <b>snippet</b> function with multiple <b>test</b> words                 | {{10,14},{29,36},{60,64}}        |   0.83736646
@@ -103,6 +104,7 @@ WHERE b.id @@@ paradedb.parse('metadata.content:test')
     OR r.id @@@ paradedb.parse('metadata.review:test')
     OR r.id @@@ paradedb.parse('metadata.review:snippet')
 ORDER BY b.id, r.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b, r)
  book_id |   author_name   |                                                                       book_snippet                                                                       |         book_positions          |                            author_snippet                            | author_positions |                                               review_snippet                                                |         review_positions         | book_score | author_score | review_score 
 ---------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------+----------------------------------------------------------------------+------------------+-------------------------------------------------------------------------------------------------------------+----------------------------------+------------+--------------+--------------
        1 | Stephen King    | This is a <b>test</b> <b>test</b> of the snippet function with multiple <b>test</b> words                                                                | {{10,14},{15,19},{58,62}}       |                                                                      |                  | This is a <b>test</b> review of the <b>snippet</b> function with multiple <b>test</b> words                 | {{10,14},{29,36},{60,64}}        | 0.21010332 |            0 |   0.83736646
@@ -166,6 +168,8 @@ LEFT JOIN reviews r ON r.book_id = b.id
 WHERE (a.id @@@ paradedb.parse('metadata.age:55'))
     AND (a.id @@@ paradedb.parse('metadata.text:author') OR b.id @@@ paradedb.parse('metadata.content:test'))
 ORDER BY a.id, b.id, r.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b, r)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 \i common/snippet_json_advanced_cleanup.sql
 DROP TABLE IF EXISTS authors;

--- a/pg_search/tests/pg_regress/expected/snippet_position_01_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_position_01_advanced.out
@@ -69,6 +69,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE b.content @@@ 'test' OR a.name @@@ 'Rowling'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id |   author_snippet    | author_positions | author_score | book_score 
 ---------+-----------+---------------------+------------------+--------------+------------
        1 |         1 | J.K. <b>Rowling</b> | {{5,12}}         |    1.5404451 |          0
@@ -90,6 +91,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE b.content @@@ 'test' OR NOT(a.name @@@ 'Rowling')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id |   author_snippet    | author_positions | author_score | book_score 
 ---------+-----------+---------------------+------------------+--------------+------------
        1 |         1 | J.K. <b>Rowling</b> | {{5,12}}         |            0 |          0
@@ -111,6 +113,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE NOT(b.content @@@ 'test') OR a.name @@@ 'Rowling'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id |   author_snippet    | author_positions | author_score | book_score 
 ---------+-----------+---------------------+------------------+--------------+------------
        1 |         1 | J.K. <b>Rowling</b> | {{5,12}}         |    1.5404451 |          0
@@ -128,6 +131,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE NOT(b.content @@@ 'test') OR NOT(a.name @@@ 'Rowling')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id | author_snippet | author_positions | author_score | book_score 
 ---------+-----------+----------------+------------------+--------------+------------
        1 |         2 |                |                  |            0 |          0
@@ -147,6 +151,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE b.content @@@ 'test' AND a.name @@@ 'Rowling'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id |   author_snippet    | author_positions | author_score | book_score 
 ---------+-----------+---------------------+------------------+--------------+------------
        3 |         1 | J.K. <b>Rowling</b> | {{5,12}}         |    1.5404451 |  0.4624617
@@ -163,6 +168,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE b.content @@@ 'test' AND NOT(a.name @@@ 'Rowling')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id | author_snippet | author_positions | author_score | book_score 
 ---------+-----------+----------------+------------------+--------------+------------
        1 |         2 |                |                  |            0 | 0.45681813
@@ -182,6 +188,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE NOT(b.content @@@ 'test') AND a.name @@@ 'Rowling'
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id |   author_snippet    | author_positions | author_score | book_score 
 ---------+-----------+---------------------+------------------+--------------+------------
        1 |         1 | J.K. <b>Rowling</b> | {{5,12}}         |    1.5404451 |          0
@@ -198,6 +205,7 @@ FROM books b
 JOIN authors a ON b.author_id = a.id
 WHERE NOT(b.content @@@ 'test') AND NOT(a.name @@@ 'Rowling')
 ORDER BY b.id, a.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  book_id | author_id | author_snippet | author_positions | author_score | book_score 
 ---------+-----------+----------------+------------------+--------------+------------
 (0 rows)
@@ -223,6 +231,7 @@ FROM book_snippets bs
 LEFT JOIN reviews r ON r.book_id = bs.book_id
 WHERE r.review @@@ 'test' AND r.review @@@ 'snippet'
 ORDER BY bs.book_id, r.id;
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
  book_id |   author_snippet    | author_positions | author_score | book_score |                            review                            |                                  review_snippet                                   |    review_positions     | review_score 
 ---------+---------------------+------------------+--------------+------------+--------------------------------------------------------------+-----------------------------------------------------------------------------------+-------------------------+--------------
        3 | J.K. <b>Rowling</b> | {{5,12}}         |    1.5404451 |  0.4624617 | test review of the snippet function with multiple test words | <b>test</b> review of the <b>snippet</b> function with multiple <b>test</b> words | {{0,4},{19,26},{50,54}} |    0.5505729
@@ -247,6 +256,7 @@ WHERE b.content @@@ 'test'
     OR r.review @@@ 'test'
     OR r.review @@@ 'snippet'
 ORDER BY b.id, r.id;
+WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b, r)
  book_id |                                                                       book_snippet                                                                       |         book_positions          |   author_snippet    | author_positions |                                               review_snippet                                                |         review_positions         | book_score | author_score | review_score 
 ---------+----------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------+---------------------+------------------+-------------------------------------------------------------------------------------------------------------+----------------------------------+------------+--------------+--------------
        1 |                                                                                                                                                          |                                 | J.K. <b>Rowling</b> | {{5,12}}         | This is a <b>test</b> review of the <b>snippet</b> function with multiple <b>test</b> words                 | {{10,14},{29,36},{60,64}}        |          0 |    1.5404451 |     0.494645

--- a/pg_search/tests/pg_regress/expected/term_set_agg.out
+++ b/pg_search/tests/pg_regress/expected/term_set_agg.out
@@ -48,7 +48,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8827079. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8051864. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id |    name     
 ----+-------------
@@ -74,7 +74,7 @@ FROM paradedb.aggregate(
   ),
   '{"count":{"value_count":{"field":"genus_id"}}}'
 );
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8827079. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8051864. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
          aggregate         
 ---------------------------
@@ -94,7 +94,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8827079. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8051864. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id | name 
 ----+------

--- a/pg_search/tests/pg_regress/expected/term_set_agg.out
+++ b/pg_search/tests/pg_regress/expected/term_set_agg.out
@@ -48,7 +48,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8051864. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id |    name     
 ----+-------------
@@ -74,7 +74,7 @@ FROM paradedb.aggregate(
   ),
   '{"count":{"value_count":{"field":"genus_id"}}}'
 );
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8051864. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
          aggregate         
 ---------------------------
@@ -94,7 +94,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
-WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8051864. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
+WARNING:  Aggregate Scan not used: unsupported aggregate function: pdb.term_set. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id | name 
 ----+------

--- a/pg_search/tests/pg_regress/expected/term_set_agg.out
+++ b/pg_search/tests/pg_regress/expected/term_set_agg.out
@@ -48,6 +48,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8827079. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id |    name     
 ----+-------------
@@ -73,6 +74,7 @@ FROM paradedb.aggregate(
   ),
   '{"count":{"value_count":{"field":"genus_id"}}}'
 );
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8827079. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
          aggregate         
 ---------------------------
@@ -92,6 +94,7 @@ SELECT plants.id, plants.name
 FROM plants, genus_terms
 WHERE plants.genus_id @@@ genus_terms.terms
 ORDER BY plants.id;
+WARNING:  Aggregate Scan not used: unsupported aggregate function OID: 8827079. To disable this warning: SET paradedb.check_aggregate_scan = false (table: genus)
 WARNING:  using `pdb.term_set` in aggregate position is deprecated
  id | name 
 ----+------

--- a/pg_search/tests/pg_regress/expected/topk-agg-facet.out
+++ b/pg_search/tests/pg_regress/expected/topk-agg-facet.out
@@ -1648,6 +1648,7 @@ GROUP BY category
 HAVING AVG(price) > 1000
 ORDER BY avg_price DESC
 LIMIT 3;
+WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
                                                                                      QUERY PLAN                                                                                      
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -1684,6 +1685,7 @@ GROUP BY category
 HAVING AVG(price) > 1000
 ORDER BY avg_price DESC
 LIMIT 3;
+WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
  category | avg_price | total_count 
 ----------+-----------+-------------
  Laptops  |      1849 |           1
@@ -1713,6 +1715,7 @@ JOIN product_categories pc ON p.category = pc.name
 WHERE p.description @@@ 'laptop'
 ORDER BY p.rating DESC
 LIMIT 3;
+WARNING:  JoinScan not used: join keys must be fast fields (tables: p, pc)
                                                                                   QUERY PLAN                                                                                   
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -1748,6 +1751,7 @@ JOIN product_categories pc ON p.category = pc.name
 WHERE p.description @@@ 'laptop'
 ORDER BY p.rating DESC
 LIMIT 3;
+WARNING:  JoinScan not used: join keys must be fast fields (tables: p, pc)
  id |    name     | rating |       category_desc        | total_count 
 ----+-------------+--------+----------------------------+-------------
   1 | MacBook Pro |    4.8 | Portable computing devices |           4
@@ -1905,6 +1909,8 @@ GROUP BY p.category, pc.description
 HAVING AVG(p.price) > 1000
 ORDER BY avg_price DESC
 LIMIT 2;
+WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, pc)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -1948,6 +1954,8 @@ GROUP BY p.category, pc.description
 HAVING AVG(p.price) > 1000
 ORDER BY avg_price DESC
 LIMIT 2;
+WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
+WARNING:  JoinScan not used: aggregates are not supported (tables: p, pc)
  category |        description         | avg_price | total_count 
 ----------+----------------------------+-----------+-------------
  Laptops  | Portable computing devices |      1849 |           1

--- a/pg_search/tests/pg_regress/expected/topk-agg-facet.out
+++ b/pg_search/tests/pg_regress/expected/topk-agg-facet.out
@@ -1910,7 +1910,6 @@ HAVING AVG(p.price) > 1000
 ORDER BY avg_price DESC
 LIMIT 2;
 WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, pc)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -1955,7 +1954,6 @@ HAVING AVG(p.price) > 1000
 ORDER BY avg_price DESC
 LIMIT 2;
 WARNING:  Aggregate Scan (DataFusion) not used: could not resolve field name for GROUP BY column (RTI=1, attno=4) (table: join)
-WARNING:  JoinScan not used: aggregates are not supported (tables: p, pc)
  category |        description         | avg_price | total_count 
 ----------+----------------------------+-----------+-------------
  Laptops  | Portable computing devices |      1849 |           1

--- a/pg_search/tests/pg_regress/sql/issue_2533.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2533.sql
@@ -1,7 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
--- TODO: See https://github.com/paradedb/paradedb/issues/5266.
-SET paradedb.enable_aggregate_custom_scan TO off;
+
 
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS products;
@@ -144,6 +143,19 @@ VALUES (11, 'brandy', 'green', '92');
 
 
 ANALYZE;
+
+-- TODO: See https://github.com/paradedb/paradedb/issues/5266.
+SET paradedb.enable_aggregate_custom_scan TO on;
+SELECT (SELECT COUNT(*)
+        FROM users
+                 LEFT JOIN products ON users.color = products.color
+        WHERE (users.name = 'bob') AND ((users.color = 'blue') AND (users.name = 'bob')) AND (products.name = 'bob')
+           OR (NOT (products.age = '20')) AND (users.name = 'bob')
+           OR ((users.color = 'blue') AND (users.name = 'bob')) AND (products.color = 'blue')
+           OR (NOT (products.name = 'bob')));
+
+-- TODO: See https://github.com/paradedb/paradedb/issues/5266.
+SET paradedb.enable_aggregate_custom_scan TO off;
 
 --
 -- each pair of queries should produce the same number of results

--- a/pg_search/tests/pg_regress/sql/issue_2533.sql
+++ b/pg_search/tests/pg_regress/sql/issue_2533.sql
@@ -1,5 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
+-- TODO: See https://github.com/paradedb/paradedb/issues/5266.
+SET paradedb.enable_aggregate_custom_scan TO off;
+
 DROP TABLE IF EXISTS users;
 DROP TABLE IF EXISTS products;
 DROP TABLE IF EXISTS orders;

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -100,6 +100,7 @@ title = "Index Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_custom_scan = off;
+SET paradedb.enable_aggregate_custom_scan = off;
 SELECT assert_plan_contains(
     $q$ SELECT count(*) FROM test where message ||| 'cheese' $q$,
     'Index Only Scan'
@@ -114,6 +115,7 @@ refresh_ms = 5
 title = "Normal Scan"
 log_tps = true
 on_connect = """
+SET paradedb.enable_aggregate_custom_scan = off;
 SELECT assert_plan_contains(
     $q$ SELECT count(*) FROM test where message ||| 'wine' $q$,
     'NormalScanExecState'

--- a/tests/tests/parallel_index_scan.rs
+++ b/tests/tests/parallel_index_scan.rs
@@ -53,6 +53,7 @@ fn dont_do_parallel_index_scan(mut conn: PgConnection) {
 
     "VACUUM paradedb.bm25_search".execute(&mut conn);
     "set enable_indexscan to off;".execute(&mut conn);
+    "set paradedb.enable_aggregate_custom_scan to off;".execute(&mut conn);
     let (plan, ) = "EXPLAIN (ANALYZE, VERBOSE, FORMAT JSON) select count(*) from paradedb.bm25_search where description @@@ 'shoes';".fetch_one::<(Value,)>(&mut conn);
     eprintln!("{plan:#?}");
     let plan = plan

--- a/tests/tests/parameterized_queries.rs
+++ b/tests/tests/parameterized_queries.rs
@@ -84,6 +84,7 @@ fn parallel_with_subselect(mut conn: PgConnection) {
         return;
     }
     "SET debug_parallel_query TO on".execute(&mut conn);
+    "SET paradedb.enable_aggregate_custom_scan TO off".execute(&mut conn);
 
     r#"
     DROP TABLE IF EXISTS test;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5075

## What

Enable the `aggregate` and `join` custom scans by default.

## Why

The aggregate and join scans have been equivalence tested against Postgres for a few releases now, and a variety of users have successfully used them in production.

For queries that they support, the aggregate and join scans will either:
1. accelerate a query (thanks to columnar access and late materialization)
2. make it possible to run at all: avoiding an "Unsupported plan shape" error (e.g. when using `pdb.score` in a join that might not otherwise be able to be recognized by the base scan)

But even for queries which are not yet supported by these scans, the warnings that they render can give useful guidance around index misconfiguration.

## How

Enable both scan GUCs by default, and improve the warnings that they render in cases where they are combined.

Additionally, make a series of fixes identified by the existing tests for the aggregate and join scans:
* Skip the aggregate scan for obscure failures such as #5266.
* Fix LTREE groupbys in the aggregate scan.
* Disable the aggregate scan for partitioned tables.