### PR TITLE
test: handle nullable where clauses in querygen tests

### DIFF
--- a/tests/tests/fixtures/querygen/joingen.rs
+++ b/tests/tests/fixtures/querygen/joingen.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashMap;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use proptest::prelude::*;

--- a/tests/tests/fixtures/querygen/joingen.rs
+++ b/tests/tests/fixtures/querygen/joingen.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashMap;
+use std::collections::HashSet;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use proptest::prelude::*;
@@ -67,6 +67,33 @@ impl JoinExpr {
             v.push(s.table.as_str());
         }
         v
+    }
+
+    /// Keep track of which tables are null extended due to outer joins.
+    pub fn null_extended_tables(&self) -> HashSet<&str> {
+        let mut joined_tables = HashSet::new();
+        let mut null_extended_tables = HashSet::new();
+
+        joined_tables.insert(self.initial_table.as_str());
+
+        for step in &self.steps {
+            match step.join_type {
+                JoinType::Inner | JoinType::Cross => {}
+                JoinType::Left => {
+                    null_extended_tables.insert(step.table.as_str());
+                }
+                JoinType::Right => {
+                    null_extended_tables.extend(joined_tables.iter().copied());
+                }
+                JoinType::Full => {
+                    null_extended_tables.extend(joined_tables.iter().copied());
+                    null_extended_tables.insert(step.table.as_str());
+                }
+            }
+            joined_tables.insert(step.table.as_str());
+        }
+
+        null_extended_tables
     }
 
     /// Render as a SQL fragment, e.g.

--- a/tests/tests/fixtures/querygen/joingen.rs
+++ b/tests/tests/fixtures/querygen/joingen.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
 use std::fmt::{self, Debug, Display, Formatter};
 
 use proptest::prelude::*;
@@ -67,33 +66,6 @@ impl JoinExpr {
             v.push(s.table.as_str());
         }
         v
-    }
-
-    /// Keep track of which tables are null extended due to outer joins.
-    pub fn null_extended_tables(&self) -> HashSet<&str> {
-        let mut joined_tables = HashSet::new();
-        let mut null_extended_tables = HashSet::new();
-
-        joined_tables.insert(self.initial_table.as_str());
-
-        for step in &self.steps {
-            match step.join_type {
-                JoinType::Inner | JoinType::Cross => {}
-                JoinType::Left => {
-                    null_extended_tables.insert(step.table.as_str());
-                }
-                JoinType::Right => {
-                    null_extended_tables.extend(joined_tables.iter().copied());
-                }
-                JoinType::Full => {
-                    null_extended_tables.extend(joined_tables.iter().copied());
-                    null_extended_tables.insert(step.table.as_str());
-                }
-            }
-            joined_tables.insert(step.table.as_str());
-        }
-
-        null_extended_tables
     }
 
     /// Render as a SQL fragment, e.g.

--- a/tests/tests/fixtures/querygen/mod.rs
+++ b/tests/tests/fixtures/querygen/mod.rs
@@ -56,6 +56,7 @@ pub struct Column {
     pub is_groupable: bool,
     pub is_whereable: bool,
     pub is_indexed: bool,
+    pub is_nullable: bool,
     pub bm25_options: Option<BM25Options>,
     pub random_generator_sql: &'static str,
     /// V2 syntax: expression to use in index column list, e.g. "(column::pdb.literal_normalized)"
@@ -77,6 +78,7 @@ impl Column {
             is_groupable: true,
             is_whereable: true,
             is_indexed: true,
+            is_nullable: false,
             bm25_options: None,
             random_generator_sql: "NULL",
             index_expression: None,
@@ -100,6 +102,11 @@ impl Column {
 
     pub const fn indexed(mut self, is_indexed: bool) -> Self {
         self.is_indexed = is_indexed;
+        self
+    }
+
+    pub const fn nullable(mut self, is_nullable: bool) -> Self {
+        self.is_nullable = is_nullable;
         self
     }
 

--- a/tests/tests/fixtures/querygen/wheregen.rs
+++ b/tests/tests/fixtures/querygen/wheregen.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 
 use proptest::prelude::*;
@@ -24,9 +25,11 @@ use crate::fixtures::querygen::Column;
 #[derive(Clone, Debug)]
 pub enum Expr {
     Atom {
+        table: String,
         name: String,
         value: String,
         is_indexed: bool,
+        is_nullable: bool,
     },
     Not(Box<Expr>),
     And(Box<Expr>, Box<Expr>),
@@ -34,24 +37,52 @@ pub enum Expr {
 }
 
 impl Expr {
-    pub fn to_sql(&self, indexed_op: &str) -> String {
+    pub fn to_sql(&self, indexed_op: &str, null_extended_tables: Option<&HashSet<&str>>) -> String {
         match self {
             Expr::Atom {
+                table,
                 name,
                 value,
                 is_indexed,
+                is_nullable,
             } => {
                 let op = if *is_indexed { indexed_op } else { " = " };
-                format!("{name} {op} {value}")
+
+                // We test for expected behaviour where `@@@` operation returns
+                // only TRUE/FALSE instead of following three-valued logic
+                //
+                // However, for null extended rows in table joins, behaviour is same as normal Postgres,
+                // NULL is returned if primary key is NULL
+                if *is_indexed && *is_nullable && indexed_op == " = " {
+                    if null_extended_tables
+                        .is_some_and(|nullable_tables| nullable_tables.contains(table.as_str()))
+                    {
+                        format!(
+                            "CASE WHEN {table}.id IS NOT NULL THEN COALESCE({name} = {value}, false) ELSE {name} = {value} END"
+                        )
+                    } else {
+                        format!("{name} IS NOT DISTINCT FROM {value}")
+                    }
+                } else {
+                    format!("{name} {op} {value}")
+                }
             }
             Expr::Not(e) => {
-                format!("NOT ({})", e.to_sql(indexed_op))
+                format!("NOT ({})", e.to_sql(indexed_op, null_extended_tables))
             }
             Expr::And(l, r) => {
-                format!("({}) AND ({})", l.to_sql(indexed_op), r.to_sql(indexed_op))
+                format!(
+                    "({}) AND ({})",
+                    l.to_sql(indexed_op, null_extended_tables),
+                    r.to_sql(indexed_op, null_extended_tables)
+                )
             }
             Expr::Or(l, r) => {
-                format!("({}) OR ({})", l.to_sql(indexed_op), r.to_sql(indexed_op))
+                format!(
+                    "({}) OR ({})",
+                    l.to_sql(indexed_op, null_extended_tables),
+                    r.to_sql(indexed_op, null_extended_tables)
+                )
             }
         }
     }
@@ -65,7 +96,14 @@ pub fn arb_wheres(tables: Vec<impl AsRef<str>>, columns: &[Column]) -> impl Stra
     let columns = columns
         .iter()
         .filter(|c| c.is_whereable)
-        .map(|c| (c.name.to_owned(), c.sample_value.to_owned(), c.is_indexed))
+        .map(|c| {
+            (
+                c.name.to_owned(),
+                c.sample_value.to_owned(),
+                c.is_indexed,
+                c.is_nullable,
+            )
+        })
         .collect::<Vec<_>>();
 
     // leaves: the atomic predicate. select a table, and a column.
@@ -73,10 +111,12 @@ pub fn arb_wheres(tables: Vec<impl AsRef<str>>, columns: &[Column]) -> impl Stra
         proptest::sample::select::<Expr>(
             columns
                 .iter()
-                .map(|(col, val, is_indexed)| Expr::Atom {
+                .map(|(col, val, is_indexed, is_nullable)| Expr::Atom {
+                    table: table.clone(),
                     name: format!("{table}.{col}"),
                     value: val.clone(),
                     is_indexed: *is_indexed,
+                    is_nullable: *is_nullable,
                 })
                 .collect::<Vec<_>>(),
         )

--- a/tests/tests/fixtures/querygen/wheregen.rs
+++ b/tests/tests/fixtures/querygen/wheregen.rs
@@ -51,8 +51,8 @@ impl Expr {
                 // We test for expected behaviour where `@@@` operation returns
                 // only TRUE/FALSE instead of following three-valued logic
                 //
-                // However, for null extended rows in table joins, behaviour is same as normal Postgres,
-                // NULL is returned if primary key is NULL
+                // However, for null extended rows in table joins, `@@@` operator can return
+                // NULL if primary key (id) is NULL
                 if *is_indexed && *is_nullable && indexed_op == " = " {
                     if null_extended_tables
                         .is_some_and(|nullable_tables| nullable_tables.contains(table.as_str()))

--- a/tests/tests/fixtures/querygen/wheregen.rs
+++ b/tests/tests/fixtures/querygen/wheregen.rs
@@ -15,7 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::collections::HashSet;
 use std::fmt::{Debug, Display};
 
 use proptest::prelude::*;
@@ -37,7 +36,7 @@ pub enum Expr {
 }
 
 impl Expr {
-    pub fn to_sql(&self, indexed_op: &str, null_extended_tables: Option<&HashSet<&str>>) -> String {
+    pub fn to_sql(&self, indexed_op: &str) -> String {
         match self {
             Expr::Atom {
                 table,
@@ -48,41 +47,25 @@ impl Expr {
             } => {
                 let op = if *is_indexed { indexed_op } else { " = " };
 
-                // We test for expected behaviour where `@@@` operation returns
-                // only TRUE/FALSE instead of following three-valued logic
-                //
-                // However, for null extended rows in table joins, `@@@` operator can return
-                // NULL if primary key (id) is NULL
+                // Match `@@@` behaviour for nullable indexed columns:
+                // - real rows with NULL values are non-matches (FALSE)
+                // - null-extended rows in outer joins preserve SQL NULL semantics
                 if *is_indexed && *is_nullable && indexed_op == " = " {
-                    if null_extended_tables
-                        .is_some_and(|nullable_tables| nullable_tables.contains(table.as_str()))
-                    {
-                        format!(
-                            "CASE WHEN {table}.id IS NOT NULL THEN COALESCE({name} = {value}, false) ELSE {name} = {value} END"
-                        )
-                    } else {
-                        format!("{name} IS NOT DISTINCT FROM {value}")
-                    }
+                    format!(
+                        "CASE WHEN {table}.id IS NOT NULL THEN COALESCE({name} = {value}, false) ELSE {name} = {value} END"
+                    )
                 } else {
                     format!("{name} {op} {value}")
                 }
             }
             Expr::Not(e) => {
-                format!("NOT ({})", e.to_sql(indexed_op, null_extended_tables))
+                format!("NOT ({})", e.to_sql(indexed_op))
             }
             Expr::And(l, r) => {
-                format!(
-                    "({}) AND ({})",
-                    l.to_sql(indexed_op, null_extended_tables),
-                    r.to_sql(indexed_op, null_extended_tables)
-                )
+                format!("({}) AND ({})", l.to_sql(indexed_op), r.to_sql(indexed_op))
             }
             Expr::Or(l, r) => {
-                format!(
-                    "({}) OR ({})",
-                    l.to_sql(indexed_op, null_extended_tables),
-                    r.to_sql(indexed_op, null_extended_tables)
-                )
+                format!("({}) OR ({})", l.to_sql(indexed_op), r.to_sql(indexed_op))
             }
         }
     }

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -56,11 +56,9 @@ const COLUMNS: &[Column] = &[
         ),
     Column::new("color", "VARCHAR", "'blue'")
         .whereable({
-            // TODO: A variety of tests fail due to the NULL here. The column exists in order to
-            // provide coverage for ORDER BY on a column containing NULL.
-            // https://github.com/paradedb/paradedb/issues/3111
-            false
+            true
         })
+        .nullable(true)
         .bm25_text_field(r#""color": { "tokenizer": { "type": "keyword" }, "fast": true }"#)
         .random_generator_sql(
             "(ARRAY ['red', 'green', 'blue', 'orange', 'purple', 'pink', 'yellow', NULL]::text[])[(floor(random() * 8) + 1)::int]"
@@ -70,11 +68,9 @@ const COLUMNS: &[Column] = &[
         .random_generator_sql("(floor(random() * 100) + 1)"),
     Column::new("quantity", "INTEGER", "'7'")
         .whereable({
-            // TODO: A variety of tests fail due to the NULL here. The column exists in order to
-            // provide coverage for ORDER BY on a column containing NULL.
-            // https://github.com/paradedb/paradedb/issues/3111
-            false
+            true
         })
+        .nullable(true)
         .bm25_numeric_field(r#""quantity": { "fast": true }"#)
         .random_generator_sql("CASE WHEN random() < 0.1 THEN NULL ELSE (floor(random() * 100) + 1)::int END"),
     Column::new("price", "NUMERIC(10,2)", "'99.99'")
@@ -181,7 +177,7 @@ impl GeneratedSubquery {
                     WHERE {inner_table_name}.{column} = {outer_table_name}.{column} \
                     AND {} {}\
                 )",
-                self.inner_where_expr.to_sql(op),
+                self.inner_where_expr.to_sql(op, None),
                 self.paging_exprs,
                 column = self.column,
             ),
@@ -189,7 +185,7 @@ impl GeneratedSubquery {
                 "{outer_table_name}.{column} IN (\
                     SELECT {column} FROM {inner_table_name} WHERE {} {}\
                 )",
-                self.inner_where_expr.to_sql(op),
+                self.inner_where_expr.to_sql(op, None),
                 self.paging_exprs,
                 column = self.column,
             ),
@@ -237,12 +233,13 @@ async fn generated_joins_small(database: Db) {
         gucs in any::<PgGucs>(),
     )| {
         let join_clause = join.to_sql();
+        let null_extended_tables = join.null_extended_tables();
 
         let from = format!("SELECT COUNT(*) {join_clause} ");
 
         compare(
-            &format!("{from} WHERE {}", where_expr.to_sql(" = ")),
-            &format!("{from} WHERE {}", where_expr.to_sql("@@@")),
+            &format!("{from} WHERE {}", where_expr.to_sql(" = ", Some(&null_extended_tables))),
+            &format!("{from} WHERE {}", where_expr.to_sql("@@@", None)),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -302,8 +299,8 @@ async fn generated_joins_large_limit(database: Db) {
         let from = format!("SELECT {target_list} {join_clause} ");
 
         compare(
-            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql(" = ")),
-            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql("@@@")),
+            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql(" = ", None)),
+            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql("@@@", None)),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -338,8 +335,8 @@ async fn generated_single_relation(database: Db) {
         target in prop_oneof![Just("COUNT(*)"), Just("id")],
     )| {
         compare(
-            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql(" = ")),
-            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql("@@@")),
+            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql(" = ", None)),
+            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql("@@@", None)),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -422,15 +419,15 @@ async fn generated_group_by_aggregates(database: Db) {
         // Create combined WHERE clause for PostgreSQL using = operator
         let pg_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql(" = "),
-            numeric_where_expr.to_sql(" < ")
+            text_where_expr.to_sql(" = ", None),
+            numeric_where_expr.to_sql(" < ", None)
         );
 
         // Create combined WHERE clause for BM25 using appropriate operators
         let bm25_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql("@@@"),
-            numeric_where_expr.to_sql(" < ")
+            text_where_expr.to_sql("@@@", None),
+            numeric_where_expr.to_sql(" < ", None)
         );
 
         let pg_query = format!(
@@ -502,8 +499,8 @@ async fn generated_paging_small(database: Db) {
         gucs in any::<PgGucs>(),
     )| {
         compare(
-            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql(" = ")),
-            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql("@@@")),
+            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql(" = ", None)),
+            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql("@@@", None)),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -601,13 +598,13 @@ async fn generated_subquery(database: Db) {
             "SELECT COUNT(*) FROM {outer_table_name} \
             WHERE {} AND {}",
             subquery.to_sql(" = ", outer_table_name, inner_table_name),
-            outer_where_expr.to_sql(" = "),
+            outer_where_expr.to_sql(" = ", None),
         );
         let bm25 = format!(
             "SELECT COUNT(*) FROM {outer_table_name} \
             WHERE {} AND {}",
             subquery.to_sql("@@@", outer_table_name, inner_table_name),
-            outer_where_expr.to_sql("@@@"),
+            outer_where_expr.to_sql("@@@", None),
         );
 
         compare(
@@ -738,13 +735,13 @@ async fn generated_joinscan(database: Db) {
         let from = format!("SELECT {distinct_kw}{target_cols} {join_clause}");
 
         // Build WHERE clause parts for BM25 query
-        let mut bm25_where_parts = vec![outer_bm25.to_sql("@@@")];
-        let mut pg_where_parts = vec![outer_bm25.to_sql(" = ")];
+        let mut bm25_where_parts = vec![outer_bm25.to_sql("@@@", None)];
+        let mut pg_where_parts = vec![outer_bm25.to_sql(" = ", None)];
 
         // Optionally add inner table BM25 predicate
         if include_inner_bm25 && num_tables >= 2 {
-            bm25_where_parts.push(inner_bm25.to_sql("@@@"));
-            pg_where_parts.push(inner_bm25.to_sql(" = "));
+            bm25_where_parts.push(inner_bm25.to_sql("@@@", None));
+            pg_where_parts.push(inner_bm25.to_sql(" = ", None));
         }
 
         // Optionally add HeapCondition (same for both queries since it's a regular comparison)
@@ -916,8 +913,8 @@ async fn generated_aggregate_join(database: Db) {
         let group_by_clause = group_by_expr.to_sql();
 
         // Build WHERE clauses
-        let bm25_where = outer_bm25.to_sql("@@@");
-        let pg_where = outer_bm25.to_sql(" = ");
+        let bm25_where = outer_bm25.to_sql("@@@", None);
+        let pg_where = outer_bm25.to_sql(" = ", None);
 
         // PostgreSQL native query
         let pg_query = format!(
@@ -1028,8 +1025,8 @@ async fn generated_aggregate_join_distinct(database: Db) {
         let select_list = group_by_expr.to_select_list();
         let group_by_clause = group_by_expr.to_sql();
 
-        let bm25_where = outer_bm25.to_sql("@@@");
-        let pg_where = outer_bm25.to_sql(" = ");
+        let bm25_where = outer_bm25.to_sql("@@@", None);
+        let pg_where = outer_bm25.to_sql(" = ", None);
 
         let pg_query = format!(
             "SELECT {select_list} {join_clause} WHERE {pg_where} {group_by_clause}"
@@ -1133,15 +1130,15 @@ async fn generated_group_by_stddev(database: Db) {
         // Create combined WHERE clause for PostgreSQL using = operator
         let pg_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql(" = "),
-            numeric_where_expr.to_sql(" < ")
+            text_where_expr.to_sql(" = ", None),
+            numeric_where_expr.to_sql(" < ", None)
         );
 
         // Create combined WHERE clause for BM25 using appropriate operators
         let bm25_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql("@@@"),
-            numeric_where_expr.to_sql(" < ")
+            text_where_expr.to_sql("@@@", None),
+            numeric_where_expr.to_sql(" < ", None)
         );
 
         let pg_query = format!(
@@ -1262,8 +1259,8 @@ async fn generated_join_aggregates(database: Db) {
         let group_by_clause = group_by_expr.to_sql();
 
         // Build WHERE clauses
-        let bm25_where = outer_bm25.to_sql("@@@");
-        let pg_where = outer_bm25.to_sql(" = ");
+        let bm25_where = outer_bm25.to_sql("@@@", None);
+        let pg_where = outer_bm25.to_sql(" = ", None);
 
         // PostgreSQL native query
         let pg_query = format!(

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -177,7 +177,7 @@ impl GeneratedSubquery {
                     WHERE {inner_table_name}.{column} = {outer_table_name}.{column} \
                     AND {} {}\
                 )",
-                self.inner_where_expr.to_sql(op, None),
+                self.inner_where_expr.to_sql(op),
                 self.paging_exprs,
                 column = self.column,
             ),
@@ -185,7 +185,7 @@ impl GeneratedSubquery {
                 "{outer_table_name}.{column} IN (\
                     SELECT {column} FROM {inner_table_name} WHERE {} {}\
                 )",
-                self.inner_where_expr.to_sql(op, None),
+                self.inner_where_expr.to_sql(op),
                 self.paging_exprs,
                 column = self.column,
             ),
@@ -233,13 +233,11 @@ async fn generated_joins_small(database: Db) {
         gucs in any::<PgGucs>(),
     )| {
         let join_clause = join.to_sql();
-        let null_extended_tables = join.null_extended_tables();
-
         let from = format!("SELECT COUNT(*) {join_clause} ");
 
         compare(
-            &format!("{from} WHERE {}", where_expr.to_sql(" = ", Some(&null_extended_tables))),
-            &format!("{from} WHERE {}", where_expr.to_sql("@@@", None)),
+            &format!("{from} WHERE {}", where_expr.to_sql(" = ")),
+            &format!("{from} WHERE {}", where_expr.to_sql("@@@")),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -299,8 +297,8 @@ async fn generated_joins_large_limit(database: Db) {
         let from = format!("SELECT {target_list} {join_clause} ");
 
         compare(
-            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql(" = ", None)),
-            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql("@@@", None)),
+            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql(" = ")),
+            &format!("{from} WHERE {} LIMIT 10;", where_expr.to_sql("@@@")),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -335,8 +333,8 @@ async fn generated_single_relation(database: Db) {
         target in prop_oneof![Just("COUNT(*)"), Just("id")],
     )| {
         compare(
-            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql(" = ", None)),
-            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql("@@@", None)),
+            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql(" = ")),
+            &format!("SELECT {target} FROM {table_name} WHERE {}", where_expr.to_sql("@@@")),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -419,15 +417,15 @@ async fn generated_group_by_aggregates(database: Db) {
         // Create combined WHERE clause for PostgreSQL using = operator
         let pg_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql(" = ", None),
-            numeric_where_expr.to_sql(" < ", None)
+            text_where_expr.to_sql(" = "),
+            numeric_where_expr.to_sql(" < ")
         );
 
         // Create combined WHERE clause for BM25 using appropriate operators
         let bm25_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql("@@@", None),
-            numeric_where_expr.to_sql(" < ", None)
+            text_where_expr.to_sql("@@@"),
+            numeric_where_expr.to_sql(" < ")
         );
 
         let pg_query = format!(
@@ -499,8 +497,8 @@ async fn generated_paging_small(database: Db) {
         gucs in any::<PgGucs>(),
     )| {
         compare(
-            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql(" = ", None)),
-            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql("@@@", None)),
+            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql(" = ")),
+            &format!("SELECT id FROM {table_name} WHERE {} {paging_exprs}", where_expr.to_sql("@@@")),
             &gucs,
             &mut pool.pull(),
             &setup_sql,
@@ -598,13 +596,13 @@ async fn generated_subquery(database: Db) {
             "SELECT COUNT(*) FROM {outer_table_name} \
             WHERE {} AND {}",
             subquery.to_sql(" = ", outer_table_name, inner_table_name),
-            outer_where_expr.to_sql(" = ", None),
+            outer_where_expr.to_sql(" = "),
         );
         let bm25 = format!(
             "SELECT COUNT(*) FROM {outer_table_name} \
             WHERE {} AND {}",
             subquery.to_sql("@@@", outer_table_name, inner_table_name),
-            outer_where_expr.to_sql("@@@", None),
+            outer_where_expr.to_sql("@@@"),
         );
 
         compare(
@@ -735,13 +733,13 @@ async fn generated_joinscan(database: Db) {
         let from = format!("SELECT {distinct_kw}{target_cols} {join_clause}");
 
         // Build WHERE clause parts for BM25 query
-        let mut bm25_where_parts = vec![outer_bm25.to_sql("@@@", None)];
-        let mut pg_where_parts = vec![outer_bm25.to_sql(" = ", None)];
+        let mut bm25_where_parts = vec![outer_bm25.to_sql("@@@")];
+        let mut pg_where_parts = vec![outer_bm25.to_sql(" = ")];
 
         // Optionally add inner table BM25 predicate
         if include_inner_bm25 && num_tables >= 2 {
-            bm25_where_parts.push(inner_bm25.to_sql("@@@", None));
-            pg_where_parts.push(inner_bm25.to_sql(" = ", None));
+            bm25_where_parts.push(inner_bm25.to_sql("@@@"));
+            pg_where_parts.push(inner_bm25.to_sql(" = "));
         }
 
         // Optionally add HeapCondition (same for both queries since it's a regular comparison)
@@ -913,8 +911,8 @@ async fn generated_aggregate_join(database: Db) {
         let group_by_clause = group_by_expr.to_sql();
 
         // Build WHERE clauses
-        let bm25_where = outer_bm25.to_sql("@@@", None);
-        let pg_where = outer_bm25.to_sql(" = ", None);
+        let bm25_where = outer_bm25.to_sql("@@@");
+        let pg_where = outer_bm25.to_sql(" = ");
 
         // PostgreSQL native query
         let pg_query = format!(
@@ -1025,8 +1023,8 @@ async fn generated_aggregate_join_distinct(database: Db) {
         let select_list = group_by_expr.to_select_list();
         let group_by_clause = group_by_expr.to_sql();
 
-        let bm25_where = outer_bm25.to_sql("@@@", None);
-        let pg_where = outer_bm25.to_sql(" = ", None);
+        let bm25_where = outer_bm25.to_sql("@@@");
+        let pg_where = outer_bm25.to_sql(" = ");
 
         let pg_query = format!(
             "SELECT {select_list} {join_clause} WHERE {pg_where} {group_by_clause}"
@@ -1130,15 +1128,15 @@ async fn generated_group_by_stddev(database: Db) {
         // Create combined WHERE clause for PostgreSQL using = operator
         let pg_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql(" = ", None),
-            numeric_where_expr.to_sql(" < ", None)
+            text_where_expr.to_sql(" = "),
+            numeric_where_expr.to_sql(" < ")
         );
 
         // Create combined WHERE clause for BM25 using appropriate operators
         let bm25_where_clause = format!(
             "({}) AND ({})",
-            text_where_expr.to_sql("@@@", None),
-            numeric_where_expr.to_sql(" < ", None)
+            text_where_expr.to_sql("@@@"),
+            numeric_where_expr.to_sql(" < ")
         );
 
         let pg_query = format!(
@@ -1259,8 +1257,8 @@ async fn generated_join_aggregates(database: Db) {
         let group_by_clause = group_by_expr.to_sql();
 
         // Build WHERE clauses
-        let bm25_where = outer_bm25.to_sql("@@@", None);
-        let pg_where = outer_bm25.to_sql(" = ", None);
+        let bm25_where = outer_bm25.to_sql("@@@");
+        let pg_where = outer_bm25.to_sql(" = ");
 
         // PostgreSQL native query
         let pg_query = format!(

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -233,6 +233,7 @@ async fn generated_joins_small(database: Db) {
         gucs in any::<PgGucs>(),
     )| {
         let join_clause = join.to_sql();
+
         let from = format!("SELECT COUNT(*) {join_clause} ");
 
         compare(


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3111

## What

**Root cause**: Negated (`NOT`) `@@@` predicates are not equivalent to negated PostgreSQL `=` predicates on nullable columns, causing mismatches/failures in `tests/qgen.rs`

## Why

- @@@ returns `TRUE` for rows found by the search index, and `FALSE` for all other rows
- postgres `=`  evaluates per row using 3-valued logic so it is `NULL` aware

This behaviour works as intended normally. But for negation, the behaviour drifts. When using `@@@`, we get a result of all row ids that match the query. This becomes `TRUE`/`FALSE` per row, information on `NULL` rows are lost

Meanwhile, postgres evaluates per row using 3-valued logic, so nullable columns can produce `NULL`

example:
| id  | age | color | = blue | @@@ blue |
| --- | --- | ----- |---|---|
| 1   | 20  | blue  | TRUE | TRUE |
| 2   | 30  | red   | FALSE | FALSE |
| 3   | 30  | NULL  | NULL | FALSE |

this PR treats this behaviour as expected and modifies the tests.

## How

### TLDR
use 
```
CASE
        WHEN table.id IS NOT NULL THEN COALESCE(table.<field> = <value>, false)
        ELSE table.<field> = <value>
END
```

for testing `@@@` behaviour on nullable columns as this query captures how it works in both single table and joined tables

### Single table queries

For single table queries, we use `COALESCE(color = blue, false)` instead of `color = blue`, this returns all non-matching values as `FALSE`, which is what the `@@@` operator does

example:
| id  | age | color | = blue | @@@ blue | IS NOT DISTINCT FROM blue |
| --- | --- | ----- |---|---|---|
| 1   | 20  | blue  | TRUE | TRUE | TRUE |
| 2   | 30  | red   | FALSE | FALSE | FALSE |
| 3   | 30  | NULL  | NULL | FALSE | FALSE |

### Joined table queries

For outer joins (`LEFT`/`RIGHT`/`FULL`), null-supplying side can produce null extended rows

example: `products RIGHT JOIN orders ON products.age = orders.age`

| products.id | products.age | products.color | orders.id | orders.age |
| ----------- | ------------ | -------------- | --------- | ---------- |
| 1           | 20           | blue           | 20        | 20         |
| NULL        | NULL         | NULL           | 11        | 99         |
| 2        | 90         | NULL           | 12        | 90         |

in this case, left table `products` might have `NULL` ids


if we perform `WHERE products.color {op} blue` on the table above, we get 

| products.id | products.age | products.color | @@@ blue | = blue |
| ----------- | ------------ | -------------- | --------- |---|
| 1           | 20           | blue           | TRUE        | TRUE |
| NULL        | NULL         | NULL           | NULL (as products.id is null)       | NULL |
| 2        | 90         | NULL           | FALSE        | NULL         |

thus
- if `id` is not null, we continue using `COALESCE(color = blue, false)`
- if `id` is null, `@@@` operator returns `NULL` for that row, which matches normal postgres behaviour

## Tests

Tests in `qgen.rs` now pass with `whereable(true)`