### PR TITLE
fix: ensure active snapshot for mutable segment materialization

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -621,6 +621,44 @@ pub fn index_memory_segment(
         PgTupleDesc,
     };
 
+    /// RAII guard that guarantees an active snapshot for the duration of the heap reads and
+    /// detoasting performed while materializing a mutable segment.
+    ///
+    /// Most callers of [`index_memory_segment`] (ordinary DML, queries, VACUUM, background merge
+    /// workers) already run with an active snapshot. The logical-replication apply worker, however,
+    /// applies remote changes without pushing one, and `pg_detoast_datum` on an out-of-line TOAST
+    /// value requires a snapshot (`get_toast_snapshot` errors otherwise). This guard pushes the
+    /// transaction snapshot only when the caller lacks one, and pops it on normal scope exit.
+    ///
+    /// On a panic / PostgreSQL ERROR the surrounding transaction aborts, which itself resets the
+    /// active-snapshot stack; popping again here would underflow it, so the drop implementation
+    /// uses `impl_safe_drop!` to skip cleanup while unwinding.
+    struct ActiveSnapshotGuard {
+        pushed: bool,
+    }
+
+    impl ActiveSnapshotGuard {
+        unsafe fn ensure() -> Self {
+            let pushed = !pg_sys::ActiveSnapshotSet();
+            if pushed {
+                pg_sys::PushActiveSnapshot(pg_sys::GetTransactionSnapshot());
+            }
+            Self { pushed }
+        }
+    }
+
+    crate::impl_safe_drop!(ActiveSnapshotGuard, |self| {
+        if self.pushed {
+            unsafe {
+                pg_sys::PopActiveSnapshot();
+            }
+        }
+    });
+
+    // Ensure an active snapshot for the heap fetches, detoasting, and expression evaluation
+    // below. Held until this function returns so it covers the entire materialization loop.
+    let _snapshot_guard = unsafe { ActiveSnapshotGuard::ensure() };
+
     let directory = RamDirectory::create();
     let ctids = segment
         .mutable_snapshot(indexrel)


### PR DESCRIPTION
## Summary

Fix logical replication apply-worker failures when pg_search materializes mutable segments containing TOASTed values.

`index_memory_segment` now ensures an active PostgreSQL snapshot exists while it fetches heap tuples, detoasts varlena values, evaluates expressions, and builds the in-memory Tantivy segment.

## RCA

Antithesis surfaced this PostgreSQL `ERROR` from the logical replication apply worker:

```text
ERROR: cannot fetch toast data without an active snapshot
CONTEXT: processing remote data for replication origin ... during message type "COMMIT"
LOG: background worker "logical replication apply worker" ... exited with exit code 1
```

This is not a postmaster or container crash. The postmaster remains alive, but the logical replication apply worker exits and replication progress can fail/retry.

This started appearing after `d453f45b157fe9286838cba35678d294100dbce7` (`fix: eager detoast in index_memory_segment to prevent TOAST race with VACUUM`).

That commit was correct. It fixed a real VACUUM/TOAST race by making `index_memory_segment` detoast varlena values eagerly while the selected heap tuple is still protected. Before that change, pg_search could fetch/deform a heap tuple, keep only a lazy TOAST pointer, and detoast later during document conversion. If VACUUM removed the old heap tuple and deleted its TOAST chunks in that gap, lazy detoast could fail with missing TOAST chunks.

The new failure exposed a separate missing invariant: PostgreSQL requires a registered or active snapshot before fetching out-of-line TOAST chunks.

PostgreSQL enforces that in `get_toast_snapshot()`:

```c
if (!HaveRegisteredOrActiveSnapshot())
    elog(ERROR, "cannot fetch toast data without an active snapshot");
```

In normal query/DML paths, a snapshot is already active. In the logical replication apply worker, PostgreSQL pushes an active snapshot while applying each replicated INSERT/UPDATE/DELETE message, then pops it after that apply step.

pg_search's mutable segment path records CTIDs during those apply steps, but it does not necessarily read the full heap row or TOAST bytes immediately. During logical replication, pg_search keeps the insert state open until transaction commit and finalizes it from a `PRE_COMMIT` transaction callback.

That callback still runs inside the transaction, but it is not inside PostgreSQL's per-row replication-step wrapper that pushes an active snapshot. So the transaction is active, but there may be no active snapshot on the snapshot stack.

When the pre-commit cleanup creates or merges a mutable segment, `index_memory_segment` fetches the heap tuple by CTID and, after `d453f45b`, eagerly calls `pg_detoast_datum`. Because no active snapshot is present in that callback context, PostgreSQL raises the observed ERROR.

## Reproduction

Run this against a build before this fix.

1. Install `pg_search` into PostgreSQL 18.

```sh
cargo pgrx install --package pg_search \
  --pg-config /opt/homebrew/opt/postgresql@18/bin/pg_config
```

2. Start two fresh PostgreSQL 18 clusters.

Publisher config:

```conf
wal_level = logical
max_replication_slots = 10
max_wal_senders = 10
```

Subscriber config:

```conf
wal_level = logical
shared_preload_libraries = 'pg_search'
max_replication_slots = 10
max_wal_senders = 10
```

3. On the publisher:

```sql
CREATE TABLE test (
  id bigserial PRIMARY KEY,
  message text
);

CREATE PUBLICATION stressgres_pub FOR TABLE test;
```

4. On the subscriber:

```sql
CREATE EXTENSION pg_search;

CREATE TABLE test (
  id bigint PRIMARY KEY,
  message text
);

CREATE INDEX idxtest ON test USING bm25 (id, message)
WITH (
  key_field = 'id',
  mutable_segment_rows = 1,
  target_segment_count = 1,
  background_layer_sizes = '0',
  layer_sizes = '1kb'
);

CREATE SUBSCRIPTION stressgres_sub
CONNECTION 'host=localhost port=<publisher_port> dbname=postgres user=<user>'
PUBLICATION stressgres_pub
WITH (copy_data = false, streaming = parallel);
```

5. Insert TOASTed rows on the publisher, each as its own transaction:

```sql
INSERT INTO test(message) VALUES (repeat('BigData_ ', 200000) || ' row_1');
INSERT INTO test(message) VALUES (repeat('BigData_ ', 200000) || ' row_2');
INSERT INTO test(message) VALUES (repeat('BigData_ ', 200000) || ' row_3');
```

6. Check the subscriber log.

Expected failure before this fix:

```text
ERROR: cannot fetch toast data without an active snapshot
CONTEXT: processing remote data for replication origin ... during message type "COMMIT"
LOG: background worker "logical replication apply worker" ... exited with exit code 1
```

The failure requires: logical replication apply worker, `bm25` index on the subscriber, mutable segment materialization, and out-of-line TOASTed indexed text.

## Fix

Make `index_memory_segment` self-sufficient: if the caller has not already pushed an active snapshot, push the current transaction snapshot before any heap tuple or TOAST pointer is fetched.

The guard is established at the top of `index_memory_segment`, before:

- reading mutable segment CTIDs,
- fetching heap tuples,
- deforming heap tuples into Datums / possible TOAST pointers,
- calling `pg_detoast_datum`.

The guard remains active through heap fetch, eager detoast, expression evaluation, and document materialization. It is popped on normal return.

This does not change row visibility semantics:

- Heap tuple selection still uses `table_index_fetch_tuple(... SnapshotAny ...)`.
- Tuple liveness is still filtered by `HeapTupleSatisfiesVacuum`.
- The pushed transaction snapshot is not used to choose a heap row or row version.
- It only satisfies PostgreSQL's TOAST active/registered snapshot requirement while detoasting the already-selected tuple's value.

If a caller already has an active snapshot, the guard is a no-op.

## Verification

The deterministic publisher/subscriber repro passes after this patch: all 3 rows replicate to the subscriber, `apply_error_count` remains `0`, and the subscriber log no longer reports `cannot fetch toast data without an active snapshot`.
