### PR TITLE
ci: fix Nix cargoHash workflow checkout for fork PRs

### DIFF
--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -48,7 +48,12 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.head_ref }}
+          # Check out the PR head's repo and ref so this works for fork PRs too;
+          # the branch only exists on the fork, not on the base repo. For
+          # same-repo PRs and workflow_dispatch this resolves to the base repo,
+          # which keeps the auto-push-a-fix path (below) targeting origin.
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Install Determinate Nix


### PR DESCRIPTION
## What

Fix the `Verify Nix Cargo Hash` job in `test-pg_search-nix.yml` so it works for pull requests opened from forks.

## Why

The checkout step set `ref: ${{ github.head_ref }}` but did **not** set `repository`, so it defaulted to the base repo (`paradedb/paradedb`). For a fork PR the head branch only exists on the contributor's fork, so the checkout failed at `git fetch` (exit code 1) **before any hash was ever verified** — the job errored on every fork PR that touched `Cargo.toml`/`Cargo.lock`/`nix/**`/`flake.*`.

Observed on #5158 (a fork PR): the job's only output was a checkout failure, never reaching the hash check.

## How

Check out the PR head's repo and ref, falling back to the base repo for same-repo PRs and `workflow_dispatch` — the same fork-safe pattern `schemabot-generate-diff.yml` already uses:

```yaml
repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
ref: ${{ github.event.pull_request.head.ref || github.ref }}
```

For same-repo PRs this resolves to the base repo exactly as before, so the auto-push-a-fix path keeps targeting `origin`. For fork PRs the job can now actually run, which also makes the existing fork-detection branch in the verify step (which prints local-fix instructions) reachable instead of dead code.

No behavior change for same-repo PRs; the GitHub App token path for forks is already gated off.