### PR TITLE
feat: dispatched sorted MPP scans behind a GUC instead of suppressing.

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -404,12 +404,11 @@ unsafe fn build_scan_node(
         )
     })?;
 
-    // Suppressed under MPP: a pre-sorted scan lowers to a throttled scan (runtime-variable
-    // partition count) that can't be coordinator-dispatched; without the hint the scan stays
-    // single-partition lazy and DataFusion handles ordering, which dispatches.
-    let sort_order = if crate::gucs::is_columnar_sort_enabled()
-        && !crate::postgres::customscan::mpp::glue::mpp_is_active()
-    {
+    // Under MPP a pre-sorted scan lowers to a multi-partition scan that coordinator dispatch
+    // can't encode (it only ships a single-partition lazy leaf), so the leader's
+    // `build_dispatch_blob` fails and the query falls back to serial. Results stay correct; the
+    // trade-off is losing MPP for sorted-source queries.
+    let sort_order = if crate::gucs::is_columnar_sort_enabled() {
         bm25_index.options().sort_by().into_iter().next()
     } else {
         None

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -221,18 +221,14 @@ pub(super) unsafe fn collect_join_sources_base_rel(
     if let Some((_, bm25_index)) = rel_get_bm25_index(relid) {
         side_info = side_info.with_indexrelid(bm25_index.oid());
 
-        // Read the sort order from the index's relation options.
-        // This allows DataFusion-based execution to leverage physical sort order
-        // for optimizations like SortPreservingMergeExec and sort-merge joins.
+        // Read the sort order from the index's relation options so DataFusion can use the
+        // physical sort order (SortPreservingMergeExec, sort-merge joins).
         //
-        // Suppressed under MPP: a pre-sorted scan lowers to a throttled scan whose partition
-        // count is decided at runtime by how many segments each worker claims, which can't be
-        // coordinator-dispatched (the leader builds a fixed-shape plan to slice). Without the
-        // hint the scan stays single-partition lazy and DataFusion's SortExec / SegmentedTopK
-        // handles ordering, which dispatches.
-        let sort_order = if crate::gucs::is_columnar_sort_enabled()
-            && !crate::postgres::customscan::mpp::glue::mpp_is_active()
-        {
+        // Under MPP a pre-sorted scan lowers to a multi-partition scan that coordinator dispatch
+        // can't encode (it only ships a single-partition lazy leaf), so the leader's
+        // `build_dispatch_blob` fails and the query falls back to serial. Results stay correct;
+        // the trade-off is losing MPP for sorted-source queries.
+        let sort_order = if crate::gucs::is_columnar_sort_enabled() {
             let sort_by = bm25_index.options().sort_by();
             sort_by.into_iter().next()
         } else {


### PR DESCRIPTION
This PR removes the `mpp_is_active()` guard that suppressed an index's physical sort order under MPP.

Stacked on #5256 (`moe/mpp-on-embedded-transport`). (Replaces this branch's earlier sorted-dispatch experiment, which didn't pan out.)

### What changed

Two sites (`joinscan/planning.rs`, `aggregatescan/datafusion_build.rs`) gated the sort order on `is_columnar_sort_enabled() && !mpp_is_active()`. The `mpp_is_active()` term is gone, so a sorted-source scan keeps its sort order under MPP.

### Behavior

A sorted scan under MPP lowers to a multi-partition scan that coordinator dispatch can't encode (it ships only a single-partition lazy leaf), so the leader's `build_dispatch_blob` fails and the query falls back to serial. Results stay correct; the trade-off is that a join or aggregate over a `sort_by`-indexed source loses MPP parallelism.

### Verified

- `cargo clippy --no-default-features --features pg18 -- -D warnings` clean.
- A sorted-source MPP join returns the same rows as the serial baseline (serial fallback).
- The existing `mpp_*` regress tests are unaffected (none of their indexes use `sort_by`, so their sort order was already `None`).

### Known follow-up

The serial fallback currently logs `This issue was likely caused by a bug in DataFusion's code. Please help us to resolve this by filing a bug report...`, which is the dispatch-failure error surfacing on what is now an expected path. Left as a separate cleanup (make that fallback quiet with a clear message).
