### PR TITLE
fix: make boost_to_fuzzy 0.24.0->0.24.1 upgrade idempotent

### DIFF
--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -1,5 +1,13 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.24.1'" to load this file. \quit
 
+-- `boost_to_fuzzy` and its cast are also defined in `fuzzy.rs`, so they live in
+-- the base install schema. Any 0.24.0 install built from a tree that already
+-- includes that change ships them, while installs from the v0.24.0 release tag
+-- do not. Drop-then-create keeps this upgrade idempotent across both cases so it
+-- never fails with "function already exists".
+DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
+DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);
+
 CREATE FUNCTION "boost_to_fuzzy"(
 	"input" pdb.boost,
 	"typmod" INT,

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -1,10 +1,10 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.24.1'" to load this file. \quit
 
 -- `boost_to_fuzzy` and its cast are also defined in `fuzzy.rs`, so they live in
--- the base install schema. Any 0.24.0 install built from a tree that already
--- includes that change ships them, while installs from the v0.24.0 release tag
--- do not. Drop-then-create keeps this upgrade idempotent across both cases so it
--- never fails with "function already exists".
+-- the base install schema. Depending on which `v0.24.0` an install was built
+-- from, they may or may not already exist (community's `v0.24.0` predates them;
+-- enterprise's folds them into the base schema). Drop-then-create keeps this
+-- upgrade idempotent in both cases so it never fails with "already exists".
 DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
 DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);
 


### PR DESCRIPTION
## Description

`boost_to_fuzzy` and its `pdb.boost -> pdb.fuzzy` cast are defined in `fuzzy.rs` (`#[pg_extern]` + `extension_sql!`), so they are part of the **base install schema**. They are **also** created by the hand-written `pg_search--0.24.0--0.24.1.sql` upgrade script.

That is correct for a clean `v0.24.0` install (which lacks the function) upgrading to 0.24.1. But any 0.24.0 install built from a tree that already includes the `fuzzy.rs` change ships the function in its base schema, and then `ALTER EXTENSION pg_search UPDATE TO '0.24.1'` fails:

```
ERROR:  function "boost_to_fuzzy" already exists with same argument types
CONTEXT:  ... extension script file "pg_search--0.24.0--0.24.1.sql", near line 3
```

This surfaced in the `paradedb-enterprise` community sync, whose upgrade path starts from a 0.24.0 that already contains the function.

## Fix

Guard the upgrade with `DROP CAST IF EXISTS` / `DROP FUNCTION IF EXISTS` before re-creating, making the script idempotent. It now applies cleanly whether or not the function is already present — no behavior change for clean `v0.24.0` installs.

## Testing

Re-running the 0.24.0->0.24.1 upgrade on an install that already has `boost_to_fuzzy` no longer errors.