### PR TITLE
ci: add weekly Valgrind regress workflow for pg_search

### DIFF
--- a/.github/scripts/scan_valgrind_log.py
+++ b/.github/scripts/scan_valgrind_log.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Scan a Postgres log produced by `cargo pgrx regress --valgrind` for genuine
+memory-corruption errors and group identical reports by error category + call
+stack, so CI output points at the offending codepath instead of dumping
+thousands of identical "Conditional jump..." lines.
+
+Leak summaries are intentionally ignored: normal Postgres operation leaks heavily
+and would drown the signal in false positives.
+
+Usage: scan_valgrind_log.py <postgres-log-path>
+Prints a deduplicated report and exits 1 if any memory error is found, else 0.
+"""
+
+import collections
+import os
+import re
+import sys
+
+# Genuine memory-corruption categories Valgrind reports between
+# VALGRINDERROR-BEGIN/END. NOT leak accounting ("definitely lost", etc.).
+ERROR_RE = re.compile(
+    r"Invalid read|Invalid write|Invalid free|Mismatched free|"
+    r"Use of uninitialised|Conditional jump or move depends on uninitialised|"
+    r"Source and destination overlap|"
+    r"Syscall param .* points to (?:unaddressable|uninitialised)"
+)
+
+# Strip Valgrind's "==<pid>== " / "==<timestamp> <pid>== " line prefix.
+PREFIX_RE = re.compile(r"^==[^=]*==\s?")
+# A stack frame: "   at 0xADDR: <symbol> (...)" or "   by 0xADDR: <symbol> (...)".
+FRAME_RE = re.compile(r"^\s*(?:at|by)\s+0x[0-9A-Fa-f]+:\s+(.*)$")
+# Drop the "(in /.../pg_search.so)" object qualifier so frames group stably
+# (the load address embedded in the path changes run to run).
+OBJ_RE = re.compile(r"\s*\(in [^)]*\)\s*$")
+
+
+def parse(path):
+    """Yield (category, [frames]) for each VALGRINDERROR block in the log."""
+    with open(path, encoding="utf-8", errors="replace") as fh:
+        in_block = False
+        category = None
+        frames = []
+        for raw in fh:
+            line = PREFIX_RE.sub("", raw.rstrip("\n"))
+            if line == "VALGRINDERROR-BEGIN":
+                in_block, category, frames = True, None, []
+                continue
+            if line == "VALGRINDERROR-END":
+                if in_block and category:
+                    yield category, frames
+                in_block = False
+                continue
+            if not in_block:
+                continue
+            if category is None:
+                # First non-empty line after BEGIN is the error category.
+                if line.strip():
+                    category = line.strip()
+                continue
+            match = FRAME_RE.match(line)
+            if match:
+                frames.append(OBJ_RE.sub("", match.group(1)).strip())
+
+
+def main():
+    if len(sys.argv) != 2:
+        sys.exit("usage: scan_valgrind_log.py <postgres-log-path>")
+    path = sys.argv[1]
+    if not os.path.isfile(path):
+        print(f"::error::Postgres log not found at {path}")
+        sys.exit(1)
+
+    # Group identical reports by (category, full call stack).
+    groups = collections.OrderedDict()
+    total = 0
+    for category, frames in parse(path):
+        if not ERROR_RE.search(category):
+            continue
+        total += 1
+        sig = (category, tuple(frames))
+        group = groups.get(sig)
+        if group is None:
+            groups[sig] = {"count": 1, "category": category, "frames": frames}
+        else:
+            group["count"] += 1
+
+    if not groups:
+        print(f"No Valgrind memory errors found in {path}")
+        return
+
+    ordered = sorted(groups.values(), key=lambda g: -g["count"])
+    print(
+        f"::error::Valgrind detected {total} memory error(s) across "
+        f"{len(ordered)} unique codepath(s) — see the grouped report below "
+        f"and the uploaded Postgres log artifact."
+    )
+    for i, group in enumerate(ordered, 1):
+        print()
+        print(f"================ Error #{i} — seen {group['count']}x ================")
+        print(group["category"])
+        if group["frames"]:
+            for depth, frame in enumerate(group["frames"]):
+                print(f"    {'at' if depth == 0 else 'by'} {frame}")
+        else:
+            print("    (no stack frames captured)")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test-pg_search-valgrind.yml
+++ b/.github/workflows/test-pg_search-valgrind.yml
@@ -1,8 +1,8 @@
 # workflows/test-pg_search-valgrind.yml
 #
-# Test pg_search Valgrind
+# Test pg_search (Valgrind)
 
-name: Test pg_search Valgrind
+name: Test pg_search (Valgrind)
 
 on:
   schedule:

--- a/.github/workflows/test-pg_search-valgrind.yml
+++ b/.github/workflows/test-pg_search-valgrind.yml
@@ -1,28 +1,12 @@
 # workflows/test-pg_search-valgrind.yml
 #
-# Test pg_search under Valgrind
-# Runs the pg_regress suite with Postgres wrapped in Valgrind to catch memory
-# corruption (invalid reads/writes, use-after-free, use of uninitialised memory)
-# at the Rust<->Postgres FFI boundary that --enable-cassert alone cannot detect.
-#
-# Why this is a separate, weekly workflow (not part of test-pg_search.yml):
-#   - Valgrind slows execution ~10-50x; a full regress run takes multiple hours,
-#     so it must stay off the per-PR critical path.
-#   - Valgrind cannot decode aarch64 atomic instructions, so this MUST run on
-#     x86_64 (our normal pgrx regress run is arm64).
-#   - pgrx 0.18.1 wires --valgrind through to `regress`, so no Postgres/pgrx
-#     patching is required (see paradedb/paradedb#5059).
+# Test pg_search Valgrind
 
 name: Test pg_search Valgrind
 
 on:
   schedule:
-    # Weekly, Tuesday overnight ET — Wednesday 07:00 UTC (~2am ET), matching the
-    # nightly test-pg_search.yml time-of-day convention.
-    - cron: "0 7 * * 3"
-  # Trigger on changes to this workflow only — scoped narrowly (not all of
-  # pg_search/) because the run takes multiple hours and shouldn't fire on every
-  # extension change. The weekly schedule covers ongoing coverage.
+    - cron: "0 7 * * 3" # Weekly on Tuesday night
   pull_request:
     types: [opened, synchronize, reopened]
     branches:
@@ -30,6 +14,7 @@ on:
       - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search-valgrind.yml"
+      - ".github/scripts/scan_valgrind_log.py"
   workflow_dispatch:
 
 concurrency:
@@ -120,45 +105,23 @@ jobs:
       # Runs the full pg_regress suite with the postmaster wrapped in Valgrind.
       # This is the multi-hour step. Valgrind output (including any memory errors)
       # is written to the Postgres log, not stdout — see the scan step below.
+      # A regress failure (output diff or crash) fails the job here; the always()
+      # scan step below still runs so we also surface any Valgrind memory errors.
       - name: Run pg_search Regression Tests under Valgrind
         run: |
           set -e
           if ! cargo pgrx regress --valgrind --resetdb --package pg_search pg${{ matrix.pg_version }} --auto; then
             git diff
-            echo "regress_failed=1" >> "$GITHUB_ENV"
+            exit 1
           fi
 
       # Memory-corruption errors do not always fail the regress run (Valgrind does
       # not exit non-zero on them by default), so scan the Postgres log explicitly.
-      # We look only for genuine memory *errors* — NOT leak summaries, since normal
-      # Postgres operation leaks heavily and would produce false positives.
+      # The script groups identical reports by codepath and ignores leak summaries
+      # (normal Postgres operation leaks heavily → false positives).
       - name: Scan Postgres log for Valgrind errors
         if: always()
-        run: |
-          set -uo pipefail
-          LOG=~/.pgrx/${{ matrix.pg_version }}.log
-          if [[ ! -f "$LOG" ]]; then
-            echo "::error::Postgres log not found at $LOG"
-            exit 1
-          fi
-
-          # VALGRINDERROR-BEGIN/END delimit each report pgrx emits via valgrind.
-          # Match the corruption categories we care about; ignore leak accounting.
-          PATTERN='Invalid read|Invalid write|Invalid free|Mismatched free|Use of uninitialised|Conditional jump or move depends on uninitialised|Source and destination overlap|Syscall param .* points to (unaddressable|uninitialised)'
-
-          if grep -nE "$PATTERN" "$LOG"; then
-            echo "::error::Valgrind detected memory errors — see matches above and the uploaded Postgres log artifact."
-            exit 1
-          fi
-
-          echo "No Valgrind memory errors found in $LOG"
-
-          # If regress itself failed (e.g. an output diff or a crash), fail the job
-          # even when no Valgrind error pattern matched.
-          if [[ "${regress_failed:-0}" == "1" ]]; then
-            echo "::error::Regression tests failed (see the regress step output above)."
-            exit 1
-          fi
+        run: python3 .github/scripts/scan_valgrind_log.py ~/.pgrx/${{ matrix.pg_version }}.log
 
       - name: Stop PostgreSQL
         if: always()
@@ -179,3 +142,41 @@ jobs:
       - name: Print the Postgres Logs
         if: always()
         run: cat ~/.pgrx/${{ matrix.pg_version }}.log
+
+  # Ping Slack if the weekly (scheduled) run fails. PR runs are watched in the
+  # checks UI, so this only fires on schedule to avoid noise.
+  notify-slack-on-failure:
+    name: Notify Slack on Failure
+    needs: [test-pg_search-valgrind]
+    if: |
+      always()
+      && github.event_name == 'schedule'
+      && needs.test-pg_search-valgrind.result == 'failure'
+    runs-on: ubuntu-latest
+    env:
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+    steps:
+      - name: Send Slack notification
+        run: |
+          if [ -n "$SLACK_WEBHOOK_URL" ]; then
+            JSON_DATA="{
+              \"text\": \"🚨 Weekly pg_search Valgrind Run Failed - <!here>\",
+              \"attachments\": [
+                {
+                  \"color\": \"danger\",
+                  \"fields\": [
+                    {\"title\": \"Repository\", \"value\": \"${{ github.repository }}\", \"short\": true},
+                    {\"title\": \"Workflow\", \"value\": \"${{ github.workflow }}\", \"short\": true},
+                    {\"title\": \"Run ID\", \"value\": \"${{ github.run_id }}\", \"short\": true},
+                    {\"title\": \"View Logs\", \"value\": \"<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Click here>\", \"short\": true}
+                  ]
+                }
+              ]
+            }"
+
+            curl -X POST -H 'Content-type: application/json' \
+              --data "$JSON_DATA" \
+              "$SLACK_WEBHOOK_URL"
+          else
+            echo "Slack webhook not configured, skipping notification"
+          fi

--- a/.github/workflows/test-pg_search-valgrind.yml
+++ b/.github/workflows/test-pg_search-valgrind.yml
@@ -1,0 +1,181 @@
+# workflows/test-pg_search-valgrind.yml
+#
+# Test pg_search under Valgrind
+# Runs the pg_regress suite with Postgres wrapped in Valgrind to catch memory
+# corruption (invalid reads/writes, use-after-free, use of uninitialised memory)
+# at the Rust<->Postgres FFI boundary that --enable-cassert alone cannot detect.
+#
+# Why this is a separate, weekly workflow (not part of test-pg_search.yml):
+#   - Valgrind slows execution ~10-50x; a full regress run takes multiple hours,
+#     so it must stay off the per-PR critical path.
+#   - Valgrind cannot decode aarch64 atomic instructions, so this MUST run on
+#     x86_64 (our normal pgrx regress run is arm64).
+#   - pgrx 0.18.1 wires --valgrind through to `regress`, so no Postgres/pgrx
+#     patching is required (see paradedb/paradedb#5059).
+
+name: Test pg_search Valgrind
+
+on:
+  schedule:
+    # Weekly, Tuesday overnight ET — Wednesday 07:00 UTC (~2am ET), matching the
+    # nightly test-pg_search.yml time-of-day convention.
+    - cron: "0 7 * * 3"
+  # Trigger on changes to this workflow only — scoped narrowly (not all of
+  # pg_search/) because the run takes multiple hours and shouldn't fire on every
+  # extension change. The weekly schedule covers ongoing coverage.
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+      - 0.*.x # Release branches
+    paths:
+      - ".github/workflows/test-pg_search-valgrind.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: test-pg_search-valgrind-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-pg_search-valgrind:
+    name: Test pg_search under Valgrind (PostgreSQL ${{ matrix.pg_version }}, x86_64)
+    # Valgrind requires x86_64 (cannot decode aarch64 atomics). Compute-optimized
+    # AMD c-family — Rust + Postgres are CPU-bound. Runs in us-east-1.
+    # See https://runs-on.com/configuration/job-labels/
+    runs-on:
+      - runs-on=${{ github.run_id }}
+      - family=c7a+c7i
+      - cpu=8
+      - ram=16
+      - image=ubuntu24-full-x64
+      - volume=80gb # default runner ships with 30GB — see https://runs-on.com/runners/linux/
+      - extras=s3-cache
+    strategy:
+      fail-fast: false
+      matrix:
+        pg_version: [18]
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v6
+
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          rustflags: "" # Use .cargo/config.toml target-cpu flags
+
+      - name: Extract pgrx Version
+        id: pgrx
+        run: echo "version=$(sed -nE 's/^pgrx = "=?([^"]+)"$/\1/p' Cargo.toml)" >> $GITHUB_OUTPUT
+
+      # Do NOT add hashFiles('**/Cargo.lock') or arch to shared-key.
+      # See test-pg_search.yml for rationale. This workflow does not save the
+      # cache (save-if: false) — it restores from the nightly-warmed default
+      # branch cache to avoid thrashing.
+      - name: Install Rust Cache
+        uses: swatinem/rust-cache@v2
+        with:
+          prefix-key: "v2-rust-cache"
+          shared-key: pg${{ matrix.pg_version }}
+          cache-targets: true
+          cache-all-crates: true
+          save-if: false
+
+      - name: Install required system tools
+        run: |
+          sudo apt-get update && sudo apt-get install -y --no-install-recommends \
+            valgrind lsof build-essential clang flex bison pkg-config ca-certificates git \
+            libreadline-dev zlib1g-dev libssl-dev libkrb5-dev liblz4-dev libzstd-dev \
+            libcurl4-openssl-dev
+
+      - name: Install llvm-tools-preview
+        run: rustup component add llvm-tools-preview
+
+      - name: Install pgrx
+        run: cargo install -j $(nproc) --locked cargo-pgrx --version "${{ steps.pgrx.outputs.version }}" --debug
+
+      # The Valgrind-enabled Postgres build (USE_VALGRIND) differs from the normal
+      # pgrx build, so it gets its own cache key suffixed with "valgrind".
+      - name: Cache pgrx-compiled Postgres (Valgrind)
+        id: cache-pgrx-pg
+        uses: actions/cache@v5
+        with:
+          path: ~/.pgrx
+          key: pgrx-pg-valgrind-${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Initialize pgrx environment with Valgrind
+        if: steps.cache-pgrx-pg.outputs.cache-hit != 'true'
+        run: cargo pgrx init --valgrind "--pg${{ matrix.pg_version }}=download" --configure-flag="--without-readline" -j $(nproc)
+
+      - name: Add pg_search to shared_preload_libraries
+        working-directory: /home/runner/.pgrx/data-${{ matrix.pg_version }}/
+        run: |
+          sed -i "s/^#shared_preload_libraries = .*/shared_preload_libraries = 'pg_search'/" postgresql.conf
+
+      - name: Compile & install pg_search extension
+        working-directory: pg_search/
+        run: cargo pgrx install --pg-config ~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config --features="pg${{ matrix.pg_version }}"
+
+      # Runs the full pg_regress suite with the postmaster wrapped in Valgrind.
+      # This is the multi-hour step. Valgrind output (including any memory errors)
+      # is written to the Postgres log, not stdout — see the scan step below.
+      - name: Run pg_search Regression Tests under Valgrind
+        run: |
+          set -e
+          if ! cargo pgrx regress --valgrind --resetdb --package pg_search pg${{ matrix.pg_version }} --auto; then
+            git diff
+            echo "regress_failed=1" >> "$GITHUB_ENV"
+          fi
+
+      # Memory-corruption errors do not always fail the regress run (Valgrind does
+      # not exit non-zero on them by default), so scan the Postgres log explicitly.
+      # We look only for genuine memory *errors* — NOT leak summaries, since normal
+      # Postgres operation leaks heavily and would produce false positives.
+      - name: Scan Postgres log for Valgrind errors
+        if: always()
+        run: |
+          set -uo pipefail
+          LOG=~/.pgrx/${{ matrix.pg_version }}.log
+          if [[ ! -f "$LOG" ]]; then
+            echo "::error::Postgres log not found at $LOG"
+            exit 1
+          fi
+
+          # VALGRINDERROR-BEGIN/END delimit each report pgrx emits via valgrind.
+          # Match the corruption categories we care about; ignore leak accounting.
+          PATTERN='Invalid read|Invalid write|Invalid free|Mismatched free|Use of uninitialised|Conditional jump or move depends on uninitialised|Source and destination overlap|Syscall param .* points to (unaddressable|uninitialised)'
+
+          if grep -nE "$PATTERN" "$LOG"; then
+            echo "::error::Valgrind detected memory errors — see matches above and the uploaded Postgres log artifact."
+            exit 1
+          fi
+
+          echo "No Valgrind memory errors found in $LOG"
+
+          # If regress itself failed (e.g. an output diff or a crash), fail the job
+          # even when no Valgrind error pattern matched.
+          if [[ "${regress_failed:-0}" == "1" ]]; then
+            echo "::error::Regression tests failed (see the regress step output above)."
+            exit 1
+          fi
+
+      - name: Stop PostgreSQL
+        if: always()
+        working-directory: pg_search/
+        run: cargo pgrx stop pg${{ matrix.pg_version }} || true
+
+      - name: Upload Postgres log
+        if: always()
+        env:
+          ACTIONS_RESULTS_URL: https://results-receiver.actions.githubusercontent.com/
+          ACTIONS_CACHE_SERVICE_V2: ""
+        uses: actions/upload-artifact@v7
+        with:
+          name: valgrind-postgres-log-${{ matrix.pg_version }}
+          path: ~/.pgrx/${{ matrix.pg_version }}.log
+          retention-days: 7
+
+      - name: Print the Postgres Logs
+        if: always()
+        run: cat ~/.pgrx/${{ matrix.pg_version }}.log

--- a/.github/workflows/test-pg_search-valgrind.yml
+++ b/.github/workflows/test-pg_search-valgrind.yml
@@ -109,6 +109,19 @@ jobs:
       # A regress failure (output diff or crash) fails the job here; the always()
       # scan step below still runs so we also surface any Valgrind memory errors.
       - name: Run pg_search Regression Tests under Valgrind
+        # pgrx hardcodes its Valgrind args (--trace-children, --leak-check=no, the
+        # error markers our scan parses), but Valgrind merges in $VALGRIND_OPTS, so
+        # we augment without patching pgrx:
+        #   --track-origins: report where an uninitialised value was allocated, not
+        #     just where it's read — turns the typical "Conditional jump..." report
+        #     into a pointer at the offending allocation. ~2x slower, fine weekly.
+        #   --num-callers=30: deeper stacks across the Rust<->C FFI boundary (12 default).
+        #   --keep-debuginfo=yes: pg_search is a dlopen'd .so; keep its symbols if the
+        #     library/backend unloads so stacks stay readable.
+        #   --expensive-definedness-checks=yes: fewer spurious uninitialised reports
+        #     from compiler optimizations (recommended by Postgres' Valgrind docs).
+        env:
+          VALGRIND_OPTS: "--track-origins=yes --num-callers=30 --keep-debuginfo=yes --expensive-definedness-checks=yes"
         run: |
           set -e
           if ! cargo pgrx regress --valgrind --resetdb --package pg_search pg${{ matrix.pg_version }} --auto; then

--- a/.github/workflows/test-pg_search-valgrind.yml
+++ b/.github/workflows/test-pg_search-valgrind.yml
@@ -1,6 +1,7 @@
 # workflows/test-pg_search-valgrind.yml
 #
 # Test pg_search (Valgrind)
+# Run the pg_regress suite under Valgrind to catch memory corruption.
 
 name: Test pg_search (Valgrind)
 

--- a/.github/workflows/test-pg_search-valgrind.yml
+++ b/.github/workflows/test-pg_search-valgrind.yml
@@ -25,6 +25,10 @@ concurrency:
 jobs:
   test-pg_search-valgrind:
     name: Test pg_search under Valgrind (PostgreSQL ${{ matrix.pg_version }}, x86_64)
+    # The Valgrind regress run takes ~7-8h with origin tracking enabled (roughly
+    # 2x a bare Memcheck run). Override the 360-min (6h) default to give it time
+    # to complete.
+    timeout-minutes: 600
     # Valgrind requires x86_64 (cannot decode aarch64 atomics). Compute-optimized
     # AMD c-family — Rust + Postgres are CPU-bound. Runs in us-east-1.
     # See https://runs-on.com/configuration/job-labels/

--- a/pg_search/src/postgres/storage/avl.rs
+++ b/pg_search/src/postgres/storage/avl.rs
@@ -100,17 +100,18 @@ impl<K: Copy, V: Copy, T: Copy> Slot<K, V, T> {
 
 impl<K: Copy, V: Copy, T: Copy> Default for Slot<K, V, T> {
     fn default() -> Self {
-        // Keys/values in unused slots are ignored. We avoid reading them when used=false.
-        // Zeroing is fine for common PODs; if your K/V cannot be zeroed, just ensure you never
-        // read key/val unless `is_used()` is true.
-        Self {
-            key: unsafe { core::mem::zeroed() },
-            val: unsafe { core::mem::zeroed() },
-            tag: unsafe { core::mem::zeroed() },
-            left: None,
-            right: None,
-            meta: 0, // used=false, height=0
-        }
+        // A `Slot` lives inside an on-disk Postgres page (the FSM root block) and the entire
+        // page is diffed into the WAL by `GenericXLog`. A struct-literal initializer leaves this
+        // struct's trailing padding (present whenever `K`/`V`/`T` don't fill out the struct's
+        // alignment, e.g. 7 bytes for `Slot<u64, (), u32>`) uninitialized, and those bytes would
+        // surface as "uninitialised value" reads when the WAL delta is computed (flagged by
+        // Valgrind, and nondeterministic bytes in the WAL stream). Building the value in zeroed
+        // memory makes every padding byte a defined zero.
+        //
+        // All-zero is exactly the intended default: left/right = None (niche 0), key/val/tag = 0,
+        // meta = 0 (used=false, height=0). Keys/values in unused slots are ignored -- we never read
+        // key/val unless `is_used()` is true -- so zeroing is fine for the PODs we store here.
+        unsafe { core::mem::zeroed() }
     }
 }
 
@@ -122,12 +123,24 @@ pub enum Error {
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct AvlTreeMapHeader {
     root: Option<usize>,
     free_head: Option<usize>,
     len: usize,
+}
+
+impl Default for AvlTreeMapHeader {
+    fn default() -> Self {
+        // This header is embedded in the on-disk FSM root block, which is diffed into the WAL by
+        // `GenericXLog`. `Option<usize>` has no niche, so each one is laid out as a 1-byte
+        // discriminant followed by 7 bytes of padding before the `usize` payload; a struct-literal
+        // initializer would leave those padding bytes uninitialized and they would surface as
+        // "uninitialised value" reads in the WAL delta. Building in zeroed memory makes the padding
+        // a defined zero. All-zero is the intended default: root/free_head = None, len = 0.
+        unsafe { core::mem::zeroed() }
+    }
 }
 
 /// Read-only view of an Array-backed AVL Tree living inside a borrowed [`&[Slot<K,V>]`]

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -163,12 +163,17 @@ pub mod v1 {
 
     impl Default for V1Header {
         fn default() -> Self {
-            Self {
-                header: FSMBlockHeader {
-                    kind: FSMBlockKind::v1_uncompressed,
-                },
-                empty: false,
-            }
+            // This header is written into an on-disk page whose full image is diffed into the WAL
+            // by `GenericXLog`. `FSMBlockHeader` is 4-byte aligned, so the `empty` bool leaves 3
+            // trailing padding bytes; a struct-literal initializer would leave them uninitialized
+            // and they would surface as "uninitialised value" reads in the WAL delta. Building in
+            // zeroed memory makes that padding a defined zero (see `v2::FSMRootBlock::default` for
+            // the full rationale). `empty` defaults to false == 0, already set by the zeroing.
+            let mut this: Self = unsafe { core::mem::zeroed() };
+            this.header = FSMBlockHeader {
+                kind: FSMBlockKind::v1_uncompressed,
+            };
+            this
         }
     }
 
@@ -691,11 +696,21 @@ pub mod v2 {
 
     impl Default for FSMRootBlock {
         fn default() -> Self {
-            Self {
-                header: V2Header::default(),
-                avl_header: Default::default(),
-                avl_arena: [AvlSlot::default(); MAX_SLOTS],
-            }
+            // This struct is written verbatim into a Postgres page, and the whole page is diffed
+            // into the WAL by `GenericXLog`. A struct-literal initializer would leave several
+            // padding regions uninitialized: the 4-byte gap between the 4-byte `V2Header` and the
+            // 8-byte-aligned `AvlTreeMapHeader`, the padding inside that header, and each slot's
+            // trailing padding. Those bytes would then show up as "uninitialised value" reads in
+            // the WAL delta -- caught (correctly) by Valgrind, and nondeterministic bytes in the
+            // WAL stream. Building in zeroed memory makes every padding byte a defined zero.
+            //
+            // All-zero is a valid bit pattern for everything except the block kind: `Option<usize>`
+            // None == 0, an all-zero `AvlSlot` is a free slot, and an all-zero `AvlTreeMapHeader`
+            // is `{ root: None, free_head: None, len: 0 }`. Only the `V2Header`'s `FSMBlockKind`
+            // discriminant needs a non-zero value, so we set it explicitly after zeroing.
+            let mut this: Self = unsafe { core::mem::zeroed() };
+            this.header = V2Header::default();
+            this
         }
     }
 


### PR DESCRIPTION
## What

Adds `.github/workflows/test-pg_search-valgrind.yml`, a standalone workflow that runs the `pg_regress` suite with Postgres wrapped in Valgrind. This catches memory corruption (invalid reads/writes, use-after-free, uninitialised memory) at the Rust/Postgres FFI boundary that `--enable-cassert` alone can't detect.

Closes #5059.

## Notes

- No Postgres or pgrx patching needed. `cargo pgrx regress --valgrind` landed in pgrx 0.18.1, which we already pin in `Cargo.toml`. The ASAN path, by contrast, needs a patched Postgres, nightly Rust, and `build-std`.
- Runs weekly plus `workflow_dispatch`, on an x86_64 runner since Valgrind can't decode aarch64 atomics. A full run takes hours, so it stays off the PR critical path; per-PR it only triggers on changes to the workflow and scan files.
- Valgrind writes errors to the Postgres log, not stdout, and doesn't exit non-zero on them, so a green regress isn't enough. A scan step greps the log for genuine corruption and ignores leak summaries, since normal Postgres operation leaks heavily. The log is uploaded as an artifact either way.
- pgrx already sets the important bits (`--trace-children=yes` so forked backends are traced, the Postgres suppression file, the error markers the scan parses). We layer on `--track-origins`, deeper stacks, and a couple of noise-reduction flags via `VALGRIND_OPTS`.

## Coverage

Valgrind only instruments code the `pg_regress` suite actually executes, so its reach is bounded by the suite's breadth — growing regress coverage is what widens it over time. Scope is Memcheck (memory corruption) only; race detectors like Helgrind are intentionally out, as they're impractically noisy on Postgres' shared-memory model.
