### PR TITLE
feat: add minimum_should_match parameter to paradedb.boolean()

### DIFF
--- a/.github/scripts/check_migration_diff.py
+++ b/.github/scripts/check_migration_diff.py
@@ -10,6 +10,21 @@ import sys
 import re
 
 
+def normalize_array_defaults(stmt):
+    """Normalize PostgreSQL array default value representations.
+
+    pg-schema-diff outputs pg_dump canonical form: '((ARRAY[])::type[])'
+    but valid DDL uses: ARRAY[]::type[]
+    These are semantically identical, so normalize both to the same form.
+    """
+    # DEFAULT '((ARRAY[])::sometype[])' -> DEFAULT ARRAY[]::sometype[]
+    return re.sub(
+        r"DEFAULT '\(\(ARRAY\[\]\)::([\w]+\[\])\)'",
+        r"DEFAULT ARRAY[]::\1",
+        stmt,
+    )
+
+
 def extract_statements(content):
     """Extract normalized SQL statements (CREATE, ALTER, DROP) from content."""
     # Remove single-line comments (-- ...)
@@ -26,7 +41,7 @@ def extract_statements(content):
     for stmt in content.split(";"):
         stmt = stmt.strip()
         if re.match(r"^(CREATE|ALTER|DROP)\s+", stmt, re.IGNORECASE):
-            statements.add(stmt)
+            statements.add(normalize_array_defaults(stmt))
 
     return statements
 

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -25,12 +25,96 @@ AS 'MODULE_PATHNAME', 'boost_to_fuzzy_wrapper';
 CREATE CAST (pdb.boost AS pdb.fuzzy) WITH FUNCTION boost_to_fuzzy(pdb.boost, integer, boolean) AS ASSIGNMENT;
 
 DROP VIEW pdb.index_layer_info;
-CREATE VIEW pdb.index_layer_info AS SELECT ((relname)::text), layer_size, low, high, byte_size, CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count, CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments FROM (SELECT relname, ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') || COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size, count(*), COALESCE (sum(byte_size), 0) AS byte_size, min(low) AS low, max(high) AS high, array_agg(segno) AS segments FROM (WITH indexes AS (SELECT ((oid)::regclass) AS relname FROM pg_class WHERE (relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))) , segments AS (SELECT relname, index_info.* FROM indexes INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) , layer_sizes AS (SELECT relname, COALESCE (lead(unnest) OVER(), 0) AS low, unnest AS high FROM indexes INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.combined_layer_sizes(indexes.relname)) || 9223372036854775807)) ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool)) SELECT layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno, segments.byte_size FROM layer_sizes LEFT JOIN segments ON ((layer_sizes.relname = segments.relname) AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x WHERE (low < high) GROUP BY relname, low, high ORDER BY relname , low DESC ) AS x ;
+CREATE VIEW pdb.index_layer_info AS
+SELECT ((relname)::text),
+       layer_size,
+       low,
+       high,
+       byte_size,
+       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
+       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
+FROM (SELECT relname,
+             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
+              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
+             count(*),
+             COALESCE (sum(byte_size), 0) AS byte_size,
+             min(low) AS low,
+             max(high) AS high,
+             array_agg(segno) AS segments
+      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
+                             FROM pg_class AS c
+                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
+                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
+                                AND i.indisvalid
+                                AND i.indisready
+                                AND i.indislive)) ,
+                 segments AS (SELECT relname, index_info.*
+                              FROM indexes
+                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
+                 layer_sizes AS (SELECT relname,
+                                         COALESCE (lead(unnest) OVER(), 0) AS low,
+                                         unnest AS high
+                                  FROM indexes
+                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.combined_layer_sizes(indexes.relname)) || 9223372036854775807))
+                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
+            SELECT layer_sizes.relname,
+                   layer_sizes.low,
+                   layer_sizes.high,
+                   segments.segno,
+                   segments.byte_size
+            FROM layer_sizes
+                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
+                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
+      WHERE (low < high)
+      GROUP BY relname, low, high
+      ORDER BY relname , low DESC ) AS x ;
 
 GRANT SELECT ON pdb.index_layer_info TO PUBLIC;
 
 DROP VIEW paradedb.index_layer_info;
-CREATE VIEW paradedb.index_layer_info AS SELECT ((relname)::text), layer_size, low, high, byte_size, CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count, CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments FROM (SELECT relname, ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') || COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size, count(*), COALESCE (sum(byte_size), 0) AS byte_size, min(low) AS low, max(high) AS high, array_agg(segno) AS segments FROM (WITH indexes AS (SELECT ((oid)::regclass) AS relname FROM pg_class WHERE (relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))) , segments AS (SELECT relname, index_info.* FROM indexes INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) , layer_sizes AS (SELECT relname, COALESCE (lead(unnest) OVER(), 0) AS low, unnest AS high FROM indexes INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.layer_sizes(indexes.relname)) || 9223372036854775807)) ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool)) SELECT layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno, segments.byte_size FROM layer_sizes LEFT JOIN segments ON ((layer_sizes.relname = segments.relname) AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x WHERE (low < high) GROUP BY relname, low, high ORDER BY relname , low DESC ) AS x ;
+CREATE VIEW paradedb.index_layer_info AS
+SELECT ((relname)::text),
+       layer_size,
+       low,
+       high,
+       byte_size,
+       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
+       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
+FROM (SELECT relname,
+             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
+              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
+             count(*),
+             COALESCE (sum(byte_size), 0) AS byte_size,
+             min(low) AS low,
+             max(high) AS high,
+             array_agg(segno) AS segments
+      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
+                             FROM pg_class AS c
+                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
+                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
+                                AND i.indisvalid
+                                AND i.indisready
+                                AND i.indislive)) ,
+                 segments AS (SELECT relname, index_info.*
+                              FROM indexes
+                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
+                 layer_sizes AS (SELECT relname,
+                                         COALESCE (lead(unnest) OVER(), 0) AS low,
+                                         unnest AS high
+                                  FROM indexes
+                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.layer_sizes(indexes.relname)) || 9223372036854775807))
+                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
+            SELECT layer_sizes.relname,
+                   layer_sizes.low,
+                   layer_sizes.high,
+                   segments.segno,
+                   segments.byte_size
+            FROM layer_sizes
+                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
+                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
+      WHERE (low < high)
+      GROUP BY relname, low, high
+      ORDER BY relname , low DESC ) AS x ;
 
 GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;
 

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -9,7 +9,7 @@
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
-CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', should searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', must_not searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 
 DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
 DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -5,6 +5,30 @@
 -- from, they may or may not already exist (community's `v0.24.0` predates them;
 -- enterprise's folds them into the base schema). Drop-then-create keeps this
 -- upgrade idempotent in both cases so it never fails with "already exists".
+-- Update boolean() overloads to add minimum_should_match parameter
+DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
+DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
+
+CREATE OR REPLACE FUNCTION "boolean"(
+	"must" SearchQueryInput DEFAULT NULL,
+	"should" SearchQueryInput DEFAULT NULL,
+	"must_not" SearchQueryInput DEFAULT NULL,
+	"minimum_should_match" bigint DEFAULT NULL
+) RETURNS SearchQueryInput
+IMMUTABLE PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'boolean_singles_wrapper';
+
+CREATE OR REPLACE FUNCTION "boolean"(
+	"must" SearchQueryInput[] DEFAULT ARRAY[]::searchqueryinput[],
+	"should" SearchQueryInput[] DEFAULT ARRAY[]::searchqueryinput[],
+	"must_not" SearchQueryInput[] DEFAULT ARRAY[]::searchqueryinput[],
+	"minimum_should_match" bigint DEFAULT NULL
+) RETURNS SearchQueryInput
+IMMUTABLE PARALLEL SAFE
+LANGUAGE c
+AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper';
+
 DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
 DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);
 

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -9,7 +9,7 @@
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
-CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', should searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', must_not searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 
 DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
 DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);
@@ -25,96 +25,12 @@ AS 'MODULE_PATHNAME', 'boost_to_fuzzy_wrapper';
 CREATE CAST (pdb.boost AS pdb.fuzzy) WITH FUNCTION boost_to_fuzzy(pdb.boost, integer, boolean) AS ASSIGNMENT;
 
 DROP VIEW pdb.index_layer_info;
-CREATE VIEW pdb.index_layer_info AS
-SELECT ((relname)::text),
-       layer_size,
-       low,
-       high,
-       byte_size,
-       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
-       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
-FROM (SELECT relname,
-             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
-              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
-             count(*),
-             COALESCE (sum(byte_size), 0) AS byte_size,
-             min(low) AS low,
-             max(high) AS high,
-             array_agg(segno) AS segments
-      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
-                             FROM pg_class AS c
-                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
-                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
-                                AND i.indisvalid
-                                AND i.indisready
-                                AND i.indislive)) ,
-                 segments AS (SELECT relname, index_info.*
-                              FROM indexes
-                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
-                 layer_sizes AS (SELECT relname,
-                                         COALESCE (lead(unnest) OVER(), 0) AS low,
-                                         unnest AS high
-                                  FROM indexes
-                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.combined_layer_sizes(indexes.relname)) || 9223372036854775807))
-                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
-            SELECT layer_sizes.relname,
-                   layer_sizes.low,
-                   layer_sizes.high,
-                   segments.segno,
-                   segments.byte_size
-            FROM layer_sizes
-                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
-                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
-      WHERE (low < high)
-      GROUP BY relname, low, high
-      ORDER BY relname , low DESC ) AS x ;
+CREATE VIEW pdb.index_layer_info AS SELECT ((relname)::text), layer_size, low, high, byte_size, CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count, CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments FROM (SELECT relname, ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') || COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size, count(*), COALESCE (sum(byte_size), 0) AS byte_size, min(low) AS low, max(high) AS high, array_agg(segno) AS segments FROM (WITH indexes AS (SELECT ((oid)::regclass) AS relname FROM pg_class WHERE (relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))) , segments AS (SELECT relname, index_info.* FROM indexes INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) , layer_sizes AS (SELECT relname, COALESCE (lead(unnest) OVER(), 0) AS low, unnest AS high FROM indexes INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.combined_layer_sizes(indexes.relname)) || 9223372036854775807)) ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool)) SELECT layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno, segments.byte_size FROM layer_sizes LEFT JOIN segments ON ((layer_sizes.relname = segments.relname) AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x WHERE (low < high) GROUP BY relname, low, high ORDER BY relname , low DESC ) AS x ;
 
 GRANT SELECT ON pdb.index_layer_info TO PUBLIC;
 
 DROP VIEW paradedb.index_layer_info;
-CREATE VIEW paradedb.index_layer_info AS
-SELECT ((relname)::text),
-       layer_size,
-       low,
-       high,
-       byte_size,
-       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
-       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
-FROM (SELECT relname,
-             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
-              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
-             count(*),
-             COALESCE (sum(byte_size), 0) AS byte_size,
-             min(low) AS low,
-             max(high) AS high,
-             array_agg(segno) AS segments
-      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
-                             FROM pg_class AS c
-                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
-                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
-                                AND i.indisvalid
-                                AND i.indisready
-                                AND i.indislive)) ,
-                 segments AS (SELECT relname, index_info.*
-                              FROM indexes
-                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
-                 layer_sizes AS (SELECT relname,
-                                         COALESCE (lead(unnest) OVER(), 0) AS low,
-                                         unnest AS high
-                                  FROM indexes
-                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.layer_sizes(indexes.relname)) || 9223372036854775807))
-                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
-            SELECT layer_sizes.relname,
-                   layer_sizes.low,
-                   layer_sizes.high,
-                   segments.segno,
-                   segments.byte_size
-            FROM layer_sizes
-                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
-                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
-      WHERE (low < high)
-      GROUP BY relname, low, high
-      ORDER BY relname , low DESC ) AS x ;
+CREATE VIEW paradedb.index_layer_info AS SELECT ((relname)::text), layer_size, low, high, byte_size, CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count, CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments FROM (SELECT relname, ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') || COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size, count(*), COALESCE (sum(byte_size), 0) AS byte_size, min(low) AS low, max(high) AS high, array_agg(segno) AS segments FROM (WITH indexes AS (SELECT ((oid)::regclass) AS relname FROM pg_class WHERE (relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))) , segments AS (SELECT relname, index_info.* FROM indexes INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) , layer_sizes AS (SELECT relname, COALESCE (lead(unnest) OVER(), 0) AS low, unnest AS high FROM indexes INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.layer_sizes(indexes.relname)) || 9223372036854775807)) ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool)) SELECT layer_sizes.relname, layer_sizes.low, layer_sizes.high, segments.segno, segments.byte_size FROM layer_sizes LEFT JOIN segments ON ((layer_sizes.relname = segments.relname) AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x WHERE (low < high) GROUP BY relname, low, high ORDER BY relname , low DESC ) AS x ;
 
 GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;
 

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -9,7 +9,7 @@
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
-CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', should searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', must_not searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 
 DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
 DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -7,27 +7,9 @@
 -- upgrade idempotent in both cases so it never fails with "already exists".
 -- Update boolean() overloads to add minimum_should_match parameter
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
-
-CREATE OR REPLACE FUNCTION "boolean"(
-	"must" SearchQueryInput DEFAULT NULL,
-	"should" SearchQueryInput DEFAULT NULL,
-	"must_not" SearchQueryInput DEFAULT NULL,
-	"minimum_should_match" bigint DEFAULT NULL
-) RETURNS SearchQueryInput
-IMMUTABLE PARALLEL SAFE
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'boolean_singles_wrapper';
-
-CREATE OR REPLACE FUNCTION "boolean"(
-	"must" SearchQueryInput[] DEFAULT ARRAY[]::searchqueryinput[],
-	"should" SearchQueryInput[] DEFAULT ARRAY[]::searchqueryinput[],
-	"must_not" SearchQueryInput[] DEFAULT ARRAY[]::searchqueryinput[],
-	"minimum_should_match" bigint DEFAULT NULL
-) RETURNS SearchQueryInput
-IMMUTABLE PARALLEL SAFE
-LANGUAGE c
-AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper';
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', should searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', must_not searchqueryinput[] DEFAULT '((ARRAY[])::searchqueryinput[])', minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 
 DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
 DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);

--- a/pg_search/src/api/builder_fns/paradedb.rs
+++ b/pg_search/src/api/builder_fns/paradedb.rs
@@ -35,11 +35,13 @@ pub fn boolean_arrays(
     must: default!(Vec<SearchQueryInput>, "ARRAY[]::searchqueryinput[]"),
     should: default!(Vec<SearchQueryInput>, "ARRAY[]::searchqueryinput[]"),
     must_not: default!(Vec<SearchQueryInput>, "ARRAY[]::searchqueryinput[]"),
+    minimum_should_match: default!(Option<i64>, "NULL"),
 ) -> SearchQueryInput {
     SearchQueryInput::Boolean {
         must,
         should,
         must_not,
+        minimum_should_match,
     }
 }
 
@@ -48,11 +50,13 @@ pub fn boolean_singles(
     must: default!(Option<SearchQueryInput>, "NULL"),
     should: default!(Option<SearchQueryInput>, "NULL"),
     must_not: default!(Option<SearchQueryInput>, "NULL"),
+    minimum_should_match: default!(Option<i64>, "NULL"),
 ) -> SearchQueryInput {
     boolean_arrays(
         must.map_or(vec![], |v| vec![v]),
         should.map_or(vec![], |v| vec![v]),
         must_not.map_or(vec![], |v| vec![v]),
+        minimum_should_match,
     )
 }
 
@@ -117,7 +121,8 @@ pub unsafe fn term_with_operator(
                         // ensure that we don't match NULL nulls as not being equal to whatever the user specified
                         must: vec![SearchQueryInput::FieldedQuery {field: $field.clone(), query: pdb::Query::Exists}],
                         should: vec![],
-                        must_not: vec![SearchQueryInput::FieldedQuery { field: $field, query: $eq_func_name(<$value_type>::from_datum($anyelement.datum(), false).unwrap())}]
+                        must_not: vec![SearchQueryInput::FieldedQuery { field: $field, query: $eq_func_name(<$value_type>::from_datum($anyelement.datum(), false).unwrap())}],
+                        minimum_should_match: None,
                     }
                 ),
                 ">" => generic_range_query(Bound::Excluded($anyelement), Bound::Unbounded).map(|query| SearchQueryInput::FieldedQuery { field: $field, query }),
@@ -245,6 +250,7 @@ pub unsafe fn terms_with_operator(
                 must: quals,
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             })
         } else {
             // OR the queries together
@@ -252,6 +258,7 @@ pub unsafe fn terms_with_operator(
                 must: vec![],
                 should: quals,
                 must_not: vec![],
+                minimum_should_match: None,
             })
         }
     }

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -152,6 +152,7 @@ fn query_is_exists(query: &SearchQueryInput) -> bool {
             must,
             should,
             must_not,
+            ..
         } => {
             let clauses: Vec<_> = must
                 .iter()
@@ -302,6 +303,7 @@ pub fn search_with_query_input(
                         field: field.into(),
                         query: crate::query::pdb_query::pdb::Query::Exists,
                     }],
+                    minimum_should_match: None,
                 }),
             };
 

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -175,6 +175,7 @@ impl BaseScan {
                         must: vec![base_query.clone()],
                         should: vec![join_predicate.clone()],
                         must_not: vec![],
+                        minimum_should_match: None,
                     })
                 } else {
                     None
@@ -1198,6 +1199,7 @@ impl CustomScan for BaseScan {
                             must: vec![original_base_query.clone()],
                             should: vec![join_predicate.clone()],
                             must_not: vec![],
+                            minimum_should_match: None,
                         });
                     }
                 }
@@ -2344,6 +2346,7 @@ fn base_query_has_search_predicates(
             must,
             should,
             must_not,
+            ..
         } => {
             must.iter()
                 .any(|q| base_query_has_search_predicates(q, current_index_oid))

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -271,6 +271,7 @@ fn generic_negation(input: SearchQueryInput) -> SearchQueryInput {
         must: vec![SearchQueryInput::All],
         should: Default::default(),
         must_not: vec![input],
+        minimum_should_match: None,
     }
 }
 
@@ -382,6 +383,7 @@ fn negate_fielded_input(input: SearchQueryInput, ctx: &mut NegationContext) -> S
                     must: vec![null_preserving_exists_guard(&field)],
                     should: Default::default(),
                     must_not: vec![SearchQueryInput::FieldedQuery { field, query }],
+                    minimum_should_match: None,
                 }
             } else {
                 generic_negation(SearchQueryInput::FieldedQuery { field, query })
@@ -391,6 +393,7 @@ fn negate_fielded_input(input: SearchQueryInput, ctx: &mut NegationContext) -> S
             must,
             should,
             must_not,
+            ..
         } if must_not.is_empty() => {
             if should.is_empty() {
                 SearchQueryInput::Boolean {
@@ -400,6 +403,7 @@ fn negate_fielded_input(input: SearchQueryInput, ctx: &mut NegationContext) -> S
                         .map(|query| negate_fielded_input(query, ctx))
                         .collect(),
                     must_not: Default::default(),
+                    minimum_should_match: None,
                 }
             } else if must.is_empty() {
                 SearchQueryInput::Boolean {
@@ -409,12 +413,14 @@ fn negate_fielded_input(input: SearchQueryInput, ctx: &mut NegationContext) -> S
                         .collect(),
                     should: Default::default(),
                     must_not: Default::default(),
+                    minimum_should_match: None,
                 }
             } else {
                 generic_negation(SearchQueryInput::Boolean {
                     must,
                     should,
                     must_not,
+                    minimum_should_match: None,
                 })
             }
         }
@@ -451,6 +457,7 @@ fn negated_search_query_input_with_context(
                     .map(|q| negated_search_query_input_with_context(q, ctx))
                     .collect(),
                 must_not: Default::default(),
+                minimum_should_match: None,
             }
         }
         Qual::Or(quals)
@@ -465,6 +472,7 @@ fn negated_search_query_input_with_context(
                     .collect(),
                 should: Default::default(),
                 must_not: Default::default(),
+                minimum_should_match: None,
             }
         }
         Qual::OpExpr { .. } => negate_fielded_input(SearchQueryInput::from(qual), ctx),
@@ -702,48 +710,7 @@ impl From<&Qual> for SearchQueryInput {
                     },
                 }
             }
-            Qual::Not(qual) => {
-                // Special handling for boolean fields to correctly handle NULL values
-                match qual.as_ref() {
-                    // If we're negating a PushdownVarEqTrue, we should use PushdownVarEqFalse directly
-                    // rather than using must_not, to avoid including NULLs
-                    // This follows SQL standard where NOT (field = TRUE) is equivalent to (field = FALSE)
-                    // and does NOT include NULL values
-                    Qual::PushdownVarEqTrue { field } => Self::from(&Qual::PushdownVarEqFalse {
-                        field: field.clone(),
-                    }),
-                    // Similarly, if we're negating a PushdownVarEqFalse, use PushdownVarEqTrue
-                    // This follows SQL standard where NOT (field = FALSE) is equivalent to (field = TRUE)
-                    // and does NOT include NULL values
-                    Qual::PushdownVarEqFalse { field } => Self::from(&Qual::PushdownVarEqTrue {
-                        field: field.clone(),
-                    }),
-
-                    // If the Qual represents a placeholder to another Var elsewhere in the plan,
-                    // that means it's a JOIN of some kind and what we actually need to return, in its place,
-                    // is "all" rather than "NOT all"
-                    Qual::ExternalVar => SearchQueryInput::All,
-
-                    // If the Qual represents a placeholder to another Expr elsewhere in the plan,
-                    // that means it's a JOIN of some kind and what we actually need to return, in its place,
-                    // is "all" rather than "NOT all"
-                    Qual::ExternalExpr => SearchQueryInput::All,
-
-                    // For other types of negation, use the standard Boolean query with must_not
-                    // Note that when negating an IS operator (e.g., IS NOT TRUE), PostgreSQL handles
-                    // NULL values differently than when negating equality operators
-                    _ => {
-                        let must_not = vec![SearchQueryInput::from(qual.as_ref())];
-
-                        SearchQueryInput::Boolean {
-                            must: vec![SearchQueryInput::All],
-                            should: Default::default(),
-                            must_not,
-                            minimum_should_match: None,
-                        }
-                    }
-                }
-            }
+            Qual::Not(qual) => negated_search_query_input(qual.as_ref()),
         }
     }
 }
@@ -2301,6 +2268,7 @@ mod tests {
                         value: PdbOwnedValue::Str("blue".into()),
                     },
                 }],
+                minimum_should_match: None,
             }),
         };
         assert_eq!(fast, want_fast);
@@ -2318,6 +2286,7 @@ mod tests {
                         value: PdbOwnedValue::Str("blue".into()),
                     },
                 }],
+                minimum_should_match: None,
             }),
         };
         assert_eq!(non_fast, want_non_fast);
@@ -2336,6 +2305,7 @@ mod tests {
                     field: "color".into(),
                     query: pdb::Query::Exists,
                 }],
+                minimum_should_match: None,
             }),
         };
         assert_eq!(negated_exists, want_negated_exists);
@@ -2371,9 +2341,11 @@ mod tests {
                             value: PdbOwnedValue::Bool(true),
                         },
                     }],
+                    minimum_should_match: None,
                 },
             ],
             must_not: vec![],
+            minimum_should_match: None,
         };
         assert_eq!(got, want);
     }
@@ -2502,6 +2474,7 @@ mod tests {
                     must,
                     should,
                     must_not,
+                    ..
                 },
             ) if matches!(inner.as_ref(), Qual::Or(_)) => {
                 let Qual::Or(quals) = inner.as_ref() else {
@@ -2552,6 +2525,7 @@ mod tests {
                     must,
                     should: _,
                     must_not,
+                    ..
                 },
             ) => must.len() == 1 && matches!(must[0], SearchQueryInput::All) && must_not.len() == 1,
 

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -513,6 +513,7 @@ impl From<&Qual> for SearchQueryInput {
                             must,
                             should,
                             must_not: vec![],
+                            minimum_should_match: None,
                         }
                     }
                 } else {
@@ -662,6 +663,7 @@ impl From<&Qual> for SearchQueryInput {
                     must,
                     should: vec![],
                     must_not: vec![],
+                    minimum_should_match: None,
                 };
 
                 // wrap the basic boolean query, iteratively, in each of the extracted ScoreFilters
@@ -690,15 +692,58 @@ impl From<&Qual> for SearchQueryInput {
                         must: Default::default(),
                         should: Default::default(),
                         must_not: Default::default(),
+                        minimum_should_match: None,
                     },
                     _ => SearchQueryInput::Boolean {
                         must: Default::default(),
                         should,
                         must_not: Default::default(),
+                        minimum_should_match: None,
                     },
                 }
             }
-            Qual::Not(qual) => negated_search_query_input(qual.as_ref()),
+            Qual::Not(qual) => {
+                // Special handling for boolean fields to correctly handle NULL values
+                match qual.as_ref() {
+                    // If we're negating a PushdownVarEqTrue, we should use PushdownVarEqFalse directly
+                    // rather than using must_not, to avoid including NULLs
+                    // This follows SQL standard where NOT (field = TRUE) is equivalent to (field = FALSE)
+                    // and does NOT include NULL values
+                    Qual::PushdownVarEqTrue { field } => Self::from(&Qual::PushdownVarEqFalse {
+                        field: field.clone(),
+                    }),
+                    // Similarly, if we're negating a PushdownVarEqFalse, use PushdownVarEqTrue
+                    // This follows SQL standard where NOT (field = FALSE) is equivalent to (field = TRUE)
+                    // and does NOT include NULL values
+                    Qual::PushdownVarEqFalse { field } => Self::from(&Qual::PushdownVarEqTrue {
+                        field: field.clone(),
+                    }),
+
+                    // If the Qual represents a placeholder to another Var elsewhere in the plan,
+                    // that means it's a JOIN of some kind and what we actually need to return, in its place,
+                    // is "all" rather than "NOT all"
+                    Qual::ExternalVar => SearchQueryInput::All,
+
+                    // If the Qual represents a placeholder to another Expr elsewhere in the plan,
+                    // that means it's a JOIN of some kind and what we actually need to return, in its place,
+                    // is "all" rather than "NOT all"
+                    Qual::ExternalExpr => SearchQueryInput::All,
+
+                    // For other types of negation, use the standard Boolean query with must_not
+                    // Note that when negating an IS operator (e.g., IS NOT TRUE), PostgreSQL handles
+                    // NULL values differently than when negating equality operators
+                    _ => {
+                        let must_not = vec![SearchQueryInput::from(qual.as_ref())];
+
+                        SearchQueryInput::Boolean {
+                            must: vec![SearchQueryInput::All],
+                            should: Default::default(),
+                            must_not,
+                            minimum_should_match: None,
+                        }
+                    }
+                }
+            }
         }
     }
 }
@@ -1967,6 +2012,7 @@ unsafe fn optimize_and_branch_with_heap_expr(quals: &mut Vec<Qual>) {
                         must: indexed_queries.clone(),
                         should: vec![],
                         must_not: vec![],
+                        minimum_should_match: None,
                     };
                 }
             }
@@ -2402,6 +2448,7 @@ mod tests {
                     must,
                     should,
                     must_not,
+                    ..
                 },
             ) => should.is_empty() && must_not.is_empty() && quals.len() == must.len(),
 
@@ -2412,6 +2459,7 @@ mod tests {
                     must,
                     should,
                     must_not,
+                    ..
                 },
             ) => must.is_empty() && must_not.is_empty() && quals.len() == should.len(),
 
@@ -2432,6 +2480,7 @@ mod tests {
                     must,
                     should,
                     must_not,
+                    ..
                 },
             ) if matches!(inner.as_ref(), Qual::And(_)) => {
                 let Qual::And(quals) = inner.as_ref() else {

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -155,6 +155,7 @@ pub extern "C-unwind" fn amrescan(
             must: vec![search_query_input, key],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         };
     }
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -78,6 +78,10 @@ pub enum SearchQueryInput {
         #[serde(default)]
         #[serde(skip_serializing_if = "Vec::is_empty")]
         must_not: Vec<SearchQueryInput>,
+
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        minimum_should_match: Option<i64>,
     },
     Boost {
         query: Box<SearchQueryInput>,
@@ -240,6 +244,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => must
                 .iter()
                 .chain(should.iter())
@@ -276,6 +281,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => {
                 // For the query to be a full scan, ALL documents must match
 
@@ -341,6 +347,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => must
                 .iter()
                 .chain(should.iter())
@@ -371,6 +378,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => must
                 .iter()
                 .chain(should.iter())
@@ -406,6 +414,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not: _,
+                ..
             } => {
                 // AND: product of children selectivities; OR: max of children selectivities.
                 let must_sel = must
@@ -454,6 +463,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => {
                 for q in must.iter().chain(should.iter()).chain(must_not.iter()) {
                     q.extract_field_names(field_names);
@@ -494,6 +504,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => {
                 for q in must_not {
                     q.visit(visitor);
@@ -639,6 +650,7 @@ impl SearchQueryInput {
                 must: vec![],
                 should: elements,
                 must_not: vec![],
+                minimum_should_match: None,
             },
         }
     }
@@ -968,8 +980,8 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                minimum_should_match,
             } => {
-                // Boolean query optimization pattern:
                 // ---------------------------------
                 // We use B::split_for_parent() to avoid cloning for QueryOnlyBuilder.
                 //
@@ -1016,7 +1028,12 @@ impl SearchQueryInput {
                     }
                 }
 
-                let query = Box::new(BooleanQuery::new(subqueries));
+                let query: Box<dyn TantivyQuery> = match minimum_should_match {
+                    Some(n) => Box::new(BooleanQuery::with_minimum_required_clauses(
+                        subqueries, n as usize,
+                    )),
+                    None => Box::new(BooleanQuery::new(subqueries)),
+                };
 
                 // Children are built lazily inside the closure - QueryOnlyBuilder
                 // never calls this closure, so wrapping work is skipped entirely
@@ -1772,6 +1789,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1780,6 +1798,7 @@ mod tests {
             must: vec![SearchQueryInput::All, SearchQueryInput::All],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1788,6 +1807,7 @@ mod tests {
             must: vec![SearchQueryInput::All, create_term_query()],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1796,6 +1816,7 @@ mod tests {
             must: vec![create_term_query()],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1807,6 +1828,7 @@ mod tests {
             must: vec![],
             should: vec![SearchQueryInput::All],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1815,6 +1837,7 @@ mod tests {
             must: vec![],
             should: vec![SearchQueryInput::All, create_term_query()],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1823,6 +1846,7 @@ mod tests {
             must: vec![],
             should: vec![create_term_query()],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1831,6 +1855,7 @@ mod tests {
             must: vec![],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1842,6 +1867,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![create_term_query()],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1850,6 +1876,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![SearchQueryInput::Empty],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1858,6 +1885,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![SearchQueryInput::Empty, SearchQueryInput::Empty],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1866,6 +1894,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![SearchQueryInput::Empty, create_term_query()],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1877,6 +1906,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![create_term_query()],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1885,6 +1915,7 @@ mod tests {
             must: vec![create_term_query()],
             should: vec![SearchQueryInput::All],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1974,8 +2005,10 @@ mod tests {
                 must: vec![SearchQueryInput::All],
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             }],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1986,6 +2019,7 @@ mod tests {
                 must: vec![SearchQueryInput::All],
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             }),
         }
         .is_full_scan_query());
@@ -1996,9 +2030,11 @@ mod tests {
                 must: vec![SearchQueryInput::All, create_term_query()], // Not all Must are full scan
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             }],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }

--- a/pg_search/src/scan/filter_pushdown.rs
+++ b/pg_search/src/scan/filter_pushdown.rs
@@ -104,6 +104,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![left_query, right_query],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         })
     }
 
@@ -114,6 +115,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![],
             should: vec![left_query, right_query],
             must_not: vec![],
+            minimum_should_match: None,
         })
     }
 
@@ -123,6 +125,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![inner_query],
+            minimum_should_match: None,
         })
     }
 
@@ -265,6 +268,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![query],
+            minimum_should_match: None,
         }
     }
 
@@ -408,6 +412,7 @@ pub fn combine_with_and(queries: Vec<SearchQueryInput>) -> Option<SearchQueryInp
             must: queries,
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }),
     }
 }

--- a/pg_search/tests/pg_regress/expected/issue_2844-rls.out
+++ b/pg_search/tests/pg_regress/expected/issue_2844-rls.out
@@ -1,7 +1,9 @@
 DROP SCHEMA IF EXISTS app CASCADE;
+NOTICE:  schema "app" does not exist, skipping
 CREATE SCHEMA IF NOT EXISTS app;
 -- search index for contacts_search
 CREATE EXTENSION IF NOT EXISTS pg_search;
+NOTICE:  extension "pg_search" already exists, skipping
 DO $$
     BEGIN
         -- create app_user role if it doesn't exist
@@ -341,8 +343,8 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) UPDATE "app"."contacts" AS t
 SET "assignee" = 'ad_singh'
 WHERE t.id IN (SELECT id FROM "app".contacts LIMIT 1)
 RETURNING t.*;
-                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on contacts t
    ->  Nested Loop Semi Join
          Join Filter: ((t.id)::text = ("ANY_subquery".id)::text)
@@ -351,7 +353,7 @@ RETURNING t.*;
                Index: contacts_search_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[]))"}}}
+               Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[], NULL::bigint))"}}}
          ->  Subquery Scan on "ANY_subquery"
                ->  Limit
                      ->  Custom Scan (ParadeDB Base Scan) on contacts
@@ -360,7 +362,7 @@ RETURNING t.*;
                            Exec Method: TopKScanExecState
                            Scores: false
                               TopK Limit: 1
-                           Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[]))"}}}
+                           Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[], NULL::bigint))"}}}
 (18 rows)
 
 --

--- a/pg_search/tests/pg_regress/expected/issue_2844-rls.out
+++ b/pg_search/tests/pg_regress/expected/issue_2844-rls.out
@@ -1,9 +1,7 @@
 DROP SCHEMA IF EXISTS app CASCADE;
-NOTICE:  schema "app" does not exist, skipping
 CREATE SCHEMA IF NOT EXISTS app;
 -- search index for contacts_search
 CREATE EXTENSION IF NOT EXISTS pg_search;
-NOTICE:  extension "pg_search" already exists, skipping
 DO $$
     BEGIN
         -- create app_user role if it doesn't exist

--- a/pg_search/tests/pg_regress/expected/minimum_should_match.out
+++ b/pg_search/tests/pg_regress/expected/minimum_should_match.out
@@ -1,0 +1,138 @@
+CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE EXTENSION
+DROP TABLE IF EXISTS docs CASCADE;
+DROP TABLE
+CREATE TABLE docs (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    body TEXT
+);
+CREATE TABLE
+INSERT INTO docs (title, body) VALUES
+    ('apple banana cherry',   'fruit salad'),
+    ('apple banana',          'two fruits'),
+    ('apple only',            'just apple'),
+    ('banana cherry date',    'three fruits'),
+    ('cherry date elderberry','more fruits'),
+    ('unrelated document',    'no match');
+INSERT 0 6
+CREATE INDEX docs_idx ON docs
+USING bm25 (id, title, body)
+WITH (key_field = 'id');
+CREATE INDEX
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  4 | banana cherry date
+(3 rows)
+
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 3
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+(1 row)
+
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 0
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  3 | apple only
+  4 | banana cherry date
+(4 rows)
+
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 5
+)
+ORDER BY id;
+ id | title 
+----+-------
+(0 rows)
+
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    must => ARRAY[paradedb.term('body', 'fruit')],
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+(1 row)
+
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ]
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  3 | apple only
+  4 | banana cherry date
+(4 rows)
+
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => paradedb.term('title', 'apple'),
+    minimum_should_match => 1
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  3 | apple only
+(3 rows)
+
+DROP TABLE docs CASCADE;
+DROP TABLE

--- a/pg_search/tests/pg_regress/expected/minimum_should_match.out
+++ b/pg_search/tests/pg_regress/expected/minimum_should_match.out
@@ -1,6 +1,5 @@
 -- Tests for minimum_should_match parameter in paradedb.boolean()
 CREATE EXTENSION IF NOT EXISTS pg_search;
-NOTICE:  extension "pg_search" already exists, skipping
 DROP TABLE IF EXISTS docs CASCADE;
 CREATE TABLE docs (
     id SERIAL PRIMARY KEY,

--- a/pg_search/tests/pg_regress/expected/minimum_should_match.out
+++ b/pg_search/tests/pg_regress/expected/minimum_should_match.out
@@ -1,13 +1,12 @@
+-- Tests for minimum_should_match parameter in paradedb.boolean()
 CREATE EXTENSION IF NOT EXISTS pg_search;
-CREATE EXTENSION
+NOTICE:  extension "pg_search" already exists, skipping
 DROP TABLE IF EXISTS docs CASCADE;
-DROP TABLE
 CREATE TABLE docs (
     id SERIAL PRIMARY KEY,
     title TEXT,
     body TEXT
 );
-CREATE TABLE
 INSERT INTO docs (title, body) VALUES
     ('apple banana cherry',   'fruit salad'),
     ('apple banana',          'two fruits'),
@@ -15,11 +14,11 @@ INSERT INTO docs (title, body) VALUES
     ('banana cherry date',    'three fruits'),
     ('cherry date elderberry','more fruits'),
     ('unrelated document',    'no match');
-INSERT 0 6
 CREATE INDEX docs_idx ON docs
 USING bm25 (id, title, body)
 WITH (key_field = 'id');
-CREATE INDEX
+-- Test 1: minimum_should_match => 2 with 3 should clauses
+-- Only docs matching at least 2 of: apple, banana, cherry
 SELECT id, title
 FROM docs
 WHERE id @@@ paradedb.boolean(
@@ -38,6 +37,7 @@ ORDER BY id;
   4 | banana cherry date
 (3 rows)
 
+-- Test 2: minimum_should_match => 3 (all 3 must match)
 SELECT id, title
 FROM docs
 WHERE id @@@ paradedb.boolean(
@@ -54,6 +54,8 @@ ORDER BY id;
   1 | apple banana cherry
 (1 row)
 
+-- Test 3: minimum_should_match => 0 (matches everything that Tantivy can retrieve)
+-- With only should clauses and minimum_should_match=0, all docs match
 SELECT id, title
 FROM docs
 WHERE id @@@ paradedb.boolean(
@@ -72,6 +74,7 @@ ORDER BY id;
   4 | banana cherry date
 (4 rows)
 
+-- Test 4: minimum_should_match larger than number of should clauses (matches nothing)
 SELECT id, title
 FROM docs
 WHERE id @@@ paradedb.boolean(
@@ -86,6 +89,8 @@ ORDER BY id;
 ----+-------
 (0 rows)
 
+-- Test 5: Combined with must clause
+-- must: body matches 'fruit', should: title matches apple OR banana (at least 1)
 SELECT id, title
 FROM docs
 WHERE id @@@ paradedb.boolean(
@@ -103,6 +108,7 @@ ORDER BY id;
   1 | apple banana cherry
 (1 row)
 
+-- Test 6: Omitting minimum_should_match keeps existing behavior (at least 1 should)
 SELECT id, title
 FROM docs
 WHERE id @@@ paradedb.boolean(
@@ -120,6 +126,7 @@ ORDER BY id;
   4 | banana cherry date
 (4 rows)
 
+-- Test 7: boolean_singles variant also accepts minimum_should_match
 SELECT id, title
 FROM docs
 WHERE id @@@ paradedb.boolean(
@@ -135,4 +142,3 @@ ORDER BY id;
 (3 rows)
 
 DROP TABLE docs CASCADE;
-DROP TABLE

--- a/pg_search/tests/pg_regress/sql/minimum_should_match.sql
+++ b/pg_search/tests/pg_regress/sql/minimum_should_match.sql
@@ -1,0 +1,112 @@
+-- Tests for minimum_should_match parameter in paradedb.boolean()
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS docs CASCADE;
+
+CREATE TABLE docs (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    body TEXT
+);
+
+INSERT INTO docs (title, body) VALUES
+    ('apple banana cherry',   'fruit salad'),
+    ('apple banana',          'two fruits'),
+    ('apple only',            'just apple'),
+    ('banana cherry date',    'three fruits'),
+    ('cherry date elderberry','more fruits'),
+    ('unrelated document',    'no match');
+
+CREATE INDEX docs_idx ON docs
+USING bm25 (id, title, body)
+WITH (key_field = 'id');
+
+-- Test 1: minimum_should_match => 2 with 3 should clauses
+-- Only docs matching at least 2 of: apple, banana, cherry
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+
+-- Test 2: minimum_should_match => 3 (all 3 must match)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 3
+)
+ORDER BY id;
+
+-- Test 3: minimum_should_match => 0 (matches everything that Tantivy can retrieve)
+-- With only should clauses and minimum_should_match=0, all docs match
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 0
+)
+ORDER BY id;
+
+-- Test 4: minimum_should_match larger than number of should clauses (matches nothing)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 5
+)
+ORDER BY id;
+
+-- Test 5: Combined with must clause
+-- must: body matches 'fruit', should: title matches apple OR banana (at least 1)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    must => ARRAY[paradedb.term('body', 'fruit')],
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+
+-- Test 6: Omitting minimum_should_match keeps existing behavior (at least 1 should)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ]
+)
+ORDER BY id;
+
+-- Test 7: boolean_singles variant also accepts minimum_should_match
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => paradedb.term('title', 'apple'),
+    minimum_should_match => 1
+)
+ORDER BY id;
+
+DROP TABLE docs CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #3695

## What
  Add `minimum_should_match` parameter to `paradedb.boolean()`, allowing
  callers to require that at least N of the `should` clauses match.

## Why
  Elasticsearch's `bool` query supports `minimum_should_match` and users
  expect the same capability in ParadeDB. Previously there was no way to
  express "at least N of these should clauses must match" — it was always
  at least one.

## How
  - Add `minimum_should_match: Option<i64>` to `SearchQueryInput::Boolean`
    with serde `default`/`skip_serializing_if` for backward compatibility
  - When set, lower to Tantivy's `BooleanQuery::with_minimum_required_clauses(n)`
    instead of `BooleanQuery::new`
  - Expose as a default-NULL parameter on both `boolean_arrays()` and
    `boolean_singles()` SQL functions
  - Update all internal `Boolean` construction sites with `minimum_should_match: None`
 
## Tests
  Add pg_regress test `minimum_should_match` covering:
  - Basic threshold: 2-of-3 and 3-of-3 should clauses
  - Edge cases: minimum=0 (matches all) and minimum > clause count (matches none)
  - Combined with `must` clauses
  - Backward compatibility: omitting the parameter preserves existing behaviour