### PR TITLE
docs: remove max_term_frequency from more_like_this options

### DIFF
--- a/docs/documentation/query-builder/specialized/more-like-this.mdx
+++ b/docs/documentation/query-builder/specialized/more-like-this.mdx
@@ -268,9 +268,8 @@ await dbContext
 
 ### Term Frequency
 
-`min_term_frequency` excludes terms that appear fewer than a certain number of times in the input document,
-while `max_term_frequency` excludes terms that appear more than that many times. By default, no terms are excluded
-based on term frequency.
+`min_term_frequency` excludes terms that appear fewer than a certain number of times in the input document.
+By default, no terms are excluded based on term frequency.
 
 For instance, the following query returns no results because no term appears twice in the input document.
 


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #5117

## What
Removes `max_term_frequency` from the More Like This `## Configuration Options` documentation.

## Why
`max_term_frequency` was documented as a valid `more_like_this` configuration option in #3328, but it was **never implemented** — the field does not exist in tantivy's `MoreLikeThis` struct (nor in upstream tantivy / Lucene / Elasticsearch), so calling `pdb.more_like_this(..., max_term_frequency => N)` errors with "function does not exist" (the bug reported in #5117).

Rather than implement a new parameter that has no upstream precedent and no validated use case, we remove the erroneous documentation so the docs match the actual API. This supersedes the earlier approach of adding the parameter (tantivy PR paradedb/tantivy#149, now closed).

## How
- Dropped the `max_term_frequency` clause from the **Term Frequency** section of `more-like-this.mdx`; `min_term_frequency` and the rest of the section are unchanged.

## Tests
Docs-only change; no code or tests affected.