### PR TITLE
fix: validate datetime fields for mutable segments

### DIFF
--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -69,7 +69,7 @@ pub struct InsertModeMutable {
     key_field_name: FieldName,
     key_field_attno: usize,
     row_limit: usize,
-    datetime_field_attnos: Vec<usize>, // attnos of columns that are dates, so we can validate they're in range at insert-time instead of read-time
+    datetime_fields: Vec<(usize, PgOid)>, // attnos & type OIDs of columns that are dates, so we can validate they're in range at insert-time instead of read-time
 }
 
 pub enum InsertMode {
@@ -115,7 +115,8 @@ impl InsertState {
                 })
                 .expect("No key field defined.");
 
-            let datetime_field_attnos = indexrel
+            // precomputing fields that are dates, so we can validate they're in range at insert-time instead of read-time
+            let datetime_fields = indexrel
                 .schema()?
                 .categorized_fields()
                 .iter()
@@ -134,7 +135,7 @@ impl InsertState {
                         )
                     )
                 })
-                .map(|(_, field)| field.attno)
+                .map(|(_, field)| (field.attno, field.base_oid, field.is_array))
                 .collect();
 
             InsertMode::Mutable(InsertModeMutable {
@@ -142,7 +143,7 @@ impl InsertState {
                 key_field_name,
                 key_field_attno,
                 row_limit: row_limit.into(),
-                datetime_field_attnos,
+                datetime_fields,
             })
         } else {
             InsertMode::Immutable(InsertModeImmutable::new(indexrel)?)
@@ -337,6 +338,12 @@ unsafe fn insert(
         InsertMode::Mutable(mode) => {
             if *isnull.add(mode.key_field_attno) {
                 panic!("{}", IndexError::KeyIdNull(mode.key_field_name.to_string()));
+            }
+
+            for (attno, typeoid) in mode.datetime_fields.iter() {
+                if *attno == 1 || typeoid.value() == pg_sys::Oid::INVALID {
+                    panic!("idk");
+                }
             }
 
             if mode.ctids.len() < mode.row_limit {

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -17,6 +17,8 @@
 
 use std::panic::{catch_unwind, resume_unwind};
 
+use crate::api::tokenizers::definitions::pdb::DatumWithType;
+use crate::api::tokenizers::{type_is_alias, type_is_tokenizer};
 use crate::api::FieldName;
 use crate::gucs;
 use crate::index::mvcc::MvccSatisfies;
@@ -28,10 +30,12 @@ use crate::postgres::storage::block::{
     MutableSegmentEntry, SegmentMetaEntry, SegmentMetaEntryContent, SegmentMetaEntryMutable,
 };
 use crate::postgres::storage::metadata::MetaPage;
+use crate::postgres::types::TantivyValue;
 use crate::postgres::utils::{
     collect_composites_for_unpacking, get_field_value, item_pointer_to_u64, row_to_search_document,
 };
 use crate::postgres::IsLogicalWorker;
+use crate::schema::FieldSource::{self};
 use crate::schema::{CategorizedFieldData, SearchField};
 
 use pgrx::{pg_guard, pg_sys, PgBuiltInOids, PgMemoryContexts, PgOid};
@@ -69,7 +73,7 @@ pub struct InsertModeMutable {
     key_field_name: FieldName,
     key_field_attno: usize,
     row_limit: usize,
-    datetime_fields: Vec<(usize, PgOid)>, // attnos & type OIDs of columns that are dates, so we can validate they're in range at insert-time instead of read-time
+    datetime_fields: Vec<CategorizedFieldData>, // For validation of datetime fields to ensure they're in range at insert-time instead of read-time
 }
 
 pub enum InsertMode {
@@ -122,6 +126,9 @@ impl InsertState {
                 .iter()
                 .filter(|(_, field)| {
                     matches!(
+                        field.source,
+                        FieldSource::Heap { .. } | FieldSource::Expression { .. }
+                    ) && matches!(
                         field.base_oid,
                         PgOid::BuiltIn(
                             PgBuiltInOids::DATEOID
@@ -135,7 +142,7 @@ impl InsertState {
                         )
                     )
                 })
-                .map(|(_, field)| (field.attno, field.base_oid, field.is_array))
+                .map(|(_, field)| field.clone())
                 .collect();
 
             InsertMode::Mutable(InsertModeMutable {
@@ -340,9 +347,24 @@ unsafe fn insert(
                 panic!("{}", IndexError::KeyIdNull(mode.key_field_name.to_string()));
             }
 
-            for (attno, typeoid) in mode.datetime_fields.iter() {
-                if *attno == 1 || typeoid.value() == pg_sys::Oid::INVALID {
-                    panic!("idk");
+            // Validating the datetime fields are in range
+            for categorized in mode.datetime_fields.iter() {
+                if !*isnull.add(categorized.attno) {
+                    let datum = if type_is_alias(categorized.pg_type.value())
+                        || type_is_tokenizer(categorized.pg_type.value())
+                    {
+                        DatumWithType::get_underlying_type(*values.add(categorized.attno)).0
+                    } else {
+                        *values.add(categorized.attno)
+                    };
+
+                    if categorized.is_array {
+                        TantivyValue::try_from_datum_array(datum, categorized.base_oid)
+                            .unwrap_or_else(|e| panic!("could not parse field: {e}"));
+                    } else {
+                        TantivyValue::try_from_datum(datum, categorized.base_oid)
+                            .unwrap_or_else(|e| panic!("could not parse field: {e}"));
+                    }
                 }
             }
 

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -34,7 +34,7 @@ use crate::postgres::utils::{
 use crate::postgres::IsLogicalWorker;
 use crate::schema::{CategorizedFieldData, SearchField};
 
-use pgrx::{pg_guard, pg_sys, PgMemoryContexts};
+use pgrx::{pg_guard, pg_sys, PgBuiltInOids, PgMemoryContexts, PgOid};
 use tantivy::index::SegmentId;
 use tantivy::TantivyDocument;
 
@@ -69,6 +69,7 @@ pub struct InsertModeMutable {
     key_field_name: FieldName,
     key_field_attno: usize,
     row_limit: usize,
+    datetime_field_attnos: Vec<usize>, // attnos of columns that are dates, so we can validate they're in range at insert-time instead of read-time
 }
 
 pub enum InsertMode {
@@ -114,11 +115,34 @@ impl InsertState {
                 })
                 .expect("No key field defined.");
 
+            let datetime_field_attnos = indexrel
+                .schema()?
+                .categorized_fields()
+                .iter()
+                .filter(|(_, field)| {
+                    matches!(
+                        field.base_oid,
+                        PgOid::BuiltIn(
+                            PgBuiltInOids::DATEOID
+                                | PgBuiltInOids::DATERANGEOID
+                                | PgBuiltInOids::TIMESTAMPOID
+                                | PgBuiltInOids::TSRANGEOID
+                                | PgBuiltInOids::TIMESTAMPTZOID
+                                | pg_sys::BuiltinOid::TSTZRANGEOID
+                                | PgBuiltInOids::TIMEOID
+                                | PgBuiltInOids::TIMETZOID
+                        )
+                    )
+                })
+                .map(|(_, field)| field.attno)
+                .collect();
+
             InsertMode::Mutable(InsertModeMutable {
                 ctids: Vec::new(),
                 key_field_name,
                 key_field_attno,
                 row_limit: row_limit.into(),
+                datetime_field_attnos,
             })
         } else {
             InsertMode::Immutable(InsertModeImmutable::new(indexrel)?)

--- a/pg_search/src/postgres/insert.rs
+++ b/pg_search/src/postgres/insert.rs
@@ -25,6 +25,7 @@ use crate::index::mvcc::MvccSatisfies;
 use crate::index::writer::index::{IndexError, IndexWriterConfig, SerialIndexWriter};
 use crate::postgres::composite::CompositeSlotValues;
 use crate::postgres::merge::{do_merge, MergeStyle};
+use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{
     MutableSegmentEntry, SegmentMetaEntry, SegmentMetaEntryContent, SegmentMetaEntryMutable,
@@ -347,7 +348,7 @@ unsafe fn insert(
                 panic!("{}", IndexError::KeyIdNull(mode.key_field_name.to_string()));
             }
 
-            // Validating the datetime fields are in range
+            // Validating the datetime fields are in range for Tantivy's nanosecond storage
             for categorized in mode.datetime_fields.iter() {
                 if !*isnull.add(categorized.attno) {
                     let datum = if type_is_alias(categorized.pg_type.value())
@@ -358,12 +359,20 @@ unsafe fn insert(
                         *values.add(categorized.attno)
                     };
 
-                    if categorized.is_array {
+                    let values_to_check: Vec<TantivyValue> = if categorized.is_array {
                         TantivyValue::try_from_datum_array(datum, categorized.base_oid)
-                            .unwrap_or_else(|e| panic!("could not parse field: {e}"));
+                            .unwrap_or_else(|e| panic!("could not parse field: {e}"))
                     } else {
-                        TantivyValue::try_from_datum(datum, categorized.base_oid)
-                            .unwrap_or_else(|e| panic!("could not parse field: {e}"));
+                        vec![TantivyValue::try_from_datum(datum, categorized.base_oid)
+                            .unwrap_or_else(|e| panic!("could not parse field: {e}"))]
+                    };
+
+                    for tv in values_to_check {
+                        if let PdbOwnedValue::Date(pg_dt) = tv.0 {
+                            let _: tantivy::DateTime = pg_dt.try_into().unwrap_or_else(|_| {
+                                panic!("could not parse field: date is outside DateTime range")
+                            });
+                        }
                     }
                 }
             }

--- a/tests/tests/datetime.rs
+++ b/tests/tests/datetime.rs
@@ -209,3 +209,71 @@ fn datetime_overflow_reports_error(
         "expected error for {col_type} value {val} beyond Tantivy nanosecond range"
     );
 }
+
+#[rstest]
+#[case::future_date("DATE", "'57439-03-01'")]
+#[case::ancient_date("DATE", "'0001-01-01'")]
+#[case::future_timestamp("TIMESTAMP", "'57439-03-01 00:00:00'")]
+#[case::ancient_timestamp("TIMESTAMP", "'0001-01-01 00:00:00'")]
+fn mutable_segment_rejects_out_of_range_datetime_at_insert(
+    mut conn: PgConnection,
+    #[case] col_type: &str,
+    #[case] val: &str,
+) {
+    format!(
+        r#"
+        CREATE TABLE mutable_overflow (id SERIAL, v {col_type});
+        CREATE INDEX mutable_overflow_idx ON mutable_overflow USING bm25 (id, v)
+            WITH (key_field = 'id', mutable_segment_rows = 1000);
+        INSERT INTO mutable_overflow (v) VALUES ('2000-01-01');
+        "#
+    )
+    .execute(&mut conn);
+
+    let result =
+        format!("INSERT INTO mutable_overflow (v) VALUES ({val})").execute_result(&mut conn);
+    assert!(
+        result.is_err(),
+        "expected INSERT to fail for {col_type} value {val} beyond Tantivy nanosecond range"
+    );
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM mutable_overflow WHERE id @@@ paradedb.all() ORDER BY id".fetch(&mut conn);
+    assert_eq!(
+        rows.len(),
+        1,
+        "valid rows should still be searchable after rejected insert"
+    );
+}
+
+#[rstest]
+#[case::date("DATE", "'1700-01-01'", "'1980-07-04'", "'2200-06-15'")]
+#[case::timestamp(
+    "TIMESTAMP",
+    "'1700-01-01 00:00:00'",
+    "'1980-07-04 12:30:00'",
+    "'2200-06-15 12:00:00'"
+)]
+fn mutable_segment_accepts_valid_wide_range_datetime(
+    mut conn: PgConnection,
+    #[case] col_type: &str,
+    #[case] val1: &str,
+    #[case] val2: &str,
+    #[case] val3: &str,
+) {
+    format!(
+        r#"
+        CREATE TABLE mutable_valid (id SERIAL, v {col_type});
+        CREATE INDEX mutable_valid_idx ON mutable_valid USING bm25 (id, v)
+            WITH (key_field = 'id', mutable_segment_rows = 1000);
+        INSERT INTO mutable_valid (v) VALUES ({val1});
+        INSERT INTO mutable_valid (v) VALUES ({val2});
+        INSERT INTO mutable_valid (v) VALUES ({val3});
+        "#
+    )
+    .execute(&mut conn);
+
+    let rows: Vec<(i32,)> =
+        "SELECT id FROM mutable_valid WHERE id @@@ paradedb.all() ORDER BY id".fetch(&mut conn);
+    assert_eq!(rows.len(), 3);
+}


### PR DESCRIPTION
Big thanks to @santoshakil for the original implementation and idea!

# Ticket(s) Closed

- Closes #3579 

## What

Validate datetime fields at INSERT time for mutable segments, preventing out-of-range dates from silently corrupting the index.

## Why

Mutable segments only store the row's `ctid` at INSERT time—they defer all field conversion to read time. This means the overflow checks added in #4156 never run during mutable inserts. Out-of-range dates (e.g. year 57439, year 0001) are silently accepted, then on the first `SELECT` the deferred conversion overflows and the **entire index breaks**—even valid rows become unsearchable.

## How

Pre-compute a `datetime_fields` vec at index init time containing only datetime-typed fields (`DATE`, `TIMESTAMP`, `TIMESTAMPTZ`, `TIME`, `TIMETZ`, and their range variants) with `Heap` or `Expression` sources. At each mutable INSERT, iterate this vec and call `TantivyValue::try_from_datum` on non-null datetime datums—this runs `checked_mul` (pure integer arithmetic, no allocation) and fails immediately with a clear error if the value overflows Tantivy's i64 nanosecond range.

Tables without datetime columns have an empty validation vec, adding no overhead.

Note: only collects fields with FieldSource::Heap or Expression source (not CompositeField, those store the entire composite blob at values[attno], not the individual field)

Why only datetime types?
All other PostgreSQL types (bool, int, float, text, json, numeric, uuid, inet, enum) have infallible conversions in try_from_datum for valid Postgres data. Only the 8 datetime types hit checked_mul which can overflow.



### Performance

Benchmarked with 10k mutable inserts (release build, 5 runs averaged):

| Scenario | Baseline (main) | With Fix | Overhead |
|---|---|---|---|
| Table WITH date column | ~27.4ms | ~29.0ms | +6% |
| Table WITHOUT date columns | ~26.1ms | ~25.9ms | ~0% |

## Tests

- `mutable_segment_rejects_out_of_range_datetime_at_insert` — creates index first, then attempts INSERT of out-of-range date/timestamp values; asserts INSERT fails and valid rows remain searchable
- `mutable_segment_accepts_valid_wide_range_datetime` — verifies wide-range dates (1700, 1980, 2200) are accepted and searchable through the mutable insert path
- All existing datetime tests continue to pass