### PR TITLE
fix: route more_like_this document path correctly when fields is provided

### DIFF
--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -111,3 +111,6 @@ FROM (SELECT relname,
       ORDER BY relname , low DESC ) AS x ;
 
 GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;
+
+DROP FUNCTION IF EXISTS pdb.more_like_this(document text, min_doc_frequency pg_catalog.int4, max_doc_frequency pg_catalog.int4, min_term_frequency pg_catalog.int4, max_query_terms pg_catalog.int4, min_word_length pg_catalog.int4, max_word_length pg_catalog.int4, boost_factor pg_catalog.float4, stopwords text[]);
+CREATE OR REPLACE FUNCTION pdb.more_like_this(document text, fields text[] DEFAULT NULL, min_doc_frequency pg_catalog.int4 DEFAULT NULL, max_doc_frequency pg_catalog.int4 DEFAULT NULL, min_term_frequency pg_catalog.int4 DEFAULT NULL, max_query_terms pg_catalog.int4 DEFAULT NULL, min_word_length pg_catalog.int4 DEFAULT NULL, max_word_length pg_catalog.int4 DEFAULT NULL, boost_factor pg_catalog.float4 DEFAULT NULL, stopwords text[] DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'more_like_this_fields_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;

--- a/pg_search/src/api/builder_fns/mlt.rs
+++ b/pg_search/src/api/builder_fns/mlt.rs
@@ -33,6 +33,7 @@ mod pdb {
     #[pg_extern(name = "more_like_this", immutable, parallel_safe)]
     pub fn more_like_this_fields(
         document: String,
+        fields: default!(Option<Vec<String>>, "NULL"),
         min_doc_frequency: default!(Option<i32>, "NULL"),
         max_doc_frequency: default!(Option<i32>, "NULL"),
         min_term_frequency: default!(Option<i32>, "NULL"),
@@ -56,7 +57,7 @@ mod pdb {
             stopwords,
             document: Some(document.into_iter().collect()),
             key_value: None,
-            fields: None,
+            fields: fields.map(|f| f.into_iter().collect()),
         }
     }
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -1216,9 +1216,14 @@ impl SearchQueryInput {
                             None => Box::new(EmptyQuery) as Box<dyn TantivyQuery>,
                         }
                     }
-                    (None, None, Some(doc)) => {
+                    (None, fields_ref, Some(doc)) => {
                         let mut fields_map = HashMap::default();
                         for (field, mut value) in doc.clone() {
+                            if let Some(fields) = fields_ref {
+                                if !fields.contains(&field) {
+                                    continue;
+                                }
+                            }
                             let search_field = schema
                                 .search_field(&field)
                                 .ok_or(QueryError::NonIndexedField(field.into()))?;

--- a/pg_search/tests/pg_regress/expected/more_like_this.out
+++ b/pg_search/tests/pg_regress/expected/more_like_this.out
@@ -125,6 +125,23 @@ SELECT * from mlt where id @@@ pdb.more_like_this(1, ARRAY['text_field_a'], max_
   4 | aaa aaa      | baz baz      |             3 | {"color": "aaa aaa"}
 (3 rows)
 
+-- Document path with additional options
+SELECT * FROM mlt WHERE id @@@ pdb.more_like_this('{"text_field_a":"aaa"}', min_term_frequency => 1, min_doc_frequency => 1);
+ id | text_field_a | text_field_b | numeric_field |        json_field        
+----+--------------+--------------+---------------+--------------------------
+  1 | aaa bbb ccc  | foo bar      |             1 | {"color": "aaa bbb ccc"}
+  2 | aaa aaa      | baz baz      |             1 | {"color": "aaa aaa"}
+  4 | aaa aaa      | baz baz      |             3 | {"color": "aaa aaa"}
+(3 rows)
+
+-- Document path with fields filter
+SELECT * FROM mlt WHERE id @@@ pdb.more_like_this('{"text_field_a":"aaa", "text_field_b":"foo"}', ARRAY['text_field_b'], min_term_frequency => 1, min_doc_frequency => 1);
+ id | text_field_a | text_field_b | numeric_field |        json_field        
+----+--------------+--------------+---------------+--------------------------
+  1 | aaa bbb ccc  | foo bar      |             1 | {"color": "aaa bbb ccc"}
+  3 | ddd eee fff  | foo foo foo  |             2 | {"color": "ddd eee fff"}
+(2 rows)
+
 -- JSON not supported
 SELECT * FROM mlt where id @@@ pdb.more_like_this(1, ARRAY['json_field']);
 ERROR:  json fields are not supported for more_like_this

--- a/pg_search/tests/pg_regress/sql/more_like_this.sql
+++ b/pg_search/tests/pg_regress/sql/more_like_this.sql
@@ -43,6 +43,12 @@ SELECT * from mlt where id @@@ pdb.more_like_this(1, ARRAY['text_field_a'], stop
 -- Max query terms
 SELECT * from mlt where id @@@ pdb.more_like_this(1, ARRAY['text_field_a'], max_query_terms => 2);
 
+-- Document path with additional options
+SELECT * FROM mlt WHERE id @@@ pdb.more_like_this('{"text_field_a":"aaa"}', min_term_frequency => 1, min_doc_frequency => 1);
+
+-- Document path with fields filter
+SELECT * FROM mlt WHERE id @@@ pdb.more_like_this('{"text_field_a":"aaa", "text_field_b":"foo"}', ARRAY['text_field_b'], min_term_frequency => 1, min_doc_frequency => 1);
+
 -- JSON not supported
 SELECT * FROM mlt where id @@@ pdb.more_like_this(1, ARRAY['json_field']);
 -- Document ID doesn't exist


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5147 

## What
Added `fields` parameter to the `more_like_this` document-path overload, allowing callers to restrict which fields from the document JSON are used for similarity matching.

## Why

Calling `pdb.more_like_this` with a document JSON and a `fields` array produced:

```
XX000: more_like_this: should be able to convert key value to datum: UnsupportedIntoConversion("i32")
```

The root cause was a missing `fields` parameter in the document-path overload (`more_like_this_fields`). Without it, the second positional slot in `more_like_this_fields` was `min_doc_frequency int32`. Postgres eliminated `more_like_this_fields`  because `text[]` cannot be implicitly cast to `int32`, leaving `more_like_this_id(anyelement, text[])` as the only candidate. The JSON document string was then treated as a key value, and converting it to the table's integer primary key type failed with `UnsupportedIntoConversion("i32")`.

A secondary issue: the match arm for the document path in `query/mod.rs` was `(None, None, Some(doc))` and would panic if `fields` was also `Some`, so fixing the routing alone was not sufficient.

## How
- Added `fields: default!(Option<Vec<String>>, "NULL")` at position 2 in more_like_this_fields `(api/builder_fns/mlt.rs)`
- Changed the document path match arm in `query/mod.rs` from `(None, None, Some(doc))` to `(None, fields_ref, Some(doc)).` When `fields_ref` is `Some`, only document keys present in the list are included in the similarity query.

## Tests
Added two regression tests in `more_like_this.sql` :
- Document path with named options `(min_term_frequency, min_doc_frequency)`, confirms no panic
- Document path with fields filter which confirms only the specified field from the document is used for similarity