### PR TITLE
ci(docs): exclude joined-scores snippet from doc smoke test

### DIFF
--- a/.github/scripts/extract_code_snippets.py
+++ b/.github/scripts/extract_code_snippets.py
@@ -21,6 +21,15 @@ IGNORED_CODEGROUPS = {
     # CodeGroup is used here to switch between Chinese, Korean, and Japanese
     # not SQL vs ORMs
     "documentation__tokenizers__available-tokenizers__lindera__group-001",
+    # The "Joined Scores" example orders by a summed BM25 score
+    # (pdb.score(o.order_id) + pdb.score(m.id)) across a join. This is a valid,
+    # correct query, but since join custom scans are enabled by default it
+    # declines JoinScan and emits the informational "JoinScan not used: ORDER BY
+    # columns must be fast fields" planner warning (combined-score sort keys are
+    # not fast fields). The smoke test treats any WARNING as a failure, so this
+    # group is excluded. See joinscan_sortby_score.out for the tested behavior.
+    # Tracked in https://github.com/paradedb/paradedb/issues/5296.
+    "documentation__sorting__score__group-003",
 }
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent


### PR DESCRIPTION
## Summary

Fixes the failing **Test ParadeDB (Docs)** → *Smoke Test Code Snippets* job ([run 27244623856](https://github.com/paradedb/paradedb/actions/runs/27244623856/job/80455768284)).

## Root cause

The "Joined Scores" example in `docs/documentation/sorting/score.mdx` ranks by a **summed** BM25 score across a join:

```sql
SELECT o.order_id, o.customer_name, m.description, pdb.score(o.order_id) + pdb.score(m.id) as score
FROM orders o JOIN mock_items m ON o.product_id = m.id
WHERE o.customer_name ||| 'Johnson' AND m.description ||| 'running shoes'
ORDER BY score DESC, o.order_id
LIMIT 5;
```

Since #5252 enabled join custom scans **by default**, this (valid) query now attempts JoinScan, declines it because combined-score sort keys are not fast fields, and emits the informational planner warning:

```
WARNING:  JoinScan not used: ORDER BY columns must be fast fields (tables: m, o)
```

The snippet smoke test treats **any** `WARNING:` as a failure, so Test Docs went red. The query itself runs correctly — this is intended, tested behavior (see `pg_search/tests/pg_regress/expected/joinscan_sortby_score.out`, which asserts the same warning for a summed-score join `ORDER BY`).

## Fix

Add `documentation__sorting__score__group-003` to the existing `IGNORED_CODEGROUPS` allowlist in `extract_code_snippets.py`, with a comment explaining why. This is the established mechanism for snippets that can't pass the strict smoke test; it's narrowly scoped to this one CodeGroup and changes neither the engine nor the documented example.

## Notes

This is independent of #5228 (extension image) — it's a main-wide docs CI regression from #5252. Merging it unblocks Test Docs on every open PR (including #5228).