### PR TITLE
fix(joinscan): canonicalize JOIN_RIGHT_SEMI/ANTI in multi-way reconstruction (#4779)

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -264,6 +264,16 @@ impl JoinKeyPair {
             None
         }
     }
+
+    /// Flip the outer/inner orientation of this key. Used when a join node's
+    /// two children are swapped (e.g. canonicalizing `RightSemi` to `Semi` in
+    /// [`JoinNode::canonicalize_orientation`]); the key still describes the same
+    /// equality, just from the mirrored side. `type_oid`/`typlen`/`typbyval`
+    /// describe the (single) key type and are unaffected by which side is outer.
+    pub fn swap_sides(&mut self) {
+        std::mem::swap(&mut self.outer_rti, &mut self.inner_rti);
+        std::mem::swap(&mut self.outer_attno, &mut self.inner_attno);
+    }
 }
 
 /// A join-level search predicate - a search query that applies to a specific relation.
@@ -707,6 +717,36 @@ pub struct JoinNode {
     /// planning pass and never reach the serialized plan.
     #[serde(skip)]
     pub absorbed_search_clauses: Vec<*mut pg_sys::RestrictInfo>,
+}
+
+impl JoinNode {
+    /// Rewrite a right-oriented semi/anti join into its left-oriented twin in
+    /// place: swap the children, flip each equi-key, relabel (`RightSemi` ->
+    /// `Semi`, `RightAnti` -> `Anti`). Non-recursive, so the children must
+    /// already be canonical (reconstruction calls this per level, child-first).
+    ///
+    /// PG emits the right-oriented form (joinrels.c) when its hash-join cost
+    /// model prefers to hash the preserved side -- a physical choice JoinScan
+    /// discards, since it joins BM25 indexes in DataFusion rather than via PG's
+    /// hash table. A right-semi is just a left-semi with the inputs swapped
+    /// (same rows, same key). The swap restores the `left == preserved side`
+    /// invariant that [`RelNode::output_sources`], visibility filtering, and
+    /// parallel partitioning (forced to index 0) assume; without it the
+    /// reconstructed join is rejected by [`RelNode::unsupported_join_types`].
+    /// `RightMark` is left as-is -- it comes from disjunctive decorrelation,
+    /// not a hash-orientation choice. See issue #4779.
+    pub(crate) fn canonicalize_orientation(&mut self) {
+        let canonical = match self.join_type {
+            JoinType::RightSemi => JoinType::Semi,
+            JoinType::RightAnti => JoinType::Anti { null_aware: false },
+            _ => return,
+        };
+        std::mem::swap(&mut self.left, &mut self.right);
+        for key in &mut self.equi_keys {
+            key.swap_sides();
+        }
+        self.join_type = canonical;
+    }
 }
 
 /// A filter node in the relational plan tree.
@@ -1576,4 +1616,141 @@ pub unsafe fn lookup_base_rel_info(
     let bm25_index = rel_get_bm25_index(relid).map(|(_, idx)| idx);
 
     Some((relid, alias, bm25_index))
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use crate::scan::info::ScanInfo;
+    use pgrx::prelude::*;
+
+    /// A bare base-relation scan identified only by its RTI; enough to verify
+    /// child ordering after a swap.
+    fn scan(rti: pg_sys::Index) -> RelNode {
+        RelNode::Scan(Box::new(JoinSource {
+            plan_position: rti as usize,
+            root_id: None,
+            scan_info: ScanInfo {
+                heap_rti: rti,
+                ..Default::default()
+            },
+        }))
+    }
+
+    /// An equi-key `outer.attno1 == inner.attno2` (distinct attnos so the
+    /// orientation flip is observable).
+    fn key(outer_rti: pg_sys::Index, inner_rti: pg_sys::Index) -> JoinKeyPair {
+        JoinKeyPair {
+            outer_rti,
+            outer_attno: 1,
+            inner_rti,
+            inner_attno: 2,
+            type_oid: pg_sys::Oid::INVALID,
+            typlen: 4,
+            typbyval: true,
+        }
+    }
+
+    /// Build a `JoinNode` directly -- canonicalization operates per node, the
+    /// same primitive reconstruction calls bottom-up.
+    fn jnode(jt: JoinType, left: RelNode, right: RelNode, keys: Vec<JoinKeyPair>) -> JoinNode {
+        JoinNode {
+            join_type: jt,
+            left,
+            right,
+            equi_keys: keys,
+            filter: None,
+            subplan_id: None,
+            absorbed_search_clauses: Vec::new(),
+        }
+    }
+
+    fn rti_of(node: &RelNode) -> pg_sys::Index {
+        match node {
+            RelNode::Scan(s) => s.scan_info.heap_rti,
+            _ => panic!("expected a Scan node"),
+        }
+    }
+
+    #[pg_test]
+    fn swap_sides_flips_only_orientation() {
+        let mut k = key(2, 1);
+        k.swap_sides();
+        assert_eq!(k.outer_rti, 1);
+        assert_eq!(k.outer_attno, 2);
+        assert_eq!(k.inner_rti, 2);
+        assert_eq!(k.inner_attno, 1);
+        // Type metadata is a property of the key, not of which side is outer.
+        assert_eq!(k.typlen, 4);
+        assert!(k.typbyval);
+    }
+
+    #[pg_test]
+    fn right_semi_becomes_semi_with_preserved_side_on_left() {
+        // PG hands us RightSemi(outer=a/rti2, inner=m/rti1); the preserved side
+        // (the rows that survive) is m, on the *right*.
+        let mut j = jnode(JoinType::RightSemi, scan(2), scan(1), vec![key(2, 1)]);
+        j.canonicalize_orientation();
+        assert!(matches!(j.join_type, JoinType::Semi));
+        assert_eq!(rti_of(&j.left), 1); // preserved side (m) now on the left
+        assert_eq!(rti_of(&j.right), 2);
+        // equi-key orientation flipped to match the swap
+        let k = &j.equi_keys[0];
+        assert_eq!((k.outer_rti, k.outer_attno), (1, 2));
+        assert_eq!((k.inner_rti, k.inner_attno), (2, 1));
+    }
+
+    #[pg_test]
+    fn right_anti_becomes_non_null_aware_anti() {
+        let mut j = jnode(JoinType::RightAnti, scan(2), scan(1), vec![key(2, 1)]);
+        j.canonicalize_orientation();
+        assert!(matches!(j.join_type, JoinType::Anti { null_aware: false }));
+        assert_eq!(rti_of(&j.left), 1);
+        assert_eq!(rti_of(&j.right), 2);
+        let k = &j.equi_keys[0];
+        assert_eq!((k.outer_rti, k.outer_attno), (1, 2));
+        assert_eq!((k.inner_rti, k.inner_attno), (2, 1));
+    }
+
+    #[pg_test]
+    fn canonicalizes_a_nested_right_semi_child_bottom_up() {
+        // Mirror how reconstruction canonicalizes: each level as it is built,
+        // children first. Semi( RightSemi(a, m), b ) must become
+        // Semi( Semi(m, a), b ) so the whole tree is left-preserved.
+        let mut inner = jnode(JoinType::RightSemi, scan(2), scan(1), vec![key(2, 1)]);
+        inner.canonicalize_orientation();
+        let mut top = jnode(
+            JoinType::Semi,
+            RelNode::Join(Box::new(inner)),
+            scan(3),
+            vec![key(1, 3)],
+        );
+        top.canonicalize_orientation();
+        let plan = RelNode::Join(Box::new(top));
+
+        let RelNode::Join(t) = &plan else {
+            panic!("expected top Join")
+        };
+        assert!(matches!(t.join_type, JoinType::Semi));
+        assert_eq!(rti_of(&t.right), 3);
+        let RelNode::Join(child) = &t.left else {
+            panic!("expected inner Join")
+        };
+        assert!(matches!(child.join_type, JoinType::Semi));
+        assert_eq!(rti_of(&child.left), 1);
+        assert_eq!(rti_of(&child.right), 2);
+        // No right-oriented join may survive anywhere in the tree.
+        assert!(plan.unsupported_join_types().is_empty());
+    }
+
+    #[pg_test]
+    fn leaves_left_oriented_joins_untouched() {
+        let mut j = jnode(JoinType::Semi, scan(1), scan(2), vec![key(1, 2)]);
+        j.canonicalize_orientation();
+        assert!(matches!(j.join_type, JoinType::Semi));
+        assert_eq!(rti_of(&j.left), 1);
+        assert_eq!(rti_of(&j.right), 2);
+        assert_eq!((j.equi_keys[0].outer_rti, j.equi_keys[0].inner_rti), (1, 2));
+    }
 }

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -708,7 +708,7 @@ unsafe fn collect_join_sources_join_rel(
             return None;
         }
 
-        let join_node = crate::postgres::customscan::joinscan::build::JoinNode {
+        let mut join_node = crate::postgres::customscan::joinscan::build::JoinNode {
             join_type: parsed_jointype,
             left: outer_node,
             right: inner_node,
@@ -719,6 +719,15 @@ unsafe fn collect_join_sources_join_rel(
         };
 
         keys.extend(join_conditions.equi_keys);
+
+        // If PG planned this sub-join right-oriented, rewrite it to its left
+        // twin (rationale on `JoinNode::canonicalize_orientation`). Per level,
+        // not recursive: `outer_node`/`inner_node` are already canonical from
+        // the collect_join_sources recursion above. Only reconstruction needs
+        // it -- the direct set_join_pathlist_hook invocation for a right join is
+        // redundant with the sibling left invocation PG also emits, so doing it
+        // there would only add a duplicate path.
+        join_node.canonicalize_orientation();
 
         return Some((RelNode::Join(Box::new(join_node)), keys));
     }

--- a/pg_search/tests/pg_regress/expected/issue_4779.out
+++ b/pg_search/tests/pg_regress/expected/issue_4779.out
@@ -1,0 +1,210 @@
+-- Regression test for issue paradedb/paradedb#4779:
+-- "JoinScan: multi-way semi/anti joins fail due to premature LIMIT pushdown
+-- validation" -- the serial-mode failure.
+--
+-- Root cause (verified): for a 2-way semijoin, PostgreSQL's make_join_rel
+-- calls add_paths_to_joinrel in BOTH orientations -- JOIN_SEMI and
+-- JOIN_RIGHT_SEMI (joinrels.c). When the *preserved* side (here `main`) is
+-- the smaller relation, PG's serial hash-join cost model picks the
+-- JOIN_RIGHT_SEMI shape (hash the small side) as the child's
+-- cheapest_total_path. JoinScan's multi-way reconstruction read that
+-- jointype and, because RightSemi was not in its supported set, declined --
+-- so the 3-way JoinScan fell back to native Hash (Right) Semi Join chains.
+-- JOIN_RIGHT_SEMI is a PG18 plan shape, so this only reproduces on pg18.
+-- Parallel mode was unaffected (partial hash joins exclude JOIN_RIGHT_SEMI,
+-- so the child's parallel-safe cheapest path is plain JOIN_SEMI), which is
+-- why issue #4910 did not close this one.
+--
+-- The fix canonicalizes RightSemi/RightAnti into Semi/Anti (swapping the
+-- children + equi-key orientation) so the preserved side is always the left
+-- child and the existing Semi/Anti path handles it.
+--
+-- This mirrors the issue's exact repro (preserved side of 100 rows, each
+-- EXISTS child 200 rows) under default join GUCs: the @@@ index scans on the
+-- children make PG's serial cost model pick the hash right-semi orientation
+-- naturally, so JoinScan's reconstruction hits JOIN_RIGHT_SEMI.
+SET client_min_messages TO WARNING;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS t_main_4779, t_a_4779, t_b_4779 CASCADE;
+CREATE TABLE t_main_4779 (id bigint PRIMARY KEY, val text)
+  WITH (autovacuum_enabled = false);
+CREATE TABLE t_a_4779 (id bigint PRIMARY KEY, main_id bigint)
+  WITH (autovacuum_enabled = false);
+CREATE TABLE t_b_4779 (id bigint PRIMARY KEY, main_id bigint)
+  WITH (autovacuum_enabled = false);
+INSERT INTO t_main_4779 SELECT i, 'val_' || i FROM generate_series(1, 100) i;
+INSERT INTO t_a_4779 SELECT i, (i % 100) + 1 FROM generate_series(1, 200) i;
+INSERT INTO t_b_4779 SELECT i, (i % 100) + 1 FROM generate_series(1, 200) i;
+CREATE INDEX t_main_4779_idx ON t_main_4779
+  USING bm25 (id, (val::pdb.literal)) WITH (key_field = 'id');
+CREATE INDEX t_a_4779_idx ON t_a_4779
+  USING bm25 (id, main_id) WITH (key_field = 'id');
+CREATE INDEX t_b_4779_idx ON t_b_4779
+  USING bm25 (id, main_id) WITH (key_field = 'id');
+ANALYZE t_main_4779;
+ANALYZE t_a_4779;
+ANALYZE t_b_4779;
+SET paradedb.enable_join_custom_scan TO on;
+SET work_mem = '1GB';
+-- ============================================================
+-- Serial mode: the originally failing case (issue's repro).
+-- ============================================================
+SET max_parallel_workers_per_gather = 0;
+-- Two EXISTS subqueries -> two semijoins over the small `main` table.
+-- Pre-fix: declined (Hash Semi Join over Hash Right Semi Join), with planner
+-- warnings about RIGHTSEMI and unsafe LIMIT pushdown. Post-fix: a single
+-- ParadeDB Join Scan absorbing all three relations with the LIMIT pushed down.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: (m SEMI b) SEMI a
+         Join Cond: m.id = a.main_id, b.main_id = m.id
+         Limit: 10
+         Order By: m.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[m]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(18 rows)
+
+-- Rows with JoinScan on (verifies correctness, not just plan shape).
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+ id  
+-----
+ 100
+  99
+  98
+  97
+  96
+  95
+  94
+  93
+  92
+  91
+(10 rows)
+
+-- Native PG control (JoinScan off): same rows must come back.
+SET paradedb.enable_join_custom_scan TO off;
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+ id  
+-----
+ 100
+  99
+  98
+  97
+  96
+  95
+  94
+  93
+  92
+  91
+(10 rows)
+
+SET paradedb.enable_join_custom_scan TO on;
+-- EXISTS + NOT EXISTS: exercises the anti side (RightAnti canonicalization)
+-- in the same serial, small-preserved-side regime.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND NOT EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: (m ANTI b) SEMI a
+         Join Cond: m.id = a.main_id, b.main_id = m.id
+         Limit: 10
+         Order By: m.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[m]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@1, main_id@0)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(18 rows)
+
+-- ============================================================
+-- Parallel mode: control. Worked pre-fix (issue #4910); guard against
+-- regressions in the simpler-to-reach parallel path.
+-- ============================================================
+SET min_parallel_table_scan_size = 0;
+SET min_parallel_index_scan_size = 0;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET max_parallel_workers_per_gather = 8;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: (m SEMI b) SEMI a
+         Join Cond: m.id = a.main_id, b.main_id = m.id
+         Limit: 10
+         Order By: m.id desc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[m]
+           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(18 rows)
+
+DROP TABLE t_main_4779, t_a_4779, t_b_4779 CASCADE;

--- a/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
+++ b/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
@@ -111,7 +111,7 @@ AND EXISTS(
     )
 )
 ORDER BY u.id;
-WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, id, t, ti)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, id, t, ti, u)
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: d, id, t, ti, u)
  id | name 
 ----+------

--- a/pg_search/tests/pg_regress/sql/issue_4779.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4779.sql
@@ -1,0 +1,115 @@
+-- Regression test for issue paradedb/paradedb#4779:
+-- "JoinScan: multi-way semi/anti joins fail due to premature LIMIT pushdown
+-- validation" -- the serial-mode failure.
+--
+-- Root cause (verified): for a 2-way semijoin, PostgreSQL's make_join_rel
+-- calls add_paths_to_joinrel in BOTH orientations -- JOIN_SEMI and
+-- JOIN_RIGHT_SEMI (joinrels.c). When the *preserved* side (here `main`) is
+-- the smaller relation, PG's serial hash-join cost model picks the
+-- JOIN_RIGHT_SEMI shape (hash the small side) as the child's
+-- cheapest_total_path. JoinScan's multi-way reconstruction read that
+-- jointype and, because RightSemi was not in its supported set, declined --
+-- so the 3-way JoinScan fell back to native Hash (Right) Semi Join chains.
+-- JOIN_RIGHT_SEMI is a PG18 plan shape, so this only reproduces on pg18.
+-- Parallel mode was unaffected (partial hash joins exclude JOIN_RIGHT_SEMI,
+-- so the child's parallel-safe cheapest path is plain JOIN_SEMI), which is
+-- why issue #4910 did not close this one.
+--
+-- The fix canonicalizes RightSemi/RightAnti into Semi/Anti (swapping the
+-- children + equi-key orientation) so the preserved side is always the left
+-- child and the existing Semi/Anti path handles it.
+--
+-- This mirrors the issue's exact repro (preserved side of 100 rows, each
+-- EXISTS child 200 rows) under default join GUCs: the @@@ index scans on the
+-- children make PG's serial cost model pick the hash right-semi orientation
+-- naturally, so JoinScan's reconstruction hits JOIN_RIGHT_SEMI.
+
+SET client_min_messages TO WARNING;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS t_main_4779, t_a_4779, t_b_4779 CASCADE;
+
+CREATE TABLE t_main_4779 (id bigint PRIMARY KEY, val text)
+  WITH (autovacuum_enabled = false);
+CREATE TABLE t_a_4779 (id bigint PRIMARY KEY, main_id bigint)
+  WITH (autovacuum_enabled = false);
+CREATE TABLE t_b_4779 (id bigint PRIMARY KEY, main_id bigint)
+  WITH (autovacuum_enabled = false);
+
+INSERT INTO t_main_4779 SELECT i, 'val_' || i FROM generate_series(1, 100) i;
+INSERT INTO t_a_4779 SELECT i, (i % 100) + 1 FROM generate_series(1, 200) i;
+INSERT INTO t_b_4779 SELECT i, (i % 100) + 1 FROM generate_series(1, 200) i;
+
+CREATE INDEX t_main_4779_idx ON t_main_4779
+  USING bm25 (id, (val::pdb.literal)) WITH (key_field = 'id');
+CREATE INDEX t_a_4779_idx ON t_a_4779
+  USING bm25 (id, main_id) WITH (key_field = 'id');
+CREATE INDEX t_b_4779_idx ON t_b_4779
+  USING bm25 (id, main_id) WITH (key_field = 'id');
+
+ANALYZE t_main_4779;
+ANALYZE t_a_4779;
+ANALYZE t_b_4779;
+
+SET paradedb.enable_join_custom_scan TO on;
+SET work_mem = '1GB';
+
+-- ============================================================
+-- Serial mode: the originally failing case (issue's repro).
+-- ============================================================
+SET max_parallel_workers_per_gather = 0;
+
+-- Two EXISTS subqueries -> two semijoins over the small `main` table.
+-- Pre-fix: declined (Hash Semi Join over Hash Right Semi Join), with planner
+-- warnings about RIGHTSEMI and unsafe LIMIT pushdown. Post-fix: a single
+-- ParadeDB Join Scan absorbing all three relations with the LIMIT pushed down.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+
+-- Rows with JoinScan on (verifies correctness, not just plan shape).
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+
+-- Native PG control (JoinScan off): same rows must come back.
+SET paradedb.enable_join_custom_scan TO off;
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+SET paradedb.enable_join_custom_scan TO on;
+
+-- EXISTS + NOT EXISTS: exercises the anti side (RightAnti canonicalization)
+-- in the same serial, small-preserved-side regime.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND NOT EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+
+-- ============================================================
+-- Parallel mode: control. Worked pre-fix (issue #4910); guard against
+-- regressions in the simpler-to-reach parallel path.
+-- ============================================================
+SET min_parallel_table_scan_size = 0;
+SET min_parallel_index_scan_size = 0;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET max_parallel_workers_per_gather = 8;
+
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT m.id FROM t_main_4779 m
+WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.all())
+  AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
+  AND m.id @@@ pdb.all()
+ORDER BY m.id DESC LIMIT 10;
+
+DROP TABLE t_main_4779, t_a_4779, t_b_4779 CASCADE;


### PR DESCRIPTION
## What

Fixes #4779. Multi-way semi/anti joins (two or more `EXISTS` / `NOT EXISTS`) failed to produce a `ParadeDB Join Scan` in **serial** mode on PG18 — the query fell back to native `Hash (Right) Semi Join` chains.

## Why

For a 2-way semijoin, PostgreSQL's `make_join_rel` calls `add_paths_to_joinrel` in **both** orientations — `JOIN_SEMI` and `JOIN_RIGHT_SEMI` (`joinrels.c`). When the *preserved* side is the smaller relation, the serial hash-join cost model picks the `JOIN_RIGHT_SEMI` shape as the child's `cheapest_total_path`. JoinScan's multi-way reconstruction read that jointype and, because `RightSemi` wasn't in its supported set, **declined**.

`JOIN_RIGHT_SEMI` is a PG18 plan shape, so this only reproduces on pg18. Parallel mode was unaffected because partial hash joins exclude `JOIN_RIGHT_SEMI` (which is why #4910 did not close this).

## How

`JoinNode::canonicalize_orientation` rewrites a right-oriented sub-join into its left twin (`RightSemi` → `Semi`, `RightAnti` → `Anti{null_aware:false}`) — swapping the children and flipping each equi-key's orientation. A right-semi is exactly a left-semi with the inputs swapped (same output rows, same equi-key); PG only distinguishes them to choose which side to hash, a physical detail JoinScan discards (it joins the BM25 indexes in DataFusion). The rewrite restores the `left == preserved side` invariant the rest of JoinScan relies on (`output_sources`, visibility filtering, parallel partitioning at index 0).

It is applied in **reconstruction only**: the direct `set_join_pathlist_hook` invocation for a right-oriented join is always redundant with the sibling `JOIN_SEMI`/`JOIN_ANTI` invocation PG also emits, so canonicalizing there would only add a duplicate path.

## Tests

- 5 `pg_test` units for the swap (`swap_sides`, RightSemi→Semi, RightAnti→Anti, nested bottom-up, left-untouched).
- `issue_4779` regress covering serial two-`EXISTS`, `EXISTS`+`NOT EXISTS`, and parallel.
- Full `pg_regress` suite: **282 passed, 0 failed**.

One adjacent, pre-existing bug surfaced during testing — `JOIN_UNIQUE_INNER` reconstruction drops the dedup and can duplicate the preserved side — is **out of scope** here and will be filed separately.

### Note on `or_exists_join_bug.out`
One decline-warning line gains a relation (`u`). The query still correctly declines (no `LIMIT`) with the identical native plan and rows; the warning lists the relations of the candidate plan, and the fix lets reconstruction assemble the full plan before the `LIMIT` gate rejects it — a more complete, still-accurate message.