### PR TITLE
perf: pre-tokenize match queries before parallel scan workers

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -403,8 +403,7 @@ impl SearchIndexReader {
             search_query_input,
             need_scores,
             mvcc_style,
-            expr_context,
-            planstate,
+            (expr_context, planstate),
             needs_tokenizer_manager,
             false,
         )
@@ -425,8 +424,7 @@ impl SearchIndexReader {
             search_query_input,
             need_scores,
             mvcc_style,
-            expr_context,
-            planstate,
+            (expr_context, planstate),
             needs_tokenizer_manager,
             true,
         )
@@ -437,8 +435,10 @@ impl SearchIndexReader {
         search_query_input: SearchQueryInput,
         need_scores: bool,
         mvcc_style: MvccSatisfies,
-        expr_context: Option<NonNull<pgrx::pg_sys::ExprContext>>,
-        planstate: Option<NonNull<pgrx::pg_sys::PlanState>>,
+        postgres_context: (
+            Option<NonNull<pgrx::pg_sys::ExprContext>>,
+            Option<NonNull<pgrx::pg_sys::PlanState>>,
+        ),
         needs_tokenizer_manager: bool,
         pretokenize_match_queries: bool,
     ) -> Result<(Self, SearchQueryInput)> {
@@ -474,8 +474,8 @@ impl SearchIndexReader {
                     &searcher,
                     index_relation.oid(),
                     index_relation.rel_oid(),
-                    expr_context,
-                    planstate,
+                    postgres_context.0,
+                    postgres_context.1,
                 )
                 .unwrap_or_else(|e| panic!("{e}"))
         };

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -398,6 +398,27 @@ impl SearchIndexReader {
         planstate: Option<NonNull<pgrx::pg_sys::PlanState>>,
         needs_tokenizer_manager: bool,
     ) -> Result<Self> {
+        let (reader, _) = Self::open_with_prepared_query(
+            index_relation,
+            search_query_input,
+            need_scores,
+            mvcc_style,
+            expr_context,
+            planstate,
+            needs_tokenizer_manager,
+        )?;
+        Ok(reader)
+    }
+
+    pub fn open_with_prepared_query(
+        index_relation: &PgSearchRelation,
+        search_query_input: SearchQueryInput,
+        need_scores: bool,
+        mvcc_style: MvccSatisfies,
+        expr_context: Option<NonNull<pgrx::pg_sys::ExprContext>>,
+        planstate: Option<NonNull<pgrx::pg_sys::PlanState>>,
+        needs_tokenizer_manager: bool,
+    ) -> Result<(Self, SearchQueryInput)> {
         let components =
             Self::open_index_components(index_relation, mvcc_style, needs_tokenizer_manager)?;
         let IndexComponents {
@@ -410,9 +431,12 @@ impl SearchIndexReader {
             schema,
         } = components;
 
+        let search_query_input =
+            search_query_input.pretokenize_match_queries(&schema, &searcher)?;
         let need_scores = need_scores || search_query_input.need_scores();
         let query = {
             search_query_input
+                .clone()
                 .into_tantivy_query(
                     &schema,
                     &|| {
@@ -436,19 +460,22 @@ impl SearchIndexReader {
             .map(|(ord, reader)| (reader.segment_id(), ord as SegmentOrdinal))
             .collect();
 
-        Ok(Self {
-            index_rel: index_relation.clone(),
-            searcher,
-            schema,
-            underlying_reader: reader,
-            underlying_index: index,
-            query,
-            need_scores,
-            total_segment_count,
-            total_docs,
-            segment_ordinal_by_id: segment_ord_by_id,
-            _cleanup_lock: cleanup_lock,
-        })
+        Ok((
+            Self {
+                index_rel: index_relation.clone(),
+                searcher,
+                schema,
+                underlying_reader: reader,
+                underlying_index: index,
+                query,
+                need_scores,
+                total_segment_count,
+                total_docs,
+                segment_ordinal_by_id: segment_ord_by_id,
+                _cleanup_lock: cleanup_lock,
+            },
+            search_query_input,
+        ))
     }
 
     pub fn segment_ids(&self) -> Vec<SegmentId> {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -398,7 +398,7 @@ impl SearchIndexReader {
         planstate: Option<NonNull<pgrx::pg_sys::PlanState>>,
         needs_tokenizer_manager: bool,
     ) -> Result<Self> {
-        let (reader, _) = Self::open_with_prepared_query(
+        Self::open_with_optional_prepared_query(
             index_relation,
             search_query_input,
             need_scores,
@@ -406,8 +406,9 @@ impl SearchIndexReader {
             expr_context,
             planstate,
             needs_tokenizer_manager,
-        )?;
-        Ok(reader)
+            false,
+        )
+        .map(|(reader, _)| reader)
     }
 
     pub fn open_with_prepared_query(
@@ -418,6 +419,28 @@ impl SearchIndexReader {
         expr_context: Option<NonNull<pgrx::pg_sys::ExprContext>>,
         planstate: Option<NonNull<pgrx::pg_sys::PlanState>>,
         needs_tokenizer_manager: bool,
+    ) -> Result<(Self, SearchQueryInput)> {
+        Self::open_with_optional_prepared_query(
+            index_relation,
+            search_query_input,
+            need_scores,
+            mvcc_style,
+            expr_context,
+            planstate,
+            needs_tokenizer_manager,
+            true,
+        )
+    }
+
+    fn open_with_optional_prepared_query(
+        index_relation: &PgSearchRelation,
+        search_query_input: SearchQueryInput,
+        need_scores: bool,
+        mvcc_style: MvccSatisfies,
+        expr_context: Option<NonNull<pgrx::pg_sys::ExprContext>>,
+        planstate: Option<NonNull<pgrx::pg_sys::PlanState>>,
+        needs_tokenizer_manager: bool,
+        pretokenize_match_queries: bool,
     ) -> Result<(Self, SearchQueryInput)> {
         let components =
             Self::open_index_components(index_relation, mvcc_style, needs_tokenizer_manager)?;
@@ -431,8 +454,11 @@ impl SearchIndexReader {
             schema,
         } = components;
 
-        let search_query_input =
-            search_query_input.pretokenize_match_queries(&schema, &searcher)?;
+        let search_query_input = if pretokenize_match_queries {
+            search_query_input.pretokenize_match_queries(&schema, &searcher)?
+        } else {
+            search_query_input
+        };
         let need_scores = need_scores || search_query_input.need_scores();
         let query = {
             search_query_input

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -1384,7 +1384,7 @@ impl CustomScan for BaseScan {
                 explainer.add_query(base_query);
             }
 
-            if explainer.is_analyze() {
+            if explainer.is_analyze() && state.custom_state().search_reader.is_some() {
                 let execution_query = state.custom_state().search_query_input();
                 if execution_query != base_query {
                     explainer.add_explainable("Prepared Tantivy Query", execution_query);

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -128,7 +128,7 @@ impl BaseScan {
         let needs_tokenizer_manager =
             search_query_input.needs_tokenizer() || state.custom_state().need_snippets();
 
-        let search_reader = SearchIndexReader::open_with_context(
+        let (search_reader, prepared_query) = SearchIndexReader::open_with_prepared_query(
             indexrel,
             search_query_input.clone(),
             need_scores,
@@ -154,6 +154,9 @@ impl BaseScan {
             needs_tokenizer_manager,
         )
         .expect("should be able to open the search index reader");
+        state
+            .custom_state_mut()
+            .set_search_query_input(prepared_query);
         state.custom_state_mut().search_reader = Some(search_reader);
 
         let csstate = addr_of_mut!(state.csstate);
@@ -1379,6 +1382,13 @@ impl CustomScan for BaseScan {
             } else {
                 // Regular display without estimates
                 explainer.add_query(base_query);
+            }
+
+            if explainer.is_analyze() {
+                let execution_query = state.custom_state().search_query_input();
+                if execution_query != base_query {
+                    explainer.add_explainable("Prepared Tantivy Query", execution_query);
+                }
             }
         } else {
             explainer.add_text("Tantivy Query", "(query not yet initialized)");

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -134,6 +134,10 @@ impl BaseScanState {
         self.base_search_query_input = input;
     }
 
+    pub fn set_search_query_input(&mut self, input: SearchQueryInput) {
+        self.search_query_input = input;
+    }
+
     pub fn search_query_input(&self) -> &SearchQueryInput {
         if matches!(self.search_query_input, SearchQueryInput::Uninitialized) {
             panic!("search_query_input should be initialized");

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -362,6 +362,72 @@ impl SearchQueryInput {
         }
     }
 
+    pub fn pretokenize_match_queries(
+        self,
+        schema: &SearchIndexSchema,
+        searcher: &Searcher,
+    ) -> Result<Self> {
+        let recurse = |query: SearchQueryInput| query.pretokenize_match_queries(schema, searcher);
+
+        match self {
+            SearchQueryInput::Boolean {
+                must,
+                should,
+                must_not,
+            } => Ok(SearchQueryInput::Boolean {
+                must: must.into_iter().map(recurse).collect::<Result<Vec<_>>>()?,
+                should: should
+                    .into_iter()
+                    .map(recurse)
+                    .collect::<Result<Vec<_>>>()?,
+                must_not: must_not
+                    .into_iter()
+                    .map(recurse)
+                    .collect::<Result<Vec<_>>>()?,
+            }),
+            SearchQueryInput::Boost { query, factor } => Ok(SearchQueryInput::Boost {
+                query: Box::new(recurse(*query)?),
+                factor,
+            }),
+            SearchQueryInput::ConstScore { query, score } => Ok(SearchQueryInput::ConstScore {
+                query: Box::new(recurse(*query)?),
+                score,
+            }),
+            SearchQueryInput::ScoreFilter { bounds, query } => Ok(SearchQueryInput::ScoreFilter {
+                bounds,
+                query: query
+                    .map(|query| recurse(*query).map(Box::new))
+                    .transpose()?,
+            }),
+            SearchQueryInput::DisjunctionMax {
+                disjuncts,
+                tie_breaker,
+            } => Ok(SearchQueryInput::DisjunctionMax {
+                disjuncts: disjuncts
+                    .into_iter()
+                    .map(recurse)
+                    .collect::<Result<Vec<_>>>()?,
+                tie_breaker,
+            }),
+            SearchQueryInput::WithIndex { oid, query } => Ok(SearchQueryInput::WithIndex {
+                oid,
+                query: Box::new(recurse(*query)?),
+            }),
+            SearchQueryInput::HeapFilter {
+                indexed_query,
+                field_filters,
+            } => Ok(SearchQueryInput::HeapFilter {
+                indexed_query: Box::new(recurse(*indexed_query)?),
+                field_filters,
+            }),
+            SearchQueryInput::FieldedQuery { field, query } => Ok(SearchQueryInput::FieldedQuery {
+                query: query.pretokenize_match_queries(&field, schema, searcher)?,
+                field,
+            }),
+            other => Ok(other),
+        }
+    }
+
     /// Returns `true` if constructing a Tantivy Scorer for this query would be expensive.
     /// Used by `estimate_selectivity` to short-circuit and return a heuristic instead.
     pub fn is_expensive_to_estimate(&self) -> bool {

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -346,6 +346,38 @@ impl pdb::Query {
         }
     }
 
+    pub(crate) fn pretokenize_match_queries(
+        self,
+        field: &FieldName,
+        schema: &SearchIndexSchema,
+        searcher: &Searcher,
+    ) -> anyhow::Result<Self> {
+        match self {
+            pdb::Query::Match {
+                value,
+                tokenizer,
+                distance,
+                transposition_cost_one,
+                prefix,
+                conjunction_mode,
+            } => Ok(pdb::Query::MatchArray {
+                tokens: tokenize_match_value(field, schema, searcher, &value, tokenizer)?,
+                distance,
+                transposition_cost_one,
+                prefix,
+                conjunction_mode,
+            }),
+            pdb::Query::ScoreAdjusted { query, score } => {
+                let query = query.pretokenize_match_queries(field, schema, searcher)?;
+                Ok(pdb::Query::ScoreAdjusted {
+                    query: Box::new(query),
+                    score,
+                })
+            }
+            other => Ok(other),
+        }
+    }
+
     pub fn apply_fuzzy_data(&mut self, new_fuzzy_data: Option<FuzzyData>) {
         if new_fuzzy_data.is_none() {
             return;
@@ -1499,7 +1531,7 @@ fn range(
     Ok(Box::new(RangeQuery::new(lower_bound, upper_bound)))
 }
 
-fn resolve_search_tokenizer(
+pub(crate) fn resolve_search_tokenizer(
     search_field: &SearchField,
     schema: &SearchIndexSchema,
     searcher: &Searcher,
@@ -1515,6 +1547,32 @@ fn resolve_search_tokenizer(
             .expect("index-level search_tokenizer should be a valid tantivy tokenizer"));
     }
     Ok(searcher.index().tokenizer_for_field(search_field.field())?)
+}
+
+fn tokenize_match_value(
+    field: &FieldName,
+    schema: &SearchIndexSchema,
+    searcher: &Searcher,
+    value: &str,
+    tokenizer: Option<Value>,
+) -> anyhow::Result<Vec<String>> {
+    let search_field = schema
+        .search_field(field.root())
+        .ok_or(QueryError::NonIndexedField(field.clone()))?;
+
+    let mut analyzer = match tokenizer {
+        Some(ref tokenizer) => SearchTokenizer::from_json_value(tokenizer)?
+            .to_tantivy_tokenizer()
+            .expect("tantivy should support tokenizer {tokenizer:?}"),
+        None => resolve_search_tokenizer(&search_field, schema, searcher)?,
+    };
+
+    let mut stream = analyzer.token_stream(value);
+    let mut tokens = Vec::new();
+    while stream.advance() {
+        tokens.push(stream.token().text.clone());
+    }
+    Ok(tokens)
 }
 
 fn tokenized_phrase(


### PR DESCRIPTION
## What changed

This adds a query-preparation pass that rewrites eligible `pdb.match` leaves into the existing `MatchArray` representation after ParadeDB has resolved the index schema and tokenizer.

The prepared query is then stored back on `BaseScanState`, so PostgreSQL parallel workers deserialize the already-tokenized form from DSM instead of rebuilding dictionary-backed tokenizer state while constructing their Tantivy query.

I also added `EXPLAIN ANALYZE` visibility for this path. The original `Tantivy Query` remains unchanged, and a `Prepared Tantivy Query` entry is shown only when the runtime query differs.

## Why

This targets #4840. Dictionary-backed tokenizers such as Lindera and Jieba can pay a large cold-start cost in each ephemeral parallel worker. For simple `match` queries, the query text can be tokenized once before workers build the reader and then represented as explicit term tokens with the existing `MatchArray` query type.

That keeps execution semantics close to the current path while avoiding repeated worker-side tokenization for this common case.

## Notes

This intentionally does not add a new query type. It reuses the existing `MatchArray` execution path and preserves the original query for normal EXPLAIN output.

## Validation

- `cargo fmt --all`
- `git diff --check`
- `cargo check -p tokenizers`

I could not complete `cargo check -p pg_search` locally because this machine does not have `PGRX_HOME`, `pg_config`, or `cargo-pgrx` configured. The build stopped inside `pgrx-pg-sys` before checking the extension crate.
