### PR TITLE
ci: rename workflows for naming consistency

### DIFF
--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -69,7 +69,7 @@ jobs:
             const owner = context.repo.owner;
             const repo  = context.repo.repo;
             const sha   = '${{ matrix.sha }}';
-            const wf = 'benchmark-pg_search-benchmarks.yml';
+            const wf = 'benchmark-pg_search-queries.yml';
 
             /*  createWorkflowDispatch must point at a branch or tag, not a
                 bare SHA, so we send `ref:"main"` and hand the commit SHA

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -1,4 +1,4 @@
-# workflows/benchmark-pg_search-benchmarks.yml
+# workflows/benchmark-pg_search-queries.yml
 #
 # Benchmark pg_search (Queries)
 # Run our queries benchmark suite against pg_search.
@@ -42,7 +42,7 @@ permissions:
 # We don't specify a concurrency group here, as we want all jobs to complete.
 
 jobs:
-  benchmark-pg_search-benchmarks:
+  benchmark-pg_search-queries:
     name: Run Benchmark Jobs
     runs-on:
       # To configure the runners: https://runs-on.com/configuration/job-labels/#how-it-works (runs in us-east-1)
@@ -342,5 +342,5 @@ jobs:
         if: failure() && github.event_name == 'push'
         run: |
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          MESSAGE="<!here> \`benchmark-pg_search-benchmarks\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          MESSAGE="<!here> \`benchmark-pg_search-queries\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}

--- a/.github/workflows/publish-paradedb-docs.yml
+++ b/.github/workflows/publish-paradedb-docs.yml
@@ -1,4 +1,4 @@
-# workflows/publish-docs.yml
+# workflows/publish-paradedb-docs.yml
 #
 # Publish ParadeDB (Docs)
 # Build and publish the documentation stored in /docs to our Mintlify documentation
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-docs:
+  publish-paradedb-docs:
     name: Publish Docs to Mintlify
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref, '-rc.') }}

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -1,4 +1,4 @@
-# workflows/test-docs.yml
+# workflows/test-paradedb-docs.yml
 #
 # Test ParadeDB (Docs)
 # Test our documentation for broken links via Mintlify.
@@ -13,17 +13,17 @@ on:
       - 0.*.x # Release branches
       - moe/** # Temporary: trigger CI on stacked PR chain
     paths:
-      - ".github/workflows/test-docs.yml"
+      - ".github/workflows/test-paradedb-docs.yml"
       - ".github/scripts/**"
       - "docs/**"
   workflow_dispatch:
 
 concurrency:
-  group: test-docs-${{ github.head_ref || github.ref }}
+  group: test-paradedb-docs-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test-docs:
+  test-paradedb-docs:
     name: Test Docs for Broken Links, SEO Issues, and Code Snippets
     runs-on:
       # Compute-optimized c-family — Rust + Postgres tests are CPU-bound.

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -1,4 +1,4 @@
-# workflows/antithesis-trigger-test-run.yml
+# workflows/test-pg_search-antithesis.yml
 #
 # Test pg_search (Antithesis)
 # Build the current commits of pg_search and the selected driver image(s) as

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -1,9 +1,9 @@
-# workflows/schemabot-generate-diff.yml
+# workflows/test-pg_search-schema.yml
 #
 # SchemaBot Generate Diff
 # Determine if a commit introduces an extension schema change for pg_search
 
-name: SchemaBot Generate Diff
+name: Test pg_search (Schema)
 
 on:
   pull_request:
@@ -13,18 +13,18 @@ on:
       - 0.*.x # Release branches
       - moe/** # Temporary: trigger CI on stacked PR chain
     paths:
-      - ".github/workflows/schemabot-generate-diff.yml"
+      - ".github/workflows/test-pg_search-schema.yml"
       - ".github/scripts/check_migration_diff.py"
       - "pg_search/**"
       - "!pg_search/README.md"
   workflow_dispatch:
 
 concurrency:
-  group: schemabot-generate-diff-${{ github.head_ref || github.ref }}
+  group: test-pg_search-schema-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  schemabot-generate-diff:
+  test-pg_search-schema:
     name: SchemaBot
     runs-on:
       # Compute-optimized c-family — Rust schema generation is CPU-bound.


### PR DESCRIPTION
## What

Renames several GitHub Actions workflows to follow the established `<verb>-<component>-<descriptor>` convention used across the rest of the workflow directory:

| Old | New |
|---|---|
| `test-docs.yml` | `test-paradedb-docs.yml` |
| `publish-docs.yml` | `publish-paradedb-docs.yml` |
| `benchmark-pg_search-benchmarks.yml` | `benchmark-pg_search-queries.yml` |
| `antithesis-trigger-test-run.yml` | `test-pg_search-antithesis.yml` |
| `schemabot-generate-diff.yml` | `test-pg_search-schema.yml` |

## Details

Each rename also updates all in-file references so nothing dangles:
- Header comments, display `name:`, `paths:` self-filters, concurrency `group:`, and job names.
- The cross-workflow dispatch reference in `benchmark-backfill.yml` (`benchmark-pg_search-queries.yml`).

Display names were already consistent (e.g. "Test pg_search (Antithesis)", "Benchmark pg_search (Queries)"), so only filenames/job identifiers changed to match.

The verb-led housekeeping workflows (`cherry-pick`, `check-typo`, `assign-github-issue`, etc.) are intentionally left as-is since they aren't tied to a single product component.