### PR TITLE
feat: Store the `pg_search` version used to create the index in the MetaPage data (#5119)

### DIFF
--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -25,6 +25,7 @@ pub mod config;
 pub mod operator;
 pub mod tokenize;
 pub mod tokenizers;
+pub mod version;
 pub mod window_aggregate;
 
 use pgrx::{

--- a/pg_search/src/api/version.rs
+++ b/pg_search/src/api/version.rs
@@ -1,0 +1,70 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[allow(dead_code)]
+pub struct Version {
+    pub major: u16,
+    pub minor: u16,
+    pub patch: u16,
+}
+
+impl Version {
+    #[allow(dead_code)]
+    pub fn new(major: u16, minor: u16, patch: u16) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl std::fmt::Display for Version {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// Parses a decimal version component at compile time. Overflow or non-digit bytes
+/// produce a compile error via the const-eval rules.
+pub const fn parse_version_component(s: &str) -> u16 {
+    let bytes = s.as_bytes();
+    let mut result: u16 = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        assert!(b >= b'0' && b <= b'9', "version component must be decimal");
+        result = result * 10 + (b - b'0') as u16;
+        i += 1;
+    }
+    result
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_ordering_is_lexicographic_on_components() {
+        assert!(Version::new(0, 18, 0) < Version::new(0, 18, 1));
+        assert!(Version::new(0, 18, 9) < Version::new(0, 19, 0));
+        assert!(Version::new(0, 99, 99) < Version::new(1, 0, 0));
+        assert_eq!(Version::new(1, 2, 3), Version::new(1, 2, 3));
+    }
+}

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::api::version::{parse_version_component, Version};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::{block_number_is_valid, SegmentMetaEntry};
 use crate::postgres::storage::buffer::{
@@ -74,6 +75,14 @@ pub struct MetaPageData {
     /// This used to be for detecting concurrent background merges,
     /// now we use advisory locks
     _dead_space_4: [pg_sys::BlockNumber; 2],
+
+    /// pg_search version that created this index.
+    /// PageInit zeroes the page at creation, so bytes past the fields that exist at creation time
+    /// are zero forever. So we can reliably say:
+    /// All zeros = created before stamping was added.
+    created_by_version_major: u16,
+    created_by_version_minor: u16,
+    created_by_version_patch: u16,
 }
 
 /// Provides read access to the metadata page
@@ -111,6 +120,13 @@ impl MetaPage {
             metadata.settings_start = LinkedBytesList::create_without_fsm(indexrel);
             metadata.segment_metas_start =
                 LinkedItemList::<SegmentMetaEntry>::create_without_fsm(indexrel);
+
+            metadata.created_by_version_major =
+                const { parse_version_component(env!("CARGO_PKG_VERSION_MAJOR")) };
+            metadata.created_by_version_minor =
+                const { parse_version_component(env!("CARGO_PKG_VERSION_MINOR")) };
+            metadata.created_by_version_patch =
+                const { parse_version_component(env!("CARGO_PKG_VERSION_PATCH")) };
         }
     }
 
@@ -227,6 +243,25 @@ impl MetaPage {
     pub fn fsm(&self) -> pg_sys::BlockNumber {
         assert!(block_number_is_valid(self.data.v2_fsm));
         self.data.v2_fsm
+    }
+
+    /// The pg_search version that created this index. Returns `None` for indices created
+    /// before version stamping was added (the on-disk fields read as zero).
+    #[allow(dead_code)]
+    pub fn created_by_version(&self) -> Option<Version> {
+        let major = self.data.created_by_version_major;
+        let minor = self.data.created_by_version_minor;
+        let patch = self.data.created_by_version_patch;
+
+        if major == 0 && minor == 0 && patch == 0 {
+            None
+        } else {
+            Some(Version {
+                major,
+                minor,
+                patch,
+            })
+        }
     }
 
     ///
@@ -347,4 +382,35 @@ unsafe fn bgmerger_state(
 ) -> TableIterator<'static, (name!(pid, i32), name!(state, String))> {
     pgrx::warning!("bgmerger_state has been deprecated");
     TableIterator::new(std::iter::empty())
+}
+
+#[cfg(any(test, feature = "pg_test"))]
+#[pgrx::pg_schema]
+mod tests {
+    use super::*;
+    use pgrx::prelude::*;
+
+    #[pg_test]
+    fn created_by_version_is_stamped_at_index_build() {
+        Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
+        Spi::run("INSERT INTO t (data) VALUES ('hello');").unwrap();
+        Spi::run("CREATE INDEX t_idx ON t USING bm25(id, data) WITH (key_field = 'id');").unwrap();
+
+        let index_oid: pg_sys::Oid =
+            Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
+                .expect("spi should succeed")
+                .unwrap();
+        let indexrel = PgSearchRelation::open(index_oid);
+
+        let stamped = MetaPage::open(&indexrel)
+            .created_by_version()
+            .expect("freshly built index should be version-stamped");
+
+        let expected = Version::new(
+            env!("CARGO_PKG_VERSION_MAJOR").parse().unwrap(),
+            env!("CARGO_PKG_VERSION_MINOR").parse().unwrap(),
+            env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
+        );
+        assert_eq!(stamped, expected);
+    }
 }


### PR DESCRIPTION
Backport of #5119 to 0.24.x