### PR TITLE
fix: Avoid aggregate scan warnings for queries which will get TopK

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -246,12 +246,18 @@ jobs:
       # Coverage instrumentation runs on schedule + push-to-main, plus PG 18
       # entries on PRs (so Codecov has fresh data per PR). Older-version PR
       # entries run plain cargo test for ~30-40% wall-clock reduction.
+      #
+      # Note: Since `cargo pgrx regress` does not natively wrap `cargo llvm-cov`,
+      # we must manually export the coverage environment variables to $GITHUB_ENV.
+      # This ensures that subsequent steps (like `cargo pgrx install` and `cargo
+      # pgrx regress`) pick up the coverage instrumentation instructions via
+      # RUSTFLAGS, and write to the correct output path (LLVM_PROFILE_FILE).
       - name: Source LLVM coverage environment (pgrx)
         if: matrix.pg_impl == 'pgrx' && (github.event_name != 'pull_request' || matrix.pg_version == 18)
         run: |
           source <(cargo llvm-cov show-env --export-prefix)
           cargo llvm-cov clean --workspace
-          env | grep -E '^(RUSTC_WRAPPER=|LLVM_PROFILE_FILE=|CARGO_LLVM_COV|__CARGO_LLVM_COV)' >> "$GITHUB_ENV"
+          env | grep -E '^(RUSTC_WRAPPER=|RUSTFLAGS=|LLVM_PROFILE_FILE=|CARGO_LLVM_COV|__CARGO_LLVM_COV)' >> "$GITHUB_ENV"
 
       - name: Compile & install pg_search extension (pgrx)
         if: matrix.pg_impl == 'pgrx'

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -27,6 +27,7 @@ pub mod join_targetlist;
 pub mod limit_offset;
 pub mod mpp;
 pub mod orderby;
+use crate::postgres::customscan::orderby::validate_topk_compatibility;
 pub mod privdat;
 pub mod scan_state;
 pub mod searchquery;
@@ -1203,6 +1204,53 @@ impl AggregateScan {
         // Below this line every Err carries a planner warning.
         let warn = |reason| AggregatePathDecline::Warn(reason);
 
+        // Check if any RTI was dropped by collect_join_agg_sources (e.g., subqueries)
+        let expected_rtis = unsafe { pgrx::pg_sys::bms_num_members(input_rel.relids) } as usize;
+        if sources.len() != expected_rtis {
+            let rtis: Vec<pgrx::pg_sys::Index> = unsafe {
+                crate::postgres::customscan::range_table::bms_iter(input_rel.relids).collect()
+            };
+            for rti in rtis {
+                if !sources.iter().any(|s| s.rti == rti) {
+                    let rte = unsafe {
+                        crate::postgres::customscan::range_table::get_rte(
+                            (*root).simple_rel_array_size as usize,
+                            (*root).simple_rte_array,
+                            rti,
+                        )
+                    };
+                    if let Some(rte_ptr) = rte {
+                        let rtekind = unsafe { (*rte_ptr).rtekind };
+                        // RTE_JOIN represents the join itself, not a base table we'd scan
+                        if rtekind == pgrx::pg_sys::RTEKind::RTE_JOIN {
+                            continue;
+                        }
+
+                        // Silent decline for subqueries with limits, as they are
+                        // handled efficiently by the BaseScan TopK pushdown natively.
+                        // We check recursively because the limit might be nested inside CTEs
+                        // or UNION arms within the subquery.
+                        if rtekind == pgrx::pg_sys::RTEKind::RTE_SUBQUERY {
+                            let subquery = unsafe { (*rte_ptr).subquery };
+                            if !subquery.is_null() && unsafe { query_will_use_topk(subquery) } {
+                                return Err(AggregatePathDecline::Quiet);
+                            }
+                        }
+
+                        return Err(warn(AggregateDeclineReason::Other(format!(
+                            "RTI {} is not a plain relation (rtekind: {:?}), which is not supported",
+                            rti, rtekind
+                        ))));
+                    } else {
+                        return Err(warn(AggregateDeclineReason::Other(format!(
+                            "RTI {} not found in simple_rte_array",
+                            rti
+                        ))));
+                    }
+                }
+            }
+        }
+
         // All tables must have BM25 indexes (DataFusion scans all via PgSearchTableProvider).
         if !all_have_bm25_index(&sources) {
             return Err(warn(AggregateDeclineReason::NotAllBm25));
@@ -2205,4 +2253,56 @@ unsafe fn get_aggregate_name(aggref: *mut pg_sys::Aggref) -> String {
     } else {
         name_str.to_uppercase()
     }
+}
+
+/// Check if the query (or any subquery/CTE within it) will trigger TopK pushdown.
+///
+/// AggregateScan currently does not support extracting `RTE_SUBQUERY` nodes and will typically
+/// emit a WARNING when it encounters one. However, if a subquery is a TopK query (has a `LIMIT`
+/// and an `ORDER BY` on a BM25 index), we want to silently decline it instead. This is because
+/// `BaseScan` will natively optimize the subquery, meaning we can safely step aside without
+/// bothering the user with a planner warning.
+unsafe fn query_will_use_topk(parse: *mut pgrx::pg_sys::Query) -> bool {
+    if parse.is_null() {
+        return false;
+    }
+
+    // If there is an explicit LIMIT, check if TopK pushdown will natively optimize it
+    if !(*parse).limitCount.is_null()
+        && crate::gucs::enable_custom_scan()
+        && validate_topk_compatibility(parse)
+    {
+        return true;
+    }
+
+    // Check subqueries in RTEs
+    if !(*parse).rtable.is_null() {
+        let rtable = pgrx::list::PgList::<pgrx::pg_sys::RangeTblEntry>::from_pg((*parse).rtable);
+        for rte in rtable.iter_ptr() {
+            if (*rte).rtekind == pgrx::pg_sys::RTEKind::RTE_SUBQUERY
+                && !(*rte).subquery.is_null()
+                && query_will_use_topk((*rte).subquery)
+            {
+                return true;
+            }
+        }
+    }
+
+    // Check CTEs (Common Table Expressions)
+    if !(*parse).cteList.is_null() {
+        let ctelist =
+            pgrx::list::PgList::<pgrx::pg_sys::CommonTableExpr>::from_pg((*parse).cteList);
+        for cte in ctelist.iter_ptr() {
+            if !(*cte).ctequery.is_null() && query_will_use_topk((*cte).ctequery.cast()) {
+                return true;
+            }
+        }
+    }
+
+    // Check setOperations (UNION/INTERSECT/EXCEPT arms)
+    // The query block for the set operations usually references the arms in rtable,
+    // but just in case, we can also descend into the setOperations tree if we needed,
+    // but since they are in rtable as RTE_SUBQUERY, iterating rtable is sufficient.
+
+    false
 }

--- a/pg_search/src/postgres/customscan/hook.rs
+++ b/pg_search/src/postgres/customscan/hook.rs
@@ -695,7 +695,7 @@ unsafe fn query_has_window_func_nodes(parse: *mut pg_sys::Query) -> bool {
 /// into executable quals. They serve different purposes:
 /// - This function: Quick boolean check for planner decisions
 /// - extract_quals: Detailed extraction and validation for execution
-unsafe fn query_has_search_operator(parse: *mut pg_sys::Query) -> bool {
+pub(crate) unsafe fn query_has_search_operator(parse: *mut pg_sys::Query) -> bool {
     // We still need to check for the @@@(anyelement, searchqueryinput) variant
     // because it's the most common and we want fast-path for it
     let target_ops = anyelement_search_opoids();

--- a/pg_search/tests/pg_regress/expected/generated_subquery_proptest_failure.out
+++ b/pg_search/tests/pg_regress/expected/generated_subquery_proptest_failure.out
@@ -82,14 +82,12 @@ ANALYZE;
 --
 -- these two queries should return the same count:  3
 SELECT COUNT(*) FROM products WHERE products.color IN (SELECT color FROM orders WHERE NOT (orders.age  =  '20') ORDER BY orders.id LIMIT 9) AND (products.name  =  'bob') AND (products.name  =  'bob');
-WARNING:  Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans (table: join)
  count 
 -------
      3
 (1 row)
 
 SELECT COUNT(*) FROM products WHERE products.color IN (SELECT color FROM orders WHERE NOT (orders.age @@@ '20') ORDER BY orders.id LIMIT 9) AND (products.name @@@ 'bob') AND (products.name @@@ 'bob');
-WARNING:  Aggregate Scan (DataFusion) not used: join has non-equi quals that cannot be pushed to individual table scans (table: join)
  count 
 -------
      3

--- a/pg_search/tests/pg_regress/expected/reciprocal_rank_fusion.out
+++ b/pg_search/tests/pg_regress/expected/reciprocal_rank_fusion.out
@@ -67,7 +67,6 @@ ORDER BY score DESC, o.order_id
 LIMIT 5;
 EXPLAIN (COSTS OFF)
 EXECUTE rrf_query('Johnson', 'running shoes');
-WARNING:  Aggregate Scan (DataFusion) not used: RTI 1 not found in join sources (table: join)
                                                                                                                                              QUERY PLAN                                                                                                                                              
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -121,7 +120,6 @@ WARNING:  Aggregate Scan (DataFusion) not used: RTI 1 not found in join sources 
 (48 rows)
 
 EXECUTE rrf_query('Johnson', 'running shoes');
-WARNING:  Aggregate Scan (DataFusion) not used: RTI 1 not found in join sources (table: join)
  order_id | customer_name |     description     |         score          
 ----------+---------------+---------------------+------------------------
         3 | Alice Johnson | Sleek running shoes | 0.03278688524590163934

--- a/pg_search/tests/pg_regress/expected/reciprocal_rank_fusion.out
+++ b/pg_search/tests/pg_regress/expected/reciprocal_rank_fusion.out
@@ -1,0 +1,137 @@
+-- Tests Reciprocal Rank Fusion on joined tables
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+-- Create test tables
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_rrf',
+  table_type => 'Items'
+);
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'orders_rrf',
+  table_type => 'Orders'
+);
+ALTER TABLE orders_rrf
+ADD CONSTRAINT foreign_key_product_id
+FOREIGN KEY (product_id)
+REFERENCES mock_items_rrf(id);
+CREATE INDEX orders_rrf_idx ON orders_rrf
+USING bm25 (order_id, product_id, order_quantity, order_total, customer_name)
+WITH (key_field = 'order_id');
+CREATE INDEX mock_items_rrf_idx ON mock_items_rrf
+USING bm25 (id, description, category, rating)
+WITH (key_field = 'id');
+-- RRF Query
+PREPARE rrf_query(text, text) AS
+WITH order_search AS (
+  SELECT order_id, RANK() OVER (ORDER BY score DESC) AS rank
+  FROM (
+    SELECT order_id, pdb.score(order_id) AS score
+    FROM orders_rrf
+    WHERE customer_name ||| $1
+    ORDER BY pdb.score(order_id) DESC
+    LIMIT 20
+  )
+),
+product_search AS (
+  SELECT o.order_id, RANK() OVER (ORDER BY score DESC) AS rank
+  FROM (
+    SELECT id, pdb.score(id) AS score
+    FROM mock_items_rrf
+    WHERE description ||| $2
+    ORDER BY pdb.score(id) DESC
+    LIMIT 20
+  ) m
+  JOIN orders_rrf o ON o.product_id = m.id
+),
+rrf AS (
+  SELECT order_id, 1.0 / (60 + rank) AS s FROM order_search
+  UNION ALL
+  SELECT order_id, 1.0 / (60 + rank) AS s FROM product_search
+)
+SELECT
+  o.order_id,
+  o.customer_name,
+  m.description,
+  sum(rrf.s) AS score
+FROM rrf
+JOIN orders_rrf o USING (order_id)
+JOIN mock_items_rrf m ON o.product_id = m.id
+GROUP BY o.order_id, o.customer_name, m.description
+ORDER BY score DESC, o.order_id
+LIMIT 5;
+EXPLAIN (COSTS OFF)
+EXECUTE rrf_query('Johnson', 'running shoes');
+WARNING:  Aggregate Scan (DataFusion) not used: RTI 1 not found in join sources (table: join)
+                                                                                                                                             QUERY PLAN                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: (sum(((1.0 / ((60 + order_search.rank))::numeric)))) DESC, o.order_id
+         ->  GroupAggregate
+               Group Key: o.order_id, m.description
+               ->  Sort
+                     Sort Key: o.order_id, m.description
+                     ->  Hash Join
+                           Hash Cond: (o.product_id = m.id)
+                           ->  Hash Join
+                                 Hash Cond: (o.order_id = order_search.order_id)
+                                 ->  Seq Scan on orders_rrf o
+                                 ->  Hash
+                                       ->  Append
+                                             ->  Subquery Scan on order_search
+                                                   ->  WindowAgg
+                                                         Window: w1 AS (ORDER BY unnamed_subquery.score ROWS UNBOUNDED PRECEDING)
+                                                         ->  Subquery Scan on unnamed_subquery
+                                                               ->  Limit
+                                                                     ->  Custom Scan (ParadeDB Base Scan) on orders_rrf
+                                                                           Table: orders_rrf
+                                                                           Index: orders_rrf_idx
+                                                                           Exec Method: TopKScanExecState
+                                                                           Scores: true
+                                                                              TopK Order By: pdb.score() desc
+                                                                              TopK Limit: 20
+                                                                           Tantivy Query: {"with_index":{"query":{"match":{"field":"customer_name","value":"Johnson","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                                             ->  Subquery Scan on product_search
+                                                   ->  WindowAgg
+                                                         Window: w1 AS (ORDER BY m_1.score ROWS UNBOUNDED PRECEDING)
+                                                         ->  Sort
+                                                               Sort Key: m_1.score DESC
+                                                               ->  Hash Join
+                                                                     Hash Cond: (o_1.product_id = m_1.id)
+                                                                     ->  Seq Scan on orders_rrf o_1
+                                                                     ->  Hash
+                                                                           ->  Subquery Scan on m_1
+                                                                                 ->  Limit
+                                                                                       ->  Custom Scan (ParadeDB Base Scan) on mock_items_rrf
+                                                                                             Table: mock_items_rrf
+                                                                                             Index: mock_items_rrf_idx
+                                                                                             Exec Method: TopKScanExecState
+                                                                                             Scores: true
+                                                                                                TopK Order By: pdb.score() desc
+                                                                                                TopK Limit: 20
+                                                                                             Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"running shoes","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+                           ->  Hash
+                                 ->  Seq Scan on mock_items_rrf m
+(48 rows)
+
+EXECUTE rrf_query('Johnson', 'running shoes');
+WARNING:  Aggregate Scan (DataFusion) not used: RTI 1 not found in join sources (table: join)
+ order_id | customer_name |     description     |         score          
+----------+---------------+---------------------+------------------------
+        3 | Alice Johnson | Sleek running shoes | 0.03278688524590163934
+        6 | Alice Johnson | White jogging shoes | 0.03028233151183970856
+       36 | Alice Johnson | White jogging shoes | 0.03028233151183970856
+        9 | Chris Wilson  | Sleek running shoes | 0.01639344262295081967
+       25 | Peter Parker  | Sleek running shoes | 0.01639344262295081967
+(5 rows)
+
+-- Cleanup
+DEALLOCATE rrf_query;
+DROP TABLE orders_rrf CASCADE;
+DROP TABLE mock_items_rrf CASCADE;

--- a/pg_search/tests/pg_regress/sql/reciprocal_rank_fusion.sql
+++ b/pg_search/tests/pg_regress/sql/reciprocal_rank_fusion.sql
@@ -1,0 +1,79 @@
+-- Tests Reciprocal Rank Fusion on joined tables
+
+\i common/common_setup.sql
+
+-- Create test tables
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_rrf',
+  table_type => 'Items'
+);
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'orders_rrf',
+  table_type => 'Orders'
+);
+
+ALTER TABLE orders_rrf
+ADD CONSTRAINT foreign_key_product_id
+FOREIGN KEY (product_id)
+REFERENCES mock_items_rrf(id);
+
+CREATE INDEX orders_rrf_idx ON orders_rrf
+USING bm25 (order_id, product_id, order_quantity, order_total, customer_name)
+WITH (key_field = 'order_id');
+
+CREATE INDEX mock_items_rrf_idx ON mock_items_rrf
+USING bm25 (id, description, category, rating)
+WITH (key_field = 'id');
+
+-- RRF Query
+PREPARE rrf_query(text, text) AS
+WITH order_search AS (
+  SELECT order_id, RANK() OVER (ORDER BY score DESC) AS rank
+  FROM (
+    SELECT order_id, pdb.score(order_id) AS score
+    FROM orders_rrf
+    WHERE customer_name ||| $1
+    ORDER BY pdb.score(order_id) DESC
+    LIMIT 20
+  )
+),
+product_search AS (
+  SELECT o.order_id, RANK() OVER (ORDER BY score DESC) AS rank
+  FROM (
+    SELECT id, pdb.score(id) AS score
+    FROM mock_items_rrf
+    WHERE description ||| $2
+    ORDER BY pdb.score(id) DESC
+    LIMIT 20
+  ) m
+  JOIN orders_rrf o ON o.product_id = m.id
+),
+rrf AS (
+  SELECT order_id, 1.0 / (60 + rank) AS s FROM order_search
+  UNION ALL
+  SELECT order_id, 1.0 / (60 + rank) AS s FROM product_search
+)
+SELECT
+  o.order_id,
+  o.customer_name,
+  m.description,
+  sum(rrf.s) AS score
+FROM rrf
+JOIN orders_rrf o USING (order_id)
+JOIN mock_items_rrf m ON o.product_id = m.id
+GROUP BY o.order_id, o.customer_name, m.description
+ORDER BY score DESC, o.order_id
+LIMIT 5;
+
+EXPLAIN (COSTS OFF)
+EXECUTE rrf_query('Johnson', 'running shoes');
+
+EXECUTE rrf_query('Johnson', 'running shoes');
+
+
+-- Cleanup
+DEALLOCATE rrf_query;
+DROP TABLE orders_rrf CASCADE;
+DROP TABLE mock_items_rrf CASCADE;


### PR DESCRIPTION
## What

Add handling to silence `aggregate` scan warnings when TopK scans are being used.

## Why

To fix #5296, we are switching to an RRF query in #5303. But that switches from a valid `join` scan warning to a spurious `aggregate` scan warning due to failing to handle subqueries:
```
WARNING:  Aggregate Scan (DataFusion) not used: RTI 1 not found in join sources (table: join)
```

We will eventually want to support incorporating subqueries into the `aggregate` scan as joins. But in cases where a TopK is already triggering, we cannot do any better with the `aggregate` scan.

## Tests

New RRF regression test.