### PR TITLE
chore: Port the common-sense config items from benchmarks to stressgres

### DIFF
--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -38,9 +38,11 @@ jobs:
     runs-on:
       # To configure the runners: https://runs-on.com/configuration/job-labels/#how-it-works (runs in us-east-1)
       - runs-on=${{ github.run_id }}
-      - family=z1d.metal # 48 vCPUs, 384 GiBs Memory, 1.8 TiBs local NVMe
-      - image=ubuntu24-full-x64
+      - family=m8gd.metal-24xl # Chosen for its performance consistency across hosts
+      - image=ubuntu24-full-arm64
       - extras=s3-cache # See https://runs-on.com/caching/magic-cache/
+      # We deliberately do not enable EBS and instead rely on the on-machine NVMe drives to avoid the variance
+      # using EBS would cause
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-stressgres')
     env:
       pg_version: 18
@@ -213,6 +215,44 @@ jobs:
 
       - name: Compile & install pg_search extension
         run: cargo pgrx install -p pg_search --sudo --release --pg-config `which pg_config` --features=pg${{ env.pg_version }} --no-default-features
+
+      - name: Start Postgres
+        working-directory: pg_search/
+        run: |
+          cargo pgrx start pg${{ env.pg_version }}
+
+      - name: Configure PostgreSQL settings and machine settings
+        working-directory: /home/runner/.pgrx/data-${{ env.pg_version }}/
+        run: |
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM RESET ALL;"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET shared_preload_libraries = pg_search;"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET maintenance_work_mem = '12GB';"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET shared_buffers = '12GB';"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET max_parallel_workers = 8;"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET max_worker_processes = 8;"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET max_parallel_maintenance_workers = 8;"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET max_parallel_workers_per_gather = 8;"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET max_wal_size = '100GB';"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET huge_pages = on;"
+          sudo sysctl -w vm.nr_hugepages=10000
+
+      - name: Restart Postgres
+        working-directory: pg_search/
+        run: |
+          cargo pgrx stop pg${{ env.pg_version }}
+          cargo pgrx start pg${{ env.pg_version }}
+
+      - name: Install pg_search
+        working-directory: pg_search/
+        run: |
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "CREATE EXTENSION IF NOT EXISTS pg_search;"
+          psql postgresql://localhost:288${{ env.pg_version }}/postgres -c "ALTER SYSTEM SET paradedb.global_target_segment_count = 48;";
+
+      - name: Restart Postgres
+        working-directory: pg_search/
+        run: |
+          cargo pgrx stop pg${{ env.pg_version }}
+          cargo pgrx start pg${{ env.pg_version }}
 
       - name: Install the Stressgres CLI tool
         working-directory: stressgres/


### PR DESCRIPTION
This PR takes the common sense config items from the benchmarking config and applies it to stressgress. This includes things like instance type, memory settings, huge pages, etc. It **does not** bring over things like turning off autovacuum and limiting wal behavior.