### PR TITLE
feat: showed MPP worker metrics in EXPLAIN ANALYZE.

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -405,6 +405,7 @@ impl CustomScan for AggregateScan {
                     custom_scan_tlist,
                     having_filter,
                     runtime: None,
+                    physical_plan: None,
                     stream: None,
                     current_batch: None,
                     batch_row_idx: 0,
@@ -424,6 +425,11 @@ impl CustomScan for AggregateScan {
     ) {
         if state.custom_state().is_datafusion_backend() {
             explainer.add_text("Backend", "DataFusion");
+            if explainer.is_analyze() {
+                if let Some(ref df_state) = state.custom_state().datafusion_state {
+                    Self::render_executed_plan_with_metrics(df_state, explainer);
+                }
+            }
             if let Some(ref df_state) = state.custom_state().datafusion_state {
                 // Show indexes from the join tree sources
                 let indexes: Vec<String> = df_state
@@ -1125,6 +1131,113 @@ impl AggregateScan {
         }
     }
 
+    /// EXPLAIN ANALYZE: merge the worker metrics that arrived over the mesh into the executed
+    /// plan and render it. The leader's own nodes already carry their metrics; the worker
+    /// fragments reported theirs as `TaskMetrics` frames when they finished.
+    fn render_executed_plan_with_metrics(
+        df_state: &scan_state::DataFusionAggState,
+        explainer: &mut Explainer,
+    ) {
+        let Some(plan) = df_state.physical_plan.clone() else {
+            return;
+        };
+        let Some(dist) = plan.as_any().downcast_ref::<DistributedExec>() else {
+            // Serial fallback: no workers, the plain metrics display tells the whole story.
+            explainer.add_text("DataFusion Physical Plan", "");
+            for line in datafusion::physical_plan::displayable(plan.as_ref())
+                .indent(false)
+                .to_string()
+                .lines()
+            {
+                explainer.add_text("  ", line);
+            }
+            return;
+        };
+        let (Some(store), Some(scan_state::MppExecState::Leader(leader))) =
+            (dist.metrics_store(), df_state.mpp.as_ref())
+        else {
+            return;
+        };
+
+        // The wire key for the metrics store: the query uuid lives on the plan's own stages.
+        fn dist_query_id(
+            plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+        ) -> Option<Vec<u8>> {
+            use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+            use datafusion_distributed::NetworkBoundaryExt;
+            let mut found = None;
+            let _ = plan.apply(|node| {
+                if let Some(nb) = node.as_network_boundary() {
+                    found = Some(nb.input_stage().query_id().as_bytes().to_vec());
+                    return Ok(TreeNodeRecursion::Stop);
+                }
+                Ok(TreeNodeRecursion::Continue)
+            });
+            found
+        }
+
+        // The workers sent their frames as they exited, after the gather already finished, so
+        // nothing has drained the leader inbox since; sweep it now.
+        use datafusion_distributed::shm::CooperativeDrainSet;
+        for _ in 0..64 {
+            if leader.mesh.try_drain_pass().is_err() {
+                break;
+            }
+        }
+        if let Some(mut rx) = leader.mesh.take_task_metrics_receiver() {
+            // Frames carry (stage, task); the query id comes from the plan's own stages.
+            let query_id = dist_query_id(&plan);
+            while let Ok((stage_id, task_number, metrics)) = rx.try_recv() {
+                if let Some(query_id) = query_id.as_ref() {
+                    store.insert(
+                        datafusion_distributed::TaskKey {
+                            query_id: query_id.clone(),
+                            stage_id: stage_id as u64,
+                            task_number: task_number as u64,
+                        },
+                        metrics,
+                    );
+                }
+            }
+        }
+
+        let Some(runtime) = df_state.runtime.as_ref() else {
+            return;
+        };
+        // `wait_for_metrics` inside the rewrite would block on any missing frame (a worker
+        // that died never reports), so bound the whole rewrite instead of trusting it.
+        let rewritten = runtime.block_on(async {
+            tokio::time::timeout(
+                std::time::Duration::from_millis(250),
+                datafusion_distributed::rewrite_distributed_plan_with_metrics(
+                    Arc::clone(&plan),
+                    datafusion_distributed::DistributedMetricsFormat::PerTask,
+                ),
+            )
+            .await
+        });
+        match rewritten {
+            Ok(Ok(plan)) => {
+                explainer.add_text("DataFusion Physical Plan", "");
+                for line in display_plan_ascii(plan.as_ref(), true).lines() {
+                    explainer.add_text("  ", line);
+                }
+            }
+            Ok(Err(e)) => {
+                explainer.add_text(
+                    "DataFusion Physical Plan",
+                    format!("(metrics merge failed: {e})"),
+                );
+            }
+            Err(_) => {
+                explainer.add_text(
+                    "DataFusion Physical Plan",
+                    "(worker metrics incomplete; a worker may not have reported)",
+                );
+            }
+        }
+    }
+
     /// Render a physical plan for EXPLAIN. `DistributedExec` roots go through
     /// `display_plan_ascii` for the boxed-stage rendering; serial plans keep
     /// the standard `displayable().indent(false)` tree so non-MPP expected
@@ -1726,6 +1839,7 @@ impl AggregateScan {
             };
 
             df_state.runtime = Some(runtime);
+            df_state.physical_plan = Some(physical_plan);
             df_state.stream = Some(stream);
         }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -631,10 +631,18 @@ impl CustomScan for AggregateScan {
     }
 
     fn shutdown_custom_scan(state: &mut CustomScanStateWrapper<Self>) {
-        // PG destroys the parallel DSM right after this hook; the leader's control senders
-        // decrement ring counters inside that mapping on drop, so release them now.
+        // PG destroys the parallel DSM right after this hook, so everything that reads or
+        // releases ring memory must happen now: drain the workers' metrics frames off the mesh
+        // (the EXPLAIN hook runs after teardown and only reads the store), then drop the
+        // leader's control senders, whose drop decrements counters inside the mapping.
         if let Some(df_state) = state.custom_state().datafusion_state.as_ref() {
             if let Some(scan_state::MppExecState::Leader(leader)) = df_state.mpp.as_ref() {
+                if let Some(plan) = df_state.physical_plan.as_ref() {
+                    crate::postgres::customscan::mpp::glue::drain_worker_metrics(
+                        plan,
+                        &leader.mesh,
+                    );
+                }
                 leader.release_control_senders();
             }
         }
@@ -1141,100 +1149,25 @@ impl AggregateScan {
         let Some(plan) = df_state.physical_plan.clone() else {
             return;
         };
-        let Some(dist) = plan.as_any().downcast_ref::<DistributedExec>() else {
+        let rendered = match (df_state.mpp.as_ref(), df_state.runtime.as_ref()) {
+            (Some(scan_state::MppExecState::Leader(_)), Some(_runtime)) => {
+                match crate::postgres::customscan::mpp::glue::merge_worker_metrics(&plan) {
+                    Some(merged) => display_plan_ascii(merged.as_ref(), true),
+                    None => {
+                        explainer.add_text(
+                            "DataFusion Physical Plan",
+                            "(worker metrics incomplete; a worker may not have reported)",
+                        );
+                        return;
+                    }
+                }
+            }
             // Serial fallback: no workers, the plain metrics display tells the whole story.
-            explainer.add_text("DataFusion Physical Plan", "");
-            for line in datafusion::physical_plan::displayable(plan.as_ref())
-                .indent(false)
-                .to_string()
-                .lines()
-            {
-                explainer.add_text("  ", line);
-            }
-            return;
+            _ => Self::render_plan_for_explain(plan.as_ref()),
         };
-        let (Some(store), Some(scan_state::MppExecState::Leader(leader))) =
-            (dist.metrics_store(), df_state.mpp.as_ref())
-        else {
-            return;
-        };
-
-        // The wire key for the metrics store: the query uuid lives on the plan's own stages.
-        fn dist_query_id(
-            plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
-        ) -> Option<Vec<u8>> {
-            use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
-            use datafusion_distributed::NetworkBoundaryExt;
-            let mut found = None;
-            let _ = plan.apply(|node| {
-                if let Some(nb) = node.as_network_boundary() {
-                    found = Some(nb.input_stage().query_id().as_bytes().to_vec());
-                    return Ok(TreeNodeRecursion::Stop);
-                }
-                Ok(TreeNodeRecursion::Continue)
-            });
-            found
-        }
-
-        // The workers sent their frames as they exited, after the gather already finished, so
-        // nothing has drained the leader inbox since; sweep it now.
-        use datafusion_distributed::shm::CooperativeDrainSet;
-        for _ in 0..64 {
-            if leader.mesh.try_drain_pass().is_err() {
-                break;
-            }
-        }
-        if let Some(mut rx) = leader.mesh.take_task_metrics_receiver() {
-            // Frames carry (stage, task); the query id comes from the plan's own stages.
-            let query_id = dist_query_id(&plan);
-            while let Ok((stage_id, task_number, metrics)) = rx.try_recv() {
-                if let Some(query_id) = query_id.as_ref() {
-                    store.insert(
-                        datafusion_distributed::TaskKey {
-                            query_id: query_id.clone(),
-                            stage_id: stage_id as u64,
-                            task_number: task_number as u64,
-                        },
-                        metrics,
-                    );
-                }
-            }
-        }
-
-        let Some(runtime) = df_state.runtime.as_ref() else {
-            return;
-        };
-        // `wait_for_metrics` inside the rewrite would block on any missing frame (a worker
-        // that died never reports), so bound the whole rewrite instead of trusting it.
-        let rewritten = runtime.block_on(async {
-            tokio::time::timeout(
-                std::time::Duration::from_millis(250),
-                datafusion_distributed::rewrite_distributed_plan_with_metrics(
-                    Arc::clone(&plan),
-                    datafusion_distributed::DistributedMetricsFormat::PerTask,
-                ),
-            )
-            .await
-        });
-        match rewritten {
-            Ok(Ok(plan)) => {
-                explainer.add_text("DataFusion Physical Plan", "");
-                for line in display_plan_ascii(plan.as_ref(), true).lines() {
-                    explainer.add_text("  ", line);
-                }
-            }
-            Ok(Err(e)) => {
-                explainer.add_text(
-                    "DataFusion Physical Plan",
-                    format!("(metrics merge failed: {e})"),
-                );
-            }
-            Err(_) => {
-                explainer.add_text(
-                    "DataFusion Physical Plan",
-                    "(worker metrics incomplete; a worker may not have reported)",
-                );
-            }
+        explainer.add_text("DataFusion Physical Plan", "");
+        for line in rendered.lines() {
+            explainer.add_text("  ", line);
         }
     }
 

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -66,6 +66,9 @@ pub struct DataFusionAggState {
     pub having_filter: Option<FilterExpr>,
     /// Tokio runtime for async DataFusion execution.
     pub runtime: Option<tokio::runtime::Runtime>,
+    /// The executed physical plan, kept so EXPLAIN ANALYZE can merge the worker metrics that
+    /// arrive over the mesh into its display.
+    pub physical_plan: Option<std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>>,
     /// DataFusion result stream.
     pub stream: Option<SendableRecordBatchStream>,
     /// Current batch being consumed row-by-row.

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1379,14 +1379,22 @@ impl CustomScan for JoinScan {
             // For EXPLAIN ANALYZE, render the plan with metrics inline.
             // VERBOSE includes timing; without VERBOSE, timing is stripped for stable output.
             if let Some(ref physical_plan) = state.custom_state().physical_plan {
+                // Under MPP the worker fragments reported their metrics as mesh frames when
+                // they exited; fold them in so the stage boxes show more than the leader's
+                // own nodes.
+                let merged = match (
+                    state.custom_state().mpp.as_ref(),
+                    state.custom_state().runtime.as_ref(),
+                ) {
+                    (Some(MppExecState::Leader(_)), Some(_runtime)) => {
+                        crate::postgres::customscan::mpp::glue::merge_worker_metrics(physical_plan)
+                    }
+                    _ => None,
+                };
+                let plan = merged.as_ref().unwrap_or(physical_plan);
                 explainer.add_text("DataFusion Physical Plan", "");
                 let mut lines = Vec::new();
-                render_plan_with_metrics(
-                    physical_plan.as_ref(),
-                    0,
-                    explainer.is_verbose(),
-                    &mut lines,
-                );
+                render_plan_with_metrics(plan.as_ref(), 0, explainer.is_verbose(), &mut lines);
                 for line in &lines {
                     explainer.add_text("  ", line);
                 }
@@ -1669,9 +1677,14 @@ impl CustomScan for JoinScan {
     }
 
     fn shutdown_custom_scan(state: &mut CustomScanStateWrapper<Self>) {
-        // PG destroys the parallel DSM right after this hook; the leader's control senders
-        // decrement ring counters inside that mapping on drop, so release them now.
+        // PG destroys the parallel DSM right after this hook, so everything that reads or
+        // releases ring memory must happen now: drain the workers' metrics frames off the mesh
+        // (the EXPLAIN hook runs after teardown and only reads the store), then drop the
+        // leader's control senders, whose drop decrements counters inside the mapping.
         if let Some(MppExecState::Leader(leader)) = state.custom_state().mpp.as_ref() {
+            if let Some(plan) = state.custom_state().physical_plan.as_ref() {
+                crate::postgres::customscan::mpp::glue::drain_worker_metrics(plan, &leader.mesh);
+            }
             leader.release_control_senders();
         }
     }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -45,9 +45,11 @@ use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
 use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::shm::{
-    proc_for_task, run_worker_fragment, CooperativeDrainSet, InProcessWorkerResolver,
-    MppFrameHeader, MppMesh, MppPartitionSink, MppSender, ShmMqWorkerTransport,
+    collect_task_metrics, proc_for_task, run_worker_fragment, CooperativeDrainSet,
+    InProcessWorkerResolver, MppFrameHeader, MppMesh, MppPartitionSink, MppSender,
+    ShmMqWorkerTransport,
 };
 use datafusion_distributed::PartitionSink;
 
@@ -319,6 +321,8 @@ pub(crate) fn run_mpp_worker(
     >;
     let result = runtime.block_on(async move {
         let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
+        let mut executed_fragments: Vec<(u32, usize, usize, Arc<dyn ExecutionPlan>)> =
+            Vec::with_capacity(fragments.len());
         for (fragment, frag_plan) in fragments.iter().zip(&plans) {
             let n_out = frag_plan
                 .properties()
@@ -463,12 +467,27 @@ pub(crate) fn run_mpp_worker(
                     }
                 }
             };
+            // Kept for the post-run metrics frame: the executed nodes (and their metrics)
+            // live in this prepared plan.
+            executed_fragments.push((
+                fragment.stage_id,
+                fragment.task_idx,
+                fragment.task_count,
+                Arc::clone(&plan),
+            ));
             futures.push(Box::pin(run_worker_fragment(
                 plan,
                 per_partition_sinks,
                 task_ctx,
             )));
         }
+        // The metrics frames go to the leader after the fragments finish; the clone keeps one
+        // sender on the leader's inbox alive past the drop below, which only delays that ring's
+        // detach observation, never a per-channel EOF.
+        let metrics_sender_base = outbound_senders
+            .first()
+            .and_then(|s| s.as_ref())
+            .map(|s| s.clone_with_header(MppFrameHeader::task_metrics(0, 0, this_proc)));
         // Drop the original outbound_senders so the only remaining Arcs to each shm_mq queue /
         // in-proc channel are the per-partition clones owned by the spawned fragments. Without
         // this, the originals would outlive the futures, the consumer-side drains would never
@@ -511,6 +530,21 @@ pub(crate) fn run_mpp_worker(
                 .collect::<Result<Vec<_>, _>>()
                 .map(|_| ())
         };
+
+        // Report each fragment's metrics to the leader, even after a fragment error: partial
+        // metrics still tell the user where the time went. Best-effort like every transport's
+        // metrics path; the bounded send drops the frame if the leader already went away.
+        if let Some(base) = metrics_sender_base {
+            for (stage_id, task_idx, task_count, plan) in &executed_fragments {
+                let frame = collect_task_metrics(plan, *task_idx, *task_count);
+                let sender = base.clone_with_header(MppFrameHeader::task_metrics(
+                    *stage_id,
+                    *task_idx as u32,
+                    this_proc,
+                ));
+                let _ = sender.send_task_metrics_best_effort(&frame).await;
+            }
+        }
         outcome
     });
     if let Err(e) = result {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -427,3 +427,95 @@ pub unsafe fn worker_setup(
         mesh: attach.mesh,
     })
 }
+
+/// Merge the worker fragments' `TaskMetrics` frames into an executed `DistributedExec` plan for
+/// EXPLAIN ANALYZE. The workers send their frames as they exit, after the leader's gather
+/// already finished, so nothing has drained the leader inbox since; sweep it, file the frames
+/// into the plan's metrics store, and rewrite. Returns the rewritten plan, or `None` when there
+/// is nothing to merge (serial plan, metrics disabled) or a frame never arrived (the rewrite is
+/// bounded rather than trusting `wait_for_metrics`, which would block on a dead worker).
+/// Drain the workers' `TaskMetrics` frames off the mesh into the plan's metrics store.
+///
+/// Must run while the parallel DSM is still mapped: the mesh receivers read ring memory inside
+/// it. `shutdown_custom_scan` is the spot; the EXPLAIN hook runs after `ExecShutdownNode` tore
+/// the DSM down, so draining there reads unmapped memory.
+pub fn drain_worker_metrics(
+    plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    mesh: &Arc<MppMesh>,
+) -> Option<()> {
+    use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
+    use datafusion_distributed::shm::CooperativeDrainSet;
+    use datafusion_distributed::{DistributedExec, NetworkBoundaryExt};
+
+    let dist = plan.as_any().downcast_ref::<DistributedExec>()?;
+    let store = dist.metrics_store()?;
+
+    // The wire frames carry (stage, task); the query uuid lives on the plan's own stages. Count
+    // the expected reports while walking: one per task of every producer stage.
+    let mut query_id = None;
+    let mut expected = 0usize;
+    let _ = plan.apply(|node| {
+        if let Some(nb) = node.as_network_boundary() {
+            let stage = nb.input_stage();
+            query_id.get_or_insert_with(|| stage.query_id().as_bytes().to_vec());
+            expected += stage.task_count();
+        }
+        Ok(TreeNodeRecursion::Continue)
+    });
+    let query_id = query_id?;
+
+    // The workers send their metrics frames right after their last EOF, which may still be in
+    // flight when shutdown reaches this node; wait briefly, bounded, and stop as soon as every
+    // expected (stage, task) reported.
+    let mut rx = mesh.take_task_metrics_receiver()?;
+    let mut got = crate::api::HashSet::default();
+    for _ in 0..100 {
+        let _ = mesh.try_drain_pass();
+        while let Ok((stage_id, task_number, metrics)) = rx.try_recv() {
+            store.insert(
+                datafusion_distributed::TaskKey {
+                    query_id: query_id.clone(),
+                    stage_id: stage_id as u64,
+                    task_number: task_number as u64,
+                },
+                metrics,
+            );
+            got.insert((stage_id, task_number));
+        }
+        if got.len() >= expected {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(1));
+    }
+    Some(())
+}
+
+/// Rewrite the executed plan with the worker metrics collected by [`drain_worker_metrics`].
+/// Mesh-free, so it is safe at EXPLAIN-render time, after the DSM is gone.
+///
+/// Owns a small timer-enabled runtime: the rewrite waits on the metrics store, and the bound on
+/// that wait needs timers, which the scans' cached runtimes don't enable.
+pub fn merge_worker_metrics(
+    plan: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+) -> Option<Arc<dyn datafusion::physical_plan::ExecutionPlan>> {
+    use datafusion_distributed::DistributedExec;
+
+    plan.as_any().downcast_ref::<DistributedExec>()?;
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .ok()?;
+    runtime
+        .block_on(async {
+            tokio::time::timeout(
+                std::time::Duration::from_millis(250),
+                datafusion_distributed::rewrite_distributed_plan_with_metrics(
+                    Arc::clone(plan),
+                    datafusion_distributed::DistributedMetricsFormat::PerTask,
+                ),
+            )
+            .await
+        })
+        .ok()?
+        .ok()
+}

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -180,6 +180,34 @@ LIMIT 10;
 (10 rows)
 
 -- =====================================================================
+-- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
+-- The values vary run to run, so assert presence, not content: the
+-- worker fragments' nodes must show row counts, which only happens
+-- when their TaskMetrics frames crossed the mesh.
+-- =====================================================================
+CREATE OR REPLACE FUNCTION mpp_explain_analyze_lines(q text) RETURNS SETOF text AS $$
+DECLARE r record;
+BEGIN
+  FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF) ' || q LOOP
+    RETURN NEXT r."QUERY PLAN";
+  END LOOP;
+END $$ LANGUAGE plpgsql;
+SELECT count(*) > 0 AS worker_metrics_shown
+FROM mpp_explain_analyze_lines(
+  'SELECT f.title, p.size_bytes
+   FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+   WHERE f.content @@@ ''Section''
+   ORDER BY f.title, p.size_bytes
+   LIMIT 10'
+) AS line
+WHERE line LIKE '%output_rows%';
+ worker_metrics_shown 
+----------------------
+ t
+(1 row)
+
+DROP FUNCTION mpp_explain_analyze_lines(text);
+-- =====================================================================
 -- Cleanup
 -- =====================================================================
 DROP TABLE mpp_join_pages;

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -181,9 +181,9 @@ LIMIT 10;
 
 -- =====================================================================
 -- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
--- The values vary run to run, so assert presence, not content: the
--- worker fragments' nodes must show row counts, which only happens
--- when their TaskMetrics frames crossed the mesh.
+-- Asserts presence, not content: how many workers launch and how they
+-- split the rows isn't pinned, so per-fragment metrics vary run to run.
+-- A fragment's row counts appear only once its TaskMetrics crossed the mesh.
 -- =====================================================================
 CREATE OR REPLACE FUNCTION mpp_explain_analyze_lines(q text) RETURNS SETOF text AS $$
 DECLARE r record;

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -111,6 +111,33 @@ ORDER BY f.title, p.size_bytes
 LIMIT 10;
 
 -- =====================================================================
+-- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
+-- The values vary run to run, so assert presence, not content: the
+-- worker fragments' nodes must show row counts, which only happens
+-- when their TaskMetrics frames crossed the mesh.
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION mpp_explain_analyze_lines(q text) RETURNS SETOF text AS $$
+DECLARE r record;
+BEGIN
+  FOR r IN EXECUTE 'EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF) ' || q LOOP
+    RETURN NEXT r."QUERY PLAN";
+  END LOOP;
+END $$ LANGUAGE plpgsql;
+
+SELECT count(*) > 0 AS worker_metrics_shown
+FROM mpp_explain_analyze_lines(
+  'SELECT f.title, p.size_bytes
+   FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+   WHERE f.content @@@ ''Section''
+   ORDER BY f.title, p.size_bytes
+   LIMIT 10'
+) AS line
+WHERE line LIKE '%output_rows%';
+
+DROP FUNCTION mpp_explain_analyze_lines(text);
+
+-- =====================================================================
 -- Cleanup
 -- =====================================================================
 

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -112,9 +112,9 @@ LIMIT 10;
 
 -- =====================================================================
 -- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
--- The values vary run to run, so assert presence, not content: the
--- worker fragments' nodes must show row counts, which only happens
--- when their TaskMetrics frames crossed the mesh.
+-- Asserts presence, not content: how many workers launch and how they
+-- split the rows isn't pinned, so per-fragment metrics vary run to run.
+-- A fragment's row counts appear only once its TaskMetrics crossed the mesh.
 -- =====================================================================
 
 CREATE OR REPLACE FUNCTION mpp_explain_analyze_lines(q text) RETURNS SETOF text AS $$


### PR DESCRIPTION
## What

This PR surfaces worker fragment metrics in `EXPLAIN ANALYZE` for MPP queries. Workers report a `TaskMetrics` frame per fragment over the shared-memory mesh as they exit, and the leader folds them into the plan it displays.

## Why

Until now only the leader's own nodes carried metrics: the worker fragments executed in parallel workers and their numbers died with the process. With the mesh able to carry control frames, the metrics can come home, which is the first production use of that channel (dynamic filters ride the same one later).

## How

- Workers keep each fragment's prepared plan through execution and, after the fragments join, send `collect_task_metrics(plan, task, task_count)` to the leader via the bounded best-effort sender. Frames go out even after a fragment error; partial metrics still show where the time went.
- The leader caches its executed plan in the scan state (the planner already enables metrics collection on the `DistributedExec`).
- `mpp::glue::merge_worker_metrics` does the shared work at explain time: sweep the leader inbox (nothing drains it after the gather finishes), file the frames into the plan's metrics store keyed by the query id from the plan's own stages, and run the fork's metrics rewrite under a 250 ms bound so a worker that never reported cannot hang `EXPLAIN`.
- Both customscans use it: joinscan's existing `EXPLAIN ANALYZE` rendering now shows worker rows, and aggregatescan gains the display.

## Tests

A regress check shows that worker row counts appear in `EXPLAIN ANALYZE` output (presence, not values: the numbers vary run to run).
