### PR TITLE
fix(pg_search): zero FSM page struct padding to avoid uninitialised WAL bytes

### DIFF
--- a/pg_search/src/postgres/storage/avl.rs
+++ b/pg_search/src/postgres/storage/avl.rs
@@ -100,17 +100,18 @@ impl<K: Copy, V: Copy, T: Copy> Slot<K, V, T> {
 
 impl<K: Copy, V: Copy, T: Copy> Default for Slot<K, V, T> {
     fn default() -> Self {
-        // Keys/values in unused slots are ignored. We avoid reading them when used=false.
-        // Zeroing is fine for common PODs; if your K/V cannot be zeroed, just ensure you never
-        // read key/val unless `is_used()` is true.
-        Self {
-            key: unsafe { core::mem::zeroed() },
-            val: unsafe { core::mem::zeroed() },
-            tag: unsafe { core::mem::zeroed() },
-            left: None,
-            right: None,
-            meta: 0, // used=false, height=0
-        }
+        // A `Slot` lives inside an on-disk Postgres page (the FSM root block) and the entire
+        // page is diffed into the WAL by `GenericXLog`. A struct-literal initializer leaves this
+        // struct's trailing padding (present whenever `K`/`V`/`T` don't fill out the struct's
+        // alignment, e.g. 7 bytes for `Slot<u64, (), u32>`) uninitialized, and those bytes would
+        // surface as "uninitialised value" reads when the WAL delta is computed (flagged by
+        // Valgrind, and nondeterministic bytes in the WAL stream). Building the value in zeroed
+        // memory makes every padding byte a defined zero.
+        //
+        // All-zero is exactly the intended default: left/right = None (niche 0), key/val/tag = 0,
+        // meta = 0 (used=false, height=0). Keys/values in unused slots are ignored -- we never read
+        // key/val unless `is_used()` is true -- so zeroing is fine for the PODs we store here.
+        unsafe { core::mem::zeroed() }
     }
 }
 
@@ -122,12 +123,24 @@ pub enum Error {
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-#[derive(Default, Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone)]
 #[repr(C)]
 pub struct AvlTreeMapHeader {
     root: Option<usize>,
     free_head: Option<usize>,
     len: usize,
+}
+
+impl Default for AvlTreeMapHeader {
+    fn default() -> Self {
+        // This header is embedded in the on-disk FSM root block, which is diffed into the WAL by
+        // `GenericXLog`. `Option<usize>` has no niche, so each one is laid out as a 1-byte
+        // discriminant followed by 7 bytes of padding before the `usize` payload; a struct-literal
+        // initializer would leave those padding bytes uninitialized and they would surface as
+        // "uninitialised value" reads in the WAL delta. Building in zeroed memory makes the padding
+        // a defined zero. All-zero is the intended default: root/free_head = None, len = 0.
+        unsafe { core::mem::zeroed() }
+    }
 }
 
 /// Read-only view of an Array-backed AVL Tree living inside a borrowed [`&[Slot<K,V>]`]

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -163,12 +163,17 @@ pub mod v1 {
 
     impl Default for V1Header {
         fn default() -> Self {
-            Self {
-                header: FSMBlockHeader {
-                    kind: FSMBlockKind::v1_uncompressed,
-                },
-                empty: false,
-            }
+            // This header is written into an on-disk page whose full image is diffed into the WAL
+            // by `GenericXLog`. `FSMBlockHeader` is 4-byte aligned, so the `empty` bool leaves 3
+            // trailing padding bytes; a struct-literal initializer would leave them uninitialized
+            // and they would surface as "uninitialised value" reads in the WAL delta. Building in
+            // zeroed memory makes that padding a defined zero (see `v2::FSMRootBlock::default` for
+            // the full rationale). `empty` defaults to false == 0, already set by the zeroing.
+            let mut this: Self = unsafe { core::mem::zeroed() };
+            this.header = FSMBlockHeader {
+                kind: FSMBlockKind::v1_uncompressed,
+            };
+            this
         }
     }
 
@@ -683,11 +688,21 @@ pub mod v2 {
 
     impl Default for FSMRootBlock {
         fn default() -> Self {
-            Self {
-                header: V2Header::default(),
-                avl_header: Default::default(),
-                avl_arena: [AvlSlot::default(); MAX_SLOTS],
-            }
+            // This struct is written verbatim into a Postgres page, and the whole page is diffed
+            // into the WAL by `GenericXLog`. A struct-literal initializer would leave several
+            // padding regions uninitialized: the 4-byte gap between the 4-byte `V2Header` and the
+            // 8-byte-aligned `AvlTreeMapHeader`, the padding inside that header, and each slot's
+            // trailing padding. Those bytes would then show up as "uninitialised value" reads in
+            // the WAL delta -- caught (correctly) by Valgrind, and nondeterministic bytes in the
+            // WAL stream. Building in zeroed memory makes every padding byte a defined zero.
+            //
+            // All-zero is a valid bit pattern for everything except the block kind: `Option<usize>`
+            // None == 0, an all-zero `AvlSlot` is a free slot, and an all-zero `AvlTreeMapHeader`
+            // is `{ root: None, free_head: None, len: 0 }`. Only the `V2Header`'s `FSMBlockKind`
+            // discriminant needs a non-zero value, so we set it explicitly after zeroing.
+            let mut this: Self = unsafe { core::mem::zeroed() };
+            this.header = V2Header::default();
+            this
         }
     }
 


### PR DESCRIPTION
Stacked on #5274 (base `ci/valgrind-sanitizer-regress`, not `main`): the fix for the memory errors that PR's Valgrind workflow surfaces. Merge here first; #5274 then carries both to `main`.

## Problem

The FSM structs are written straight into Postgres pages (`*contents = X::default()`), and `GenericXLog` diffs the whole page image into the WAL. Several of these `#[repr(C)]` structs have padding a struct-literal initializer never writes: a 4-byte gap in `v2::FSMRootBlock`, 7 bytes per `Option<usize>` in `avl::AvlTreeMapHeader`, 7 trailing bytes in `avl::Slot<u64, (), u32>`, and 3 in `v1::V1Header`.

Those bytes land in the page uninitialised at creation, and every later full-page `GenericXLog` delta reads them back. Valgrind flags it, correctly:

```
Conditional jump or move depends on uninitialised value(s)
    at computeRegionDelta (generic_xlog.c)
    by GenericXLogFinish ... by V2FSM::drain / BufferMut::drop
```

Harmless for correctness (nothing reads the padding), but it writes nondeterministic bytes into the WAL and keeps the Valgrind run (#5274) red on every FSM write.

## Fix

Build the affected `Default` values in zeroed memory (`core::mem::zeroed()`) so every padding byte is a defined zero. All-zero is the intended default (`Option` niche `None == 0`, an all-zero `Slot` is free, etc.); only the `FSMBlockKind` discriminant is non-zero, set explicitly after zeroing.

On-disk layout stays byte-identical, so existing indexes remain readable. The padding only goes uninitialised at creation; field-wise mutations afterward (e.g. `header.root = Some(x)` lowers to `stp x8, x1`, discriminant zero-extended into a full register) write the padding as zero too and never re-poison it.

## Testing

`cargo check -p pg_search --features pg17` is clean and all 11 in-memory `avl::` unit tests pass. The real regression guard is the Valgrind workflow in #5274.
