### PR TITLE
fix: run vacuum to ensure visibility map is updated

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -256,6 +256,12 @@ async fn run_benchmarks(args: &BenchmarkArgs) -> anyhow::Result<Vec<QueryResult>
             .execute(&mut utility_conn)
             .await
             .with_context(|| "Failed to vacuum")?;
+        // VACUUM FULL does not update the visibility map. Run both types so that our heap file
+        // contains no wasted space and we get an updated vm
+        sqlx::query("VACUUM ANALYZE")
+            .execute(&mut utility_conn)
+            .await
+            .with_context(|| "Failed to vacuum")?;
     }
 
     if args.prewarm {


### PR DESCRIPTION
The visibility map does not get updated from `VACUUM FULL`. Running both a full and regular vacuum ensures the heap file has no fragmented space and the visibility map is updated.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
