### PR TITLE
fix(mpp): stopped `work_mem` overflow and cancellation from crashing the server.

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -49,6 +49,7 @@ use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTas
 use datafusion_distributed::shm::MppMesh;
 
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
+use crate::postgres::customscan::mpp::interrupt::{process_pending, HeldInterrupts};
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
@@ -633,16 +634,22 @@ impl CustomScan for AggregateScan {
         // context is finally destroyed). Harmless when the gather already reached EOF.
         if let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() {
             df_state.stream = None;
+            // Release the DSM-backed control senders before `recv`. A producer's `work_mem`
+            // overflow (or any worker error) is re-raised in the leader from inside `recv`, which
+            // longjmps out of this hook; a release placed after it would never run, leaving the
+            // senders to drop at xact commit, past the DSM's lifetime, where their `fetch_sub`
+            // faults. The query is done producing here, so the senders aren't needed.
+            if let Some(leader) = df_state.mpp.as_ref() {
+                leader.release_control_senders();
+            }
             if let Some(leader) = df_state.mpp.as_mut() {
                 if let Some(finish) = leader.finish.as_mut() {
                     let _ = finish.recv();
                 }
             }
         }
-        // PG destroys the parallel DSM right after this hook, so everything that reads or
-        // releases ring memory must happen now: drain the workers' metrics frames off the mesh
-        // (the EXPLAIN hook runs after teardown and only reads the store), then drop the
-        // leader's control senders, whose drop decrements counters inside the mapping.
+        // PG destroys the parallel DSM right after this hook, so drain the workers' metrics frames
+        // off the mesh now (the EXPLAIN hook runs after teardown and only reads the store).
         if let Some(df_state) = state.custom_state().datafusion_state.as_ref() {
             if let Some(leader) = df_state.mpp.as_ref() {
                 if let Some(plan) = df_state.physical_plan.as_ref() {
@@ -651,7 +658,6 @@ impl CustomScan for AggregateScan {
                         &leader.mesh,
                     );
                 }
-                leader.release_control_senders();
             }
         }
     }
@@ -1652,7 +1658,18 @@ impl AggregateScan {
             let runtime = df_state.runtime.as_ref().unwrap();
             let stream = df_state.stream.as_mut().unwrap();
 
-            let next = runtime.block_on(async { stream.next().await });
+            let next = {
+                // Hold cancel/die off across the pull so a subroutine's `CHECK_FOR_INTERRUPTS`
+                // can't `proc_exit` out of the live runtime; the consumer drain polls
+                // cooperatively to bail. Resumes at end of block.
+                let _held = HeldInterrupts::hold();
+                runtime.block_on(async { stream.next().await })
+            };
+
+            // The consumer drain bails cooperatively on a pending cancel/die so the runtime
+            // can unwind first; service it now with the runtime idle (a die `proc_exit`s here)
+            // before the error match below.
+            process_pending();
 
             match next {
                 Some(Ok(batch)) => {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -49,7 +49,7 @@ use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTas
 use datafusion_distributed::shm::MppMesh;
 
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
-use crate::postgres::customscan::mpp::interrupt::{process_pending, HeldInterrupts};
+use crate::postgres::customscan::mpp::interrupt::block_on_next;
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
@@ -100,7 +100,6 @@ use crate::postgres::utils::{add_vars_to_tlist, is_unnest_func, make_text_const}
 use crate::postgres::ParallelScanArgs;
 use crate::postgres::PgSearchRelation;
 use crate::scan::codec::serialize_logical_plan;
-use futures::StreamExt;
 use pgrx::{pg_sys, PgList, PgMemoryContexts, PgTupleDesc};
 use std::ffi::CStr;
 
@@ -647,10 +646,9 @@ impl CustomScan for AggregateScan {
                     let _ = finish.recv();
                 }
             }
-        }
-        // PG destroys the parallel DSM right after this hook, so drain the workers' metrics frames
-        // off the mesh now (the EXPLAIN hook runs after teardown and only reads the store).
-        if let Some(df_state) = state.custom_state().datafusion_state.as_ref() {
+            // PG destroys the parallel DSM right after this hook, so drain the workers' metrics
+            // frames off the mesh now (the EXPLAIN hook runs after teardown and only reads the
+            // store).
             if let Some(leader) = df_state.mpp.as_ref() {
                 if let Some(plan) = df_state.physical_plan.as_ref() {
                     crate::postgres::customscan::mpp::glue::drain_worker_metrics(
@@ -1655,21 +1653,10 @@ impl AggregateScan {
             }
 
             // Fetch next batch from stream
-            let runtime = df_state.runtime.as_ref().unwrap();
-            let stream = df_state.stream.as_mut().unwrap();
-
-            let next = {
-                // Hold cancel/die off across the pull so a subroutine's `CHECK_FOR_INTERRUPTS`
-                // can't `proc_exit` out of the live runtime; the consumer drain polls
-                // cooperatively to bail. Resumes at end of block.
-                let _held = HeldInterrupts::hold();
-                runtime.block_on(async { stream.next().await })
-            };
-
-            // The consumer drain bails cooperatively on a pending cancel/die so the runtime
-            // can unwind first; service it now with the runtime idle (a die `proc_exit`s here)
-            // before the error match below.
-            process_pending();
+            let next = block_on_next(
+                df_state.runtime.as_ref().unwrap(),
+                df_state.stream.as_mut().unwrap(),
+            );
 
             match next {
                 Some(Ok(batch)) => {

--- a/pg_search/src/postgres/customscan/datafusion/memory.rs
+++ b/pg_search/src/postgres/customscan/datafusion/memory.rs
@@ -17,7 +17,9 @@
 
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::DataFusionError;
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 use datafusion::execution::memory_pool::{GreedyMemoryPool, MemoryPool, MemoryReservation};
+use datafusion::execution::runtime_env::{RuntimeEnv, RuntimeEnvBuilder};
 use datafusion::physical_plan::joins::{HashJoinExec, SortMergeJoinExec};
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
@@ -108,6 +110,21 @@ pub fn create_memory_pool(
     .expect("Failed to traverse plan for estimating memory");
 
     Arc::new(WorkMemMemoryPool::new(total_memory.max(work_mem)))
+}
+
+/// Build the DataFusion `RuntimeEnv` for JoinScan and AggregateScan: the `work_mem` pool plus a
+/// disabled disk manager, so a `try_grow` past the budget errors instead of writing untracked
+/// temp files. Spilling isn't wired to PG's temp-file management yet.
+pub fn build_runtime_env(memory_pool: Arc<dyn MemoryPool>) -> Arc<RuntimeEnv> {
+    Arc::new(
+        RuntimeEnvBuilder::new()
+            .with_memory_pool(memory_pool)
+            .with_disk_manager_builder(
+                DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
+            )
+            .build()
+            .expect("Failed to create RuntimeEnv"),
+    )
 }
 
 #[cfg(test)]

--- a/pg_search/src/postgres/customscan/datafusion/memory.rs
+++ b/pg_search/src/postgres/customscan/datafusion/memory.rs
@@ -17,52 +17,47 @@
 
 use datafusion::common::tree_node::{TreeNode, TreeNodeRecursion};
 use datafusion::common::DataFusionError;
-use datafusion::execution::memory_pool::{MemoryPool, MemoryReservation};
+use datafusion::execution::memory_pool::{GreedyMemoryPool, MemoryPool, MemoryReservation};
 use datafusion::physical_plan::joins::{HashJoinExec, SortMergeJoinExec};
 use datafusion::physical_plan::sorts::sort::SortExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use std::sync::Arc;
 
-// TODO: Instead of panicking, implement a `MemoryPool` that integrates with PostgreSQL's
-// temporary file management (BufFile/VFD) to allow DataFusion to spill to disk when
-// `work_mem` is exceeded.
+/// Caps DataFusion allocations at PostgreSQL's `work_mem` and reports an overflow as a
+/// query error. A panic here used to abort the backend: on the MPP path the pool runs in
+/// a parallel worker, so the panic took down the whole server instead of failing the one
+/// query. The caller pairs this with a disabled disk manager, so a `try_grow` past the
+/// limit aborts the query rather than spilling to untracked temp files.
+///
+// TODO: spill through PostgreSQL's temp-file management (BufFile/VFD) so large
+// aggregates and sorts complete instead of erroring once `work_mem` is exceeded.
 #[derive(Debug)]
-struct PanicOnOOMMemoryPool {
-    pool: datafusion::execution::memory_pool::GreedyMemoryPool,
+struct WorkMemMemoryPool {
+    pool: GreedyMemoryPool,
     limit: usize,
 }
 
-impl PanicOnOOMMemoryPool {
+impl WorkMemMemoryPool {
     fn new(limit: usize) -> Self {
         Self {
-            pool: datafusion::execution::memory_pool::GreedyMemoryPool::new(limit),
+            pool: GreedyMemoryPool::new(limit),
             limit,
         }
     }
-
-    fn check_limit(&self, additional: usize) {
-        if self.pool.reserved() + additional > self.limit {
-            panic!(
-                "JoinScan: Out of memory! Query exceeded work_mem limit of {} bytes.",
-                self.limit
-            );
-        }
-    }
 }
 
-impl std::fmt::Display for PanicOnOOMMemoryPool {
+impl std::fmt::Display for WorkMemMemoryPool {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "PanicOnOOMMemoryPool")
+        write!(f, "WorkMemMemoryPool")
     }
 }
 
-impl MemoryPool for PanicOnOOMMemoryPool {
+impl MemoryPool for WorkMemMemoryPool {
     fn name(&self) -> &str {
-        "PanicOnOOMMemoryPool"
+        "WorkMemMemoryPool"
     }
 
     fn grow(&self, reservation: &MemoryReservation, additional: usize) {
-        self.check_limit(additional);
         self.pool.grow(reservation, additional);
     }
 
@@ -75,12 +70,12 @@ impl MemoryPool for PanicOnOOMMemoryPool {
         reservation: &MemoryReservation,
         additional: usize,
     ) -> Result<(), DataFusionError> {
-        self.check_limit(additional);
-        // Delegate to inner pool, though we've already done our own check.
-        // The inner pool also enforces the limit but returns Error.
-        // We want to panic if WE detect it, so we did check_limit above.
-        // But for correctness of inner state, we call it.
-        self.pool.try_grow(reservation, additional)
+        self.pool.try_grow(reservation, additional).map_err(|_| {
+            DataFusionError::ResourcesExhausted(format!(
+                "query exceeded the work_mem limit of {} bytes; raise work_mem to run it",
+                self.limit
+            ))
+        })
     }
 
     fn reserved(&self) -> usize {
@@ -88,10 +83,12 @@ impl MemoryPool for PanicOnOOMMemoryPool {
     }
 }
 
-/// Returns a memory pool that panics when the memory limit is exceeded.
+/// Returns a memory pool that fails the query with a `ResourcesExhausted` error when the
+/// `work_mem` budget is exceeded, rather than crashing the backend.
 ///
-/// This is used to enforce `work_mem` limits in `JoinScan` and prevent
-/// DataFusion from attempting to spill to disk (which is not yet implemented safely).
+/// Sized for `JoinScan` and `AggregateScan`. The estimate is per-operator: `HashJoinExec`
+/// reserves `work_mem * hash_mem_multiplier`, sorts reserve `work_mem`, each times their
+/// partition count.
 pub fn create_memory_pool(
     plan: &Arc<dyn ExecutionPlan>,
     work_mem: usize,
@@ -110,5 +107,32 @@ pub fn create_memory_pool(
     })
     .expect("Failed to traverse plan for estimating memory");
 
-    Arc::new(PanicOnOOMMemoryPool::new(total_memory.max(work_mem)))
+    Arc::new(WorkMemMemoryPool::new(total_memory.max(work_mem)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion::execution::memory_pool::MemoryConsumer;
+
+    #[test]
+    fn try_grow_past_work_mem_errors_instead_of_panicking() {
+        let pool: Arc<dyn MemoryPool> = Arc::new(WorkMemMemoryPool::new(1024));
+        let res = MemoryConsumer::new("test").register(&pool);
+        res.try_grow(512).expect("within budget should succeed");
+        let err = res
+            .try_grow(4096)
+            .expect_err("over budget must return an error, not panic");
+        assert!(matches!(err, DataFusionError::ResourcesExhausted(_)));
+        assert!(err.to_string().contains("work_mem"));
+    }
+
+    #[test]
+    fn grow_is_infallible_past_work_mem() {
+        // The infallible path must not panic even past the limit; only `try_grow` enforces.
+        let pool: Arc<dyn MemoryPool> = Arc::new(WorkMemMemoryPool::new(1024));
+        let res = MemoryConsumer::new("test").register(&pool);
+        res.grow(8192);
+        assert_eq!(pool.reserved(), 8192);
+    }
 }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -179,6 +179,7 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::{mpp_is_active, producer_worker_count};
+use crate::postgres::customscan::mpp::interrupt::{process_pending, HeldInterrupts};
 use datafusion_distributed::shm::MppMesh;
 
 use crate::postgres::customscan::parallel::compute_nworkers;
@@ -1552,6 +1553,10 @@ impl CustomScan for JoinScan {
 
                 let next_batch = {
                     let custom_state = state.custom_state_mut();
+                    // Hold cancel/die off across the pull so a subroutine's
+                    // `CHECK_FOR_INTERRUPTS` can't `proc_exit` out of the live runtime; the
+                    // consumer drain polls cooperatively to bail. Resumes at end of block.
+                    let _held = HeldInterrupts::hold();
                     custom_state.runtime.as_mut().unwrap().block_on(async {
                         custom_state
                             .datafusion_stream
@@ -1561,6 +1566,11 @@ impl CustomScan for JoinScan {
                             .await
                     })
                 };
+
+                // The consumer drain bails cooperatively on a pending cancel/die so the
+                // runtime can unwind first; service it now with the runtime idle (a die
+                // `proc_exit`s here) before the error match below.
+                process_pending();
 
                 match next_batch {
                     Some(Ok(batch)) => {
@@ -1579,6 +1589,14 @@ impl CustomScan for JoinScan {
         // leader-inbox detach, so producers blocked on full rings stop. Harmless when the gather
         // already reached EOF.
         state.custom_state_mut().datafusion_stream = None;
+        // Release the DSM-backed control senders before `recv`. A producer's `work_mem` overflow
+        // (or any worker error) is re-raised in the leader from inside `recv`, which `longjmp`s
+        // out of this hook; a release placed after it would never run, leaving the senders to drop
+        // at xact commit, past the DSM's lifetime, where their `fetch_sub` faults. The query is
+        // done producing here, so the senders aren't needed, and the drop runs while DSM is mapped.
+        if let Some(leader) = state.custom_state().mpp.as_ref() {
+            leader.release_control_senders();
+        }
         // Wait for the producer workers to finish and flush their `TaskMetrics` before draining:
         // `recv` blocks until every worker detaches its completion queue, which it does only after
         // sending metrics. PG's parallel teardown joins Gather-spawned workers here; the
@@ -1590,13 +1608,11 @@ impl CustomScan for JoinScan {
             }
         }
         // The EXPLAIN hook runs after teardown and only reads the store, so drain the workers'
-        // metrics frames off the mesh now, then drop the leader's control senders (their drop
-        // decrements counters inside the still-mapped DSM).
+        // metrics frames off the mesh now.
         if let Some(leader) = state.custom_state().mpp.as_ref() {
             if let Some(plan) = state.custom_state().physical_plan.as_ref() {
                 crate::postgres::customscan::mpp::glue::drain_worker_metrics(plan, &leader.mesh);
             }
-            leader.release_control_senders();
         }
     }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -179,7 +179,7 @@ use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_fields;
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::{mpp_is_active, producer_worker_count};
-use crate::postgres::customscan::mpp::interrupt::{process_pending, HeldInterrupts};
+use crate::postgres::customscan::mpp::interrupt::block_on_next;
 use datafusion_distributed::shm::MppMesh;
 
 use crate::postgres::customscan::parallel::compute_nworkers;
@@ -195,7 +195,6 @@ use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
 use datafusion_distributed::{display_plan_ascii, DistributedExec};
-use futures::StreamExt;
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
 use std::sync::Arc;
@@ -1553,24 +1552,11 @@ impl CustomScan for JoinScan {
 
                 let next_batch = {
                     let custom_state = state.custom_state_mut();
-                    // Hold cancel/die off across the pull so a subroutine's
-                    // `CHECK_FOR_INTERRUPTS` can't `proc_exit` out of the live runtime; the
-                    // consumer drain polls cooperatively to bail. Resumes at end of block.
-                    let _held = HeldInterrupts::hold();
-                    custom_state.runtime.as_mut().unwrap().block_on(async {
-                        custom_state
-                            .datafusion_stream
-                            .as_mut()
-                            .unwrap()
-                            .next()
-                            .await
-                    })
+                    block_on_next(
+                        custom_state.runtime.as_ref().unwrap(),
+                        custom_state.datafusion_stream.as_mut().unwrap(),
+                    )
                 };
-
-                // The consumer drain bails cooperatively on a pending cancel/die so the
-                // runtime can unwind first; service it now with the runtime idle (a die
-                // `proc_exit`s here) before the error match below.
-                process_pending();
 
                 match next_batch {
                     Some(Ok(batch)) => {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -74,13 +74,11 @@ use tantivy::index::SegmentId;
 use super::planning::get_source_attno_by_name;
 use crate::api::{NullTestKind, OrderByFeature, SortDirection};
 use crate::index::fast_fields_helper::WhichFastField;
-use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use crate::postgres::customscan::datafusion::memory::{build_runtime_env, create_memory_pool};
 use crate::postgres::customscan::joinscan::build::{
     self as build, CtidColumn, JoinCSClause, JoinSource, RelNode, RelationAlias,
 };
 use crate::postgres::customscan::joinscan::planner::SortMergeJoinEnforcer;
-use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
-use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::TaskContext;
 use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
 
@@ -474,17 +472,7 @@ pub fn build_task_context(
     Arc::new(
         TaskContext::default()
             .with_session_config(ctx.state().config().clone())
-            .with_runtime(Arc::new(
-                RuntimeEnvBuilder::new()
-                    .with_memory_pool(memory_pool)
-                    // Spilling isn't wired to PG's temp-file management yet, so keep it
-                    // off: a `work_mem` overflow errors instead of writing untracked files.
-                    .with_disk_manager_builder(
-                        DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
-                    )
-                    .build()
-                    .expect("Failed to create RuntimeEnv"),
-            )),
+            .with_runtime(build_runtime_env(memory_pool)),
     )
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -79,6 +79,7 @@ use crate::postgres::customscan::joinscan::build::{
     self as build, CtidColumn, JoinCSClause, JoinSource, RelNode, RelationAlias,
 };
 use crate::postgres::customscan::joinscan::planner::SortMergeJoinEnforcer;
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::TaskContext;
 use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
@@ -476,6 +477,11 @@ pub fn build_task_context(
             .with_runtime(Arc::new(
                 RuntimeEnvBuilder::new()
                     .with_memory_pool(memory_pool)
+                    // Spilling isn't wired to PG's temp-file management yet, so keep it
+                    // off: a `work_mem` overflow errors instead of writing untracked files.
+                    .with_disk_manager_builder(
+                        DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
+                    )
                     .build()
                     .expect("Failed to create RuntimeEnv"),
             )),

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -33,6 +33,7 @@
 
 use std::sync::Arc;
 
+use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
 use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
 use datafusion::prelude::SessionContext;
@@ -443,6 +444,11 @@ pub(crate) fn run_mpp_worker(
                     .with_runtime(Arc::new(
                         RuntimeEnvBuilder::new()
                             .with_memory_pool(memory_pool)
+                            // Spilling isn't wired to PG's temp-file management yet, so keep
+                            // it off: a `work_mem` overflow errors instead of writing files.
+                            .with_disk_manager_builder(
+                                DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
+                            )
                             .build()
                             .expect("Failed to create RuntimeEnv"),
                     )),

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -54,7 +54,7 @@ use datafusion_distributed::PartitionSink;
 
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
 use crate::postgres::customscan::mpp::glue::producer_worker_count;
-use crate::postgres::customscan::mpp::interrupt::{process_pending, HeldInterrupts};
+use crate::postgres::customscan::mpp::interrupt::{check_for_interrupts, HeldInterrupts};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::customscan::parallel::list_segment_ids;
@@ -551,7 +551,7 @@ pub(crate) fn run_mpp_worker(
     // deferred, now on a stack with no live runtime; for a die this `proc_exit`s here instead
     // of mid-`block_on`.
     drop(held);
-    process_pending();
+    check_for_interrupts();
     if let Err(e) = result {
         pgrx::error!("mpp worker: fragment dispatch failed: {e}");
     }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -56,6 +56,7 @@ use datafusion_distributed::PartitionSink;
 
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
 use crate::postgres::customscan::mpp::glue::producer_worker_count;
+use crate::postgres::customscan::mpp::interrupt::{process_pending, HeldInterrupts};
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::customscan::parallel::list_segment_ids;
@@ -320,6 +321,10 @@ pub(crate) fn run_mpp_worker(
                 + Send,
         >,
     >;
+    // Hold cancel/die off for the duration so neither our drain/send loops nor a subroutine
+    // (the scanner's own `CHECK_FOR_INTERRUPTS`, a buffer wait) can `proc_exit` out of the
+    // live runtime. The loops poll cooperatively to bail promptly; see `mpp::interrupt`.
+    let held = HeldInterrupts::hold();
     let result = runtime.block_on(async move {
         let mut futures: Vec<FragmentFuture> = Vec::with_capacity(fragments.len());
         let mut executed_fragments: Vec<(u32, usize, usize, Arc<dyn ExecutionPlan>)> =
@@ -553,6 +558,12 @@ pub(crate) fn run_mpp_worker(
         }
         outcome
     });
+    // `block_on` has returned, so the runtime is idle and every fragment future (with its
+    // DSM senders) has dropped. Resume interrupts, then service any cancel/die the loops
+    // deferred, now on a stack with no live runtime; for a die this `proc_exit`s here instead
+    // of mid-`block_on`.
+    drop(held);
+    process_pending();
     if let Err(e) = result {
         pgrx::error!("mpp worker: fragment dispatch failed: {e}");
     }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -33,8 +33,6 @@
 
 use std::sync::Arc;
 
-use datafusion::execution::disk_manager::{DiskManagerBuilder, DiskManagerMode};
-use datafusion::execution::runtime_env::RuntimeEnvBuilder;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
@@ -45,7 +43,7 @@ use pgrx::pg_sys;
 use tantivy::index::SegmentId;
 
 use crate::api::HashSet;
-use crate::postgres::customscan::datafusion::memory::create_memory_pool;
+use crate::postgres::customscan::datafusion::memory::{build_runtime_env, create_memory_pool};
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::shm::{
     collect_task_metrics, proc_for_task, run_worker_fragment, CooperativeDrainSet,
@@ -446,17 +444,7 @@ pub(crate) fn run_mpp_worker(
             let task_ctx = Arc::new(
                 TaskContext::default()
                     .with_session_config(cfg)
-                    .with_runtime(Arc::new(
-                        RuntimeEnvBuilder::new()
-                            .with_memory_pool(memory_pool)
-                            // Spilling isn't wired to PG's temp-file management yet, so keep
-                            // it off: a `work_mem` overflow errors instead of writing files.
-                            .with_disk_manager_builder(
-                                DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
-                            )
-                            .build()
-                            .expect("Failed to create RuntimeEnv"),
-                    )),
+                    .with_runtime(build_runtime_env(memory_pool)),
             );
 
             // Wrap the fragment's plan in a fresh `DistributedExec` and run `prepare_in_process_plan`

--- a/pg_search/src/postgres/customscan/mpp/interrupt.rs
+++ b/pg_search/src/postgres/customscan/mpp/interrupt.rs
@@ -39,7 +39,7 @@
 //!
 //! `block_on` returns, the runtime goes idle, every fragment future (with its DSM senders)
 //! drops while the segment is still mapped, the hold resumes, and the caller calls
-//! [`process_pending`] to let PG act on the cancel/die with nothing left on the stack.
+//! [`check_for_interrupts`] to let PG act on the cancel/die with nothing left on the stack.
 
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::DataFusionError;
@@ -94,24 +94,24 @@ pub(crate) fn cancel_pending() -> bool {
 }
 
 /// Error an MPP loop returns when it bails on a pending cancel/die. The dispatcher discards
-/// it and calls [`process_pending`] once `block_on` has returned.
+/// it and calls [`check_for_interrupts`] once `block_on` has returned.
 pub(crate) fn interrupted() -> DataFusionError {
     DataFusionError::Execution("mpp: query interrupted".into())
 }
 
 /// Act on the cancel/die that [`HeldInterrupts`] held off and the drain loops bailed on
-/// cooperatively, now that `block_on` has returned and the runtime is idle. It's a named step
-/// rather than an inline `check_for_interrupts!()` in the loops because acting mid-`block_on`
+/// cooperatively, now that `block_on` has returned and the runtime is idle. Acting mid-`block_on`
 /// would `proc_exit` out of the live runtime; this is the safe point. Cancel `longjmp`s into PG
 /// error handling (caught and unwound by pgrx); die `proc_exit`s. Either way the runtime is off
-/// the stack, so the later customscan-state drop tears down cleanly.
+/// the stack, so the later customscan-state drop tears down cleanly. It's a function so the
+/// lib-test build, which doesn't link PG, can stub it to a no-op.
 #[cfg(not(test))]
-pub(crate) fn process_pending() {
+pub(crate) fn check_for_interrupts() {
     pgrx::check_for_interrupts!();
 }
 
 #[cfg(test)]
-pub(crate) fn process_pending() {}
+pub(crate) fn check_for_interrupts() {}
 
 /// Drive one batch out of an MPP gather `stream` under the cancel/die holdoff, then service any
 /// interrupt the drain deferred. The holdoff wraps the synchronous `block_on`, not the async
@@ -126,6 +126,6 @@ pub(crate) fn block_on_next(
         let _held = HeldInterrupts::hold();
         runtime.block_on(async { stream.next().await })
     };
-    process_pending();
+    check_for_interrupts();
     next
 }

--- a/pg_search/src/postgres/customscan/mpp/interrupt.rs
+++ b/pg_search/src/postgres/customscan/mpp/interrupt.rs
@@ -1,0 +1,109 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Cooperative cancel/die handling for the MPP execution loops.
+//!
+//! The producers and the leader consumer drive their DataFusion streams under a
+//! current-thread `tokio` runtime via `Runtime::block_on`. A backend-die (SIGTERM, which PG
+//! sends to the surviving parallel workers as soon as one of them errors) processes through
+//! `ProcessInterrupts` into `proc_exit`, which does NOT unwind the Rust stack. Taken from a
+//! `CHECK_FOR_INTERRUPTS()` inside `block_on`, that runs transaction cleanup while the tokio
+//! runtime is still live on the same stack, the customscan-state drop then drops the
+//! mid-flight runtime, and tokio aborts the process. (Query-cancel reaches PG via an
+//! `ereport` that pgrx catches and unwinds, so it's already safe; the die path is the one
+//! that crashes.)
+//!
+//! Two pieces cooperate:
+//!
+//! - [`HeldInterrupts`] wraps `block_on` in PG's `HOLD_INTERRUPTS()` / `RESUME_INTERRUPTS()`,
+//!   so a `CHECK_FOR_INTERRUPTS()` anywhere under the runtime (the scanner's own check, a
+//!   buffer wait, our drain loops) can't `proc_exit` mid-flight. The hold covers the
+//!   subroutine checks our cooperative polling can't reach.
+//! - The drain/send loops still poll [`cancel_pending`] and bail with [`interrupted`] so a
+//!   pending cancel/die makes `block_on` return promptly instead of running the held query to
+//!   completion.
+//!
+//! `block_on` returns, the runtime goes idle, every fragment future (with its DSM senders)
+//! drops while the segment is still mapped, the hold resumes, and the caller calls
+//! [`process_pending`] to let PG act on the cancel/die with nothing left on the stack.
+
+use datafusion::common::DataFusionError;
+
+/// RAII holdoff for cancel/die, mirroring PG's `HOLD_INTERRUPTS()` / `RESUME_INTERRUPTS()`.
+/// While one of these is alive, `ProcessInterrupts` returns without acting, so a backend-die
+/// can't `proc_exit` out of the live tokio runtime even if a subroutine runs
+/// `CHECK_FOR_INTERRUPTS()`. `Drop` resumes, including when a panic unwinds through `block_on`.
+pub(crate) struct HeldInterrupts {
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl HeldInterrupts {
+    pub(crate) fn hold() -> Self {
+        // SAFETY: backend-thread-only increment of the holdoff counter, paired with the
+        // decrement in `Drop`. Matches the `HOLD_INTERRUPTS()` macro.
+        #[cfg(not(test))]
+        unsafe {
+            pgrx::pg_sys::InterruptHoldoffCount += 1;
+        }
+        Self {
+            _not_send: std::marker::PhantomData,
+        }
+    }
+}
+
+impl Drop for HeldInterrupts {
+    fn drop(&mut self) {
+        #[cfg(not(test))]
+        unsafe {
+            pgrx::pg_sys::InterruptHoldoffCount -= 1;
+        }
+    }
+}
+
+/// True when a query-cancel (SIGINT) or backend-die (SIGTERM) is pending. Reads the signal
+/// flags directly so it never enters `ProcessInterrupts`, which could `proc_exit` out of the
+/// live runtime.
+#[cfg(not(test))]
+pub(crate) fn cancel_pending() -> bool {
+    // SAFETY: plain reads of the backend's interrupt flags on the backend thread.
+    unsafe { pgrx::pg_sys::QueryCancelPending != 0 || pgrx::pg_sys::ProcDiePending != 0 }
+}
+
+/// The lib-test binary doesn't link the PG globals; nothing in tests drives a real backend
+/// interrupt, so treat it as never pending.
+#[cfg(test)]
+pub(crate) fn cancel_pending() -> bool {
+    false
+}
+
+/// Error an MPP loop returns when it bails on a pending cancel/die. The dispatcher discards
+/// it and calls [`process_pending`] once `block_on` has returned.
+pub(crate) fn interrupted() -> DataFusionError {
+    DataFusionError::Execution("mpp: query interrupted".into())
+}
+
+/// Service a deferred cancel/die now that `block_on` has returned and the runtime is idle.
+/// Cancel `longjmp`s into PG error handling (caught and unwound by pgrx); die `proc_exit`s.
+/// Either way the runtime is no longer on the stack, so the later customscan-state drop tears
+/// down cleanly.
+#[cfg(not(test))]
+pub(crate) fn process_pending() {
+    pgrx::check_for_interrupts!();
+}
+
+#[cfg(test)]
+pub(crate) fn process_pending() {}

--- a/pg_search/src/postgres/customscan/mpp/interrupt.rs
+++ b/pg_search/src/postgres/customscan/mpp/interrupt.rs
@@ -41,7 +41,10 @@
 //! drops while the segment is still mapped, the hold resumes, and the caller calls
 //! [`process_pending`] to let PG act on the cancel/die with nothing left on the stack.
 
+use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::common::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use futures::StreamExt;
 
 /// RAII holdoff for cancel/die, mirroring PG's `HOLD_INTERRUPTS()` / `RESUME_INTERRUPTS()`.
 /// While one of these is alive, `ProcessInterrupts` returns without acting, so a backend-die
@@ -96,10 +99,12 @@ pub(crate) fn interrupted() -> DataFusionError {
     DataFusionError::Execution("mpp: query interrupted".into())
 }
 
-/// Service a deferred cancel/die now that `block_on` has returned and the runtime is idle.
-/// Cancel `longjmp`s into PG error handling (caught and unwound by pgrx); die `proc_exit`s.
-/// Either way the runtime is no longer on the stack, so the later customscan-state drop tears
-/// down cleanly.
+/// Act on the cancel/die that [`HeldInterrupts`] held off and the drain loops bailed on
+/// cooperatively, now that `block_on` has returned and the runtime is idle. It's a named step
+/// rather than an inline `check_for_interrupts!()` in the loops because acting mid-`block_on`
+/// would `proc_exit` out of the live runtime; this is the safe point. Cancel `longjmp`s into PG
+/// error handling (caught and unwound by pgrx); die `proc_exit`s. Either way the runtime is off
+/// the stack, so the later customscan-state drop tears down cleanly.
 #[cfg(not(test))]
 pub(crate) fn process_pending() {
     pgrx::check_for_interrupts!();
@@ -107,3 +112,20 @@ pub(crate) fn process_pending() {
 
 #[cfg(test)]
 pub(crate) fn process_pending() {}
+
+/// Drive one batch out of an MPP gather `stream` under the cancel/die holdoff, then service any
+/// interrupt the drain deferred. The holdoff wraps the synchronous `block_on`, not the async
+/// poll, so it can't move into the `Stream` itself: a `CHECK_FOR_INTERRUPTS` taken while
+/// `block_on` drives the runtime would `proc_exit` out of it. Shared by the JoinScan and
+/// AggregateScan consumers.
+pub(crate) fn block_on_next(
+    runtime: &tokio::runtime::Runtime,
+    stream: &mut SendableRecordBatchStream,
+) -> Option<Result<RecordBatch, DataFusionError>> {
+    let next = {
+        let _held = HeldInterrupts::hold();
+        runtime.block_on(async { stream.next().await })
+    };
+    process_pending();
+    next
+}

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -28,6 +28,7 @@
 pub mod dispatch;
 pub mod exec_worker;
 pub mod glue;
+pub mod interrupt;
 pub mod launch;
 pub mod pg_seams;
 pub mod task_estimator;

--- a/pg_search/src/postgres/customscan/mpp/pg_seams.rs
+++ b/pg_search/src/postgres/customscan/mpp/pg_seams.rs
@@ -24,6 +24,8 @@
 use datafusion::common::{DataFusionError, Result};
 use datafusion_distributed::shm::{Interrupt, Wakeup};
 
+use crate::postgres::customscan::mpp::interrupt::{cancel_pending, interrupted};
+
 /// A receiver backend as `(pgprocno, pid)`. The `pid` rules out a recycled `PGPROC` slot.
 type ReceiverProc = (i32, i32);
 
@@ -100,16 +102,17 @@ unsafe fn wake_receiver_via_pg_sys(pgprocno: i32, expected_pid: i32) {
     unsafe { pg_sys::SetLatch(&raw mut (*proc).procLatch) };
 }
 
-/// Cancellation seam: runs `check_for_interrupts!`, which longjmps out of the backend on a user
-/// CANCEL or query timeout. Checked at the transport's block points (the send spin and the consumer
-/// pull loop).
+/// Cancellation seam, checked at the transport's block points (the send spin and the consumer pull
+/// loop). Those run under `Runtime::block_on`, so it bails cooperatively with an error rather than
+/// servicing the interrupt here: a die taken inside `block_on` would `proc_exit` out of the live
+/// runtime. The caller services the deferred interrupt once `block_on` returns. See `mpp::interrupt`.
 pub struct PgInterrupt;
 
 impl Interrupt for PgInterrupt {
     fn check(&self) -> Result<(), DataFusionError> {
-        // Cfg'd out of the lib-test binary, which doesn't link PG's interrupt machinery.
-        #[cfg(not(test))]
-        pgrx::check_for_interrupts!();
+        if cancel_pending() {
+            return Err(interrupted());
+        }
         Ok(())
     }
 }

--- a/pg_search/tests/pg_regress/expected/join_execution_limits.out
+++ b/pg_search/tests/pg_regress/expected/join_execution_limits.out
@@ -77,7 +77,7 @@ JOIN large_suppliers ls ON lo.supplier_id = ls.id
 WHERE lo.description @@@ 'wireless'
 ORDER BY lo.id
 LIMIT 10;
-ERROR:  JoinScan: Out of memory! Query exceeded work_mem limit of 196608 bytes.
+ERROR:  DataFusion execution failed: Resources exhausted: query exceeded the work_mem limit of 196608 bytes; raise work_mem to run it
 -- Reset work_mem
 RESET work_mem;
 -- =============================================================================
@@ -137,7 +137,7 @@ JOIN mem_test_suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 5;
-ERROR:  JoinScan: Out of memory! Query exceeded work_mem limit of 196608 bytes.
+ERROR:  DataFusion execution failed: Resources exhausted: query exceeded the work_mem limit of 196608 bytes; raise work_mem to run it
 RESET work_mem;
 -- =============================================================================
 -- TEST 3: Large result set (functional, not performance)

--- a/pg_search/tests/pg_regress/expected/mpp_workmem.out
+++ b/pg_search/tests/pg_regress/expected/mpp_workmem.out
@@ -1,0 +1,111 @@
+-- =====================================================================
+-- MPP must not crash the backend when a worker hits the work_mem limit.
+--
+-- A `work_mem` overflow inside an MPP fragment makes one worker error and
+-- the leader tear down the parallel query. Both the JoinScan and the
+-- AggregateScan leader teardowns used to drop DSM-backed senders after the
+-- worker error had already torn down the parallel segment, faulting the
+-- leader. This test forces the overflow on both paths and checks the
+-- backend returns a clean error and keeps serving on the same connection.
+--
+-- The overflow margin is deliberately huge (a ~200k-row TopN sort, then a
+-- 200k-group hash aggregate, both against a 64kB-derived pool), so the trip
+-- is platform-independent. The error is caught so the exact byte count
+-- stays out of the expected output.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+CREATE TABLE mpp_wm_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_wm_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+INSERT INTO mpp_wm_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 200000) AS g;
+CREATE INDEX mpp_wm_files_idx ON mpp_wm_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+CREATE INDEX mpp_wm_pages_idx ON mpp_wm_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+ANALYZE mpp_wm_files;
+ANALYZE mpp_wm_pages;
+-- A TopN sort over the full match set can't fit in the minimum pool. The
+-- branch taken is recorded so the output stays independent of the exact
+-- byte count; a crash here would drop the connection instead of being
+-- caught, and the expected output wouldn't match.
+SET work_mem TO '64kB';
+CREATE TABLE mpp_wm_outcome (msg text);
+DO $$
+BEGIN
+    PERFORM f.title, p.size_bytes
+    FROM mpp_wm_files f JOIN mpp_wm_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    ORDER BY p.size_bytes, p.id
+    LIMIT 200000;
+    INSERT INTO mpp_wm_outcome VALUES ('join: unexpected success under 64kB work_mem');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO mpp_wm_outcome VALUES ('join: work_mem overflow returned a clean error');
+END$$;
+-- The aggregate path (GROUP BY over the join) routes through AggregateScan
+-- MPP, which has its own leader teardown. A high-cardinality hash aggregate
+-- over the full match set also overruns the minimum pool.
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM mpp_wm_files f JOIN mpp_wm_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO mpp_wm_outcome VALUES ('agg: unexpected success under 64kB work_mem');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO mpp_wm_outcome VALUES ('agg: work_mem overflow returned a clean error');
+END$$;
+RESET work_mem;
+SELECT msg FROM mpp_wm_outcome ORDER BY msg;
+                      msg                       
+------------------------------------------------
+ agg: work_mem overflow returned a clean error
+ join: work_mem overflow returned a clean error
+(2 rows)
+
+-- The backend survived both teardowns and still serves queries on the same
+-- connection. (If the server had crashed, this errors out with a lost
+-- connection and the expected output won't match.)
+SELECT count(*) AS files_still_readable
+FROM mpp_wm_files
+WHERE content @@@ 'Section';
+ files_still_readable 
+----------------------
+                  200
+(1 row)
+
+DROP TABLE mpp_wm_outcome;
+DROP TABLE mpp_wm_pages;
+DROP TABLE mpp_wm_files;

--- a/pg_search/tests/pg_regress/sql/mpp_workmem.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_workmem.sql
@@ -1,0 +1,114 @@
+-- =====================================================================
+-- MPP must not crash the backend when a worker hits the work_mem limit.
+--
+-- A `work_mem` overflow inside an MPP fragment makes one worker error and
+-- the leader tear down the parallel query. Both the JoinScan and the
+-- AggregateScan leader teardowns used to drop DSM-backed senders after the
+-- worker error had already torn down the parallel segment, faulting the
+-- leader. This test forces the overflow on both paths and checks the
+-- backend returns a clean error and keeps serving on the same connection.
+--
+-- The overflow margin is deliberately huge (a ~200k-row TopN sort, then a
+-- 200k-group hash aggregate, both against a 64kB-derived pool), so the trip
+-- is platform-independent. The error is caught so the exact byte count
+-- stays out of the expected output.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+CREATE TABLE mpp_wm_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE mpp_wm_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+
+INSERT INTO mpp_wm_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 200000) AS g;
+
+CREATE INDEX mpp_wm_files_idx ON mpp_wm_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+
+CREATE INDEX mpp_wm_pages_idx ON mpp_wm_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {}}'
+);
+
+ANALYZE mpp_wm_files;
+ANALYZE mpp_wm_pages;
+
+-- A TopN sort over the full match set can't fit in the minimum pool. The
+-- branch taken is recorded so the output stays independent of the exact
+-- byte count; a crash here would drop the connection instead of being
+-- caught, and the expected output wouldn't match.
+SET work_mem TO '64kB';
+CREATE TABLE mpp_wm_outcome (msg text);
+DO $$
+BEGIN
+    PERFORM f.title, p.size_bytes
+    FROM mpp_wm_files f JOIN mpp_wm_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    ORDER BY p.size_bytes, p.id
+    LIMIT 200000;
+    INSERT INTO mpp_wm_outcome VALUES ('join: unexpected success under 64kB work_mem');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO mpp_wm_outcome VALUES ('join: work_mem overflow returned a clean error');
+END$$;
+
+-- The aggregate path (GROUP BY over the join) routes through AggregateScan
+-- MPP, which has its own leader teardown. A high-cardinality hash aggregate
+-- over the full match set also overruns the minimum pool.
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM mpp_wm_files f JOIN mpp_wm_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO mpp_wm_outcome VALUES ('agg: unexpected success under 64kB work_mem');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO mpp_wm_outcome VALUES ('agg: work_mem overflow returned a clean error');
+END$$;
+RESET work_mem;
+SELECT msg FROM mpp_wm_outcome ORDER BY msg;
+
+-- The backend survived both teardowns and still serves queries on the same
+-- connection. (If the server had crashed, this errors out with a lost
+-- connection and the expected output won't match.)
+SELECT count(*) AS files_still_readable
+FROM mpp_wm_files
+WHERE content @@@ 'Section';
+
+DROP TABLE mpp_wm_outcome;
+
+DROP TABLE mpp_wm_pages;
+DROP TABLE mpp_wm_files;

--- a/tests/tests/mpp_cancel.rs
+++ b/tests/tests/mpp_cancel.rs
@@ -1,0 +1,172 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! A cancel or `pg_terminate_backend` taken while an MPP query runs used to
+//! crash the leader during teardown (a die serviced from inside the tokio
+//! `block_on`, or DSM senders dropped after the parallel segment was gone),
+//! which resets the whole cluster. These tests signal a running MPP query from
+//! a second connection and assert a witness connection kept open the whole
+//! time survives. A cluster reset would have dropped it.
+
+mod fixtures;
+
+use anyhow::Result;
+use fixtures::*;
+use rstest::*;
+use sqlx::{Executor, PgConnection};
+use std::time::{Duration, Instant};
+use tokio::time::sleep;
+
+const SETUP_SQL: &str = r#"
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+CREATE TABLE mpp_sig_files (id SERIAL PRIMARY KEY, title TEXT, content TEXT);
+CREATE TABLE mpp_sig_pages (id SERIAL PRIMARY KEY, file_id INTEGER, page_text TEXT);
+
+INSERT INTO mpp_sig_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+INSERT INTO mpp_sig_pages (file_id, page_text)
+SELECT (g % 200) + 1, 'Page text for page ' || g
+FROM generate_series(1, 200000) AS g;
+
+CREATE INDEX mpp_sig_files_idx ON mpp_sig_files
+USING bm25 (id, title, content)
+WITH (key_field='id', text_fields='{"title": {"fast": true}, "content": {}}');
+
+CREATE INDEX mpp_sig_pages_idx ON mpp_sig_pages
+USING bm25 (id, file_id, page_text)
+WITH (key_field='id', numeric_fields='{"file_id": {"fast": true}}', text_fields='{"page_text": {}}');
+
+ANALYZE mpp_sig_files;
+ANALYZE mpp_sig_pages;
+"#;
+
+// Forces the join through MPP and zeroes the parallel costs so the planner always picks it.
+const MPP_GUCS: &str = r#"
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+"#;
+
+// Streams 200k rows out of an MPP join. No sort/aggregate, so it stays under `work_mem`
+// (the point here is a live query to signal, not an overflow), but it runs long enough that
+// the killer reliably catches the backend mid-execution.
+const MPP_QUERY: &str = r#"
+SELECT f.title, p.page_text
+FROM mpp_sig_files f JOIN mpp_sig_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+"#;
+
+/// Spin until `victim_app`'s backend is running the MPP query, then run `signal_fn(pid)`
+/// (`pg_cancel_backend` or `pg_terminate_backend`) on it. Returns the pid that was signalled.
+async fn signal_running_mpp_backend(
+    killer: &mut PgConnection,
+    victim_app: &str,
+    signal_fn: &str,
+) -> Result<i32> {
+    let deadline = Instant::now() + Duration::from_secs(30);
+    loop {
+        // Parallel workers inherit the leader's `application_name`, so pin to the client backend
+        // to signal the leader (the connection running the top-level query), not a worker.
+        let pid: Option<i32> = sqlx::query_scalar(
+            "SELECT pid FROM pg_stat_activity \
+             WHERE application_name = $1 AND backend_type = 'client backend' \
+             AND state = 'active' AND query LIKE '%mpp_sig_pages%'",
+        )
+        .bind(victim_app)
+        .fetch_optional(&mut *killer)
+        .await?;
+
+        if let Some(pid) = pid {
+            sqlx::query(&format!("SELECT {signal_fn}($1)"))
+                .bind(pid)
+                .execute(&mut *killer)
+                .await?;
+            return Ok(pid);
+        }
+        if Instant::now() >= deadline {
+            anyhow::bail!("victim backend never showed up active running the MPP query");
+        }
+        sleep(Duration::from_millis(5)).await;
+    }
+}
+
+/// Run the MPP query in a loop on `victim` until its connection or query is cut off. The
+/// loop keeps the backend busy so the killer has a wide window to land the signal mid-query.
+async fn run_until_signalled(mut victim: PgConnection, app_name: &str) {
+    if victim
+        .execute(format!("SET application_name = '{app_name}';").as_str())
+        .await
+        .is_err()
+    {
+        return;
+    }
+    if victim.execute(MPP_GUCS).await.is_err() {
+        return;
+    }
+    // A terminate drops the connection and a cancel errors the in-flight query; either way
+    // the next iteration's error ends the loop.
+    while victim.execute(MPP_QUERY).await.is_ok() {}
+}
+
+async fn assert_cluster_alive(witness: &mut PgConnection) -> Result<()> {
+    // A backend crash during teardown makes the postmaster reset the cluster, which would have
+    // killed this long-lived connection. If it still answers, no reset happened.
+    let one: i32 = sqlx::query_scalar("SELECT 1")
+        .fetch_one(&mut *witness)
+        .await?;
+    assert_eq!(one, 1, "witness connection lost: the backend crashed");
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn mpp_signal_does_not_crash_backend(database: Db) -> Result<()> {
+    let mut setup = database.connection().await;
+    setup.execute(SETUP_SQL).await?;
+
+    // Opened before any signal and reused after each, so a cluster reset would surface as a
+    // failure on this connection.
+    let mut witness = database.connection().await;
+    witness
+        .execute("CREATE EXTENSION IF NOT EXISTS pg_search;")
+        .await?;
+    assert_cluster_alive(&mut witness).await?;
+
+    for (app, signal_fn) in [
+        ("mpp_sig_cancel", "pg_cancel_backend"),
+        ("mpp_sig_terminate", "pg_terminate_backend"),
+    ] {
+        let victim = database.connection().await;
+        let loop_handle = tokio::spawn(run_until_signalled(victim, app));
+
+        let mut killer = database.connection().await;
+        signal_running_mpp_backend(&mut killer, app, signal_fn).await?;
+
+        let _ = loop_handle.await;
+        assert_cluster_alive(&mut witness).await?;
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5334
- Also fixes the MPP teardown crash diagnosed in #5061

## What

This PR makes MPP fail cleanly under memory pressure and cancellation instead of crashing the backend. A `work_mem` overflow returns a query error, and a worker error, a cancel, or a `pg_terminate_backend` during an MPP query tears the parallel group down without taking the server into recovery.

## Why

Two crashes (the postmaster resets the cluster, every session drops):

1. The MPP memory pool `panic!`d when a query exceeded `work_mem`. Inside a parallel worker the panic crashed the backend.

2. Once a worker errored (for any reason), the leader tore the parallel group down, and the teardown corrupted memory two ways:
   - The leader released its DSM-backed control senders only after the `recv()` join in `shutdown_custom_scan`. The worker error is re-raised in the leader from inside that `recv()` and longjmps past the release, so the senders dropped at transaction commit, after PG had already destroyed the parallel DSM. Their drop decrements an atomic inside that freed segment, so the leader `SIGSEGV`d at commit.
   - A cancel or die taken from a `CHECK_FOR_INTERRUPTS()` inside `Runtime::block_on` ran `proc_exit`, which dropped the still-live tokio runtime. Tokio aborts when its runtime is dropped from inside itself.

Fixing only (1) wasn't enough: the clean error from one worker still tripped (2), so the server kept crashing on a `work_mem` overflow.

## How

`try_grow` past the budget returns `DataFusionError::ResourcesExhausted`, which means `grow` delegates without panicking. The serial and worker `RuntimeEnv`s disable the disk manager so the limit errors instead of spilling (native spilling isn't wired to PG temp-file management). The spilling will be done as a follow-up.

Teardown:
- `shutdown_custom_scan` (both `JoinScan` and `AggregateScan`) releases the leader's control senders before the `recv()` join, while the DSM is still mapped. The query is done producing by then, so the senders aren't needed.
- The MPP `block_on` sites hold cancel/die off (`HOLD_INTERRUPTS`) for their duration, so neither our drain/send loops nor a subroutine's `CHECK_FOR_INTERRUPTS` (e.g. the scanner's own) can `proc_exit` out of the live runtime. The loops poll the cancel/die flags cooperatively so `block_on` still returns promptly. The deferred interrupt is serviced once `block_on` has returned and the runtime is idle.

## Tests

`WorkMemMemoryPool` unit tests cover the overflow-returns-error and `grow` paths.

The `mpp_workmem` regress test forces an MPP `work_mem` overflow on both paths (a `JOIN ... ORDER BY ... LIMIT` TopN sort through `JoinScan`, and a high-cardinality `GROUP BY` over the join through `AggregateScan`) and checks the backend returns a clean error and still serves on the same connection (a crash would drop the connection and fail the test).

The `mpp_cancel` integration test signals a running MPP query from a second connection (`pg_cancel_backend`, then `pg_terminate_backend`) and asserts a witness connection kept open the whole time survives, since a teardown crash would reset the cluster and drop it.
