### PR TITLE
fix(joinscan): absorb 3-way joins when sub-join path is Gather Merge -> Sort

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -550,7 +550,7 @@ unsafe fn collect_join_sources_join_rel(
     if raw_path.is_null() {
         return None;
     }
-    // Peel parallel/projection wrappers (Gather, GatherMerge, Material,
+    // Peel parallel/projection wrappers (Gather, GatherMerge, Sort, Material,
     // Projection) so we can recognize a JoinPath that PG wrapped for
     // parallel-mode bridging. This is the fix for issue #4910 -- without
     // peeling, the recursive 3-way reconstruction bails and the top-level
@@ -752,20 +752,21 @@ unsafe fn is_join_path(path: *mut pg_sys::Path) -> bool {
 ///
 /// Parallel-mode `cheapest_total_path` for an intermediate join rel is often
 /// wrapped in a `GatherPath` / `GatherMergePath` (parallel-to-serial bridging),
-/// a `MaterialPath` (cached for inner-side replay), or a `ProjectionPath`
-/// (target-list adjustment). The actual `JoinPath` lives below; the loop peels
-/// each wrapper in turn so chains like `GatherPath -> MaterialPath -> JoinPath`
-/// are also handled. Without peeling, [`is_join_path`] returns false on the
-/// wrapper and 3-way absorption fails -- issue #4910.
+/// a `SortPath` (required by GatherMerge), a `MaterialPath` (cached for
+/// inner-side replay), or a `ProjectionPath` (target-list adjustment). The
+/// actual `JoinPath` lives below; the loop peels each wrapper in turn so
+/// chains like `GatherMergePath -> SortPath -> HashPath` are also handled.
+/// Without peeling, [`is_join_path`] returns false on the wrapper and 3-way
+/// absorption fails -- issue #4910.
 ///
 /// # Adding a new wrapper
 ///
 /// Only add path types that exist for execution mechanics (parallelism,
-/// caching, column projection) and wrap a `subpath` representing the same
-/// join. Whether the resulting plan is actually safe to push into JoinScan
-/// is decided downstream (`is_limit_pushdown_safe`, activation checks,
-/// fast-field validation) -- this helper's only job is to surface the
-/// underlying `JoinPath` so those gates can run.
+/// sorting, caching, column projection) and wrap a `subpath` representing
+/// the same join. Whether the resulting plan is actually safe to push into
+/// JoinScan is decided downstream (`is_limit_pushdown_safe`, activation
+/// checks, fast-field validation) -- this helper's only job is to surface
+/// the underlying `JoinPath` so those gates can run.
 unsafe fn unwrap_path_wrappers(mut path: *mut pg_sys::Path) -> *mut pg_sys::Path {
     loop {
         if path.is_null() {
@@ -776,6 +777,9 @@ unsafe fn unwrap_path_wrappers(mut path: *mut pg_sys::Path) -> *mut pg_sys::Path
             pg_sys::NodeTag::T_GatherPath => (*(path as *mut pg_sys::GatherPath)).subpath,
             // Sorted parallel-to-serial bridge: same rows, preserves order.
             pg_sys::NodeTag::T_GatherMergePath => (*(path as *mut pg_sys::GatherMergePath)).subpath,
+            // Required below GatherMerge when PG sorts each worker's partial
+            // path before merging: same rows, only adds ordering.
+            pg_sys::NodeTag::T_SortPath => (*(path as *mut pg_sys::SortPath)).subpath,
             // Cached materialisation for inner-side replay: same rows, same schema.
             pg_sys::NodeTag::T_MaterialPath => (*(path as *mut pg_sys::MaterialPath)).subpath,
             // Adjusts the target list above the underlying path; the join

--- a/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
@@ -1,0 +1,160 @@
+-- Regression test for parallel 3-way DISTINCT JoinScan absorption.
+--
+-- Under parallel execution, the cheapest_total_path of an intermediate join
+-- rel can be wrapped as `Gather Merge -> Sort -> Hash Join`. The 3-way
+-- JoinScan path reconstruction peels the Gather/GatherMerge wrappers but used
+-- to stop at the intervening `Sort`, so `is_join_path` returned false, the
+-- sub-join failed to reconstruct, and the third relation was never absorbed.
+-- JoinScan then declined the whole join -- surfacing (misleadingly) as
+-- "DISTINCT columns must be fast fields" -- and the query fell back to a
+-- native plan.
+--
+-- The fix peels `SortPath` too (see `unwrap_path_wrappers`). This test guards
+-- that a parallel 3-way DISTINCT search join runs as a ParadeDB Join Scan and
+-- returns correct results. Without the fix the EXPLAIN below shows a native
+-- Hash/Nested Loop plan instead of `Parallel Custom Scan (ParadeDB Join Scan)`.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET client_min_messages = warning;
+DROP TABLE IF EXISTS js_parallel_distinct_users CASCADE;
+DROP TABLE IF EXISTS js_parallel_distinct_products CASCADE;
+DROP TABLE IF EXISTS js_parallel_distinct_orders CASCADE;
+CREATE TABLE js_parallel_distinct_users (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    uuid UUID,
+    name TEXT,
+    age INTEGER
+);
+CREATE TABLE js_parallel_distinct_products (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    uuid UUID,
+    name TEXT,
+    age INTEGER
+);
+CREATE TABLE js_parallel_distinct_orders (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    uuid UUID,
+    name TEXT,
+    age INTEGER
+);
+CREATE INDEX js_parallel_distinct_users_idx
+ON js_parallel_distinct_users
+USING bm25 (id, uuid, name, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }',
+    numeric_fields = '{ "age": { "fast": true } }',
+    target_segment_count = 2
+);
+CREATE INDEX js_parallel_distinct_products_idx
+ON js_parallel_distinct_products
+USING bm25 (id, uuid, name, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }',
+    numeric_fields = '{ "age": { "fast": true } }',
+    target_segment_count = 2
+);
+CREATE INDEX js_parallel_distinct_orders_idx
+ON js_parallel_distinct_orders
+USING bm25 (id, uuid, name, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }',
+    numeric_fields = '{ "age": { "fast": true } }',
+    target_segment_count = 2
+);
+INSERT INTO js_parallel_distinct_users (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(1, 100) AS g(i);
+INSERT INTO js_parallel_distinct_products (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(1, 100) AS g(i);
+INSERT INTO js_parallel_distinct_orders (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(1, 100) AS g(i);
+ANALYZE js_parallel_distinct_users;
+ANALYZE js_parallel_distinct_products;
+ANALYZE js_parallel_distinct_orders;
+-- Force a parallel plan so the intermediate {users, products} sub-join is
+-- reconstructed from a `Gather Merge -> Sort -> Hash Join` cheapest_total_path.
+SET paradedb.enable_join_custom_scan = true;
+SET enable_seqscan = true;
+SET enable_indexscan = false;
+SET max_parallel_workers = 8;
+SET max_parallel_workers_per_gather = 2;
+SET parallel_leader_participation = false;
+SET paradedb.enable_columnar_sort = true;
+SET debug_parallel_query = on;
+-- The plan must be a Parallel Custom Scan (ParadeDB Join Scan); without the fix
+-- this is a native Hash/Nested Loop plan and a "JoinScan not used" warning.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT DISTINCT u.id, u.name, p.id, o.id
+FROM js_parallel_distinct_users u
+JOIN js_parallel_distinct_products p ON u.id = p.id
+JOIN js_parallel_distinct_orders o ON p.age = o.age
+WHERE u.name @@@ 'bob'
+  AND p.name @@@ 'bob'
+ORDER BY u.id, p.id, o.id
+LIMIT 48;
+                                                                                                     QUERY PLAN                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Unique
+         ->  Gather Merge
+               Workers Planned: 1
+               ->  Parallel Custom Scan (ParadeDB Join Scan)
+                     Relation Tree: u INNER (p INNER o)
+                     Join Cond: u.id = p.id, p.age = o.age
+                     Limit: 48
+                     Distinct: true
+                     Order By: u.id asc, o.id asc, u.name asc
+                     DataFusion Physical Plan: 
+                       : ProjectionExec: expr=[col_1@0 as col_1, col_2@1 as col_2, col_3@2 as col_3, col_4@3 as col_4, ctid_0@4 as ctid_0, ctid_1@6 as ctid_1, ctid_2@5 as ctid_2]
+                       :   SortExec: TopK(fetch=48), expr=[col_1@0 ASC NULLS LAST, col_4@3 ASC NULLS LAST, col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     AggregateExec: mode=Single, gby=[id@1 as col_1, name@2 as col_2, id@4 as col_3, id@6 as col_4], aggr=[ctid_0, ctid_2, ctid_1]
+                       :       VisibilityFilterExec: tables=[u, p, o]
+                       :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@5, age@1)], projection=[ctid_0@0, id@1, name@2, ctid_1@3, id@4, ctid_2@6, id@8]
+                       :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
+                       :             CooperativeExec
+                       :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                       :             CooperativeExec
+                       :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                       :           CooperativeExec
+                       :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(23 rows)
+
+-- And it must return the correct rows (DISTINCT + LIMIT).
+SELECT count(*) AS distinct_limited_rows
+FROM (
+    SELECT DISTINCT u.id, u.name, p.id, o.id
+    FROM js_parallel_distinct_users u
+    JOIN js_parallel_distinct_products p ON u.id = p.id
+    JOIN js_parallel_distinct_orders o ON p.age = o.age
+    WHERE u.name @@@ 'bob'
+      AND p.name @@@ 'bob'
+    ORDER BY u.id, p.id, o.id
+    LIMIT 48
+) q;
+ distinct_limited_rows 
+-----------------------
+                    48
+(1 row)
+

--- a/pg_search/tests/pg_regress/sql/joinscan_parallel_distinct.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_parallel_distinct.sql
@@ -1,0 +1,144 @@
+-- Regression test for parallel 3-way DISTINCT JoinScan absorption.
+--
+-- Under parallel execution, the cheapest_total_path of an intermediate join
+-- rel can be wrapped as `Gather Merge -> Sort -> Hash Join`. The 3-way
+-- JoinScan path reconstruction peels the Gather/GatherMerge wrappers but used
+-- to stop at the intervening `Sort`, so `is_join_path` returned false, the
+-- sub-join failed to reconstruct, and the third relation was never absorbed.
+-- JoinScan then declined the whole join -- surfacing (misleadingly) as
+-- "DISTINCT columns must be fast fields" -- and the query fell back to a
+-- native plan.
+--
+-- The fix peels `SortPath` too (see `unwrap_path_wrappers`). This test guards
+-- that a parallel 3-way DISTINCT search join runs as a ParadeDB Join Scan and
+-- returns correct results. Without the fix the EXPLAIN below shows a native
+-- Hash/Nested Loop plan instead of `Parallel Custom Scan (ParadeDB Join Scan)`.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET client_min_messages = warning;
+
+DROP TABLE IF EXISTS js_parallel_distinct_users CASCADE;
+DROP TABLE IF EXISTS js_parallel_distinct_products CASCADE;
+DROP TABLE IF EXISTS js_parallel_distinct_orders CASCADE;
+
+CREATE TABLE js_parallel_distinct_users (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    uuid UUID,
+    name TEXT,
+    age INTEGER
+);
+
+CREATE TABLE js_parallel_distinct_products (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    uuid UUID,
+    name TEXT,
+    age INTEGER
+);
+
+CREATE TABLE js_parallel_distinct_orders (
+    id SERIAL8 NOT NULL PRIMARY KEY,
+    uuid UUID,
+    name TEXT,
+    age INTEGER
+);
+
+CREATE INDEX js_parallel_distinct_users_idx
+ON js_parallel_distinct_users
+USING bm25 (id, uuid, name, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }',
+    numeric_fields = '{ "age": { "fast": true } }',
+    target_segment_count = 2
+);
+
+CREATE INDEX js_parallel_distinct_products_idx
+ON js_parallel_distinct_products
+USING bm25 (id, uuid, name, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }',
+    numeric_fields = '{ "age": { "fast": true } }',
+    target_segment_count = 2
+);
+
+CREATE INDEX js_parallel_distinct_orders_idx
+ON js_parallel_distinct_orders
+USING bm25 (id, uuid, name, age)
+WITH (
+    key_field = 'id',
+    text_fields = '{
+        "uuid": { "tokenizer": { "type": "keyword" }, "fast": true },
+        "name": { "tokenizer": { "type": "keyword" }, "fast": true }
+    }',
+    numeric_fields = '{ "age": { "fast": true } }',
+    target_segment_count = 2
+);
+
+INSERT INTO js_parallel_distinct_users (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(1, 100) AS g(i);
+
+INSERT INTO js_parallel_distinct_products (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(1, 100) AS g(i);
+
+INSERT INTO js_parallel_distinct_orders (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(1, 100) AS g(i);
+
+ANALYZE js_parallel_distinct_users;
+ANALYZE js_parallel_distinct_products;
+ANALYZE js_parallel_distinct_orders;
+
+-- Force a parallel plan so the intermediate {users, products} sub-join is
+-- reconstructed from a `Gather Merge -> Sort -> Hash Join` cheapest_total_path.
+SET paradedb.enable_join_custom_scan = true;
+SET enable_seqscan = true;
+SET enable_indexscan = false;
+SET max_parallel_workers = 8;
+SET max_parallel_workers_per_gather = 2;
+SET parallel_leader_participation = false;
+SET paradedb.enable_columnar_sort = true;
+SET debug_parallel_query = on;
+
+-- The plan must be a Parallel Custom Scan (ParadeDB Join Scan); without the fix
+-- this is a native Hash/Nested Loop plan and a "JoinScan not used" warning.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT DISTINCT u.id, u.name, p.id, o.id
+FROM js_parallel_distinct_users u
+JOIN js_parallel_distinct_products p ON u.id = p.id
+JOIN js_parallel_distinct_orders o ON p.age = o.age
+WHERE u.name @@@ 'bob'
+  AND p.name @@@ 'bob'
+ORDER BY u.id, p.id, o.id
+LIMIT 48;
+
+-- And it must return the correct rows (DISTINCT + LIMIT).
+SELECT count(*) AS distinct_limited_rows
+FROM (
+    SELECT DISTINCT u.id, u.name, p.id, o.id
+    FROM js_parallel_distinct_users u
+    JOIN js_parallel_distinct_products p ON u.id = p.id
+    JOIN js_parallel_distinct_orders o ON p.age = o.age
+    WHERE u.name @@@ 'bob'
+      AND p.name @@@ 'bob'
+    ORDER BY u.id, p.id, o.id
+    LIMIT 48
+) q;


### PR DESCRIPTION
## What

Fix `ParadeDB Join Scan` so it engages for parallel 3-way (or deeper) `DISTINCT`
full-text search joins. Before this change, such a query silently declined and
fell back to a native PostgreSQL plan.

## Why

Under parallel execution, the `cheapest_total_path` of an intermediate join rel
can be wrapped as:

    Gather Merge -> Sort -> Hash Join

The 3-way JoinScan path reconstruction (`collect_join_sources_join_rel`) peels
the `Gather` / `GatherMerge` wrappers via `unwrap_path_wrappers`, but it stopped
at the intervening `Sort`. As a result `is_join_path` returned false, the
sub-join failed to reconstruct, the third relation was never absorbed, and
JoinScan declined the whole join.

The decline surfaced in two confusing ways:

  - with `DISTINCT`: "JoinScan not used: DISTINCT columns must be fast fields"
    (misleading -- the columns are fast fields; the real cause is the
    un-reconstructed sub-join)
  - without `DISTINCT`: "LIMIT pushdown is unsafe due to un-absorbed relations"

Either way the query still returned correct results via the native plan, but the
JoinScan optimization was lost. The `generated_joinscan` property test flags this
under forced parallelism.

## How

Peel `SortPath` in `unwrap_path_wrappers` as well. A `Sort` only reorders rows,
so it is transparent to join-structure reconstruction (RTIs, equi-keys,
jointype are unchanged), and JoinScan re-derives its own ordering from
`query_pathkeys`. This mirrors the existing `Gather` / `GatherMerge` / `Material`
/ `Projection` arms; it is read-only path navigation with no ownership, Drop,
refcount, or allocation involved.

## Test

Adds a deterministic pg_regress test `joinscan_parallel_distinct` that:

  - forces a parallel plan (debug_parallel_query = on) for a 3-way DISTINCT
    `@@@` join, and
  - asserts via `EXPLAIN` that the plan is a
    `Parallel Custom Scan (ParadeDB Join Scan)`, plus a row-count check.

Without the fix the EXPLAIN is a native Hash/Nested Loop plan, so the test fails;
with the fix it passes. Verified both directions locally:

    cargo pgrx regress pg18 joinscan_parallel_distinct
    -> with fix:    PASS
    -> without fix: FAIL (native plan + "JoinScan not used" warning)
