### PR TITLE
docs: Update Rails tokenizer references

### DIFF
--- a/.github/scripts/smoke_test_code_snippets.sh
+++ b/.github/scripts/smoke_test_code_snippets.sh
@@ -163,7 +163,7 @@ if [[ $ORMS =~ "rails" ]]; then
   echo "Installing rails-paradedb from RubyGems..."
   GEM_HOME="$RUBY_GEM_HOME" GEM_PATH="$RUBY_GEM_HOME" \
     gem install --silent --no-document --install-dir "$RUBY_GEM_HOME" \
-    "rails-paradedb:0.7.0" \
+    "rails-paradedb:0.8.0" \
     "pg"
 
   while IFS= read -r snippet_file; do

--- a/docs/documentation/full-text/match.mdx
+++ b/docs/documentation/full-text/match.mdx
@@ -276,7 +276,7 @@ with Session(engine) as session:
 
 ```ruby Rails
 MockItem.search(:description)
-        .matching_any("running shoes", tokenizer: Tokenizer.whitespace())
+        .matching_any("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
         .select(:description, :rating, :category)
 ```
 

--- a/docs/documentation/full-text/phrase.mdx
+++ b/docs/documentation/full-text/phrase.mdx
@@ -231,7 +231,7 @@ with Session(engine) as session:
 
 ```ruby Rails
 MockItem.search(:description)
-        .phrase("running shoes", tokenizer: Tokenizer.whitespace())
+        .phrase("running shoes", tokenizer: ParadeDB::Tokenizer.whitespace())
         .select(:description, :rating, :category)
 ```
 

--- a/docs/documentation/getting-started/environment.mdx
+++ b/docs/documentation/getting-started/environment.mdx
@@ -583,7 +583,7 @@ cd paradedb
 Add the [rails-paradedb](https://rubygems.org/gems/rails-paradedb) gem to your `Gemfile`:
 
 ```ruby Gemfile
-gem "rails-paradedb", "0.7.0", require: "parade_db"
+gem "rails-paradedb", "0.8.0", require: "parade_db"
 ```
 
 Then install it:

--- a/docs/documentation/indexing/columnar.mdx
+++ b/docs/documentation/indexing/columnar.mdx
@@ -156,7 +156,7 @@ ActiveRecord::Base.connection.add_bm25_index(
   fields: {
     id: {},
     description: {
-      tokenizer: Tokenizer.unicode_words(options: { columnar: true })
+      tokenizer: ParadeDB::Tokenizer.unicode_words(options: { columnar: true })
     },
     rating: {}
   },

--- a/docs/documentation/indexing/create-index.mdx
+++ b/docs/documentation/indexing/create-index.mdx
@@ -196,7 +196,7 @@ ActiveRecord::Base.connection.add_bm25_index(
   :mock_items,
   fields: {
     id: {},
-    description: { tokenizer: Tokenizer.icu() },
+    description: { tokenizer: ParadeDB::Tokenizer.icu() },
     category: {}
   },
   key_field: :id,
@@ -420,7 +420,7 @@ ActiveRecord::Base.connection.add_bm25_index(
   fields: {
     id: {},
     description: {
-      tokenizer: Tokenizer.simple(options: { stemmer: "english" })
+      tokenizer: ParadeDB::Tokenizer.simple(options: { stemmer: "english" })
     },
     category: {}
   },

--- a/docs/documentation/indexing/indexing-arrays.mdx
+++ b/docs/documentation/indexing/indexing-arrays.mdx
@@ -155,7 +155,7 @@ ActiveRecord::Base.connection.add_bm25_index(
   :array_demo,
   fields: {
     id: {},
-    categories: { tokenizer: Tokenizer.literal() }
+    categories: { tokenizer: ParadeDB::Tokenizer.literal() }
   },
   key_field: :id,
   name: :search_idx

--- a/docs/documentation/indexing/indexing-expressions.mdx
+++ b/docs/documentation/indexing/indexing-expressions.mdx
@@ -90,7 +90,7 @@ ActiveRecord::Base.connection.add_bm25_index(
   fields: {
     id: {},
     "(description || ' ' || category)" => {
-      tokenizer: Tokenizer.simple(options: { alias: "description_concat" })
+      tokenizer: ParadeDB::Tokenizer.simple(options: { alias: "description_concat" })
     }
   },
   key_field: :id,

--- a/docs/documentation/indexing/indexing-json.mdx
+++ b/docs/documentation/indexing/indexing-json.mdx
@@ -147,7 +147,7 @@ ActiveRecord::Base.connection.add_bm25_index(
   :mock_items,
   fields: {
     id: {},
-    metadata: { tokenizer: Tokenizer.ngram(2, 3) }
+    metadata: { tokenizer: ParadeDB::Tokenizer.ngram(2, 3) }
   },
   key_field: :id,
   name: :search_idx
@@ -235,7 +235,7 @@ ActiveRecord::Base.connection.add_bm25_index(
   :mock_items,
   fields: {
     id: {},
-    "metadata->>'color'" => { tokenizer: Tokenizer.ngram(2, 3) }
+    "metadata->>'color'" => { tokenizer: ParadeDB::Tokenizer.ngram(2, 3) }
   },
   key_field: :id,
   name: :search_idx


### PR DESCRIPTION
# Ticket(s) Closed

Updates the doc snippets to use the new structure from https://github.com/paradedb/rails-paradedb/pull/108.

## What

## Why

## How

## Tests
