### PR TITLE
fix: Resolve uncorrelated params in heap filters

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -91,16 +91,16 @@ pub enum AggregateType {
 }
 
 impl SolvePostgresExpressions for AggregateType {
-    fn has_heap_filters(&mut self) -> bool {
-        self.filter_expr_mut()
-            .as_mut()
-            .is_some_and(|filter| filter.has_heap_filters())
-    }
-
     fn has_postgres_expressions(&mut self) -> bool {
         self.filter_expr_mut()
             .as_mut()
             .is_some_and(|filter| filter.has_postgres_expressions())
+    }
+
+    fn has_parameters(&mut self) -> bool {
+        self.filter_expr_mut()
+            .as_mut()
+            .is_some_and(|filter| filter.has_parameters())
     }
 
     fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -374,7 +374,8 @@ impl CustomScan for AggregateScan {
                 builder.custom_state().indexrelid = indexrelid;
                 builder.custom_state().execution_rti =
                     unsafe { (*builder.args().cscan).scan.scanrelid as pg_sys::Index };
-                builder.custom_state().aggregate_clause = *aggregate_clause;
+                builder.custom_state().aggregate_clause = *aggregate_clause.clone();
+                builder.custom_state().base_aggregate_clause = Some(*aggregate_clause);
                 builder.build()
             }
             PrivateData::DataFusion {
@@ -397,6 +398,7 @@ impl CustomScan for AggregateScan {
                     plan,
                     targetlist,
                     topk,
+                    base_join_level_predicates: Some(join_level_predicates.clone()),
                     join_level_predicates,
                     multi_table_predicates,
                     custom_exprs,

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -50,6 +50,8 @@ pub struct DataFusionAggState {
     pub topk: Option<DataFusionTopK>,
     /// Cross-table search predicates for join-level filtering.
     pub join_level_predicates: Vec<JoinLevelSearchPredicate>,
+    /// Original predicates preserved for rescans.
+    pub base_join_level_predicates: Option<Vec<JoinLevelSearchPredicate>>,
     /// Non-@@@ cross-table predicates (descriptions for EXPLAIN).
     pub multi_table_predicates: Vec<MultiTablePredicateInfo>,
     /// Raw PG Expr pointers from custom_exprs (after setrefs transforms
@@ -123,6 +125,7 @@ pub struct AggregateScanState {
     pub indexrel: Option<(pg_sys::LOCKMODE, PgSearchRelation)>,
     pub execution_rti: pg_sys::Index,
     pub aggregate_clause: AggregateCSClause,
+    pub base_aggregate_clause: Option<AggregateCSClause>,
 
     /// DataFusion backend state. When `Some`, the DataFusion path is active
     /// and the Tantivy-specific fields above are unused.
@@ -205,17 +208,6 @@ impl CustomScanState for AggregateScanState {
 }
 
 impl SolvePostgresExpressions for AggregateScanState {
-    fn has_heap_filters(&mut self) -> bool {
-        if self.is_datafusion_backend() {
-            return false;
-        }
-        self.aggregate_clause.query_mut().has_heap_filters()
-            || self
-                .aggregate_clause
-                .aggregates_mut()
-                .any(|agg| agg.has_heap_filters())
-    }
-
     fn has_postgres_expressions(&mut self) -> bool {
         // Check both the Tantivy-path search queries and DataFusion-path
         // join-level predicates for unresolved PostgresExpression nodes
@@ -234,6 +226,34 @@ impl SolvePostgresExpressions for AggregateScanState {
                 .aggregate_clause
                 .aggregates_mut()
                 .any(|agg| agg.has_postgres_expressions())
+    }
+
+    fn has_parameters(&mut self) -> bool {
+        if let Some(ref mut df) = self.datafusion_state {
+            if df
+                .join_level_predicates
+                .iter_mut()
+                .any(|p| p.query.has_parameters())
+            {
+                return true;
+            }
+        }
+        self.aggregate_clause.query_mut().has_parameters()
+            || self
+                .aggregate_clause
+                .aggregates_mut()
+                .any(|agg| agg.has_parameters())
+    }
+
+    fn init_search_query_input(&mut self) {
+        if let Some(base) = &self.base_aggregate_clause {
+            self.aggregate_clause = base.clone();
+        }
+        if let Some(ref mut df) = self.datafusion_state {
+            if let Some(base) = &df.base_join_level_predicates {
+                df.join_level_predicates = base.clone();
+            }
+        }
     }
 
     fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) {

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -491,12 +491,12 @@ impl SolvePostgresExpressions for BaseScanState {
         self.search_query_input = self.base_search_query_input.clone();
     }
 
-    fn has_heap_filters(&mut self) -> bool {
-        self.base_search_query_input.has_heap_filters()
-    }
-
     fn has_postgres_expressions(&mut self) -> bool {
         self.search_query_input.has_postgres_expressions()
+    }
+
+    fn has_parameters(&mut self) -> bool {
+        self.search_query_input.has_parameters()
     }
 
     fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) {

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1095,7 +1095,7 @@ impl JoinScan {
     fn source_queries_need_executor_state(join_clause: &JoinCSClause) -> bool {
         join_clause.plan.sources().iter().any(|source| {
             let mut query = source.scan_info.query.clone();
-            query.has_postgres_expressions()
+            query.has_postgres_expressions() || query.has_parameters()
         })
     }
 }

--- a/pg_search/src/postgres/customscan/solve_expr.rs
+++ b/pg_search/src/postgres/customscan/solve_expr.rs
@@ -40,6 +40,18 @@ impl SearchQueryInput {
         found
     }
 
+    pub fn has_parameters(&mut self) -> bool {
+        let mut found = false;
+        self.visit(&mut |sqi| {
+            if let SearchQueryInput::HeapFilter { field_filters, .. } = sqi {
+                if field_filters.iter().any(|f| f.has_parameters()) {
+                    found = true;
+                }
+            }
+        });
+        found
+    }
+
     pub fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState) -> usize {
         let mut cnt = 0;
         self.visit(&mut |sqi| {
@@ -61,8 +73,8 @@ impl SearchQueryInput {
 
             PgMemoryContexts::For((*expr_context).ecxt_per_tuple_memory).switch_to(|_| {
                 let sqi_typoid = searchqueryinput_typoid();
-                self.visit(&mut |sqi| {
-                    if let SearchQueryInput::PostgresExpression { expr } = sqi {
+                self.visit(&mut |sqi| match sqi {
+                    SearchQueryInput::PostgresExpression { expr } => {
                         if let Some(resolved_sqi) = expr.solve(expr_context, sqi_typoid) {
                             *sqi = resolved_sqi;
                         } else {
@@ -75,6 +87,12 @@ impl SearchQueryInput {
                             *sqi = SearchQueryInput::Empty;
                         }
                     }
+                    SearchQueryInput::HeapFilter { field_filters, .. } => {
+                        for filter in field_filters {
+                            filter.solve_parameters(expr_context);
+                        }
+                    }
+                    _ => {}
                 });
             })
         }
@@ -108,8 +126,8 @@ impl PostgresExpression {
 
 pub trait SolvePostgresExpressions {
     fn init_postgres_expressions(&mut self, planstate: *mut pg_sys::PlanState);
-    fn has_heap_filters(&mut self) -> bool;
     fn has_postgres_expressions(&mut self) -> bool;
+    fn has_parameters(&mut self) -> bool;
     fn solve_postgres_expressions(&mut self, expr_context: *mut pg_sys::ExprContext);
 
     unsafe fn init_expr_context(
@@ -117,7 +135,7 @@ pub trait SolvePostgresExpressions {
         estate: *mut pg_sys::EState,
         planstate: *mut pg_sys::PlanState,
     ) {
-        if self.has_postgres_expressions() || self.has_heap_filters() {
+        if self.has_postgres_expressions() || self.has_parameters() {
             // we have some runtime Postgres expressions/sub-queries that need to be evaluated
             //
             // Our planstate's ExprContext isn't sufficiently configured for that, so we need to
@@ -143,7 +161,7 @@ pub trait SolvePostgresExpressions {
         expr_context: *mut pg_sys::ExprContext,
     ) {
         self.init_search_query_input();
-        if self.has_postgres_expressions() {
+        if self.has_postgres_expressions() || self.has_parameters() {
             self.init_postgres_expressions(planstate);
             self.solve_postgres_expressions(expr_context);
         }

--- a/pg_search/src/query/heap_field_filter.rs
+++ b/pg_search/src/query/heap_field_filter.rs
@@ -182,7 +182,118 @@ impl HeapFieldFilter {
         self.expr_node.0.cast()
     }
 
-    // The new expression-based approach handles evaluation directly
+    /// Returns true if this filter contains any PostgreSQL parameters (like $1 or InitPlans).
+    pub fn has_parameters(&self) -> bool {
+        unsafe {
+            let expr_node = self.expr_node.0.cast::<pg_sys::Node>();
+            if expr_node.is_null() {
+                return false;
+            }
+
+            #[pgrx::pg_guard]
+            unsafe extern "C-unwind" fn param_walker(
+                node: *mut pg_sys::Node,
+                _context: *mut core::ffi::c_void,
+            ) -> bool {
+                if node.is_null() {
+                    return false;
+                }
+                if (*node).type_ == pg_sys::NodeTag::T_Param {
+                    return true;
+                }
+
+                pg_sys::expression_tree_walker(node, Some(param_walker), _context)
+            }
+
+            pg_sys::expression_tree_walker(expr_node, Some(param_walker), std::ptr::null_mut())
+        }
+    }
+
+    /// Replaces Param nodes in the expression with Const nodes containing their evaluated values.
+    /// This is required because custom parallel workers do not inherit the leader's EState.
+    pub fn solve_parameters(&mut self, expr_context: *mut pg_sys::ExprContext) {
+        unsafe {
+            let expr_node = self.expr_node.0.cast::<pg_sys::Node>();
+            if expr_node.is_null() {
+                return;
+            }
+
+            #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
+            let new_node = {
+                let fnptr = param_resolver_mutator as *const ();
+                let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
+                    std::mem::transmute(fnptr);
+                pg_sys::expression_tree_mutator(
+                    expr_node,
+                    Some(mutator),
+                    expr_context as *mut core::ffi::c_void,
+                )
+            };
+
+            #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+            let new_node = pg_sys::expression_tree_mutator_impl(
+                expr_node,
+                Some(param_resolver_mutator),
+                expr_context as *mut core::ffi::c_void,
+            );
+
+            self.expr_node = PostgresPointer(new_node.cast());
+        }
+    }
+}
+
+#[pgrx::pg_guard]
+unsafe extern "C-unwind" fn param_resolver_mutator(
+    node: *mut pg_sys::Node,
+    context: *mut core::ffi::c_void,
+) -> *mut pg_sys::Node {
+    if node.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    if (*node).type_ == pg_sys::NodeTag::T_Param {
+        let param = node.cast::<pg_sys::Param>();
+        let expr_context = context.cast::<pg_sys::ExprContext>();
+
+        let mut is_null = false;
+
+        // Evaluate the parameter using a minimal expression state
+        let expr_state = pg_sys::ExecInitExpr(node.cast(), std::ptr::null_mut());
+        let result = pg_sys::ExecEvalExpr(expr_state, expr_context, &mut is_null);
+
+        let param_type = (*param).paramtype;
+        let param_typmod = (*param).paramtypmod;
+        let param_collid = (*param).paramcollid;
+
+        let mut typlen = 0;
+        let mut typbyval = false;
+        pg_sys::get_typlenbyval(param_type, &mut typlen, &mut typbyval);
+
+        let const_node = pg_sys::makeConst(
+            param_type,
+            param_typmod,
+            param_collid,
+            typlen.into(),
+            result,
+            is_null,
+            typbyval,
+        );
+
+        return const_node.cast();
+    }
+
+    #[cfg(not(any(feature = "pg16", feature = "pg17", feature = "pg18")))]
+    {
+        let fnptr = param_resolver_mutator as *const ();
+        let mutator: unsafe extern "C-unwind" fn() -> *mut pg_sys::Node =
+            std::mem::transmute(fnptr);
+        pg_sys::expression_tree_mutator(node, Some(mutator), context)
+    }
+
+    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+    {
+        pg_sys::expression_tree_mutator_impl(node, Some(param_resolver_mutator), context)
+    }
 }
 
 /// Tantivy query that combines indexed search with heap field filtering

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -771,7 +771,7 @@ impl PgSearchTableProvider {
         // deserializes the logical plan in its own executor context. The
         // planstate and expr_context are injected by the execution codec.
         let mut query = self.combine_query_with_filters(self.scan_info.query.clone(), filters);
-        if query.has_postgres_expressions() {
+        if query.has_postgres_expressions() || query.has_parameters() {
             let Some(planstate) = planstate else {
                 return Err(DataFusionError::Internal(
                     "postgres expressions have not been solved: missing planstate".to_string(),

--- a/pg_search/tests/pg_regress/expected/issue_4598.out
+++ b/pg_search/tests/pg_regress/expected/issue_4598.out
@@ -20,8 +20,33 @@ ERROR:  unrecognized configuration parameter "force_parallel_mode"
 SELECT COUNT(*) FROM issue_4598_repro
 WHERE mock_text @@@ paradedb.all()
 AND mock_hash = ANY(ARRAY(SELECT mock_hash FROM issue_4598_repro LIMIT 5));
-WARNING:  terminating connection because of crash of another server process
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-connection to server was lost
+ count 
+-------
+     5
+(1 row)
+
+-- trigger prepared statement PARAM_EXTERN in parallel worker
+PREPARE issue_4598_prep(text) AS
+SELECT COUNT(*) FROM issue_4598_repro
+WHERE mock_text @@@ paradedb.all()
+AND mock_hash = $1;
+EXECUTE issue_4598_prep('098f6bcd4621d373cade4e832627b4f6');
+ count 
+-------
+     0
+(1 row)
+
+-- trigger prepared statement PARAM_EXTERN parallel worker SIGSEGV
+PREPARE issue_4598_prep(text) AS
+SELECT COUNT(*) FROM issue_4598_repro
+WHERE text_searchable @@@ paradedb.all()
+AND doc_id_hash = $1;
+ERROR:  column "text_searchable" does not exist at character 78
+EXECUTE issue_4598_prep('098f6bcd4621d373cade4e832627b4f6');
+ count 
+-------
+     0
+(1 row)
+
+-- cleanup
+DROP TABLE issue_4598_repro CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_4598.out
+++ b/pg_search/tests/pg_regress/expected/issue_4598.out
@@ -1,0 +1,27 @@
+-- setup
+CREATE TABLE issue_4598_repro (
+    id int,
+    mock_text text,
+    mock_hash text
+);
+INSERT INTO issue_4598_repro (id, mock_text, mock_hash)
+SELECT i, 'test content ' || i, md5(i::text)
+FROM generate_series(1, 1000) i;
+CREATE INDEX issue_4598_idx ON issue_4598_repro USING bm25 (id, mock_text, mock_hash) WITH (key_field=id);
+-- force parallel execution
+SET max_parallel_workers_per_gather = 2;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET parallel_leader_participation = off;
+SET force_parallel_mode = on;
+ERROR:  unrecognized configuration parameter "force_parallel_mode"
+-- trigger InitPlan array parameter in parallel worker
+SELECT COUNT(*) FROM issue_4598_repro
+WHERE mock_text @@@ paradedb.all()
+AND mock_hash = ANY(ARRAY(SELECT mock_hash FROM issue_4598_repro LIMIT 5));
+WARNING:  terminating connection because of crash of another server process
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost

--- a/pg_search/tests/pg_regress/sql/issue_4598.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4598.sql
@@ -32,5 +32,13 @@ AND mock_hash = $1;
 
 EXECUTE issue_4598_prep('098f6bcd4621d373cade4e832627b4f6');
 
+-- trigger prepared statement PARAM_EXTERN parallel worker SIGSEGV
+PREPARE issue_4598_prep(text) AS
+SELECT COUNT(*) FROM issue_4598_repro
+WHERE text_searchable @@@ paradedb.all()
+AND doc_id_hash = $1;
+
+EXECUTE issue_4598_prep('098f6bcd4621d373cade4e832627b4f6');
+
 -- cleanup
 DROP TABLE issue_4598_repro CASCADE;

--- a/pg_search/tests/pg_regress/sql/issue_4598.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4598.sql
@@ -1,0 +1,36 @@
+-- setup
+CREATE TABLE issue_4598_repro (
+    id int,
+    mock_text text,
+    mock_hash text
+);
+
+INSERT INTO issue_4598_repro (id, mock_text, mock_hash)
+SELECT i, 'test content ' || i, md5(i::text)
+FROM generate_series(1, 1000) i;
+
+CREATE INDEX issue_4598_idx ON issue_4598_repro USING bm25 (id, mock_text, mock_hash) WITH (key_field=id);
+
+-- force parallel execution
+SET max_parallel_workers_per_gather = 2;
+SET parallel_setup_cost = 0;
+SET parallel_tuple_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET parallel_leader_participation = off;
+SET force_parallel_mode = on;
+
+-- trigger InitPlan array parameter in parallel worker
+SELECT COUNT(*) FROM issue_4598_repro
+WHERE mock_text @@@ paradedb.all()
+AND mock_hash = ANY(ARRAY(SELECT mock_hash FROM issue_4598_repro LIMIT 5));
+
+-- trigger prepared statement PARAM_EXTERN in parallel worker
+PREPARE issue_4598_prep(text) AS
+SELECT COUNT(*) FROM issue_4598_repro
+WHERE mock_text @@@ paradedb.all()
+AND mock_hash = $1;
+
+EXECUTE issue_4598_prep('098f6bcd4621d373cade4e832627b4f6');
+
+-- cleanup
+DROP TABLE issue_4598_repro CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4598

## What

Partially solves expressions in heap filters in the leader. Uses the same mechanism as our existing partial solving for constant expressions inside other query nodes.

## Why

Param nodes cannot safely be resolved inside of custom scan parallel workers, and so caused a segfault.

## Tests

New regress test.