### PR TITLE
fix: Flip sign so parallel state is only passed on first query

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -391,7 +391,7 @@ impl ExecMethod for TopKScanExecState {
             // We are passing parallel_state because it contains the shared threshold. We only want
             // to use the shared threshold on the first query, as additional queries will
             // necessarily be below it.
-            let maybe_parallel_state = if state.query_count() > 1 {
+            let maybe_parallel_state = if state.query_count() == 1 {
                 state.parallel_state
             } else {
                 None


### PR DESCRIPTION
## What
Fix the sign comparison direction. This worked before because not using the shared threshold on the first query _also_ has the effect of the returning the correct rows since only 2 queries are necessary in the test checking this. However, this PR corrects for the actual behavior we want.