### PR TITLE
perf: apply ctid sorting by default

### DIFF
--- a/benchmarks/datasets/stackoverflow/create_index.sql
+++ b/benchmarks/datasets/stackoverflow/create_index.sql
@@ -14,7 +14,6 @@ USING bm25 (
     owner_user_id
 ) WITH (
     key_field = 'id',
-    sort_by = 'owner_user_id ASC NULLS FIRST'
 );
 
 CREATE INDEX badges_idx ON badges
@@ -27,7 +26,6 @@ USING bm25 (
     tag_based
 ) WITH (
     key_field = 'id',
-    sort_by = 'user_id ASC NULLS FIRST'
  );
 
 CREATE INDEX comments_idx ON comments
@@ -40,7 +38,6 @@ USING bm25 (
     (user_display_name::pdb.literal)
 ) WITH (
     key_field = 'id',
-    sort_by = 'post_id ASC NULLS FIRST'
 );
 
 CREATE INDEX users_idx ON users
@@ -51,5 +48,4 @@ USING bm25 (
     reputation
 ) WITH (
     key_field = 'id',
-    sort_by = 'id ASC NULLS FIRST'
 );

--- a/pg_search/src/postgres/options.rs
+++ b/pg_search/src/postgres/options.rs
@@ -397,7 +397,7 @@ impl BM25IndexOptions {
     }
 
     /// Returns the sort_by configuration.
-    /// - Not specified: defaults to none (no segment sorting)
+    /// - Not specified: defaults to `ctid ASC NULLS FIRST`
     /// - "none": returns empty vec (no sorting)
     /// - Otherwise: returns parsed sort fields
     pub fn sort_by(&self) -> Vec<SortByField> {
@@ -729,7 +729,7 @@ impl BM25IndexOptionsData {
     }
 
     /// Returns the sort_by configuration.
-    /// - Empty string (not specified): defaults to none (no segment sorting)
+    /// - Empty string (not specified): defaults to `ctid ASC NULLS FIRST`
     /// - "none": returns empty vec (no sorting)
     /// - Otherwise: returns parsed sort fields
     ///
@@ -738,8 +738,12 @@ impl BM25IndexOptionsData {
     pub fn sort_by(&self) -> Vec<SortByField> {
         let sort_by_str = self.get_str(self.sort_by_offset, "".to_string());
         if sort_by_str.is_empty() {
-            // Default: no segment sorting
-            return vec![];
+            // Default: sort segments by ctid ascending so they're laid out in
+            // heap (tid) order unless the user explicitly opts out with 'none'.
+            return vec![SortByField::new(
+                FieldName::from("ctid".to_string()),
+                SortByDirection::Asc,
+            )];
         }
         parse_sort_by_string(&sort_by_str)
     }


### PR DESCRIPTION
Refs: 5265

# Ticket(s) Closed

- Closes #

## What

Applied `ctid` sorting by default to give best performance when performing visibility checks.

## Why

For aggregate / scan queries of shuffled / non ctid sorted indexes the visibility checking algorithm ends up accessing / releasing the same heap buffer multiple times.

By applying `ctid` sorting by default it minimizes the number of buffer access for a given block number across batches. Only at the boundary of the batch size could we access a buffer at the end of a batch and then beginning of the next after this change.

## How

## Tests
