### PR TITLE
ci: cap benchmark chart history and add scheduled gh-pages squash

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -79,6 +79,7 @@ runs:
         auto-push: ${{ github.ref == 'refs/heads/main' }}
         benchmark-data-dir-path: benchmarks
         alert-threshold: "115%"
+        max-items-in-chart: 100
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us
         alert-comment-cc-users: "@${{ github.actor }}"
         comment-always: ${{ github.event_name == 'pull_request' }}

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -131,6 +131,7 @@ runs:
         auto-push: ${{ github.event_name != 'pull_request' }}
         benchmark-data-dir-path: stressgres
         alert-threshold: "115%"
+        max-items-in-chart: 100
         comment-on-alert: true # We comment and alert rather than failing, as we have both Github and Slack messages to notify us
         alert-comment-cc-users: "@${{ github.actor }}"
         comment-always: ${{ github.event_name == 'pull_request' }}
@@ -159,6 +160,7 @@ runs:
         auto-push: ${{ github.event_name != 'pull_request' }}
         benchmark-data-dir-path: stressgres
         alert-threshold: "110%"
+        max-items-in-chart: 100
         comment-on-alert: true
         alert-comment-cc-users: "@${{ github.actor }}"
         comment-always: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/squash-gh-pages.yml
+++ b/.github/workflows/squash-gh-pages.yml
@@ -1,0 +1,49 @@
+# workflows/squash-gh-pages.yml
+#
+# Squash gh-pages History
+# Periodically squash the gh-pages branch history into one commit to reclaim
+# historical benchmark packfile bloat.
+
+name: Squash gh-pages History
+
+on:
+  schedule:
+    - cron: "0 3 1 * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: squash-gh-pages
+  cancel-in-progress: false
+
+jobs:
+  squash-gh-pages:
+    name: Squash gh-pages History
+    runs-on: ubuntu-latest
+    if: github.repository == 'paradedb/paradedb'
+
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          # Only the current tree is needed to re-orphan and squash; fetching the
+          # full (bloated) history would download the very data this job removes.
+          fetch-depth: 1
+
+      - name: Capture gh-pages Base SHA
+        run: echo "GHP_BASE_SHA=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+
+      - name: Configure Git User
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Squash gh-pages History
+        run: |
+          git checkout --orphan squashed-gh-pages
+          git add -A
+          git commit -m "Squash gh-pages history"
+          git push --force-with-lease=gh-pages:"$GHP_BASE_SHA" origin squashed-gh-pages:gh-pages


### PR DESCRIPTION
# Ticket(s) Closed

- Refs #4753

## What

Caps the per-series history of the continuous benchmark charts and adds a scheduled workflow to squash `gh-pages` history, so the repository's clone size stops growing unbounded.

- Add `max-items-in-chart: 100` to the `benchmark-action/github-action-benchmark@v1` publish steps in `.github/actions/benchmark-queries/action.yml` and both publish steps (TPS and Other Metrics) in `.github/actions/benchmark-stressgres/action.yml`.
- Add `.github/workflows/squash-gh-pages.yml`: a monthly (`cron`) + `workflow_dispatch` workflow that re-orphans `gh-pages` into a single commit and force-pushes it.

This is a partial fix. It ships the recurring-prevention machinery; the one-time destructive rewrite of the existing ~1.8 GB `gh-pages` branch is a maintainer-only operation (write access to force-push the live branch) and is intentionally not performed in this diff. A maintainer can trigger the new workflow manually once to reclaim the historical bloat immediately.

## Why

Per #4753, full clones take ~86s because `.git` is ~1.8 GB, almost entirely from `gh-pages`. The `benchmark-action` step appends a new full blob to `benchmarks/data.js` (~23 MB, ~4,197 commits) and `stressgres/data.js` (~8 MB, ~11,848 commits) on every push to `main`; git cannot delta-compress these, producing ~1.7 GB of packfile data. Capping the retained data points stops each `data.js` from regrowing forever, and a recurring squash keeps the branch history from re-accumulating.

## How

- `max-items-in-chart` is a documented input of `benchmark-action/github-action-benchmark@v1` (unsigned integer >= 1); each chart series keeps only the most recent 100 points.
- The squash workflow is gated to `schedule` + `workflow_dispatch` only (never on `pull_request`/`push`), guarded with `if: github.repository == 'paradedb/paradedb'` so forks do not run it, and uses `permissions: contents: write` (it never touches `main`). The checkout stays shallow (`fetch-depth: 1`) so the job does not download the bloated history it is meant to remove, and the force-push uses `--force-with-lease` anchored to the checked-out `gh-pages` tip so a concurrent benchmark publish cannot be silently clobbered (the push fails loudly instead).

## Tests

CI/config-only change; no extension/Rust code is touched, so no `cargo pgrx` build is required to verify.

- `prettier --check` passes on all three files (the repo's `lint-yaml` gate).
- All three files parse as valid YAML.
