### PR TITLE
fix: Fix jsonb error handling and enable serde_json float_roundtrip

### DIFF
--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -40,7 +40,10 @@ tokenizers = { path = "../tokenizers" }
 pgrx.workspace = true
 rustc-hash = "2.1.2"
 serde = "1.0.228"
-serde_json = { version = "1.0.149", features = ["preserve_order"] }
+serde_json = { version = "1.0.149", features = [
+  "preserve_order",
+  "float_roundtrip",
+] }
 serde_cbor = "0.11.2"
 tantivy.workspace = true
 thiserror = "2.0.18"

--- a/pg_search/src/postgres/jsonb_support.rs
+++ b/pg_search/src/postgres/jsonb_support.rs
@@ -16,7 +16,9 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use pgrx::{pg_sys, AnyNumeric, FromDatum};
+use serde_json::Error as SerdeError;
 use std::str::{FromStr, Utf8Error};
+use thiserror::Error;
 
 // we redefine these functions because we don't want pgrx' per-function FFI wrappers -- we intend
 // to use them, together, in a single FFI wrapper closure
@@ -30,6 +32,14 @@ extern "C-unwind" {
 
 }
 
+#[derive(Error, Debug)]
+pub enum JsonbConversionError {
+    #[error(transparent)]
+    Utf8(#[from] Utf8Error),
+    #[error(transparent)]
+    Serde(#[from] SerdeError),
+}
+
 /// Efficiently convert a raw `jsonb` [`pg_sys::Datum`] given to us by Postgres into a [`serde_json::Value`]
 /// structure.  The provided datum does not need to be detoasted as this function handles it.
 ///
@@ -39,7 +49,7 @@ extern "C-unwind" {
 /// the caller's responsibility.
 pub unsafe fn jsonb_datum_to_serde_json_value(
     datum: pg_sys::Datum,
-) -> Option<Result<serde_json::Value, Utf8Error>> {
+) -> Option<Result<serde_json::Value, JsonbConversionError>> {
     if datum.is_null() {
         return None;
     }
@@ -61,7 +71,7 @@ pub unsafe fn jsonb_datum_to_serde_json_value(
 
 unsafe fn jsonb_iterate(
     iter: &mut *mut pg_sys::JsonbIterator,
-) -> Result<serde_json::Value, Utf8Error> {
+) -> Result<serde_json::Value, JsonbConversionError> {
     let mut jsonb_value = pg_sys::JsonbValue::default();
 
     let mut stack = Vec::new();
@@ -173,7 +183,7 @@ unsafe fn jsonb_iterate(
 
 unsafe fn jsonb_value_to_serde_value(
     value: &pg_sys::JsonbValue,
-) -> Result<serde_json::Value, Utf8Error> {
+) -> Result<serde_json::Value, JsonbConversionError> {
     let value = match value.type_ {
         pg_sys::jbvType::jbvNull => serde_json::Value::Null,
         pg_sys::jbvType::jbvString => {
@@ -197,9 +207,7 @@ unsafe fn jsonb_value_to_serde_value(
             let num = AnyNumeric::from_datum(pg_sys::Datum::from(value.val.numeric), false)
                 .unwrap_unchecked();
             // yucko!  however, this is what Postgres does internally
-            serde_json::Value::Number(
-                serde_json::Number::from_str(num.to_string().as_str()).unwrap(),
-            )
+            serde_json::Value::Number(serde_json::Number::from_str(num.to_string().as_str())?)
         }
         pg_sys::jbvType::jbvBool => serde_json::Value::Bool(value.val.boolean),
         pg_sys::jbvType::jbvArray => {
@@ -212,7 +220,7 @@ unsafe fn jsonb_value_to_serde_value(
             let vec = elems
                 .iter()
                 .map(|value| jsonb_value_to_serde_value(value))
-                .collect::<Result<Vec<_>, Utf8Error>>()?;
+                .collect::<Result<Vec<_>, _>>()?;
             serde_json::Value::Array(vec)
         }
         pg_sys::jbvType::jbvObject => {

--- a/pg_search/src/postgres/jsonb_support.rs
+++ b/pg_search/src/postgres/jsonb_support.rs
@@ -340,4 +340,30 @@ mod tests {
             }
         });
     }
+
+    /// Regression test for https://github.com/paradedb/paradedb/issues/5217.
+    ///
+    /// `f64::MAX` (`1.7976931348623157e308`) is a valid, finite float, but
+    /// Postgres stores jsonb numbers as `numeric` and `numeric_out` expands it to
+    /// a 309-digit plain-decimal string. serde_json's default float parser
+    /// reconstructs that string via an `f64` multiply that rounds up to infinity,
+    /// so `Number::from_str(...).unwrap()` in `jsonb_value_to_serde_value` errors
+    /// out and panics (which aborts the backend across the FFI boundary during a
+    /// real index build). The value must instead round-trip back to `f64::MAX`.
+    #[pg_test]
+    fn jsonb_f64_max_round_trips() {
+        // Build the Value with `from_f64` (no string parsing), then let Postgres
+        // store it as `numeric` — mirroring how a real row reaches the index. The
+        // crashing path is the conversion *back* out of the jsonb datum.
+        let value = serde_json::json!({"a": {"max": f64::MAX, "min": 0}});
+        let datum = JsonB(value.clone()).into_datum().unwrap();
+
+        let result = unsafe {
+            jsonb_datum_to_serde_json_value(datum)
+                .unwrap()
+                .expect("f64::MAX inside jsonb must round-trip instead of crashing")
+        };
+
+        assert_eq!(result, value);
+    }
 }

--- a/pg_search/src/postgres/types.rs
+++ b/pg_search/src/postgres/types.rs
@@ -43,6 +43,8 @@ use std::str::FromStr;
 use tantivy::schema::{Facet, IntoIpv6Addr};
 use thiserror::Error;
 
+use super::jsonb_support::JsonbConversionError;
+
 /// A row-oriented wrapper around Tantivy's OwnedValue.
 ///
 /// When working with large batches of TantivyValues, consider using the `types_arrow` module
@@ -238,7 +240,7 @@ impl TantivyValue {
                 PgBuiltInOids::JSONBOID => {
                     let serde_json_value = jsonb_datum_to_serde_json_value(datum)
                         .ok_or(TantivyValueError::DatumDeref)?
-                        .map_err(TantivyValueError::Utf8ConversionError)?;
+                        .map_err(TantivyValueError::from)?;
                     Self::try_json_value_to_tantivy_value(serde_json_value)
                 }
                 PgBuiltInOids::JSONOID => {
@@ -1309,6 +1311,14 @@ pub enum TantivyValueError {
 
     #[error("UTF8 conversion error: {0}")]
     Utf8ConversionError(#[from] std::str::Utf8Error),
+}
+impl From<JsonbConversionError> for TantivyValueError {
+    fn from(value: JsonbConversionError) -> Self {
+        match value {
+            JsonbConversionError::Utf8(v) => Self::Utf8ConversionError(v),
+            JsonbConversionError::Serde(v) => Self::SerdeJsonError(v),
+        }
+    }
 }
 
 /// Check if the given OID is a date/time type that requires special conversion


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5217 

## What
This PR addresses two concerns raised by #5217:
1) A panic inside the jsonb conversion code will crash postgres because we're operating inside of pgrx's `pg_guard_ffi_boundary`. This PR broadens the returned error type and removes the `unwrap` that caused the crash. I examined the other possible `unwrap/except` sites and they all look good to me, I think this was just an oversight.
2) `serde_json` parses long number strings as integers, and then if they don't fit, floats. Since we get the number from postgres as a non-scientific string, serde_json is parsing a 309-digit number for `f64::MAX`.  That overflows the integer representation, so it falls back to float parsing. By default, serde_json uses a fast-path that will cause slight rounding errors for extreme values. When parsing the integer representation of `f64::MAX`, this causes it to round to infinity and return a `Number out of bounds` error. 

    This PR enables the `float_roundtrip` feature, which causes the use of a different parser that does not have this problem, at the expense of a ~2x performance penalty for parsing floats. 

## Why
Correctness and not crashing are two must-haves in a database

## Tests
- Added a regression test for this bug. It fails if `float_roundtrip` is not enabled.