### PR TITLE
fix: Add support for solving heap filters in `mpp` plans.

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -688,7 +688,8 @@ impl JoinScan {
             (src.scan_info.segment_count, src.scan_info.estimate)
         };
 
-        let nworkers = if mpp_is_active() {
+        let use_mpp = mpp_is_active() && !JoinScan::source_queries_have_parameters(&join_clause);
+        let nworkers = if use_mpp {
             // MPP needs exactly `producer_worker_count()` workers to match the n_procs x n_procs
             // mesh dimensions. Override the heuristic-based parallel-worker count.
             producer_worker_count() as usize
@@ -774,7 +775,7 @@ impl JoinScan {
         // For MPP the customscan launches its own producer workers from exec via the builder, so
         // the path stays serial to PG (no Gather). Only the regular non-MPP parallel join is marked
         // parallel-aware; `nworkers` still feeds the per-source row estimates above either way.
-        if nworkers > 0 && !mpp_is_active() {
+        if nworkers > 0 && !use_mpp {
             custom_path.path.parallel_aware = true;
             custom_path.path.parallel_safe = true;
             custom_path.path.parallel_workers =
@@ -976,6 +977,15 @@ impl JoinScan {
             .collect()
     }
 
+    fn source_queries_have_parameters(join_clause: &JoinCSClause) -> bool {
+        // TODO(#5445): Implement `SolvePostgresExpressions` for `JoinScan` to solve
+        // these parameters on the leader before dispatch.
+        join_clause.plan.sources().iter().any(|source| {
+            let mut query = source.scan_info.query.clone();
+            query.has_parameters()
+        })
+    }
+
     fn source_queries_need_executor_state(join_clause: &JoinCSClause) -> bool {
         join_clause.plan.sources().iter().any(|source| {
             let mut query = source.scan_info.query.clone();
@@ -1002,7 +1012,9 @@ impl JoinScan {
     /// success, installs the leader state so the consumer plan reads from the mesh. A short launch
     /// (or any setup fallback) leaves `mpp` unset and the query runs serially.
     fn maybe_launch_mpp(state: &mut CustomScanStateWrapper<Self>) {
-        if !mpp_is_active() {
+        if !mpp_is_active()
+            || Self::source_queries_have_parameters(&state.custom_state().join_clause)
+        {
             return;
         }
         let Some(plan_bytes) = state.custom_state_mut().mpp_plan_bytes.take() else {
@@ -1388,7 +1400,10 @@ impl CustomScan for JoinScan {
             // can write it into the DSM region. Only the leader runs this branch
             // (`ParallelWorkerNumber == -1`); workers read the bytes back from DSM in
             // initialize_worker_custom_scan via `worker_setup`.
-            if mpp_is_active() && unsafe { pg_sys::ParallelWorkerNumber } == -1 {
+            if mpp_is_active()
+                && !Self::source_queries_have_parameters(&state.custom_state().join_clause)
+                && unsafe { pg_sys::ParallelWorkerNumber } == -1
+            {
                 if let Some(bytes) = state.custom_state().logical_plan.clone() {
                     state.custom_state_mut().mpp_plan_bytes = Some(bytes.to_vec());
                     let partitioning_idx =

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -42,6 +42,7 @@ use crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context;
 use crate::postgres::customscan::mpp::worker_fragments::{
     collect_dispatched_stages, FragmentAssignment, FragmentRouting,
 };
+use crate::postgres::utils::ExprContextGuard;
 use crate::scan::codec::deserialize_logical_plan_with_runtime;
 use crate::scan::physical_codec::{
     deserialize_physical_plan_with_runtime, serialize_physical_plan,
@@ -151,7 +152,7 @@ pub fn build_dispatch_blob(
     runtime: &tokio::runtime::Runtime,
     non_partitioning_segments: &[HashSet<SegmentId>],
 ) -> Result<(Vec<u8>, Vec<StagePlan>)> {
-    let expr_context_guard = crate::postgres::utils::ExprContextGuard::new();
+    let expr_context_guard = ExprContextGuard::new();
     let logical = deserialize_logical_plan_with_runtime(
         logical_bytes,
         &seed.task_ctx(),

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -151,11 +151,12 @@ pub fn build_dispatch_blob(
     runtime: &tokio::runtime::Runtime,
     non_partitioning_segments: &[HashSet<SegmentId>],
 ) -> Result<(Vec<u8>, Vec<StagePlan>)> {
+    let expr_context_guard = crate::postgres::utils::ExprContextGuard::new();
     let logical = deserialize_logical_plan_with_runtime(
         logical_bytes,
         &seed.task_ctx(),
         None,
-        None,
+        Some(expr_context_guard.as_ptr()),
         None,
         Vec::new(),
         Vec::new(),
@@ -182,6 +183,7 @@ pub fn build_dispatch_blob(
             None,
             non_partitioning_segments.to_vec(),
             Vec::new(),
+            Some(expr_context_guard.as_ptr()),
         )?;
         dispatched.push(DispatchedStage {
             stage_num: stage.stage_num,

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -282,6 +282,7 @@ pub(crate) fn run_mpp_worker(
     };
     let decode_ctx = session.task_ctx();
     let mut plans = Vec::with_capacity(frames.len());
+    let expr_context_guard = crate::postgres::utils::ExprContextGuard::new();
     for (fragment, frame) in fragments.iter().zip(frames) {
         let Some(set_plan) = frame.set_plan else {
             pgrx::error!(
@@ -296,6 +297,7 @@ pub(crate) fn run_mpp_worker(
             parallel_state,
             non_partitioning_segments.to_vec(),
             index_segment_ids.to_vec(),
+            Some(expr_context_guard.as_ptr()),
         ) {
             Ok(plan) => plans.push(plan),
             Err(e) => pgrx::error!(

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -58,6 +58,7 @@ use crate::postgres::customscan::mpp::interrupt::{check_for_interrupts, HeldInte
 use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::customscan::parallel::list_segment_ids;
+use crate::postgres::utils::ExprContextGuard;
 use crate::postgres::ParallelScanState;
 use crate::scan::physical_codec::deserialize_physical_plan_with_runtime;
 use datafusion_distributed::shm::SetPlanFrame;
@@ -282,7 +283,10 @@ pub(crate) fn run_mpp_worker(
     };
     let decode_ctx = session.task_ctx();
     let mut plans = Vec::with_capacity(frames.len());
-    let expr_context_guard = crate::postgres::utils::ExprContextGuard::new();
+    let expr_context_guard = ExprContextGuard::new();
+
+    // Deserialize under the decode ctx, not the run ctx. The run ctx limits
+    // allocations aggressively; decode builds the plan graph and can spike memory.
     for (fragment, frame) in fragments.iter().zip(frames) {
         let Some(set_plan) = frame.set_plan else {
             pgrx::error!(

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -372,7 +372,8 @@ impl PgSearchScanPlan {
         buf: &[u8],
         parallel_state: Option<*mut ParallelScanState>,
         non_partitioning_segment_ids: &[HashSet<SegmentId>],
-    ) -> Result<Arc<dyn ExecutionPlan>> {
+        expr_context: Option<*mut pg_sys::ExprContext>,
+    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         let descriptor: ScanDispatchDescriptor = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("PgSearchScan dispatch: deserialize: {e}"))
         })?;
@@ -427,8 +428,10 @@ impl PgSearchScanPlan {
             query.clone(),
             descriptor.score_needed,
             mvcc,
-            None, // expr_context: the query ships pre-solved
-            None, // planstate: same
+            expr_context.and_then(std::ptr::NonNull::new),
+            // The worker lacks a Postgres PlanState tree. This is safe because ExecInitExpr
+            // accepts null_mut() for expressions that do not reference external plan contexts.
+            None,
             needs_tokenizer,
         )
         .map_err(|e| {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -373,7 +373,7 @@ impl PgSearchScanPlan {
         parallel_state: Option<*mut ParallelScanState>,
         non_partitioning_segment_ids: &[HashSet<SegmentId>],
         expr_context: Option<*mut pg_sys::ExprContext>,
-    ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
+    ) -> Result<Arc<dyn ExecutionPlan>> {
         let descriptor: ScanDispatchDescriptor = serde_json::from_slice(buf).map_err(|e| {
             DataFusionError::Internal(format!("PgSearchScan dispatch: deserialize: {e}"))
         })?;

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -429,8 +429,8 @@ impl PgSearchScanPlan {
             descriptor.score_needed,
             mvcc,
             expr_context.and_then(std::ptr::NonNull::new),
-            // The worker lacks a Postgres PlanState tree. This is safe because ExecInitExpr
-            // accepts null_mut() for expressions that do not reference external plan contexts.
+            // TODO: MPP is currently disabled when a scan requires parameter solving: see
+            // https://github.com/paradedb/paradedb/issues/5445.
             None,
             needs_tokenizer,
         )

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -70,6 +70,7 @@ pub struct PgSearchPhysicalExtensionCodec {
     /// Canonical segment ID sets for all join sources, indexed by `plan_position`. Injected into
     /// `SearchPredicateUDF` on decode, same as the logical codec.
     index_segment_ids: Vec<HashSet<SegmentId>>,
+    expr_context: Option<*mut pgrx::pg_sys::ExprContext>,
 }
 
 // Same justification as the logical `PgSearchExtensionCodec`: Postgres extensions run
@@ -94,6 +95,7 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                 payload,
                 self.parallel_state,
                 &self.non_partitioning_segment_ids,
+                self.expr_context,
             ),
             // The deferred execs (visibility ctid resolvers, tantivy lookup, segmented top-k)
             // carry live `FFHelper`s that can't travel. Decode is bottom-up, so the scans below
@@ -360,11 +362,13 @@ pub fn deserialize_physical_plan_with_runtime(
     parallel_state: Option<*mut ParallelScanState>,
     non_partitioning_segment_ids: Vec<HashSet<SegmentId>>,
     index_segment_ids: Vec<HashSet<SegmentId>>,
+    expr_context: Option<*mut pgrx::pg_sys::ExprContext>,
 ) -> Result<Arc<dyn ExecutionPlan>> {
     let codec = combined_codec(PgSearchPhysicalExtensionCodec {
         parallel_state,
         non_partitioning_segment_ids,
         index_segment_ids,
+        expr_context,
     });
     let proto = <PhysicalPlanNode as prost::Message>::decode(bytes).map_err(|e| {
         DataFusionError::Internal(format!("Failed to decode dispatched PhysicalPlanNode: {e}"))

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -70,6 +70,7 @@ pub struct PgSearchPhysicalExtensionCodec {
     /// Canonical segment ID sets for all join sources, indexed by `plan_position`. Injected into
     /// `SearchPredicateUDF` on decode, same as the logical codec.
     index_segment_ids: Vec<HashSet<SegmentId>>,
+    /// The `ExprContext` workers use to evaluate heap filters.
     expr_context: Option<*mut pgrx::pg_sys::ExprContext>,
 }
 

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -203,6 +203,65 @@ WHERE line LIKE '%output_rows%';
 
 DROP FUNCTION mpp_explain_analyze_lines(text);
 -- =====================================================================
+-- Pass 4: MPP with heap filter
+--
+-- A heap filter (like `length(f.title) > 0`) must be evaluated in the
+-- worker. This tests that the expression context is properly provided
+-- to the worker.
+-- =====================================================================
+SET paradedb.enable_mpp TO on;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 0
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+                                                                                                                                                     QUERY PLAN                                                                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.title, p.size_bytes
+   ->  Gather Merge
+         Output: f.title, p.size_bytes
+         Workers Planned: 3
+         ->  Parallel Custom Scan (ParadeDB Join Scan)
+               Output: f.title, p.size_bytes
+               Relation Tree: p INNER f
+               Join Cond: f.id = p.file_id
+               Limit: 10
+               Order By: f.title asc, p.size_bytes asc
+               DataFusion Physical Plan: 
+                 : ┌───── DistributedExec ── Tasks: t0:[p0]
+                 : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
+                 : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                 : └──────────────────────────────────────────────────
+                 :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+                 :   │ LocalLimitExec: fetch=10
+                 :   │   TantivyLookupExec: decode=[title]
+                 :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+                 :   │       VisibilityFilterExec: tables=[p, f]
+                 :   │         ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
+                 :   │           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
+                 :   │             CoalescePartitionsExec
+                 :   │               [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+                 :   │             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+                 :   │               PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :   └──────────────────────────────────────────────────
+                 :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                 :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+                 :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 0)"}]}}]}}
+                 :     └──────────────────────────────────────────────────
+(33 rows)
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 0
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+ERROR:  An expression context must be provided when heap filtering.
+-- =====================================================================
 -- Cleanup
 -- =====================================================================
 DROP TABLE mpp_join_pages;

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -205,7 +205,7 @@ DROP FUNCTION mpp_explain_analyze_lines(text);
 -- =====================================================================
 -- Pass 4: MPP with heap filter
 --
--- A heap filter (like `length(f.title) > 0`) must be evaluated in the
+-- A heap filter (like `length(f.title) > 6`) must be evaluated in the
 -- worker. This tests that the expression context is properly provided
 -- to the worker.
 -- =====================================================================
@@ -214,7 +214,7 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
-  AND length(f.title) > 0
+  AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
                                                                                                                                                   QUERY PLAN                                                                                                                                                  
@@ -246,28 +246,83 @@ LIMIT 10;
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 0)"}]}}]}}
+           :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :     └──────────────────────────────────────────────────
 (29 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
-  AND length(f.title) > 0
+  AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-  title  | size_bytes 
----------+------------
- file-1  |        616
- file-1  |       1312
- file-1  |       2008
- file-1  |       2704
- file-1  |       3400
- file-10 |        153
- file-10 |       1465
- file-10 |       2161
- file-10 |       2857
- file-10 |       3553
+  title   | size_bytes 
+----------+------------
+ file-10  |        153
+ file-10  |       1465
+ file-10  |       2161
+ file-10  |       2857
+ file-10  |       3553
+ file-100 |        291
+ file-100 |        987
+ file-100 |       1683
+ file-100 |       2995
+ file-100 |       3691
+(10 rows)
+
+-- =====================================================================
+-- Pass 5: Serial fallback check
+--
+-- Ensure the same query returns identical results when executed serially.
+-- =====================================================================
+SET paradedb.enable_mpp TO off;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 6
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+                                                                                                                                                    QUERY PLAN                                                                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.title, p.size_bytes
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: f.title, p.size_bytes
+         Relation Tree: p INNER f
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: f.title asc, p.size_bytes asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   TantivyLookupExec: decode=[title]
+           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+           :       VisibilityFilterExec: tables=[p, f]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 6
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+  title   | size_bytes 
+----------+------------
+ file-10  |        153
+ file-10  |       1465
+ file-10  |       2161
+ file-10  |       2857
+ file-10  |       3553
+ file-100 |        291
+ file-100 |        987
+ file-100 |       1683
+ file-100 |       2995
+ file-100 |       3691
 (10 rows)
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -217,42 +217,38 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 0
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                     QUERY PLAN                                                                                                                                                     
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                  QUERY PLAN                                                                                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
-   ->  Gather Merge
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: f.title, p.size_bytes
-         Workers Planned: 3
-         ->  Parallel Custom Scan (ParadeDB Join Scan)
-               Output: f.title, p.size_bytes
-               Relation Tree: p INNER f
-               Join Cond: f.id = p.file_id
-               Limit: 10
-               Order By: f.title asc, p.size_bytes asc
-               DataFusion Physical Plan: 
-                 : ┌───── DistributedExec ── Tasks: t0:[p0]
-                 : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
-                 : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-                 : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
-                 : └──────────────────────────────────────────────────
-                 :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
-                 :   │ LocalLimitExec: fetch=10
-                 :   │   TantivyLookupExec: decode=[title]
-                 :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
-                 :   │       VisibilityFilterExec: tables=[p, f]
-                 :   │         ProjectionExec: expr=[ctid_0@2 as ctid_0, size_bytes@3 as size_bytes, ctid_1@0 as ctid_1, title@1 as title]
-                 :   │           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_1@0, title@2, ctid_0@3, size_bytes@5]
-                 :   │             CoalescePartitionsExec
-                 :   │               [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-                 :   │             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :   │               PgSearchScan: segments=1, dynamic_filters=1, query="all"
-                 :   └──────────────────────────────────────────────────
-                 :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
-                 :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-                 :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 0)"}]}}]}}
-                 :     └──────────────────────────────────────────────────
-(33 rows)
+         Relation Tree: p INNER f
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: f.title asc, p.size_bytes asc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   │ LocalLimitExec: fetch=10
+           :   │   TantivyLookupExec: decode=[title]
+           :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+           :   │       VisibilityFilterExec: tables=[p, f]
+           :   │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
+           :   │           CoalescePartitionsExec
+           :   │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 0)"}]}}]}}
+           :     └──────────────────────────────────────────────────
+(29 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -260,7 +256,20 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 0
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-ERROR:  An expression context must be provided when heap filtering.
+  title  | size_bytes 
+---------+------------
+ file-1  |        616
+ file-1  |       1312
+ file-1  |       2008
+ file-1  |       2704
+ file-1  |       3400
+ file-10 |        153
+ file-10 |       1465
+ file-10 |       2161
+ file-10 |       2857
+ file-10 |       3553
+(10 rows)
+
 -- =====================================================================
 -- Cleanup
 -- =====================================================================

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -140,7 +140,7 @@ DROP FUNCTION mpp_explain_analyze_lines(text);
 -- =====================================================================
 -- Pass 4: MPP with heap filter
 --
--- A heap filter (like `length(f.title) > 0`) must be evaluated in the
+-- A heap filter (like `length(f.title) > 6`) must be evaluated in the
 -- worker. This tests that the expression context is properly provided
 -- to the worker.
 -- =====================================================================
@@ -151,14 +151,37 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
-  AND length(f.title) > 0
+  AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
-  AND length(f.title) > 0
+  AND length(f.title) > 6
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+-- =====================================================================
+-- Pass 5: Serial fallback check
+--
+-- Ensure the same query returns identical results when executed serially.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO off;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 6
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
 

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -138,6 +138,31 @@ WHERE line LIKE '%output_rows%';
 DROP FUNCTION mpp_explain_analyze_lines(text);
 
 -- =====================================================================
+-- Pass 4: MPP with heap filter
+--
+-- A heap filter (like `length(f.title) > 0`) must be evaluated in the
+-- worker. This tests that the expression context is properly provided
+-- to the worker.
+-- =====================================================================
+
+SET paradedb.enable_mpp TO on;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 0
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+SELECT f.title, p.size_bytes
+FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+  AND length(f.title) > 0
+ORDER BY f.title, p.size_bytes
+LIMIT 10;
+
+-- =====================================================================
 -- Cleanup
 -- =====================================================================
 


### PR DESCRIPTION
## What

Add support for applying heap filters in the mpp scans.

## Why

For parity with no-mpp.

## Tests

New regress test.