### PR TITLE
feat: Backport Docker auto-tuning (#5273, #5290) to 0.24.x

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -166,12 +166,17 @@ jobs:
             local log_message="$2"
             local tuning_block
 
-            docker logs "$name" 2>&1 | grep -F "$log_message"
+            if ! docker logs "$name" 2>&1 | grep -F "$log_message"; then
+              echo "Error: ${name} logs did not contain: ${log_message}"
+              dump_autotune_container "$name"
+              exit 1
+            fi
             tuning_block="$(docker exec "$name" bash -c 'awk "/# Begin ParadeDB tuning recommendations/ {show=1} show {print} /# End ParadeDB tuning recommendations/ {show=0}" "$PGDATA/postgresql.conf"')"
             echo "$tuning_block"
 
             if [ -n "$tuning_block" ]; then
               echo "Error: ${name} unexpectedly appended auto-tuning settings"
+              dump_autotune_container "$name"
               exit 1
             fi
           }
@@ -189,10 +194,43 @@ jobs:
 
             if [ ! -s "$actual_file" ]; then
               echo "Error: ${name} did not append auto-tuning settings"
+              dump_autotune_container "$name"
               exit 1
             fi
 
-            git diff --no-index -- "$expected_file" "$actual_file"
+            if ! git diff --no-index -- "$expected_file" "$actual_file"; then
+              dump_autotune_container "$name"
+              exit 1
+            fi
+          }
+
+          dump_autotune_container() {
+            local name="$1"
+
+            docker ps -a --filter "name=^/${name}$"
+            docker logs "$name" 2>&1 || true
+            docker exec "$name" bash -c 'awk "/# Begin ParadeDB tuning recommendations/ {show=1} show {print} /# End ParadeDB tuning recommendations/ {show=0}" "$PGDATA/postgresql.conf"' || true
+          }
+
+          wait_for_bootstrap() {
+            local name="$1"
+
+            for i in $(seq 1 30); do
+              if docker logs "$name" 2>&1 | grep -F "ParadeDB bootstrap completed!" > /dev/null; then
+                echo "${name} bootstrap completed after ${i}s"
+                return 0
+              fi
+              if [ "$(docker inspect -f '{{.State.Status}}' "$name")" = "exited" ]; then
+                echo "Error: ${name} exited before bootstrap completed"
+                dump_autotune_container "$name"
+                exit 1
+              fi
+              sleep 1
+            done
+
+            echo "Error: ${name} did not finish bootstrap within 30s"
+            dump_autotune_container "$name"
+            exit 1
           }
 
           echo "TEST: Skip tuning when it is disabled with PDB_TUNE"
@@ -205,7 +243,7 @@ jobs:
             -e POSTGRES_DB=mydatabase \
             -e PDB_TUNE=false \
             paradedb/paradedb:latest
-          sleep 8
+          wait_for_bootstrap paradedb-autotune-disabled
           assert_not_tuned paradedb-autotune-disabled "Auto-tuning is disabled, skipping."
           docker rm -f paradedb-autotune-disabled
           echo && echo && echo
@@ -219,7 +257,7 @@ jobs:
             -e POSTGRES_PASSWORD=mypassword \
             -e POSTGRES_DB=mydatabase \
             paradedb/paradedb:latest
-          sleep 8
+          wait_for_bootstrap paradedb-autotune-low-memory
           assert_not_tuned paradedb-autotune-low-memory "Available memory is less than 512mb, skipping auto tuning."
           docker rm -f paradedb-autotune-low-memory
           echo && echo && echo
@@ -231,11 +269,12 @@ jobs:
             -e POSTGRES_PASSWORD=mypassword \
             -e POSTGRES_DB=mydatabase \
             paradedb/paradedb:latest
-          sleep 8
+          wait_for_bootstrap paradedb-autotune-default-resources
           tuning_block="$(docker exec paradedb-autotune-default-resources bash -c 'awk "/# Begin ParadeDB tuning recommendations/ {show=1} show {print} /# End ParadeDB tuning recommendations/ {show=0}" "$PGDATA/postgresql.conf"')"
           echo "$tuning_block"
           if [ -z "$tuning_block" ]; then
             echo "Error: paradedb-autotune-default-resources did not append auto-tuning settings"
+            dump_autotune_container paradedb-autotune-default-resources
             exit 1
           fi
           docker rm -f paradedb-autotune-default-resources
@@ -250,7 +289,7 @@ jobs:
             -e POSTGRES_PASSWORD=mypassword \
             -e POSTGRES_DB=mydatabase \
             paradedb/paradedb:latest
-          sleep 8
+          wait_for_bootstrap paradedb-autotune-fractional-cpu
           assert_tuned paradedb-autotune-fractional-cpu <<'EOF'
           # Begin ParadeDB tuning recommendations
           # Parameters based on auto-detected 2.7 CPUs and 2048MB RAM
@@ -276,7 +315,7 @@ jobs:
             -e POSTGRES_PASSWORD=mypassword \
             -e POSTGRES_DB=mydatabase \
             paradedb/paradedb:latest
-          sleep 8
+          wait_for_bootstrap paradedb-autotune-1cpu-1gb
           assert_tuned paradedb-autotune-1cpu-1gb <<'EOF'
           # Begin ParadeDB tuning recommendations
           # Parameters based on auto-detected 1 CPUs and 1024MB RAM
@@ -302,7 +341,7 @@ jobs:
             -e POSTGRES_PASSWORD=mypassword \
             -e POSTGRES_DB=mydatabase \
             paradedb/paradedb:latest
-          sleep 8
+          wait_for_bootstrap paradedb-autotune-4cpu-8gb
           assert_tuned paradedb-autotune-4cpu-8gb <<'EOF'
           # Begin ParadeDB tuning recommendations
           # Parameters based on auto-detected 4 CPUs and 8192MB RAM

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -158,6 +158,167 @@ jobs:
         if: matrix.flavor == 'paradedb'
         run: docker exec paradedb barman-cloud-wal-archive --help
 
+      - name: Test Postgres Auto-tuning
+        if: steps.release_gate.outputs.skip != 'true'
+        run: |
+          assert_not_tuned() {
+            local name="$1"
+            local log_message="$2"
+            local tuning_block
+
+            docker logs "$name" 2>&1 | grep -F "$log_message"
+            tuning_block="$(docker exec "$name" bash -c 'awk "/# Begin ParadeDB tuning recommendations/ {show=1} show {print} /# End ParadeDB tuning recommendations/ {show=0}" "$PGDATA/postgresql.conf"')"
+            echo "$tuning_block"
+
+            if [ -n "$tuning_block" ]; then
+              echo "Error: ${name} unexpectedly appended auto-tuning settings"
+              exit 1
+            fi
+          }
+
+          assert_tuned() {
+            local name="$1"
+            local actual_file
+            local expected_file
+
+            expected_file="$(mktemp)"
+            actual_file="$(mktemp)"
+            cat > "$expected_file"
+            docker exec "$name" bash -c 'awk "/# Begin ParadeDB tuning recommendations/ {show=1} show {print} /# End ParadeDB tuning recommendations/ {show=0}" "$PGDATA/postgresql.conf"' > "$actual_file"
+            cat "$actual_file"
+
+            if [ ! -s "$actual_file" ]; then
+              echo "Error: ${name} did not append auto-tuning settings"
+              exit 1
+            fi
+
+            git diff --no-index -- "$expected_file" "$actual_file"
+          }
+
+          echo "TEST: Skip tuning when it is disabled with PDB_TUNE"
+          docker run -d \
+            --name paradedb-autotune-disabled \
+            --cpus 2 \
+            --memory 1g \
+            -e POSTGRES_USER=myuser \
+            -e POSTGRES_PASSWORD=mypassword \
+            -e POSTGRES_DB=mydatabase \
+            -e PDB_TUNE=false \
+            paradedb/paradedb:latest
+          sleep 8
+          assert_not_tuned paradedb-autotune-disabled "Auto-tuning is disabled, skipping."
+          docker rm -f paradedb-autotune-disabled
+          echo && echo && echo
+
+          echo "TEST: Skip tuning when memory is less than 512mb"
+          docker run -d \
+            --name paradedb-autotune-low-memory \
+            --cpus 2 \
+            --memory 511m \
+            -e POSTGRES_USER=myuser \
+            -e POSTGRES_PASSWORD=mypassword \
+            -e POSTGRES_DB=mydatabase \
+            paradedb/paradedb:latest
+          sleep 8
+          assert_not_tuned paradedb-autotune-low-memory "Available memory is less than 512mb, skipping auto tuning."
+          docker rm -f paradedb-autotune-low-memory
+          echo && echo && echo
+
+          echo "TEST: Tunes successfully when no explicit limits are set"
+          docker run -d \
+            --name paradedb-autotune-default-resources \
+            -e POSTGRES_USER=myuser \
+            -e POSTGRES_PASSWORD=mypassword \
+            -e POSTGRES_DB=mydatabase \
+            paradedb/paradedb:latest
+          sleep 8
+          tuning_block="$(docker exec paradedb-autotune-default-resources bash -c 'awk "/# Begin ParadeDB tuning recommendations/ {show=1} show {print} /# End ParadeDB tuning recommendations/ {show=0}" "$PGDATA/postgresql.conf"')"
+          echo "$tuning_block"
+          if [ -z "$tuning_block" ]; then
+            echo "Error: paradedb-autotune-default-resources did not append auto-tuning settings"
+            exit 1
+          fi
+          docker rm -f paradedb-autotune-default-resources
+          echo && echo && echo
+
+          echo "TEST: Tunes with a fractional CPU value"
+          docker run -d \
+            --name paradedb-autotune-fractional-cpu \
+            --cpus 2.7 \
+            --memory 2g \
+            -e POSTGRES_USER=myuser \
+            -e POSTGRES_PASSWORD=mypassword \
+            -e POSTGRES_DB=mydatabase \
+            paradedb/paradedb:latest
+          sleep 8
+          assert_tuned paradedb-autotune-fractional-cpu <<'EOF'
+          # Begin ParadeDB tuning recommendations
+          # Parameters based on auto-detected 2.7 CPUs and 2048MB RAM
+          shared_buffers = '512MB'                      # 25% of RAM, capped at 16GB
+          effective_cache_size = '1536MB'               # 75% of RAM
+          maintenance_work_mem = '128MB'                # RAM / 16, capped at 2GB
+          work_mem = '15MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
+          max_parallel_workers = '13'                   # CPUs * 5
+          max_worker_processes = '21'                   # max_parallel_workers + 8
+          max_parallel_workers_per_gather = '1'         # CPUs / 2, at least 1
+          max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
+          # End ParadeDB tuning recommendations
+          EOF
+          docker rm -f paradedb-autotune-fractional-cpu
+          echo && echo && echo
+
+          echo "TEST: Tunes with 1 CPU and 1GB RAM"
+          docker run -d \
+            --name paradedb-autotune-1cpu-1gb \
+            --cpus 1 \
+            --memory 1g \
+            -e POSTGRES_USER=myuser \
+            -e POSTGRES_PASSWORD=mypassword \
+            -e POSTGRES_DB=mydatabase \
+            paradedb/paradedb:latest
+          sleep 8
+          assert_tuned paradedb-autotune-1cpu-1gb <<'EOF'
+          # Begin ParadeDB tuning recommendations
+          # Parameters based on auto-detected 1 CPUs and 1024MB RAM
+          shared_buffers = '256MB'                      # 25% of RAM, capped at 16GB
+          effective_cache_size = '768MB'                # 75% of RAM
+          maintenance_work_mem = '64MB'                 # RAM / 16, capped at 2GB
+          work_mem = '15MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
+          max_parallel_workers = '5'                    # CPUs * 5
+          max_worker_processes = '13'                   # max_parallel_workers + 8
+          max_parallel_workers_per_gather = '1'         # CPUs / 2, at least 1
+          max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
+          # End ParadeDB tuning recommendations
+          EOF
+          docker rm -f paradedb-autotune-1cpu-1gb
+          echo && echo && echo
+
+          echo "TEST: Tunes with 4 CPU and 8GB RAM"
+          docker run -d \
+            --name paradedb-autotune-4cpu-8gb \
+            --cpus 4 \
+            --memory 8g \
+            -e POSTGRES_USER=myuser \
+            -e POSTGRES_PASSWORD=mypassword \
+            -e POSTGRES_DB=mydatabase \
+            paradedb/paradedb:latest
+          sleep 8
+          assert_tuned paradedb-autotune-4cpu-8gb <<'EOF'
+          # Begin ParadeDB tuning recommendations
+          # Parameters based on auto-detected 4 CPUs and 8192MB RAM
+          shared_buffers = '2048MB'                     # 25% of RAM, capped at 16GB
+          effective_cache_size = '6144MB'               # 75% of RAM
+          maintenance_work_mem = '512MB'                # RAM / 16, capped at 2GB
+          work_mem = '20MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
+          max_parallel_workers = '20'                   # CPUs * 5
+          max_worker_processes = '28'                   # max_parallel_workers + 8
+          max_parallel_workers_per_gather = '2'         # CPUs / 2, at least 1
+          max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
+          # End ParadeDB tuning recommendations
+          EOF
+          docker rm -f paradedb-autotune-4cpu-8gb
+          echo && echo && echo
+
       # Useful for debugging discrepancies between local and remote ParadeDB Docker images
       - name: Print the ParadeDB Docker Image History
         run: docker history paradedb/paradedb:latest

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -2,12 +2,99 @@
 # shellcheck disable=SC2154
 
 # Executed at container start to bootstrap ParadeDB extensions and Postgres settings.
+# This file is NOT executed when running in CloudNativePG as it circumvents the normal
+# Postgres container entrypoint.
 
 # Exit on subcommand errors
 set -Eeuo pipefail
 
 # Perform all actions as $POSTGRES_USER
 export PGUSER="$POSTGRES_USER"
+PDB_TUNE=${PDB_TUNE:-true}
+
+container_memory_mb() {
+  local bytes=""
+
+  if [ -r /sys/fs/cgroup/memory.max ]; then
+    # cgroup v2: "max" means the container has no explicit memory limit.
+    bytes=$(cat /sys/fs/cgroup/memory.max)
+    [ "$bytes" = "max" ] && bytes=""
+  elif [ -r /sys/fs/cgroup/memory/memory.limit_in_bytes ]; then
+    # cgroup v1: very large values are used as an effectively-unlimited sentinel.
+    bytes=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+    [ "$bytes" -ge 10000000000000000 ] && bytes=""
+  fi
+
+  # If cgroups are unavailable or unlimited, fall back to host-visible memory.
+  if [ -z "$bytes" ]; then
+    awk '/MemTotal/ {print int($2 / 1024)}' /proc/meminfo
+  else
+    awk "BEGIN {print int($bytes / 1024 / 1024)}"
+  fi
+}
+
+container_cpu_count() {
+  local quota="" period="" cpus=""
+
+  if [ -r /sys/fs/cgroup/cpu.max ]; then
+    # cgroup v2: "max" means there is no quota, only the scheduler default.
+    read -r quota period < /sys/fs/cgroup/cpu.max
+    [ "$quota" = "max" ] && quota=""
+  elif [ -r /sys/fs/cgroup/cpu/cpu.cfs_quota_us ]; then
+    # cgroup v1: a negative quota means the CPU quota is unlimited.
+    quota=$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)
+    period=$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)
+    [ "$quota" -lt 0 ] && quota=""
+  fi
+
+  if [ -n "$quota" ]; then
+    # quota / period gives the number of CPUs allowed by the cgroup.
+    cpus=$(awk "BEGIN {print $quota / $period}")
+  else
+    # If there is no CPU quota, use the CPU count visible to the process.
+    cpus=$(nproc)
+  fi
+
+  # Choose the minimum of the CPU count detected between the cgroup and nproc in case the cgroup quota is higher than the cpuset
+  # Set 1 CPU as the minimum.
+  awk -v cpus="$cpus" -v visible_cpus="$(nproc)" 'BEGIN {cpus = cpus > visible_cpus ? visible_cpus : cpus; print (cpus < 1 ? 1 : cpus)}'
+}
+
+tune() {
+  if [[ "$PDB_TUNE" == "false" ]]; then
+    echo "Auto-tuning is disabled, skipping."
+    return 0
+  fi
+
+  TOTAL_RAM_MB=$(container_memory_mb)
+  CPU_COUNT=$(container_cpu_count)
+
+  if [ "$TOTAL_RAM_MB" -lt 512 ]; then
+    echo "Available memory is less than 512mb, skipping auto tuning."
+    return 0
+  fi
+
+  SHARED_BUFFERS_MB=$(awk "BEGIN {s=int($TOTAL_RAM_MB * 0.25); print (s > 16384 ? 16384 : s)}")
+  MAX_CONNECTIONS=100 # This is the postgres default
+  WORK_MEM_MB=$(awk "BEGIN {w=int(($TOTAL_RAM_MB - $SHARED_BUFFERS_MB) / ($MAX_CONNECTIONS * 3)); print (w < 15 ? 15 : w)}")
+  PARALLEL_WORKERS=$(awk "BEGIN {print int($CPU_COUNT * 5)}")
+
+  echo "ParadeDB auto-tune: Writing configuration to $PGDATA/postgresql.conf"
+  {
+    echo
+    echo "# Begin ParadeDB tuning recommendations"
+    echo "# Parameters based on auto-detected $CPU_COUNT CPUs and ${TOTAL_RAM_MB}MB RAM"
+    printf "%-45s # %s\n" "shared_buffers = '${SHARED_BUFFERS_MB}MB'" "25% of RAM, capped at 16GB"
+    printf "%-45s # %s\n" "effective_cache_size = '$(awk "BEGIN {print int($TOTAL_RAM_MB * 0.75)}")MB'" "75% of RAM"
+    printf "%-45s # %s\n" "maintenance_work_mem = '$(awk "BEGIN {m=int($TOTAL_RAM_MB / 16); print (m > 2048 ? 2048 : m)}")MB'" "RAM / 16, capped at 2GB"
+    printf "%-45s # %s\n" "work_mem = '${WORK_MEM_MB}MB'" "(RAM - shared_buffers) / (3 * max_connections), at least 15MB"
+    printf "%-45s # %s\n" "max_parallel_workers = '$PARALLEL_WORKERS'" "CPUs * 5"
+    printf "%-45s # %s\n" "max_worker_processes = '$(awk "BEGIN {print int($PARALLEL_WORKERS + 8)}")'" "max_parallel_workers + 8"
+    printf "%-45s # %s\n" "max_parallel_workers_per_gather = '$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p < 1 ? 1 : p)}")'" "CPUs / 2, at least 1"
+    printf "%-45s # %s\n" "max_parallel_maintenance_workers = '$(awk "BEGIN {p=int($CPU_COUNT / 2); print (p > 8 ? 8 : (p < 2 ? 2 : p))}")'" "CPUs / 2, at least 2, at most 8"
+    echo "# End ParadeDB tuning recommendations"
+  } | tee -a "$PGDATA/postgresql.conf"
+}
 
 # The `pg_cron` extension can only be installed in the `postgres` database, as per
 # our configuration in our Dockerfile. Therefore, we install it separately here.
@@ -40,5 +127,9 @@ for DB in template1 paradedb "$POSTGRES_DB"; do
   echo "Adding 'paradedb' search_path to $DB"
   psql -d "$DB" -c "ALTER DATABASE \"$DB\" SET search_path TO public,paradedb;"
 done
+
+
+# Tune postgresql.conf settings for the available hardware
+tune
 
 echo "ParadeDB bootstrap completed!"

--- a/docs/documentation/performance-tuning/create-index.mdx
+++ b/docs/documentation/performance-tuning/create-index.mdx
@@ -16,9 +16,11 @@ SET max_parallel_maintenance_workers = 8;
 
 In order for `max_parallel_maintenance_workers` to take effect, it must be less than or equal to both `max_parallel_workers` and `max_worker_processes`.
 
+A good rule of thumb for `max_parallel_maintenance_workers` is `CPUs / 2 (minimum 2, maximum 8)`.
+
 ### Configure Indexing Memory
 
-The default Postgres `maintenance_work_mem` value of `64MB` is quite conservative and can slow down parallel index builds. We recommend at least `64MB` per
+The default Postgres `maintenance_work_mem` value of `64MB` is quite conservative and can slow down parallel index builds. A good starting value is `RAM / 16` and at least `64MB` per
 [parallel indexing worker](#raise-parallel-indexing-workers).
 
 ```sql

--- a/docs/documentation/performance-tuning/overview.mdx
+++ b/docs/documentation/performance-tuning/overview.mdx
@@ -20,6 +20,38 @@ These settings can be changed in several ways:
 SET maintenance_work_mem = '8GB'
 ```
 
+## Docker
+
+When running ParadeDB in Docker, sensible default parameters are automatically configured based on the resources available to the container. For example, running a container with 4 CPUs and 8GB memory will cause the following to be appended to `postgresql.conf`. Be sure to adjust these parameters as you tune your deployment.
+
+```postgresql.conf
+# Begin ParadeDB tuning recommendations
+# Parameters based on auto-detected 4 CPUs and 8192MB RAM
+shared_buffers = '2048MB'                     # 25% of RAM, capped at 16GB
+effective_cache_size = '6144MB'               # 75% of RAM
+maintenance_work_mem = '512MB'                # RAM / 16, capped at 2GB
+work_mem = '20MB'                             # (RAM - shared_buffers) / (3 * max_connections), at least 15MB
+max_parallel_workers = '20'                   # CPUs * 5
+max_worker_processes = '28'                   # max_parallel_workers + 8
+max_parallel_workers_per_gather = '2'         # CPUs / 2, at least 1
+max_parallel_maintenance_workers = '2'        # CPUs / 2, at least 2, at most 8
+# End ParadeDB tuning recommendations
+```
+
+To disable auto-tuning, set `PDB_TUNE=false` when you first run the container:
+
+```
+docker run \
+    -e POSTGRES_USER=postgres \
+    -e POSTGRES_PASSWORD=postgres \
+    -e POSTGRES_DB=postgres \
+    -p 5432:5432 \
+    -e PDB_TUNE=false \
+    -d paradedb/paradedb:latest
+```
+
+## CloudNativePG
+
 If ParadeDB is deployed with [CloudNativePG](/deploy/self-hosted/kubernetes), these settings should be set in your
 `.tfvars` file.
 

--- a/docs/documentation/performance-tuning/reads.mdx
+++ b/docs/documentation/performance-tuning/reads.mdx
@@ -17,15 +17,23 @@ parallel queries. Finally, `max_parallel_workers_per_gather` limits how many wor
 
 ```init postgresql.conf
 max_worker_processes = 72
-max_parallel_workers = 64;
-max_parallel_workers_per_gather = 4;
+max_parallel_workers = 64
+max_parallel_workers_per_gather = 4
 ```
 
 In the above example, the maximum number of workers that a single query can receive is set to `4`. The `max_parallel_workers` pool
 is set to `64`, which means that `16` queries can execute simultaneously with `4` workers each. Finally, `max_worker_processes` is
 set to `72` to give headroom for other workers like autovacuum and replication.
 
-In practice, we recommend experimenting with different settings, as the best configuration depends on the underlying hardware,
+This is a good starting point:
+
+```
+max_parallel_workers = 5 * CPUs
+max_worker_processes = max_parallel_workers + 8
+max_parallel_workers_per_gather = CPUs / 2
+```
+
+We recommend experimenting with different settings, as the best configuration depends on the underlying hardware,
 query patterns, and volume of data.
 
 <Note>
@@ -37,8 +45,7 @@ query patterns, and volume of data.
 
 ## Raise Shared Buffers
 
-`shared_buffers` controls how much memory is available to the Postgres buffer cache. We recommend allocating no more than 40% of total memory
-to `shared_buffers`.
+`shared_buffers` controls how much memory is available to the Postgres buffer cache. We recommend starting with 25% of total memory for `shared_buffers` and no more than 40% of total memory.
 
 ```bash postgresql.conf
 shared_buffers = 8GB

--- a/docs/documentation/performance-tuning/writes.mdx
+++ b/docs/documentation/performance-tuning/writes.mdx
@@ -35,7 +35,7 @@ Setting `layer_sizes` to `0` disables foreground merging, and setting `backgroun
 `work_mem` controls how much memory to allocate to a single `INSERT`/`UPDATE`/`COPY` statement. Each statement that writes to a BM25 index is required to have at least `15MB` memory. If
 `work_mem` is below `15MB`, it will be ignored and `15MB` will be used.
 
-If your typical update patterns are large, bulk updates (not single-row updates) a larger value may be better.
+A good starting point for `work_mem` is `(RAM - shared_buffers) / (3 * max_connections)`. If your typical update patterns are large, bulk updates (not single-row updates) a larger value may be better.
 
 ```sql
 SET work_mem = 64MB;

--- a/scripts/update-nix-cargo-hash.sh
+++ b/scripts/update-nix-cargo-hash.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Updates the cargoHash in nix/pg_search.nix by building the cargoDeps
 # derivation with a fake hash and extracting the correct one from the error.


### PR DESCRIPTION
Backports the Docker auto-tuning feature (and its test refinement) to `0.24.x`:

- **#5273** — `feat: Auto-tune in Docker` (adds `tune()` to `docker/bootstrap.sh` + the auto-tuning assertions in `test-pg_search-docker.yml`)
- **#5290** — `test: Wait for bootstrap to finish before asserting auto-tuning`

## Why

The `Publish ParadeDB (Docker)` run for `v0.24.1` failed the **Test Postgres Auto-tuning** step:

```
Error: paradedb-autotune-disabled logs did not contain: Auto-tuning is disabled, skipping.
```

`workflow_run`-triggered publish runs execute the reusable `test-pg_search-docker.yml` from `main` (which asserts auto-tuning), but build the release image from `0.24.x` code — whose `bootstrap.sh` had no auto-tuning because #5273 was `Do Not Cherry Pick`. This backport brings the feature (and test) onto `0.24.x` so the published image tunes and the test passes.

Cherry-picked cleanly; `bash -n docker/bootstrap.sh` passes.

---

Note: the docs smoke-test fix (#5295, #5303) was split out into a separate PR (#5377).