### PR TITLE
ci: Publish Docker from the release ref + restore beta PG 18 Docker images

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -11,13 +11,7 @@
 # `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
 #
 # This workflow is dispatched by `publish-pg_search-debian.yml` (once the .deb is published) via
-# `workflow_dispatch` pinned to the release ref. We deliberately avoid a `workflow_run` trigger: it
-# always loads the workflow — and its local `uses: ./...` reusable workflows (e.g.
-# test-pg_search-docker.yml) — from the default branch (main). That means a release cut from a stable
-# branch (e.g. 0.24.x) would run main's definitions and tests against the release's artifacts.
-# `workflow_dispatch` honors the dispatched ref, so a release runs entirely from its own branch's
-# workflows. The ref is forwarded dynamically by the upstream, so nothing here needs to change when new
-# stable branches (0.25.x, etc.) are created.
+# `workflow_dispatch` pinned to the release ref so that it runs on the same commit as the other deploy jobs.
 
 name: Publish ParadeDB (Docker)
 
@@ -346,8 +340,7 @@ jobs:
     needs:
       - generate-dockerfiles
       - publish-paradedb-docker-image
-    # Skip for beta (`-rc.`) releases — we don't want to open Dockerfile-update PRs for prereleases
-    # (and a beta only regenerates the PG 18 Dockerfiles).
+    # Skip for beta (`-rc.`) releases, since we don't want to open Dockerfile-update PRs for prereleases
     if: ${{ needs.generate-dockerfiles.outputs.has_changes == 'true' && !contains(needs.generate-dockerfiles.outputs.version, '-rc.') }}
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -48,9 +48,6 @@ jobs:
   set-matrix:
     name: Define the PostgreSQL Version Matrix
     runs-on: ubuntu-latest
-    # Release candidates never publish Docker images. The upstream debian publish already skips them, so
-    # it won't dispatch for an -rc. tag; this guard also covers manual dispatches.
-    if: ${{ !contains(github.event.inputs.version || github.ref_name, '-rc.') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -60,7 +57,7 @@ jobs:
           REF_NAME="${{ github.event.inputs.version || github.ref_name }}"
           echo "Evaluating ref: $REF_NAME"
           if [[ "$REF_NAME" == *"-"* ]]; then
-            echo "GitHub ref contains a dash. Release candidate tag detected; using only PostgreSQL version 18."
+            echo "Pre-release version (contains a dash, e.g. a beta -rc. tag); publishing PostgreSQL 18 only."
             echo "matrix=[18]" >> $GITHUB_OUTPUT
           else
             echo "Regular promotion tag detected; using provided PostgreSQL version(s)."
@@ -145,7 +142,12 @@ jobs:
           fi
 
       - name: Generate Dockerfiles
-        run: docker/generate-dockerfiles.sh "${{ steps.version.outputs.version }}"
+        # Only generate the PG majors we're publishing this run. For beta (`-rc.`) releases the matrix
+        # is [18], and only the PG 18 .deb is published — generating the others would 404 on the
+        # checksum fetch and fail the script.
+        run: |
+          PG_MAJORS=$(echo '${{ needs.set-matrix.outputs.matrix }}' | jq -r 'map(tostring) | join(" ")')
+          docker/generate-dockerfiles.sh "${{ steps.version.outputs.version }}" "$PG_MAJORS"
 
       - name: Commit Generated Dockerfiles
         id: generated_branch
@@ -250,6 +252,8 @@ jobs:
     needs:
       - generate-dockerfiles
       - test-generated-dockerfiles
+    # Beta (`-rc.`) releases publish only the runnable PG 18 image, not the mountable extension image.
+    if: ${{ !contains(needs.generate-dockerfiles.outputs.version, '-rc.') }}
     strategy:
       matrix:
         # Mounted extension images require PostgreSQL 18+ because
@@ -342,7 +346,9 @@ jobs:
     needs:
       - generate-dockerfiles
       - publish-paradedb-docker-image
-    if: ${{ needs.generate-dockerfiles.outputs.has_changes == 'true' }}
+    # Skip for beta (`-rc.`) releases — we don't want to open Dockerfile-update PRs for prereleases
+    # (and a beta only regenerates the PG 18 Dockerfiles).
+    if: ${{ needs.generate-dockerfiles.outputs.has_changes == 'true' && !contains(needs.generate-dockerfiles.outputs.version, '-rc.') }}
     steps:
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -23,8 +23,8 @@ on:
         required: true
         default: ""
       pg_version:
-        description: "The Postgres major version(s) to build ParadeDB for. This needs to be a comma-separated list of integers (e.g. [15] or [15, 16, 17, 18])."
-        required: true
+        description: "The Postgres major version(s) to build ParadeDB for. This needs to be a comma-separated list of integers (e.g. [15] or [15, 16, 17, 18]). Beta (-rc.) releases always resolve to [18] regardless of this value."
+        required: false
         default: "[15, 16, 17, 18]"
 
 concurrency:
@@ -80,8 +80,6 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
         with:
-          # github.ref is the ref this workflow was dispatched on — the release tag (or branch), which
-          # is exactly the code we want to build and test against.
           ref: ${{ github.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
@@ -135,10 +133,9 @@ jobs:
             echo "is_latest=false" >> $GITHUB_OUTPUT
           fi
 
+      # Only generate the PG majors we're publishing this run. For beta (`-rc.`) releases the matrix
+      # is [18], and only the PG 18 .deb is published.
       - name: Generate Dockerfiles
-        # Only generate the PG majors we're publishing this run. For beta (`-rc.`) releases the matrix
-        # is [18], and only the PG 18 .deb is published — generating the others would 404 on the
-        # checksum fetch and fail the script.
         run: |
           PG_MAJORS=$(echo '${{ needs.set-matrix.outputs.matrix }}' | jq -r 'map(tostring) | join(" ")')
           docker/generate-dockerfiles.sh "${{ steps.version.outputs.version }}" "$PG_MAJORS"
@@ -240,13 +237,13 @@ jobs:
           subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
 
+  # Beta (`-rc.`) releases publish only the runnable PG 18 image, not the mountable extension image.
   publish-extension-image:
     name: Publish ParadeDB Extension Image for PostgreSQL ${{ matrix.pg_version }}
     runs-on: ubuntu-latest
     needs:
       - generate-dockerfiles
       - test-generated-dockerfiles
-    # Beta (`-rc.`) releases publish only the runnable PG 18 image, not the mountable extension image.
     if: ${{ !contains(needs.generate-dockerfiles.outputs.version, '-rc.') }}
     strategy:
       matrix:
@@ -334,13 +331,13 @@ jobs:
           subject-digest: ${{ steps.build-push.outputs.digest }}
           push-to-registry: true
 
+  # Skip for beta (`-rc.`) releases, since we don't want to open Dockerfile-update PRs for prereleases
   open-dockerfile-prs:
     name: Open Dockerfile Update PRs
     runs-on: ubuntu-latest
     needs:
       - generate-dockerfiles
       - publish-paradedb-docker-image
-    # Skip for beta (`-rc.`) releases, since we don't want to open Dockerfile-update PRs for prereleases
     if: ${{ needs.generate-dockerfiles.outputs.has_changes == 'true' && !contains(needs.generate-dockerfiles.outputs.version, '-rc.') }}
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -10,7 +10,7 @@
 # so they can run compatibility checks against the new version. This is done in
 # `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
 #
-# This workflow is dispatched by `publish-pg_search-debian.yml` (once the .deb is published) via
+# This workflow is dispatched by `publish-pg_search-debian.yml` (once the Debian binaries are published) via
 # `workflow_dispatch` pinned to the release ref so that it runs on the same commit as the other deploy jobs.
 
 name: Publish ParadeDB (Docker)
@@ -134,7 +134,7 @@ jobs:
           fi
 
       # Only generate the PG majors we're publishing this run. For beta (`-rc.`) releases the matrix
-      # is [18], and only the PG 18 .deb is published.
+      # is [18], and only the PG 18 .deb are published.
       - name: Generate Dockerfiles
         run: |
           PG_MAJORS=$(echo '${{ needs.set-matrix.outputs.matrix }}' | jq -r 'map(tostring) | join(" ")')

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -9,15 +9,19 @@
 # Once the runnable Docker images are published, notify ORM wrapper repositories via repository_dispatch
 # so they can run compatibility checks against the new version. This is done in
 # `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
+#
+# This workflow is dispatched by `publish-pg_search-debian.yml` (once the .deb is published) via
+# `workflow_dispatch` pinned to the release ref. We deliberately avoid a `workflow_run` trigger: it
+# always loads the workflow — and its local `uses: ./...` reusable workflows (e.g.
+# test-pg_search-docker.yml) — from the default branch (main). That means a release cut from a stable
+# branch (e.g. 0.24.x) would run main's definitions and tests against the release's artifacts.
+# `workflow_dispatch` honors the dispatched ref, so a release runs entirely from its own branch's
+# workflows. The ref is forwarded dynamically by the upstream, so nothing here needs to change when new
+# stable branches (0.25.x, etc.) are created.
 
 name: Publish ParadeDB (Docker)
 
 on:
-  workflow_run:
-    workflows:
-      - Publish pg_search (Debian)
-    types:
-      - completed
   workflow_dispatch:
     inputs:
       version:
@@ -30,7 +34,7 @@ on:
         default: "[15, 16, 17, 18]"
 
 concurrency:
-  group: publish-paradedb-docker-${{ github.event.workflow_run.head_branch || github.event.inputs.version || github.head_ref || github.ref }}
+  group: publish-paradedb-docker-${{ github.event.inputs.version || github.ref }}
   cancel-in-progress: true
 
 # Used by actions/attest-build-provenance to sign the builds
@@ -44,14 +48,16 @@ jobs:
   set-matrix:
     name: Define the PostgreSQL Version Matrix
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && startsWith(github.event.workflow_run.head_branch, 'v') && !contains(github.event.workflow_run.head_branch, '-rc.')) }}
+    # Release candidates never publish Docker images. The upstream debian publish already skips them, so
+    # it won't dispatch for an -rc. tag; this guard also covers manual dispatches.
+    if: ${{ !contains(github.event.inputs.version || github.ref_name, '-rc.') }}
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - name: Define the PostgreSQL Version Matrix
         id: set-matrix
         run: |
-          REF_NAME="${{ github.event.workflow_run.head_branch || github.event.inputs.version || github.ref_name }}"
+          REF_NAME="${{ github.event.inputs.version || github.ref_name }}"
           echo "Evaluating ref: $REF_NAME"
           if [[ "$REF_NAME" == *"-"* ]]; then
             echo "GitHub ref contains a dash. Release candidate tag detected; using only PostgreSQL version 18."
@@ -83,18 +89,16 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          # github.ref is the ref this workflow was dispatched on — the release tag (or branch), which
+          # is exactly the code we want to build and test against.
+          ref: ${{ github.ref }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Retrieve GitHub Release Version
         id: version
         run: |
-          # If this was triggered by publish-pg_search-debian, use the tag from that workflow run.
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            TAG="${{ github.event.workflow_run.head_branch }}"
-            VERSION=${TAG#v}
           # If no workflow_dispatch version is provided, we use workflow tag trigger version.
-          elif [ -z "${{ github.event.inputs.version }}" ]; then
+          if [ -z "${{ github.event.inputs.version }}" ]; then
             if [[ $GITHUB_REF == refs/tags/v* ]]; then
               VERSION=${GITHUB_REF#refs/tags/v}
               TAG=${GITHUB_REF#refs/tags/}
@@ -396,7 +400,7 @@ jobs:
     name: Notify ORM Repos of New Release
     runs-on: ubuntu-latest
     needs: publish-paradedb-docker-image
-    if: ${{ !contains(github.event.workflow_run.head_branch || github.event.inputs.version || github.ref, '-rc.') }}
+    if: ${{ !contains(github.event.inputs.version || github.ref, '-rc.') }}
     env:
       # ORM repos to notify on new releases
       ORM_REPOS: |
@@ -410,10 +414,7 @@ jobs:
       - name: Retrieve GitHub Release Version
         id: version
         run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            VERSION="${{ github.event.workflow_run.head_branch }}"
-            VERSION=${VERSION#v}
-          elif [ -z "${{ github.event.inputs.version }}" ]; then
+          if [ -z "${{ github.event.inputs.version }}" ]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           else
             VERSION=${{ github.event.inputs.version }}

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -375,9 +375,9 @@ jobs:
           client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
+      # This job only runs on a version-tag push, so the version is always the tag.
       - name: Resolve Release Version
         id: version
-        # This job only runs on a version-tag push, so the version is always the tag.
         run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch ParadeDB Docker Publish on This Release Ref

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -29,7 +29,9 @@ permissions:
   attestations: write
 
 jobs:
-  publish-pg_search:
+  # Stable releases build the full matrix. Beta releases (`-rc.` tags) build only what the PG 18
+  # Docker image needs (the Debian 13 (Trixie) .deb for both arches).
+  publish-pg_search-debian:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     # Compute-optimized c-family — Rust release build inside matrix.image container is CPU-bound.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.
@@ -41,8 +43,6 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
-    # Stable releases build the full matrix. Beta releases (`-rc.` tags) build only what the PG 18
-    # Docker image needs (the Debian 13 (Trixie) .deb for both arches).
     if: ${{ !contains(github.ref, '-rc.') || (matrix.pg_version == 18 && matrix.name == 'Debian 13 (Trixie)') }}
     strategy:
       matrix:
@@ -358,19 +358,13 @@ jobs:
           MESSAGE="<!here> \`publish-pg_search-debian\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
 
-  # Once every .deb is published, kick off the ParadeDB Docker publish. We dispatch it explicitly
-  # (rather than letting it chain via `workflow_run`) so it runs pinned to *this* release ref:
-  # `workflow_dispatch` honors `--ref`, whereas `workflow_run` always loads the workflow from the
-  # default branch (main). github.ref_name is the tag that triggered this run, so a release from
-  # 0.24.x publishes using 0.24.x's workflows — and nothing here needs to change when future stable
-  # branches (0.25.x, ...) are cut. This runs for both stable and beta (`-rc.`) tags: betas publish a
-  # PG 18 Docker image (the docker workflow's matrix resolves to [18] for `-rc.` versions). We gate on
-  # an actual version-tag push so manual/test dispatches of this workflow don't kick off a publish.
+  # Once the Debian packages are published, kick off the ParadeDB Docker publish. The Docker
+  # image publishing runs after Debian since it installs the Debian packages to avoid needing to build
+  # them from source again.
   trigger-docker-publish:
     name: Trigger ParadeDB Docker Publish
     runs-on: ubuntu-latest
-    needs: publish-pg_search
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    needs: publish-pg_search-debian
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -397,5 +391,4 @@ jobs:
           gh workflow run publish-paradedb-docker.yml \
             --repo "${{ github.repository }}" \
             --ref "${{ github.ref_name }}" \
-            -f version="${{ steps.version.outputs.version }}" \
-            -f pg_version="[15, 16, 17, 18]"
+            -f version="${{ steps.version.outputs.version }}"

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -355,3 +355,43 @@ jobs:
           GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           MESSAGE="<!here> \`publish-pg_search-debian\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
+
+  # Once every .deb is published, kick off the ParadeDB Docker publish. We dispatch it explicitly
+  # (rather than letting it chain via `workflow_run`) so it runs pinned to *this* release ref:
+  # `workflow_dispatch` honors `--ref`, whereas `workflow_run` always loads the workflow from the
+  # default branch (main). github.ref_name is the tag that triggered this run (or the branch, for a
+  # manual dispatch), so a release from 0.24.x publishes using 0.24.x's workflows — and nothing here
+  # needs to change when future stable branches (0.25.x, ...) are cut.
+  trigger-docker-publish:
+    name: Trigger ParadeDB Docker Publish
+    runs-on: ubuntu-latest
+    needs: publish-pg_search
+    if: ${{ !contains(github.ref, '-rc.') }}
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+
+      - name: Resolve Release Version
+        id: version
+        run: |
+          # If no workflow_dispatch version is provided, derive it from the tag that triggered this run.
+          if [ -z "${{ github.event.inputs.version }}" ]; then
+            VERSION=${GITHUB_REF#refs/tags/v}
+          else
+            VERSION=${{ github.event.inputs.version }}
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch ParadeDB Docker Publish on This Release Ref
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh workflow run publish-paradedb-docker.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ github.ref_name }}" \
+            -f version="${{ steps.version.outputs.version }}" \
+            -f pg_version="[15, 16, 17, 18]"

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -41,7 +41,10 @@ jobs:
       - image=${{ matrix.runner_image }}
     container:
       image: ${{ matrix.image }}
-    if: ${{ !contains(github.ref, '-rc.') }}
+    # Stable releases build the full matrix. Beta releases (`-rc.` tags) build only what the PG 18
+    # Docker image needs — the Debian 13 (Trixie) .deb for both arches — so betas still ship a
+    # PG 18 Docker image without spending CI on the other 14 combinations.
+    if: ${{ !contains(github.ref, '-rc.') || (matrix.pg_version == 18 && matrix.name == 'Debian 13 (Trixie)') }}
     strategy:
       matrix:
         include:
@@ -359,14 +362,16 @@ jobs:
   # Once every .deb is published, kick off the ParadeDB Docker publish. We dispatch it explicitly
   # (rather than letting it chain via `workflow_run`) so it runs pinned to *this* release ref:
   # `workflow_dispatch` honors `--ref`, whereas `workflow_run` always loads the workflow from the
-  # default branch (main). github.ref_name is the tag that triggered this run (or the branch, for a
-  # manual dispatch), so a release from 0.24.x publishes using 0.24.x's workflows — and nothing here
-  # needs to change when future stable branches (0.25.x, ...) are cut.
+  # default branch (main). github.ref_name is the tag that triggered this run, so a release from
+  # 0.24.x publishes using 0.24.x's workflows — and nothing here needs to change when future stable
+  # branches (0.25.x, ...) are cut. This runs for both stable and beta (`-rc.`) tags: betas publish a
+  # PG 18 Docker image (the docker workflow's matrix resolves to [18] for `-rc.` versions). We gate on
+  # an actual version-tag push so manual/test dispatches of this workflow don't kick off a publish.
   trigger-docker-publish:
     name: Trigger ParadeDB Docker Publish
     runs-on: ubuntu-latest
     needs: publish-pg_search
-    if: ${{ !contains(github.ref, '-rc.') }}
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Generate GitHub App Token
         id: app-token

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -360,11 +360,13 @@ jobs:
 
   # Once the Debian packages are published, kick off the ParadeDB Docker publish. The Docker
   # image publishing runs after Debian since it installs the Debian packages to avoid needing to build
-  # them from source again.
+  # them from source again. We gate on an actual version-tag push (not workflow_dispatch) so a manual
+  # run can republish the .deb without also republishing the Docker images.
   trigger-docker-publish:
     name: Trigger ParadeDB Docker Publish
     runs-on: ubuntu-latest
     needs: publish-pg_search-debian
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
@@ -375,14 +377,8 @@ jobs:
 
       - name: Resolve Release Version
         id: version
-        run: |
-          # If no workflow_dispatch version is provided, derive it from the tag that triggered this run.
-          if [ -z "${{ github.event.inputs.version }}" ]; then
-            VERSION=${GITHUB_REF#refs/tags/v}
-          else
-            VERSION=${{ github.event.inputs.version }}
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        # This job only runs on a version-tag push, so the version is always the tag.
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Dispatch ParadeDB Docker Publish on This Release Ref
         env:

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -360,12 +360,12 @@ jobs:
 
   # Once the Debian packages are published, kick off the ParadeDB Docker publish. The Docker
   # image publishing runs after Debian since it installs the Debian packages to avoid needing to build
-  # them from source again. We gate on an actual version-tag push (not workflow_dispatch) so a manual
-  # run can republish the .deb without also republishing the Docker images.
+  # them from source again.
   trigger-docker-publish:
     name: Trigger ParadeDB Docker Publish
     runs-on: ubuntu-latest
     needs: publish-pg_search-debian
+    # Only on release-tag pushes, so a manual .deb rebuild doesn't also republish the Docker images.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     steps:
       - name: Generate GitHub App Token

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -42,8 +42,7 @@ jobs:
     container:
       image: ${{ matrix.image }}
     # Stable releases build the full matrix. Beta releases (`-rc.` tags) build only what the PG 18
-    # Docker image needs — the Debian 13 (Trixie) .deb for both arches — so betas still ship a
-    # PG 18 Docker image without spending CI on the other 14 combinations.
+    # Docker image needs (the Debian 13 (Trixie) .deb for both arches).
     if: ${{ !contains(github.ref, '-rc.') || (matrix.pg_version == 18 && matrix.name == 'Debian 13 (Trixie)') }}
     strategy:
       matrix:

--- a/docker/generate-dockerfiles.sh
+++ b/docker/generate-dockerfiles.sh
@@ -12,16 +12,28 @@
 
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
+if [[ $# -lt 1 || $# -gt 2 ]]; then
   echo "Error: PG_SEARCH_VERSION is required"
-  echo "Usage: $0 0.24.0"
+  echo "Usage: $0 <pg_search_version> [pg_majors]"
+  echo "Example: $0 0.24.0            # generate all supported PG majors"
+  echo "Example: $0 0.24.0-rc.1 \"18\"  # generate only PG 18 (e.g. beta releases)"
   exit 1
 fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-versions=(15 16 17 18)
-latest_version=${versions[${#versions[@]} - 1]}
+all_versions=(15 16 17 18)
+# `latest_version` decides which PG major gets the antithesis flavor; keep it tied to the true latest
+# regardless of any version restriction below.
+latest_version=${all_versions[${#all_versions[@]} - 1]}
 PG_SEARCH_VERSION="${1}"
+
+# Optionally restrict which PG majors to generate (space-separated), e.g. "18" for beta releases that
+# only ship a PG 18 Docker image. Defaults to all supported majors.
+if [[ -n "${2:-}" ]]; then
+  read -r -a versions <<< "${2}"
+else
+  versions=("${all_versions[@]}")
+fi
 
 tmp_dir="$(mktemp -d)"
 trap 'rm -rf "$tmp_dir"' EXIT

--- a/docker/generate-dockerfiles.sh
+++ b/docker/generate-dockerfiles.sh
@@ -15,14 +15,14 @@ set -euo pipefail
 if [[ $# -lt 1 || $# -gt 2 ]]; then
   echo "Error: PG_SEARCH_VERSION is required"
   echo "Usage: $0 <pg_search_version> [pg_majors]"
-  echo "Example: $0 0.24.0            # generate all supported PG majors"
+  echo "Example: $0 0.24.0              # generate all supported PG majors"
   echo "Example: $0 0.24.0-rc.1 \"18\"  # generate only PG 18 (e.g. beta releases)"
   exit 1
 fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 all_versions=(15 16 17 18)
-# `latest_version` decides which PG major gets the antithesis flavor; keep it tied to the true latest
+# `latest_version` decides which PG major gets the Antithesis flavor; keep it tied to the true latest
 # regardless of any version restriction below.
 latest_version=${all_versions[${#all_versions[@]} - 1]}
 PG_SEARCH_VERSION="${1}"


### PR DESCRIPTION
Two coupled fixes to the Docker publish pipeline. They touch the same machinery, so they're in one PR (happy to split if preferred).

## 1. Publish Docker images from the release ref, not main

`Publish ParadeDB (Docker)` chained off `Publish pg_search (Debian)` via `workflow_run`, which always loads the workflow — and its local `uses: ./…` reusable workflows (`test-pg_search-docker.yml`) — from the **default branch (main)**. So a release cut from a stable branch ran main's definitions/tests against the release's artifacts. (This is what made `v0.24.1` fail the auto-tuning test.)

Fix: drop the `workflow_run` trigger; the upstream debian publish (tag-triggered, already running from the release commit) now dispatches the Docker publish via `workflow_dispatch --ref "${{ github.ref_name }}"`. `workflow_dispatch` honors the ref, so the publish + its reusable test run entirely from the release branch. The ref is forwarded dynamically — **no edits needed for future stable branches (0.25.x, …).**

## 2. Restore PG 18 Docker images for beta releases

Betas stopped shipping a Docker image after the move to Debian-package-based images. A beta is an `-rc.` tag, which `publish-pg_search-debian` skipped entirely → no `.deb` published → the Docker image (which pulls the released `.deb`) couldn't be built. The "beta publishes PG 18" behavior has been silently broken on `main`.

A beta is a real GitHub **prerelease** (`v0.25.0-rc.1`), so the `.deb` just goes on its own Release assets — no workflow artifact or throwaway `0.0.0` tag needed. End-to-end fix:

- **`publish-pg_search-debian`**: for `-rc.` tags, build the **Debian 13 (Trixie) PG 18** `.deb` for both arches (the only artifact the PG 18 image consumes) instead of skipping the matrix. The other 14 matrix legs skip with no runner cost.
- **`trigger-docker-publish`**: dispatch for both stable and beta version-tag pushes (gated to actual `refs/tags/v*` pushes so manual/test dispatches don't publish).
- **`publish-paradedb-docker`**: betas pass through `set-matrix`; the existing dash-detection resolves the matrix to `[18]`. The generate step now only generates the PG majors being published (so the generator doesn't 404 fetching missing PG 15–17 debs). Extension image and Dockerfile-update PRs are skipped for betas; ORM notifications and `latest`/`pg`/`latest-pg` floating tags remain stable-only.
- **`generate-dockerfiles.sh`**: accepts an optional list of PG majors (defaults to all).

Net for a beta `v0.25.0-rc.1`: publishes `paradedb/paradedb` PG 18 multi-arch with version-pinned tags (e.g. `0.25.0-rc.1`, `0.25.0-rc.1-pg18`), no floating tags, no extension image, no ORM dispatch.

## Validation
- Both workflows parse as YAML; `bash -n docker/generate-dockerfiles.sh` passes; matrix→majors transform verified (`[18]`→`18`, `[15,16,17,18]`→`15 16 17 18`).
- App token must have **Actions: write** for `gh workflow run` (called out previously).