### PR TITLE
fix: Backport docs smoke-test fix to 0.24.x (#5295, #5303)

### DIFF
--- a/.github/scripts/extract_code_snippets.py
+++ b/.github/scripts/extract_code_snippets.py
@@ -21,6 +21,15 @@ IGNORED_CODEGROUPS = {
     # CodeGroup is used here to switch between Chinese, Korean, and Japanese
     # not SQL vs ORMs
     "documentation__tokenizers__available-tokenizers__lindera__group-001",
+    # The "Joined Scores" example orders by a summed BM25 score
+    # (pdb.score(o.order_id) + pdb.score(m.id)) across a join. This is a valid,
+    # correct query, but since join custom scans are enabled by default it
+    # declines JoinScan and emits the informational "JoinScan not used: ORDER BY
+    # columns must be fast fields" planner warning (combined-score sort keys are
+    # not fast fields). The smoke test treats any WARNING as a failure, so this
+    # group is excluded. See joinscan_sortby_score.out for the tested behavior.
+    # Tracked in https://github.com/paradedb/paradedb/issues/5296.
+    "documentation__sorting__score__group-003",
 }
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent

--- a/.github/scripts/extract_code_snippets.py
+++ b/.github/scripts/extract_code_snippets.py
@@ -21,15 +21,6 @@ IGNORED_CODEGROUPS = {
     # CodeGroup is used here to switch between Chinese, Korean, and Japanese
     # not SQL vs ORMs
     "documentation__tokenizers__available-tokenizers__lindera__group-001",
-    # The "Joined Scores" example orders by a summed BM25 score
-    # (pdb.score(o.order_id) + pdb.score(m.id)) across a join. This is a valid,
-    # correct query, but since join custom scans are enabled by default it
-    # declines JoinScan and emits the informational "JoinScan not used: ORDER BY
-    # columns must be fast fields" planner warning (combined-score sort keys are
-    # not fast fields). The smoke test treats any WARNING as a failure, so this
-    # group is excluded. See joinscan_sortby_score.out for the tested behavior.
-    # Tracked in https://github.com/paradedb/paradedb/issues/5296.
-    "documentation__sorting__score__group-003",
 }
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent.parent

--- a/docs/documentation/sorting/score.mdx
+++ b/docs/documentation/sorting/score.mdx
@@ -187,137 +187,55 @@ WITH (key_field = 'order_id');
 ```
 
 Next, let's compute a "combined BM25 score" over a join across both tables.
-The Django example assumes an `Order` model with `product = models.ForeignKey(MockItem, db_column='product_id', to_field='id', ...)`.
+
+<Note>
+  Directly computing and ordering by the sum of scores across a join (e.g.
+  `ORDER BY pdb.score(t1) + pdb.score(t2)`) is currently not efficient. For more
+  details on implementing efficient support for this operation, please refer to
+  [Issue #5300](https://github.com/paradedb/paradedb/issues/5300).
+</Note>
+
+The recommended approach for combining scores from multiple tables is to use [Reciprocal Rank Fusion (RRF)](https://www.paradedb.com/learn/search-concepts/reciprocal-rank-fusion). RRF combines the ranked results from separate queries into a single unified ranking.
 
 <CodeGroup>
 ```sql SQL
-SELECT o.order_id, o.customer_name, m.description, pdb.score(o.order_id) + pdb.score(m.id) as score
-FROM orders o
+WITH order_search AS (
+  SELECT order_id, RANK() OVER (ORDER BY score DESC) AS rank
+  FROM (
+    SELECT order_id, pdb.score(order_id) AS score
+    FROM orders
+    WHERE customer_name ||| 'Johnson'
+    ORDER BY pdb.score(order_id) DESC
+    LIMIT 20
+  )
+),
+product_search AS (
+  SELECT o.order_id, RANK() OVER (ORDER BY score DESC) AS rank
+  FROM (
+    SELECT id, pdb.score(id) AS score
+    FROM mock_items
+    WHERE description ||| 'running shoes'
+    ORDER BY pdb.score(id) DESC
+    LIMIT 20
+  ) m
+  JOIN orders o ON o.product_id = m.id
+),
+rrf AS (
+  SELECT order_id, 1.0 / (60 + rank) AS s FROM order_search
+  UNION ALL
+  SELECT order_id, 1.0 / (60 + rank) AS s FROM product_search
+)
+SELECT
+  o.order_id,
+  o.customer_name,
+  m.description,
+  sum(rrf.s) AS score
+FROM rrf
+JOIN orders o USING (order_id)
 JOIN mock_items m ON o.product_id = m.id
-WHERE o.customer_name ||| 'Johnson' AND m.description ||| 'running shoes'
+GROUP BY o.order_id, o.customer_name, m.description
 ORDER BY score DESC, o.order_id
 LIMIT 5;
-```
-
-```ts Drizzle
-import { and, desc, eq, sql } from "drizzle-orm";
-import { search } from "@paradedb/drizzle-paradedb";
-
-const score = sql`${search.score(orders.orderId)} + ${search.score(mockItems.id)}`;
-
-await db
-  .select({
-    orderId: orders.orderId,
-    customerName: orders.customerName,
-    description: mockItems.description,
-    score,
-  })
-  .from(orders)
-  .innerJoin(mockItems, eq(orders.productId, mockItems.id))
-  .where(
-    and(
-      search.matchAny(orders.customerName, "Johnson"),
-      search.matchAny(mockItems.description, "running shoes"),
-    ),
-  )
-  .orderBy(desc(score), orders.orderId)
-  .limit(5);
-```
-
-```python Django
-from django.db.models import F, FloatField
-from django.db.models.expressions import RawSQL
-from paradedb import MatchAny, ParadeDB, Score
-
-Order.objects.filter(
-    customer_name=ParadeDB(MatchAny('Johnson')),
-    product__description=ParadeDB(MatchAny('running shoes')),
-).annotate(
-    order_score=Score(),
-    product_score=RawSQL('pdb.score(mock_items.id)', [], output_field=FloatField()),
-).annotate(
-    score=F('order_score') + F('product_score')
-).values(
-    'order_id', 'customer_name', 'product__description', 'score'
-).order_by('-score', 'order_id')[:5]
-```
-
-```python SQLAlchemy
-from sqlalchemy import desc, select
-from sqlalchemy.orm import Session
-from paradedb.sqlalchemy import pdb, search
-
-stmt = (
-    select(
-        Order.order_id,
-        Order.customer_name,
-        MockItem.description,
-        (pdb.score(Order.order_id) + pdb.score(MockItem.id)).label("score"),
-    )
-    .select_from(Order)
-    .join(MockItem, Order.product_id == MockItem.id)
-    .where(
-        search.match_any(Order.customer_name, "Johnson"),
-        search.match_any(MockItem.description, "running shoes"),
-    )
-    .order_by(desc("score"), Order.order_id)
-    .limit(5)
-)
-
-with Session(engine) as session:
-    session.execute(stmt).all()
-```
-
-```ruby Rails
-orders = Order.arel_table
-mock_items = MockItem.arel_table
-combined_score = Arel::Nodes::Addition.new(
-  orders[:order_id].pdb_score,
-  mock_items[:id].pdb_score
-)
-join = orders.join(mock_items).on(orders[:product_id].eq(mock_items[:id])).join_sources
-
-Order.joins(join)
-     .search(:customer_name)
-     .matching_any("Johnson")
-     .search(mock_items[:description])
-     .matching_any("running shoes")
-     .select(
-       orders[:order_id],
-       orders[:customer_name],
-       mock_items[:description].as("product_description"),
-       combined_score.as("score")
-     )
-     .order(
-       Arel::Nodes::Descending.new(combined_score),
-       Arel::Nodes::Ascending.new(orders[:order_id])
-     )
-     .limit(5)
-```
-
-```cs EF Core
-await dbContext
-    .Orders.Join(
-        dbContext.MockItems,
-        order => order.ProductId,
-        item => item.Id,
-        (order, item) => new { Order = order, Item = item }
-    )
-    .Where(row =>
-        EF.Functions.MatchAny(row.Order.CustomerName, "Johnson")
-        && EF.Functions.MatchAny(row.Item.Description, "running shoes")
-    )
-    .Select(row => new
-    {
-        row.Order.OrderId,
-        row.Order.CustomerName,
-        row.Item.Description,
-        Score = EF.Functions.Score(row.Order.OrderId) + EF.Functions.Score(row.Item.Id)
-    })
-    .OrderByDescending(row => row.Score)
-    .ThenBy(row => row.OrderId)
-    .Take(5)
-    .ToListAsync();
 ```
 
 </CodeGroup>


### PR DESCRIPTION
Backports the docs smoke-test fix to `0.24.x` (present on `main`, missing here).

- **#5295** — `ci(docs): exclude joined-scores snippet from doc smoke test`
- **#5303** — `fix: Convert sum-of-scores query in docs to RRF`

These are a pair: #5295 temporarily excluded the broken `joined-scores` snippet from the smoke test, and #5303 reverted that exclusion and properly fixed `docs/documentation/sorting/score.mdx`. Net effect on `0.24.x`: `.github/scripts/extract_code_snippets.py` is unchanged; `score.mdx` is corrected — fixing the docs smoke test.

Split out from #5375 (Docker auto-tuning backport) so the docs fix lands independently.

Both cherry-picks applied cleanly.