### PR TITLE
ci: Backport ORM-notify token scope fix to 0.24.x (#5249)

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -296,7 +296,7 @@ jobs:
           if [ -n "$PR" ]; then
             echo "Main PR already exists: #$PR"
           else
-            gh pr create --base main --head "$BRANCH" --title "chore: Generate Dockerfiles for $TAG" --body "Updates generated Dockerfiles for $TAG after the Docker images were published."
+            gh pr create --base main --head "$BRANCH" --title "chore: Generate Dockerfiles for $TAG" --body "Updates generated Dockerfiles for $TAG after the Docker images were published." --label "Do Not Cherry Pick"
           fi
 
   notify-orm-repos:
@@ -335,9 +335,11 @@ jobs:
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: |
+            drizzle-paradedb
             django-paradedb
-            rails-paradedb
             sqlalchemy-paradedb
+            rails-paradedb
+            efcore-paradedb
 
       - name: Notify ORM Repos of New Release
         env:


### PR DESCRIPTION
Backports **#5249** to `0.24.x`.

## Why

Retriggering the `0.24.1` Docker publish succeeded for the images but failed in **Notify ORM Repos of New Release**:

```
Dispatching to paradedb/drizzle-paradedb...
gh: Resource not accessible by integration (HTTP 403)
```

On `0.24.x`, `ORM_REPOS` iterates 5 repos (`drizzle`, `django`, `sqlalchemy`, `rails`, `efcore`) but the GitHub App token was only scoped to 3 (`django`, `rails`, `sqlalchemy`). The loop hits `drizzle-paradedb` first — which the token can't access → 403 — and the fail-fast `bash -e` loop aborts.

#5249 (already on `main`) aligns the token's `repositories:` list with `ORM_REPOS` (adds `drizzle-paradedb` and `efcore-paradedb`), which clears the 403. It also adds a `Do Not Cherry Pick` label to the auto-generated Dockerfile PR.

Note: the images themselves published fine — this only blocked the downstream ORM-repo notification.

Cherry-picked cleanly (`-x`), single file changed.