### PR TITLE
fix: range query panics on mixed-type numeric bounds

### DIFF
--- a/pg_search/src/query/numeric.rs
+++ b/pg_search/src/query/numeric.rs
@@ -290,6 +290,66 @@ where
     }
 }
 
+/// Normalize a pair of numeric bounds to a common type when they parse to
+/// different numeric "shapes".
+///
+/// JSON numeric values are inferred independently per bound (see
+/// [`string_to_json_numeric`]), so a range like `[35.1 TO 40]` yields an
+/// `F64` lower bound and an `I64`/`U64` upper bound. Tantivy's `RangeQuery`
+/// requires both bound terms to share the same value type; a mismatch causes a
+/// downstream `Option::unwrap()` panic when the typed bounds are extracted.
+///
+/// When exactly one bound is a float and the other is an integer, the integer
+/// bound is promoted to `F64` so both bounds agree on type. Bounds that already
+/// agree (or where either side is unbounded / non-numeric) are returned
+/// unchanged.
+pub fn normalize_numeric_bound_pair(
+    lower: Bound<PdbOwnedValue>,
+    upper: Bound<PdbOwnedValue>,
+) -> (Bound<PdbOwnedValue>, Bound<PdbOwnedValue>) {
+    fn bound_value(bound: &Bound<PdbOwnedValue>) -> Option<&PdbOwnedValue> {
+        match bound {
+            Bound::Included(v) | Bound::Excluded(v) => Some(v),
+            Bound::Unbounded => None,
+        }
+    }
+
+    fn is_float(value: &PdbOwnedValue) -> bool {
+        matches!(value, PdbOwnedValue::F64(_))
+    }
+
+    fn integer_to_f64(value: &PdbOwnedValue) -> Option<f64> {
+        match value {
+            PdbOwnedValue::I64(i) => Some(*i as f64),
+            PdbOwnedValue::U64(u) => Some(*u as f64),
+            _ => None,
+        }
+    }
+
+    fn promote_bound(bound: Bound<PdbOwnedValue>) -> Bound<PdbOwnedValue> {
+        match bound {
+            Bound::Included(v) => match integer_to_f64(&v) {
+                Some(f) => Bound::Included(PdbOwnedValue::F64(f)),
+                None => Bound::Included(v),
+            },
+            Bound::Excluded(v) => match integer_to_f64(&v) {
+                Some(f) => Bound::Excluded(PdbOwnedValue::F64(f)),
+                None => Bound::Excluded(v),
+            },
+            Bound::Unbounded => Bound::Unbounded,
+        }
+    }
+
+    let lower_is_float = bound_value(&lower).map(is_float).unwrap_or(false);
+    let upper_is_float = bound_value(&upper).map(is_float).unwrap_or(false);
+
+    match (lower_is_float, upper_is_float) {
+        (true, false) => (lower, promote_bound(upper)),
+        (false, true) => (promote_bound(lower), upper),
+        _ => (lower, upper),
+    }
+}
+
 /// Scale a numeric bound value for Numeric64 storage.
 pub fn scale_numeric_bound(
     bound: Bound<PdbOwnedValue>,

--- a/pg_search/src/query/pdb_query.rs
+++ b/pg_search/src/query/pdb_query.rs
@@ -21,8 +21,9 @@ use crate::postgres::datetime::PostgresDateTime;
 use crate::postgres::pdb_owned_value::PdbOwnedValue;
 use crate::postgres::types::is_pgoid_datetime_type;
 use crate::query::numeric::{
-    convert_value_for_field, convert_value_for_range_field, map_bound, numeric_bound_to_bytes,
-    scale_numeric_bound, string_to_f64, string_to_i64, string_to_json_numeric, string_to_u64,
+    convert_value_for_field, convert_value_for_range_field, map_bound,
+    normalize_numeric_bound_pair, numeric_bound_to_bytes, scale_numeric_bound, string_to_f64,
+    string_to_i64, string_to_json_numeric, string_to_u64,
 };
 use crate::query::pdb_query::pdb::{FuzzyData, ScoreAdjustStyle, SlopData};
 use crate::query::proximity::query::ProximityQuery;
@@ -1558,9 +1559,15 @@ fn range(
             (lower, upper)
         }
         SearchFieldType::Json(_) => {
-            // For JSON fields, convert string numeric values to appropriate JSON types
+            // For JSON fields, convert string numeric values to appropriate JSON types.
+            // Each bound is inferred independently, so a mixed-shape range such as
+            // `[35.1 TO 40]` yields an F64 lower bound and an I64 upper bound. Tantivy's
+            // RangeQuery requires both bound terms to share a value type, so normalize the
+            // pair to a common numeric type before building terms (otherwise a downstream
+            // Option::unwrap() panics on the mismatched bound).
             let lower = map_bound(lower_bound, string_to_json_numeric);
             let upper = map_bound(upper_bound, string_to_json_numeric);
+            let (lower, upper) = normalize_numeric_bound_pair(lower, upper);
             check_range_bounds(typeoid, lower, upper)?
         }
         SearchFieldType::I64(_) => {

--- a/pg_search/tests/pg_regress/expected/json_range.out
+++ b/pg_search/tests/pg_regress/expected/json_range.out
@@ -161,3 +161,102 @@ ORDER BY id;
 (2 rows)
 
 DROP TABLE json_range_test;
+-- ============================================================================
+-- Regression: mixed-type numeric range bounds (issue #5077)
+-- ============================================================================
+-- A JSON numeric subpath whose lower and upper bounds are written with
+-- different numeric "shapes" (e.g. [35.1 TO 40]) used to panic with
+-- `called Option::unwrap() on a None value` because each bound was inferred
+-- independently (F64 lower, I64 upper) and Tantivy's RangeQuery requires both
+-- bounds to share a value type. The bounds are now normalized to a common
+-- numeric type, so these queries return the same rows as the all-float form
+-- instead of panicking.
+CREATE TABLE json_mixed_range_test (
+    id SERIAL PRIMARY KEY,
+    metadata JSONB
+);
+-- Float values force the fast field to store the subpath as F64.
+INSERT INTO json_mixed_range_test (metadata) VALUES
+    ('{"price": 35.0}'),
+    ('{"price": 35.1}'),
+    ('{"price": 36.0}'),
+    ('{"price": 39.9}'),
+    ('{"price": 40.0}'),
+    ('{"price": 41.0}');
+CREATE INDEX json_mixed_range_test_idx ON json_mixed_range_test
+USING bm25 (id, metadata)
+WITH (
+    key_field = 'id',
+    json_fields = '{"metadata": {"fast": true}}'
+);
+-- float lower bound, integer upper bound ([35.1 TO 40])
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35.1},
+        "upper_bound": {"included": 40}
+    }
+}'::jsonb
+ORDER BY id;
+ id | price 
+----+-------
+  2 | 35.1
+  3 | 36.0
+  4 | 39.9
+  5 | 40.0
+(4 rows)
+
+-- integer lower bound, float upper bound ([35 TO 40.5])
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35},
+        "upper_bound": {"included": 40.5}
+    }
+}'::jsonb
+ORDER BY id;
+ id | price 
+----+-------
+  1 | 35.0
+  2 | 35.1
+  3 | 36.0
+  4 | 39.9
+  5 | 40.0
+(5 rows)
+
+-- excluded integer upper bound parity with the JSON builder repro from #5077
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35.1},
+        "upper_bound": {"excluded": 36}
+    }
+}'::jsonb
+ORDER BY id;
+ id | price 
+----+-------
+  2 | 35.1
+(1 row)
+
+-- all-float control form returns the same rows as the mixed-type form above
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35.1},
+        "upper_bound": {"included": 40.0}
+    }
+}'::jsonb
+ORDER BY id;
+ id | price 
+----+-------
+  2 | 35.1
+  3 | 36.0
+  4 | 39.9
+  5 | 40.0
+(4 rows)
+
+DROP TABLE json_mixed_range_test;

--- a/pg_search/tests/pg_regress/sql/json_range.sql
+++ b/pg_search/tests/pg_regress/sql/json_range.sql
@@ -102,3 +102,81 @@ WHERE id @@@ '{
 ORDER BY id;
 
 DROP TABLE json_range_test;
+
+-- ============================================================================
+-- Regression: mixed-type numeric range bounds (issue #5077)
+-- ============================================================================
+-- A JSON numeric subpath whose lower and upper bounds are written with
+-- different numeric "shapes" (e.g. [35.1 TO 40]) used to panic with
+-- `called Option::unwrap() on a None value` because each bound was inferred
+-- independently (F64 lower, I64 upper) and Tantivy's RangeQuery requires both
+-- bounds to share a value type. The bounds are now normalized to a common
+-- numeric type, so these queries return the same rows as the all-float form
+-- instead of panicking.
+
+CREATE TABLE json_mixed_range_test (
+    id SERIAL PRIMARY KEY,
+    metadata JSONB
+);
+
+-- Float values force the fast field to store the subpath as F64.
+INSERT INTO json_mixed_range_test (metadata) VALUES
+    ('{"price": 35.0}'),
+    ('{"price": 35.1}'),
+    ('{"price": 36.0}'),
+    ('{"price": 39.9}'),
+    ('{"price": 40.0}'),
+    ('{"price": 41.0}');
+
+CREATE INDEX json_mixed_range_test_idx ON json_mixed_range_test
+USING bm25 (id, metadata)
+WITH (
+    key_field = 'id',
+    json_fields = '{"metadata": {"fast": true}}'
+);
+
+-- float lower bound, integer upper bound ([35.1 TO 40])
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35.1},
+        "upper_bound": {"included": 40}
+    }
+}'::jsonb
+ORDER BY id;
+
+-- integer lower bound, float upper bound ([35 TO 40.5])
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35},
+        "upper_bound": {"included": 40.5}
+    }
+}'::jsonb
+ORDER BY id;
+
+-- excluded integer upper bound parity with the JSON builder repro from #5077
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35.1},
+        "upper_bound": {"excluded": 36}
+    }
+}'::jsonb
+ORDER BY id;
+
+-- all-float control form returns the same rows as the mixed-type form above
+SELECT id, metadata->>'price' AS price FROM json_mixed_range_test
+WHERE id @@@ '{
+    "range": {
+        "field": "metadata.price",
+        "lower_bound": {"included": 35.1},
+        "upper_bound": {"included": 40.0}
+    }
+}'::jsonb
+ORDER BY id;
+
+DROP TABLE json_mixed_range_test;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5077

## What

Range queries over a JSON numeric subpath panic with `ERROR: called Option::unwrap() on a None value` when the lower and upper bounds are written with different numeric "shapes" -- e.g. `[35.1 TO 40]` or the equivalent JSON range builder with `lower_bound: {"included": 35.1}` and `upper_bound: {"excluded": 36}`. All-integer (`[35 TO 40]`) and all-float (`[35.1 TO 40.1]`) ranges already worked; only the mixed int/float case failed.

This PR normalizes a mixed-shape numeric bound pair to a common type before the range query is built, so these queries return rows instead of panicking.

## Why

For a JSON numeric field, each range bound is inferred independently by `string_to_json_numeric`, so `35.1` becomes `F64` while `40` becomes `I64`. The two bounds then produce Tantivy terms with different fast-value types. Tantivy's `RangeQuery` requires both bound terms to share a value type, and the mismatch leads to an `Option::unwrap()` on a `None` deep in the typed-bound extraction -- surfacing to the user as a panic. A maintainer acknowledged the report on #5077.

## How

- Added `normalize_numeric_bound_pair` in `pg_search/src/query/numeric.rs`. When exactly one bound is an `F64` and the other is an integer (`I64`/`U64`), it promotes the integer bound to `F64` so both bounds agree on type. Bounds that already agree, are unbounded, or are non-numeric are returned unchanged.
- Wired it into the JSON branch of `range()` in `pg_search/src/query/pdb_query.rs`, immediately after the per-bound `string_to_json_numeric` conversion and before `check_range_bounds`. This is the exact path used by both the `paradedb.range(...)` builder and the legacy `{"range": {...}}` JSONB form.

The change is confined to the bound-conversion helpers; the executor is untouched. Other field-type branches were already type-consistent (`F64` fields map both bounds via `string_to_f64`; the standard path already coerces integers to `F64` via `coerce_bound_to_field_type`), so JSON was the only affected path.

## Tests

Added a regression section to `pg_search/tests/pg_regress/sql/json_range.sql` (with matching `expected/json_range.out`) covering, against a JSONB subpath stored as F64:

- float-lower / integer-upper (`[35.1 TO 40]`)
- integer-lower / float-upper (`[35 TO 40.5]`)
- excluded integer upper bound (`{"included": 35.1}` / `{"excluded": 36}`) -- the exact JSON builder repro from #5077
- an all-float control form, confirming the mixed-type form returns the same rows

Verified locally with `cargo pgrx regress pg18 json_range` against PostgreSQL 18:

- On `main` (fix reverted, test kept), the mixed-type queries reproduce the `called Option::unwrap() on a None value` panic.
- With the fix, the same queries pass and the mixed-type `[35.1 TO 40]` returns the same rows as the all-float `[35.1 TO 40.0]` control.

`cargo fmt --check -p pg_search` and `cargo check -p pg_search` are clean. I did not run the full regression suite, only the `json_range` test relevant to this change.
