### PR TITLE
ci: Never mark beta releases as latest

### DIFF
--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -127,10 +127,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Beta (prerelease) releases are never the latest release. GitHub already ignores
-          # make_latest for prereleases, but we set it explicitly so the intent is clear.
+          # Beta releases should never be the latest release
           if [[ "${{ github.event.inputs.beta }}" == "true" ]]; then
-            echo "Beta release; never marked as latest."
             echo "is_latest=false" >> $GITHUB_OUTPUT
             exit 0
           fi

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -127,6 +127,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # Beta (prerelease) releases are never the latest release. GitHub already ignores
+          # make_latest for prereleases, but we set it explicitly so the intent is clear.
+          if [[ "${{ github.event.inputs.beta }}" == "true" ]]; then
+            echo "Beta release; never marked as latest."
+            echo "is_latest=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
           current_tag_version="${{ github.event.inputs.version }}"
           latest_tag_version=$(gh release list --jq '.[] | select(.isLatest == true) | .name' --json=name,isLatest | sed 's/^v//')
           echo "Current latest release is $latest_tag_version"


### PR DESCRIPTION
## What

In `publish-github-release.yml`, the `Determine if Release Should be Marked as Latest` step computes `is_latest` with a plain semver `>` check and passes it directly to `make_latest`. A beta (e.g. `0.25.0-rc.1`) released ahead of the current latest stable satisfies `0.25.0-rc.1 > 0.24.1`, so it would request `make_latest: true` on a `prerelease: true` release.

GitHub ignores `make_latest` for prereleases, so this was harmless in practice — but the intent was wrong. This short-circuits `is_latest` to `false` for beta releases so a prerelease can never be (or appear to request being) the latest release.

## Context

Split out from #5376 (which restores PG 18 Docker images for beta releases) as a follow-up tidy, per review discussion — this is a pre-existing issue, independent of that PR.