### PR TITLE
ci: Suffix publish-pg_search job ids with their platform

### DIFF
--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -29,7 +29,7 @@ permissions:
   attestations: write
 
 jobs:
-  publish-pg_search:
+  publish-pg_search-macos:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} arm64
     runs-on: ${{ matrix.runner }}
     if: ${{ !contains(github.ref, '-rc.') }}

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -14,7 +14,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  publish-pg_search:
+  publish-pg_search-pgxn:
     name: Publish pg_search to PGXN
     runs-on: ubuntu-latest
     if: ${{ !contains(github.ref, '-rc.') }}

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -31,7 +31,7 @@ permissions:
   attestations: write
 
 jobs:
-  publish-pg_search:
+  publish-pg_search-postgresapp:
     name: Publish pg_search for Postgres.app (PostgreSQL ${{ matrix.pg_version }}, arm64)
     runs-on: macos-15
     if: ${{ !contains(github.ref, '-rc.') }}

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -29,7 +29,7 @@ permissions:
   attestations: write
 
 jobs:
-  publish-pg_search:
+  publish-pg_search-rhel:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     # Compute-optimized c-family — Rust release build inside matrix.image container is CPU-bound.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -29,7 +29,7 @@ permissions:
   attestations: write
 
 jobs:
-  publish-pg_search:
+  publish-pg_search-ubuntu:
     name: Publish pg_search for PostgreSQL ${{ matrix.pg_version }} on ${{ matrix.name }} ${{ matrix.arch }}
     # Compute-optimized c-family — Rust release build is CPU-bound.
     # See https://runs-on.com/configuration/job-labels/ — runs in us-east-1.


### PR DESCRIPTION
Renames the `publish-pg_search` job id to `publish-pg_search-<platform>` in the remaining publish workflows, for consistency with the `publish-pg_search-debian` rename in #5376:

- `publish-pg_search-macos.yml` → `publish-pg_search-macos`
- `publish-pg_search-ubuntu.yml` → `publish-pg_search-ubuntu`
- `publish-pg_search-rhel.yml` → `publish-pg_search-rhel`
- `publish-pg_search-pgxn.yml` → `publish-pg_search-pgxn`
- `publish-pg_search-postgresapp.yml` → `publish-pg_search-postgresapp`

Job ids only — the displayed `name:` of each job (and thus required status-check names) is unchanged. Each of these workflows has a single job with no `needs:` dependents, so the rename is contained to one line per file. All five parse as valid YAML.

Split out from #5376 per review (kept that PR focused on the Docker publish trigger + beta fix).