### PR TITLE
ci: Publish Docker via workflow_call from the Debian publish

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -10,17 +10,31 @@
 # so they can run compatibility checks against the new version. This is done in
 # `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
 #
-# This workflow is dispatched by `publish-pg_search-debian.yml` (once the Debian binaries are published) via
-# `workflow_dispatch` pinned to the release ref so that it runs on the same commit as the other deploy jobs.
+# This workflow is called by `publish-pg_search-debian.yml` (once the Debian binaries are published) via
+# `workflow_call`. Because it's a local reusable workflow, it runs on the same commit as the caller — the
+# release tag — so the Docker images (and the reusable test workflow it calls) build from the release ref.
+# Version is derived from that tag; the caller passes nothing. It also keeps `workflow_dispatch` for manual runs.
 
 name: Publish ParadeDB (Docker)
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: "The version to publish (e.g. 0.22.0). Omit to derive it from the release tag the caller ran on."
+        required: false
+        type: string
+        default: ""
+      pg_version:
+        description: "The Postgres major version(s) to build for, as a JSON array (e.g. [15] or [15, 16, 17, 18]). Beta (-rc.) releases always resolve to [18]."
+        required: false
+        type: string
+        default: "[15, 16, 17, 18]"
   workflow_dispatch:
     inputs:
       version:
         description: "The version to set for the ParadeDB release (e.g. 0.22.0). This publishes the latest commit of the chosen branch and tags it with the provided version."
-        required: true
+        required: false
         default: ""
       pg_version:
         description: "The Postgres major version(s) to build ParadeDB for. This needs to be a comma-separated list of integers (e.g. [15] or [15, 16, 17, 18]). Beta (-rc.) releases always resolve to [18] regardless of this value."
@@ -28,7 +42,7 @@ on:
         default: "[15, 16, 17, 18]"
 
 concurrency:
-  group: publish-paradedb-docker-${{ github.event.inputs.version || github.ref }}
+  group: publish-paradedb-docker-${{ inputs.version || github.ref }}
   cancel-in-progress: true
 
 # Used by actions/attest-build-provenance to sign the builds
@@ -48,14 +62,14 @@ jobs:
       - name: Define the PostgreSQL Version Matrix
         id: set-matrix
         run: |
-          REF_NAME="${{ github.event.inputs.version || github.ref_name }}"
+          REF_NAME="${{ inputs.version || github.ref_name }}"
           echo "Evaluating ref: $REF_NAME"
           if [[ "$REF_NAME" == *"-"* ]]; then
             echo "Pre-release version (contains a dash, e.g. a beta -rc. tag); publishing PostgreSQL 18 only."
             echo "matrix=[18]" >> $GITHUB_OUTPUT
           else
             echo "Regular promotion tag detected; using provided PostgreSQL version(s)."
-            echo "matrix=${{ github.event.inputs.pg_version || '[15, 16, 17, 18]' }}" >> $GITHUB_OUTPUT
+            echo "matrix=${{ inputs.pg_version || '[15, 16, 17, 18]' }}" >> $GITHUB_OUTPUT
           fi
 
   generate-dockerfiles:
@@ -87,7 +101,7 @@ jobs:
         id: version
         run: |
           # If no workflow_dispatch version is provided, we use workflow tag trigger version.
-          if [ -z "${{ github.event.inputs.version }}" ]; then
+          if [ -z "${{ inputs.version }}" ]; then
             if [[ $GITHUB_REF == refs/tags/v* ]]; then
               VERSION=${GITHUB_REF#refs/tags/v}
               TAG=${GITHUB_REF#refs/tags/}
@@ -97,8 +111,8 @@ jobs:
               TAG="v0.0.0"
             fi
           else
-            VERSION=${{ github.event.inputs.version }}
-            TAG=v${{ github.event.inputs.version }}
+            VERSION=${{ inputs.version }}
+            TAG=v${{ inputs.version }}
           fi
           RELEASE_VERSION=${VERSION%%-*}
           IFS=. read -r MAJOR MINOR _ <<< "$RELEASE_VERSION"
@@ -396,7 +410,7 @@ jobs:
     name: Notify ORM Repos of New Release
     runs-on: ubuntu-latest
     needs: publish-paradedb-docker-image
-    if: ${{ !contains(github.event.inputs.version || github.ref, '-rc.') }}
+    if: ${{ !contains(inputs.version || github.ref, '-rc.') }}
     env:
       # ORM repos to notify on new releases
       ORM_REPOS: |
@@ -410,10 +424,10 @@ jobs:
       - name: Retrieve GitHub Release Version
         id: version
         run: |
-          if [ -z "${{ github.event.inputs.version }}" ]; then
+          if [ -z "${{ inputs.version }}" ]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           else
-            VERSION=${{ github.event.inputs.version }}
+            VERSION=${{ inputs.version }}
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -22,11 +22,14 @@ concurrency:
   group: publish-pg_search-debian-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# Used by actions/attest-build-provenance to sign the builds
+# contents/id-token/attestations are used by actions/attest-build-provenance to sign the builds.
+# pull-requests is required by the reusable publish-paradedb-docker workflow (a called workflow can't
+# have more GITHUB_TOKEN permission than its caller).
 permissions:
   contents: write
   id-token: write
   attestations: write
+  pull-requests: write
 
 jobs:
   # Stable releases build the full matrix. Beta releases (`-rc.` tags) build only what the PG 18
@@ -358,33 +361,14 @@ jobs:
           MESSAGE="<!here> \`publish-pg_search-debian\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
           curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}
 
-  # Once the Debian packages are published, kick off the ParadeDB Docker publish. The Docker
-  # image publishing runs after Debian since it installs the Debian packages to avoid needing to build
-  # them from source again.
-  trigger-docker-publish:
-    name: Trigger ParadeDB Docker Publish
-    runs-on: ubuntu-latest
+  # Once the Debian packages are published, publish the ParadeDB Docker images. The Docker image
+  # publishing runs after Debian since it installs the published Debian packages rather than rebuilding
+  # from source. We call it as a reusable workflow (rather than dispatching it) so it runs in this same
+  # run on this same commit — the release tag — and derives its version from that tag. Gated to actual
+  # version-tag pushes so a manual .deb rebuild doesn't also republish the Docker images.
+  publish-docker:
+    name: Publish ParadeDB Docker Images
     needs: publish-pg_search-debian
-    # Only on release-tag pushes, so a manual .deb rebuild doesn't also republish the Docker images.
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-    steps:
-      - name: Generate GitHub App Token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-          private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-
-      # This job only runs on a version-tag push, so the version is always the tag.
-      - name: Resolve Release Version
-        id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
-
-      - name: Dispatch ParadeDB Docker Publish on This Release Ref
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: |
-          gh workflow run publish-paradedb-docker.yml \
-            --repo "${{ github.repository }}" \
-            --ref "${{ github.ref_name }}" \
-            -f version="${{ steps.version.outputs.version }}"
+    uses: ./.github/workflows/publish-paradedb-docker.yml
+    secrets: inherit


### PR DESCRIPTION
Converts the one real dependency edge in the release pipeline — Docker ← Debian — from a `gh workflow run` dispatch to a reusable-workflow call. (Per discussion: the independent publishers stay independent; only this edge changes.)

## What

- `publish-paradedb-docker.yml` gains an `on: workflow_call:` trigger (keeps `workflow_dispatch` for manual runs). All input reads move from `github.event.inputs.*` to the `inputs.*` context, which works for both trigger types.
- `publish-pg_search-debian.yml`'s `trigger-docker-publish` job (app token → resolve version → `gh workflow run`) becomes a single call job:
  ```yaml
  publish-docker:
    needs: publish-pg_search-debian
    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
    uses: ./.github/workflows/publish-paradedb-docker.yml
    secrets: inherit
  ```

## Why

- **Same ref, for free.** A *local* reusable workflow runs on the caller's commit. The Debian publish is tag-triggered, so the Docker publish (and the `test-pg_search-docker.yml` it calls) build from the release tag — the ref-pinning we wanted, without `--ref`. Version is derived from the tag; the caller passes nothing.
- **Removes the `Actions: write` requirement.** No more `gh workflow run`, so the app-token-permission 403 class that bit us is gone.
- **One run, real dependency.** Docker becomes a `needs:` edge in the Debian run instead of a separate dispatched run.

## Behavior preserved
- Gated to actual version-tag pushes, so a manual `.deb` rebuild (workflow_dispatch of the Debian publish) does **not** republish Docker.
- Betas still resolve to PG 18; stable to the full matrix.
- `workflow_dispatch` stays on the Docker workflow for independent manual runs.

## Trade-off (intended)
The Docker publish now **nests inside the Debian run** rather than appearing as a separate "Publish ParadeDB (Docker)" top-level run. A Docker failure reds the release run (arguably more correct). Manual independent runs are still available via the Docker workflow's own `workflow_dispatch`.

## Notes
- Added `pull-requests: write` to the Debian workflow's permissions — a called workflow can't exceed its caller's `GITHUB_TOKEN` permissions, and the Docker workflow declares it.
- Nesting depth: `debian → docker → test` = 2 (limit 4).
- Both workflows validated as YAML.