### PR TITLE
chore: Build/infra cleanup (Tier 6 audit findings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,9 +27,6 @@ target/
 # Ruff
 .ruff_cache/
 
-# pgvector
-pgvector/
-
 # Env files
 .env
 

--- a/META.json.in
+++ b/META.json.in
@@ -1,4 +1,3 @@
-
 {
    "name": "pg_search",
    "abstract": "@CRATE_DESC@",

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ There are three flavors of files generated:
 
 - `paradedb`: The default ParadeDB Docker image, published to `paradedb/paradedb`. Includes Barman Cloud which is used in our CNPG deployments.
 - `official`: The image for Docker Official Images which will be published to `paradedb` once approved by Docker. Does not include Barman.
-- `antithesis`: The image used by Antithesis test runs. Includes `libvoidstar`, Antithesis' instrumentation library.
+- `antithesis`: The image used by Antithesis test runs. It is built from a `.deb` that CI instruments with `libvoidstar` (Antithesis' instrumentation library).
 
 `paradedb` and `official` both install Debian artifacts published to GitHub Releases. `antithesis` installs a locally built `.deb` so that it can be run on a per-commit basis.
 

--- a/docker/generate-dockerfiles.sh
+++ b/docker/generate-dockerfiles.sh
@@ -21,6 +21,8 @@ if [[ $# -lt 1 || $# -gt 2 ]]; then
 fi
 
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# Supported PostgreSQL majors. Keep in sync with the canonical list in pg_search/Cargo.toml
+# (also duplicated in flake.nix's supportedPgVersions).
 all_versions=(15 16 17 18)
 # `latest_version` decides which PG major gets the Antithesis flavor; keep it tied to the true latest
 # regardless of any version restriction below.

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -87,6 +87,3 @@ prost = "0.14.3"
 pgrx-tests.workspace = true
 rstest = "0.25.0"
 proptest = "1.11.0"
-
-[package.metadata.cargo-machete]
-ignored = ["indexmap", "libc", "tantivy-common"]

--- a/scripts/pg_search_common.sh
+++ b/scripts/pg_search_common.sh
@@ -84,3 +84,6 @@ rm -rf /tmp/ephemeral_postgres_logs/*
 
 # Export the PG_CONFIG variable for use by sourcing scripts
 export PG_CONFIG="${HOME}/.pgrx/${PGVER}/pgrx-install/bin/pg_config"
+
+# Disable command tracing (enabled above) so it doesn't leak into the scripts that source this file.
+{ set +x; } 2>/dev/null

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -18,7 +18,7 @@ humantime = "2.3.0"
 image = "0.25.9"
 libc = "0.2.186"
 parking_lot = "0.12.5"
-pgrx-pg-config = "0.13.1"
+pgrx-pg-config = "=0.18.1" # Keep in lockstep with the workspace `pgrx` pin (it reads the ~/.pgrx config).
 plotters = "0.3.7"
 postgres = "0.19.13"
 rust_decimal = { version = "1.41.0", features = ["db-postgres"] }


### PR DESCRIPTION
Small, low-risk build/infra cleanups from the repository audit (the "Tier 6" group). No functional/runtime behavior change.

| # | Change | Why |
|---|--------|-----|
| 1 | `stressgres/Cargo.toml`: `pgrx-pg-config` `0.13.1` → `=0.18.1` | Real version skew — the rest of the workspace pins `pgrx`/`pgrx-tests` at `=0.18.1`. A 0.13 config parser can misread a pgrx-0.18-managed `~/.pgrx`. (0.18.1 is already in the tree, pulled by `pgrx` itself.) |
| 2 | `pg_search/Cargo.toml`: drop `[package.metadata.cargo-machete] ignored = [...]` | `indexmap`, `libc`, `tantivy-common` are no longer dependencies of the crate, so the allowlist was stale/misleading. |
| 3 | `docker/README.md`: reword the `antithesis` bullet | The image doesn't "include libvoidstar" directly — CI builds a `libvoidstar`-instrumented `.deb` that the image installs. |
| 4 | `scripts/pg_search_common.sh`: add `set +x` at the end | This file is **sourced** by `pg_search_run.sh`/`pg_search_test.sh`; the `set -x` enabled mid-file leaked tracing into the sourcing scripts. |
| 5 | `META.json.in`: remove the leading blank line | Generated `META.json` started with `\n{` — sloppy for PGXN distribution metadata. |
| 6 | `.gitignore`: remove dead `pgvector/` entry | pgvector now comes via apt (Docker) / the `pgvector` crate (tests); the vendored-checkout layout is gone. |
| 7 | `docker/generate-dockerfiles.sh`: cross-reference the canonical PG-major list | The `{15,16,17,18}` list is duplicated in several files (all currently agree); a comment points to `pg_search/Cargo.toml` as the source of truth, matching what `flake.nix` already does. |

### Notes
- **The `pgrx-pg-config` bump is the only change with build risk** (API could have drifted across 0.13→0.18). I validated the edits locally (TOML parses, `bash -n` passes) and kicked off a local `cargo check -p stressgres`; CI's stressgres build is the authoritative check. The API stressgres uses is small (`Pgrx::from_config`, `Pgrx::get`, `PgConfig::{new,from_path,path}`).
- The audit also flagged the `Makefile` `PGRXV` regex as "order-sensitive" — on inspection it's **already robust** (`^pgrx\s+=` can't match `pgrx-tests`), so it's intentionally left unchanged.
- True de-duplication of the PG-major / Rust-version lists across Cargo/nix/docker/shell isn't feasible without a generator; the cross-reference comment is the pragmatic fix.