### PR TITLE
ci: Restore fail_on_error default in benchmark-pg_search-queries

### DIFF
--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -335,7 +335,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error }}
+          fail_on_error: ${{ inputs.fail_on_error || true }}
 
       - name: Restore "stackoverflow" Heap Snapshot (1M)
         if: >-
@@ -369,7 +369,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error }}
+          fail_on_error: ${{ inputs.fail_on_error || true }}
 
       - name: Restore "stackoverflow" Heap Snapshot (20M)
         if: >-
@@ -403,7 +403,7 @@ jobs:
           slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
-          fail_on_error: ${{ inputs.fail_on_error }}
+          fail_on_error: ${{ inputs.fail_on_error || true }}
 
       - name: Notify Slack on Failure (push only)
         if: failure() && github.event_name == 'push'


### PR DESCRIPTION
## What

Re-adds `|| true` to the `fail_on_error` input in `benchmark-pg_search-queries.yml`, reverting the relevant part of #5150 (commit 2c417e9).

## Why

The audit fix dropped `|| true` from `fail_on_error`, reasoning that an explicit boolean `false` was being coerced to `true` (so backfills could never disable fail-on-error). That reasoning is correct *for `workflow_dispatch`*, but `fail_on_error` is **only** defined as an input on the `workflow_dispatch` trigger.

This workflow also runs on `push` (to `main`) and `pull_request` (labeled) — the common paths. On those events `inputs.fail_on_error` evaluates to an empty string, so the composite action received `--fail-on-error` with **no value**, breaking the benchmark invocation on every push/PR run.

Re-adding `|| true` restores the intended default-fail-on-error behavior for push/PR runs.

## Trade-off

This restores the original behavior, including that a `workflow_dispatch` run with `fail_on_error: false` is coerced back to `true` (the falsy-`false` issue the audit flagged). Backfills that need fail-on-error disabled are the only affected case; if we want to support that properly later, it needs an event-aware expression rather than a plain `||` default. Prioritizing un-breaking the normal benchmark runs here.