### PR TITLE
docs: Fix ORM list in roadmap

### DIFF
--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -17,7 +17,7 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 
 ### Ecosystem Integrations
 
-- **ORMs**. Official support for more ORMs, like Prisma and others, is coming. [Django](https://github.com/paradedb/django-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb) are already available.
+- **ORMs**. Official extensions are available for [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Django](https://github.com/paradedb/django-paradedb), [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), and [Entity Framework Core](https://github.com/paradedb/efcore-paradedb). Support for additional ORMs is coming.
 - **AI Frameworks**. Official support for LangChain, LLamaIndex, CrewAI, and others are coming.
 - **PaaS Providers**. Official tutorials for hosting ParadeDB on more platform-as-a-service providers like Porter.run and others is coming. [Railway](/deploy/cloud-platforms/railway), [Render](/deploy/cloud-platforms/render), and [DigitalOcean](/deploy/cloud-platforms/digitalocean) are already available.
 

--- a/docs/welcome/roadmap.mdx
+++ b/docs/welcome/roadmap.mdx
@@ -17,7 +17,7 @@ We're a lean team that likes to ship at [incredibly high velocity](https://githu
 
 ### Ecosystem Integrations
 
-- **ORMs**. Official extensions are available for [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Django](https://github.com/paradedb/django-paradedb), [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), [Prisma](https://github.com/paradedb/prisma-paradedb), and [Entity Framework Core](https://github.com/paradedb/efcore-paradedb). Support for additional ORMs is coming.
+- **ORMs**. Official support for more ORMs, like Prisma and others, is coming. [Drizzle](https://github.com/paradedb/drizzle-paradedb), [Django](https://github.com/paradedb/django-paradedb), [SQLAlchemy](https://github.com/paradedb/sqlalchemy-paradedb), [Rails](https://github.com/paradedb/rails-paradedb), and [Entity Framework Core](https://github.com/paradedb/efcore-paradedb) are already available.
 - **AI Frameworks**. Official support for LangChain, LLamaIndex, CrewAI, and others are coming.
 - **PaaS Providers**. Official tutorials for hosting ParadeDB on more platform-as-a-service providers like Porter.run and others is coming. [Railway](/deploy/cloud-platforms/railway), [Render](/deploy/cloud-platforms/render), and [DigitalOcean](/deploy/cloud-platforms/digitalocean) are already available.
 


### PR DESCRIPTION
## What

The roadmap's **ORMs** bullet under *Ecosystem Integrations* omitted two ORMs that already have official extensions and are documented on the [Configure your Environment](https://docs.paradedb.com/documentation/getting-started/environment) page:

- [Drizzle](https://github.com/paradedb/drizzle-paradedb)
- [Entity Framework Core](https://github.com/paradedb/efcore-paradedb)

## Change

Added Drizzle and Entity Framework Core to the list of already-available ORMs (alongside Django, SQLAlchemy, and Rails). Prisma support is still in progress, so the "coming" language is unchanged.

## Notes

I also checked the sibling roadmap claims while here — **AI Frameworks** (LangChain/LlamaIndex/CrewAI) and **PaaS Providers** (Porter) genuinely have no extensions/repos yet, so those "coming" statements remain accurate and were left unchanged.