### PR TITLE
feat: Add pdb.alyze UAX #29 word tokenizer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alyze"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42bfad2ca5a240c7e212d0ebb05d3b0bcd8e00bb7fcb5294f7b8734891e95a9b"
+dependencies = [
+ "ahash 0.8.12",
+ "phf 0.13.1",
+ "rust-stemmers",
+ "tpuf_icu_properties_211",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,7 +154,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -153,7 +165,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2708,7 +2720,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3028,7 +3040,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3835,7 +3847,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4207,7 +4219,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5357,7 +5369,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5747,6 +5759,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -5789,6 +5802,19 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand 2.4.1",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6264,7 +6290,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6972,7 +6998,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7030,7 +7056,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7459,7 +7485,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8096,7 +8122,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8282,6 +8308,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 name = "tokenizers"
 version = "0.24.1"
 dependencies = [
+ "alyze",
  "anyhow",
  "emojis",
  "icu_properties",
@@ -8554,6 +8581,67 @@ name = "tower-service"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tpuf_icu_collections_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d222a8d90299a48d0a9a247a3eef0d92eb0e7c6fe2988800448c035066ecf90b"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "tpuf_icu_locale_core_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed07e77de2e982b19f8c3ef48d45cfe9300ae7f8b5f03f01ca03c6031881eb02"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "tpuf_icu_properties_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c455fcb9714106a167df19d9fc495799d9fe154c01bdf1e60ef53e3b33459ce4"
+dependencies = [
+ "tpuf_icu_collections_211",
+ "tpuf_icu_locale_core_211",
+ "tpuf_icu_properties_data_211",
+ "tpuf_icu_provider_211",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "tpuf_icu_properties_data_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63d9d9272c84599f796b52595ca71045d8a97e377e949a26405f7760dc75c554"
+
+[[package]]
+name = "tpuf_icu_provider_211"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3603ac1b818b23d55b832c277df9ff75bd0cdbb2bde06b6f6d4e54cc04d0e402"
+dependencies = [
+ "displaydoc",
+ "tpuf_icu_locale_core_211",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
 
 [[package]]
 name = "tracing"
@@ -9069,7 +9157,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -75,6 +75,7 @@
                             "group": "Available Tokenizers",
                             "pages": [
                               "documentation/tokenizers/available-tokenizers/unicode",
+                              "documentation/tokenizers/available-tokenizers/alyze",
                               "documentation/tokenizers/available-tokenizers/literal",
                               "documentation/tokenizers/available-tokenizers/literal-normalized",
                               "documentation/tokenizers/available-tokenizers/whitespace",

--- a/docs/documentation/tokenizers/available-tokenizers/alyze.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/alyze.mdx
@@ -1,0 +1,46 @@
+---
+title: Alyze
+description: A high-performance UAX #29 word tokenizer
+canonical: https://docs.paradedb.com/documentation/tokenizers/available-tokenizers/alyze
+---
+
+The `alyze` tokenizer splits text according to the word boundaries defined by [Unicode Standard Annex #29](https://www.unicode.org/reports/tr29/),
+using the [`alyze`](https://github.com/turbopuffer/alyze) crate's hand-rolled deterministic finite automaton (DFA). It produces
+the same word boundaries as the [unicode](/documentation/tokenizers/available-tokenizers/unicode) tokenizer, but is implemented
+for high throughput. All characters are [lowercased](/documentation/token-filters/lowercase) by default.
+
+```sql
+CREATE INDEX search_idx ON mock_items
+USING bm25 (id, (description::pdb.alyze))
+WITH (key_field='id');
+```
+
+To get a feel for this tokenizer, run the following command and replace the text with your own:
+
+```sql
+SELECT 'Tokenize me!'::pdb.alyze::text[];
+```
+
+```ini Expected Response
+     text
+---------------
+ {tokenize,me}
+(1 row)
+```
+
+## Word-like filtering
+
+By default, only "word-like" spans are kept — runs containing letters, digits, CJK ideographs, or emoji.
+Whitespace and punctuation segments that UAX #29 also emits are discarded. To instead emit every UAX #29
+segment (including punctuation and whitespace), set `word_like` to `false`.
+
+```sql
+SELECT 'a, b'::pdb.alyze('word_like=false')::text[];
+```
+
+```ini Expected Response
+     text
+---------------
+ {a,","," ",b}
+(1 row)
+```

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-IkcJjujnkY+128Gf52hDJR4CRNgp/qaAoiwxEOA+s34=";
+  cargoHash = "sha256-cdqhj3sgFgHazRWBCRWwOlIEQt2o7hmhAcJmfmKAKgg=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -712,6 +712,24 @@ pub(crate) mod pdb {
         custom_typmod = false
     );
 
+    define_tokenizer_type!(
+        "AlyzeDef",
+        Alyze,
+        SearchTokenizer::Alyze {
+            word_like: true,
+            filters: SearchTokenizerFilters::default()
+        },
+        tokenize_alyze,
+        json_to_alyze,
+        jsonb_to_alyze,
+        uuid_to_alyze,
+        text_array_to_alyze,
+        varchar_array_to_alyze,
+        "alyze",
+        preferred = false,
+        custom_typmod = false
+    );
+
     struct AliasMarker;
     impl SqlNameMarker for AliasMarker {
         const SQL_NAME: &'static str = "pdb.alias";

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -37,8 +37,8 @@ mod typmod;
 use crate::schema::{IndexRecordOption, SearchFieldConfig};
 
 pub use crate::api::tokenizers::typmod::{
-    AliasTypmod, EdgeNgramTypmod, GenericTypmod, JiebaTypmod, LinderaTypmod, NgramTypmod,
-    RegexTypmod, Typmod, UncheckedTypmod, UnicodeWordsTypmod,
+    AliasTypmod, AlyzeTypmod, EdgeNgramTypmod, GenericTypmod, JiebaTypmod, LinderaTypmod,
+    NgramTypmod, RegexTypmod, Typmod, UncheckedTypmod, UnicodeWordsTypmod,
 };
 
 // if a ::pdb.<tokenizer> cast is used, ie ::pdb.simple, ::pdb.lindera, etc.
@@ -122,6 +122,10 @@ fn tokenizer_from_name(name: &str) -> Option<SearchTokenizer> {
         "source_code" => SearchTokenizer::SourceCode(SearchTokenizerFilters::default()),
         "unicode_words" | "unicode" => SearchTokenizer::UnicodeWords {
             remove_emojis: false,
+            filters: SearchTokenizerFilters::default(),
+        },
+        "alyze" => SearchTokenizer::Alyze {
+            word_like: true,
             filters: SearchTokenizerFilters::default(),
         },
         _ => return None,
@@ -253,6 +257,12 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
         } => {
             if let Some(v) = parsed.try_get("remove_emojis", 0).and_then(|p| p.as_bool()) {
                 *remove_emojis = v;
+            }
+            *filters = SearchTokenizerFilters::from(parsed);
+        }
+        SearchTokenizer::Alyze { word_like, filters } => {
+            if let Some(v) = parsed.try_get("word_like", 0).and_then(|p| p.as_bool()) {
+                *word_like = v;
             }
             *filters = SearchTokenizerFilters::from(parsed);
         }
@@ -492,6 +502,14 @@ pub fn apply_typmod(tokenizer: &mut SearchTokenizer, typmod: Typmod) {
             });
             *remove_emojis = unicode_typmod.remove_emojis;
             *filters = unicode_typmod.filters;
+        }
+
+        SearchTokenizer::Alyze { word_like, filters } => {
+            let alyze_typmod = AlyzeTypmod::try_from(typmod).unwrap_or_else(|e| {
+                panic!("{}", e);
+            });
+            *word_like = alyze_typmod.word_like;
+            *filters = alyze_typmod.filters;
         }
 
         SearchTokenizer::Keyword => {}

--- a/pg_search/src/api/tokenizers/typmod/definitions.rs
+++ b/pg_search/src/api/tokenizers/typmod/definitions.rs
@@ -78,6 +78,12 @@ pub struct UnicodeWordsTypmod {
     pub filters: SearchTokenizerFilters,
 }
 
+// for pdb.alyze
+pub struct AlyzeTypmod {
+    pub word_like: bool,
+    pub filters: SearchTokenizerFilters,
+}
+
 trait TypmodRules {
     fn rules() -> Vec<PropertyRule>;
 
@@ -199,6 +205,12 @@ impl TypmodRules for UnicodeWordsTypmod {
             ValueConstraint::Boolean,
             positional = 0
         )]
+    }
+}
+
+impl TypmodRules for AlyzeTypmod {
+    fn rules() -> Vec<PropertyRule> {
+        vec![rule!("word_like", ValueConstraint::Boolean, positional = 0)]
     }
 }
 
@@ -371,6 +383,21 @@ impl TryFrom<i32> for UnicodeWordsTypmod {
             remove_emojis,
             filters,
         })
+    }
+}
+
+impl TryFrom<i32> for AlyzeTypmod {
+    type Error = typmod::Error;
+
+    fn try_from(typmod: i32) -> Result<Self, Self::Error> {
+        let parsed = Self::parsed(typmod)?;
+        let filters = SearchTokenizerFilters::from(&parsed);
+        // `word_like` defaults to true: keep only word-like spans unless explicitly disabled.
+        let word_like = parsed
+            .try_get("word_like", 0)
+            .and_then(|p| p.as_bool())
+            .unwrap_or(true);
+        Ok(AlyzeTypmod { word_like, filters })
     }
 }
 

--- a/pg_search/tests/pg_regress/expected/tokenizer-alyze.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-alyze.out
@@ -1,0 +1,61 @@
+-- Tests the `alyze` tokenizer (UAX #29 word segmentation via the alyze crate)
+\i common/common_setup.sql
+CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Disable parallel workers to avoid differences in plans
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+SET paradedb.enable_columnar_exec = true;
+-- Inline tokenization. The default lowercases and keeps only word-like spans,
+-- dropping punctuation and whitespace.
+SELECT 'Hello, world! 123'::pdb.alyze::text[];
+       text        
+-------------------
+ {hello,world,123}
+(1 row)
+
+-- Contractions stay together; CJK ideographs split per-character; emoji are kept.
+SELECT 'won''t 中文 👍'::pdb.alyze::text[];
+       text       
+------------------
+ {won't,中,文,👍}
+(1 row)
+
+-- With word_like=false, every UAX #29 segment is emitted, including punctuation
+-- and whitespace.
+SELECT 'a, b'::pdb.alyze('word_like=false')::text[];
+     text      
+---------------
+ {a,","," ",b}
+(1 row)
+
+-- Standard filters still apply on top of the tokenizer.
+SELECT 'The Quick Brown Foxes'::pdb.alyze('stemmer=English')::text[];
+         text          
+-----------------------
+ {the,quick,brown,fox}
+(1 row)
+
+-- The tokenizer is usable in a BM25 index.
+DROP TABLE IF EXISTS alyze_items;
+CREATE TABLE alyze_items(
+    id serial8 not null primary key,
+    description text
+);
+INSERT INTO alyze_items(description) VALUES
+    ('Running shoes for athletes'),
+    ('A quick brown fox'),
+    ('Database indexing strategies');
+CREATE INDEX idxalyze ON alyze_items USING bm25 (id, (description::pdb.alyze)) WITH (key_field = 'id');
+SELECT id, description FROM alyze_items WHERE description @@@ 'running' ORDER BY id;
+ id |        description         
+----+----------------------------
+  1 | Running shoes for athletes
+(1 row)
+
+SELECT id, description FROM alyze_items WHERE description @@@ 'quick' ORDER BY id;
+ id |    description    
+----+-------------------
+  2 | A quick brown fox
+(1 row)
+
+DROP TABLE alyze_items;

--- a/pg_search/tests/pg_regress/sql/tokenizer-alyze.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-alyze.sql
@@ -1,0 +1,33 @@
+-- Tests the `alyze` tokenizer (UAX #29 word segmentation via the alyze crate)
+\i common/common_setup.sql
+
+-- Inline tokenization. The default lowercases and keeps only word-like spans,
+-- dropping punctuation and whitespace.
+SELECT 'Hello, world! 123'::pdb.alyze::text[];
+
+-- Contractions stay together; CJK ideographs split per-character; emoji are kept.
+SELECT 'won''t 中文 👍'::pdb.alyze::text[];
+
+-- With word_like=false, every UAX #29 segment is emitted, including punctuation
+-- and whitespace.
+SELECT 'a, b'::pdb.alyze('word_like=false')::text[];
+
+-- Standard filters still apply on top of the tokenizer.
+SELECT 'The Quick Brown Foxes'::pdb.alyze('stemmer=English')::text[];
+
+-- The tokenizer is usable in a BM25 index.
+DROP TABLE IF EXISTS alyze_items;
+CREATE TABLE alyze_items(
+    id serial8 not null primary key,
+    description text
+);
+INSERT INTO alyze_items(description) VALUES
+    ('Running shoes for athletes'),
+    ('A quick brown fox'),
+    ('Database indexing strategies');
+CREATE INDEX idxalyze ON alyze_items USING bm25 (id, (description::pdb.alyze)) WITH (key_field = 'id');
+
+SELECT id, description FROM alyze_items WHERE description @@@ 'running' ORDER BY id;
+SELECT id, description FROM alyze_items WHERE description @@@ 'quick' ORDER BY id;
+
+DROP TABLE alyze_items;

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [dependencies]
+alyze = "0.1.3"
 anyhow = "1.0.102"
 lindera = { version = "1.5.1", features = [
   "embedded-cc-cedict",

--- a/tokenizers/src/alyze.rs
+++ b/tokenizers/src/alyze.rs
@@ -1,0 +1,193 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! A [`tantivy`] tokenizer backed by [`alyze`](https://github.com/turbopuffer/alyze), a
+//! high-performance [UAX #29](https://www.unicode.org/reports/tr29/) word segmenter implemented
+//! as a hand-rolled deterministic finite automaton (DFA).
+//!
+//! `alyze` exposes a push-based API: [`alyze::uax29::word::tokenize`] drives a callback with each
+//! word boundary it discovers. tantivy's [`TokenStream`] is pull-based, so we eagerly run the
+//! segmenter once per input in [`Tokenizer::token_stream`], collecting the byte spans we want to
+//! keep, then hand them out one at a time from [`TokenStream::advance`].
+//!
+//! Each boundary callback reports the [`TokenProperties`] of the span that just closed. When
+//! `word_like_only` is set (the default) we keep only spans alyze classifies as "word-like"
+//! (letters, digits, CJK ideographs, emoji, etc.), discarding the whitespace and punctuation
+//! segments that UAX #29 also emits. This mirrors the behavior of the `unicode_words` tokenizer.
+
+use alyze::uax29::word::{tokenize, Options};
+use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
+
+#[derive(Clone)]
+pub struct AlyzeTokenizer {
+    token: Token,
+    /// When true, only word-like spans are emitted (whitespace/punctuation are dropped).
+    word_like_only: bool,
+}
+
+impl Default for AlyzeTokenizer {
+    fn default() -> Self {
+        Self::new(true)
+    }
+}
+
+impl AlyzeTokenizer {
+    pub fn new(word_like_only: bool) -> Self {
+        Self {
+            token: Token::default(),
+            word_like_only,
+        }
+    }
+}
+
+pub struct AlyzeTokenStream<'a> {
+    text: &'a str,
+    token: &'a mut Token,
+    /// Byte spans `[offset_from, offset_to)` of the tokens we decided to keep, in order.
+    spans: std::vec::IntoIter<(usize, usize)>,
+}
+
+impl Tokenizer for AlyzeTokenizer {
+    type TokenStream<'a> = AlyzeTokenStream<'a>;
+
+    fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        let word_like_only = self.word_like_only;
+
+        // `alyze` reports each boundary as the *end* of the span that just closed, together with
+        // that span's properties. The very first callback is the leading boundary at byte 0, which
+        // closes no span (it carries default/vacuous properties), so we skip it by only emitting
+        // once we have a previous boundary to pair with.
+        let mut spans: Vec<(usize, usize)> = Vec::new();
+        let mut prev: Option<usize> = None;
+        tokenize(text, Options::default(), |boundary, props| {
+            if let Some(start) = prev {
+                if !word_like_only || props.is_word_like() {
+                    spans.push((start, boundary));
+                }
+            }
+            prev = Some(boundary);
+            true
+        });
+
+        // Reset the position counter so the first `advance()` yields position 0 (it wraps from
+        // `usize::MAX`, which is `Token`'s default).
+        self.token.position = usize::MAX;
+
+        AlyzeTokenStream {
+            text,
+            token: &mut self.token,
+            spans: spans.into_iter(),
+        }
+    }
+}
+
+impl TokenStream for AlyzeTokenStream<'_> {
+    fn advance(&mut self) -> bool {
+        match self.spans.next() {
+            Some((offset_from, offset_to)) => {
+                self.token.position = self.token.position.wrapping_add(1);
+                self.token.offset_from = offset_from;
+                self.token.offset_to = offset_to;
+                self.token.text.clear();
+                self.token.text.push_str(&self.text[offset_from..offset_to]);
+                true
+            }
+            None => false,
+        }
+    }
+
+    fn token(&self) -> &Token {
+        self.token
+    }
+
+    fn token_mut(&mut self) -> &mut Token {
+        self.token
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AlyzeTokenizer;
+    use tantivy::tokenizer::{TokenStream, Tokenizer};
+
+    fn collect(tokenizer: &mut AlyzeTokenizer, text: &str) -> Vec<(String, usize, usize, usize)> {
+        let mut stream = tokenizer.token_stream(text);
+        let mut tokens = vec![];
+        while stream.advance() {
+            let token = stream.token();
+            tokens.push((
+                token.text.clone(),
+                token.position,
+                token.offset_from,
+                token.offset_to,
+            ));
+        }
+        tokens
+    }
+
+    #[test]
+    fn test_word_like_only_default() {
+        // Default keeps only word-like spans: punctuation and whitespace are dropped, offsets and
+        // positions track the original text.
+        let mut tokenizer = AlyzeTokenizer::default();
+        let tokens = collect(&mut tokenizer, "Hello, world! 123");
+        assert_eq!(
+            tokens,
+            vec![
+                ("Hello".into(), 0, 0, 5),
+                ("world".into(), 1, 7, 12),
+                ("123".into(), 2, 14, 17),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_contractions_and_cjk_and_emoji() {
+        let mut tokenizer = AlyzeTokenizer::default();
+        let tokens = collect(&mut tokenizer, "won't 中文 👍");
+        let texts: Vec<String> = tokens.iter().map(|(t, ..)| t.clone()).collect();
+        assert_eq!(texts, vec!["won't", "中", "文", "👍"]);
+    }
+
+    #[test]
+    fn test_keep_all_segments() {
+        // With word_like_only disabled, every UAX #29 segment is emitted, including the spaces
+        // and punctuation between words.
+        let mut tokenizer = AlyzeTokenizer::new(false);
+        let texts: Vec<String> = collect(&mut tokenizer, "a, b")
+            .into_iter()
+            .map(|(t, ..)| t)
+            .collect();
+        assert_eq!(texts, vec!["a", ",", " ", "b"]);
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let mut tokenizer = AlyzeTokenizer::default();
+        assert!(collect(&mut tokenizer, "").is_empty());
+    }
+
+    #[test]
+    fn test_stream_reuse_resets_position() {
+        // Re-running the same tokenizer must restart positions at 0 rather than continuing.
+        let mut tokenizer = AlyzeTokenizer::default();
+        let _ = collect(&mut tokenizer, "alpha beta");
+        let tokens = collect(&mut tokenizer, "gamma delta");
+        assert_eq!(tokens[0], ("gamma".into(), 0, 0, 5));
+        assert_eq!(tokens[1], ("delta".into(), 1, 6, 11));
+    }
+}

--- a/tokenizers/src/lib.rs
+++ b/tokenizers/src/lib.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+pub mod alyze;
 pub mod chinese_convert;
 pub mod cjk;
 pub mod code;

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -18,6 +18,7 @@
 
 use std::fmt::Write;
 
+use crate::alyze::AlyzeTokenizer;
 use crate::edge_ngram::{EdgeNgramTokenizer, TokenCharClass};
 use crate::icu::ICUTokenizer;
 use crate::ngram::NgramTokenizer;
@@ -421,6 +422,13 @@ pub enum SearchTokenizer {
         remove_emojis: bool,
         filters: SearchTokenizerFilters,
     },
+    /// UAX #29 word tokenizer backed by the `alyze` crate's DFA implementation.
+    Alyze {
+        /// When true (default), only word-like spans are kept; whitespace and punctuation
+        /// segments produced by UAX #29 are discarded.
+        word_like: bool,
+        filters: SearchTokenizerFilters,
+    },
 }
 
 #[derive(Default, Serialize, Clone, Debug, PartialEq, Eq, strum_macros::VariantNames, AsRefStr)]
@@ -544,6 +552,13 @@ impl SearchTokenizer {
                     remove_emojis,
                     filters,
                 })
+            }
+            "alyze" => {
+                let word_like: bool = value
+                    .get("word_like")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(true);
+                Ok(SearchTokenizer::Alyze { word_like, filters })
             }
             _ => Err(anyhow::anyhow!(
                 "unknown tokenizer type: {}",
@@ -704,6 +719,9 @@ impl SearchTokenizer {
             } => {
                 add_filters!(UnicodeWordsTokenizer::new(*remove_emojis), filters)
             }
+            SearchTokenizer::Alyze { word_like, filters } => {
+                add_filters!(AlyzeTokenizer::new(*word_like), filters)
+            }
         };
 
         Some(analyzer)
@@ -736,6 +754,7 @@ impl SearchTokenizer {
             SearchTokenizer::Jieba { filters, .. } => filters,
             SearchTokenizer::UnicodeWordsDeprecated { filters, .. } => filters,
             SearchTokenizer::UnicodeWords { filters, .. } => filters,
+            SearchTokenizer::Alyze { filters, .. } => filters,
         }
     }
 
@@ -885,6 +904,10 @@ impl SearchTokenizer {
                 remove_emojis,
                 filters: _,
             } => format!("unicode_words_removeemojis:{remove_emojis}{filters_suffix}"),
+            SearchTokenizer::Alyze {
+                word_like,
+                filters: _,
+            } => format!("alyze_wordlike:{word_like}{filters_suffix}"),
         }
     }
 }

--- a/tokenizers/src/unicode_words.rs
+++ b/tokenizers/src/unicode_words.rs
@@ -44,6 +44,13 @@ impl Tokenizer for UnicodeWordsTokenizer {
     type TokenStream<'a> = UnicodeWordsTokenStream<'a>;
 
     fn token_stream<'a>(&'a mut self, text: &'a str) -> Self::TokenStream<'a> {
+        // tantivy reuses a single tokenizer instance across every document in a segment, and the
+        // `Token` (with its `position` counter) lives on the tokenizer. Reset it per call so
+        // positions restart at 0 for each document, matching tantivy's built-in tokenizers
+        // (`SimpleTokenizer`/`WhitespaceTokenizer` both call `self.token.reset()` here). Without
+        // this the counter accumulates across the whole segment, producing huge position values
+        // that bloat the positions index (and risk a u32 overflow on very large segments).
+        self.token.reset();
         UnicodeWordsTokenStream {
             remove_emojis: self.remove_emojis,
             iter: text.split_word_bounds(),
@@ -152,5 +159,29 @@ mod tests {
                 ("hurray".into(), 4, 35, 41)
             ]
         )
+    }
+
+    /// Regression test: tantivy reuses one tokenizer instance across every document in a segment,
+    /// so token positions must restart at 0 for each `token_stream` call. Previously the position
+    /// counter leaked across documents, producing ever-growing positions that bloat the positions
+    /// index (~2.7x on a real corpus) and risk a u32 overflow on large segments.
+    #[test]
+    fn test_position_resets_between_documents() {
+        fn positions(stream: &mut impl TokenStream) -> Vec<usize> {
+            let mut p = vec![];
+            while stream.advance() {
+                p.push(stream.token().position);
+            }
+            p
+        }
+
+        // One tokenizer instance reused across two "documents", as tantivy does during indexing.
+        let mut tokenizer = UnicodeWordsTokenizer::default();
+        let first = positions(&mut tokenizer.token_stream("alpha beta gamma"));
+        let second = positions(&mut tokenizer.token_stream("delta epsilon"));
+
+        assert_eq!(first, vec![0, 1, 2]);
+        // The second document must start at position 0 again, not continue from 3.
+        assert_eq!(second, vec![0, 1]);
     }
 }


### PR DESCRIPTION
Adds `pdb.alyze`, a new text tokenizer backed by Turbopuffer's [alyze ](https://github.com/turbopuffer/alyze)crate, which does UAX #29 word segmentation with a single-pass DFA. It's an alternative to the default `pdb.unicode_words` (built on the unicode-segmentation crate).

  - New SearchTokenizer::Alyze { word_like, filters } variant wrapping alyze::uax29::word::tokenize as a Tantivy Tokenizer (tokenizers/src/alyze.rs).
  - word_like typmod option (default true): keep only word-like spans, dropping the punctuation/whitespace that UAX#29 also emits.
  - Full SQL plumbing: the `pdb.alyze` type, casts, typmod, and inline ::text[] / `paradedb.tokenize` support.
  - pg_regress test (tokenizer-alyze) and a docs page.

## Why

  alyze's DFA segmenter produces the same tokenization as `unicode_words` but is faster to build (16% on a two CPU 28M document index build). This PR adds the tokenizer so we can benchmark and evaluate it; with a possible follow-up of default adopting it.

## Equivalence

  Token-equivalent to unicode_words on 28.7M hn_items rows: 1,722,166,199 vs 1,722,174,314 tokens, differing on only 670 docs of decorative-script content (Braille/Tibetan). With positions
  reset correctly, the merged BM25 indexes are byte-for-byte identical.

##Notes

  - Adds the alyze dependency, and transitively tpuf_icu_*, rust-stemmers, phf, ahash (see Cargo.lock).
  
closes #5394 