### PR TITLE
chore: Drop datetime_fields panic to warning and improve the error message

### DIFF
--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -192,7 +192,7 @@ unsafe fn validate_index_config(index_relation: &PgSearchRelation) {
     if created_by_version.stores_datetimes_in_i64() {
         if datetime_configs.iter().flatten().next().is_some() {
             warning!(
-                "As of v0.24.1, \"datetime_fields\" is deprecated and should be removed. It no longer has any effect. The config knobs it provided are now on by default."
+                "As of v0.24.1, \"datetime_fields\" is deprecated and should be removed. It no longer has any effect. The performance improvement options it provided are now on by default."
             );
         }
     } else {

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -191,8 +191,8 @@ unsafe fn validate_index_config(index_relation: &PgSearchRelation) {
     let datetime_configs = options.datetime_config();
     if created_by_version.stores_datetimes_in_i64() {
         if datetime_configs.iter().flatten().next().is_some() {
-            panic!(
-                "As of v0.24.1, \"datetime_fields\" should be removed, as it's no longer necessary."
+            warning!(
+                "As of v0.24.1, \"datetime_fields\" is deprecated and should be removed. It no longer has any effect. The config knobs it provided are now on by default."
             );
         }
     } else {


### PR DESCRIPTION
## What
Downgrade the invalid presence of `datetime_fields` message from a panic to a warning.

## Why
Users have reported issues testing upgrades using existing index definitions.