### PR TITLE
chore: Upgrade pgrx to 0.19.0

### DIFF
--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -94,14 +94,11 @@ runs:
       shell: bash
       run: RUST_BACKTRACE=1 cargo pgrx stop pg${{ inputs.pg_version }}
 
-    - name: Install the pgrx version for ParadeDB
-      shell: bash
-      run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --force --debug
-
-    - name: Initialize pgrx environment for ParadeDB
-      shell: bash
-      run: cargo pgrx init "--pg${{ inputs.pg_version }}=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
-
+    # Check out the new code BEFORE installing the new cargo-pgrx so that the
+    # PR's rust-toolchain.toml is active during the install. Otherwise the prior
+    # version's pinned (older) toolchain is in effect, and installing a newer
+    # cargo-pgrx whose MSRV exceeds it fails (e.g. cargo-pgrx 0.19.0 needs rustc
+    # 1.96, while ParadeDB v0.21.0 pins 1.90).
     - name: Fetch and Checkout PR Head (PR) or Pushed Commit (push)
       shell: bash
       run: |
@@ -116,6 +113,14 @@ runs:
           git fetch origin ${{ github.sha }}:commit-${{ github.sha }}
           git checkout commit-${{ github.sha }}
         fi
+
+    - name: Install the pgrx version for ParadeDB
+      shell: bash
+      run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --force --debug
+
+    - name: Initialize pgrx environment for ParadeDB
+      shell: bash
+      run: cargo pgrx init "--pg${{ inputs.pg_version }}=/usr/lib/postgresql/${{ inputs.pg_version }}/bin/pg_config"
 
     - name: Compile & install pg_search
       working-directory: pg_search/

--- a/.github/actions/test-pg_search-upgrade/action.yml
+++ b/.github/actions/test-pg_search-upgrade/action.yml
@@ -94,11 +94,6 @@ runs:
       shell: bash
       run: RUST_BACKTRACE=1 cargo pgrx stop pg${{ inputs.pg_version }}
 
-    # Check out the new code BEFORE installing the new cargo-pgrx so that the
-    # PR's rust-toolchain.toml is active during the install. Otherwise the prior
-    # version's pinned (older) toolchain is in effect, and installing a newer
-    # cargo-pgrx whose MSRV exceeds it fails (e.g. cargo-pgrx 0.19.0 needs rustc
-    # 1.96, while ParadeDB v0.21.0 pins 1.90).
     - name: Fetch and Checkout PR Head (PR) or Pushed Commit (push)
       shell: bash
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,16 +97,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "annotate-snippets"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
-dependencies = [
- "anstyle",
- "unicode-width 0.2.2",
-]
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -394,7 +384,7 @@ version = "58.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30a1365d7a7dc50cc847e54154e6af49e4c4b0fddc9f607b687f29212082743"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "serde_core",
  "serde_json",
 ]
@@ -779,8 +769,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "annotate-snippets",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -821,9 +810,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -1074,35 +1063,26 @@ dependencies = [
 
 [[package]]
 name = "cargo-platform"
-version = "0.1.9"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+checksum = "dd0061da739915fae12ea00e16397555ed4371a6bb285431aab930f61b0aa4ba"
 dependencies = [
  "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "cargo_metadata"
-version = "0.18.1"
+version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
 dependencies = [
  "camino",
  "cargo-platform",
  "semver",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "cargo_toml"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbd1fe9db3ebf71b89060adaf7b0504c2d6a425cf061313099547e382c2e472"
-dependencies = [
- "serde",
- "toml 0.8.23",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1254,13 +1234,15 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
+checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
 dependencies = [
  "anstyle",
  "cargo_metadata",
  "clap",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1611,7 +1593,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -2717,7 +2699,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -3028,7 +3010,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3188,7 +3170,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "rustc_version",
 ]
 
@@ -3244,7 +3226,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c7e611d49285d4c4b2e1727b72cf05353558885cc5252f93707b845dfcaf3d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "core-foundation 0.9.4",
  "core-graphics",
@@ -3835,7 +3817,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.57.0",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4207,7 +4189,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4578,7 +4560,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
  "redox_syscall 0.7.4",
@@ -5163,7 +5145,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "dispatch2",
  "objc2",
 ]
@@ -5180,7 +5162,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "objc2",
 ]
 
@@ -5279,7 +5261,7 @@ version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -5374,8 +5356,7 @@ version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 dependencies = [
- "supports-color 2.1.0",
- "supports-color 3.0.2",
+ "supports-color",
 ]
 
 [[package]]
@@ -5573,11 +5554,11 @@ dependencies = [
 
 [[package]]
 name = "pgrx"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06eb76205437c489284e76c3910c81378d525e3e7e8364c31875ec105cc63cd1"
+checksum = "c3a83847efc71051a6dc93846e5c6dea5cbdac92b6fcff9a62b4ffcad487c396"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bitvec",
  "enum-map",
  "libc",
@@ -5588,21 +5569,21 @@ dependencies = [
  "serde",
  "serde_cbor",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "uuid",
 ]
 
 [[package]]
 name = "pgrx-bindgen"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b64cb3d6abab7fa588a83cb154938ba403e5bd41349cf5cbe82eca971ab0a2"
+checksum = "5f2f7026019bc1b69b9fd9c272dcc67c4c4873385eee19a2b16de0f5f1fd0cc8"
 dependencies = [
  "bindgen",
  "cc",
  "clang-sys",
  "eyre",
- "pgrx-pg-config 0.18.1",
+ "pgrx-pg-config",
  "proc-macro2",
  "quote",
  "regex",
@@ -5613,9 +5594,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-macros"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd9d49f184d3a9d5f66c55ec489c2288b31313843007570636b007c7a6fddde4"
+checksum = "c548a0ead422dbcf430e222a5ad58a4d7646cc37dd122ec6ae0f090c90719dac"
 dependencies = [
  "pgrx-sql-entity-graph",
  "proc-macro2",
@@ -5625,29 +5606,11 @@ dependencies = [
 
 [[package]]
 name = "pgrx-pg-config"
-version = "0.13.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05be49ab66e458f4c164b45daa885e53dbbadc4f37bb47e8b5d85d5b4d9a0be4"
+checksum = "6cca92965c1dc76b2a2083afb7dadcf2601d1f04d174311914b6faa49e728fea"
 dependencies = [
- "cargo_toml 0.21.0",
- "eyre",
- "home",
- "owo-colors",
- "pathsearch",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "toml 0.8.23",
- "url",
-]
-
-[[package]]
-name = "pgrx-pg-config"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b061c1ee4e22341c6efffb578e081fc87904e000e056adc9c87e53d073954e3"
-dependencies = [
- "cargo_toml 0.22.3",
+ "cargo_toml",
  "codepage",
  "encoding_rs",
  "eyre",
@@ -5655,17 +5618,17 @@ dependencies = [
  "pathsearch",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
- "toml 0.5.11",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
  "url",
  "winapi",
 ]
 
 [[package]]
 name = "pgrx-pg-sys"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32d5d61594a030a34bd68dfa1cc3b51cdfd58f96d77548c12def496a0d800ca7"
+checksum = "e78e46545f1d6d0c9fd8d73099aa0bc9390dddc8fd6d7aabd98ad08e9086db52"
 dependencies = [
  "cee-scape",
  "libc",
@@ -5677,9 +5640,9 @@ dependencies = [
 
 [[package]]
 name = "pgrx-sql-entity-graph"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82169b961269f7436bfba3b9464f4d6be6b500f0ace1de694be77398b58c09a7"
+checksum = "5d6888b62533c49fda36ab44a82abb96d62e1eba522556244f8a76783097b3b5"
 dependencies = [
  "convert_case",
  "eyre",
@@ -5687,15 +5650,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "unescape",
 ]
 
 [[package]]
 name = "pgrx-tests"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "455747374115c38c70635861fa2f35c6ce01f1b7d34743b9c97291c9a5acd7ca"
+checksum = "fc0bbad9d4a83d86413c97bc0f7f02e201a36d6e96dc0f615030b5e4b503315f"
 dependencies = [
  "clap-cargo",
  "eyre",
@@ -5703,14 +5666,14 @@ dependencies = [
  "owo-colors",
  "pgrx",
  "pgrx-macros",
- "pgrx-pg-config 0.18.1",
+ "pgrx-pg-config",
  "postgres",
  "rand 0.10.1",
  "regex",
  "shlex 2.0.1",
  "sysinfo 0.39.3",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "winapi",
 ]
 
@@ -5959,7 +5922,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -6225,7 +6188,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -6264,7 +6227,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6600,7 +6563,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6609,7 +6572,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -6955,7 +6918,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -6968,11 +6931,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7030,7 +6993,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7111,7 +7074,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7600,7 +7563,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -7646,7 +7609,7 @@ dependencies = [
  "atoi",
  "base64",
  "bigdecimal",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -7735,7 +7698,7 @@ dependencies = [
  "libc",
  "openssl",
  "parking_lot",
- "pgrx-pg-config 0.13.1",
+ "pgrx-pg-config",
  "plotters",
  "postgres",
  "postgres-openssl",
@@ -7791,16 +7754,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "supports-color"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
-dependencies = [
- "is-terminal",
- "is_ci",
-]
 
 [[package]]
 name = "supports-color"
@@ -8096,7 +8049,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8402,15 +8355,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
@@ -8434,6 +8378,21 @@ dependencies = [
  "toml_parser",
  "toml_writer",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -8531,7 +8490,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
  "http",
@@ -8974,7 +8933,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -9554,7 +9513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,8 +39,8 @@ tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy"
   "stemmer",
   "stopwords",
 ], default-features = false }
-pgrx = "=0.18.1"
-pgrx-tests = "=0.18.1"
+pgrx = "=0.19.0"
+pgrx-tests = "=0.19.0"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-IkcJjujnkY+128Gf52hDJR4CRNgp/qaAoiwxEOA+s34=";
+  cargoHash = "sha256-1mb9PWom7KKFUJT3dEmxGuCd6vKaPaG2ArCEU1aV6bw=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -312,12 +312,12 @@ pub(crate) mod pdb {
                 const TYPE_IDENT: &'static str = pgrx::pgrx_resolved_type!($rust_name);
                 const TYPE_ORIGIN: TypeOrigin = TypeOrigin::External;
                 const ARGUMENT_SQL: Result<SqlMappingRef, ArgumentError> =
-                    Ok(SqlMappingRef::literal($sql_name));
+                    Ok(SqlMappingRef::literal(concat!("pdb.", $sql_name)));
                 const RETURN_SQL: Result<ReturnsRef, ReturnsError> =
-                    Ok(ReturnsRef::One(SqlMappingRef::literal($sql_name)));
+                    Ok(ReturnsRef::One(SqlMappingRef::literal(concat!("pdb.", $sql_name))));
             }
 
-            #[pg_extern(immutable, parallel_safe)]
+            #[pg_extern(immutable, parallel_safe, requires = [$def_name])]
             fn $cast_name(s: $rust_name, fcinfo: pg_sys::FunctionCallInfo) -> Vec<String> {
                 let mut tokenizer = $rust_name::make_search_tokenizer();
 

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -18,7 +18,7 @@ humantime = "2.3.0"
 image = "0.25.9"
 libc = "0.2.186"
 parking_lot = "0.12.5"
-pgrx-pg-config = "0.13.1"
+pgrx-pg-config = "=0.19.0"
 plotters = "0.3.7"
 postgres = "0.19.13"
 rust_decimal = { version = "1.41.0", features = ["db-postgres"] }


### PR DESCRIPTION
## What

Upgrades `pgrx` and `pgrx-tests` from `0.18.1` to `0.19.0` ([pgrx#2333](https://github.com/pgcentralfoundation/pgrx/pull/2333), [release notes](https://github.com/pgcentralfoundation/pgrx/releases/tag/v0.19.0)).

Also bumps `stressgres`' `pgrx-pg-config` from the stale `0.13.1` to `=0.19.0` so it tracks the same pgrx version as the rest of the repo.

## Why

pgrx 0.19.0 adds Postgres 19beta1 support and moves pgrx to the Rust 2024 edition. The changes are additive on our side — no source changes were required.

## Notes

- The full workspace (`pg_search`, `tests`, `tokenizers`, `benchmarks`, `macros`, `stressgres`) `cargo check`s cleanly against pg18, including the `pg_test`/`pgrx-tests` harness.
- CI derives the `cargo-pgrx` version from the `pgrx` line in `Cargo.toml` via `sed`, so the version bump propagates to all workflows automatically — no workflow hardcodes a pgrx version.
- The larger-than-usual `Cargo.lock` churn comes from `pgrx-pg-config 0.19.0` replacing `cargo-edit` with `crates-index`/`toml_edit`.
- This does **not** add a `pg19` build target to `pg_search` (pg19 is still beta); that can be a follow-up.