### PR TITLE
test(replication): use RETRIES/RETRY_DELAY constants and add clarifying comments

### DIFF
--- a/tests/tests/replication.rs
+++ b/tests/tests/replication.rs
@@ -551,9 +551,12 @@ async fn test_physical_streaming_replication() -> Result<()> {
     std::thread::sleep(std::time::Duration::from_secs(2));
 
     // Verify that the initial data replicated
-    let standby_data: Vec<(String,)> =
-        "SELECT info FROM test_data"
-            .fetch_retry(&mut standby_conn, 60, 1000, |result| !result.is_empty());
+    let standby_data: Vec<(String,)> = "SELECT info FROM test_data".fetch_retry(
+        &mut standby_conn,
+        RETRIES,
+        RETRY_DELAY,
+        |result| !result.is_empty(),
+    );
 
     assert_eq!(standby_data.len(), 1);
     assert_eq!(standby_data[0].0, "initial");
@@ -562,7 +565,9 @@ async fn test_physical_streaming_replication() -> Result<()> {
     "INSERT INTO test_data (info) VALUES ('from_primary');".execute(&mut primary_conn);
 
     let standby_data: Vec<(String,)> = "SELECT info FROM test_data WHERE info='from_primary'"
-        .fetch_retry(&mut standby_conn, 60, 1000, |result| !result.is_empty());
+        .fetch_retry(&mut standby_conn, RETRIES, RETRY_DELAY, |result| {
+            !result.is_empty()
+        });
 
     assert_eq!(standby_data.len(), 1);
 
@@ -571,7 +576,9 @@ async fn test_physical_streaming_replication() -> Result<()> {
 
     // Now, check for 'from_primary_2'
     let standby_data: Vec<(String,)> = "SELECT info FROM test_data WHERE info='from_primary_2'"
-        .fetch_retry(&mut standby_conn, 60, 1000, |result| !result.is_empty());
+        .fetch_retry(&mut standby_conn, RETRIES, RETRY_DELAY, |result| {
+            !result.is_empty()
+        });
 
     assert_eq!(standby_data.len(), 1);
 
@@ -592,8 +599,8 @@ async fn test_physical_streaming_replication() -> Result<()> {
 
     let sync_row: Vec<(String,)> = "SELECT info FROM test_data WHERE info='sync_test'".fetch_retry(
         &mut standby_conn,
-        60,
-        1000,
+        RETRIES,
+        RETRY_DELAY,
         |result| !result.is_empty(),
     );
     assert_eq!(sync_row.len(), 1);
@@ -615,7 +622,9 @@ async fn test_physical_streaming_replication() -> Result<()> {
 
     // Ensure we can read back the inserted row from the now promoted standby
     let promoted_data: Vec<(String,)> = "SELECT info FROM test_data WHERE info='promoted_standby'"
-        .fetch_retry(&mut standby_conn, 60, 1000, |result| !result.is_empty());
+        .fetch_retry(&mut standby_conn, RETRIES, RETRY_DELAY, |result| {
+            !result.is_empty()
+        });
     assert_eq!(promoted_data.len(), 1);
 
     Ok(())
@@ -629,6 +638,7 @@ async fn test_wal_streaming_replication_with_pg_search() -> Result<()> {
         wal_level = replica
         max_wal_senders = 4
         shared_preload_libraries = 'pg_search'
+        # It's often helpful to have a short wal_keep_size or max_wal_senders for testing
     ";
     let pg_hba_conf = "
         host replication all 127.0.0.1/32 md5
@@ -654,6 +664,7 @@ async fn test_wal_streaming_replication_with_pg_search() -> Result<()> {
     )"
     .execute(&mut source_conn);
 
+    // Insert initial data
     "INSERT INTO items (description, category, created_at) VALUES
         ('Red running shoes', 'Footwear', NOW()),
         ('Blue sports shoes', 'Footwear', NOW()),
@@ -665,6 +676,8 @@ async fn test_wal_streaming_replication_with_pg_search() -> Result<()> {
     let target_tempdir = TempDir::new().expect("Failed to create temp dir for standby");
     let target_tempdir_path = target_tempdir.keep();
 
+    // Permissions for the --pgdata directory passed to pg_basebackup
+    // should be u=rwx (0700) or u=rwx,g=rx (0750)
     std::fs::set_permissions(
         target_tempdir_path.as_path(),
         std::fs::Permissions::from_mode(0o700),
@@ -682,6 +695,7 @@ async fn test_wal_streaming_replication_with_pg_search() -> Result<()> {
     )
     .expect("Failed to run pg_basebackup for standby setup");
 
+    // Start the standby also with pg_search preloaded
     let standby_config = "
         shared_preload_libraries = 'pg_search'
         hot_standby = on
@@ -698,8 +712,8 @@ async fn test_wal_streaming_replication_with_pg_search() -> Result<()> {
     // Confirm baseline streaming: the standby sees the four pre-bm25 rows.
     let standby_rows: Vec<(String,)> = "SELECT description FROM items ORDER BY id".fetch_retry(
         &mut standby_conn,
-        60,
-        1000,
+        RETRIES,
+        RETRY_DELAY,
         |result| result.len() == 4,
     );
     assert_eq!(standby_rows.len(), 4);


### PR DESCRIPTION
## What

Small readability cleanup in `tests/tests/replication.rs`, ported from the `paradedb-enterprise` fork to reduce drift between the two. **No behavior change.**

### 1. Use the existing `RETRIES` / `RETRY_DELAY` constants

The file already defines:
```rust
const RETRIES: u32 = 60;
const RETRY_DELAY: u64 = 1000; // measured in milliseconds
```
and uses them in `test_logical_replication`, but `test_physical_streaming_replication` and `test_wal_streaming_replication_with_pg_search` still passed the raw `60, 1000` literals to `fetch_retry`. This swaps those over so the retry tuning is consistent and named everywhere.

### 2. A few clarifying comments in `test_wal_streaming_replication_with_pg_search`

Added comments above code that was previously uncommented (the insert step, the `--pgdata` permissions requirement — which already has the identical comment in `test_ephemeral_postgres_with_pg_basebackup` — and the standby pg_search preload).

## Notes

- Values are identical (`RETRIES == 60`, `RETRY_DELAY == 1000`), so retry behavior is unchanged.
- `cargo fmt --check` is clean (rustfmt wrapped a few of the now-longer `fetch_retry` calls).
- Scope is limited to comments + constant substitution; no test logic changed.