### PR TITLE
style(aggregate): blank line after parallel worker setup in execute_aggregate

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -545,6 +545,7 @@ pub fn execute_aggregate(
                 bucket_limit as _,
                 &mut state,
             );
+
             if let Some(agg_results) = worker.execute_aggregate(
                 QueryWorkerStyle::NonParallel,
                 Some(expr_context),


### PR DESCRIPTION
Tiny readability tweak in `execute_aggregate`: a blank line between the `ParallelAggregationWorker::new_local(...)` call and the subsequent `worker.execute_aggregate(...)` block.

This also brings the file in line with the spacing in the paradedb-enterprise fork at this spot, shrinking the enterprise↔community diff by one line. No behavior change; `cargo fmt --check` is clean.