### PR TITLE
ci: Bump third-party GitHub Actions to their latest versions

### DIFF
--- a/.github/actions/benchmarks-from-main/action.yml
+++ b/.github/actions/benchmarks-from-main/action.yml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
     - name: Fetch the Latest Benchmark Queries
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         repository: ${{ github.repository }}
         path: bench-temp

--- a/.github/workflows/benchmark-backfill.yml
+++ b/.github/workflows/benchmark-backfill.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - name: Checkout Git Repository at ref=gh-pages
         if: ${{ inputs.reset_data }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: gh-pages
 

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -128,7 +128,7 @@ jobs:
           fi
 
       - name: Checkout Git Repository at ref=${{ steps.determine-ref.outputs.ref }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
           fetch-depth: 0
@@ -151,7 +151,7 @@ jobs:
       - name: Fetch the Latest Composite Actions
         if: >-
           !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
           path: actions-temp

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -84,7 +84,7 @@ jobs:
           fi
 
       - name: Checkout Git Repository at ref=${{ steps.determine-ref.outputs.ref }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.determine-ref.outputs.ref }}
           fetch-depth: 0
@@ -98,7 +98,7 @@ jobs:
 
       - name: Fetch the Latest Composite Actions
         if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-stressgres' }}
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
           path: actions-temp

--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # The `skip` parameter is a total mess, read up before adding.
       # https://github.com/codespell-project/codespell/issues/1915

--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -26,7 +26,7 @@ jobs:
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/generate-benchmark-snapshots.yml
+++ b/.github/workflows/generate-benchmark-snapshots.yml
@@ -82,7 +82,7 @@ jobs:
       BACKREST_REPO_S3_KEY_TYPE: shared
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python Environment
         uses: actions/setup-python@v6
@@ -32,7 +32,7 @@ jobs:
           python-version: "3.11"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Find Dockerfiles
         id: dockerfiles

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check for CRLF Files
         run: |

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up NodeJS Environment
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-github-release.yml
+++ b/.github/workflows/publish-github-release.yml
@@ -46,7 +46,7 @@ jobs:
           fi
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # We confirm that if the release type is beta, the version in Cargo.toml matches with "-rc.X", and that the
       # version provided matches the version in Cargo.toml. If the user forgot to increment the version, they will

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -78,7 +78,7 @@ jobs:
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.ref }}
           token: ${{ steps.app-token.outputs.token }}
@@ -185,7 +185,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.generate-dockerfiles.outputs.branch }}
 
@@ -257,7 +257,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.generate-dockerfiles.outputs.branch }}
 
@@ -348,7 +348,7 @@ jobs:
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ needs.generate-dockerfiles.outputs.branch }}
           fetch-depth: 2

--- a/.github/workflows/publish-paradedb-docs.yml
+++ b/.github/workflows/publish-paradedb-docs.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Publish Docs to Mintlify
         run: |

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -183,7 +183,7 @@ jobs:
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Used to upload the release to GitHub Releases
       - name: Install GitHub CLI
@@ -245,7 +245,7 @@ jobs:
 
       - name: Cache pgrx binary
         id: cache-pgrx
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}-debian-${{ matrix.image }}

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -71,7 +71,7 @@ jobs:
         run: brew reinstall git
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Used to upload the release to GitHub Releases. We force install gh to make sure it is in PATH.
       - name: Install GitHub CLI
@@ -116,7 +116,7 @@ jobs:
 
       - name: Cache pgrx binary
         id: cache-pgrx
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Bundle the Release
         run: make dist

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -48,7 +48,7 @@ jobs:
         run: brew reinstall git
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Used to query/update the GitHub Release and open the PostgresApp/PostgresApp PR.
       - name: Install GitHub CLI
@@ -110,7 +110,7 @@ jobs:
 
       - name: Cache pgrx binary
         id: cache-pgrx
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -221,7 +221,7 @@ jobs:
           sudo dnf install -y rpmdevtools
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Used to upload the release to GitHub Releases
       - name: Install GitHub CLI
@@ -280,7 +280,7 @@ jobs:
 
       - name: Cache pgrx binary
         id: cache-pgrx
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}-rhel-${{ matrix.image }}

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Extract pgrx Version
         id: pgrx

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -163,7 +163,7 @@ jobs:
         run: DEBIAN_FRONTEND=noninteractive sudo apt-get update && sudo apt-get install -y wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       # Used to upload the release to GitHub Releases
       - name: Install GitHub CLI
@@ -222,7 +222,7 @@ jobs:
 
       - name: Cache pgrx binary
         id: cache-pgrx
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}-ubuntu

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -128,7 +128,7 @@ jobs:
         run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
@@ -167,7 +167,7 @@ jobs:
 
       - name: Cache pgrx binary
         id: cache-pgrx
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-pgrx
           key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -265,7 +265,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ env.COMMIT_SHA }}
 
@@ -368,7 +368,7 @@ jobs:
       # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
       # antithesis.source ensures Community and Enteprise have separate histories
       - name: Trigger Antithesis Test
-        uses: antithesishq/antithesis-trigger-action@v0.11
+        uses: antithesishq/antithesis-trigger-action@v0.12
         with:
           notebook_name: ${{ github.event.inputs.notebook || 'paradedb' }}
           tenant: paradedb

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 
@@ -444,7 +444,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -45,7 +45,7 @@ jobs:
           private-key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
 
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           # Check out the PR head's repo and ref so this works for fork PRs too;
           # the branch only exists on the fork, not on the base repo. For

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetch the entire history
           ref: ${{ github.event.pull_request.head.ref || github.ref }}

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -36,7 +36,7 @@ jobs:
       prior_matrix: ${{ steps.compute.outputs.prior_matrix }}
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetch the entire history (required to read tags)
 
@@ -88,7 +88,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0 # Fetch the entire history (required to checkout tags)
 

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -78,7 +78,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -143,7 +143,7 @@ jobs:
       - name: Cache pgrx-compiled Postgres
         if: matrix.pg_impl == 'pgrx'
         id: cache-pgrx-pg
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: ~/.pgrx
           key: pgrx-pg-${{ matrix.pg_version }}-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}
@@ -335,7 +335,7 @@ jobs:
     if: success()
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download All Coverage Artifacts
         uses: actions/download-artifact@v8
@@ -345,7 +345,7 @@ jobs:
           merge-multiple: true
 
       - name: Upload to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           directory: ./coverage-reports
           files: "*.lcov"

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout Git Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4


### PR DESCRIPTION
Bumps the third-party actions that were behind their latest major version. Pure version bumps — no other changes.

| Action | From | To | Occurrences |
|---|---|---|---|
| `actions/checkout` | `@v6` | `@v7` | 41 |
| `actions/cache` | `@v5` | `@v6` | 7 |
| `codecov/codecov-action` | `@v6` | `@v7` | 1 |
| `astral-sh/setup-uv` | `@v7` | `@v8` | 1 |
| `antithesishq/antithesis-trigger-action` | `@v0.11` | `@v0.12` | 1 |

Everything else (`attest-build-provenance@v4`, `create-github-app-token@v3`, `download-artifact@v8`, `github-script@v9`, `setup-node@v6`, `setup-python@v6`, `setup-dotnet@v5`, `upload-artifact@v7`, all `docker/*`, `swatinem/rust-cache@v2`, etc.) is already at its latest major.

`DeterminateSystems/determinate-nix-action@main` is intentionally pinned to a branch, so it's left untouched.

Verified the diff only touches `uses:` lines and all changed workflows still parse as YAML.