### PR TITLE
chore: Make the extension smoke-test comment fork-agnostic

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -407,8 +407,8 @@ jobs:
           docker run --name temp-inspect-paradedb --entrypoint /bin/bash paradedb-ci -c "ls -la /var/lib/postgresql"
           docker rm temp-inspect-paradedb
 
-  # Smoke-test that docker/Dockerfile.extension (the non-runnable, FROM scratch
-  # paradedb/paradedb-extension payload) builds for PostgreSQL 18 on each arch.
+  # Smoke-test that the non-runnable, FROM-scratch extension-image payload builds
+  # for PostgreSQL 18 on each arch.
   # This image is only built at release time in publish-paradedb-docker.yml, so
   # without this job a break in the .deb layout or the COPY paths would not surface
   # until a publish fails. Building per arch natively keeps it consistent with the

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,6 +2,8 @@
 
 ParadeDB's Dockerfiles are automatically generated from `Dockerfile.template`. To make a change to the files, modify `Dockerfile.template`, run `./generate-dockerfiles.sh <<current-version>>`, and commit the generated changes.
 
+## Generated Images
+
 There are three flavors of files generated:
 
 - `paradedb`: The default ParadeDB Docker image, published to `paradedb/paradedb`. Includes Barman Cloud which is used in our CNPG deployments.
@@ -10,10 +12,10 @@ There are three flavors of files generated:
 
 `paradedb` and `official` both install Debian artifacts published to GitHub Releases. `antithesis` installs a locally built `.deb` so that it can be run on a per-commit basis.
 
-## Extension image
+## Extension Image
 
 `Dockerfile.extension` is **not** generated from the template — it is a standalone, hand-maintained Dockerfile. Unlike the runnable images above, it builds a non-runnable `FROM scratch` artifact (`paradedb/paradedb-extension`) containing only pg_search's shared library, control file, SQL scripts, and license. It is meant to be **mounted** into a Postgres container by operators that support extension images — e.g. CloudNativePG, following the [cloudnative-pg/postgres-extensions-containers](https://github.com/cloudnative-pg/postgres-extensions-containers) `<version>-<pg-major>-<distro>` tag convention. It requires PostgreSQL 18+ (which introduced `extension_control_path`) and is built and published at release time alongside the runnable images by `publish-paradedb-docker.yml`.
 
-## Release process
+## Release Process
 
 Because the Dockerfiles depend on the Debian artifacts, they are published after the latest `.deb`s are published to GitHub. The Dockerfiles themselves can't be updated until the latest `.deb`s exist. Because of this, once a release is triggered and the `.deb`s are published, new versions of the Dockerfiles are generated in CI using the latest version. These new versions are then tested and published, and PRs are automatically opened to commit the updated files back to the repo. The files must be committed so they can be referenced by the Docker Official Images manifest file in [docker-library/official-images](https://github.com/docker-library/official-images).

--- a/docker/README.md
+++ b/docker/README.md
@@ -10,6 +10,10 @@ There are three flavors of files generated:
 
 `paradedb` and `official` both install Debian artifacts published to GitHub Releases. `antithesis` installs a locally built `.deb` so that it can be run on a per-commit basis.
 
+## Extension image
+
+`Dockerfile.extension` is **not** generated from the template — it is a standalone, hand-maintained Dockerfile. Unlike the runnable images above, it builds a non-runnable `FROM scratch` artifact (`paradedb/paradedb-extension`) containing only pg_search's shared library, control file, SQL scripts, and license. It is meant to be **mounted** into a Postgres container by operators that support extension images — e.g. CloudNativePG, following the [cloudnative-pg/postgres-extensions-containers](https://github.com/cloudnative-pg/postgres-extensions-containers) `<version>-<pg-major>-<distro>` tag convention. It requires PostgreSQL 18+ (which introduced `extension_control_path`) and is built and published at release time alongside the runnable images by `publish-paradedb-docker.yml`.
+
 ## Release process
 
 Because the Dockerfiles depend on the Debian artifacts, they are published after the latest `.deb`s are published to GitHub. The Dockerfiles themselves can't be updated until the latest `.deb`s exist. Because of this, once a release is triggered and the `.deb`s are published, new versions of the Dockerfiles are generated in CI using the latest version. These new versions are then tested and published, and PRs are automatically opened to commit the updated files back to the repo. The files must be committed so they can be referenced by the Docker Official Images manifest file in [docker-library/official-images](https://github.com/docker-library/official-images).


### PR DESCRIPTION
Two small, related docker cleanups:

### 1. Fork-agnostic smoke-test comment (`test-pg_search-docker.yml`)
Genericizes the extension-image smoke-test comment so it no longer hard-codes `docker/Dockerfile.extension` / `paradedb/paradedb-extension` (the build command right below already names the file). This keeps the comment accurate in both `paradedb` and the `paradedb-enterprise` fork — which builds a differently named Dockerfile/image — so it stops being a perpetual diff in the enterprise rebase.

### 2. Document the extension image (`docker/README.md`)
The README listed only the three template-generated flavors (`paradedb`, `official`, `antithesis`) and never mentioned `Dockerfile.extension` — the standalone, non-runnable `FROM scratch` `paradedb/paradedb-extension` payload that operators like CloudNativePG mount as an extension image. Adds a section describing it (what it is, that it's not template-generated, the PG 18+ requirement, and the CloudNativePG `postgres-extensions-containers` tag convention).

Both are docs/comment-only — no behavior change. markdownlint + YAML parse clean.