### PR TITLE
ci: Gate Docker smoke tests on this repo's release ($GITHUB_REPOSITORY)

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -99,14 +99,13 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          repo="$(sed -E 's#https://(api\.)?github\.com/(repos/)?([^/]+/[^/]+)/releases/.*#\3#' <<< "$url")"
           tag="$(grep -oE 'v[0-9][^"/]*' <<< "$url" | head -1)"
-          echo "Dockerfile ${dockerfile} installs pg_search from ${repo}@${tag}"
-          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
-            echo "Release ${repo}@${tag} is published — running the smoke test."
+          echo "Dockerfile ${dockerfile} pins pg_search ${tag}; gating on ${GITHUB_REPOSITORY}@${tag}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release ${GITHUB_REPOSITORY}@${tag} is published — running the smoke test."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::Release ${repo}@${tag} is not published yet — skipping the Docker smoke test. It will run once the release exists."
+            echo "::notice::Release ${GITHUB_REPOSITORY}@${tag} is not published yet — skipping the Docker smoke test. It will run once the release exists."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -467,15 +466,14 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          repo="$(sed -E 's#https://(api\.)?github\.com/(repos/)?([^/]+/[^/]+)/releases/.*#\3#' <<< "$url")"
           tag="$(grep -oE 'v[0-9][^"/]*' <<< "$url" | head -1)"
-          echo "Dockerfile ${dockerfile} installs pg_search from ${repo}@${tag}"
           echo "version=${tag#v}" >> "$GITHUB_OUTPUT"
-          if gh release view "$tag" --repo "$repo" >/dev/null 2>&1; then
-            echo "Release ${repo}@${tag} is published — building the extension image."
+          echo "Dockerfile ${dockerfile} pins pg_search ${tag}; gating on ${GITHUB_REPOSITORY}@${tag}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release ${GITHUB_REPOSITORY}@${tag} is published — building the extension image."
             echo "skip=false" >> "$GITHUB_OUTPUT"
           else
-            echo "::notice::Release ${repo}@${tag} is not published yet — skipping the extension image build. It will run once the release exists."
+            echo "::notice::Release ${GITHUB_REPOSITORY}@${tag} is not published yet — skipping the extension image build. It will run once the release exists."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
The `release_gate` steps in `test-pg_search-docker.yml` skip the Docker smoke tests when the pinned pg_search release isn't published yet (it reads the version from the committed Dockerfile). They parsed the **repo** out of the Dockerfile's release URL and checked `gh release view --repo "$repo"`.

In `paradedb/paradedb` that's correct. But the `paradedb-enterprise` fork inherits this workflow via its rebase, and there the images build from the **enterprise** `.deb` in `paradedb/paradedb-enterprise` — while the gate still parsed `paradedb/paradedb` from the shared `Dockerfile.paradedb-18` URL. So the gate could pass (community release exists) while the enterprise build then failed on a missing enterprise asset.

Fix: gate on **`$GITHUB_REPOSITORY`** — the repo the workflow runs in, which is exactly where the build pulls its `.deb` from in each fork (`paradedb/paradedb` here, `paradedb/paradedb-enterprise` there). The same code is now correct in both, so the enterprise fork no longer needs an enterprise-only divergence here.

No behavior change for `paradedb/paradedb` (this gate is already a no-op here — the release is always published before the Dockerfile commit lands). YAML + prettier clean.