### PR TITLE
ci: Don't push an empty update-dockerfiles branch when nothing changed

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -145,10 +145,6 @@ jobs:
         run: |
           git add docker
           if git diff --cached --quiet; then
-            # Nothing was regenerated — either a re-run of an already-generated version,
-            # or a version-agnostic Dockerfile that bakes in no version (as in the
-            # enterprise fork). There's no branch to push: build the downstream jobs from
-            # the release commit and skip the PR jobs (gated on has_changes below).
             echo "No generated Dockerfile changes to commit; building from the release commit."
             echo "branch=${{ github.sha }}" >> $GITHUB_OUTPUT
             echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -143,22 +143,26 @@ jobs:
       - name: Commit Generated Dockerfiles
         id: generated_branch
         run: |
-          BRANCH="update-dockerfiles/${{ steps.version.outputs.tag }}"
-          git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
-          git checkout -B "$BRANCH"
-          git config user.name "paradedb-github-app[bot]"
-          git config user.email "282009505+paradedb-github-app[bot]@users.noreply.github.com"
           git add docker
           if git diff --cached --quiet; then
-            echo "No generated Dockerfile changes to commit."
-            HAS_CHANGES=false
+            # Nothing was regenerated — either a re-run of an already-generated version,
+            # or a version-agnostic Dockerfile that bakes in no version (as in the
+            # enterprise fork). There's no branch to push: build the downstream jobs from
+            # the release commit and skip the PR jobs (gated on has_changes below).
+            echo "No generated Dockerfile changes to commit; building from the release commit."
+            echo "branch=${{ github.sha }}" >> $GITHUB_OUTPUT
+            echo "has_changes=false" >> $GITHUB_OUTPUT
           else
+            BRANCH="update-dockerfiles/${{ steps.version.outputs.tag }}"
+            git fetch origin "$BRANCH:refs/remotes/origin/$BRANCH" || true
+            git checkout -B "$BRANCH"
+            git config user.name "paradedb-github-app[bot]"
+            git config user.email "282009505+paradedb-github-app[bot]@users.noreply.github.com"
             git commit -m "Generate Dockerfiles for ${{ steps.version.outputs.tag }}"
-            HAS_CHANGES=true
+            git push --force-with-lease origin "$BRANCH"
+            echo "branch=$BRANCH" >> $GITHUB_OUTPUT
+            echo "has_changes=true" >> $GITHUB_OUTPUT
           fi
-          git push --force-with-lease origin "$BRANCH"
-          echo "branch=$BRANCH" >> $GITHUB_OUTPUT
-          echo "has_changes=$HAS_CHANGES" >> $GITHUB_OUTPUT
 
   test-generated-dockerfiles:
     name: Test Generated Dockerfiles


### PR DESCRIPTION
The **Generate Dockerfiles** step in `publish-paradedb-docker.yml` always created and force-pushed `update-dockerfiles/<tag>`, even when regeneration produced **no diff**:

- a re-run of an already-generated version, or
- the `paradedb-enterprise` fork, whose version-agnostic `Dockerfile.paradedb-enterprise` bakes in no version and therefore never changes on a release.

In those cases an empty branch (just pointing at the release commit) was pushed and left behind, accumulating one per tag.

### Change
Only create / commit / push `update-dockerfiles/<tag>` when `git diff --cached` actually shows changes. Otherwise:
- set `branch` output to `$GITHUB_SHA` (the release commit) so the downstream `test-generated-dockerfiles` and `publish-*` jobs check out the right tree, and
- set `has_changes=false`.

The two PR-opening steps are already gated on `has_changes == 'true'`, so they correctly no-op when nothing was regenerated — no behavior change for normal `paradedb/paradedb` releases (which always regenerate the per-version Dockerfiles → `has_changes=true` → branch pushed + PRs opened as before).

This also removes the empty-branch noise from the enterprise fork's deploys via the normal sync. YAML + prettier clean.