### PR TITLE
ci: Update benchmark CI labels to new names

### DIFF
--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -1,7 +1,7 @@
 # workflows/benchmark-pg_search-queries.yml
 #
 # Benchmark pg_search (Queries)
-# Run our queries benchmark suite against pg_search.
+# Run our queries benchmark suite (stackoverflow and/or cohere) against pg_search.
 
 name: Benchmark pg_search (Queries)
 

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -337,7 +337,7 @@ jobs:
           pr_label: ${{ steps.pr_label.outputs.result }}
           fail_on_error: ${{ inputs.fail_on_error || true }}
 
-      # Cohere (vector): restore a snapshot like stackoverflow, then benchmark (HNSW index + kNN).
+      # Cohere (vector): restore a snapshot like stackoverflow, then benchmark (HNSW or IVFFlat index + kNN, per COHERE_INDEX).
       - name: Restore "cohere" Heap Snapshot (1M)
         if: ${{ env.RUN_COHERE == 'true' }}
         run: |

--- a/.github/workflows/benchmark-pg_search-queries.yml
+++ b/.github/workflows/benchmark-pg_search-queries.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       dataset:
-        description: "Dataset to benchmark on a manual run. Ignored otherwise: push and the benchmark/benchmark-queries labels run stackoverflow; benchmark-cohere-{hnsw,ivfflat} labels run cohere."
+        description: "Dataset to benchmark on a manual run. Ignored otherwise: push and the benchmarks/benchmark-stackoverflow labels run stackoverflow; benchmark-cohere-{hnsw,ivfflat} labels run cohere."
         required: true
         type: choice
         options:
@@ -74,7 +74,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
-        contains(fromJson('["benchmark", "benchmark-queries", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
+        contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
       )
     env:
       pg_version: 18
@@ -85,27 +85,27 @@ jobs:
       BACKREST_REPO_ENDPOINT: s3.us-east-1.amazonaws.com
       BACKREST_REPO_S3_KEY_TYPE: shared
       # Which datasets this run benchmarks, resolved once.
-      # stackoverflow: push to main, the benchmark/benchmark-queries PR labels, or a manual run.
+      # stackoverflow: push to main, the benchmarks/benchmark-stackoverflow PR labels, or a manual run.
       # cohere: opt-in only -- the benchmark-cohere-{hnsw,ivfflat} PR labels, or a manual run. The
       # chosen index comes from the dispatch input or the label name (no default).
-      RUN_STACKOVERFLOW: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'stackoverflow')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmark", "benchmark-queries"]'), github.event.label.name)) }}
+      RUN_STACKOVERFLOW: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'stackoverflow')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmarks", "benchmark-stackoverflow"]'), github.event.label.name)) }}
       RUN_COHERE: ${{ (github.event_name == 'workflow_dispatch' && (inputs.dataset == 'all' || inputs.dataset == 'cohere')) || (github.event_name == 'pull_request' && contains(fromJson('["benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)) }}
       COHERE_INDEX: ${{ inputs.cohere_index || (github.event.label.name == 'benchmark-cohere-ivfflat' && 'ivfflat') || (github.event.label.name == 'benchmark-cohere-hnsw' && 'hnsw') }}
 
     steps:
-      # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
+      # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label
         if: >-
           github.event_name == 'pull_request' &&
-          contains(fromJson('["benchmark", "benchmark-queries", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
+          contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --remove-label benchmark \
-            --remove-label benchmark-queries \
+            --remove-label benchmarks \
+            --remove-label benchmark-stackoverflow \
             --remove-label benchmark-cohere-hnsw \
             --remove-label benchmark-cohere-ivfflat || true
 
@@ -150,7 +150,7 @@ jobs:
       # always fetch the actions from main, unless we've explicitly overridden that, or triggered this via label (like you would on a PR)
       - name: Fetch the Latest Composite Actions
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
         uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
@@ -161,18 +161,18 @@ jobs:
 
       - name: Copy latest actions into place
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
         run: cp -rv actions-temp/.github/actions .github/
 
       - name: Cleanup temporary checkout
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
         run: rm -rf actions-temp
 
       # always fetch the code from main, unless we've explicitly overridden that, or triggered this via label (like you would on a PR)
       - name: Fetch latest benchmark code, suites
         if: >-
-          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmark", "benchmark-queries", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
+          !inputs.use_benchmarks_from_ref && !contains(fromJson('["benchmarks", "benchmark-stackoverflow", "benchmark-cohere-hnsw", "benchmark-cohere-ivfflat"]'), github.event.label.name)
         uses: ./.github/actions/benchmarks-from-main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -6,7 +6,7 @@
 
 name: Benchmark pg_search (Stressgres)
 
-# We run benchmarks on `main`, and on `benchmark`-labeled PRs.
+# We run benchmarks on `main`, and on `benchmarks`-labeled PRs.
 on:
   push:
     branches:
@@ -48,21 +48,21 @@ jobs:
       - extras=s3-cache # See https://runs-on.com/caching/magic-cache/
       # We deliberately do not enable EBS and instead rely on the on-machine NVMe drives to avoid the variance
       # using EBS would cause
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-stressgres')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.label.name == 'benchmarks') || (github.event_name == 'pull_request' && github.event.label.name == 'benchmark-stressgres')
     env:
       pg_version: 18
 
     steps:
-      # The job can be triggered manually by attaching the `benchmark` label to a PR. This step
+      # The job can be triggered manually by attaching the `benchmarks` label to a PR. This step
       # removes the label once the job has started, so it can be applied again if needed.
       - name: Maybe Remove Label
-        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmark' || github.event.label.name == 'benchmark-stressgres')
+        if: github.event_name == 'pull_request' && (github.event.label.name == 'benchmarks' || github.event.label.name == 'benchmark-stressgres')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh pr edit ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
-            --remove-label benchmark \
+            --remove-label benchmarks \
             --remove-label benchmark-stressgres || true
 
       - name: Determine Ref to Benchmark
@@ -97,7 +97,7 @@ jobs:
           echo "Deriving short commit: $short_commit"
 
       - name: Fetch the Latest Composite Actions
-        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-stressgres' }}
+        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmarks' && github.event.label.name != 'benchmark-stressgres' }}
         uses: actions/checkout@v7
         with:
           repository: ${{ github.repository }}
@@ -107,16 +107,16 @@ jobs:
           ref: main
 
       - name: Copy latest actions into place
-        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-stressgres' }}
+        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmarks' && github.event.label.name != 'benchmark-stressgres' }}
         run: cp -rv actions-temp/.github/actions .github/
 
       - name: Cleanup temporary checkout
-        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-stressgres' }}
+        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmarks' && github.event.label.name != 'benchmark-stressgres' }}
         run: rm -rf actions-temp
 
       # only fetch the latest from main when, essentially, we're merging to main.  otherwise, use whatever we checked out in the ref we're benchmarking
       - name: Fetch latest benchmark code, suites
-        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmark' && github.event.label.name != 'benchmark-stressgres' }}
+        if: ${{ !inputs.use_benchmarks_from_ref && github.event.label.name != 'benchmarks' && github.event.label.name != 'benchmark-stressgres' }}
         uses: ./.github/actions/benchmarks-from-main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Ticket(s) Closed

N/A

## What

Updates the benchmark CI workflows to use the renamed labels:

| Old label | New label |
|-----------|-----------|
| \`benchmark\` | \`benchmarks\` |
| \`benchmark-queries\` | \`benchmark-stackoverflow\` |

The \`benchmark-cohere-hnsw\`, \`benchmark-cohere-ivfflat\`, and \`benchmark-stressgres\` labels were already aligned and are unchanged.

## Why

The repository's labels were renamed (\`benchmark\` → \`benchmarks\`, \`benchmark-queries\` → \`benchmark-stackoverflow\`), so the workflow trigger conditions and label-removal steps that referenced the old names would no longer fire. This realigns the CI with the current label names.

## How

Updated the trigger \`if:\` conditions, the \`RUN_STACKOVERFLOW\` env resolution, the \`Maybe Remove Label\` steps, and the \`use_benchmarks_from_ref\` guards in:
- \`.github/workflows/benchmark-pg_search-queries.yml\`
- \`.github/workflows/benchmark-pg_search-stressgres.yml\`

Comments and the \`workflow_dispatch\` input description were updated to match.

## Tests

N/A — CI configuration only.