### PR TITLE
chore: bump to 0.24.2 and move minimum_should_match migration off released 0.24.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,7 +716,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -4769,7 +4769,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5465,7 +5465,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7648,7 +7648,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -8028,7 +8028,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -8198,7 +8198,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/docs/legacy/advanced/compound/boolean.mdx
+++ b/docs/legacy/advanced/compound/boolean.mdx
@@ -84,6 +84,11 @@ WHERE id @@@
   A query object or an `ARRAY` of query objects as conditions of which at least
   one must be matched.
 </ParamField>
+<ParamField body="minimum_should_match">
+  The minimum number of `should` conditions that must match for a document to be
+  returned. Defaults to `NULL`, which preserves the standard behavior where at
+  least one `should` condition must match (unless `must` clauses are present).
+</ParamField>
 
 In order for a boolean query to return a result, one of `must` or `should` must be provided.
 `must_not` acts as a mask and does not produce a result set.

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-T5Nj0OIHEc2P4p74xXlBk3PH7qKYkXHYeeWtBkoLL3Q=";
+  cargoHash = "sha256-BgkFDlZih72nJuKc0HBBUgH3d6vP0CmuiV7VIPDJ5Ys=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.24.0--0.24.1.sql
+++ b/pg_search/sql/pg_search--0.24.0--0.24.1.sql
@@ -5,12 +5,6 @@
 -- from, they may or may not already exist (community's `v0.24.0` predates them;
 -- enterprise's folds them into the base schema). Drop-then-create keeps this
 -- upgrade idempotent in both cases so it never fails with "already exists".
--- Update boolean() overloads to add minimum_should_match parameter
-DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
-CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
-DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
-CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
-
 DROP CAST IF EXISTS (pdb.boost AS pdb.fuzzy);
 DROP FUNCTION IF EXISTS "boost_to_fuzzy"(pdb.boost, integer, boolean);
 

--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -1,0 +1,7 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.24.2'" to load this file. \quit
+
+-- Update boolean() overloads to add minimum_should_match parameter
+DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;


### PR DESCRIPTION
## What

- Bump the workspace version `0.24.1` → `0.24.2` (Cargo.toml + Cargo.lock).
- Move the `paradedb.boolean(... minimum_should_match)` overload changes added by #5281 out of the **already-released** `pg_search--0.24.0--0.24.1.sql` and into a new `pg_search--0.24.1--0.24.2.sql` upgrade script.
- Document the new `minimum_should_match` parameter on `paradedb.boolean()`.

## Why

#5281 landed on `main` while the workspace version was still `0.24.1`, so per the SchemaBot convention its schema delta was written into `pg_search--0.24.0--0.24.1.sql`. But **v0.24.1 had already been released** (tagged on `0.24.x`). Editing a released migration file means anyone already on 0.24.1 never runs the new statements and never gets the `minimum_should_match` overloads.

The fix is to open a new dev cycle: bump to `0.24.2` and put the delta on the `0.24.1 → 0.24.2` upgrade path instead.

## Companion PR

The feature itself (#5281) was never backported to `0.24.x`; a separate PR cherry-picks it there, also targeting the `0.24.2` migration path.

## Note on pre-existing drift

Independent of this PR, `main`'s `pg_search--0.24.0--0.24.1.sql` has accumulated other post-release additions (`index_layer_info` views, amcheck re-emissions, `tokenizer` signature fix, etc.) that are not present in the released v0.24.1. That broader drift is **out of scope** here — this PR only relocates the #5281 boolean delta — but flagging it since it stems from the same missing post-release version bump.