### PR TITLE
feat: add minimum_should_match parameter to paradedb.boolean() (backport of #5281 to 0.24.x)

### DIFF
--- a/.github/scripts/check_migration_diff.py
+++ b/.github/scripts/check_migration_diff.py
@@ -10,6 +10,21 @@ import sys
 import re
 
 
+def normalize_array_defaults(stmt):
+    """Normalize PostgreSQL array default value representations.
+
+    pg-schema-diff outputs pg_dump canonical form: '((ARRAY[])::type[])'
+    but valid DDL uses: ARRAY[]::type[]
+    These are semantically identical, so normalize both to the same form.
+    """
+    # DEFAULT '((ARRAY[])::sometype[])' -> DEFAULT ARRAY[]::sometype[]
+    return re.sub(
+        r"DEFAULT '\(\(ARRAY\[\]\)::([\w]+\[\])\)'",
+        r"DEFAULT ARRAY[]::\1",
+        stmt,
+    )
+
+
 def extract_statements(content):
     """Extract normalized SQL statements (CREATE, ALTER, DROP) from content."""
     # Remove single-line comments (-- ...)
@@ -26,7 +41,7 @@ def extract_statements(content):
     for stmt in content.split(";"):
         stmt = stmt.strip()
         if re.match(r"^(CREATE|ALTER|DROP)\s+", stmt, re.IGNORECASE):
-            statements.add(stmt)
+            statements.add(normalize_array_defaults(stmt))
 
     return statements
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,7 +788,7 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "benchmarks"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -4909,7 +4909,7 @@ dependencies = [
 
 [[package]]
 name = "macros"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "pg_search"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -7822,7 +7822,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stressgres"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -8212,7 +8212,7 @@ dependencies = [
 
 [[package]]
 name = "tests"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "approx",
@@ -8382,7 +8382,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokenizers"
-version = "0.24.1"
+version = "0.24.2"
 dependencies = [
  "anyhow",
  "emojis",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.24.1"
+version = "0.24.2"
 edition = "2021"
 license = "AGPL-3.0"
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-+pAuGubZefpAWPGT2xRtGO8DKX/LXvF2qeMcROYun4k=";
+  cargoHash = "sha256-2p9EdU5lgIiH1z/PDBhu/cfm9IHJ50Ef415bohnXTb0=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -1,0 +1,7 @@
+\echo Use "ALTER EXTENSION pg_search UPDATE TO '0.24.2'" to load this file. \quit
+
+-- Update boolean() overloads to add minimum_should_match parameter
+DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
+CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;

--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -5,3 +5,102 @@ DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+
+-- The `index_layer_info` view re-emissions below were originally added to
+-- `pg_search--0.24.0--0.24.1.sql` on `main` *after* v0.24.1 had already shipped,
+-- so anyone already running the released 0.24.1 would never have run them. Moved
+-- onto the 0.24.1 -> 0.24.2 upgrade path so those upgraders converge on the same
+-- schema as a fresh install. DROP-then-CREATE keeps it idempotent.
+DROP VIEW pdb.index_layer_info;
+CREATE VIEW pdb.index_layer_info AS
+SELECT ((relname)::text),
+       layer_size,
+       low,
+       high,
+       byte_size,
+       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
+       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
+FROM (SELECT relname,
+             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
+              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
+             count(*),
+             COALESCE (sum(byte_size), 0) AS byte_size,
+             min(low) AS low,
+             max(high) AS high,
+             array_agg(segno) AS segments
+      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
+                             FROM pg_class AS c
+                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
+                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
+                                AND i.indisvalid
+                                AND i.indisready
+                                AND i.indislive)) ,
+                 segments AS (SELECT relname, index_info.*
+                              FROM indexes
+                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
+                 layer_sizes AS (SELECT relname,
+                                         COALESCE (lead(unnest) OVER(), 0) AS low,
+                                         unnest AS high
+                                  FROM indexes
+                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.combined_layer_sizes(indexes.relname)) || 9223372036854775807))
+                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
+            SELECT layer_sizes.relname,
+                   layer_sizes.low,
+                   layer_sizes.high,
+                   segments.segno,
+                   segments.byte_size
+            FROM layer_sizes
+                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
+                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
+      WHERE (low < high)
+      GROUP BY relname, low, high
+      ORDER BY relname , low DESC ) AS x ;
+
+GRANT SELECT ON pdb.index_layer_info TO PUBLIC;
+
+DROP VIEW paradedb.index_layer_info;
+CREATE VIEW paradedb.index_layer_info AS
+SELECT ((relname)::text),
+       layer_size,
+       low,
+       high,
+       byte_size,
+       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
+       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
+FROM (SELECT relname,
+             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
+              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
+             count(*),
+             COALESCE (sum(byte_size), 0) AS byte_size,
+             min(low) AS low,
+             max(high) AS high,
+             array_agg(segno) AS segments
+      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
+                             FROM pg_class AS c
+                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
+                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
+                                AND i.indisvalid
+                                AND i.indisready
+                                AND i.indislive)) ,
+                 segments AS (SELECT relname, index_info.*
+                              FROM indexes
+                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
+                 layer_sizes AS (SELECT relname,
+                                         COALESCE (lead(unnest) OVER(), 0) AS low,
+                                         unnest AS high
+                                  FROM indexes
+                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.layer_sizes(indexes.relname)) || 9223372036854775807))
+                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
+            SELECT layer_sizes.relname,
+                   layer_sizes.low,
+                   layer_sizes.high,
+                   segments.segno,
+                   segments.byte_size
+            FROM layer_sizes
+                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
+                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
+      WHERE (low < high)
+      GROUP BY relname, low, high
+      ORDER BY relname , low DESC ) AS x ;
+
+GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -294,10 +294,17 @@ fn index_info(
     // validated the existence of the relation. We are safe calling the function below as
     // long we do not pass pg_sys::NoLock without any other locking mechanism of our own.
     let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
-    let index_kind = IndexKind::for_index(index)?;
+    let index_kind = IndexKind::for_index(index.clone())?;
+    if !index.is_usable() {
+        return Ok(TableIterator::new(Vec::new()));
+    }
 
     let mut results = Vec::new();
     for index in index_kind.partitions() {
+        if !index.is_usable() {
+            continue;
+        }
+
         // open the specified index
         let mut segment_components = MetaPage::open(&index).segment_metas();
         let all_entries = unsafe { segment_components.list(None) };
@@ -827,9 +834,13 @@ from (select relname,
              min(low)                                                                                   as low,
              max(high)                                                                                  as high,
              array_agg(segno)                                                                           as segments
-      from (with indexes as (select oid::regclass as relname
-                             from pg_class
-                             where relam = (select oid from pg_am where amname = 'bm25')),
+      from (with indexes as (select c.oid::regclass as relname
+                             from pg_class c
+                                      join pg_index i on i.indexrelid = c.oid
+                             where c.relam = (select oid from pg_am where amname = 'bm25')
+                               and i.indisvalid
+                               and i.indisready
+                               and i.indislive),
                  segments as (select relname, index_info.*
                               from indexes
                                        inner join paradedb.index_info(indexes.relname, true) on true),
@@ -871,9 +882,13 @@ from (select relname,
              min(low)                                                                                   as low,
              max(high)                                                                                  as high,
              array_agg(segno)                                                                           as segments
-      from (with indexes as (select oid::regclass as relname
-                             from pg_class
-                             where relam = (select oid from pg_am where amname = 'bm25')),
+      from (with indexes as (select c.oid::regclass as relname
+                             from pg_class c
+                                      join pg_index i on i.indexrelid = c.oid
+                             where c.relam = (select oid from pg_am where amname = 'bm25')
+                               and i.indisvalid
+                               and i.indisready
+                               and i.indislive),
                  segments as (select relname, index_info.*
                               from indexes
                                        inner join paradedb.index_info(indexes.relname, true) on true),

--- a/pg_search/src/api/builder_fns/paradedb.rs
+++ b/pg_search/src/api/builder_fns/paradedb.rs
@@ -35,11 +35,13 @@ pub fn boolean_arrays(
     must: default!(Vec<SearchQueryInput>, "ARRAY[]::searchqueryinput[]"),
     should: default!(Vec<SearchQueryInput>, "ARRAY[]::searchqueryinput[]"),
     must_not: default!(Vec<SearchQueryInput>, "ARRAY[]::searchqueryinput[]"),
+    minimum_should_match: default!(Option<i64>, "NULL"),
 ) -> SearchQueryInput {
     SearchQueryInput::Boolean {
         must,
         should,
         must_not,
+        minimum_should_match,
     }
 }
 
@@ -48,11 +50,13 @@ pub fn boolean_singles(
     must: default!(Option<SearchQueryInput>, "NULL"),
     should: default!(Option<SearchQueryInput>, "NULL"),
     must_not: default!(Option<SearchQueryInput>, "NULL"),
+    minimum_should_match: default!(Option<i64>, "NULL"),
 ) -> SearchQueryInput {
     boolean_arrays(
         must.map_or(vec![], |v| vec![v]),
         should.map_or(vec![], |v| vec![v]),
         must_not.map_or(vec![], |v| vec![v]),
+        minimum_should_match,
     )
 }
 
@@ -117,7 +121,8 @@ pub unsafe fn term_with_operator(
                         // ensure that we don't match NULL nulls as not being equal to whatever the user specified
                         must: vec![SearchQueryInput::FieldedQuery {field: $field.clone(), query: pdb::Query::Exists}],
                         should: vec![],
-                        must_not: vec![SearchQueryInput::FieldedQuery { field: $field, query: $eq_func_name(<$value_type>::from_datum($anyelement.datum(), false).unwrap())}]
+                        must_not: vec![SearchQueryInput::FieldedQuery { field: $field, query: $eq_func_name(<$value_type>::from_datum($anyelement.datum(), false).unwrap())}],
+                        minimum_should_match: None,
                     }
                 ),
                 ">" => generic_range_query(Bound::Excluded($anyelement), Bound::Unbounded).map(|query| SearchQueryInput::FieldedQuery { field: $field, query }),
@@ -245,6 +250,7 @@ pub unsafe fn terms_with_operator(
                 must: quals,
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             })
         } else {
             // OR the queries together
@@ -252,6 +258,7 @@ pub unsafe fn terms_with_operator(
                 must: vec![],
                 should: quals,
                 must_not: vec![],
+                minimum_should_match: None,
             })
         }
     }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -175,6 +175,7 @@ impl BaseScan {
                         must: vec![base_query.clone()],
                         should: vec![join_predicate.clone()],
                         must_not: vec![],
+                        minimum_should_match: None,
                     })
                 } else {
                     None
@@ -1194,6 +1195,7 @@ impl CustomScan for BaseScan {
                             must: vec![original_base_query.clone()],
                             should: vec![join_predicate.clone()],
                             must_not: vec![],
+                            minimum_should_match: None,
                         });
                     }
                 }
@@ -2335,6 +2337,7 @@ fn base_query_has_search_predicates(
             must,
             should,
             must_not,
+            ..
         } => {
             must.iter()
                 .any(|q| base_query_has_search_predicates(q, current_index_oid))

--- a/pg_search/src/postgres/customscan/qual_inspect.rs
+++ b/pg_search/src/postgres/customscan/qual_inspect.rs
@@ -289,6 +289,7 @@ impl From<&Qual> for SearchQueryInput {
                             must,
                             should,
                             must_not: vec![],
+                            minimum_should_match: None,
                         }
                     }
                 } else {
@@ -429,6 +430,7 @@ impl From<&Qual> for SearchQueryInput {
                     must,
                     should: vec![],
                     must_not: vec![],
+                    minimum_should_match: None,
                 };
 
                 // wrap the basic boolean query, iteratively, in each of the extracted ScoreFilters
@@ -457,11 +459,13 @@ impl From<&Qual> for SearchQueryInput {
                         must: Default::default(),
                         should: Default::default(),
                         must_not: Default::default(),
+                        minimum_should_match: None,
                     },
                     _ => SearchQueryInput::Boolean {
                         must: Default::default(),
                         should,
                         must_not: Default::default(),
+                        minimum_should_match: None,
                     },
                 }
             }
@@ -502,6 +506,7 @@ impl From<&Qual> for SearchQueryInput {
                             must: vec![SearchQueryInput::All],
                             should: Default::default(),
                             must_not,
+                            minimum_should_match: None,
                         }
                     }
                 }
@@ -1750,6 +1755,7 @@ unsafe fn optimize_and_branch_with_heap_expr(quals: &mut Vec<Qual>) {
                         must: indexed_queries.clone(),
                         should: vec![],
                         must_not: vec![],
+                        minimum_should_match: None,
                     };
                 }
             }
@@ -2025,6 +2031,7 @@ mod tests {
                     must,
                     should,
                     must_not,
+                    ..
                 },
             ) => should.is_empty() && must_not.is_empty() && quals.len() == must.len(),
 
@@ -2035,6 +2042,7 @@ mod tests {
                     must,
                     should,
                     must_not,
+                    ..
                 },
             ) => must.is_empty() && must_not.is_empty() && quals.len() == should.len(),
 
@@ -2045,6 +2053,7 @@ mod tests {
                     must,
                     should: _,
                     must_not,
+                    ..
                 },
             ) => must.len() == 1 && matches!(must[0], SearchQueryInput::All) && must_not.len() == 1,
 

--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -279,6 +279,24 @@ impl PgSearchRelation {
         unsafe { (*(*self.as_ptr()).rd_index).indisvalid }
     }
 
+    /// Returns false if the index should not receive writes yet, such as during
+    /// the early stages of `CREATE INDEX CONCURRENTLY` or `REINDEX CONCURRENTLY`.
+    pub fn is_ready(&self) -> bool {
+        unsafe { (*(*self.as_ptr()).rd_index).indisready }
+    }
+
+    /// Returns false if the index is in a concurrent drop phase and should not
+    /// be touched by callers.
+    pub fn is_live(&self) -> bool {
+        unsafe { (*(*self.as_ptr()).rd_index).indislive }
+    }
+
+    /// Returns true when Postgres considers this index safe to inspect as a
+    /// complete, usable index.
+    pub fn is_usable(&self) -> bool {
+        self.is_valid() && self.is_ready() && self.is_live()
+    }
+
     /// Allows the user to decide for themselves if this [`PgSearchRelation`] instance (and all its
     /// clones) need to do WAL or not.
     pub fn set_need_wal(&mut self, need_wal: bool) {

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -155,6 +155,7 @@ pub extern "C-unwind" fn amrescan(
             must: vec![search_query_input, key],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         };
     }
 

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -78,6 +78,10 @@ pub enum SearchQueryInput {
         #[serde(default)]
         #[serde(skip_serializing_if = "Vec::is_empty")]
         must_not: Vec<SearchQueryInput>,
+
+        #[serde(default)]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        minimum_should_match: Option<i64>,
     },
     Boost {
         query: Box<SearchQueryInput>,
@@ -240,6 +244,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => must
                 .iter()
                 .chain(should.iter())
@@ -276,6 +281,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => {
                 // For the query to be a full scan, ALL documents must match
 
@@ -341,6 +347,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => must
                 .iter()
                 .chain(should.iter())
@@ -371,6 +378,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => must
                 .iter()
                 .chain(should.iter())
@@ -406,6 +414,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not: _,
+                ..
             } => {
                 // AND: product of children selectivities; OR: max of children selectivities.
                 let must_sel = must
@@ -454,6 +463,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => {
                 for q in must.iter().chain(should.iter()).chain(must_not.iter()) {
                     q.extract_field_names(field_names);
@@ -494,6 +504,7 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                ..
             } => {
                 for q in must_not {
                     q.visit(visitor);
@@ -639,6 +650,7 @@ impl SearchQueryInput {
                 must: vec![],
                 should: elements,
                 must_not: vec![],
+                minimum_should_match: None,
             },
         }
     }
@@ -968,8 +980,8 @@ impl SearchQueryInput {
                 must,
                 should,
                 must_not,
+                minimum_should_match,
             } => {
-                // Boolean query optimization pattern:
                 // ---------------------------------
                 // We use B::split_for_parent() to avoid cloning for QueryOnlyBuilder.
                 //
@@ -1016,7 +1028,12 @@ impl SearchQueryInput {
                     }
                 }
 
-                let query = Box::new(BooleanQuery::new(subqueries));
+                let query: Box<dyn TantivyQuery> = match minimum_should_match {
+                    Some(n) => Box::new(BooleanQuery::with_minimum_required_clauses(
+                        subqueries, n as usize,
+                    )),
+                    None => Box::new(BooleanQuery::new(subqueries)),
+                };
 
                 // Children are built lazily inside the closure - QueryOnlyBuilder
                 // never calls this closure, so wrapping work is skipped entirely
@@ -1772,6 +1789,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1780,6 +1798,7 @@ mod tests {
             must: vec![SearchQueryInput::All, SearchQueryInput::All],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1788,6 +1807,7 @@ mod tests {
             must: vec![SearchQueryInput::All, create_term_query()],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1796,6 +1816,7 @@ mod tests {
             must: vec![create_term_query()],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1807,6 +1828,7 @@ mod tests {
             must: vec![],
             should: vec![SearchQueryInput::All],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1815,6 +1837,7 @@ mod tests {
             must: vec![],
             should: vec![SearchQueryInput::All, create_term_query()],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1823,6 +1846,7 @@ mod tests {
             must: vec![],
             should: vec![create_term_query()],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1831,6 +1855,7 @@ mod tests {
             must: vec![],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1842,6 +1867,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![create_term_query()],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1850,6 +1876,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![SearchQueryInput::Empty],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1858,6 +1885,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![SearchQueryInput::Empty, SearchQueryInput::Empty],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1866,6 +1894,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![SearchQueryInput::Empty, create_term_query()],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1877,6 +1906,7 @@ mod tests {
             must: vec![SearchQueryInput::All],
             should: vec![create_term_query()],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1885,6 +1915,7 @@ mod tests {
             must: vec![create_term_query()],
             should: vec![SearchQueryInput::All],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }
@@ -1974,8 +2005,10 @@ mod tests {
                 must: vec![SearchQueryInput::All],
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             }],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
 
@@ -1986,6 +2019,7 @@ mod tests {
                 must: vec![SearchQueryInput::All],
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             }),
         }
         .is_full_scan_query());
@@ -1996,9 +2030,11 @@ mod tests {
                 must: vec![SearchQueryInput::All, create_term_query()], // Not all Must are full scan
                 should: vec![],
                 must_not: vec![],
+                minimum_should_match: None,
             }],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }
         .is_full_scan_query());
     }

--- a/pg_search/src/scan/filter_pushdown.rs
+++ b/pg_search/src/scan/filter_pushdown.rs
@@ -104,6 +104,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![left_query, right_query],
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         })
     }
 
@@ -114,6 +115,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![],
             should: vec![left_query, right_query],
             must_not: vec![],
+            minimum_should_match: None,
         })
     }
 
@@ -123,6 +125,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![inner_query],
+            minimum_should_match: None,
         })
     }
 
@@ -265,6 +268,7 @@ impl<'a> FilterAnalyzer<'a> {
             must: vec![SearchQueryInput::All],
             should: vec![],
             must_not: vec![query],
+            minimum_should_match: None,
         }
     }
 
@@ -408,6 +412,7 @@ pub fn combine_with_and(queries: Vec<SearchQueryInput>) -> Option<SearchQueryInp
             must: queries,
             should: vec![],
             must_not: vec![],
+            minimum_should_match: None,
         }),
     }
 }

--- a/pg_search/tests/pg_regress/expected/index_layer_info.out
+++ b/pg_search/tests/pg_regress/expected/index_layer_info.out
@@ -49,6 +49,38 @@ SELECT * FROM paradedb.combined_layer_sizes('mock_items_2_idx');
  {102400,1048576,10485760,104857600,1048576000,10485760000}
 (1 row)
 
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_not_ready'
+);
+CREATE INDEX mock_items_not_ready_idx_ccnew ON mock_items_not_ready
+USING bm25 (id, description, category)
+WITH (key_field='id');
+SET allow_system_table_mods = on;
+UPDATE pg_index
+SET indisvalid = false,
+    indisready = false
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pdb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'pdb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'paradedb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_info('mock_items_not_ready_idx_ccnew', true)) THEN
+        RAISE EXCEPTION 'paradedb.index_info should skip indexes that are not valid and ready';
+    END IF;
+END
+$$;
+UPDATE pg_index
+SET indisvalid = true,
+    indisready = true
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+SET allow_system_table_mods = off;
 ALTER INDEX mock_items_1_idx SET (layer_sizes = '0');
 ALTER INDEX mock_items_1_idx SET (background_layer_sizes = '10kb, 100kb, 1mb, 100mb');
 SELECT relname, layer_size FROM pdb.index_layer_info WHERE relname = 'mock_items_1_idx' OR relname = 'mock_items_2_idx';
@@ -102,3 +134,4 @@ SELECT * FROM paradedb.combined_layer_sizes('mock_items_1_idx');
 
 DROP TABLE mock_items_1;
 DROP TABLE mock_items_2;
+DROP TABLE mock_items_not_ready;

--- a/pg_search/tests/pg_regress/expected/issue_2844-rls.out
+++ b/pg_search/tests/pg_regress/expected/issue_2844-rls.out
@@ -341,8 +341,8 @@ EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) UPDATE "app"."contacts" AS t
 SET "assignee" = 'ad_singh'
 WHERE t.id IN (SELECT id FROM "app".contacts LIMIT 1)
 RETURNING t.*;
-                                                                                                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                                                                                                             
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Update on contacts t
    ->  Nested Loop Semi Join
          Join Filter: ((t.id)::text = ("ANY_subquery".id)::text)
@@ -351,7 +351,7 @@ RETURNING t.*;
                Index: contacts_search_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[]))"}}}
+               Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[], NULL::bigint))"}}}
          ->  Subquery Scan on "ANY_subquery"
                ->  Limit
                      ->  Custom Scan (ParadeDB Base Scan) on contacts
@@ -360,7 +360,7 @@ RETURNING t.*;
                            Exec Method: TopKScanExecState
                            Scores: false
                               TopK Limit: 1
-                           Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[]))"}}}
+                           Tantivy Query: {"postgres_expression":{"expr":{"expr_desc":"paradedb.with_index('app.contacts_search_idx'::regclass, paradedb.\"boolean\"((ARRAY[paradedb.term('org_id'::paradedb.fieldname, current_setting('app.org_id'::text))] || CASE WHEN (current_setting('app.has_full_contacts_access'::text) = 'true'::text) THEN '{}'::paradedb.searchqueryinput[] ELSE ARRAY[paradedb.term('assignee'::paradedb.fieldname, (app.current_actor_id())::text)] END), '{}'::paradedb.searchqueryinput[], '{}'::paradedb.searchqueryinput[], NULL::bigint))"}}}
 (18 rows)
 
 --

--- a/pg_search/tests/pg_regress/expected/minimum_should_match.out
+++ b/pg_search/tests/pg_regress/expected/minimum_should_match.out
@@ -1,0 +1,143 @@
+-- Tests for minimum_should_match parameter in paradedb.boolean()
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS docs CASCADE;
+CREATE TABLE docs (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    body TEXT
+);
+INSERT INTO docs (title, body) VALUES
+    ('apple banana cherry',   'fruit salad'),
+    ('apple banana',          'two fruits'),
+    ('apple only',            'just apple'),
+    ('banana cherry date',    'three fruits'),
+    ('cherry date elderberry','more fruits'),
+    ('unrelated document',    'no match');
+CREATE INDEX docs_idx ON docs
+USING bm25 (id, title, body)
+WITH (key_field = 'id');
+-- Test 1: minimum_should_match => 2 with 3 should clauses
+-- Only docs matching at least 2 of: apple, banana, cherry
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  4 | banana cherry date
+(3 rows)
+
+-- Test 2: minimum_should_match => 3 (all 3 must match)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 3
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+(1 row)
+
+-- Test 3: minimum_should_match => 0 (matches everything that Tantivy can retrieve)
+-- With only should clauses and minimum_should_match=0, all docs match
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 0
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  3 | apple only
+  4 | banana cherry date
+(4 rows)
+
+-- Test 4: minimum_should_match larger than number of should clauses (matches nothing)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 5
+)
+ORDER BY id;
+ id | title 
+----+-------
+(0 rows)
+
+-- Test 5: Combined with must clause
+-- must: body matches 'fruit', should: title matches apple OR banana (at least 1)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    must => ARRAY[paradedb.term('body', 'fruit')],
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+(1 row)
+
+-- Test 6: Omitting minimum_should_match keeps existing behavior (at least 1 should)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ]
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  3 | apple only
+  4 | banana cherry date
+(4 rows)
+
+-- Test 7: boolean_singles variant also accepts minimum_should_match
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => paradedb.term('title', 'apple'),
+    minimum_should_match => 1
+)
+ORDER BY id;
+ id |        title        
+----+---------------------
+  1 | apple banana cherry
+  2 | apple banana
+  3 | apple only
+(3 rows)
+
+DROP TABLE docs CASCADE;

--- a/pg_search/tests/pg_regress/sql/index_layer_info.sql
+++ b/pg_search/tests/pg_regress/sql/index_layer_info.sql
@@ -22,6 +22,41 @@ SELECT relname, layer_size FROM pdb.index_layer_info WHERE relname = 'mock_items
 SELECT * FROM paradedb.combined_layer_sizes('mock_items_1_idx');
 SELECT * FROM paradedb.combined_layer_sizes('mock_items_2_idx');
 
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_not_ready'
+);
+
+CREATE INDEX mock_items_not_ready_idx_ccnew ON mock_items_not_ready
+USING bm25 (id, description, category)
+WITH (key_field='id');
+
+SET allow_system_table_mods = on;
+UPDATE pg_index
+SET indisvalid = false,
+    indisready = false
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pdb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'pdb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'paradedb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_info('mock_items_not_ready_idx_ccnew', true)) THEN
+        RAISE EXCEPTION 'paradedb.index_info should skip indexes that are not valid and ready';
+    END IF;
+END
+$$;
+UPDATE pg_index
+SET indisvalid = true,
+    indisready = true
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+SET allow_system_table_mods = off;
+
 ALTER INDEX mock_items_1_idx SET (layer_sizes = '0');
 ALTER INDEX mock_items_1_idx SET (background_layer_sizes = '10kb, 100kb, 1mb, 100mb');
 
@@ -36,3 +71,4 @@ SELECT * FROM paradedb.combined_layer_sizes('mock_items_1_idx');
 
 DROP TABLE mock_items_1;
 DROP TABLE mock_items_2;
+DROP TABLE mock_items_not_ready;

--- a/pg_search/tests/pg_regress/sql/minimum_should_match.sql
+++ b/pg_search/tests/pg_regress/sql/minimum_should_match.sql
@@ -1,0 +1,112 @@
+-- Tests for minimum_should_match parameter in paradedb.boolean()
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS docs CASCADE;
+
+CREATE TABLE docs (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    body TEXT
+);
+
+INSERT INTO docs (title, body) VALUES
+    ('apple banana cherry',   'fruit salad'),
+    ('apple banana',          'two fruits'),
+    ('apple only',            'just apple'),
+    ('banana cherry date',    'three fruits'),
+    ('cherry date elderberry','more fruits'),
+    ('unrelated document',    'no match');
+
+CREATE INDEX docs_idx ON docs
+USING bm25 (id, title, body)
+WITH (key_field = 'id');
+
+-- Test 1: minimum_should_match => 2 with 3 should clauses
+-- Only docs matching at least 2 of: apple, banana, cherry
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+
+-- Test 2: minimum_should_match => 3 (all 3 must match)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 3
+)
+ORDER BY id;
+
+-- Test 3: minimum_should_match => 0 (matches everything that Tantivy can retrieve)
+-- With only should clauses and minimum_should_match=0, all docs match
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 0
+)
+ORDER BY id;
+
+-- Test 4: minimum_should_match larger than number of should clauses (matches nothing)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ],
+    minimum_should_match => 5
+)
+ORDER BY id;
+
+-- Test 5: Combined with must clause
+-- must: body matches 'fruit', should: title matches apple OR banana (at least 1)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    must => ARRAY[paradedb.term('body', 'fruit')],
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana'),
+        paradedb.term('title', 'cherry')
+    ],
+    minimum_should_match => 2
+)
+ORDER BY id;
+
+-- Test 6: Omitting minimum_should_match keeps existing behavior (at least 1 should)
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => ARRAY[
+        paradedb.term('title', 'apple'),
+        paradedb.term('title', 'banana')
+    ]
+)
+ORDER BY id;
+
+-- Test 7: boolean_singles variant also accepts minimum_should_match
+SELECT id, title
+FROM docs
+WHERE id @@@ paradedb.boolean(
+    should => paradedb.term('title', 'apple'),
+    minimum_should_match => 1
+)
+ORDER BY id;
+
+DROP TABLE docs CASCADE;


### PR DESCRIPTION
## What

Backports #5281 (`minimum_should_match` on `paradedb.boolean()`) to the `0.24.x` release branch. #5281 was merged to `main` but never cherry-picked here.

## Migration / versioning

`v0.24.1` was already released from this branch, so the schema delta must **not** be written into the released `pg_search--0.24.0--0.24.1.sql`. Instead this PR:

- Bumps the workspace version `0.24.1` → `0.24.2`.
- Adds the `boolean()` overload changes to a new `pg_search--0.24.1--0.24.2.sql` upgrade script.

This mirrors the corrective PR on `main` (#5415), so both branches converge on the same `0.24.1 → 0.24.2` upgrade path.

## Backport notes

- `0.24.x` lacks the main-only negation / null-preserving-exists machinery that #5281 incidentally touched in `searchqueryinput.rs` and `qual_inspect.rs`. Those cherry-pick conflicts were resolved by keeping `0.24.x`'s code and re-applying the `Boolean` variant's new `minimum_should_match` field to this branch's own construction/match sites.
- `searchqueryinput.rs` needed no change here (it has no `Boolean` sites on `0.24.x`).
- Includes the pg_regress test, the `issue_2844-rls.out` expected update (new `NULL::bigint` arg in the deparsed call), and the `check_migration_diff.py` array-default normalization helper from #5281.