### PR TITLE
fix: skip not-ready BM25 indexes in index info (backport of #5279 to 0.24.x)

### DIFF
--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -5,3 +5,102 @@ DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput[], should searchqueryinput[], must_not searchqueryinput[]);
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], should searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], must_not searchqueryinput[] DEFAULT ARRAY[]::searchqueryinput[], minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_arrays_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;
+
+-- The `index_layer_info` view re-emissions below were originally added to
+-- `pg_search--0.24.0--0.24.1.sql` on `main` *after* v0.24.1 had already shipped,
+-- so anyone already running the released 0.24.1 would never have run them. Moved
+-- onto the 0.24.1 -> 0.24.2 upgrade path so those upgraders converge on the same
+-- schema as a fresh install. DROP-then-CREATE keeps it idempotent.
+DROP VIEW pdb.index_layer_info;
+CREATE VIEW pdb.index_layer_info AS
+SELECT ((relname)::text),
+       layer_size,
+       low,
+       high,
+       byte_size,
+       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
+       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
+FROM (SELECT relname,
+             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
+              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
+             count(*),
+             COALESCE (sum(byte_size), 0) AS byte_size,
+             min(low) AS low,
+             max(high) AS high,
+             array_agg(segno) AS segments
+      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
+                             FROM pg_class AS c
+                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
+                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
+                                AND i.indisvalid
+                                AND i.indisready
+                                AND i.indislive)) ,
+                 segments AS (SELECT relname, index_info.*
+                              FROM indexes
+                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
+                 layer_sizes AS (SELECT relname,
+                                         COALESCE (lead(unnest) OVER(), 0) AS low,
+                                         unnest AS high
+                                  FROM indexes
+                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.combined_layer_sizes(indexes.relname)) || 9223372036854775807))
+                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
+            SELECT layer_sizes.relname,
+                   layer_sizes.low,
+                   layer_sizes.high,
+                   segments.segno,
+                   segments.byte_size
+            FROM layer_sizes
+                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
+                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
+      WHERE (low < high)
+      GROUP BY relname, low, high
+      ORDER BY relname , low DESC ) AS x ;
+
+GRANT SELECT ON pdb.index_layer_info TO PUBLIC;
+
+DROP VIEW paradedb.index_layer_info;
+CREATE VIEW paradedb.index_layer_info AS
+SELECT ((relname)::text),
+       layer_size,
+       low,
+       high,
+       byte_size,
+       CASE WHEN (segments = ARRAY[NULL]) THEN 0 ELSE count END AS count,
+       CASE WHEN (segments = ARRAY[NULL]) THEN NULL ELSE segments END AS segments
+FROM (SELECT relname,
+             ((COALESCE (pg_size_pretty(CASE WHEN (low = 0) THEN NULL ELSE low END), '') || '..') ||
+              COALESCE (pg_size_pretty(CASE WHEN (high = 9223372036854775807) THEN NULL ELSE high END), '')) AS layer_size,
+             count(*),
+             COALESCE (sum(byte_size), 0) AS byte_size,
+             min(low) AS low,
+             max(high) AS high,
+             array_agg(segno) AS segments
+      FROM (WITH indexes AS (SELECT ((c.oid)::regclass) AS relname
+                             FROM pg_class AS c
+                                      INNER JOIN pg_index AS i ON (i.indexrelid = c.oid)
+                             WHERE ((c.relam = (SELECT oid FROM pg_am WHERE (amname = 'bm25')))
+                                AND i.indisvalid
+                                AND i.indisready
+                                AND i.indislive)) ,
+                 segments AS (SELECT relname, index_info.*
+                              FROM indexes
+                                       INNER JOIN paradedb.index_info(indexes.relname, (('t')::pg_catalog.bool)) ON (('t')::pg_catalog.bool)) ,
+                 layer_sizes AS (SELECT relname,
+                                         COALESCE (lead(unnest) OVER(), 0) AS low,
+                                         unnest AS high
+                                  FROM indexes
+                                           INNER JOIN LATERAL (SELECT unnest(((0 || paradedb.layer_sizes(indexes.relname)) || 9223372036854775807))
+                                                               ORDER BY 1 DESC ) AS x ON (('t')::pg_catalog.bool))
+            SELECT layer_sizes.relname,
+                   layer_sizes.low,
+                   layer_sizes.high,
+                   segments.segno,
+                   segments.byte_size
+            FROM layer_sizes
+                     LEFT JOIN segments ON ((layer_sizes.relname = segments.relname)
+                         AND ((((byte_size * 1.33))::pg_catalog.int8) BETWEEN low AND high))) AS x
+      WHERE (low < high)
+      GROUP BY relname, low, high
+      ORDER BY relname , low DESC ) AS x ;
+
+GRANT SELECT ON paradedb.index_layer_info TO PUBLIC;

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -294,10 +294,17 @@ fn index_info(
     // validated the existence of the relation. We are safe calling the function below as
     // long we do not pass pg_sys::NoLock without any other locking mechanism of our own.
     let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
-    let index_kind = IndexKind::for_index(index)?;
+    let index_kind = IndexKind::for_index(index.clone())?;
+    if !index.is_usable() {
+        return Ok(TableIterator::new(Vec::new()));
+    }
 
     let mut results = Vec::new();
     for index in index_kind.partitions() {
+        if !index.is_usable() {
+            continue;
+        }
+
         // open the specified index
         let mut segment_components = MetaPage::open(&index).segment_metas();
         let all_entries = unsafe { segment_components.list(None) };
@@ -827,9 +834,13 @@ from (select relname,
              min(low)                                                                                   as low,
              max(high)                                                                                  as high,
              array_agg(segno)                                                                           as segments
-      from (with indexes as (select oid::regclass as relname
-                             from pg_class
-                             where relam = (select oid from pg_am where amname = 'bm25')),
+      from (with indexes as (select c.oid::regclass as relname
+                             from pg_class c
+                                      join pg_index i on i.indexrelid = c.oid
+                             where c.relam = (select oid from pg_am where amname = 'bm25')
+                               and i.indisvalid
+                               and i.indisready
+                               and i.indislive),
                  segments as (select relname, index_info.*
                               from indexes
                                        inner join paradedb.index_info(indexes.relname, true) on true),
@@ -871,9 +882,13 @@ from (select relname,
              min(low)                                                                                   as low,
              max(high)                                                                                  as high,
              array_agg(segno)                                                                           as segments
-      from (with indexes as (select oid::regclass as relname
-                             from pg_class
-                             where relam = (select oid from pg_am where amname = 'bm25')),
+      from (with indexes as (select c.oid::regclass as relname
+                             from pg_class c
+                                      join pg_index i on i.indexrelid = c.oid
+                             where c.relam = (select oid from pg_am where amname = 'bm25')
+                               and i.indisvalid
+                               and i.indisready
+                               and i.indislive),
                  segments as (select relname, index_info.*
                               from indexes
                                        inner join paradedb.index_info(indexes.relname, true) on true),

--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -279,6 +279,24 @@ impl PgSearchRelation {
         unsafe { (*(*self.as_ptr()).rd_index).indisvalid }
     }
 
+    /// Returns false if the index should not receive writes yet, such as during
+    /// the early stages of `CREATE INDEX CONCURRENTLY` or `REINDEX CONCURRENTLY`.
+    pub fn is_ready(&self) -> bool {
+        unsafe { (*(*self.as_ptr()).rd_index).indisready }
+    }
+
+    /// Returns false if the index is in a concurrent drop phase and should not
+    /// be touched by callers.
+    pub fn is_live(&self) -> bool {
+        unsafe { (*(*self.as_ptr()).rd_index).indislive }
+    }
+
+    /// Returns true when Postgres considers this index safe to inspect as a
+    /// complete, usable index.
+    pub fn is_usable(&self) -> bool {
+        self.is_valid() && self.is_ready() && self.is_live()
+    }
+
     /// Allows the user to decide for themselves if this [`PgSearchRelation`] instance (and all its
     /// clones) need to do WAL or not.
     pub fn set_need_wal(&mut self, need_wal: bool) {

--- a/pg_search/tests/pg_regress/expected/index_layer_info.out
+++ b/pg_search/tests/pg_regress/expected/index_layer_info.out
@@ -49,6 +49,38 @@ SELECT * FROM paradedb.combined_layer_sizes('mock_items_2_idx');
  {102400,1048576,10485760,104857600,1048576000,10485760000}
 (1 row)
 
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_not_ready'
+);
+CREATE INDEX mock_items_not_ready_idx_ccnew ON mock_items_not_ready
+USING bm25 (id, description, category)
+WITH (key_field='id');
+SET allow_system_table_mods = on;
+UPDATE pg_index
+SET indisvalid = false,
+    indisready = false
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pdb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'pdb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'paradedb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_info('mock_items_not_ready_idx_ccnew', true)) THEN
+        RAISE EXCEPTION 'paradedb.index_info should skip indexes that are not valid and ready';
+    END IF;
+END
+$$;
+UPDATE pg_index
+SET indisvalid = true,
+    indisready = true
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+SET allow_system_table_mods = off;
 ALTER INDEX mock_items_1_idx SET (layer_sizes = '0');
 ALTER INDEX mock_items_1_idx SET (background_layer_sizes = '10kb, 100kb, 1mb, 100mb');
 SELECT relname, layer_size FROM pdb.index_layer_info WHERE relname = 'mock_items_1_idx' OR relname = 'mock_items_2_idx';
@@ -102,3 +134,4 @@ SELECT * FROM paradedb.combined_layer_sizes('mock_items_1_idx');
 
 DROP TABLE mock_items_1;
 DROP TABLE mock_items_2;
+DROP TABLE mock_items_not_ready;

--- a/pg_search/tests/pg_regress/sql/index_layer_info.sql
+++ b/pg_search/tests/pg_regress/sql/index_layer_info.sql
@@ -22,6 +22,41 @@ SELECT relname, layer_size FROM pdb.index_layer_info WHERE relname = 'mock_items
 SELECT * FROM paradedb.combined_layer_sizes('mock_items_1_idx');
 SELECT * FROM paradedb.combined_layer_sizes('mock_items_2_idx');
 
+CALL paradedb.create_bm25_test_table(
+  schema_name => 'public',
+  table_name => 'mock_items_not_ready'
+);
+
+CREATE INDEX mock_items_not_ready_idx_ccnew ON mock_items_not_ready
+USING bm25 (id, description, category)
+WITH (key_field='id');
+
+SET allow_system_table_mods = on;
+UPDATE pg_index
+SET indisvalid = false,
+    indisready = false
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pdb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'pdb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_layer_info WHERE relname = 'mock_items_not_ready_idx_ccnew') THEN
+        RAISE EXCEPTION 'paradedb.index_layer_info should skip indexes that are not valid and ready';
+    END IF;
+
+    IF EXISTS (SELECT 1 FROM paradedb.index_info('mock_items_not_ready_idx_ccnew', true)) THEN
+        RAISE EXCEPTION 'paradedb.index_info should skip indexes that are not valid and ready';
+    END IF;
+END
+$$;
+UPDATE pg_index
+SET indisvalid = true,
+    indisready = true
+WHERE indexrelid = 'mock_items_not_ready_idx_ccnew'::regclass;
+SET allow_system_table_mods = off;
+
 ALTER INDEX mock_items_1_idx SET (layer_sizes = '0');
 ALTER INDEX mock_items_1_idx SET (background_layer_sizes = '10kb, 100kb, 1mb, 100mb');
 
@@ -36,3 +71,4 @@ SELECT * FROM paradedb.combined_layer_sizes('mock_items_1_idx');
 
 DROP TABLE mock_items_1;
 DROP TABLE mock_items_2;
+DROP TABLE mock_items_not_ready;


### PR DESCRIPTION
## What

Backports #5279 ("skip not-ready BM25 indexes in index info") to `0.24.x` for the 0.24.2 patch. Fixes the `REINDEX INDEX CONCURRENTLY` crash:

```
could not read blocks 0..0 ... read only 0 of 8192 bytes
```

caused by `index_layer_info` enumerating transient `*_ccnew` BM25 relations before their storage is ready.

## Why this rides along with index_layer_info

The `index_layer_info` view re-emission that drifted into main's released delta (re-homed onto the 0.24.2 path in the companion main PR #5418) is just the **SQL half** of #5279. The actual fix is in the Rust code (`is_usable()` guards in `index_info()` / `rel.rs`, plus the base-schema view definitions). The views are meaningless without it, so the whole PR is backported here.

## Migration / versioning

Mirrors the #5281 backport (#5417): the version is already `0.24.2` and the `index_layer_info` view re-emission is placed on the `0.24.1 → 0.24.2` upgrade path, **not** the released `0.24.0--0.24.1.sql`. The resulting `pg_search--0.24.1--0.24.2.sql` is now **byte-identical to main's** (boolean overloads + index_layer_info views).

## Stacking

⚠️ **Stacked on #5417** (base branch `backport-5281-to-0.24.x`). Merge #5417 first; GitHub will retarget this to `0.24.x`. Reviewing against the #5417 branch keeps this diff limited to #5279's own changes.

Companion to main PRs #5415 / #5418 and the #5281 backport #5417.