### PR TITLE
ci: guard against editing already-released migration scripts

### DIFF
--- a/.github/workflows/check-released-migrations.yml
+++ b/.github/workflows/check-released-migrations.yml
@@ -1,0 +1,38 @@
+# workflows/check-released-migrations.yml
+#
+# Check Released Migrations
+# Fails a PR that edits a pg_search migration script whose target version is
+# already released (a `vY` tag exists), since such edits never reach users
+# already on that version. New schema must go on the current upgrade path after
+# bumping the workspace version -- see RELEASE.md.
+
+name: Check Released Migrations
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main, 0.*.x]
+    paths: ["pg_search/sql/**"]
+
+jobs:
+  check-released-migrations:
+    name: Check Released Migrations
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Reject edits to already-released migrations
+        run: |
+          fail=0
+          for f in $(git diff --name-only --diff-filter=AMD \
+              "${{ github.event.pull_request.base.sha }}...HEAD" \
+              -- 'pg_search/sql/pg_search--*--*.sql'); do
+            target="${f##*--}"; target="${target%.sql}"
+            if git rev-parse -q --verify "refs/tags/v$target" >/dev/null; then
+              echo "::error file=$f::Edits released migration (v$target is tagged). Bump workspace.package.version and add the change to a new pg_search--<released>--<next>.sql script instead. See RELEASE.md."
+              fail=1
+            fi
+          done
+          exit $fail

--- a/.github/workflows/check-released-migrations.yml
+++ b/.github/workflows/check-released-migrations.yml
@@ -2,7 +2,7 @@
 #
 # Check Released Migrations
 # Fails a PR that edits a pg_search migration script whose target version is
-# already released (a `vY` tag exists), since such edits never reach users
+# already released (a `vX.Y.Z` tag exists), since such edits never reach users
 # already on that version. New schema must go on the current upgrade path after
 # bumping the workspace version -- see RELEASE.md.
 
@@ -11,19 +11,23 @@ name: Check Released Migrations
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main, 0.*.x]
-    paths: ["pg_search/sql/**"]
+    branches:
+      - main
+      - 0.*.x # Release branches
+    paths:
+      - "pg_search/sql/**"
 
 jobs:
   check-released-migrations:
     name: Check Released Migrations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - name: Checkout Git Repository
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
-      - name: Reject edits to already-released migrations
+      - name: Reject Edits to Already-Released Migrations
         run: |
           fail=0
           for f in $(git diff --name-only --diff-filter=AMD \
@@ -31,7 +35,7 @@ jobs:
               -- 'pg_search/sql/pg_search--*--*.sql'); do
             target="${f##*--}"; target="${target%.sql}"
             if git rev-parse -q --verify "refs/tags/v$target" >/dev/null; then
-              echo "::error file=$f::Edits released migration (v$target is tagged). Bump workspace.package.version and add the change to a new pg_search--<released>--<next>.sql script instead. See RELEASE.md."
+              echo "::error file=$f::Edits released migration (v$target is tagged). Bump workspace.package.version in Cargo.toml and add the change to a new pg_search--<released>--<next>.sql script instead. See RELEASE.md."
               fail=1
             fi
           done

--- a/.github/workflows/check-released-migrations.yml
+++ b/.github/workflows/check-released-migrations.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          fetch-tags: true # Required: the check resolves release tags locally
 
       - name: Reject Edits to Already-Released Migrations
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,8 +64,13 @@ To publish a patch for an older release:
 ## Post-Release Steps
 
 1. **Verify** that the GitHub Release and GitHub Tag properly created and that all jobs completed.
-2. **Open a post-release PR** against `main` to bump `Cargo.toml` to the next development version (e.g. `0.25.0` or `0.25.0-rc.1`).
-3. **Merge** that PR so `main` reflects ongoing work.
-4. **Release** `paradedb/paradedb-enterprise`, `paradedb/charts` and `paradedb/terraform-paradedb-byoc`. More context to come here as we automate more of the release flow.
+2. **Release** `paradedb/paradedb-enterprise`, `paradedb/charts` and `paradedb/terraform-paradedb-byoc`. More context to come here as we automate more of the release flow.
+3. **Open a post-release PR** against `main` to bump `Cargo.toml` to the next development version (e.g. `0.24.2` if the previous version was `0.24.1`), run `cargo check` to refresh `Cargo.lock`, and merge it so `main` reflects ongoing work.
+
+> [!IMPORTANT]
+> **Do step 3 before merging any new schema work.** Until `main` is bumped, the
+> current upgrade script targets the version you just released, so it's frozen —
+> changes added to it never reach users already on that version. The
+> **Check Released Migrations** CI guard enforces this.
 
 That's it! Go for a walk, you deserve it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -64,7 +64,7 @@ To publish a patch for an older release:
 ## Post-Release Steps
 
 1. **Verify** that the GitHub Release and GitHub Tag properly created and that all jobs completed.
-2. **Release** `paradedb/paradedb-enterprise`, `paradedb/charts` and `paradedb/terraform-paradedb-byoc`. More context to come here as we automate more of the release flow.
+2. **Release** `paradedb/paradedb-enterprise` by following the instructions in the repository's RELEASE.md file.
 3. **Open a post-release PR** against `main` to bump `Cargo.toml` to the next development version (e.g. `0.24.2` if the previous version was `0.24.1`), run `cargo check` to refresh `Cargo.lock`, and merge it so `main` reflects ongoing work.
 
 > [!IMPORTANT]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -63,7 +63,7 @@ To publish a patch for an older release:
 
 ## Post-Release Steps
 
-1. **Verify** that the GitHub Release and GitHub Tag properly created and that all jobs completed.
+1. **Verify** that the GitHub Release and GitHub Tag properly created and that all jobs completed successfully.
 2. **Release** `paradedb/paradedb-enterprise` by following the instructions in the repository's RELEASE.md file.
 3. **Open a post-release PR** against `main` to bump `Cargo.toml` to the next development version (e.g. `0.24.2` if the previous version was `0.24.1`), run `cargo check` to refresh `Cargo.lock`, and merge it so `main` reflects ongoing work.
 


### PR DESCRIPTION
Fails a PR that edits a `pg_search--X--Y.sql` migration whose target version `Y` is already released (a `vY` tag exists). Once `vY` ships, that file is frozen — anyone already on `Y` never re-runs it, so changes added afterward never reach them. This is how `minimum_should_match` (#5281) and `index_layer_info` (#5279) got stranded in the shipped `0.24.0--0.24.1.sql`.

- Inline workflow (diff the PR, parse the target version, fail if `vY` is tagged) — no separate script.
- Override with the `migration-allow-released-edit` label for deliberate edits.
- RELEASE.md notes the rule on the existing post-release version-bump step.

Verified locally: flags edits to `0.24.0--0.24.1.sql` (v0.24.1 released), passes edits to `0.24.1--0.24.2.sql` (unreleased).