### PR TITLE
feat: added opt-in disk spilling behind `paradedb.spill_to_disk`.

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -157,6 +157,11 @@ static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// a raw per-inbox byte count.
 static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(8 * 1024 * 1024);
 
+/// Opt-in disk spilling for the DataFusion `work_mem` pool used by JoinScan and
+/// AggregateScan (serial and MPP). Off (default) keeps the `ResourcesExhausted` error on
+/// overflow; on lets large sorts and aggregates spill to disk and complete.
+static SPILL_TO_DISK: GucSetting<bool> = GucSetting::<bool>::new(false);
+
 /// The maximum size of an InList that can be pushed down to a TermSet Query.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
     GucSetting::<i32>::new(16 * 1024 * 1024);
@@ -646,6 +651,17 @@ pub fn init() {
         GucContext::Userset,
         GucFlags::UNIT_BYTE,
     );
+
+    GucRegistry::define_bool_guc(
+        c"paradedb.spill_to_disk",
+        c"Let JoinScan and AggregateScan spill to disk instead of erroring on work_mem overflow",
+        c"When off (default), a query that exceeds `work_mem` on the DataFusion path returns a \
+          `ResourcesExhausted` error. When on, it spills to disk so large sorts and aggregates \
+          complete.",
+        &SPILL_TO_DISK,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
 }
 
 pub fn enable_custom_scan() -> bool {
@@ -845,6 +861,10 @@ pub fn mpp_debug() -> bool {
 
 pub fn mpp_trace() -> bool {
     MPP_TRACE.get()
+}
+
+pub fn spill_to_disk() -> bool {
+    SPILL_TO_DISK.get()
 }
 
 pub fn mpp_queue_size() -> usize {

--- a/pg_search/src/postgres/customscan/datafusion/memory.rs
+++ b/pg_search/src/postgres/customscan/datafusion/memory.rs
@@ -28,11 +28,9 @@ use std::sync::Arc;
 /// Caps DataFusion allocations at PostgreSQL's `work_mem` and reports an overflow as a
 /// query error. A panic here used to abort the backend: on the MPP path the pool runs in
 /// a parallel worker, so the panic took down the whole server instead of failing the one
-/// query. The caller pairs this with a disabled disk manager, so a `try_grow` past the
-/// limit aborts the query rather than spilling to untracked temp files.
-///
-// TODO: spill through PostgreSQL's temp-file management (BufFile/VFD) so large
-// aggregates and sorts complete instead of erroring once `work_mem` is exceeded.
+/// query. With `paradedb.spill_to_disk` off (the default), the caller pairs this with a disabled
+/// disk manager (see [`spill_disk_manager`]), so a `try_grow` past the limit aborts the query;
+/// with it on, sorts and aggregates spill instead.
 #[derive(Debug)]
 struct WorkMemMemoryPool {
     pool: GreedyMemoryPool,
@@ -112,19 +110,72 @@ pub fn create_memory_pool(
     Arc::new(WorkMemMemoryPool::new(total_memory.max(work_mem)))
 }
 
-/// Build the DataFusion `RuntimeEnv` for JoinScan and AggregateScan: the `work_mem` pool plus a
-/// disabled disk manager, so a `try_grow` past the budget errors instead of writing untracked
-/// temp files. Spilling isn't wired to PG's temp-file management yet.
+/// Build the DataFusion `RuntimeEnv` for JoinScan and AggregateScan: the `work_mem` pool plus the
+/// spill disk manager. With `paradedb.spill_to_disk` off (the default) spilling is disabled, so a
+/// `try_grow` past the budget errors instead of writing temp files; with it on, sorts and
+/// aggregates spill.
 pub fn build_runtime_env(memory_pool: Arc<dyn MemoryPool>) -> Arc<RuntimeEnv> {
     Arc::new(
         RuntimeEnvBuilder::new()
             .with_memory_pool(memory_pool)
-            .with_disk_manager_builder(
-                DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled),
-            )
+            .with_disk_manager_builder(spill_disk_manager())
             .build()
             .expect("Failed to create RuntimeEnv"),
     )
+}
+/// Disk-manager config for the JoinScan and AggregateScan DataFusion runtimes (serial and MPP),
+/// gated on `paradedb.spill_to_disk`.
+///
+/// Off (default): spilling is disabled, so a `work_mem` overflow surfaces as the
+/// `ResourcesExhausted` error from [`WorkMemMemoryPool`]. On: DataFusion spills sorts and
+/// aggregates to a per-backend subdirectory of PostgreSQL's temp directory and the query
+/// completes. DataFusion gives each `RuntimeEnv` its own `datafusion-*` sub-subdirectory and
+/// removes it when the runtime drops, so concurrent fragments in one backend don't collide.
+///
+/// These spill files use DataFusion's own OS temp-file backend, so they don't count against
+/// `temp_file_limit` and aren't tied to PG's per-transaction cleanup. PG removes `base/pgsql_tmp`
+/// on restart, which clears anything an aborted query leaked.
+///
+// TODO: spill through PostgreSQL's BufFile so spill files respect `temp_file_limit` and
+// `temp_tablespaces` and are cleaned up with the transaction, once DataFusion's spill engine
+// takes a pluggable temp-file backend.
+#[cfg(not(test))]
+pub fn spill_disk_manager() -> DiskManagerBuilder {
+    if !crate::gucs::spill_to_disk() {
+        return DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled);
+    }
+    let dir = pg_search_spill_dir();
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        pgrx::warning!(
+            "paradedb.spill_to_disk: could not create spill directory {}: {e}; spilling stays off",
+            dir.display()
+        );
+        return DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled);
+    }
+    DiskManagerBuilder::default().with_mode(DiskManagerMode::Directories(vec![dir]))
+}
+
+/// The lib-test binary doesn't link PG globals and never drives a real query, so spilling is
+/// inert there.
+#[cfg(test)]
+pub fn spill_disk_manager() -> DiskManagerBuilder {
+    DiskManagerBuilder::default().with_mode(DiskManagerMode::Disabled)
+}
+
+/// Per-backend spill directory under PG's temp-file directory (`<DataDir>/base/pgsql_tmp`), so
+/// spill files land on the data volume and PG's startup cleanup removes any crash residue.
+#[cfg(not(test))]
+fn pg_search_spill_dir() -> std::path::PathBuf {
+    // SAFETY: `DataDir` and `MyProcPid` are set once at startup and read-only thereafter; this
+    // runs on the backend thread.
+    let data_dir = unsafe { std::ffi::CStr::from_ptr(pgrx::pg_sys::DataDir) }
+        .to_string_lossy()
+        .into_owned();
+    let pid = unsafe { pgrx::pg_sys::MyProcPid };
+    std::path::Path::new(&data_dir)
+        .join("base")
+        .join("pgsql_tmp")
+        .join(format!("pgsql_tmp_pg_search.{pid}"))
 }
 
 #[cfg(test)]

--- a/pg_search/tests/pg_regress/expected/spill_to_disk.out
+++ b/pg_search/tests/pg_regress/expected/spill_to_disk.out
@@ -1,0 +1,119 @@
+-- =====================================================================
+-- Disk spilling (`paradedb.spill_to_disk`), serial and MPP.
+--
+-- Off (default), a `work_mem` overflow on the DataFusion path returns a clean
+-- error. On, DataFusion spills to disk and large aggregates complete, both for
+-- serial JoinScan/AggregateScan and for MPP.
+--
+-- For MPP, spilling that fails (a budget too small to spill even one batch) must
+-- still tear the parallel group down without crashing the backend: the in-flight
+-- spill tasks hold DSM-backed handles, and the fix in datafusion-distributed
+-- flips a detach flag so dropping them after the segment unmaps no-ops instead
+-- of faulting.
+--
+-- Outcomes are caught and recorded as branch labels so the result stays
+-- independent of exact byte counts; a crash would drop the connection and the
+-- expected output wouldn't match.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+CREATE TABLE spd_files (id SERIAL PRIMARY KEY, title TEXT, content TEXT);
+CREATE TABLE spd_pages (id SERIAL PRIMARY KEY, file_id INTEGER, page_text TEXT);
+INSERT INTO spd_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+-- High group cardinality (one group per page id) so the hash aggregate overruns
+-- a small pool well before it can finish.
+INSERT INTO spd_pages (file_id, page_text)
+SELECT (g % 200) + 1, 'Page text for page ' || g
+FROM generate_series(1, 400000) AS g;
+CREATE INDEX spd_files_idx ON spd_files
+USING bm25 (id, title, content)
+WITH (key_field='id', text_fields='{"title": {"fast": true}, "content": {}}');
+CREATE INDEX spd_pages_idx ON spd_pages
+USING bm25 (id, file_id, page_text)
+WITH (key_field='id', numeric_fields='{"file_id": {"fast": true}}', text_fields='{"page_text": {}}');
+WARNING:  only 2 parallel workers were available for index build
+ANALYZE spd_files;
+ANALYZE spd_pages;
+CREATE TABLE spd_outcome (msg text);
+-- A 400k-group hash aggregate over the join overruns a 1MB pool.
+SET work_mem TO '1MB';
+-- Serial (no MPP): off errors, on spills and completes.
+SET paradedb.enable_mpp TO off;
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('serial off: unexpected success');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('serial off: clean error');
+END$$;
+SET paradedb.spill_to_disk TO on;
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('serial on: completed');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('serial on: errored');
+END$$;
+-- MPP: the same aggregate spills across workers and completes.
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 4;
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('mpp on: completed');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('mpp on: errored');
+END$$;
+-- MPP, but a 64kB pool can't hold even one spill batch, so spilling fails. The
+-- teardown still must not crash the backend (the detach-flag fix).
+SET work_mem TO '64kB';
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('mpp tiny: unexpected success');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('mpp tiny: clean error');
+END$$;
+RESET work_mem;
+SET paradedb.spill_to_disk TO off;
+SELECT msg FROM spd_outcome ORDER BY msg;
+           msg           
+-------------------------
+ mpp on: completed
+ mpp tiny: clean error
+ serial off: clean error
+ serial on: completed
+(4 rows)
+
+-- The backend survived every teardown and still serves on the same connection.
+SELECT count(*) AS files_still_readable
+FROM spd_files
+WHERE content @@@ 'Section';
+ files_still_readable 
+----------------------
+                  200
+(1 row)
+
+DROP TABLE spd_outcome;
+DROP TABLE spd_pages;
+DROP TABLE spd_files;

--- a/pg_search/tests/pg_regress/sql/spill_to_disk.sql
+++ b/pg_search/tests/pg_regress/sql/spill_to_disk.sql
@@ -1,0 +1,122 @@
+-- =====================================================================
+-- Disk spilling (`paradedb.spill_to_disk`), serial and MPP.
+--
+-- Off (default), a `work_mem` overflow on the DataFusion path returns a clean
+-- error. On, DataFusion spills to disk and large aggregates complete, both for
+-- serial JoinScan/AggregateScan and for MPP.
+--
+-- For MPP, spilling that fails (a budget too small to spill even one batch) must
+-- still tear the parallel group down without crashing the backend: the in-flight
+-- spill tasks hold DSM-backed handles, and the fix in datafusion-distributed
+-- flips a detach flag so dropping them after the segment unmaps no-ops instead
+-- of faulting.
+--
+-- Outcomes are caught and recorded as branch labels so the result stays
+-- independent of exact byte counts; a crash would drop the connection and the
+-- expected output wouldn't match.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+CREATE TABLE spd_files (id SERIAL PRIMARY KEY, title TEXT, content TEXT);
+CREATE TABLE spd_pages (id SERIAL PRIMARY KEY, file_id INTEGER, page_text TEXT);
+
+INSERT INTO spd_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+-- High group cardinality (one group per page id) so the hash aggregate overruns
+-- a small pool well before it can finish.
+INSERT INTO spd_pages (file_id, page_text)
+SELECT (g % 200) + 1, 'Page text for page ' || g
+FROM generate_series(1, 400000) AS g;
+
+CREATE INDEX spd_files_idx ON spd_files
+USING bm25 (id, title, content)
+WITH (key_field='id', text_fields='{"title": {"fast": true}, "content": {}}');
+
+CREATE INDEX spd_pages_idx ON spd_pages
+USING bm25 (id, file_id, page_text)
+WITH (key_field='id', numeric_fields='{"file_id": {"fast": true}}', text_fields='{"page_text": {}}');
+
+ANALYZE spd_files;
+ANALYZE spd_pages;
+
+CREATE TABLE spd_outcome (msg text);
+
+-- A 400k-group hash aggregate over the join overruns a 1MB pool.
+SET work_mem TO '1MB';
+
+-- Serial (no MPP): off errors, on spills and completes.
+SET paradedb.enable_mpp TO off;
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('serial off: unexpected success');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('serial off: clean error');
+END$$;
+
+SET paradedb.spill_to_disk TO on;
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('serial on: completed');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('serial on: errored');
+END$$;
+
+-- MPP: the same aggregate spills across workers and completes.
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 4;
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('mpp on: completed');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('mpp on: errored');
+END$$;
+
+-- MPP, but a 64kB pool can't hold even one spill batch, so spilling fails. The
+-- teardown still must not crash the backend (the detach-flag fix).
+SET work_mem TO '64kB';
+DO $$
+BEGIN
+    PERFORM p.id, count(*)
+    FROM spd_files f JOIN spd_pages p ON f.id = p.file_id
+    WHERE f.content @@@ 'Section'
+    GROUP BY p.id;
+    INSERT INTO spd_outcome VALUES ('mpp tiny: unexpected success');
+EXCEPTION WHEN OTHERS THEN
+    INSERT INTO spd_outcome VALUES ('mpp tiny: clean error');
+END$$;
+
+RESET work_mem;
+SET paradedb.spill_to_disk TO off;
+SELECT msg FROM spd_outcome ORDER BY msg;
+
+-- The backend survived every teardown and still serves on the same connection.
+SELECT count(*) AS files_still_readable
+FROM spd_files
+WHERE content @@@ 'Section';
+
+DROP TABLE spd_outcome;
+DROP TABLE spd_pages;
+DROP TABLE spd_files;


### PR DESCRIPTION
This PR adds opt-in disk spilling behind `paradedb.spill_to_disk` (default off).

First increment of #4064.

## Why

Off (the default), a `work_mem` overflow on the DataFusion path returns a clean error, the #5336 behavior. On, DataFusion spills sorts and aggregates to disk and large queries complete instead of erroring. The flag gates the DataFusion disk manager used by JoinScan (serial and MPP) and AggregateScan MPP, so it is named generally rather than `mpp_spill`.

Enabling spilling exposed a teardown use-after-free. The spill path leaves in-flight tasks holding DSM-backed ring handles, and PG unmaps the parallel segment during transaction abort before those handles drop (a memory-context reset drops the tokio runtime after the segment is already gone). Cancelling the tasks then read freed shared memory and `SIGSEGV`d the leader.

## How

- `paradedb.spill_to_disk` GUC, default off. `spill_disk_manager()` routes spilling to a per-backend subdirectory of `base/pgsql_tmp`; off keeps the disk manager disabled so an overflow errors.
- The fork bump (datafusion-distributed#26) gives every ring handle an out-of-DSM `alive` flag, checked before each shared-memory access and on `Drop`. An `on_dsm_detach` hook flips it through `MppMesh::mark_detached` while the segment is still mapped, so a handle dropped after teardown no-ops instead of faulting.

## Tests

`mpp_spill` regress test: at `work_mem = 1MB` the MPP `GROUP BY` aggregate errors with `spill_to_disk` off and completes with it on; at 64kB, spilling fails (the pool can't hold even one spill batch) but the teardown no longer crashes the backend. `mpp_workmem` still passes against the bumped fork rev.

## Relationship to #4064

#4064 (JOINs: M3) asks for spilling through PostgreSQL's `BufFile` so spill files respect `temp_file_limit` and `temp_tablespaces` and are cleaned up with the transaction. This PR delivers the spilling and the teardown-crash fix, but on DataFusion's OS temp-file backend (cleanup via `base/pgsql_tmp` removal at restart, no `temp_file_limit`). DataFusion 54's spill engine is path-based with no pluggable backend, so the `BufFile` `DiskManager` is a separate `paradedb/datafusion` fork change that closes #4064 on top of this.

## Follow-ups

- `BufFile` `DiskManager` (closes #4064): respect `temp_file_limit` / `temp_tablespaces`, transaction-scoped cleanup.
- Only the leader arms the detach hook (the observed crash was leader-only). Arming workers too is defensive symmetry.
