### PR TITLE
ci: disable ThinLTO for instrumented Antithesis build (fixes undefined-symbol initdb crash)

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -193,7 +193,7 @@ jobs:
           CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
             cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH"
 
-      # Catch the broken-symbol case above before shipping to Antithesis (a 6h run away).
+      # Catch the broken-symbol case above before shipping to Antithesis.
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.
       - name: Verify pg_search Has No Unresolved Rust Symbols
         run: |

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -182,7 +182,8 @@ jobs:
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           cargo pgrx init --pg${{ env.PG_VERSION }}=$PG_CONFIG_PATH
 
-      # ThinLTO drops Rust symbols under the sancov pass, breaking dlopen — disable LTO here.
+      # The Antithesis build adds a sancov pass (-Cpasses=sancov-module) for coverage instrumentation.
+      # ThinLTO drops Rust symbols under that pass, producing a pg_search.so that fails to dlopen, so disable LTO here.
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
         run: |
@@ -192,6 +193,7 @@ jobs:
           CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
             cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH"
 
+      # Catch the broken-symbol case above before shipping to Antithesis (a 6h run away).
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.
       - name: Verify pg_search Has No Unresolved Rust Symbols
         run: |

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -182,16 +182,9 @@ jobs:
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           cargo pgrx init --pg${{ env.PG_VERSION }}=$PG_CONFIG_PATH
 
+      # ThinLTO drops Rust symbols under the sancov pass, breaking dlopen — disable LTO here.
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
-        # CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off disables ThinLTO for this build only.
-        # The release profile uses `lto = "thin"`, which is incompatible with the manually
-        # injected sancov pass (`-Cpasses=sancov-module`): ThinLTO internalizes/drops a
-        # monomorphized function in the module that defines it while another module keeps an
-        # external reference, producing a pg_search.so with an undefined Rust symbol (e.g.
-        # `datafusion_sql::utils::rebase_expr`) that fails to dlopen inside CloudNativePG's
-        # initdb. Coverage-instrumented builds don't benefit from LTO, so turning it off is
-        # the surgical fix and leaves production builds untouched.
         run: |
           sudo curl -fsSL -o /usr/lib/libvoidstar.so https://antithesis.com/assets/instrumentation/libvoidstar.so
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
@@ -199,11 +192,8 @@ jobs:
           CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
             cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH"
 
+      # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.
       - name: Verify pg_search Has No Unresolved Rust Symbols
-        # A Postgres extension legitimately leaves its C API symbols (palloc, elog, …)
-        # undefined — the backend resolves them at LOAD time. But an undefined *Rust* symbol
-        # (mangled `_ZN…`/`_R…`) means codegen/LTO dropped a definition and the .so will fail
-        # to dlopen. Fail here in seconds rather than 6 hours later in Antithesis.
         run: |
           LIB_PATH="target/release-with-debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
           undefined_rust="$(nm -D -u "$LIB_PATH" | awk '{print $NF}' | grep -E '^_(ZN|R)' || true)"

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -184,11 +184,35 @@ jobs:
 
       - name: Package pg_search Extension with pgrx
         working-directory: pg_search/
+        # CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off disables ThinLTO for this build only.
+        # The release profile uses `lto = "thin"`, which is incompatible with the manually
+        # injected sancov pass (`-Cpasses=sancov-module`): ThinLTO internalizes/drops a
+        # monomorphized function in the module that defines it while another module keeps an
+        # external reference, producing a pg_search.so with an undefined Rust symbol (e.g.
+        # `datafusion_sql::utils::rebase_expr`) that fails to dlopen inside CloudNativePG's
+        # initdb. Coverage-instrumented builds don't benefit from LTO, so turning it off is
+        # the surgical fix and leaves production builds untouched.
         run: |
           sudo curl -fsSL -o /usr/lib/libvoidstar.so https://antithesis.com/assets/instrumentation/libvoidstar.so
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -lvoidstar" \
+          CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
             cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH"
+
+      - name: Verify pg_search Has No Unresolved Rust Symbols
+        # A Postgres extension legitimately leaves its C API symbols (palloc, elog, …)
+        # undefined — the backend resolves them at LOAD time. But an undefined *Rust* symbol
+        # (mangled `_ZN…`/`_R…`) means codegen/LTO dropped a definition and the .so will fail
+        # to dlopen. Fail here in seconds rather than 6 hours later in Antithesis.
+        run: |
+          LIB_PATH="target/release-with-debug/pg_search-pg${{ env.PG_VERSION }}/usr/lib/postgresql/${{ env.PG_VERSION }}/lib/pg_search.so"
+          undefined_rust="$(nm -D -u "$LIB_PATH" | awk '{print $NF}' | grep -E '^_(ZN|R)' || true)"
+          if [ -n "$undefined_rust" ]; then
+            echo "::error::pg_search.so has unresolved Rust symbols — the build is broken and would fail to load:"
+            echo "$undefined_rust"
+            exit 1
+          fi
+          echo "OK: pg_search.so has no unresolved Rust symbols"
 
       - name: Split pg_search Debug Symbols
         run: |


### PR DESCRIPTION
## Problem

The nightly Antithesis runs for `bbe51ae56` went deep red: 6 `initdb` container exits, every `quickstart/singleton_driver_*.sh` workload failing, and 15 proptests panicking with `could not create test database`. All of it traces to one broken artifact — the `initdb` container loops on:

```
FATAL: could not load library ".../pg_search.so": undefined symbol:
  _ZN14datafusion_sql5utils11rebase_expr17h1e00999ce900a318E   (= datafusion_sql::utils::rebase_expr)
```

The GitHub Actions build is green because the link *succeeds* — the `.so` only fails at `dlopen` time inside CloudNativePG's `initdb`.

## Root cause

The Antithesis image is compiled with a manually injected sancov pass:

```
RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 ..."
cargo pgrx package --profile=release-with-debug
```

`release-with-debug` inherits `[profile.release]`, which sets **`lto = "thin"`**. ThinLTO and a forced custom pass pipeline (`-Cpasses=`) are incompatible: ThinLTO does per-module compilation with import/internalization bookkeeping, and the injected pass disrupts it — a monomorphized function (`datafusion_sql::utils::rebase_expr`) gets internalized/dropped in the module that defines it while another module keeps an external reference. Result: a dangling undefined Rust symbol in the final `cdylib`.

Two facts confirm this is a link/codegen artifact, not a dependency issue:
- `rebase_expr` **exists** in our pinned DataFusion fork (54.0.0 @ `65a35ad`) — nothing was removed or version-skewed.
- Only the Antithesis image is affected. Production `.deb`/Docker builds don't pass `-Cpasses=sancov-module`, so they link cleanly — which is why everything else is green.

It surfaced now because the build profile switched from fat to thin LTO (#5160). Under fat LTO all modules merge before optimization, so there's no cross-module internalization step to corrupt and the sancov injection was benign.

## Fix

1. **`CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off`** on the package step — disables LTO for this instrumented build only. Coverage builds don't benefit from LTO, and production builds are untouched.
2. **A fail-fast symbol check** after packaging: a Postgres extension legitimately leaves its C API symbols (`palloc`, `elog`, …) undefined, but an undefined *Rust* symbol (`_ZN…`/`_R…`) means codegen dropped a definition. We now reject such a `.so` in seconds instead of discovering it 6 hours into an Antithesis run.

## Sync note

Raised in `paradedb/paradedb`; this workflow is synced to `paradedb-enterprise`, where the failing nightly runs occurred.