### PR TITLE
test: Antithesis control run for #5425 (do not merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,5 @@ We welcome contributions of all sizes! Check out our [good first issues](https:/
 ## License
 
 ParadeDB Community is licensed under the [GNU Affero General Public License v3.0](LICENSE). For [ParadeDB Enterprise](https://docs.paradedb.com/deploy/enterprise) licensing, contact [sales@paradedb.com](mailto:sales@paradedb.com).
+
+<!-- antithesis control run for PR #5425: intentionally reproduces the pre-fix ThinLTO undefined-symbol failure. Do not merge. -->


### PR DESCRIPTION
## Control run — do not merge

This PR exists only to trigger an **ephemeral** Antithesis run from current `main` **without** the ThinLTO fix in #5425, as a control.

- **Expected result:** reproduces the failure — `initdb` exits 1 on `undefined symbol: datafusion_sql::utils::rebase_expr`, the cluster never becomes ready, and the stressgres workload fails.
- **Compare against:** #5425, which disables ThinLTO for the instrumented build and should come up clean.

The only diff is an inert HTML comment in `README.md`; the build path is untouched. PR-triggered Antithesis runs are ephemeral (`antithesis.is_ephemeral=true`), so this does not affect the tracked history.

Close once the control run has reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
