### PR TITLE
feat(mpp): enabled MPP plan partitioning by default.

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -131,8 +131,8 @@ static DYNAMIC_FILTER_BATCH_SIZE: GucSetting<i32> = GucSetting::<i32>::new(0);
 static ENABLE_SEGMENTED_TOPK: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// Gate the MPP (Massively Parallel Processing) plan partitioning path for JoinScan
-/// and AggregateScan. When off, behavior is identical to `origin/main`.
-static ENABLE_MPP: GucSetting<bool> = GucSetting::<bool>::new(false);
+/// and AggregateScan. When off, behavior is identical to the non-MPP path.
+static ENABLE_MPP: GucSetting<bool> = GucSetting::<bool>::new(true);
 
 /// When on, `mpp_log!()` routes through `pgrx::warning!()` so runtime traces appear in
 /// the Postgres server log (and in CI benchmark logs). When off, `mpp_log!()` is a no-op.
@@ -555,7 +555,7 @@ pub fn init() {
         c"Enable ParadeDB's MPP (Massively Parallel Processing) plan partitioning",
         c"When enabled, JoinScan and AggregateScan may hash-partition every table by the \
           join key and shuffle intermediate rows between workers, so each row is scanned \
-          exactly once. Default is false; off path is identical to non-MPP behavior.",
+          exactly once. Default is true; turn it off to fall back to the non-MPP path.",
         &ENABLE_MPP,
         GucContext::Userset,
         GucFlags::default(),

--- a/pg_search/src/postgres/customscan/mpp/mod.rs
+++ b/pg_search/src/postgres/customscan/mpp/mod.rs
@@ -19,7 +19,7 @@
 //!
 //! Hash-partitions every table by the join key and shuffles intermediate rows between
 //! workers through PostgreSQL `shm_mq` queues, so each row is scanned exactly once.
-//! Guarded by `paradedb.enable_mpp` (default off).
+//! Guarded by `paradedb.enable_mpp` (default on).
 //!
 //! The transport lives in `datafusion_distributed::shm`. Deadlock avoidance is a
 //! cooperative inline drain: a producer stalled on a full outbound pulls its own inbound

--- a/pg_search/tests/pg_regress/expected/issue_4779.out
+++ b/pg_search/tests/pg_regress/expected/issue_4779.out
@@ -185,8 +185,8 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
 WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
 WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
 WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
-                                                         QUERY PLAN                                                         
-----------------------------------------------------------------------------------------------------------------------------
+                                                          QUERY PLAN                                                          
+------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: (m SEMI b) SEMI a
@@ -194,17 +194,23 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
          Limit: 10
          Order By: m.id desc
          DataFusion Physical Plan: 
-           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
-           :   SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[false]
-           :     VisibilityFilterExec: tables=[m]
-           :       HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           :         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-(18 rows)
+           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           : │   SortPreservingMergeExec: [id@1 DESC], fetch=10
+           : │     SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
+           : │       VisibilityFilterExec: tables=[m]
+           : │         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           : │           CoalescePartitionsExec
+           : │             [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           : │             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   │ HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :   │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :   │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │     PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :   └──────────────────────────────────────────────────
+(24 rows)
 
 DROP TABLE t_main_4779, t_a_4779, t_b_4779 CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_4910.out
+++ b/pg_search/tests/pg_regress/expected/issue_4910.out
@@ -79,29 +79,41 @@ WHERE
     AND contact_id @@@ paradedb.range(field => 'contact_id', range => '(0,)'::int8range)
 ORDER BY revenue_rank DESC NULLS LAST, contact_id ASC
 LIMIT 25;
-                                                                                             QUERY PLAN                                                                                              
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
-   ->  Gather Merge
-         Workers Planned: 1
-         ->  Parallel Custom Scan (ParadeDB Join Scan)
-               Relation Tree: (cccf ANTI cne) SEMI ce
-               Join Cond: cccf.company_id = ce.company_id, cne.company_id = cccf.company_id
-               Limit: 25
-               Order By: cccf.revenue_rank desc nulls last, cccf.contact_id asc
-               DataFusion Physical Plan: 
-                 : ProjectionExec: expr=[contact_id@3 as col_1, company_id@1 as col_2, revenue_rank@2 as col_3, ctid_0@0 as ctid_0]
-                 :   SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[false]
-                 :     VisibilityFilterExec: tables=[cccf]
-                 :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
-                 :         CooperativeExec
-                 :           PgSearchScan: segments=1, query="all"
-                 :         HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
-(20 rows)
+   ->  Custom Scan (ParadeDB Join Scan)
+         Relation Tree: (cccf ANTI cne) SEMI ce
+         Join Cond: cccf.company_id = ce.company_id, cne.company_id = cccf.company_id
+         Limit: 25
+         Order By: cccf.revenue_rank desc nulls last, cccf.contact_id asc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : │ ProjectionExec: expr=[contact_id@3 as col_1, company_id@1 as col_2, revenue_rank@2 as col_3, ctid_0@0 as ctid_0]
+           : │   SortPreservingMergeExec: [revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], fetch=25
+           : │     [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   │ SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[true]
+           :   │   VisibilityFilterExec: tables=[cccf]
+           :   │     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
+           :   │       CoalescePartitionsExec
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │       HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
+           :   │         CoalescePartitionsExec
+           :   │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, query="all"
+           :     └──────────────────────────────────────────────────
+           :     ┌───── Stage 2 ── Tasks: t0:[p0..p2]
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
+           :     └──────────────────────────────────────────────────
+(32 rows)
 
 -- Result rows in parallel mode (verifies correctness, not just plan shape).
 SELECT contact_id, company_id, revenue_rank

--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -18,7 +18,7 @@ LOAD 'pg_search';
 SHOW paradedb.enable_mpp;
  paradedb.enable_mpp 
 ---------------------
- off
+ on
 (1 row)
 
 SHOW paradedb.mpp_debug;
@@ -39,11 +39,11 @@ SHOW paradedb.mpp_queue_size;
  64MB
 (1 row)
 
--- Defaults: MPP is off until explicitly enabled.
-SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
- enable_mpp_default_off 
-------------------------
- f
+-- Defaults: MPP is on; the debug knob stays off.
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_on;
+ enable_mpp_default_on 
+-----------------------
+ t
 (1 row)
 
 SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;

--- a/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
+++ b/pg_search/tests/pg_regress/expected/prepared_statement_parallel.out
@@ -52,7 +52,10 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
   AND c.dwf_doid @@@ paradedb.match('author', 'brian griffin')
   AND c.created_at::date >= $2::date
   AND c.created_at::date <= $3::date;
--- Execute multiple times to trigger generic plan
+-- The auto custom-to-generic switch is cost-based, so it lands differently across
+-- machines. Pin custom plans here and cover generic plans in the block below, so the
+-- per-plan planning warning is the same everywhere.
+SET plan_cache_mode = force_custom_plan;
 -- All executions should return consistent results
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
@@ -89,7 +92,6 @@ WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE c
    122
 (1 row)
 
--- 6th execution should use generic plan and return same result
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
@@ -99,6 +101,7 @@ WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE c
 
 -- Try with different parameters
 EXECUTE test_parallel_join('ea', '2024-06-01', '2025-01-01');
+WARNING:  Aggregate Scan (DataFusion) not used: cross-table predicate in WHERE clause cannot be pushed into the aggregate scan (table: join)
  count 
 -------
     72

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -22,8 +22,8 @@ SHOW paradedb.mpp_debug;
 SHOW paradedb.mpp_worker_count;
 SHOW paradedb.mpp_queue_size;
 
--- Defaults: MPP is off until explicitly enabled.
-SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_off;
+-- Defaults: MPP is on; the debug knob stays off.
+SELECT current_setting('paradedb.enable_mpp')::bool AS enable_mpp_default_on;
 SELECT current_setting('paradedb.mpp_debug')::bool AS mpp_debug_default_off;
 SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default;
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_default;

--- a/pg_search/tests/pg_regress/sql/prepared_statement_parallel.sql
+++ b/pg_search/tests/pg_regress/sql/prepared_statement_parallel.sql
@@ -57,15 +57,17 @@ WHERE dt.dwf_doid @@@ paradedb.parse_with_field('full_text', $1)
   AND c.created_at::date >= $2::date
   AND c.created_at::date <= $3::date;
 
--- Execute multiple times to trigger generic plan
+-- The auto custom-to-generic switch is cost-based, so it lands differently across
+-- machines. Pin custom plans here and cover generic plans in the block below, so the
+-- per-plan planning warning is the same everywhere.
+SET plan_cache_mode = force_custom_plan;
+
 -- All executions should return consistent results
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
-
--- 6th execution should use generic plan and return same result
 EXECUTE test_parallel_join('ea', '2024-01-01', '2025-01-01');
 
 -- Try with different parameters


### PR DESCRIPTION
## What

This PR enables MPP plan partitioning by default.

## Why

MPP has lived behind `paradedb.enable_mpp`, off by default. With it on, JoinScan and AggregateScan hash-partition each table by the join key and shuffle intermediate rows between workers, so every row is scanned once.

## How

`paradedb.enable_mpp` now defaults to `true`. Turn it off to fall back to the non-MPP path.

## Tests

Existing tests.
