### PR TITLE
fix(mpp): set the leader's `ParallelScanState` for JoinScan execution.

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1027,6 +1027,10 @@ impl JoinScan {
             args,
             partitioning_idx,
         ) {
+            // The leader runs the top fragment itself. When a non-partitioning source lands there
+            // (the SEMI/ANTI broadcast strategy), its scan claims per-source segments against the
+            // same shared state the workers use, so the codec needs this pointer to install it.
+            state.custom_state_mut().parallel_state = Some(leader.parallel_state);
             state.custom_state_mut().mpp = Some(leader);
         }
     }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -49,6 +49,7 @@ use crate::gucs::{
     enable_mpp, mpp_queue_size as gucs_mpp_queue_size, mpp_worker_count as gucs_mpp_worker_count,
 };
 use crate::postgres::customscan::mpp::pg_seams::{pack_receiver, PgInterrupt, PgWakeup};
+use crate::postgres::ParallelScanState;
 
 /// Minimum total procs for MPP: leader (consumer-only) plus at least 2 producers. Single
 /// source of truth so [`mpp_is_active`] and [`mpp_worker_count`] don't drift on the
@@ -146,6 +147,12 @@ pub struct MppLeaderState {
     /// the workers and destroy the parallel context. `None` until `launch` installs it on the
     /// success path.
     pub finish: Option<crate::parallel_worker::builder::ParallelProcessFinish>,
+    /// The shared `ParallelScanState` the leader populated in DSM. The leader runs the top fragment
+    /// itself, and a non-partitioning source can land there (e.g. the SEMI/ANTI broadcast strategy),
+    /// where the scan claims per-source segments against this state just like a worker. The leader
+    /// stashes it on its custom state so the codec installs it into those providers. Null until
+    /// `launch` sets it.
+    pub parallel_state: *mut ParallelScanState,
 }
 
 /// The `(pgprocno, pid)` of this backend, packed into the receiver token the transport stores so a
@@ -222,6 +229,7 @@ pub unsafe fn leader_setup(
         stage_plans: std::sync::Mutex::new(stage_plans),
         plans_delivered: std::sync::atomic::AtomicBool::new(false),
         finish: None,
+        parallel_state: std::ptr::null_mut(),
     })
 }
 

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -283,6 +283,7 @@ fn launch_mpp(
     go.store(GO_RUN, Ordering::Release);
 
     leader.finish = Some(finish);
+    leader.parallel_state = scan_ptr;
     Some(leader)
 }
 


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR gives the MPP leader its shared `ParallelScanState` so SEMI/ANTI joins don't crash the backend.

## Why

The leader runs the top fragment itself. The SEMI/ANTI broadcast strategy lands a non-partitioning scan in the leader's own fragment, and that scan claims its per-source segments against the shared `ParallelScanState`. The leader never received that state, so the claim hit a null pointer and crashed the backend.

It's latent on `main` since `paradedb.enable_mpp` is off by default. It surfaces as soon as MPP is on.

## How

The leader launches workers through the builder, not a PG `Gather`, so `initialize_dsm_custom_scan` never runs and the leader's `parallel_state` stayed null. Normal joins survive because the leader only scans the partitioning source (`mpp_source_idx = None`), which doesn't claim per-source. The SEMI/ANTI broadcast strategy puts a non-partitioning (`mpp_source_idx = Some`) scan in the leader fragment, which does.

The fix threads the leader's already-populated `ParallelScanState` through `MppLeaderState` onto the scan's custom state, so the codec installs it. The leader then participates in the shared per-source claim like a worker.

## Tests

Reproduces with `SET paradedb.enable_mpp = on` on a SEMI/ANTI join; `joinscan-subquery-parallel-rti` is the regress case. Before the fix the backend crashes mid-query; with it, the query executes via MPP and returns correct rows. The full `pg_regress` suite passes (behavior is unchanged with the default still off).
