### PR TITLE
feat(tokenizers): expose Lindera NFKC normalization and reading-form options

### DIFF
--- a/docs/documentation/tokenizers/available-tokenizers/lindera.mdx
+++ b/docs/documentation/tokenizers/available-tokenizers/lindera.mdx
@@ -58,3 +58,33 @@ SELECT 'Hello world! 你好!'::pdb.lindera(chinese, 'keep_whitespace=true')::tex
  {hello," ",world,!," ",你好,!}
 (1 row)
 ```
+
+## NFKC Normalization
+
+Set `nfkc` to `true` to apply [Unicode NFKC normalization](https://unicode.org/reports/tr15/) to the text before it is segmented. This collapses compatibility characters such as full-width Latin letters and digits to their canonical half-width forms, so that, for example, `ＡＢＣ` and `ABC` produce the same tokens.
+
+```sql
+SELECT 'ＡＢＣ１２３'::pdb.lindera(japanese, 'nfkc=true', 'lowercase=false')::text[];
+```
+
+```ini Expected Response
+   text
+----------
+ {ABC,123}
+(1 row)
+```
+
+## Reading Form
+
+Set `reading_form` to `true` to replace each token with its dictionary reading form after segmentation. For Japanese (IPADIC), the surface form is replaced with its katakana reading; for Korean (KoDic), Hanja are replaced with their Hangul reading. This is supported for Japanese and Korean only.
+
+```sql
+SELECT '日本語'::pdb.lindera(japanese, 'reading_form=true', 'lowercase=false')::text[];
+```
+
+```ini Expected Response
+    text
+------------
+ {ニホンゴ}
+(1 row)
+```

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -575,6 +575,8 @@ pub(crate) mod pdb {
             language: LinderaLanguage::Chinese,
             filters: SearchTokenizerFilters::default(),
             keep_whitespace: false,
+            nfkc: false,
+            reading_form: false,
         },
         tokenize_lindera,
         json_to_lindera,

--- a/pg_search/src/api/tokenizers/mod.rs
+++ b/pg_search/src/api/tokenizers/mod.rs
@@ -88,6 +88,8 @@ fn tokenizer_from_name(name: &str) -> Option<SearchTokenizer> {
             language: LinderaLanguage::default(),
             filters: SearchTokenizerFilters::default(),
             keep_whitespace: false,
+            nfkc: false,
+            reading_form: false,
         },
         "icu" => SearchTokenizer::ICUTokenizer(SearchTokenizerFilters::default()),
         "jieba" => SearchTokenizer::Jieba {
@@ -207,6 +209,8 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
             language,
             filters,
             keep_whitespace,
+            nfkc,
+            reading_form,
         } => {
             if let Some(s) = parsed.try_get("language", 0).and_then(|p| p.as_str()) {
                 let lcase = s.to_lowercase();
@@ -220,6 +224,17 @@ fn apply_expression_params(tokenizer: &mut SearchTokenizer, parsed: &typmod::Par
             *filters = SearchTokenizerFilters::from(parsed);
             if let Some(v) = parsed.get("keep_whitespace").and_then(|p| p.as_bool()) {
                 *keep_whitespace = v;
+            }
+            if let Some(v) = parsed.get("nfkc").and_then(|p| p.as_bool()) {
+                *nfkc = v;
+            }
+            if let Some(v) = parsed.get("reading_form").and_then(|p| p.as_bool()) {
+                *reading_form = v;
+            }
+            if *reading_form && *language == LinderaLanguage::Chinese {
+                pgrx::error!(
+                    "reading_form=true is not supported for the Lindera Chinese tokenizer"
+                );
             }
         }
         SearchTokenizer::Jieba {
@@ -416,6 +431,8 @@ pub fn apply_typmod(tokenizer: &mut SearchTokenizer, typmod: Typmod) {
             language,
             filters,
             keep_whitespace,
+            nfkc,
+            reading_form,
         } => {
             let lindera_typmod = LinderaTypmod::try_from(typmod).unwrap_or_else(|e| {
                 panic!("{}", e);
@@ -423,6 +440,8 @@ pub fn apply_typmod(tokenizer: &mut SearchTokenizer, typmod: Typmod) {
             *language = lindera_typmod.language;
             *filters = lindera_typmod.filters;
             *keep_whitespace = lindera_typmod.keep_whitespace;
+            *nfkc = lindera_typmod.nfkc;
+            *reading_form = lindera_typmod.reading_form;
         }
 
         SearchTokenizer::ChineseLindera {

--- a/pg_search/src/api/tokenizers/typmod/definitions.rs
+++ b/pg_search/src/api/tokenizers/typmod/definitions.rs
@@ -70,6 +70,8 @@ pub struct LinderaTypmod {
     pub language: LinderaLanguage,
     pub filters: SearchTokenizerFilters,
     pub keep_whitespace: bool,
+    pub nfkc: bool,
+    pub reading_form: bool,
 }
 
 // for pdb.unicode_words
@@ -188,6 +190,8 @@ impl TypmodRules for LinderaTypmod {
                 positional = 0
             ),
             rule!("keep_whitespace", ValueConstraint::Boolean),
+            rule!("nfkc", ValueConstraint::Boolean),
+            rule!("reading_form", ValueConstraint::Boolean),
         ]
     }
 }
@@ -352,10 +356,23 @@ impl TryFrom<i32> for LinderaTypmod {
             .get("keep_whitespace")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
+        let nfkc = parsed
+            .get("nfkc")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let reading_form = parsed
+            .get("reading_form")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if reading_form && language == LinderaLanguage::Chinese {
+            panic!("reading_form=true is not supported for the Lindera Chinese tokenizer");
+        }
         Ok(LinderaTypmod {
             language,
             filters,
             keep_whitespace,
+            nfkc,
+            reading_form,
         })
     }
 }

--- a/pg_search/src/index/search.rs
+++ b/pg_search/src/index/search.rs
@@ -69,9 +69,7 @@ pub fn setup_tokenizers(index_relation: &PgSearchRelation, index: &mut Index) ->
                     tokenizers.push(SearchTokenizer::KoreanLinderaDeprecated(filters.clone()));
                 }
                 SearchTokenizer::Lindera {
-                    language,
-                    filters,
-                    keep_whitespace: _,
+                    language, filters, ..
                 } => {
                     tokenizers.push(SearchTokenizer::LinderaDeprecated(
                         language.clone(),

--- a/pg_search/tests/pg_regress/expected/test_tokenizer_params.out
+++ b/pg_search/tests/pg_regress/expected/test_tokenizer_params.out
@@ -32,9 +32,9 @@ CREATE INDEX idx_ngram ON test_tokenizer_params
 USING bm25 (id, (content::pdb.ngram(2, 4, 'prefix_only=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_ngram;
--- lindera: language
+-- lindera: language, nfkc, reading_form
 CREATE INDEX idx_lindera ON test_tokenizer_params
-USING bm25 (id, (content::pdb.lindera('japanese')))
+USING bm25 (id, (content::pdb.lindera('japanese', 'nfkc=true', 'reading_form=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_lindera;
 -- regex: pattern
@@ -99,7 +99,7 @@ ERROR:  Invalid option: 'language'. Allowed options: alias, alpha_num_only, asci
 CREATE INDEX idx_bad ON test_tokenizer_params
 USING bm25 (id, (content::pdb.lindera('chinese', 'min=2')))
 WITH (key_field = 'id');
-ERROR:  Invalid option: 'min'. Allowed options: alias, alpha_num_only, ascii_folding, b, columnar, fieldnorms, k1, keep_whitespace, language, lowercase, normalizer, remove_long, remove_short, stemmer, stopwords, stopwords_language, trim.
+ERROR:  Invalid option: 'min'. Allowed options: alias, alpha_num_only, ascii_folding, b, columnar, fieldnorms, k1, keep_whitespace, language, lowercase, nfkc, normalizer, reading_form, remove_long, remove_short, stemmer, stopwords, stopwords_language, trim.
 -------------------------------------------------------------
 -- Cleanup
 -------------------------------------------------------------

--- a/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
+++ b/pg_search/tests/pg_regress/expected/tokenizer-typmod.out
@@ -159,6 +159,52 @@ SELECT 'Running Shoes.  olé'::pdb.lindera(korean, 'keep_whitespace=false', 'low
  {Running,Shoes,.,olé}
 (1 row)
 
+-- nfkc: a character filter applied before segmentation. With nfkc=true the
+-- full-width characters ＡＢＣ１２３ are normalized to half-width ABC / 123.
+-- The off vs on pair proves the option changes the token stream.
+SELECT 'ＡＢＣ１２３'::pdb.lindera(japanese, 'lowercase=false')::text[];
+       text        
+-------------------
+ {ＡＢＣ,１,２,３}
+(1 row)
+
+SELECT 'ＡＢＣ１２３'::pdb.lindera(japanese, 'nfkc=true', 'lowercase=false')::text[];
+   text    
+-----------
+ {ABC,123}
+(1 row)
+
+-- reading_form: a token filter applied after segmentation. For Japanese the
+-- surface form 日本語 is replaced with its IPADIC katakana reading ニホンゴ.
+SELECT '日本語'::pdb.lindera(japanese, 'lowercase=false')::text[];
+   text   
+----------
+ {日本語}
+(1 row)
+
+SELECT '日本語'::pdb.lindera(japanese, 'reading_form=true', 'lowercase=false')::text[];
+    text    
+------------
+ {ニホンゴ}
+(1 row)
+
+-- reading_form for Korean replaces the Hanja 韓國 with its ko-dic Hangul
+-- reading 한국.
+SELECT '韓國'::pdb.lindera(korean, 'lowercase=false')::text[];
+  text  
+--------
+ {韓國}
+(1 row)
+
+SELECT '韓國'::pdb.lindera(korean, 'reading_form=true', 'lowercase=false')::text[];
+  text  
+--------
+ {한국}
+(1 row)
+
+-- reading_form is rejected for Chinese, which has no reading field.
+SELECT '韓國'::pdb.lindera(chinese, 'reading_form=true', 'lowercase=false')::text[]; -- error
+ERROR:  reading_form=true is not supported for the Lindera Chinese tokenizer
 SELECT 'Running Shoes.  olé'::pdb.jieba::text[];
                 text                
 ------------------------------------

--- a/pg_search/tests/pg_regress/sql/test_tokenizer_params.sql
+++ b/pg_search/tests/pg_regress/sql/test_tokenizer_params.sql
@@ -36,9 +36,9 @@ USING bm25 (id, (content::pdb.ngram(2, 4, 'prefix_only=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_ngram;
 
--- lindera: language
+-- lindera: language, nfkc, reading_form
 CREATE INDEX idx_lindera ON test_tokenizer_params
-USING bm25 (id, (content::pdb.lindera('japanese')))
+USING bm25 (id, (content::pdb.lindera('japanese', 'nfkc=true', 'reading_form=true')))
 WITH (key_field = 'id');
 DROP INDEX idx_lindera;
 

--- a/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
+++ b/pg_search/tests/pg_regress/sql/tokenizer-typmod.sql
@@ -33,6 +33,22 @@ SELECT 'Running Shoes.  olé'::pdb.lindera(korean, 'lowercase=false', 'stemmer=e
 SELECT 'Running Shoes.  olé'::pdb.lindera(korean, 'keep_whitespace=true', 'lowercase=false')::text[];
 SELECT 'Running Shoes.  olé'::pdb.lindera(korean, 'keep_whitespace=false', 'lowercase=false')::text[];
 
+-- nfkc: a character filter applied before segmentation. With nfkc=true the
+-- full-width characters ＡＢＣ１２３ are normalized to half-width ABC / 123.
+-- The off vs on pair proves the option changes the token stream.
+SELECT 'ＡＢＣ１２３'::pdb.lindera(japanese, 'lowercase=false')::text[];
+SELECT 'ＡＢＣ１２３'::pdb.lindera(japanese, 'nfkc=true', 'lowercase=false')::text[];
+-- reading_form: a token filter applied after segmentation. For Japanese the
+-- surface form 日本語 is replaced with its IPADIC katakana reading ニホンゴ.
+SELECT '日本語'::pdb.lindera(japanese, 'lowercase=false')::text[];
+SELECT '日本語'::pdb.lindera(japanese, 'reading_form=true', 'lowercase=false')::text[];
+-- reading_form for Korean replaces the Hanja 韓國 with its ko-dic Hangul
+-- reading 한국.
+SELECT '韓國'::pdb.lindera(korean, 'lowercase=false')::text[];
+SELECT '韓國'::pdb.lindera(korean, 'reading_form=true', 'lowercase=false')::text[];
+-- reading_form is rejected for Chinese, which has no reading field.
+SELECT '韓國'::pdb.lindera(chinese, 'reading_form=true', 'lowercase=false')::text[]; -- error
+
 SELECT 'Running Shoes.  olé'::pdb.jieba::text[];
 SELECT 'Running Shoes.  olé'::pdb.jieba('lowercase=false')::text[];
 SELECT 'Running Shoes.  olé'::pdb.jieba('lowercase=false', 'stemmer=english', 'ascii_folding=true')::text[];

--- a/tokenizers/src/lindera.rs
+++ b/tokenizers/src/lindera.rs
@@ -24,68 +24,154 @@
  * By using this file, you agree to comply with the AGPL v3.0 terms.
  *
  */
+use lindera::character_filter::unicode_normalize::{
+    UnicodeNormalizeCharacterFilter, UnicodeNormalizeKind,
+};
+use lindera::character_filter::BoxCharacterFilter;
 use lindera::dictionary::load_dictionary;
 use lindera::mode::Mode;
 use lindera::token::Token as LinderaToken;
+use lindera::token_filter::japanese_reading_form::JapaneseReadingFormTokenFilter;
+use lindera::token_filter::korean_reading_form::KoreanReadingFormTokenFilter;
+use lindera::token_filter::BoxTokenFilter;
 use lindera::tokenizer::Tokenizer as LinderaTokenizer;
-use once_cell::sync::Lazy;
+use once_cell::sync::{Lazy, OnceCell};
 use std::sync::Arc;
 use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
 
-static CMN_TOKENIZER_KEEP_WHITESPACE: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary = load_dictionary("embedded://cc-cedict")
-        .expect("Lindera `cc-cedict` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(true),
-    ))
-});
-static CMN_TOKENIZER: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary = load_dictionary("embedded://cc-cedict")
-        .expect("Lindera `cc-cedict` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(false),
-    ))
-});
+/// The set of configurable options that distinguish one cached Lindera
+/// tokenizer from another. Each unique combination maps to a single lazily
+/// built tokenizer instance per language (see [`LinderaOptions::index`]).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct LinderaOptions {
+    keep_whitespace: bool,
+    /// Apply Unicode NFKC normalization as a character filter, before
+    /// segmentation.
+    nfkc: bool,
+    /// Replace each token's surface form with its dictionary reading form, as
+    /// a token filter, after segmentation. Only meaningful for Japanese and
+    /// Korean.
+    reading_form: bool,
+}
 
-static JPN_TOKENIZER_KEEP_WHITESPACE: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ipadic").expect("Lindera `ipadic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(true),
-    ))
-});
-static JPN_TOKENIZER: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ipadic").expect("Lindera `ipadic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(false),
-    ))
-});
+impl LinderaOptions {
+    const fn new(keep_whitespace: bool, nfkc: bool, reading_form: bool) -> Self {
+        Self {
+            keep_whitespace,
+            nfkc,
+            reading_form,
+        }
+    }
 
-static KOR_TOKENIZER_KEEP_WHITESPACE: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ko-dic").expect("Lindera `ko-dic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(true),
-    ))
-});
-static KOR_TOKENIZER: Lazy<Arc<LinderaTokenizer>> = Lazy::new(|| {
-    let dictionary =
-        load_dictionary("embedded://ko-dic").expect("Lindera `ko-dic` dictionary must be present");
-    Arc::new(LinderaTokenizer::new(
-        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None).keep_whitespace(false),
-    ))
-});
+    /// A dense index in `0..8` derived from the three boolean options, used to
+    /// address the per-language tokenizer cache.
+    const fn index(self) -> usize {
+        (self.keep_whitespace as usize)
+            | ((self.nfkc as usize) << 1)
+            | ((self.reading_form as usize) << 2)
+    }
+}
+
+/// Which reading-form token filter, if any, a language supports.
+#[derive(Clone, Copy)]
+enum ReadingForm {
+    None,
+    Japanese,
+    Korean,
+}
+
+/// Build a Lindera tokenizer for `dictionary_uri`, appending the NFKC
+/// character filter and the reading-form token filter when the corresponding
+/// options are set.
+fn build_lindera_tokenizer(
+    dictionary_uri: &str,
+    dictionary_name: &str,
+    options: LinderaOptions,
+    reading_form: ReadingForm,
+) -> Arc<LinderaTokenizer> {
+    let dictionary = load_dictionary(dictionary_uri)
+        .unwrap_or_else(|_| panic!("Lindera `{dictionary_name}` dictionary must be present"));
+    let mut tokenizer = LinderaTokenizer::new(
+        lindera::segmenter::Segmenter::new(Mode::Normal, dictionary, None)
+            .keep_whitespace(options.keep_whitespace),
+    );
+
+    if options.nfkc {
+        tokenizer.append_character_filter(BoxCharacterFilter::from(
+            UnicodeNormalizeCharacterFilter::new(UnicodeNormalizeKind::NFKC),
+        ));
+    }
+
+    if options.reading_form {
+        match reading_form {
+            ReadingForm::None => {}
+            ReadingForm::Japanese => {
+                tokenizer.append_token_filter(BoxTokenFilter::from(
+                    JapaneseReadingFormTokenFilter::new(),
+                ));
+            }
+            ReadingForm::Korean => {
+                tokenizer
+                    .append_token_filter(BoxTokenFilter::from(KoreanReadingFormTokenFilter::new()));
+            }
+        }
+    }
+
+    Arc::new(tokenizer)
+}
+
+// One lazily built tokenizer per option combination per language. There are
+// only three boolean options, so eight slots cover every combination.
+static CMN_TOKENIZERS: Lazy<[OnceCell<Arc<LinderaTokenizer>>; 8]> =
+    Lazy::new(|| std::array::from_fn(|_| OnceCell::new()));
+static JPN_TOKENIZERS: Lazy<[OnceCell<Arc<LinderaTokenizer>>; 8]> =
+    Lazy::new(|| std::array::from_fn(|_| OnceCell::new()));
+static KOR_TOKENIZERS: Lazy<[OnceCell<Arc<LinderaTokenizer>>; 8]> =
+    Lazy::new(|| std::array::from_fn(|_| OnceCell::new()));
+
+fn chinese_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
+    CMN_TOKENIZERS[options.index()].get_or_init(|| {
+        build_lindera_tokenizer(
+            "embedded://cc-cedict",
+            "cc-cedict",
+            options,
+            ReadingForm::None,
+        )
+    })
+}
+
+fn japanese_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
+    JPN_TOKENIZERS[options.index()].get_or_init(|| {
+        build_lindera_tokenizer(
+            "embedded://ipadic",
+            "ipadic",
+            options,
+            ReadingForm::Japanese,
+        )
+    })
+}
+
+fn korean_tokenizer(options: LinderaOptions) -> &'static Arc<LinderaTokenizer> {
+    KOR_TOKENIZERS[options.index()].get_or_init(|| {
+        build_lindera_tokenizer("embedded://ko-dic", "ko-dic", options, ReadingForm::Korean)
+    })
+}
 
 #[derive(Clone, Default)]
 pub struct LinderaChineseTokenizer {
-    keep_whitespace: bool,
+    options: LinderaOptions,
     token: Token,
 }
 impl LinderaChineseTokenizer {
     pub fn new(keep_whitespace: bool) -> Self {
+        Self::with_options(keep_whitespace, false)
+    }
+
+    pub fn with_options(keep_whitespace: bool, nfkc: bool) -> Self {
         Self {
-            keep_whitespace,
+            // Chinese (cc-cedict) has no reading field, so reading_form is
+            // always false here.
+            options: LinderaOptions::new(keep_whitespace, nfkc, false),
             token: Default::default(),
         }
     }
@@ -94,12 +180,16 @@ impl LinderaChineseTokenizer {
 #[derive(Clone, Default)]
 pub struct LinderaJapaneseTokenizer {
     token: Token,
-    keep_whitespace: bool,
+    options: LinderaOptions,
 }
 impl LinderaJapaneseTokenizer {
     pub fn new(keep_whitespace: bool) -> Self {
+        Self::with_options(keep_whitespace, false, false)
+    }
+
+    pub fn with_options(keep_whitespace: bool, nfkc: bool, reading_form: bool) -> Self {
         Self {
-            keep_whitespace,
+            options: LinderaOptions::new(keep_whitespace, nfkc, reading_form),
             token: Default::default(),
         }
     }
@@ -107,13 +197,17 @@ impl LinderaJapaneseTokenizer {
 
 #[derive(Clone, Default)]
 pub struct LinderaKoreanTokenizer {
-    keep_whitespace: bool,
+    options: LinderaOptions,
     token: Token,
 }
 impl LinderaKoreanTokenizer {
     pub fn new(keep_whitespace: bool) -> Self {
+        Self::with_options(keep_whitespace, false, false)
+    }
+
+    pub fn with_options(keep_whitespace: bool, nfkc: bool, reading_form: bool) -> Self {
         Self {
-            keep_whitespace,
+            options: LinderaOptions::new(keep_whitespace, nfkc, reading_form),
             token: Default::default(),
         }
     }
@@ -127,11 +221,7 @@ impl Tokenizer for LinderaChineseTokenizer {
             return MultiLanguageTokenStream::Empty;
         }
 
-        let tokenizer = if self.keep_whitespace {
-            &CMN_TOKENIZER_KEEP_WHITESPACE
-        } else {
-            &CMN_TOKENIZER
-        };
+        let tokenizer = chinese_tokenizer(self.options);
 
         let lindera_token_stream = LinderaTokenStream {
             tokens: tokenizer
@@ -152,11 +242,7 @@ impl Tokenizer for LinderaJapaneseTokenizer {
             return MultiLanguageTokenStream::Empty;
         }
 
-        let tokenizer = if self.keep_whitespace {
-            &JPN_TOKENIZER_KEEP_WHITESPACE
-        } else {
-            &JPN_TOKENIZER
-        };
+        let tokenizer = japanese_tokenizer(self.options);
 
         let lindera_token_stream = LinderaTokenStream {
             tokens: tokenizer
@@ -177,11 +263,7 @@ impl Tokenizer for LinderaKoreanTokenizer {
             return MultiLanguageTokenStream::Empty;
         }
 
-        let tokenizer = if self.keep_whitespace {
-            &KOR_TOKENIZER_KEEP_WHITESPACE
-        } else {
-            &KOR_TOKENIZER
-        };
+        let tokenizer = korean_tokenizer(self.options);
 
         let lindera_token_stream = LinderaTokenStream {
             tokens: tokenizer
@@ -330,6 +412,76 @@ mod tests {
             assert_eq!(token.position, 0);
             assert_eq!(token.position_length, 1);
         }
+    }
+
+    fn token_texts<T: Tokenizer>(tokenizer: &mut T, text: &str) -> Vec<String> {
+        test_helper(tokenizer, text)
+            .iter()
+            .map(|token| token.text.clone())
+            .collect()
+    }
+
+    // NFKC is a character filter that runs before segmentation. Enabling it
+    // normalizes full-width compatibility characters (e.g. "ＡＢＣ１２３") to
+    // their canonical half-width forms, which then also changes how they
+    // segment. The OFF/ON comparison proves the option is not a no-op.
+    #[rstest]
+    fn test_lindera_japanese_tokenizer_with_nfkc() {
+        let input = "ＡＢＣ１２３";
+
+        let mut off = LinderaJapaneseTokenizer::with_options(false, false, false);
+        let off_tokens = token_texts(&mut off, input);
+        assert_eq!(off_tokens, vec!["ＡＢＣ", "１", "２", "３"]);
+
+        let mut on = LinderaJapaneseTokenizer::with_options(false, true, false);
+        let on_tokens = token_texts(&mut on, input);
+        assert_eq!(on_tokens, vec!["ABC", "123"]);
+
+        assert_ne!(
+            off_tokens, on_tokens,
+            "nfkc must change the token stream; otherwise the option is a no-op"
+        );
+    }
+
+    // The Japanese reading-form token filter runs after segmentation and
+    // replaces each recognized token's surface form with its IPADIC reading
+    // (katakana). "日本語" -> "ニホンゴ".
+    #[rstest]
+    fn test_lindera_japanese_tokenizer_with_reading_form() {
+        let input = "日本語";
+
+        let mut off = LinderaJapaneseTokenizer::with_options(false, false, false);
+        let off_tokens = token_texts(&mut off, input);
+        assert_eq!(off_tokens, vec!["日本語"]);
+
+        let mut on = LinderaJapaneseTokenizer::with_options(false, false, true);
+        let on_tokens = token_texts(&mut on, input);
+        assert_eq!(on_tokens, vec!["ニホンゴ"]);
+
+        assert_ne!(
+            off_tokens, on_tokens,
+            "reading_form must change the token stream; otherwise the option is a no-op"
+        );
+    }
+
+    // The Korean reading-form token filter replaces Hanja (Chinese-character)
+    // tokens with their ko-dic Hangul reading. "韓國" -> "한국".
+    #[rstest]
+    fn test_lindera_korean_tokenizer_with_reading_form() {
+        let input = "韓國";
+
+        let mut off = LinderaKoreanTokenizer::with_options(false, false, false);
+        let off_tokens = token_texts(&mut off, input);
+        assert_eq!(off_tokens, vec!["韓國"]);
+
+        let mut on = LinderaKoreanTokenizer::with_options(false, false, true);
+        let on_tokens = token_texts(&mut on, input);
+        assert_eq!(on_tokens, vec!["한국"]);
+
+        assert_ne!(
+            off_tokens, on_tokens,
+            "reading_form must change the token stream; otherwise the option is a no-op"
+        );
     }
 
     #[rstest]

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -412,6 +412,8 @@ pub enum SearchTokenizer {
         language: LinderaLanguage,
         filters: SearchTokenizerFilters,
         keep_whitespace: bool,
+        nfkc: bool,
+        reading_form: bool,
     },
     UnicodeWordsDeprecated {
         remove_emojis: bool,
@@ -628,13 +630,22 @@ impl SearchTokenizer {
             SearchTokenizer::ChineseLindera {
                 filters,
                 keep_whitespace,
+            } => {
+                add_filters!(LinderaChineseTokenizer::new(*keep_whitespace), filters)
             }
-            | SearchTokenizer::Lindera {
+            SearchTokenizer::Lindera {
                 language: LinderaLanguage::Chinese,
                 filters,
                 keep_whitespace,
+                nfkc,
+                // reading_form is not supported for Chinese; it is rejected at
+                // parse time and ignored here.
+                reading_form: _,
             } => {
-                add_filters!(LinderaChineseTokenizer::new(*keep_whitespace), filters)
+                add_filters!(
+                    LinderaChineseTokenizer::with_options(*keep_whitespace, *nfkc),
+                    filters
+                )
             }
             SearchTokenizer::JapaneseLinderaDeprecated(filters)
             | SearchTokenizer::LinderaDeprecated(LinderaLanguage::Japanese, filters) => {
@@ -643,13 +654,20 @@ impl SearchTokenizer {
             SearchTokenizer::JapaneseLindera {
                 filters,
                 keep_whitespace,
+            } => {
+                add_filters!(LinderaJapaneseTokenizer::new(*keep_whitespace), filters)
             }
-            | SearchTokenizer::Lindera {
+            SearchTokenizer::Lindera {
                 language: LinderaLanguage::Japanese,
                 filters,
                 keep_whitespace,
+                nfkc,
+                reading_form,
             } => {
-                add_filters!(LinderaJapaneseTokenizer::new(*keep_whitespace), filters)
+                add_filters!(
+                    LinderaJapaneseTokenizer::with_options(*keep_whitespace, *nfkc, *reading_form),
+                    filters
+                )
             }
             SearchTokenizer::KoreanLinderaDeprecated(filters)
             | SearchTokenizer::LinderaDeprecated(LinderaLanguage::Korean, filters) => {
@@ -658,13 +676,20 @@ impl SearchTokenizer {
             SearchTokenizer::KoreanLindera {
                 filters,
                 keep_whitespace,
+            } => {
+                add_filters!(LinderaKoreanTokenizer::new(*keep_whitespace), filters)
             }
-            | SearchTokenizer::Lindera {
+            SearchTokenizer::Lindera {
                 language: LinderaLanguage::Korean,
                 filters,
                 keep_whitespace,
+                nfkc,
+                reading_form,
             } => {
-                add_filters!(LinderaKoreanTokenizer::new(*keep_whitespace), filters)
+                add_filters!(
+                    LinderaKoreanTokenizer::with_options(*keep_whitespace, *nfkc, *reading_form),
+                    filters
+                )
             }
             SearchTokenizer::ICUTokenizer(filters) => {
                 add_filters!(ICUTokenizer, filters)
@@ -852,20 +877,31 @@ impl SearchTokenizer {
                 language,
                 filters: _,
                 keep_whitespace,
-            } => match language {
-                LinderaLanguage::Unspecified => {
-                    panic!("LinderaStyle::Unspecified is not supported")
-                }
-                LinderaLanguage::Chinese => {
-                    format!("chinese_lindera_keepwhitespace:{keep_whitespace}{filters_suffix}")
-                }
-                LinderaLanguage::Japanese => {
-                    format!("japanese_lindera_keepwhitespace:{keep_whitespace}{filters_suffix}")
-                }
-                LinderaLanguage::Korean => {
-                    format!("korean_lindera_keepwhitespace:{keep_whitespace}{filters_suffix}")
-                }
-            },
+                nfkc,
+                reading_form,
+            } => {
+                // Only emit option suffixes when the option is enabled, so that
+                // the name of a tokenizer with no extra options is byte-for-byte
+                // identical to what previous versions produced. This keeps
+                // existing indexes valid across upgrades.
+                let nfkc_suffix = if *nfkc { "_nfkc:true" } else { "" };
+                let reading_form_suffix = if *reading_form {
+                    "_readingform:true"
+                } else {
+                    ""
+                };
+                let lang = match language {
+                    LinderaLanguage::Unspecified => {
+                        panic!("LinderaStyle::Unspecified is not supported")
+                    }
+                    LinderaLanguage::Chinese => "chinese",
+                    LinderaLanguage::Japanese => "japanese",
+                    LinderaLanguage::Korean => "korean",
+                };
+                format!(
+                    "{lang}_lindera_keepwhitespace:{keep_whitespace}{nfkc_suffix}{reading_form_suffix}{filters_suffix}"
+                )
+            }
             SearchTokenizer::ICUTokenizer(_filters) => format!("icu{filters_suffix}"),
             SearchTokenizer::Jieba {
                 chinese_convert,


### PR DESCRIPTION
# Ticket(s) Closed
- Closes #4808

## What
Adds two Lindera tokenizer options — `nfkc` (NFKC Unicode normalization) and `reading_form` (Japanese / Korean reading-form) — exposed through the pgrx typmod layer as fields on the existing `Lindera` tokenizer variant.

## Why
#4808 asks to expose Lindera's NFKC normalization and IPADIC / ko-dic reading-form alignment, which the underlying `lindera` crate already supports but `pg_search` did not surface. NFKC folds compatibility characters (e.g. full-width Latin letters and digits) to their canonical forms before segmentation; reading-form maps tokens to their kana / hangul reading after segmentation.

This re-submits the feature from #5140, which was closed for red CI (not a design rejection) with an invitation to re-open once tests pass. #5140 added a new `SearchTokenizer::LinderaWithOptions` variant, which surfaced a `lindera_with_options` row in `paradedb.tokenizers()` and broke the `list_tokenizers` golden-list test. This implementation instead adds the options as fields on the existing `Lindera` variant, mirroring the merged `keep_whitespace` template (#4481), so the tokenizer registry stays at 23 entries and `list_tokenizers` passes. Credit to @dask-58 for the original groundwork in #5140.

## How
- `nfkc` is wired as a Lindera `unicode_normalize` character filter (NFKC kind); `reading_form` as the `japanese_reading_form` / `korean_reading_form` token filters, selected by the active dictionary (Chinese reading-form is unsupported and returns a clear error).
- The per-language tokenizer cache key widens from one bool (`keep_whitespace`) to three; `LinderaOptions::index()` packs the three bools into a dense `0..8` index over a per-language `OnceCell` array, since each option alters the produced token stream and must be baked into the cached instance.

## Tests
- `cargo test -p tokenizers lindera` — 14/14, including discriminating off→on cases: `ＡＢＣ１２３` → `{ABC, 123}` with NFKC; `日本語` → `{ニホンゴ}` with Japanese reading-form.
- `cargo pgrx regress pg18` — `tokenizer-typmod` and `test_tokenizer_params` pass; `list_tokenizers` (the test #5140 broke) passes.
- `cargo fmt --check` and `cargo clippy -D warnings` clean.
