### PR TITLE
docs(pg_search): document shared_preload_libraries requirement for cargo pgrx run

### DIFF
--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -56,7 +56,13 @@ PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make install
 
 ## Running the Extension
 
-Start an interactive Postgres session with the extension built and loaded:
+`pg_search` must be loaded via `shared_preload_libraries`. Before running for the first time, add it to the pgrx-managed `postgresql.conf` (replace `18` with your target version):
+
+```bash
+echo "shared_preload_libraries = 'pg_search'" >> ~/.pgrx/data-18/postgresql.conf
+```
+
+Then start an interactive Postgres session with the extension built and loaded:
 
 ```bash
 cargo pgrx run


### PR DESCRIPTION
## Summary

- `pg_search` errors at startup if not loaded via `shared_preload_libraries`, but the README gave no indication this step was needed before `CREATE EXTENSION`
- Added a one-liner to the "Running the Extension" section showing how to set it in the pgrx-managed `postgresql.conf`

## Test plan

- [x] Follow the updated README steps on a clean pgrx install and confirm `cargo pgrx run` + `CREATE EXTENSION pg_search` succeeds without error