### PR TITLE
fix(mpp): pick the dispatched top-k `FFHelper` by `indexrelid`

### DIFF
--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -110,12 +110,8 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
             }
             TAG_SEGMENTED_TOPK => {
                 let input = single_input(inputs)?;
-                let ffhelper = first_scan_ffhelper(&input).ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "SegmentedTopKExec dispatch: no scan ffhelper in subtree".into(),
-                    )
-                })?;
-                SegmentedTopKExec::decode_for_dispatch(payload, input, ffhelper, ctx)
+                let ffhelpers = collect_ffhelpers_by_indexrelid(&input);
+                SegmentedTopKExec::decode_for_dispatch(payload, input, ffhelpers, ctx)
             }
             other => Err(DataFusionError::NotImplemented(format!(
                 "PgSearchPhysicalExtensionCodec: unknown physical node tag {other}"
@@ -276,13 +272,6 @@ fn collect_ffhelpers_by_indexrelid(input: &Arc<dyn ExecutionPlan>) -> HashMap<u3
         }
     }
     map
-}
-
-/// The first scan ffhelper below this node, for the segmented top-k exec (single source).
-fn first_scan_ffhelper(input: &Arc<dyn ExecutionPlan>) -> Option<Arc<FFHelper>> {
-    let mut scans = Vec::new();
-    collect_scan_runtime(input, &mut scans);
-    scans.into_iter().find_map(|s| s.ffhelper)
 }
 
 /// [`DistributedCodec`] with the pg_search UDF names carved out of its UDF/UDAF handling.

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -243,13 +243,32 @@ impl SegmentedTopKExec {
     pub(crate) fn decode_for_dispatch(
         buf: &[u8],
         input: Arc<dyn ExecutionPlan>,
-        ffhelper: Arc<FFHelper>,
+        ffhelpers: HashMap<u32, Arc<FFHelper>>,
         ctx: &TaskContext,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let (sort_bytes, deferred_columns, k): (Vec<Vec<u8>>, Vec<DeferredSortColumn>, usize) =
             serde_json::from_slice(buf).map_err(|e| {
                 DataFusionError::Internal(format!("SegmentedTopKExec dispatch: deserialize: {e}"))
             })?;
+        // The deferred sort columns all resolve against one index (the sorted relation), and
+        // `ff_index` is relative to that index's fast-field list. A join leaves the other
+        // index's scan in the same subtree, so pick the helper by `indexrelid` instead of
+        // grabbing whichever scan comes first.
+        let ffhelper = match deferred_columns.first() {
+            Some(first) => ffhelpers
+                .get(&first.canonical.indexrelid)
+                .cloned()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "SegmentedTopKExec dispatch: no ffhelper for indexrelid {}",
+                        first.canonical.indexrelid
+                    ))
+                })?,
+            None => ffhelpers
+                .into_values()
+                .next()
+                .unwrap_or_else(|| Arc::new(FFHelper::empty())),
+        };
         let sort_proto = sort_bytes
             .iter()
             .map(|b| {

--- a/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
@@ -1,0 +1,80 @@
+-- Regression test for the FFHelper picked by a dispatched `SegmentedTopKExec`.
+--
+-- A top-k over a join sorts by a text fast field of the outer table. The deferred
+-- sort column's `ff_index` is relative to that table's index. When the fragment is
+-- dispatched to an MPP worker, the worker rewires the top-k to a scan in its subtree.
+-- Picking the first scan instead of the one matching the column's `indexrelid` lands
+-- on the joined table's helper, whose shorter fast-field list makes `ff_index` overrun
+-- and the worker panics ("index out of bounds"), surfacing on the leader as
+-- "transport receiver detached before this channel's EOF; the producer went away".
+--
+-- The outer table needs more fast fields than the joined one so a misindex overruns.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.enable_mpp = on;
+SET paradedb.mpp_worker_count = 4;
+SET paradedb.min_rows_per_worker = 0;
+SET max_parallel_workers = 4;
+SET max_parallel_workers_per_gather = 4;
+SET parallel_tuple_cost = 0;
+SET parallel_setup_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET min_parallel_index_scan_size = 0;
+SET parallel_leader_participation = off;
+DROP TABLE IF EXISTS mpp_topk_posts CASCADE;
+DROP TABLE IF EXISTS mpp_topk_users CASCADE;
+-- `C` collation keeps the byte-ordered sort that the top-k path requires, regardless of
+-- the cluster's `initdb` locale.
+CREATE TABLE mpp_topk_users (
+    id INTEGER PRIMARY KEY,
+    about_me TEXT COLLATE "C",
+    display_name TEXT COLLATE "C"
+) WITH (autovacuum_enabled = false);
+CREATE TABLE mpp_topk_posts (
+    id INTEGER PRIMARY KEY,
+    owner_user_id INTEGER,
+    title TEXT COLLATE "C",
+    body TEXT COLLATE "C",
+    tags TEXT COLLATE "C"
+) WITH (autovacuum_enabled = false);
+SET paradedb.global_mutable_segment_rows = 0;
+-- The joined table has two text fast fields.
+CREATE INDEX mpp_topk_users_bm25 ON mpp_topk_users
+USING bm25 (
+    id,
+    (about_me::pdb.unicode_words('columnar=true')),
+    (display_name::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+-- The sorted table has three, so `title`'s `ff_index` overruns the joined table's helper.
+CREATE INDEX mpp_topk_posts_bm25 ON mpp_topk_posts
+USING bm25 (
+    id,
+    owner_user_id,
+    (title::pdb.unicode_words('columnar=true')),
+    (body::pdb.unicode_words('columnar=true')),
+    (tags::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+INSERT INTO mpp_topk_users (id, about_me, display_name)
+SELECT i, 'about java code', 'David John Alex'
+FROM generate_series(1, 5000) i;
+INSERT INTO mpp_topk_posts (id, owner_user_id, title, body, tags)
+SELECT i, (i % 5000) + 1, 'title ' || lpad(i::text, 6, '0') || ' code', 'body code text', 'tag'
+FROM generate_series(1, 50000) i;
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE;
+-- No `EXPLAIN`: the dispatched plan prints per-task partition and segment counts that vary by
+-- machine. Unique titles keep the top-k order deterministic across workers and locales.
+SELECT p.id, p.title
+FROM mpp_topk_posts p
+WHERE p.owner_user_id IN (
+    SELECT id FROM mpp_topk_users
+    WHERE about_me ||| 'java' AND display_name ||| 'David'
+)
+ORDER BY p.title ASC
+LIMIT 25;
+ERROR:  DataFusion execution failed: Execution error: transport receiver detached before this channel's EOF; the producer went away
+server closed the connection unexpectedly
+	This probably means the server terminated abnormally
+	before or while processing the request.
+connection to server was lost

--- a/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
@@ -73,8 +73,34 @@ WHERE p.owner_user_id IN (
 )
 ORDER BY p.title ASC
 LIMIT 25;
-ERROR:  DataFusion execution failed: Execution error: transport receiver detached before this channel's EOF; the producer went away
-server closed the connection unexpectedly
-	This probably means the server terminated abnormally
-	before or while processing the request.
-connection to server was lost
+ id |       title       
+----+-------------------
+  1 | title 000001 code
+  2 | title 000002 code
+  3 | title 000003 code
+  4 | title 000004 code
+  5 | title 000005 code
+  6 | title 000006 code
+  7 | title 000007 code
+  8 | title 000008 code
+  9 | title 000009 code
+ 10 | title 000010 code
+ 11 | title 000011 code
+ 12 | title 000012 code
+ 13 | title 000013 code
+ 14 | title 000014 code
+ 15 | title 000015 code
+ 16 | title 000016 code
+ 17 | title 000017 code
+ 18 | title 000018 code
+ 19 | title 000019 code
+ 20 | title 000020 code
+ 21 | title 000021 code
+ 22 | title 000022 code
+ 23 | title 000023 code
+ 24 | title 000024 code
+ 25 | title 000025 code
+(25 rows)
+
+DROP TABLE mpp_topk_posts CASCADE;
+DROP TABLE mpp_topk_users CASCADE;

--- a/pg_search/tests/pg_regress/sql/mpp_join_topk_ffhelper.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_join_topk_ffhelper.sql
@@ -1,0 +1,90 @@
+-- Regression test for the FFHelper picked by a dispatched `SegmentedTopKExec`.
+--
+-- A top-k over a join sorts by a text fast field of the outer table. The deferred
+-- sort column's `ff_index` is relative to that table's index. When the fragment is
+-- dispatched to an MPP worker, the worker rewires the top-k to a scan in its subtree.
+-- Picking the first scan instead of the one matching the column's `indexrelid` lands
+-- on the joined table's helper, whose shorter fast-field list makes `ff_index` overrun
+-- and the worker panics ("index out of bounds"), surfacing on the leader as
+-- "transport receiver detached before this channel's EOF; the producer went away".
+--
+-- The outer table needs more fast fields than the joined one so a misindex overruns.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_custom_scan = on;
+SET paradedb.enable_join_custom_scan = on;
+SET paradedb.enable_mpp = on;
+SET paradedb.mpp_worker_count = 4;
+SET paradedb.min_rows_per_worker = 0;
+SET max_parallel_workers = 4;
+SET max_parallel_workers_per_gather = 4;
+SET parallel_tuple_cost = 0;
+SET parallel_setup_cost = 0;
+SET min_parallel_table_scan_size = 0;
+SET min_parallel_index_scan_size = 0;
+SET parallel_leader_participation = off;
+
+DROP TABLE IF EXISTS mpp_topk_posts CASCADE;
+DROP TABLE IF EXISTS mpp_topk_users CASCADE;
+
+-- `C` collation keeps the byte-ordered sort that the top-k path requires, regardless of
+-- the cluster's `initdb` locale.
+CREATE TABLE mpp_topk_users (
+    id INTEGER PRIMARY KEY,
+    about_me TEXT COLLATE "C",
+    display_name TEXT COLLATE "C"
+) WITH (autovacuum_enabled = false);
+
+CREATE TABLE mpp_topk_posts (
+    id INTEGER PRIMARY KEY,
+    owner_user_id INTEGER,
+    title TEXT COLLATE "C",
+    body TEXT COLLATE "C",
+    tags TEXT COLLATE "C"
+) WITH (autovacuum_enabled = false);
+
+SET paradedb.global_mutable_segment_rows = 0;
+
+-- The joined table has two text fast fields.
+CREATE INDEX mpp_topk_users_bm25 ON mpp_topk_users
+USING bm25 (
+    id,
+    (about_me::pdb.unicode_words('columnar=true')),
+    (display_name::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+
+-- The sorted table has three, so `title`'s `ff_index` overruns the joined table's helper.
+CREATE INDEX mpp_topk_posts_bm25 ON mpp_topk_posts
+USING bm25 (
+    id,
+    owner_user_id,
+    (title::pdb.unicode_words('columnar=true')),
+    (body::pdb.unicode_words('columnar=true')),
+    (tags::pdb.unicode_words('columnar=true'))
+) WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
+
+INSERT INTO mpp_topk_users (id, about_me, display_name)
+SELECT i, 'about java code', 'David John Alex'
+FROM generate_series(1, 5000) i;
+
+INSERT INTO mpp_topk_posts (id, owner_user_id, title, body, tags)
+SELECT i, (i % 5000) + 1, 'title ' || lpad(i::text, 6, '0') || ' code', 'body code text', 'tag'
+FROM generate_series(1, 50000) i;
+
+RESET paradedb.global_mutable_segment_rows;
+ANALYZE;
+
+-- No `EXPLAIN`: the dispatched plan prints per-task partition and segment counts that vary by
+-- machine. Unique titles keep the top-k order deterministic across workers and locales.
+SELECT p.id, p.title
+FROM mpp_topk_posts p
+WHERE p.owner_user_id IN (
+    SELECT id FROM mpp_topk_users
+    WHERE about_me ||| 'java' AND display_name ||| 'David'
+)
+ORDER BY p.title ASC
+LIMIT 25;
+
+DROP TABLE mpp_topk_posts CASCADE;
+DROP TABLE mpp_topk_users CASCADE;


### PR DESCRIPTION
## What

Dispatched `SegmentedTopKExec` to an MPP worker picks its `FFHelper` by the deferred sort column's `indexrelid`, not the first scan in its subtree.

## Why

A top-k over a join sorts by a text fast field of the outer table. The deferred sort column's `ff_index` is relative to that table's index. When the fragment runs on a worker, the worker rewires the top-k to a scan decoded in its subtree. Grabbing the first scan uses the joined table's helper in a join, and its shorter fast-field list makes `ff_index` overrun. The worker panics with `index out of bounds`, and the leader reports `transport receiver detached before this channel's EOF; the producer went away`.

The serial planner already selects the helper by `indexrelid` (`lookup.ffhelper(target_indexrelid)`), and `TantivyLookupExec` does the same through its `indexrelid` map. Only the dispatched top-k path skipped it.

## How

`decode_for_dispatch` takes the `indexrelid -> FFHelper` map (like the tantivy lookup) and selects the helper matching the deferred columns' shared `indexrelid`. Removed the now-unused `first_scan_ffhelper`.

## Tests

`mpp_join_topk_ffhelper` runs a join top-k that sorts by a text fast field, with the worker dispatch forced (`min_rows_per_worker = 0`, multiple segments). It panics without this change and returns the rows with it.
