### PR TITLE
ci: check out base branch in cherry-pick workflow

### DIFF
--- a/.github/workflows/cherry-pick.yml
+++ b/.github/workflows/cherry-pick.yml
@@ -28,6 +28,8 @@ jobs:
       - name: Checkout Git Repository
         uses: actions/checkout@v7
         with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.ref }}
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Fixes the cherry-pick workflow failure on fork PRs after actions/checkout@v7 started refusing implicit pull_request_target fork checkouts.

The workflow only needs trusted base repository code before running the backport action, so this explicitly checks out the base repo/base branch instead of opting into unsafe fork checkout.

Validation:
- git diff --check
- YAML parse check
- pre-commit hooks during commit