### PR TITLE
docs: fix broken examples and stale versions in deploy guides

### DIFF
--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -32,8 +32,7 @@ sed -i "s/^shared_preload_libraries = .*/shared_preload_libraries = 'citus,pg_se
 <Note>
   The example above installs Citus 14 for Postgres 18. Match the Citus version to
   your Postgres major version: **Citus 13** supports Postgres 15–17, and **Citus
-  14** supports Postgres 16–18. For example, on Postgres 15 use
-  `postgresql-15-citus-13.0` instead — `citus-14.0` does not support Postgres 15.
+  14** supports Postgres 16–18.
 </Note>
 
 <Note>

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -30,6 +30,13 @@ sed -i "s/^shared_preload_libraries = .*/shared_preload_libraries = 'citus,pg_se
 ```
 
 <Note>
+  The example above installs Citus 14 for Postgres 18. Match the Citus version to
+  your Postgres major version: **Citus 13** supports Postgres 15–17, and **Citus
+  14** supports Postgres 16–18. For example, on Postgres 15 use
+  `postgresql-15-citus-13.0` instead — `citus-14.0` does not support Postgres 15.
+</Note>
+
+<Note>
   The order in `shared_preload_libraries` matters. Always list `citus` before
   `pg_search` to ensure proper planner hook chaining.
 </Note>

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -30,9 +30,11 @@ sed -i "s/^shared_preload_libraries = .*/shared_preload_libraries = 'citus,pg_se
 ```
 
 <Note>
-  The example above installs Citus 14 for Postgres 18. Match the Citus version to
-  your Postgres major version: **Citus 13** supports Postgres 15–17, and **Citus
-  14** supports Postgres 16–18.
+  The example above installs Citus 14 for Postgres 18. Match the Citus version
+  to your Postgres major version: Citus 13 supports Postgres 15–17, and Citus 14
+  supports Postgres 16–18. For example, on Postgres 15 use
+  `postgresql-15-citus-13.0` instead — `citus-14.0` does not support Postgres
+  15.
 </Note>
 
 <Note>

--- a/docs/deploy/citus.mdx
+++ b/docs/deploy/citus.mdx
@@ -30,11 +30,8 @@ sed -i "s/^shared_preload_libraries = .*/shared_preload_libraries = 'citus,pg_se
 ```
 
 <Note>
-  The example above installs Citus 14 for Postgres 18. Match the Citus version
-  to your Postgres major version: Citus 13 supports Postgres 15–17, and Citus 14
-  supports Postgres 16–18. For example, on Postgres 15 use
-  `postgresql-15-citus-13.0` instead — `citus-14.0` does not support Postgres
-  15.
+  Match the Citus version to your Postgres major version: Citus 13 supports
+  Postgres 15–17, and Citus 14 supports Postgres 16–18.
 </Note>
 
 <Note>

--- a/docs/deploy/logical-replication/multi-database.mdx
+++ b/docs/deploy/logical-replication/multi-database.mdx
@@ -33,7 +33,7 @@ As shown in the diagram:
 - Each microservice database (db1, db2, db3) uses a schema matching its database name
 - All databases replicate to a single ParadeDB instance via logical replication
 - In ParadeDB, tables are accessible with fully-qualified names (e.g., `db1.table1`, `db2.table1`)
-- This enables cross-database joins like: `SELECT db1.users.user_id FROM db1.users, db2.orders WHERE db1.users.id = db2.orders.user_id`
+- This enables cross-database joins like: `SELECT db1.users.id, db2.orders.id FROM db1.users JOIN db2.orders ON db1.users.id = db2.orders.user_id`
 
 Instead of having all tables in the `public` schema across multiple databases:
 

--- a/docs/deploy/self-hosted/kubernetes.mdx
+++ b/docs/deploy/self-hosted/kubernetes.mdx
@@ -90,10 +90,10 @@ For ParadeDB Enterprise, you should have received an enterprise Docker username 
 credentials to Kubernetes and should be skipped if you are deploying ParadeDB Community.
 
 ```bash ParadeDB Enterprise
-kubectl create secret docker-registry paradedb-enterprise-registry-cred
---namespace <your-namespace>
---docker-server="https://index.docker.io/v1/"
---docker-username="<enterprise_docker_username>"
+kubectl create secret docker-registry paradedb-enterprise-registry-cred \
+--namespace <your-namespace> \
+--docker-server="https://index.docker.io/v1/" \
+--docker-username="<enterprise_docker_username>" \
 --docker-password="<enterprise_docker_access_token>"
 ```
 
@@ -136,7 +136,7 @@ spec:
     extensions:
       - name: pg_search
         image:
-          reference: docker.io/paradedb/paradedb-extension:0.24.0-18-trixie
+          reference: docker.io/paradedb/paradedb-extension:0.24.1-18-trixie
         extension_control_path:
           - /share
         dynamic_library_path:
@@ -157,11 +157,11 @@ spec:
     name: paradedb
   extensions:
     - name: pg_search
-      version: "0.24.0"
+      version: "0.24.1"
 ```
 
 The extension image tag format is `<paradedb-version>-<postgres-major>-trixie`.
-For example, use `0.24.0-18-trixie` for ParadeDB `0.24.0` on Postgres 18.
+For example, use `0.24.1-18-trixie` for ParadeDB `0.24.1` on Postgres 18.
 
 ## Connect to the Cluster
 
@@ -185,7 +185,7 @@ To connect to the Grafana dashboard for your cluster, we suggested port forwardi
 kubectl --namespace prometheus-community port-forward svc/prometheus-community-grafana 3000:80
 ```
 
-`You can then access the Grafana dasbhoard at `localhost:3000` using the credentials`admin`as username
-and`prom-operator` as password. These default credentials are defined in the [`kube-stack-config.yaml`](https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/docs/src/samples/monitoring/kube-stack-config.yaml)
-file used as the `values.yaml`file in [Installing the Prometheus CRDs](#installing-the-prometheus-stack) and can be modified by providing
-your own`values.yaml` file. A more detailed guide on monitoring the cluster can be found in the [CloudNativePG documentation](https://cloudnative-pg.io/docs/1.28/monitoring).
+You can then access the Grafana dashboard at `localhost:3000` using `admin` as the username
+and `prom-operator` as the password. These default credentials are defined in the [`kube-stack-config.yaml`](https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/main/docs/src/samples/monitoring/kube-stack-config.yaml)
+file used as the `values.yaml` file in [Installing the Prometheus CRDs](#installing-the-prometheus-stack) and can be modified by providing
+your own `values.yaml` file. A more detailed guide on monitoring the cluster can be found in the [CloudNativePG documentation](https://cloudnative-pg.io/docs/1.28/monitoring).


### PR DESCRIPTION
Fixes a batch of correctness issues in the deployment docs that would break for readers copy-pasting the examples.

## Changes

**`docs/deploy/self-hosted/kubernetes.mdx`**
- **Secret command (line ~92):** the `kubectl create secret docker-registry` block was missing line-continuation `\` characters, so it would not run as written. Added them.
- **Grafana sentence (line ~188):** repaired a mangled sentence with stray backticks, run-together words, and a `dasbhoard` typo.
- **Extension image version (lines ~139, ~160, ~164):** bumped hardcoded `0.24.0` references to the latest released version `0.24.1` (current `v0.24.1` tag; `0.24.2` is still unreleased dev).

**`docs/deploy/logical-replication/multi-database.mdx`**
- **Cross-DB JOIN example (line ~36):** the example selected a non-existent column (`db1.users.user_id`). Rewrote it to select existing columns with valid `JOIN ... ON` syntax: `SELECT db1.users.id, db2.orders.id FROM db1.users JOIN db2.orders ON db1.users.id = db2.orders.user_id`.

**`docs/deploy/citus.mdx`**
- **Citus version compatibility:** the install command pins `postgresql-18-citus-14.0` (valid for PG18) with no note that other Postgres versions need a different Citus version. Added a compatibility note — Citus 13 supports PG15–17, Citus 14 supports PG16–18 — so a PG15 reader doesn't install `citus-14.0`, which fails. The matrix matches the repo's own CI (`.github/workflows/test-pg_search.yml`).

## Test plan
Docs-only change. Verified the corrected JOIN/SQL and shell syntax, and cross-checked version facts against the latest git tag and the Citus CI compatibility matrix.