### PR TITLE
chore: fix typos in comments, error messages, and identifiers

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1376,6 +1376,6 @@ async fn evict_postgres_buffer_cache(conn: &mut PgConnection) -> anyhow::Result<
     sqlx::raw_sql(evict_query)
         .execute(conn)
         .await
-        .with_context(|| format!("Failed to PostgreSQL buffer cache: {evict_query}"))?;
+        .with_context(|| format!("Failed to evict PostgreSQL buffer cache: {evict_query}"))?;
     Ok(())
 }

--- a/macros/src/builder_fn.rs
+++ b/macros/src/builder_fn.rs
@@ -61,7 +61,7 @@ fn build_function(item_fn: &ItemFn) -> Result<proc_macro2::TokenStream, syn::Err
     if attributes.is_empty() {
         return Err(syn::Error::new(
             item_fn.span(),
-            err("`#[builder_fn]` be attached to a function prior to the `#[pg_extern]` definition"),
+            err("`#[builder_fn]` must be attached to a function prior to the `#[pg_extern]` definition"),
         ));
     }
 

--- a/pg_search/src/api/operator/boost.rs
+++ b/pg_search/src/api/operator/boost.rs
@@ -157,7 +157,7 @@ mod typedef {
     /// it through a [`half::f16`] so that the user's value will fit in the positive side of an i32,
     /// which is all Postgres lets us use.
     ///
-    /// We clamp the user-provided value to `[-2048.0..2028.0]` to avoid confusion around precision
+    /// We clamp the user-provided value to `[-2048.0..2048.0]` to avoid confusion around precision
     /// loss of larger integers, due to the nature of 16 bit floats.
     #[pg_extern(immutable, parallel_safe)]
     fn boost_typmod_in(typmod_parts: Array<&CStr>) -> i32 {

--- a/pg_search/src/api/operator/const_score.rs
+++ b/pg_search/src/api/operator/const_score.rs
@@ -164,7 +164,7 @@ mod typedef {
     /// it through a [`half::f16`] so that the user's value will fit in the positive side of an i32,
     /// which is all Postgres lets us use.
     ///
-    /// We clamp the user-provided value to `[-2048.0..2028.0]` to avoid confusion around precision
+    /// We clamp the user-provided value to `[-2048.0..2048.0]` to avoid confusion around precision
     /// loss of larger integers, due to the nature of 16 bit floats.
     #[pg_extern(immutable, parallel_safe)]
     fn const_typmod_in(typmod_parts: Array<&CStr>) -> i32 {

--- a/pg_search/src/postgres/build_parallel.rs
+++ b/pg_search/src/postgres/build_parallel.rs
@@ -191,7 +191,7 @@ impl ParallelWorker for BuildWorker<'_> {
         let scandesc = state_manager
             .object::<pg_sys::ParallelTableScanDescData>(1)
             .expect("should be able to get ParallelTableScanDesc")
-            .expect("ParallelTableDescDesc should not be NULL");
+            .expect("ParallelTableScanDesc should not be NULL");
         let coordination = state_manager
             .object::<WorkerCoordination>(2)
             .expect("should be able to get ProcessCoordination")

--- a/pg_search/src/postgres/catalog.rs
+++ b/pg_search/src/postgres/catalog.rs
@@ -153,7 +153,7 @@ pub fn is_citext_oid(oid: pg_sys::Oid) -> bool {
 /// Helper function to lookup a function's [`pg_sys::Oid`] by name, argument types, and namespace
 pub fn lookup_procoid(
     namespace: &CStr,
-    fucname: &CStr,
+    funcname: &CStr,
     argtypes: &[pg_sys::Oid],
 ) -> Option<pg_sys::Oid> {
     unsafe {
@@ -161,7 +161,7 @@ pub fn lookup_procoid(
         let procoid = pg_sys::GetSysCacheOid(
             pg_sys::SysCacheIdentifier::PROCNAMEARGSNSP as _,
             pg_sys::Anum_pg_proc_oid as _,
-            pg_sys::Datum::from(fucname.as_ptr()),
+            pg_sys::Datum::from(funcname.as_ptr()),
             pg_sys::Datum::from(argvec),
             lookup_namespace(namespace).into_datum()?,
             pg_sys::Datum::null(),

--- a/pg_search/src/postgres/datetime.rs
+++ b/pg_search/src/postgres/datetime.rs
@@ -28,18 +28,18 @@ pub static MICROSECONDS_IN_SECOND: u32 = 1_000_000;
 
 /// The Unix epoch is midnight 1970-01-01. The postgres epoch is midnight 2000-01-01.
 /// This is the difference between them in microseconds.
-pub static PG_EPOCH_DIFF_FROM_UNIX_EPHOCH_MICROS: i64 = 946_684_800 * MICROSECONDS_IN_SECOND as i64;
+pub static PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS: i64 = 946_684_800 * MICROSECONDS_IN_SECOND as i64;
 
 #[cfg(any(test, feature = "pg_test"))]
 pub fn pg_micros_to_unix_micros(pg_micros: i64) -> i64 {
     pg_micros
-        .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPHOCH_MICROS)
+        .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
         .unwrap()
 }
 
 pub fn unix_micros_to_pg_micros(unix_micros: i64) -> i64 {
     unix_micros
-        .checked_sub(PG_EPOCH_DIFF_FROM_UNIX_EPHOCH_MICROS)
+        .checked_sub(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
         .unwrap()
 }
 
@@ -183,7 +183,7 @@ impl TryFrom<String> for PostgresDateTime {
 impl TryFrom<&str> for PostgresDateTime {
     type Error = DateTimeConversionError;
 
-    /// Tantivy uses rfc3999 as it's supported date parsing method, so we'll replicate that here,
+    /// Tantivy uses rfc3339 as it's supported date parsing method, so we'll replicate that here,
     /// as this is largely used for user-supplied datetime strings
     /// If you need something more lenient, use one of:
     /// - `PostgresDateTime::try_from_date_str`
@@ -202,7 +202,7 @@ impl TryFrom<&str> for PostgresDateTime {
         Err(DateTimeConversionError::InvalidFormat)
     }
 }
-/// Cheap way to skip full parsing of things that can't be valid rfc3999 dates
+/// Cheap way to skip full parsing of things that can't be valid rfc3339 dates
 fn can_be_rfc3339_date_time(text: &str) -> bool {
     if let Some(&first_byte) = text.as_bytes().first() {
         if first_byte.is_ascii_digit() {
@@ -215,7 +215,7 @@ fn can_be_rfc3339_date_time(text: &str) -> bool {
 
 impl From<PostgresDateTime> for String {
     fn from(value: PostgresDateTime) -> Self {
-        // append Z to make the output rfc3999-compliant
+        // append Z to make the output rfc3339-compliant
         format!("{}Z", value.0.to_iso_string())
     }
 }
@@ -291,7 +291,7 @@ impl TryFrom<tantivy::DateTime> for PostgresDateTime {
     fn try_from(val: tantivy::DateTime) -> Result<Self, DateTimeConversionError> {
         let unix_micros = val.into_timestamp_micros();
         let pg_micros = unix_micros
-            .checked_sub(PG_EPOCH_DIFF_FROM_UNIX_EPHOCH_MICROS)
+            .checked_sub(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
             .ok_or(DateTimeConversionError::OutOfRange)?;
         Self::try_from_raw(pg_micros)
     }
@@ -302,7 +302,7 @@ impl TryFrom<PostgresDateTime> for tantivy::DateTime {
     fn try_from(val: PostgresDateTime) -> Result<Self, DateTimeConversionError> {
         let unix_micros = val
             .into_inner()
-            .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPHOCH_MICROS)
+            .checked_add(PG_EPOCH_DIFF_FROM_UNIX_EPOCH_MICROS)
             .ok_or(DateTimeConversionError::OutOfRange)?;
         if !(MIN_SAFE_TANTIVY_UNIX_MICROS..=MAX_SAFE_TANTIVY_UNIX_MICROS).contains(&unix_micros) {
             return Err(DateTimeConversionError::OutOfRange);

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -241,7 +241,7 @@ pub unsafe extern "C-unwind" fn ambulkdelete(
         if needs_commit {
             let meta_change = deleter
                 .commit(&index)
-                .expect("ambulkdelete: segment deletercommit should succeed");
+                .expect("ambulkdelete: segment deleter commit should succeed");
             if let Some((old_meta, new_meta)) = meta_change {
                 old_metas.push(old_meta);
                 new_metas.push(new_meta);

--- a/stressgres/src/auto.rs
+++ b/stressgres/src/auto.rs
@@ -101,9 +101,9 @@ pub fn setup_server(server: &Server, other_servers: &Vec<Server>) -> anyhow::Res
         std::fs::remove_file(&log_path).ok();
         std::fs::remove_dir_all(&pg_data).ok();
 
-        let is_wal_reciver = matches!(postgresql_conf, PostgresqlConf::WalReceiver);
+        let is_wal_receiver = matches!(postgresql_conf, PostgresqlConf::WalReceiver);
 
-        if is_wal_reciver {
+        if is_wal_receiver {
             let mut subscriber_server = None;
             for server in other_servers {
                 if server.is_subscriber() {
@@ -158,7 +158,7 @@ pub fn setup_server(server: &Server, other_servers: &Vec<Server>) -> anyhow::Res
             }
         }
 
-        if !is_wal_reciver {
+        if !is_wal_receiver {
             createdb(&pg_config, "stressgres", &pg_data)?;
         }
 

--- a/tests/tests/helpers.rs
+++ b/tests/tests/helpers.rs
@@ -25,7 +25,7 @@ use rstest::*;
 use sqlx::PgConnection;
 
 #[rstest]
-fn defult_tokenizer(mut conn: PgConnection) {
+fn default_tokenizer(mut conn: PgConnection) {
     let rows: Vec<(String, i32)> = r#"
     SELECT * FROM paradedb.tokenize(paradedb.tokenizer('default'), 'hello world');
     "#

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -172,7 +172,7 @@ impl SearchTokenizerFilters {
         }
         if let Some(alpha_num_only) = value.get("alpha_num_only") {
             filters.alpha_num_only = Some(alpha_num_only.as_bool().ok_or_else(|| {
-                anyhow::anyhow!("ascii_folding tokenizer requires a valid 'alpha_num_only' field")
+                anyhow::anyhow!("alpha_num_only tokenizer requires a valid 'alpha_num_only' field")
             })?);
         }
         if let Some(ascii_folding) = value.get("ascii_folding") {
@@ -538,7 +538,7 @@ impl SearchTokenizer {
                 let remove_emojis: bool = serde_json::from_value(value["remove_emojis"].clone())
                     .map_err(|_| {
                         anyhow::anyhow!(
-                            "unicode_words tokenizer requires an integer 'remove_emojis' field"
+                            "unicode_words tokenizer requires a boolean 'remove_emojis' field"
                         )
                     })?;
 


### PR DESCRIPTION
Tier 5 typo cleanup. Every change here is **internal-only** — comments, panic/error strings, local variables, a test name, and one function parameter — with **no impact on the public SQL surface**, so it's safe to land as a batch.

## Fixes

| File | Fix |
|------|-----|
| `pg_search/src/postgres/datetime.rs` | `PG_EPOCH_DIFF_FROM_UNIX_EPHOCH_MICROS` → `…UNIX_EPOCH…`; `rfc3999` → `rfc3339` (×3 comments) |
| `pg_search/src/api/operator/const_score.rs`, `boost.rs` | clamp-range comment `[-2048.0..2028.0]` → `…2048.0]` |
| `tests/tests/helpers.rs` | test fn `defult_tokenizer` → `default_tokenizer` |
| `stressgres/src/auto.rs` | local `is_wal_reciver` → `is_wal_receiver` (×3) |
| `pg_search/src/postgres/catalog.rs` | `lookup_procoid` param `fucname` → `funcname` |
| `pg_search/src/postgres/delete.rs` | `"segment deletercommit"` → `"segment deleter commit"` |
| `pg_search/src/postgres/build_parallel.rs` | `.expect("ParallelTableDescDesc …")` → `ParallelTableScanDesc` (matches the type actually fetched) |
| `benchmarks/src/main.rs` | `"Failed to PostgreSQL buffer cache"` → `"Failed to evict PostgreSQL buffer cache"` |
| `macros/src/builder_fn.rs` | error text missing verb: `` `#[builder_fn]` be attached `` → `` … must be attached `` |
| `tokenizers/src/manager.rs` | `alpha_num_only` error named the wrong tokenizer (`ascii_folding`); `remove_emojis` is a **boolean**, error said `integer` |

## Deliberately out of scope

The public SQL function typo `search_with_fieled_query_input` (the function behind the `@@@(anyelement, pdb.query)` operator) is **not** in this PR. Renaming it changes the public `paradedb` schema and requires a SchemaBot migration that must be regenerated and validated with a full `cargo pgrx schema` build. It will be handled in a dedicated PR.

## Test plan
No behavioral change. Identifier renames are confined to a single file each (verified no external references); the rest are comment/string-literal edits.