### PR TITLE
fix: rename search_with_fieled_query_input -> search_with_field_query_input

### DIFF
--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -81,7 +81,10 @@ jobs:
       - name: Install pg-schema-diff and its Required Dependencies
         run: |
           sudo apt install clang llvm diffutils
-          cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --debug --force
+          # TEMPORARY: pin to the pg-schema-diff branch that fixes operator-name quoting in
+          # DROP/ALTER OPERATOR (paradedb/pg-schema-diff#2). Revert to the default branch once
+          # that PR is merged. See pg_search/sql/pg_search--0.24.1--0.24.2.sql.
+          cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --branch fix/unquoted-operator-names --debug --force
 
       - name: Install pgrx
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -81,10 +81,7 @@ jobs:
       - name: Install pg-schema-diff and its Required Dependencies
         run: |
           sudo apt install clang llvm diffutils
-          # TEMPORARY: pin to the pg-schema-diff branch that fixes operator-name quoting in
-          # DROP/ALTER OPERATOR (paradedb/pg-schema-diff#2). Revert to the default branch once
-          # that PR is merged. See pg_search/sql/pg_search--0.24.1--0.24.2.sql.
-          cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --branch fix/unquoted-operator-names --debug --force
+          cargo install -j $(nproc) --git https://github.com/paradedb/pg-schema-diff.git --debug --force
 
       - name: Install pgrx
         run: cargo install -j $(nproc) --locked cargo-pgrx --version ${{ steps.pgrx.outputs.version }} --debug

--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -122,7 +122,7 @@ ALTER TYPE pdb.alias SET (TYPMOD_IN = alias_typmod_in, TYPMOD_OUT = generic_typm
 -- NOTE: drop the operator before the function it depends on. (pg-schema-diff emits these in the
 -- opposite order; the migration-diff check is order-independent, but the upgrade runs top-to-bottom
 -- and DROP FUNCTION would fail while the @@@ operator still references it.)
-DROP OPERATOR IF EXISTS pg_catalog."@@@"(anyelement, pdb.query);
+DROP OPERATOR IF EXISTS pg_catalog.@@@(anyelement, pdb.query);
 DROP FUNCTION IF EXISTS search_with_fieled_query_input(_element anyelement, query pdb.query);
 /* </end connected objects> */
 

--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -113,3 +113,27 @@ LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'alias_typmod_in_wrapper';
 
 ALTER TYPE pdb.alias SET (TYPMOD_IN = alias_typmod_in, TYPMOD_OUT = generic_typmod_out);
+
+-- Fix the typo in the function behind the `@@@(anyelement, pdb.query)` operator:
+-- `search_with_fieled_query_input` -> `search_with_field_query_input`. This function is never
+-- called directly (it only panics), but it is part of the public `paradedb` schema. Because the
+-- underlying C wrapper symbol is derived from the Rust function name, the symbol changes with the
+-- rename, so the operator and function are dropped and recreated rather than renamed in place.
+DROP OPERATOR IF EXISTS pg_catalog.@@@(anyelement, pdb.query);
+DROP FUNCTION IF EXISTS paradedb.search_with_fieled_query_input(anyelement, pdb.query);
+
+CREATE FUNCTION paradedb.search_with_field_query_input(
+    "_element" anyelement,
+    "query" pdb.Query
+) RETURNS bool
+    IMMUTABLE STRICT PARALLEL SAFE COST 1000000000
+    LANGUAGE c
+AS 'MODULE_PATHNAME', 'search_with_field_query_input_wrapper';
+
+CREATE OPERATOR pg_catalog.@@@ (
+    PROCEDURE="search_with_field_query_input",
+    LEFTARG=anyelement,
+    RIGHTARG=pdb.Query
+);
+
+ALTER FUNCTION paradedb.search_with_field_query_input SUPPORT paradedb.atatat_support;

--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -117,23 +117,30 @@ ALTER TYPE pdb.alias SET (TYPMOD_IN = alias_typmod_in, TYPMOD_OUT = generic_typm
 -- Fix the typo in the function behind the `@@@(anyelement, pdb.query)` operator:
 -- `search_with_fieled_query_input` -> `search_with_field_query_input`. This function is never
 -- called directly (it only panics), but it is part of the public `paradedb` schema. Because the
--- underlying C wrapper symbol is derived from the Rust function name, the symbol changes with the
--- rename, so the operator and function are dropped and recreated rather than renamed in place.
-DROP OPERATOR IF EXISTS pg_catalog.@@@(anyelement, pdb.query);
-DROP FUNCTION IF EXISTS paradedb.search_with_fieled_query_input(anyelement, pdb.query);
+-- pgrx-generated C wrapper symbol is derived from the Rust function name, the symbol changes with
+-- the rename, so the operator and function are dropped and recreated rather than renamed in place.
+-- NOTE: drop the operator before the function it depends on. (pg-schema-diff emits these in the
+-- opposite order; the migration-diff check is order-independent, but the upgrade runs top-to-bottom
+-- and DROP FUNCTION would fail while the @@@ operator still references it.)
+DROP OPERATOR IF EXISTS pg_catalog."@@@"(anyelement, pdb.query);
+DROP FUNCTION IF EXISTS search_with_fieled_query_input(_element anyelement, query pdb.query);
+/* </end connected objects> */
 
-CREATE FUNCTION paradedb.search_with_field_query_input(
-    "_element" anyelement,
-    "query" pdb.Query
-) RETURNS bool
-    IMMUTABLE STRICT PARALLEL SAFE COST 1000000000
-    LANGUAGE c
+/* <begin connected objects> */
+-- pg_search/src/api/operator/atatat.rs:41
+-- pg_search::api::operator::atatat::search_with_field_query_input
+CREATE  FUNCTION "search_with_field_query_input"(
+	"_element" anyelement, /* AnyElement */
+	"query" pdb.Query /* pdb :: Query */
+) RETURNS bool /* bool */
+IMMUTABLE STRICT PARALLEL SAFE COST 1000000000
+LANGUAGE c /* Rust */
 AS 'MODULE_PATHNAME', 'search_with_field_query_input_wrapper';
-
+-- pg_search/src/api/operator/atatat.rs:41
+-- pg_search::api::operator::atatat::search_with_field_query_input
 CREATE OPERATOR pg_catalog.@@@ (
-    PROCEDURE="search_with_field_query_input",
-    LEFTARG=anyelement,
-    RIGHTARG=pdb.Query
+	PROCEDURE="search_with_field_query_input",
+	LEFTARG=anyelement, /* AnyElement */
+	RIGHTARG=pdb.Query /* pdb :: Query */
 );
-
 ALTER FUNCTION paradedb.search_with_field_query_input SUPPORT paradedb.atatat_support;

--- a/pg_search/src/api/operator/atatat.rs
+++ b/pg_search/src/api/operator/atatat.rs
@@ -40,7 +40,7 @@ pub fn search_with_parse(_element: AnyElement, query: &str) -> bool {
 
 #[pg_operator(immutable, parallel_safe, cost = 1000000000)]
 #[opname(pg_catalog.@@@)]
-pub fn search_with_fieled_query_input(_element: AnyElement, query: pdb::Query) -> bool {
+pub fn search_with_field_query_input(_element: AnyElement, query: pdb::Query) -> bool {
     panic!("query is incompatible with pg_search's `@@@(field, pdb.query)` operator: `{query:?}`")
 }
 
@@ -186,13 +186,13 @@ pub fn atatat_support(arg: Internal) -> ReturnedNodePointer {
 extension_sql!(
     r#"
         ALTER FUNCTION paradedb.search_with_parse SUPPORT paradedb.atatat_support;
-        ALTER FUNCTION paradedb.search_with_fieled_query_input SUPPORT paradedb.atatat_support;
+        ALTER FUNCTION paradedb.search_with_field_query_input SUPPORT paradedb.atatat_support;
         ALTER FUNCTION paradedb.search_with_proximity_clause SUPPORT paradedb.atatat_support;
     "#,
     name = "atatat_support_fn",
     requires = [
         search_with_parse,
-        search_with_fieled_query_input,
+        search_with_field_query_input,
         search_with_proximity_clause,
         atatat_support
     ]


### PR DESCRIPTION
Follow-up to #5442 (Tier 5 typos). That PR deliberately left out this one typo because it touches the **public `paradedb` SQL surface** and therefore needs a SchemaBot migration.

## What

`search_with_fieled_query_input` → `search_with_field_query_input` — the `fieled` → `field` typo in the function backing the `@@@(anyelement, pdb.query)` operator.

## Why it's safe behaviorally

This function is never called directly: it only `panic!`s, and in normal planning `@@@` is rewritten to use `searchqueryinput`. The rename is behaviorally inert — it's purely a cosmetic fix to the public schema.

## Migration

`pg_search/src/api/operator/atatat.rs` — renamed the Rust fn (3 spots: the `#[pg_operator]` definition, the `extension_sql!` `ALTER FUNCTION … SUPPORT`, and the `requires` list).

`pg_search/sql/pg_search--0.24.1--0.24.2.sql` — added the upgrade statements. Because the pgrx-generated C wrapper symbol (`…_wrapper`) is derived from the Rust function name, an `ALTER FUNCTION … RENAME` would leave a stale symbol binding, so the operator + function are **dropped and recreated** with the new name, and the `atatat_support` binding is re-applied.

The historical migration files (`0.17.12→0.18.0`, `0.18.15→0.19.0`) that reference the old name are intentionally **not** touched — they record past schema states.

## SchemaBot note

The migration here is best-effort and hand-written. SchemaBot (`pg-schema-diff`) regenerates the canonical upgrade script in CI; if its output differs from what I wrote, I'll reconcile the migration file to match exactly. Verifying that requires the CI run, which compiles `cargo-pgrx` + `pg-schema-diff` and can't be reproduced locally here.

## Test plan
- [x] SchemaBot (Test pg_search (Schema)) passes — migration matches generated diff
- [x] pg_search build + regression tests pass with the renamed function