### PR TITLE
fix(mpp): release leader control senders via on_dsm_detach, not xact abort

### DIFF
--- a/pg_search/src/parallel_worker/builder.rs
+++ b/pg_search/src/parallel_worker/builder.rs
@@ -208,6 +208,12 @@ impl ParallelProcessFinish {
         &mut self.launcher.state_manager
     }
 
+    /// The DSM segment backing this parallel process, valid until [`Self::wait_for_finish`]
+    /// destroys the parallel context.
+    pub fn dsm_segment(&self) -> *mut pg_sys::dsm_segment {
+        unsafe { (*self.launcher.pcxt.as_ptr()).seg }
+    }
+
     /// Blocking receive from all worker message queues.
     ///
     /// Each worker sends at most one message. Queues that have already delivered

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -641,8 +641,8 @@ impl CustomScan for AggregateScan {
             // Release the DSM-backed control senders before `recv`. A producer's `work_mem`
             // overflow (or any worker error) is re-raised in the leader from inside `recv`, which
             // longjmps out of this hook; a release placed after it would never run, leaving the
-            // senders to drop at xact commit, past the DSM's lifetime, where their `fetch_sub`
-            // faults. The query is done producing here, so the senders aren't needed.
+            // senders for the detach callback, which clears them while the mapping is still live.
+            // The query is done producing here, so the senders aren't needed.
             if let Some(leader) = df_state.mpp.leader() {
                 leader.release_control_senders();
             }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1522,9 +1522,9 @@ impl CustomScan for JoinScan {
         state.custom_state_mut().datafusion_stream = None;
         // Release the DSM-backed control senders before `recv`. A producer's `work_mem` overflow
         // (or any worker error) is re-raised in the leader from inside `recv`, which `longjmp`s
-        // out of this hook; a release placed after it would never run, leaving the senders to drop
-        // at xact commit, past the DSM's lifetime, where their `fetch_sub` faults. The query is
-        // done producing here, so the senders aren't needed, and the drop runs while DSM is mapped.
+        // out of this hook; a release placed after it would never run, leaving the senders for the
+        // detach callback, which clears them while the mapping is still live. The query is done
+        // producing here, so the senders aren't needed, and the drop runs while DSM is mapped.
         if let Some(leader) = state.custom_state().mpp.leader() {
             leader.release_control_senders();
         }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -131,6 +131,12 @@ pub struct MppLaunchTiming {
     pub workers: u32,
 }
 
+/// The leader's control senders behind their shared lock. The scan state, the mesh's cancel
+/// path, and the `on_dsm_detach` callback all hold the same `Arc<ControlSenders>`; the
+/// callback's `Arc::from_raw` cast relies on this alias being the single definition of the
+/// pointee type.
+pub type ControlSenders = std::sync::Mutex<Vec<Option<MppSender>>>;
+
 /// Returned to the leader from [`leader_setup`]. The customscan stashes this on its execution
 /// state and consults it during `exec_custom_scan`.
 ///
@@ -152,7 +158,7 @@ pub struct MppLeaderState {
     /// (registered via `on_dsm_detach` by `launch`) clears them on every other path — abort, and a
     /// `proc_exit` from `pg_terminate_backend` that skips shutdown — always before PG unmaps the
     /// segment. The scan state's own drop runs after detach and must find this empty.
-    pub control_senders: Arc<std::sync::Mutex<Vec<Option<MppSender>>>>,
+    pub control_senders: Arc<ControlSenders>,
     /// The builder handle owning the launched producer workers. The leader controls the launch, so
     /// it owns the teardown too: `end_custom_scan` takes this and calls `wait_for_finish` to join
     /// the workers and destroy the parallel context. `None` until `launch` installs it on the
@@ -251,12 +257,11 @@ pub unsafe fn leader_setup(
 /// `arg` is the senders `Arc`, leaked via `Arc::into_raw` at registration; reclaiming it here
 /// balances that. Idempotent — `clear` on the already-empty Vec (success path) is a no-op.
 #[pgrx::pg_guard]
-pub(crate) unsafe extern "C-unwind" fn release_control_senders_on_detach(
+unsafe extern "C-unwind" fn release_control_senders_on_detach(
     _seg: *mut pg_sys::dsm_segment,
     arg: pg_sys::Datum,
 ) {
-    let senders =
-        unsafe { Arc::from_raw(arg.cast_mut_ptr::<std::sync::Mutex<Vec<Option<MppSender>>>>()) };
+    let senders = unsafe { Arc::from_raw(arg.cast_mut_ptr::<ControlSenders>()) };
     // Tolerate a poisoned mutex rather than panic across the C boundary; the Vec data is still
     // valid to clear.
     let mut guard = senders
@@ -290,6 +295,9 @@ impl MppLeaderState {
     /// `shutdown_custom_scan` on the success path; [`release_control_senders_on_detach`] (registered
     /// via `on_dsm_detach`) covers every other teardown path. Idempotent.
     pub fn release_control_senders(&self) {
+        // Unlike the detach callback, a poisoned lock panics here on purpose: this runs on the
+        // success path inside the executor, where poison means a real bug and an ERROR is safe
+        // to raise. The callback can't afford that mid-`dsm_detach`.
         self.control_senders.lock().unwrap().clear();
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -131,11 +131,17 @@ pub struct MppLaunchTiming {
     pub workers: u32,
 }
 
-/// The leader's control senders behind their shared lock. The scan state, the mesh's cancel
-/// path, and the `on_dsm_detach` callback all hold the same `Arc<ControlSenders>`; the
-/// callback's `Arc::from_raw` cast relies on this alias being the single definition of the
-/// pointee type.
+/// The leader's control senders behind their shared lock. The scan state and mesh cancel path
+/// share this `Arc`; `DsmDetachState` retains another reference so the detach callback can clear
+/// the stored senders while the DSM is still mapped.
 pub type ControlSenders = std::sync::Mutex<Vec<Option<MppSender>>>;
+
+/// State retained by PostgreSQL until DSM detach. The callback marks the shared mesh dead before
+/// clearing stored senders, so escaped sender clones can later drop without touching unmapped DSM.
+struct DsmDetachState {
+    alive: shm::AliveFlag,
+    control_senders: Arc<ControlSenders>,
+}
 
 /// Returned to the leader from [`leader_setup`]. The customscan stashes this on its execution
 /// state and consults it during `exec_custom_scan`.
@@ -152,12 +158,13 @@ pub struct MppLeaderState {
     /// sender count of zero before every worker attaches (the rings latch `detached` permanently at
     /// zero).
     ///
-    /// Dropping one of these decrements a counter inside the DSM ring, so they must never
-    /// outlive the mapping: [`MppLeaderState::release_control_senders`] clears them from
-    /// `shutdown_custom_scan` on the success path, and [`release_control_senders_on_detach`]
-    /// (registered via `on_dsm_detach` by `launch`) clears them on every other path — abort, and a
-    /// `proc_exit` from `pg_terminate_backend` that skips shutdown — always before PG unmaps the
-    /// segment. The scan state's own drop runs after detach and must find this empty.
+    /// While the mesh is live, dropping one of these decrements a counter inside its DSM ring.
+    /// [`MppLeaderState::release_control_senders`] clears them from `shutdown_custom_scan` on the
+    /// success path. [`release_control_senders_on_detach`] covers every other path — abort, and a
+    /// `proc_exit` from `pg_terminate_backend` that skips shutdown — by marking the mesh dead and
+    /// clearing this vector before PG unmaps the segment. Escaped sender clones can then drop
+    /// safely without accessing DSM. The scan state's own drop runs after detach and must find
+    /// this vector empty.
     pub control_senders: Arc<ControlSenders>,
     /// The builder handle owning the launched producer workers. The leader controls the launch, so
     /// it owns the teardown too: `end_custom_scan` takes this and calls `wait_for_finish` to join
@@ -245,48 +252,66 @@ pub unsafe fn leader_setup(
     })
 }
 
-/// `on_dsm_detach` callback that releases the leader's DSM-backed control senders while the MPP
-/// segment is still mapped.
+/// `on_dsm_detach` callback that invalidates the leader's mesh handles and releases its stored
+/// DSM-backed control senders while the MPP segment is still mapped.
 ///
-/// Dropping a sender decrements an atomic inside the ring, which lives in the parallel-context
-/// DSM, so it must happen before PG unmaps that segment. `on_dsm_detach` runs while the mapping is
-/// still live, on every teardown path. A transaction-abort callback can't replace it: it fires
-/// after `AtEOXact_Parallel` has already detached the DSM, and a backend FATAL skips
+/// While the mesh is live, dropping a sender decrements an atomic inside its DSM ring. The
+/// callback first marks every handle dead and then clears the stored senders while the mapping is
+/// live; an escaped clone can subsequently drop without touching DSM. `on_dsm_detach` runs on
+/// every teardown path. A transaction-abort callback can't replace it: it fires after
+/// `AtEOXact_Parallel` has already detached the DSM, and a backend FATAL skips
 /// `shutdown_custom_scan` entirely.
 ///
-/// `arg` is the senders `Arc`, leaked via `Arc::into_raw` at registration; reclaiming it here
-/// balances that. Idempotent — `clear` on the already-empty Vec (success path) is a no-op.
+/// `arg` is the detach-state `Arc` converted into a raw pointer at registration;
+/// [`Arc::from_raw`] reclaims that reference exactly once. The success path may already have
+/// emptied the sender vector, in which case clearing it again is a no-op.
 #[pgrx::pg_guard]
 unsafe extern "C-unwind" fn release_control_senders_on_detach(
     _seg: *mut pg_sys::dsm_segment,
     arg: pg_sys::Datum,
 ) {
-    let senders = unsafe { Arc::from_raw(arg.cast_mut_ptr::<ControlSenders>()) };
+    let state = unsafe { Arc::from_raw(arg.cast_mut_ptr::<DsmDetachState>()) };
+    release_control_senders_on_detach_impl(&state);
+}
+
+fn release_control_senders_on_detach_impl(state: &DsmDetachState) {
+    // `send_set_plan` can retain a sender clone after releasing the vector lock. Invalidate every
+    // handle before clearing the known senders so escaped clones no-op if dropped after DSM unmaps.
+    state
+        .alive
+        .store(false, std::sync::atomic::Ordering::Release);
+
     // Tolerate a poisoned mutex rather than panic across the C boundary; the Vec data is still
     // valid to clear.
-    let mut guard = senders
+    let mut guard = state
+        .control_senders
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    // Today this drop path is panic-free (Arc drops, atomics, receiver wakeup), but keep panics
-    // from any future sender field from unwinding through PostgreSQL's C teardown.
+    // The current sender drop path is panic-free. `catch_unwind` contains any future panic so it
+    // cannot unwind through PostgreSQL's C teardown.
     let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
         guard.clear();
     }));
 }
 
 impl MppLeaderState {
-    /// Register the DSM detach cleanup for the leader senders. PostgreSQL stores the raw pointer;
-    /// [`release_control_senders_on_detach`] turns it back into the same `Arc` and drops it.
+    /// Register the DSM detach cleanup for the leader mesh liveness flag and senders. PostgreSQL
+    /// stores the raw pointer; [`release_control_senders_on_detach`] turns it back into the same
+    /// `Arc` and drops it.
     ///
     /// # Safety
     /// `seg` must be the live DSM segment that owns the ring memory targeted by
     /// `self.control_senders`.
     pub unsafe fn register_control_senders_on_detach(&self, seg: *mut pg_sys::dsm_segment) {
+        let state = Arc::new(DsmDetachState {
+            alive: self.mesh.detached_flag(),
+            control_senders: Arc::clone(&self.control_senders),
+        });
         unsafe {
             pg_sys::on_dsm_detach(
                 seg,
                 Some(release_control_senders_on_detach),
-                pg_sys::Datum::from(Arc::into_raw(Arc::clone(&self.control_senders)) as *mut c_void),
+                pg_sys::Datum::from(Arc::into_raw(state) as *mut c_void),
             );
         }
     }
@@ -299,6 +324,63 @@ impl MppLeaderState {
         // success path inside the executor, where poison means a real bug and an ERROR is safe
         // to raise. The callback can't afford that mid-`dsm_detach`.
         self.control_senders.lock().unwrap().clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use datafusion_distributed::shm::{MppFrameHeader, NoInterrupt};
+    use std::sync::atomic::Ordering;
+
+    struct NoopWakeup;
+
+    impl Wakeup for NoopWakeup {
+        fn wake(&self, _token: u64) {}
+    }
+
+    #[test]
+    fn dsm_detach_marks_mesh_before_a_set_plan_clone_can_drop() {
+        // Sender Drop may touch ring memory while the mesh is live, so keep the backing region
+        // alive through the final drop.
+        let region_bytes = shm::dsm_region_bytes(3, 64 * 1024, 0).unwrap();
+        let mut region = vec![0_u64; region_bytes.div_ceil(std::mem::size_of::<u64>())];
+        let attach = unsafe {
+            shm::leader_setup(
+                region.as_mut_ptr().cast(),
+                3,
+                64 * 1024,
+                &[],
+                Arc::new(NoopWakeup),
+                1,
+                Arc::new(NoInterrupt),
+                true,
+            )
+            .unwrap()
+        };
+        // Model the sender clone `send_set_plan` can retain after releasing the control-sender
+        // lock; clearing the stored vector does not release this clone.
+        let delayed_set_plan_sender = attach
+            .outbound_senders
+            .iter()
+            .flatten()
+            .next()
+            .unwrap()
+            .clone_with_header(MppFrameHeader::set_plan(0, 0, 0));
+        let mesh = attach.mesh;
+        let state = DsmDetachState {
+            alive: mesh.detached_flag(),
+            control_senders: Arc::new(std::sync::Mutex::new(attach.outbound_senders)),
+        };
+
+        release_control_senders_on_detach_impl(&state);
+
+        assert!(state.control_senders.lock().unwrap().is_empty());
+        assert!(
+            !mesh.detached_flag().load(Ordering::Acquire),
+            "DSM detach must invalidate mesh handles before delayed SetPlan senders can drop"
+        );
+        drop(delayed_set_plan_sender);
     }
 }
 

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -142,8 +142,9 @@ pub struct MppLeaderState {
     /// it at execute time.
     pub mesh: Arc<MppMesh>,
     /// The leader's outbound senders, one per peer inbox; the control-plane path for `SetPlan`
-    /// frames. Held for the query's lifetime so no ring observes a sender count of zero before
-    /// every worker attaches (the rings latch `detached` permanently at zero).
+    /// frames and stream cancel messages. Held for the query's lifetime so no ring observes a
+    /// sender count of zero before every worker attaches (the rings latch `detached` permanently at
+    /// zero).
     ///
     /// Dropping one of these decrements a counter inside the DSM ring, so they must never
     /// outlive the mapping: [`MppLeaderState::release_control_senders`] clears them from
@@ -261,10 +262,30 @@ pub(crate) unsafe extern "C-unwind" fn release_control_senders_on_detach(
     let mut guard = senders
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
-    guard.clear();
+    // Today this drop path is panic-free (Arc drops, atomics, receiver wakeup), but keep panics
+    // from any future sender field from unwinding through PostgreSQL's C teardown.
+    let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        guard.clear();
+    }));
 }
 
 impl MppLeaderState {
+    /// Register the DSM detach cleanup for the leader senders. PostgreSQL stores the raw pointer;
+    /// [`release_control_senders_on_detach`] turns it back into the same `Arc` and drops it.
+    ///
+    /// # Safety
+    /// `seg` must be the live DSM segment that owns the ring memory targeted by
+    /// `self.control_senders`.
+    pub unsafe fn register_control_senders_on_detach(&self, seg: *mut pg_sys::dsm_segment) {
+        unsafe {
+            pg_sys::on_dsm_detach(
+                seg,
+                Some(release_control_senders_on_detach),
+                pg_sys::Datum::from(Arc::into_raw(Arc::clone(&self.control_senders)) as *mut c_void),
+            );
+        }
+    }
+
     /// Drop the DSM-backed control senders while the mapping is still attached. Called from
     /// `shutdown_custom_scan` on the success path; [`release_control_senders_on_detach`] (registered
     /// via `on_dsm_detach`) covers every other teardown path. Idempotent.

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -147,9 +147,10 @@ pub struct MppLeaderState {
     ///
     /// Dropping one of these decrements a counter inside the DSM ring, so they must never
     /// outlive the mapping: [`MppLeaderState::release_control_senders`] clears them from
-    /// `shutdown_custom_scan` on the success path, and a transaction-abort callback (registered
-    /// in [`leader_setup`]) clears them on the error path, both before PG detaches the DSM.
-    /// The scan state's own drop runs after detach and must find this empty.
+    /// `shutdown_custom_scan` on the success path, and [`release_control_senders_on_detach`]
+    /// (registered via `on_dsm_detach` by `launch`) clears them on every other path — abort, and a
+    /// `proc_exit` from `pg_terminate_backend` that skips shutdown — always before PG unmaps the
+    /// segment. The scan state's own drop runs after detach and must find this empty.
     pub control_senders: Arc<std::sync::Mutex<Vec<Option<MppSender>>>>,
     /// The builder handle owning the launched producer workers. The leader controls the launch, so
     /// it owns the teardown too: `end_custom_scan` takes this and calls `wait_for_finish` to join
@@ -225,24 +226,9 @@ pub unsafe fn leader_setup(
     }
     let control_senders = Arc::new(std::sync::Mutex::new(attach.outbound_senders));
     // Hand the senders to the mesh too, so its early-termination cancel can reach the producers.
-    // The mesh shares this `Arc`, so clearing it below releases both views before the DSM unmaps.
+    // The mesh shares this `Arc`, so clearing either view releases both before the DSM unmaps.
     mesh.set_cancel_senders(Arc::clone(&control_senders));
-    // On abort, `AbortTransaction` unmaps the DSM before these callbacks run, so the senders must
-    // not touch their ring headers as they drop. The mesh's liveness flag is process-local, so
-    // flip it here (every ring handle reads it) and the senders' drop skips the freed-ring write
-    // while their heap is still freed. `PreCommit` covers a subtransaction rollback where no abort
-    // fires; the success path releases the senders in `shutdown_custom_scan` while the segment is
-    // still mapped, so the vec is empty by then.
-    let make_detacher = || {
-        let alive = mesh.detached_flag();
-        let senders = Arc::clone(&control_senders);
-        move || {
-            alive.store(false, std::sync::atomic::Ordering::Release);
-            senders.lock().unwrap().clear();
-        }
-    };
-    pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::Abort, make_detacher());
-    pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::PreCommit, make_detacher());
+    // Released before the DSM unmaps via [`release_control_senders_on_detach`], registered by `launch`.
     Ok(MppLeaderState {
         mesh,
         control_senders,
@@ -252,9 +238,36 @@ pub unsafe fn leader_setup(
     })
 }
 
+/// `on_dsm_detach` callback that releases the leader's DSM-backed control senders while the MPP
+/// segment is still mapped.
+///
+/// Dropping a sender decrements an atomic inside the ring, which lives in the parallel-context
+/// DSM, so it must happen before PG unmaps that segment. `on_dsm_detach` runs while the mapping is
+/// still live, on every teardown path. A transaction-abort callback can't replace it: it fires
+/// after `AtEOXact_Parallel` has already detached the DSM, and a backend FATAL skips
+/// `shutdown_custom_scan` entirely.
+///
+/// `arg` is the senders `Arc`, leaked via `Arc::into_raw` at registration; reclaiming it here
+/// balances that. Idempotent — `clear` on the already-empty Vec (success path) is a no-op.
+#[pgrx::pg_guard]
+pub(crate) unsafe extern "C-unwind" fn release_control_senders_on_detach(
+    _seg: *mut pg_sys::dsm_segment,
+    arg: pg_sys::Datum,
+) {
+    let senders =
+        unsafe { Arc::from_raw(arg.cast_mut_ptr::<std::sync::Mutex<Vec<Option<MppSender>>>>()) };
+    // Tolerate a poisoned mutex rather than panic across the C boundary; the Vec data is still
+    // valid to clear.
+    let mut guard = senders
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    guard.clear();
+}
+
 impl MppLeaderState {
     /// Drop the DSM-backed control senders while the mapping is still attached. Called from
-    /// `shutdown_custom_scan`; the abort callback covers the error path. Idempotent.
+    /// `shutdown_custom_scan` on the success path; [`release_control_senders_on_detach`] (registered
+    /// via `on_dsm_detach`) covers every other teardown path. Idempotent.
     pub fn release_control_senders(&self) {
         self.control_senders.lock().unwrap().clear();
     }

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -56,7 +56,8 @@ use crate::postgres::customscan::mpp::dispatch::{
 };
 use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, producer_worker_count, worker_setup, MppLeaderState,
+    estimate_dsm_size, leader_setup, producer_worker_count, release_control_senders_on_detach,
+    worker_setup, MppLeaderState,
 };
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
 
@@ -413,6 +414,18 @@ pub fn launch_mpp_commit(
     };
     timing.leader_setup_us = t_setup.elapsed().as_micros() as u64;
     leader.timing = timing;
+
+    // Registered here (not in `leader_setup`) because this is the first point with both the segment
+    // (`finish`) and the senders (`leader`) in hand. See [`release_control_senders_on_detach`].
+    unsafe {
+        pg_sys::on_dsm_detach(
+            finish.dsm_segment(),
+            Some(release_control_senders_on_detach),
+            pg_sys::Datum::from(std::sync::Arc::into_raw(std::sync::Arc::clone(
+                &leader.control_senders,
+            )) as *mut c_void),
+        );
+    }
 
     // Release the workers into ring attach + plan wait.
     go.store(GO_RUN, Ordering::Release);

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -56,8 +56,7 @@ use crate::postgres::customscan::mpp::dispatch::{
 };
 use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
 use crate::postgres::customscan::mpp::glue::{
-    estimate_dsm_size, leader_setup, producer_worker_count, release_control_senders_on_detach,
-    worker_setup, MppLeaderState,
+    estimate_dsm_size, leader_setup, producer_worker_count, worker_setup, MppLeaderState,
 };
 use crate::postgres::{ParallelScanArgs, ParallelScanState};
 
@@ -416,16 +415,8 @@ pub fn launch_mpp_commit(
     leader.timing = timing;
 
     // Registered here (not in `leader_setup`) because this is the first point with both the segment
-    // (`finish`) and the senders (`leader`) in hand. See [`release_control_senders_on_detach`].
-    unsafe {
-        pg_sys::on_dsm_detach(
-            finish.dsm_segment(),
-            Some(release_control_senders_on_detach),
-            pg_sys::Datum::from(std::sync::Arc::into_raw(std::sync::Arc::clone(
-                &leader.control_senders,
-            )) as *mut c_void),
-        );
-    }
+    // (`finish`) and the senders (`leader`) in hand.
+    unsafe { leader.register_control_senders_on_detach(finish.dsm_segment()) };
 
     // Release the workers into ring attach + plan wait.
     go.store(GO_RUN, Ordering::Release);

--- a/tests/tests/mpp_cancel.rs
+++ b/tests/tests/mpp_cancel.rs
@@ -15,12 +15,11 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! A cancel or `pg_terminate_backend` taken while an MPP query runs used to
-//! crash the leader during teardown (a die serviced from inside the tokio
-//! `block_on`, or DSM senders dropped after the parallel segment was gone),
-//! which resets the whole cluster. These tests signal a running MPP query from
-//! a second connection and assert a witness connection kept open the whole
-//! time survives. A cluster reset would have dropped it.
+//! A cancel or `pg_terminate_backend` taken while an MPP query runs used to crash the leader during
+//! teardown (a die serviced from inside the tokio `block_on`, or DSM control senders dropped after
+//! the parallel segment was already detached), which resets the whole cluster. These tests signal a
+//! running MPP query from a second connection and assert a witness connection kept open the whole
+//! time survives — a cluster reset would have dropped it.
 
 use anyhow::Result;
 use rstest::*;
@@ -29,51 +28,77 @@ use std::time::{Duration, Instant};
 use tests::fixtures::*;
 use tokio::time::sleep;
 
+// Three 20k-row tables. `age` is in [0,50), so `users.age = products.age` fans out to millions of
+// intermediate rows — that scan-dominated join is what keeps the leader inside its MPP `block_on`
+// for ~2s, a window wide enough for the killer to land a signal mid-flight. (A small/cheap join
+// finishes in milliseconds and the signal misses the window — it then can't catch the teardown
+// bug at all.)
 const SETUP_SQL: &str = r#"
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
-CREATE TABLE mpp_sig_files (id SERIAL PRIMARY KEY, title TEXT, content TEXT);
-CREATE TABLE mpp_sig_pages (id SERIAL PRIMARY KEY, file_id INTEGER, page_text TEXT);
+CREATE TABLE mpp_users    (id bigserial primary key, uuid uuid, name text, age int, category text);
+CREATE TABLE mpp_products (id bigserial primary key, uuid uuid, name text, age int);
+CREATE TABLE mpp_orders   (id bigserial primary key, uuid uuid, name text, age int);
 
-INSERT INTO mpp_sig_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
+INSERT INTO mpp_users (uuid, name, age, category)
+SELECT gen_random_uuid(), (ARRAY['bob','alice','carol','dave'])[1 + (g % 4)], g % 50, 'c' || (g % 5)
+FROM generate_series(1, 20000) AS g;
 
-INSERT INTO mpp_sig_pages (file_id, page_text)
-SELECT (g % 200) + 1, 'Page text for page ' || g
-FROM generate_series(1, 200000) AS g;
+INSERT INTO mpp_products (uuid, name, age)
+SELECT gen_random_uuid(), (ARRAY['bob','alice'])[1 + (g % 2)], g % 50
+FROM generate_series(1, 20000) AS g;
 
-CREATE INDEX mpp_sig_files_idx ON mpp_sig_files
-USING bm25 (id, title, content)
-WITH (key_field='id', text_fields='{"title": {"fast": true}, "content": {}}');
+INSERT INTO mpp_orders (uuid, name, age)
+SELECT gen_random_uuid(), 'x', g % 50
+FROM generate_series(1, 20000) AS g;
 
-CREATE INDEX mpp_sig_pages_idx ON mpp_sig_pages
-USING bm25 (id, file_id, page_text)
-WITH (key_field='id', numeric_fields='{"file_id": {"fast": true}}', text_fields='{"page_text": {}}');
+CREATE INDEX mpp_users_idx ON mpp_users USING bm25 (id, uuid, name, age, category)
+WITH (key_field='id', text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true},"category":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
 
-ANALYZE mpp_sig_files;
-ANALYZE mpp_sig_pages;
+CREATE INDEX mpp_products_idx ON mpp_products USING bm25 (id, uuid, name, age)
+WITH (key_field='id', text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+
+CREATE INDEX mpp_orders_idx ON mpp_orders USING bm25 (id, uuid, name, age)
+WITH (key_field='id', text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+
+ANALYZE mpp_users;
+ANALYZE mpp_products;
+ANALYZE mpp_orders;
 "#;
 
 // Forces the join through MPP and zeroes the parallel costs so the planner always picks it.
 const MPP_GUCS: &str = r#"
 SET paradedb.enable_join_custom_scan TO on;
-SET paradedb.mpp_worker_count TO 4;
+SET paradedb.enable_mpp TO on;
+SET paradedb.mpp_worker_count TO 3;
 SET max_parallel_workers_per_gather TO 4;
 SET max_parallel_workers TO 8;
 SET min_parallel_table_scan_size TO 0;
 SET parallel_setup_cost TO 0;
 SET parallel_tuple_cost TO 0;
+SET work_mem TO '512MB';
 "#;
 
-// Streams 200k rows out of an MPP join. No sort/aggregate, so it stays under `work_mem`
-// (the point here is a live query to signal, not an overflow), but it runs long enough that
-// the killer reliably catches the backend mid-execution.
+// The top-level ORDER BY ... LIMIT is what makes the join JoinScan-eligible; together with the
+// `age` fan-out above it plans as `Custom Scan (ParadeDB Join Scan)` -> `DistributedExec` and runs
+// long enough to be signalled mid-flight. (The `orders` uuids don't match `products`, so the result
+// is empty — irrelevant; the point is the in-flight join work, not the rows.)
 const MPP_QUERY: &str = r#"
-SELECT f.title, p.page_text
-FROM mpp_sig_files f JOIN mpp_sig_pages p ON f.id = p.file_id
-WHERE f.content @@@ 'Section'
+SELECT mpp_users.id, mpp_users.name, mpp_users.age, mpp_products.age
+FROM mpp_users JOIN mpp_products ON mpp_users.age = mpp_products.age
+JOIN mpp_orders ON mpp_products.uuid = mpp_orders.uuid
+WHERE NOT ((mpp_users.name @@@ 'bob') AND (mpp_users.name @@@ 'bob'))
+  AND mpp_users.age >= mpp_products.age
+ORDER BY mpp_users.id LIMIT 31
 "#;
+
+// The crash needs the leader caught mid-`block_on` with its DSM senders live — not during planning
+// or worker launch. So after the backend first shows up `active`, wait this long before signalling,
+// to let execution get well inside the join (the query runs ~2s). Signalling immediately lands too
+// early and misses the window entirely. A few attempts then make it robust against host timing; on
+// the fixed build every attempt is a clean teardown.
+const SIGNAL_DELAY: Duration = Duration::from_millis(800);
+const ATTEMPTS: usize = 3;
 
 /// Spin until `victim_app`'s backend is running the MPP query, then run `signal_fn(pid)`
 /// (`pg_cancel_backend` or `pg_terminate_backend`) on it. Returns the pid that was signalled.
@@ -89,13 +114,15 @@ async fn signal_running_mpp_backend(
         let pid: Option<i32> = sqlx::query_scalar(
             "SELECT pid FROM pg_stat_activity \
              WHERE application_name = $1 AND backend_type = 'client backend' \
-             AND state = 'active' AND query LIKE '%mpp_sig_pages%'",
+             AND state = 'active' AND query LIKE '%mpp_users.age = mpp_products.age%'",
         )
         .bind(victim_app)
         .fetch_optional(&mut *killer)
         .await?;
 
         if let Some(pid) = pid {
+            // Let execution get well inside the MPP join (senders live) before signalling.
+            sleep(SIGNAL_DELAY).await;
             sqlx::query(&format!("SELECT {signal_fn}($1)"))
                 .bind(pid)
                 .execute(&mut *killer)
@@ -109,9 +136,9 @@ async fn signal_running_mpp_backend(
     }
 }
 
-/// Run the MPP query in a loop on `victim` until its connection or query is cut off. The
-/// loop keeps the backend busy so the killer has a wide window to land the signal mid-query.
-async fn run_until_signalled(mut victim: PgConnection, app_name: &str) {
+/// Run the MPP query in a loop on `victim` until its connection or query is cut off. The loop keeps
+/// the backend busy so the killer has a wide window to land the signal mid-query.
+async fn run_until_signalled(mut victim: PgConnection, app_name: String) {
     if victim
         .execute(format!("SET application_name = '{app_name}';").as_str())
         .await
@@ -122,8 +149,8 @@ async fn run_until_signalled(mut victim: PgConnection, app_name: &str) {
     if victim.execute(MPP_GUCS).await.is_err() {
         return;
     }
-    // A terminate drops the connection and a cancel errors the in-flight query; either way
-    // the next iteration's error ends the loop.
+    // A terminate drops the connection and a cancel errors the in-flight query; either way the next
+    // iteration's error ends the loop.
     while victim.execute(MPP_QUERY).await.is_ok() {}
 }
 
@@ -143,8 +170,8 @@ async fn mpp_signal_does_not_crash_backend(database: Db) -> Result<()> {
     let mut setup = database.connection().await;
     setup.execute(SETUP_SQL).await?;
 
-    // Opened before any signal and reused after each, so a cluster reset would surface as a
-    // failure on this connection.
+    // Opened before any signal and reused after each, so a cluster reset would surface as a failure
+    // on this connection.
     let mut witness = database.connection().await;
     witness
         .execute("CREATE EXTENSION IF NOT EXISTS pg_search;")
@@ -155,14 +182,17 @@ async fn mpp_signal_does_not_crash_backend(database: Db) -> Result<()> {
         ("mpp_sig_cancel", "pg_cancel_backend"),
         ("mpp_sig_terminate", "pg_terminate_backend"),
     ] {
-        let victim = database.connection().await;
-        let loop_handle = tokio::spawn(run_until_signalled(victim, app));
+        for attempt in 0..ATTEMPTS {
+            let app_name = format!("{app}_{attempt}");
+            let victim = database.connection().await;
+            let loop_handle = tokio::spawn(run_until_signalled(victim, app_name.clone()));
 
-        let mut killer = database.connection().await;
-        signal_running_mpp_backend(&mut killer, app, signal_fn).await?;
+            let mut killer = database.connection().await;
+            signal_running_mpp_backend(&mut killer, &app_name, signal_fn).await?;
 
-        let _ = loop_handle.await;
-        assert_cluster_alive(&mut witness).await?;
+            let _ = loop_handle.await;
+            assert_cluster_alive(&mut witness).await?;
+        }
     }
 
     Ok(())

--- a/tests/tests/mpp_cancel.rs
+++ b/tests/tests/mpp_cancel.rs
@@ -29,10 +29,9 @@ use tests::fixtures::*;
 use tokio::time::sleep;
 
 // Three 20k-row tables. `age` is in [0,50), so `users.age = products.age` fans out to millions of
-// intermediate rows — that scan-dominated join is what keeps the leader inside its MPP `block_on`
-// for ~2s, a window wide enough for the killer to land a signal mid-flight. (A small/cheap join
-// finishes in milliseconds and the signal misses the window — it then can't catch the teardown
-// bug at all.)
+// intermediate rows. That scan-dominated join keeps the leader inside its MPP `block_on` long
+// enough for the killer to land a signal mid-flight. A small join can finish before the signal and
+// miss the teardown bug entirely.
 const SETUP_SQL: &str = r#"
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
@@ -92,13 +91,30 @@ WHERE NOT ((mpp_users.name @@@ 'bob') AND (mpp_users.name @@@ 'bob'))
 ORDER BY mpp_users.id LIMIT 31
 "#;
 
-// The crash needs the leader caught mid-`block_on` with its DSM senders live — not during planning
-// or worker launch. So after the backend first shows up `active`, wait this long before signalling,
-// to let execution get well inside the join (the query runs ~2s). Signalling immediately lands too
-// early and misses the window entirely. A few attempts then make it robust against host timing; on
+// The crash needs the leader caught mid-`block_on` with its DSM senders live, not during planning
+// or worker launch. After the backend first shows up `active`, wait briefly so execution gets well
+// inside the join before signalling. A few attempts make the test robust against host timing; on
 // the fixed build every attempt is a clean teardown.
 const SIGNAL_DELAY: Duration = Duration::from_millis(800);
 const ATTEMPTS: usize = 3;
+const VICTIM_LOOP_TIMEOUT: Duration = Duration::from_secs(30);
+
+async fn assert_query_plans_as_mpp(conn: &mut PgConnection) -> Result<()> {
+    conn.execute(MPP_GUCS).await?;
+    let rows: Vec<(String,)> = sqlx::query_as(&format!("EXPLAIN (COSTS OFF, VERBOSE) {MPP_QUERY}"))
+        .fetch_all(&mut *conn)
+        .await?;
+    let explain = rows
+        .into_iter()
+        .map(|(line,)| line)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        explain.contains("DistributedExec"),
+        "MPP cancel test query must plan as DistributedExec:\n{explain}"
+    );
+    Ok(())
+}
 
 /// Spin until `victim_app`'s backend is running the MPP query, then run `signal_fn(pid)`
 /// (`pg_cancel_backend` or `pg_terminate_backend`) on it. Returns the pid that was signalled.
@@ -138,20 +154,29 @@ async fn signal_running_mpp_backend(
 
 /// Run the MPP query in a loop on `victim` until its connection or query is cut off. The loop keeps
 /// the backend busy so the killer has a wide window to land the signal mid-query.
-async fn run_until_signalled(mut victim: PgConnection, app_name: String) {
+async fn run_until_signalled(mut victim: PgConnection, app_name: String) -> Result<()> {
     if victim
         .execute(format!("SET application_name = '{app_name}';").as_str())
         .await
         .is_err()
     {
-        return;
+        return Ok(());
     }
     if victim.execute(MPP_GUCS).await.is_err() {
-        return;
+        return Ok(());
     }
-    // A terminate drops the connection and a cancel errors the in-flight query; either way the next
-    // iteration's error ends the loop.
-    while victim.execute(MPP_QUERY).await.is_ok() {}
+    // A terminate drops the connection and a cancel errors the in-flight query; if the signal
+    // misses, the deadline turns the would-be hang into a test failure.
+    let deadline = Instant::now() + VICTIM_LOOP_TIMEOUT;
+    while victim.execute(MPP_QUERY).await.is_ok() {
+        if Instant::now() >= deadline {
+            anyhow::bail!(
+                "victim query loop was not interrupted within {:?}; the signal likely missed",
+                VICTIM_LOOP_TIMEOUT
+            );
+        }
+    }
+    Ok(())
 }
 
 async fn assert_cluster_alive(witness: &mut PgConnection) -> Result<()> {
@@ -177,6 +202,7 @@ async fn mpp_signal_does_not_crash_backend(database: Db) -> Result<()> {
         .execute("CREATE EXTENSION IF NOT EXISTS pg_search;")
         .await?;
     assert_cluster_alive(&mut witness).await?;
+    assert_query_plans_as_mpp(&mut setup).await?;
 
     for (app, signal_fn) in [
         ("mpp_sig_cancel", "pg_cancel_backend"),
@@ -190,7 +216,7 @@ async fn mpp_signal_does_not_crash_backend(database: Db) -> Result<()> {
             let mut killer = database.connection().await;
             signal_running_mpp_backend(&mut killer, &app_name, signal_fn).await?;
 
-            let _ = loop_handle.await;
+            loop_handle.await??;
             assert_cluster_alive(&mut witness).await?;
         }
     }


### PR DESCRIPTION
## Summary

A `pg_terminate_backend` (or any backend FATAL) on an **MPP leader** mid-query SIGSEGVs the leader and takes the whole cluster into crash recovery. This survives #5336. The fix moves the leader's control-sender release onto the DSM segment's own lifecycle (`on_dsm_detach`) so it always runs while the segment is still mapped.

## Root cause

The leader's control senders point into the parallel-context DSM; dropping one does a `fetch_sub` on an atomic **inside that segment**, so they must be released **before PG unmaps it**.

On `main` they're released in two places: from `shutdown_custom_scan` (success path) and from an `XACT_EVENT_ABORT` callback (error path, added in #5256). A direct leader FATAL takes **neither**:

- `proc_exit` abandons the executor, so `ExecShutdownNode` → `shutdown_custom_scan` never runs; and
- it reaches `CallXactCallbacks(XACT_EVENT_ABORT)` (xact.c:157) only **after** `AtEOXact_Parallel` (xact.c:103) has already detached the parallel DSM.

So the abort callback drops the senders into a freed segment → `fetch_sub` on unmapped memory → **SIGSEGV**.

## The fix

Register the release on the segment via **`on_dsm_detach`**. PG runs those callbacks while the mapping is still live, immediately before unmap, on **every** teardown path — commit, abort, and `proc_exit`. `launch` registers `release_control_senders_on_detach` on the MPP segment (reachable via the new `ParallelProcessFinish::dsm_segment`), passing the senders `Arc`; the callback clears them while mapped, then drops the reclaimed reference.

## On removing the `XACT_EVENT_ABORT` callback

The `XACT_EVENT_ABORT` callback (from #5256) is removed as the **now-superseded mechanism — not an independent fix**. Keeping it would be a harmless no-op, since `on_dsm_detach` (at `AtEOXact_Parallel`) empties the Vec before `CallXactCallbacks` runs. It's removed because, left in place, it's dead code and a latent footgun: it would silently become the sole release again if `on_dsm_detach` were ever refactored away. `release_control_senders` stays as the success-path early release; the new callback is idempotent over it.

## Relationship to #5336

Orthogonal and additive. All of #5336 is preserved (the `HOLD_INTERRUPTS` machinery, the release-before-`recv` in `shutdown_custom_scan`, the `work_mem` overflow fix). The only thing swapped out is the older (#5256-era) error-path release, which was mis-timed against the DSM detach.

## Reproduction

On a pg18 cluster with `pg_search` in `shared_preload_libraries`.

**1. Setup** (self-contained; 20k rows/table, `age` in `[0,50)` so `users.age = products.age` fans out and the join runs ~2s):

```sql
CREATE EXTENSION IF NOT EXISTS pg_search;
CREATE TABLE users    (id bigserial primary key, uuid uuid, name text, age int, category text);
CREATE TABLE products (id bigserial primary key, uuid uuid, name text, age int);
CREATE TABLE orders   (id bigserial primary key, uuid uuid, name text, age int);
INSERT INTO users    (uuid,name,age,category) SELECT gen_random_uuid(), (ARRAY['bob','alice','carol','dave'])[1+(g%4)], g%50, 'c'||(g%5) FROM generate_series(1,20000) g;
INSERT INTO products (uuid,name,age)          SELECT gen_random_uuid(), (ARRAY['bob','alice'])[1+(g%2)],            g%50          FROM generate_series(1,20000) g;
INSERT INTO orders   (uuid,name,age)          SELECT gen_random_uuid(), 'x',                                        g%50          FROM generate_series(1,20000) g;
CREATE INDEX idxusers    ON users    USING bm25 (id, uuid, name, age, category) WITH (key_field=id, text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true},"category":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
CREATE INDEX idxproducts ON products USING bm25 (id, uuid, name, age)           WITH (key_field=id, text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
CREATE INDEX idxorders   ON orders   USING bm25 (id, uuid, name, age)           WITH (key_field=id, text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
ANALYZE;
```

**2. Session A** — run the MPP query (plans as `Custom Scan (ParadeDB Join Scan)` → `DistributedExec`):

```sql
SET max_parallel_workers = 8;
SET max_parallel_workers_per_gather = 4;
SET paradedb.enable_mpp = on;
SET paradedb.mpp_worker_count = 3;          -- leader + 2 producers
SET paradedb.enable_join_custom_scan = on;
SET work_mem = '512MB';

SELECT users.id, users.name, users.age, products.age
FROM users JOIN products ON users.age = products.age
JOIN orders ON products.uuid = orders.uuid
WHERE NOT ((users.name @@@ 'bob') AND (users.name @@@ 'bob'))
  AND users.age >= products.age
ORDER BY users.id LIMIT 31;
```

**3. Session B** — ~1s into the run (so the leader is mid-execution, senders live), terminate the leader:

```sql
SELECT pg_terminate_backend(pid) FROM pg_stat_activity
WHERE backend_type = 'client backend' AND state = 'active'
  AND query LIKE '%users.age = products.age%';
-- (terminating a parallel worker — leader_pid IS NOT NULL — crashes the leader too)
```

**4. Result**
- **Before fix:** the leader dies with `signal 11: Segmentation fault`; the server log shows `terminating any other active server processes` and `all server processes terminated; reinitializing` — the whole cluster resets.
- **After fix:** clean `FATAL: terminating connection due to administrator command`; the cluster stays up.

## Testing

**Regression test** — `tests/tests/mpp_cancel.rs` is rewritten to actually exercise the MPP path. (Its prior 2-table query planned as a plain parallel Hash Join — no MPP leader, no control senders — and signalled on first `active`, so it passed even unfixed.) It now runs the scan-dominated 3-way join above (`DistributedExec`, ~2s) and waits ~0.8s after the backend is `active` before signalling, to catch the leader mid-`block_on`. Verified on the same cluster:
- stock `main` → **test fails** (`client backend … terminated by signal 11` + crash recovery);
- this fix → **test passes** (3 cancel + 3 terminate attempts, all clean teardowns).

**Kill-fuzzing harness** (captures each victim's own backend pid before killing): stock `main` SIGSEGVs the MPP leader **20/20** on terminate; the fix is **0 crashes across 75 real kills** (leader/worker terminate, cancel, single-node JoinScan and Aggregate), including an adversarial early/mid timing run.