### PR TITLE
feat: port pg_search MPP onto the WorkerChannel-based datafusion-distributed fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2087,10 +2087,8 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=f2087994c4e7b8f742168762b2e1da5e9a9c13c1#f2087994c4e7b8f742168762b2e1da5e9a9c13c1"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=a09c34a5c36e165c4709b468f956612ed63a5a79#a09c34a5c36e165c4709b468f956612ed63a5a79"
 dependencies = [
- "arrow-ipc",
- "arrow-select",
  "async-stream",
  "async-trait",
  "bincode 1.3.3",
@@ -2106,6 +2104,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "moka",
+ "num-traits",
  "object_store",
  "pin-project",
  "prost",
@@ -2114,6 +2113,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "tonic-prost",
  "url",
  "uuid",
 ]
@@ -2650,7 +2650,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2970,7 +2970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3782,7 +3782,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4154,7 +4154,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5304,7 +5304,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6192,7 +6192,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6900,7 +6900,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6958,7 +6958,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7387,7 +7387,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8014,7 +8014,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8433,6 +8433,37 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tonic"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac2a5518c70fa84342385732db33fb3f44bc4cc748936eb5833d2df34d6445ef"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project",
+ "sync_wrapper",
+ "tokio-stream",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
 
 [[package]]
 name = "tower"
@@ -8993,7 +9024,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2087,7 +2087,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=a09c34a5c36e165c4709b468f956612ed63a5a79#a09c34a5c36e165c4709b468f956612ed63a5a79"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=741f0c14caee0b74793865483dd49b4ec93b14f8#741f0c14caee0b74793865483dd49b4ec93b14f8"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-tQoddWgHHdbqX88ImexER7r5qKraoKHP/73wvVkMhUQ=";
+  cargoHash = "sha256-g38+rNaQ0fdShf1oepDLGm3blOOyxjVgOuyHYjNdKc8=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-g38+rNaQ0fdShf1oepDLGm3blOOyxjVgOuyHYjNdKc8=";
+  cargoHash = "sha256-uj0YGiK9VP+UaF2vVWITEPUdOil86FPrg47ZpKdDC0w=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -81,7 +81,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "54", default-features = false }
 datafusion-proto = { version = "54", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "a09c34a5c36e165c4709b468f956612ed63a5a79", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "741f0c14caee0b74793865483dd49b4ec93b14f8", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -81,7 +81,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "54", default-features = false }
 datafusion-proto = { version = "54", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "f2087994c4e7b8f742168762b2e1da5e9a9c13c1", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "a09c34a5c36e165c4709b468f956612ed63a5a79", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1548,7 +1548,7 @@ impl AggregateScan {
 
             // MPP leader: install the mesh + DF-D fork's distributed planner so
             // `create_physical_plan` produces a `DistributedExec` whose
-            // `NetworkShuffleExec`s use our `ShmMqWorkerTransport` to read
+            // `NetworkShuffleExec`s use our `ShmChannelResolver` to read
             // from worker queues at execute time. Otherwise: existing serial
             // session context.
             let ctx = match df_state.mpp.as_ref() {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -44,7 +44,9 @@ use crate::postgres::catalog::is_ltree_oid;
 
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTaskContext};
+use datafusion_distributed::{
+    display_plan_ascii, DistributedExec, DistributedExt, DistributedTaskContext,
+};
 
 use datafusion_distributed::shm::MppMesh;
 
@@ -1553,15 +1555,14 @@ impl AggregateScan {
             // session context.
             let ctx = match df_state.mpp.as_ref() {
                 Some(leader) => {
-                    // Workers are launched and draining their inboxes (the launcher already
-                    // verified the full producer set came up, else it fell back to serial); ship
-                    // each fragment's plan frame now.
-                    if let Err(e) =
-                        crate::postgres::customscan::mpp::glue::deliver_set_plans(leader)
-                    {
-                        pgrx::error!("mpp aggregate: plan delivery failed: {e}");
-                    }
+                    // The coordinator sources these structure-only subplans and routes them to the
+                    // workers during execution, so there is no separate delivery pass.
+                    let source =
+                        crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::new(
+                            &leader.stage_plans.lock().unwrap(),
+                        );
                     Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
+                        .with_distributed_dispatch_plan_source(source)
                 }
                 _ => create_aggregate_session_context(),
             };

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -193,7 +193,7 @@ use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
-use datafusion_distributed::{display_plan_ascii, DistributedExec};
+use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedExt};
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
 use std::sync::Arc;
@@ -1486,14 +1486,14 @@ impl CustomScan for JoinScan {
                 // plan and the worker fragments would have nothing to consume from.
                 let ctx = match state.custom_state().mpp.as_ref() {
                     Some(leader) => {
-                        // Workers are launched and draining (the launcher verified the full producer
-                        // set came up, else it fell back to serial); ship each fragment's plan now.
-                        if let Err(e) =
-                            crate::postgres::customscan::mpp::glue::deliver_set_plans(leader)
-                        {
-                            pgrx::error!("mpp join: plan delivery failed: {e}");
-                        }
+                        // The coordinator sources these structure-only subplans and routes them to
+                        // the workers during execution, so there is no separate delivery pass.
+                        let source =
+                            crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::new(
+                                &leader.stage_plans.lock().unwrap(),
+                            );
                         Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
+                            .with_distributed_dispatch_plan_source(source)
                     }
                     _ => create_datafusion_session_context(SessionContextProfile::Join),
                 };

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -58,13 +58,12 @@ struct DispatchedStage {
     routing: FragmentRouting,
 }
 
-/// One stage's plan bytes, headed for per-task `SetPlan` frames. Stays leader-side: the leader
-/// stamps each task's `TaskKey` from `query_id`/`stage_num` and ships `plan_proto` once per task.
+/// One stage's plan bytes. The coordinator's `DispatchPlanSource` looks these up by `stage_num`
+/// and routes `plan_proto` to every task of the stage; each worker specializes its own slice on
+/// decode.
 #[derive(Clone)]
 pub struct StagePlan {
     pub stage_num: u32,
-    pub query_id: Vec<u8>,
-    pub task_count: usize,
     /// `PhysicalPlanNode`-encoded `stage.local_plan()` (via the combined codec).
     pub plan_proto: Vec<u8>,
 }
@@ -193,8 +192,6 @@ pub fn build_dispatch_blob(
         });
         stage_plans.push(StagePlan {
             stage_num: stage.stage_num,
-            query_id: stage.query_id.as_bytes().to_vec(),
-            task_count: stage.task_count,
             plan_proto,
         });
     }

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -48,7 +48,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::shm::{
     collect_task_metrics, proc_for_task, run_worker_fragment, CooperativeDrainSet,
     InProcessWorkerResolver, MppFrameHeader, MppMesh, MppPartitionSink, MppSender,
-    ShmMqWorkerTransport,
+    ShmChannelResolver, ShmDiscardedPlanCodec,
 };
 use datafusion_distributed::PartitionSink;
 
@@ -158,7 +158,7 @@ pub(crate) fn build_mpp_session_context(
     // opens a WorkerConnection, so the fork's default transport sits unused.
     if let Some(mesh) = mesh {
         state_builder =
-            state_builder.with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh));
+            state_builder.with_distributed_channel_resolver(ShmChannelResolver::new(mesh));
     }
     let state_builder = state_builder
         // Broadcast-subtree cap. Chain order matters: this has to come before the leaf
@@ -168,9 +168,11 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)`: the leader serializes per-stage subplans through
-        // a combined codec built explicitly in `scan::physical_codec`, and each worker decodes
-        // the same way. Nothing drives the session's user-codec slot.
+        // The coordinator serializes each stage subplan into the dispatch request before handing it
+        // to the channel. We deliver plans over DSM and the shm channel discards that request, so
+        // the codec only has to let the throwaway encode succeed for nodes DataFusion's proto can't
+        // represent (`PgSearchScan`, `SortMergeJoinExec`).
+        .with_distributed_user_codec(ShmDiscardedPlanCodec)
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }
@@ -458,7 +460,7 @@ pub(crate) fn run_mpp_worker(
             // `Stage::Remote`. Without this, a nested `NetworkShuffleExec` /
             // `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task count
             // exceeds 1; with the conversion, those boundaries dispatch through
-            // `ShmMqWorkerTransport` exactly like outer boundaries.
+            // `ShmChannelResolver` exactly like outer boundaries.
             let plan = {
                 let dist = Arc::new(DistributedExec::new(Arc::clone(frag_plan)));
                 match dist.prepare_in_process_plan(&task_ctx) {

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -168,10 +168,11 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // The coordinator serializes each stage subplan into the dispatch request before handing it
-        // to the channel. We deliver plans over DSM and the shm channel discards that request, so
-        // the codec only has to let the throwaway encode succeed for nodes DataFusion's proto can't
-        // represent (`PgSearchScan`, `SortMergeJoinExec`).
+        // Workers dispatch their fragment's NESTED stages in process via `prepare_in_process_plan`,
+        // which encodes each subplan through the session codec. Those bytes are discarded (nested
+        // stages run from the local plan), but the encode still has to succeed for `PgSearchScan`.
+        // The leader overrides this on its exec session with a `DispatchPlanSource` that ships the
+        // structure-only bytes for the top-level dispatch.
         .with_distributed_user_codec(ShmDiscardedPlanCodec)
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -120,7 +120,7 @@ pub fn producer_worker_count() -> u32 {
 /// producer fragment itself. Its outbound senders are dropped inside `leader_setup`.
 pub struct MppLeaderState {
     /// Runtime mesh handle. Install on the leader's `SessionContext` via
-    /// `with_extension(Arc::clone(&mesh))` so `ShmMqWorkerTransport` can find
+    /// `with_extension(Arc::clone(&mesh))` so `ShmChannelResolver` can find
     /// it at execute time.
     pub mesh: Arc<MppMesh>,
     /// The leader's outbound senders, one per peer inbox; the control-plane path for `SetPlan`
@@ -304,7 +304,7 @@ pub fn deliver_set_plans(leader: &MppLeaderState) -> Result<(), String> {
                     set_plan: Some(SetPlanRequest {
                         plan_proto: sp.plan_proto.clone(),
                         task_count: sp.task_count as u64,
-                        task_key: Some(TaskKey {
+                        task_key: Some(datafusion_distributed::proto::TaskKey {
                             query_id: sp.query_id.clone(),
                             stage_id: sp.stage_num as u64,
                             task_number: task as u64,
@@ -420,7 +420,7 @@ pub fn drain_worker_metrics(
     let _ = plan.apply(|node| {
         if let Some(nb) = node.as_network_boundary() {
             let stage = nb.input_stage();
-            query_id.get_or_insert_with(|| stage.query_id().as_bytes().to_vec());
+            query_id.get_or_insert_with(|| stage.query_id());
             expected += stage.task_count();
         }
         Ok(TreeNodeRecursion::Continue)
@@ -435,14 +435,18 @@ pub fn drain_worker_metrics(
     for _ in 0..100 {
         let _ = mesh.try_drain_pass();
         while let Ok((stage_id, task_number, metrics)) = rx.try_recv() {
-            store.insert(
-                datafusion_distributed::TaskKey {
-                    query_id: query_id.clone(),
-                    stage_id: stage_id as u64,
-                    task_number: task_number as u64,
-                },
-                metrics,
-            );
+            // The frames carry proto metrics; the store holds the decoded in-memory form the rewrite
+            // reads. A frame that fails to decode is still counted so the wait doesn't spin.
+            if let Ok(metrics) = datafusion_distributed::decode_task_metrics(metrics) {
+                store.insert(
+                    TaskKey {
+                        query_id,
+                        stage_id: stage_id as usize,
+                        task_number: task_number as usize,
+                    },
+                    metrics,
+                );
+            }
             got.insert((stage_id, task_number));
         }
         if got.len() >= expected {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -36,11 +36,7 @@ use std::sync::Arc;
 
 use pgrx::pg_sys;
 
-use datafusion_distributed::proto::SetPlanRequest;
-use datafusion_distributed::shm::{
-    self, proc_for_task, CooperativeDrainSet, Interrupt, MppFrameHeader, MppMesh, MppSender,
-    SendBatchStats, SetPlanFrame, Wakeup,
-};
+use datafusion_distributed::shm::{self, Interrupt, MppMesh, MppSender, Wakeup};
 use datafusion_distributed::TaskKey;
 
 use crate::postgres::customscan::mpp::dispatch::StagePlan;
@@ -133,15 +129,10 @@ pub struct MppLeaderState {
     /// in [`leader_setup`]) clears them on the error path, both before PG detaches the DSM.
     /// The scan state's own drop runs after detach and must find this empty.
     pub control_senders: Arc<std::sync::Mutex<Vec<Option<MppSender>>>>,
-    /// Plans for [`deliver_set_plans`], which runs at exec time when the launched workers are
-    /// draining their inboxes. Sending from the init callback instead could fill a small ring
-    /// with no drainer behind it and wedge the leader. Kept (not drained) so a parallel rescan
-    /// can re-deliver to relaunched workers, the frame analog of the plan blob persisting in
-    /// DSM. Mutex because the exec hook only sees a shared borrow of the scan state.
+    /// The structure-only subplans the leader wraps in a [`StagePlanDispatchSource`] on the exec
+    /// session; the coordinator sources them by `stage_num` and routes them to the workers during
+    /// execution. Mutex because the exec hook only sees a shared borrow of the scan state.
     pub stage_plans: std::sync::Mutex<Vec<StagePlan>>,
-    /// One delivery per worker generation: set by [`deliver_set_plans`], reset by the rescan
-    /// path before workers relaunch.
-    pub plans_delivered: std::sync::atomic::AtomicBool,
     /// The builder handle owning the launched producer workers. The leader controls the launch, so
     /// it owns the teardown too: `end_custom_scan` takes this and calls `wait_for_finish` to join
     /// the workers and destroy the parallel context. `None` until `launch` installs it on the
@@ -248,7 +239,6 @@ pub unsafe fn leader_setup(
         mesh,
         control_senders,
         stage_plans: std::sync::Mutex::new(stage_plans),
-        plans_delivered: std::sync::atomic::AtomicBool::new(false),
         finish: None,
         parallel_state: std::ptr::null_mut(),
     })
@@ -262,68 +252,31 @@ impl MppLeaderState {
     }
 }
 
-/// Ship every dispatched plan as `SetPlan` frames: one per `(stage, task)`, to the proc hosting
-/// the task, carrying the same `SetPlanRequest` Flight would put on its coordinator stream.
-///
-/// Runs at exec time, after the launched-worker check: the workers are attaching and draining by
-/// then, so a plan bigger than a ring drains through instead of wedging the send spin. One
-/// delivery per worker generation; re-execution without a relaunch is a no-op.
-pub fn deliver_set_plans(leader: &MppLeaderState) -> Result<(), String> {
-    if leader
-        .plans_delivered
-        .swap(true, std::sync::atomic::Ordering::SeqCst)
-    {
-        return Ok(());
-    }
-    let stage_plans = leader.stage_plans.lock().unwrap().clone();
-    if stage_plans.is_empty() {
-        return Ok(());
-    }
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| format!("mpp: set-plan runtime build: {e}"))?;
-    let n_workers = leader.mesh.n_workers();
-    runtime.block_on(async {
-        let mut stats = SendBatchStats::default();
-        for sp in &stage_plans {
-            for task in 0..sp.task_count {
-                let dest = proc_for_task(n_workers, task as u32);
-                // Clone the sender out under the lock so the guard never spans the await below.
-                let sender = {
-                    let senders = leader.control_senders.lock().unwrap();
-                    let Some(base) = senders.get(dest as usize).and_then(|s| s.as_ref()) else {
-                        return Err(format!("mpp: no leader sender for proc {dest}"));
-                    };
-                    base.clone_with_header(MppFrameHeader::set_plan(sp.stage_num, task as u32, 0))
-                        .with_cooperative_drain(
-                            Arc::clone(&leader.mesh) as Arc<dyn CooperativeDrainSet>
-                        )
-                };
-                let frame = SetPlanFrame {
-                    set_plan: Some(SetPlanRequest {
-                        plan_proto: sp.plan_proto.clone(),
-                        task_count: sp.task_count as u64,
-                        task_key: Some(datafusion_distributed::proto::TaskKey {
-                            query_id: sp.query_id.clone(),
-                            stage_id: sp.stage_num as u64,
-                            task_number: task as u64,
-                        }),
-                        work_unit_feed_declarations: vec![],
-                        target_worker_url: String::new(),
-                        query_start_time_ns: 0,
-                    }),
-                    header_keys: vec![],
-                    header_values: vec![],
-                };
-                sender
-                    .send_set_plan_traced(&frame, &mut stats)
-                    .await
-                    .map_err(|e| format!("mpp: set-plan send failed: {e}"))?;
-            }
+/// The dispatch bytes the coordinator routes to workers, keyed by `stage_num`. pg builds a
+/// structure-only subplan per producer stage (`build_dispatch_blob`) whose scans stay segment-free
+/// recipes; the coordinator ships those instead of encoding its exec-time plan, which carries state
+/// wrong to dispatch (a runtime `Limit`, `FilterPassthroughExec`) or not serializable (its
+/// `SortMergeJoinExec` variant). Every task of a stage runs the same subplan; each worker
+/// specializes its own segment slice on decode.
+pub struct StagePlanDispatchSource {
+    plans: std::collections::HashMap<u32, Vec<u8>>,
+}
+
+impl StagePlanDispatchSource {
+    pub fn new(stage_plans: &[StagePlan]) -> Self {
+        Self {
+            plans: stage_plans
+                .iter()
+                .map(|sp| (sp.stage_num, sp.plan_proto.clone()))
+                .collect(),
         }
-        Ok(())
-    })
+    }
+}
+
+impl datafusion_distributed::DispatchPlanSource for StagePlanDispatchSource {
+    fn dispatch_plan_proto(&self, stage_id: usize, _task_number: usize) -> Option<Vec<u8>> {
+        self.plans.get(&(stage_id as u32)).cloned()
+    }
 }
 
 /// Returned to a worker from [`worker_setup`]. The customscan reads the plan bytes, runs the

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -208,33 +208,22 @@ pub unsafe fn leader_setup(
     // Hand the senders to the mesh too, so its early-termination cancel can reach the producers.
     // The mesh shares this `Arc`, so clearing it below releases both views before the DSM unmaps.
     mesh.set_cancel_senders(Arc::clone(&control_senders));
-    // Forget these senders instead of dropping them: `AbortTransaction` unmaps the DSM before the
-    // xact callbacks run, so a sender's drop would write its detach signal into a freed ring
-    // header. This DF-D rev has no ring liveness flag, so the drop can't tell the mapping is gone
-    // and guard itself. The signal has no audience anyway, since the abort already terminated the
-    // workers. `PreCommit` covers a subtransaction rollback where no abort fires; a populated vec
-    // at either event means the mapping is already gone (the success path clears it in
-    // `shutdown_custom_scan`).
-    //
-    // TODO: once the DF-D pin has `MppMesh::mark_detached` / `detached_flag`, flip that
-    // process-local flag here and drop the senders normally, so their own `Drop` skips the
-    // freed-ring write and frees their heap instead of leaking it.
-    let forget_senders = |senders: &Arc<std::sync::Mutex<Vec<Option<MppSender>>>>| {
-        let senders = Arc::clone(senders);
+    // On abort, `AbortTransaction` unmaps the DSM before these callbacks run, so the senders must
+    // not touch their ring headers as they drop. The mesh's liveness flag is process-local, so
+    // flip it here (every ring handle reads it) and the senders' drop skips the freed-ring write
+    // while their heap is still freed. `PreCommit` covers a subtransaction rollback where no abort
+    // fires; the success path releases the senders in `shutdown_custom_scan` while the segment is
+    // still mapped, so the vec is empty by then.
+    let make_detacher = || {
+        let alive = mesh.detached_flag();
+        let senders = Arc::clone(&control_senders);
         move || {
-            for sender in senders.lock().unwrap().drain(..).flatten() {
-                std::mem::forget(sender);
-            }
+            alive.store(false, std::sync::atomic::Ordering::Release);
+            senders.lock().unwrap().clear();
         }
     };
-    pgrx::register_xact_callback(
-        pgrx::PgXactCallbackEvent::Abort,
-        forget_senders(&control_senders),
-    );
-    pgrx::register_xact_callback(
-        pgrx::PgXactCallbackEvent::PreCommit,
-        forget_senders(&control_senders),
-    );
+    pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::Abort, make_detacher());
+    pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::PreCommit, make_detacher());
     Ok(MppLeaderState {
         mesh,
         control_senders,

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -109,8 +109,6 @@ pub enum FragmentRouting {
 pub struct StageEntry {
     /// `input_stage.num` of the boundary whose producer side this stage belongs to.
     pub stage_num: u32,
-    /// The query's id, carried so the leader can stamp each task's `TaskKey`.
-    pub query_id: uuid::Uuid,
     /// Total task count for the stage (= `input_stage.tasks.len()`).
     pub task_count: usize,
     /// How to route each output partition to a destination proc.
@@ -239,7 +237,6 @@ fn collect_stages(
         if let Some(stage_plan) = stage.local_plan() {
             out.push(StageEntry {
                 stage_num: stage_id,
-                query_id: stage.query_id(),
                 task_count,
                 routing,
                 plan: Arc::clone(stage_plan),


### PR DESCRIPTION
## What

Repins `datafusion-distributed` to our `WorkerChannel`-based shared-memory transport and adapts the MPP customscan to it.

## Why

The DF-D fork is moving onto the maintainer's lower-level `WorkerChannel` abstraction (datafusion-contrib#512), away from the `WorkerTransport` umbrella our MPP was built on. This proves our shared-memory MPP transport runs on that abstraction, so we can follow the upstream direction without losing MPP. It pins our DF-D fork branch that ports the shm transport onto `WorkerChannel` (paradedb/datafusion-distributed#28, stacked on the gRPC abstraction #27).

## How

- `pg_search/Cargo.toml`: pin `datafusion-distributed` to `9e7210d` (branch `moe/shm-on-protocol-grpc`).
- The shm transport is a `ChannelResolver` now, not a `WorkerTransport`. `exec_worker.rs` registers it with `with_distributed_channel_resolver(ShmChannelResolver::new(mesh))` (was `with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh))`). The `datafusion_distributed::shm::{...}` facade is otherwise unchanged.
- `glue.rs`: the set-plan frame and the metrics drain now speak the plain protocol types. `WorkerChannel` exposes plain `TaskKey` (`Uuid` / `usize`) and `WorkUnitMsg` rather than the proto `Vec<u8>` / `u64` shapes, so the customscan builds those and decodes inbound proto metric frames via the new `decode_task_metrics`.

## Tests

- `cargo check -p pg_search --no-default-features --features pg18` is green, no warnings.
- The MPP regress suites (`mpp_aggregate`, `mpp_aggregate_postagg`, `mpp_joinscan`) still need a pg18 run. The changes are mechanical (a transport rename plus proto-to-plain type swaps), but the runtime path should be confirmed before this leaves draft.

## Note

The DF-D side is split so the shm transport PR (paradedb/datafusion-distributed#28) is purely `src/shm/*`. The embedder APIs this customscan reads (`route_partition` / `partitions_per_consumer_task`, `metrics_store`, `prepare_in_process_plan`) that #512 dropped live in a separate upstreamable PR (#29), and the proto/transport-completion in #27. So pinning #28 transitively pulls all three.
