### PR TITLE
fix(pg_search): release buffer pin on dead HOT chain tuple in index_memory_segment

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -811,6 +811,11 @@ pub fn index_memory_segment(
                 }
 
                 if htsv_result == HTSV_Result::HEAPTUPLE_DEAD {
+                    // table_index_fetch_tuple stored this dead tuple in a buffer-backed slot. Since
+                    // this branch skips the tuple, clear the slot before any HOT-chain retry or ctid
+                    // skip so the slot releases its buffer pin.
+                    pg_sys::ExecClearTuple(heap_fetch_state.slot());
+
                     // This copy of the tuple is no longer visible to any transaction. Are there
                     // more in the HOT chain?
                     if call_again {
@@ -820,14 +825,6 @@ pub fn index_memory_segment(
                     } else {
                         // There are no more entries in the HOT chain, so no copy of the tuple is
                         // visible in any transaction.
-                        //
-                        // Release the buffer pin acquired by table_index_fetch_tuple before moving
-                        // on. Without this, each dead HOT-chain dead-end leaks a pin, which causes
-                        // Postgres to invalidate rd_smgr at transaction end. Subsequent buffer ops
-                        // then read a garbage tablespace OID and crash with a pg_tblspc/... path
-                        // that does not exist. The success path already calls ExecClearTuple after
-                        // detoasting; this mirrors that cleanup for the dead-tuple branch.
-                        pg_sys::ExecClearTuple(heap_fetch_state.slot());
                         writer.insert(tantivy::TantivyDocument::new(), ctid, || {
                             unreachable!("No limits configured: should not finalize.")
                         })?;

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -820,6 +820,14 @@ pub fn index_memory_segment(
                     } else {
                         // There are no more entries in the HOT chain, so no copy of the tuple is
                         // visible in any transaction.
+                        //
+                        // Release the buffer pin acquired by table_index_fetch_tuple before moving
+                        // on. Without this, each dead HOT-chain dead-end leaks a pin, which causes
+                        // Postgres to invalidate rd_smgr at transaction end. Subsequent buffer ops
+                        // then read a garbage tablespace OID and crash with a pg_tblspc/... path
+                        // that does not exist. The success path already calls ExecClearTuple after
+                        // detoasting; this mirrors that cleanup for the dead-tuple branch.
+                        pg_sys::ExecClearTuple(heap_fetch_state.slot());
                         writer.insert(tantivy::TantivyDocument::new(), ctid, || {
                             unreachable!("No limits configured: should not finalize.")
                         })?;


### PR DESCRIPTION
Closes #5449

## What

Release the buffer pin held by `table_index_fetch_tuple` when a tuple is found to be `HEAPTUPLE_DEAD` and there are no further entries in its HOT chain.

## Why

During a concurrent BM25 index build, `index_memory_segment` scans the heap and calls `table_index_fetch_tuple` for each CTID. When the fetched tuple is dead and there are no additional HOT chain entries to inspect, the code immediately continued to the next CTID without first calling `ExecClearTuple`. As a result, the buffer pin remained held.

Under heavy concurrent writes (where updates create dead tuple versions), this leaks one buffer pin for each dead-end in a HOT chain. At the end of the transaction, PostgreSQL detects the leaked buffer pins, invalidates the relation's smgr cache entry, and subsequent buffer operations use a stale tablespace OID, producing an invalid path such as `pg_tblspc/<garbage>/...`. Since that path does not exist, the index build crashes.

The normal success path already calls `ExecClearTuple` (around line 899). This change adds the missing call in the dead-tuple branch to ensure the buffer pin is always released.

## How

Added `pg_sys::ExecClearTuple(heap_fetch_state.slot())` immediately before `continue 'next_ctid` in the `HEAPTUPLE_DEAD && !call_again` branch inside `index_memory_segment` in `pg_search/src/index/directory/mvcc.rs`.

## Tests

I haven't added a dedicated test for this change yet. However, I ran the existing test suite, and all tests passed successfully.
