### PR TITLE
ci: drop the base-branch filter from pull_request triggers

### DIFF
--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -8,9 +8,6 @@ name: Test ParadeDB (Docs)
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-paradedb-docs.yml"
       - ".github/scripts/**"

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -11,9 +11,6 @@ name: Test pg_search (Docker)
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search-docker.yml"
       - "docker/**"

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -8,9 +8,6 @@ name: Test pg_search (Nix)
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search-nix.yml"
       - "nix/**"

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -8,9 +8,6 @@ name: Test pg_search (Schema)
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search-schema.yml"
       - ".github/scripts/check_migration_diff.py"

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -8,9 +8,6 @@ name: Test pg_search (Upgrade)
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - 0.*.x # Release branches
     paths:
       - ".github/workflows/test-pg_search-upgrade.yml"
       - ".github/actions/test-pg_search-upgrade/**"

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -11,9 +11,6 @@ on:
     - cron: "0 7 * * *" # daily 07:00 UTC (~2am ET)
   pull_request:
     types: [opened, synchronize, reopened]
-    branches:
-      - main
-      - 0.*.x # Release branches
     paths:
       - "Cargo.toml"
       - "Cargo.lock"


### PR DESCRIPTION
This PR drops the `branches:` filter from the `pull_request` trigger of the 6 `pg_search` test workflows.

Stacked PRs target `moe/**` base branches. The trigger was restricted to `main` and the `0.*.x` release branches, so a PR based on a `moe/**` branch never ran these checks. Its head SHA then had no check runs, and retargeting to `main` or marking it ready did not create them (those actions push no commit, so no `synchronize` fires).

Removing the branches filter lets the checks run at `opened` and on every push regardless of base. The runs land on the head SHA, so they carry over when the PR is later retargeted to `main`. The `paths:` filters are unchanged, so path-gating still applies.

This supersedes #5454. With checks running independent of the base branch, adding `ready_for_review` to re-run on the draft-to-ready transition is no longer needed.

Workflows changed: `test-pg_search`, `test-pg_search-docker`, `test-pg_search-nix`, `test-pg_search-schema`, `test-pg_search-upgrade`, `test-paradedb-docs`. The `lint-*` and `check-typo` workflows already had no branches filter. `check-released-migrations` and `test-stressgres-docker` keep their existing filters on purpose.
