### PR TITLE
ci: run PR checks when a draft is marked ready for review

### DIFF
--- a/.github/workflows/check-released-migrations.yml
+++ b/.github/workflows/check-released-migrations.yml
@@ -10,7 +10,7 @@ name: Check Released Migrations
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -7,7 +7,7 @@ name: Check Typo
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -7,7 +7,7 @@ name: Lint Bash
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "**/*.sh"
       - ".github/workflows/lint-bash.yml"

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -7,7 +7,7 @@ name: Lint Docker
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - ".github/workflows/lint-docker.yml"
       - "docker/**"

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -7,7 +7,7 @@ name: Lint Format
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -7,7 +7,7 @@ name: Lint Markdown
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "**/*.md"
       - "**/*.mdx"

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -7,7 +7,7 @@ name: Lint Rust
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "**/*.rs"
       - "**/*.toml"

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -7,7 +7,7 @@ name: Lint YAML
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - "**/*.yml"
       - "**/*.yaml"

--- a/.github/workflows/test-paradedb-docs.yml
+++ b/.github/workflows/test-paradedb-docs.yml
@@ -7,7 +7,7 @@ name: Test ParadeDB (Docs)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -10,7 +10,7 @@ name: Test pg_search (Docker)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search-nix.yml
+++ b/.github/workflows/test-pg_search-nix.yml
@@ -7,7 +7,7 @@ name: Test pg_search (Nix)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -7,7 +7,7 @@ name: Test pg_search (Schema)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -7,7 +7,7 @@ name: Test pg_search (Upgrade)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -10,7 +10,7 @@ on:
   schedule:
     - cron: "0 7 * * *" # daily 07:00 UTC (~2am ET)
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
       - 0.*.x # Release branches

--- a/.github/workflows/test-stressgres-docker.yml
+++ b/.github/workflows/test-stressgres-docker.yml
@@ -7,7 +7,7 @@ name: Test Stressgres (Docker)
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - main
     paths:


### PR DESCRIPTION
This PR adds `ready_for_review` to the `pull_request` activity types of the 15 PR-gating workflows.

These workflows listened only to `[opened, synchronize, reopened]`. Marking a draft PR ready fires `ready_for_review`, and changing the base branch fires `edited` — neither pushes a commit, so `synchronize` never fires and no check re-runs. A draft that was opened without ever matching the branch filter (a stacked PR based on a `moe/**` branch) ends up with no checks on its head SHA, and no amount of "mark ready" or "change base to main" brings them back. The only workflow that reacted to a base change was `lint-pr-title.yml`, because it alone carries `edited`.

`ready_for_review` is the low-noise fix: it fires once on the draft to ready transition, re-evaluates the branch and path filters against the current base, and runs the required checks. I left `edited` out on purpose. It also fires on every title and body edit, which would rerun the full test matrix each time.

Repro:

```
1. Open a draft PR (or base it on a moe/** branch so the branch filter skips it).
2. Change the base to main, then mark it ready for review.
3. Observe: only "Lint PR Title" runs; the test suite never does.
```

Affected workflows: `test-pg_search`, `test-pg_search-docker`, `test-pg_search-nix`, `test-pg_search-schema`, `test-pg_search-upgrade`, `test-paradedb-docs`, `test-stressgres-docker`, `lint-rust`, `lint-bash`, `lint-docker`, `lint-markdown`, `lint-yaml`, `lint-format`, `check-typo`, `check-released-migrations`.
