### PR TITLE
feat(pg_search): visibility filtering in SegmentedTopK (#4525)

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -362,10 +362,17 @@ pub fn create_datafusion_session_context(profile: SessionContextProfile) -> Sess
 
     match profile {
         SessionContextProfile::Join => {
+            use crate::scan::visibility_ctid_resolver_rule::VisibilityCtidResolverRule;
             builder = builder
                 .with_physical_optimizer_rule(Arc::new(
                     crate::scan::segmented_topk_rule::SegmentedTopKRule,
                 ))
+                // SegmentedTopKRule absorbs VisibilityFilterExec and creates a fresh
+                // AbsorbedVisibilityData with empty ctid resolvers.  We must run
+                // VisibilityCtidResolverRule again here, *after* SegmentedTopKRule, so
+                // that it wires resolvers into the STK node rather than the (now-removed)
+                // VisibilityFilterExec node.
+                .with_physical_optimizer_rule(Arc::new(VisibilityCtidResolverRule))
                 .with_physical_optimizer_rule(Arc::new(FilterPushdown::new_post_optimization()));
         }
         SessionContextProfile::Aggregate => {

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -832,6 +832,10 @@ impl VisibilityFilterExec {
         }
         Ok(Arc::new(exec))
     }
+
+    pub fn table_names(&self) -> &[String] {
+        &self.table_names
+    }
 }
 
 impl DisplayAs for VisibilityFilterExec {
@@ -1016,7 +1020,7 @@ impl ExecutionPlan for VisibilityFilterExec {
 
 /// Reusable buffers for per-segment ctid materialization.
 #[derive(Default)]
-struct DeferredCtidMaterializationState {
+pub(crate) struct DeferredCtidMaterializationState {
     resolved_ctids: Vec<Option<u64>>,
     segment_doc_ids: Vec<DocId>,
     segment_ctids: Vec<Option<u64>>,
@@ -1026,7 +1030,7 @@ struct DeferredCtidMaterializationState {
 ///
 /// Each packed value encodes (segment_ord, doc_id). The FFHelper's ctid()
 /// column is used to look up the real ctid for each document.
-fn materialize_deferred_ctid(
+pub(crate) fn materialize_deferred_ctid(
     ffhelper: &FFHelper,
     doc_addr_array: &UInt64Array,
     state: &mut DeferredCtidMaterializationState,

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -132,14 +132,14 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
                 // Re-collect the live ctid resolvers from the decoded subtree so a dispatched
                 // fragment can rebuild its absorbed visibility data (same as VFExec above).
                 let resolvers = collect_ctid_resolvers(&input);
-                let stk_resolvers = resolvers.into_iter().map(|(pos, _, ff)| (pos, ff)).collect();
                 SegmentedTopKExec::decode_for_dispatch(
                     payload,
                     input,
                     ffhelpers,
-                    stk_resolvers,
+                    resolvers,
                     ctx,
                     &self.non_partitioning_segment_ids,
+                    &self.index_segment_ids,
                     self.parallel_state,
                 )
             }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -129,10 +129,15 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
             TAG_SEGMENTED_TOPK => {
                 let input = single_input(inputs)?;
                 let ffhelpers = collect_ffhelpers_by_indexrelid(&input);
+                // Re-collect the live ctid resolvers from the decoded subtree so a dispatched
+                // fragment can rebuild its absorbed visibility data (same as VFExec above).
+                let resolvers = collect_ctid_resolvers(&input);
+                let stk_resolvers = resolvers.into_iter().map(|(pos, _, ff)| (pos, ff)).collect();
                 SegmentedTopKExec::decode_for_dispatch(
                     payload,
                     input,
                     ffhelpers,
+                    stk_resolvers,
                     ctx,
                     &self.non_partitioning_segment_ids,
                     self.parallel_state,

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -70,7 +70,7 @@
 //! tied across the *entire* sort key are conservatively retained, per the
 //! `survivors_s` bound above.
 
-use crate::api::{HashMap, HashSet};
+use crate::api::HashMap;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, FFType, NULL_TERM_ORDINAL};
 use crate::postgres::customscan::joinscan::build::CtidColumn;
 use crate::postgres::customscan::joinscan::visibility_filter::{
@@ -106,16 +106,15 @@ use std::sync::{Arc, Mutex};
 use tantivy::termdict::TermOrdinal;
 use tantivy::{DocId, SegmentOrdinal};
 
-/// Minimum number of buffered candidate rows that must accumulate before a visibility
-/// prune cycle runs in [`SegmentedTopKState::maybe_compact`]. Visibility checking has a
+/// Minimum per-segment buffer capacity on visibility plans. Visibility checking has a
 /// per-batch setup cost (snapshot acquisition, packed-DocAddress → ctid resolution, HOT
 /// chain search), so running it on tiny batches is wasteful.
 ///
-/// Each segment's buffer must reach
-/// `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)` before its visibility pass runs, so every
-/// check is a reasonably sized batch and no segment is checked on a tiny batch. Only
-/// affects visibility plans; non-visibility plans keep the original `4 * K * segments`
-/// compaction trigger.
+/// On visibility plans a segment's buffer capacity is
+/// `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)`: [`SegmentedTopKState::truncate_top_k`]
+/// runs only once the buffer fills, so every visibility pass covers a reasonably sized
+/// batch and no segment is checked on a tiny batch. Non-visibility plans use a plain
+/// `2 * K` capacity (no visibility pass, so no reason to delay the QuickSelect).
 ///
 /// Aligned with `DEFERRED_BATCH_SIZE` (the deferred-field scan batch size), since this
 /// path batches deferred rows. Tunable via benchmarking.
@@ -638,10 +637,8 @@ impl ExecutionPlan for SegmentedTopKExec {
             row_converter,
             segment_bufs: Vec::new(),
             segment_cutoffs: Vec::new(),
-            distinct_segments: HashSet::default(),
             dynamic_filter: Arc::clone(&self.dynamic_filter),
             batches: Vec::new(),
-            row_ordinals: Vec::new(),
             pass_through_rows: Vec::new(),
             last_segment_cutoffs: Vec::new(),
             mat_row_converter,
@@ -659,9 +656,14 @@ impl ExecutionPlan for SegmentedTopKExec {
                 let batch = batch_res?;
                 state.rows_input.add(batch.num_rows());
 
+                // Store the batch BEFORE collecting: collect_batch can fire
+                // truncate_top_k, whose visibility pass reads the current batch's
+                // rows out of state.batches. Cloning a RecordBatch only bumps the
+                // column Arcs.
                 let batch_idx = state.batches.len();
-                state.collect_batch(&batch, batch_idx)?;
                 state.batches.push(batch);
+                let batch = state.batches[batch_idx].clone();
+                state.collect_batch(&batch, batch_idx)?;
                 state.maybe_compact()?;
             }
 
@@ -734,6 +736,22 @@ struct StkVisibilityEntry {
     deferred_ctid_state: DeferredCtidMaterializationState,
 }
 
+/// One segment's rolling buffer of top-K candidates.
+///
+/// `rows` holds `(batch_idx, row_idx, sort row)` entries whose locations refer to
+/// [`SegmentedTopKState::batches`]. The buffer fills up to its capacity (`2 * K`, or
+/// `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)` on visibility plans) and is then pruned
+/// back to its K best rows by [`SegmentedTopKState::truncate_top_k`].
+#[derive(Default)]
+struct SegmentBuf {
+    rows: Vec<(usize, usize, OwnedRow)>,
+    /// Visibility watermark: `rows[..checked]` have been visibility checked and are
+    /// alive. Rows at or past `checked` have not been checked yet. Visibility against
+    /// a fixed query snapshot never changes mid-query, so checked rows are checked at
+    /// most once. Meaningless (always trailing) on non-visibility plans.
+    checked: usize,
+}
+
 struct SegmentedTopKState {
     sort_exprs: LexOrdering,
     deferred_columns: Vec<DeferredSortColumn>,
@@ -741,36 +759,21 @@ struct SegmentedTopKState {
     k: usize,
     schema: SchemaRef,
     row_converter: RowConverter,
-    /// Per-segment rolling buffers of comparable Rows, indexed by `SegmentOrdinal`
-    /// (dense, 0..N). Each buffer grows up to 2 * K rows; when it reaches 2 * K,
-    /// `select_nth_unstable(k - 1)` partitions it so the K best rows occupy the front,
-    /// the K-th best is recorded in `segment_cutoffs`, and the buffer is truncated to K.
-    ///
-    /// **Non-visibility plans:** updated in `collect_batch` on every accepted row; the
-    /// inline QuickSelect fires when a buffer hits 2 * K.
-    ///
-    /// **Visibility plans:** NOT updated in `collect_batch`. Rebuilt from visible
-    /// survivors inside `maybe_compact()` after each prune cycle, so every published
-    /// cutoff is based exclusively on live rows.
-    segment_bufs: Vec<Option<Vec<OwnedRow>>>,
+    /// Per-segment rolling buffers, indexed by `SegmentOrdinal` (dense, 0..N).
+    /// Filled in `collect_batch` identically for visibility and non-visibility plans;
+    /// pruned to the K best rows by `truncate_top_k` whenever a buffer reaches its
+    /// capacity, and eagerly before batch compaction.
+    segment_bufs: Vec<Option<SegmentBuf>>,
     /// Per-segment K-th best row (the cutoff threshold) after the most recent
-    /// QuickSelect, indexed by `SegmentOrdinal`. `None` for segments that have not yet
-    /// had a QuickSelect run. Updated by inline QuickSelect in `collect_batch` (non-vis)
-    /// and by the prune-cycle rebuild in `maybe_compact` (vis).
+    /// `truncate_top_k`, indexed by `SegmentOrdinal`. `None` for segments that have not
+    /// yet accumulated K rows. On visibility plans, dead rows are removed before the
+    /// QuickSelect, so a cutoff is always derived from live rows only.
     segment_cutoffs: Vec<Option<OwnedRow>>,
-    /// Set of all segment ordinals encountered during collection. Used to compute the
-    /// prune-cycle trigger for visibility plans. Updated in `collect_batch` for EVERY
-    /// ingested row, including visibility plans where `segment_bufs` is not rebuilt
-    /// until the first prune cycle, and is never cleared.
-    distinct_segments: HashSet<SegmentOrdinal>,
     /// Dynamic filter updated with global thresholds (materialized strings).
     /// Pushed down through DataFusion's standard filter pushdown to the scanner.
     dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
     /// Buffered batches during the collection phase.
     batches: Vec<RecordBatch>,
-    /// Keeps track of the buffered rows for compaction.
-    /// (batch_idx, row_idx, seg_ord, row_data)
-    row_ordinals: Vec<(usize, usize, SegmentOrdinal, OwnedRow)>,
     /// Buffered pass-through rows (NULL ordinals) that bypass
     /// ordinal comparison. These are included in the final sort + limit.
     pass_through_rows: Vec<(usize, usize)>,
@@ -794,7 +797,7 @@ struct SegmentedTopKState {
     /// Segments with only NULLs are not counted.
     segments_seen: Count,
     /// Counts rows removed because they were dead (invisible) under the current snapshot.
-    /// Incremented during prune cycles (maybe_compact) and at final emission (emit_final_topk).
+    /// Incremented by `truncate_top_k` and at final emission (emit_final_topk).
     rows_filtered_invisible: Count,
     /// Runtime visibility checker entries, one per absorbed `(plan_pos, heap_oid)` pair.
     /// Empty when no `VisibilityFilterExec` was absorbed.
@@ -810,6 +813,96 @@ impl SegmentedTopKState {
             vec.resize_with(idx + 1, || None);
         }
         &mut vec[idx]
+    }
+
+    /// Per-segment buffer capacity: `2 * K`, raised to
+    /// `MINIMUM_VISIBILITY_CHECK_SIZE` on visibility plans so that each visibility
+    /// pass in [`Self::truncate_top_k`] covers a reasonably sized batch.
+    fn buffer_capacity(&self) -> usize {
+        if self.visibility_entries.is_empty() {
+            2 * self.k
+        } else {
+            (2 * self.k).max(MINIMUM_VISIBILITY_CHECK_SIZE)
+        }
+    }
+
+    /// Prune one segment's buffer down to its K best rows:
+    ///
+    /// 1. visibility check the unchecked suffix of the buffer (everything past the
+    ///    `checked` watermark; the whole buffer on its first fill) and drop dead rows,
+    /// 2. QuickSelect the K best of the remaining (all live) rows,
+    /// 3. record the K-th best as the segment cutoff and truncate the buffer to K,
+    /// 4. publish the (possibly improved) global threshold.
+    ///
+    /// On non-visibility plans step 1 is a no-op, which is what lets one code path
+    /// serve both cases. On visibility plans, every row behind the watermark was
+    /// checked alive against the query snapshot, and visibility against a fixed
+    /// snapshot never changes mid-query, so each row is checked at most once and the
+    /// cutoff (and therefore the published threshold) is always derived from live
+    /// rows only. That also means a previously published threshold can never become
+    /// too aggressive after dead rows are removed: dead rows only ever exist past the
+    /// watermark and never define a cutoff.
+    fn truncate_top_k(&mut self, seg_idx: usize) -> Result<()> {
+        if self.k == 0 {
+            return Ok(());
+        }
+
+        // Step 1: visibility check the unchecked suffix and drop dead rows.
+        if !self.visibility_entries.is_empty() {
+            let (watermark, row_keys) = {
+                let Some(buf) = self.segment_bufs.get(seg_idx).and_then(|b| b.as_ref()) else {
+                    return Ok(());
+                };
+                let keys: Vec<(usize, usize)> = buf.rows[buf.checked..]
+                    .iter()
+                    .map(|(bi, ri, _)| (*bi, *ri))
+                    .collect();
+                (buf.checked, keys)
+            };
+            if !row_keys.is_empty() {
+                // Corrected ctids are discarded here: the stored batches keep packed
+                // DocAddresses (real ctid write-back happens at emit_final_topk).
+                let (visible_mask, _) = self.check_rows_visible(&row_keys)?;
+                let dead = visible_mask.iter().filter(|&&v| !v).count();
+                if dead > 0 {
+                    self.rows_filtered_invisible.add(dead);
+                    if let Some(buf) = self.segment_bufs.get_mut(seg_idx).and_then(|b| b.as_mut()) {
+                        let mut idx = 0usize;
+                        buf.rows.retain(|_| {
+                            let keep = idx < watermark || visible_mask[idx - watermark];
+                            idx += 1;
+                            keep
+                        });
+                    }
+                }
+            }
+            if let Some(buf) = self.segment_bufs.get_mut(seg_idx).and_then(|b| b.as_mut()) {
+                buf.checked = buf.rows.len();
+            }
+        }
+
+        // Steps 2 + 3: QuickSelect around the K-th element, record the cutoff,
+        // truncate the buffer to its K best rows.
+        let cutoff = {
+            let Some(buf) = self.segment_bufs.get_mut(seg_idx).and_then(|b| b.as_mut()) else {
+                return Ok(());
+            };
+            if buf.rows.len() < self.k {
+                // Fewer than K live rows so far (only possible before this segment's
+                // first cutoff): no cutoff yet, keep filling.
+                return Ok(());
+            }
+            buf.rows
+                .select_nth_unstable_by(self.k - 1, |a, b| a.2.cmp(&b.2));
+            let cutoff = buf.rows[self.k - 1].2.clone();
+            buf.rows.truncate(self.k);
+            buf.checked = buf.checked.min(buf.rows.len());
+            cutoff
+        };
+        *Self::ensure_slot(&mut self.segment_cutoffs, seg_idx) = Some(cutoff);
+
+        // Step 4: publish the improved threshold so the scan can prune earlier.
+        self.publish_global_threshold()
     }
 
     /// Ingest a single batch: extract ordinals, update per-segment buffers,
@@ -853,6 +946,11 @@ impl SegmentedTopKState {
 
         let converted_rows = self.row_converter.convert_columns(&sort_arrays)?;
 
+        // Buffer capacity: plain 2 * K, but on visibility plans at least
+        // MINIMUM_VISIBILITY_CHECK_SIZE so each visibility pass in truncate_top_k
+        // covers a reasonably sized batch.
+        let capacity = self.buffer_capacity();
+
         for row_idx in 0..num_rows {
             if pass_through[row_idx] {
                 continue;
@@ -861,67 +959,36 @@ impl SegmentedTopKState {
                 let seg_idx = seg_ord as usize;
                 let row_val = converted_rows.row(row_idx).owned();
 
-                // Track distinct segments for the compaction trigger. Always updated
-                // here so the trigger denominator is accurate even for visibility plans
-                // where `segment_bufs` is not rebuilt until `maybe_compact()`.
-                if self.distinct_segments.insert(seg_ord) {
+                // Pre-filter: rows already worse than this segment's cutoff cannot
+                // enter the top K, so drop them before they reach the buffer. On
+                // visibility plans the cutoff is always derived from live rows (see
+                // truncate_top_k), so this never prunes a row that a dead row would
+                // otherwise have displaced.
+                let is_worse = self
+                    .segment_cutoffs
+                    .get(seg_idx)
+                    .and_then(|c| c.as_ref())
+                    .is_some_and(|cutoff| &row_val > cutoff);
+                if is_worse {
+                    continue;
+                }
+
+                let slot = Self::ensure_slot(&mut self.segment_bufs, seg_idx);
+                if slot.is_none() {
                     self.segments_seen.add(1);
                 }
-                if self.visibility_entries.is_empty() {
-                    // Non-visibility plan: pre-filter rows already worse than the current
-                    // segment cutoff, then push to the buffer. When the buffer reaches
-                    // 2 * K, QuickSelect partitions it and the K-th element becomes the
-                    // new cutoff.
-                    let is_worse = self
-                        .segment_cutoffs
-                        .get(seg_idx)
-                        .and_then(|c| c.as_ref())
-                        .is_some_and(|cutoff| &row_val > cutoff);
-                    if is_worse {
-                        continue;
-                    }
-                    let buf = Self::ensure_slot(&mut self.segment_bufs, seg_idx)
-                        .get_or_insert_with(Vec::new);
-                    buf.push(row_val.clone());
-                    self.row_ordinals
-                        .push((batch_idx, row_idx, seg_ord, row_val));
-                    if self.k > 0 && buf.len() >= 2 * self.k {
-                        buf.select_nth_unstable(self.k - 1);
-                        let cutoff = buf[self.k - 1].clone();
-                        buf.truncate(self.k);
-                        *Self::ensure_slot(&mut self.segment_cutoffs, seg_idx) = Some(cutoff);
-                    }
-                } else {
-                    // Visibility plan: `segment_bufs` is NEVER updated here. Buffers are
-                    // rebuilt inside `maybe_compact()` only after visibility checking, so
-                    // every published cutoff reflects exclusively live rows.
-                    //
-                    // Pre-filter using the last prune cycle's alive cutoff (read-only):
-                    // rows provably worse than the alive K-th are rejected early to bound
-                    // buffer growth between prune cycles.
-                    let is_candidate = self
-                        .segment_cutoffs
-                        .get(seg_idx)
-                        .and_then(|c| c.as_ref())
-                        .is_none_or(|cutoff| &row_val <= cutoff);
-                    if is_candidate {
-                        self.row_ordinals
-                            .push((batch_idx, row_idx, seg_ord, row_val));
-                    }
+                let buf = slot.get_or_insert_with(SegmentBuf::default);
+                buf.rows.push((batch_idx, row_idx, row_val));
+
+                if self.k > 0 && buf.rows.len() >= capacity {
+                    self.truncate_top_k(seg_idx)?;
                 }
             }
         }
 
-        // Non-visibility plans: publish threshold after each batch so PgSearchScan can
-        // prune as early as possible. Safe: no dead rows can inflate the threshold.
-        //
-        // Visibility plans: threshold is published ONLY inside maybe_compact() after
-        // visibility checking. Publishing here would base the threshold on rows that have
-        // not yet been checked for MVCC visibility; dead rows in the buffer would inflate
-        // the threshold, causing PgSearchScan to prune live rows it shouldn't.
-        if self.visibility_entries.is_empty() {
-            self.publish_global_threshold()?;
-        }
+        // The global threshold is published inside truncate_top_k, right after a
+        // segment's cutoff changes; between truncations the cutoffs are unchanged,
+        // so publishing here would be a no-op.
 
         // Buffer pass-through rows (NULL ordinals) for the final sort.
         for (row_idx, &is_pt) in pass_through.iter().enumerate() {
@@ -1157,25 +1224,6 @@ impl SegmentedTopKState {
             .reduce(|a, b| Arc::new(BinaryExpr::new(a, Operator::Or, b)) as Arc<dyn PhysicalExpr>)
     }
 
-    /// Build the set of all survivors across all segments. A row survives if
-    /// its `OwnedRow` is <= the cutoff (K-th best row) for its segment, or
-    /// if the segment never reached 2×k rows and therefore has no cutoff yet
-    /// (in which case every row from that segment is a candidate).
-    fn build_survivors(&self) -> crate::api::HashSet<(usize, usize)> {
-        let mut survivors = crate::api::HashSet::default();
-        for (batch_idx, row_idx, seg_ord, row_val) in &self.row_ordinals {
-            let dominated = self
-                .segment_cutoffs
-                .get(*seg_ord as usize)
-                .and_then(|c| c.as_ref())
-                .is_none_or(|cutoff| row_val <= cutoff);
-            if dominated {
-                survivors.insert((*batch_idx, *row_idx));
-            }
-        }
-        survivors
-    }
-
     /// Evaluates the current local thresholds across all segments to determine
     /// if a new global threshold can be published.
     ///
@@ -1356,170 +1404,55 @@ impl SegmentedTopKState {
         Ok(values)
     }
 
-    /// Compact buffered batches by discarding rows that cannot survive the
-    /// current per-segment cutoffs. This bounds memory at O(K * segments)
+    /// Compact the stored batches by discarding rows no longer referenced by any
+    /// per-segment buffer (or pass-through). This bounds memory at O(K * segments)
     /// instead of O(N) for large inputs — analogous to the batch compaction
     /// step in upstream DataFusion Top K.
-    ///
-    /// When visibility data was absorbed, dead rows are also removed here so that the
-    /// global threshold is never inflated by rows that are invisible to the current
-    /// snapshot. `segment_bufs` is rebuilt from the visible survivors.
     fn maybe_compact(&mut self) -> Result<()> {
-        // Use `distinct_segments` (not `segment_bufs`) to count segments: for visibility
-        // plans, `segment_bufs` is empty before the first prune cycle, which would cause
-        // an under-count and fire prune cycles too early.
-        let num_segments = self.distinct_segments.len().max(1);
+        // Fire only when the stored batches hold at least twice as many rows as are
+        // still referenced, so each compaction at least halves the stored rows
+        // (amortized O(1) work per input row). The floor keeps small inputs from
+        // ever compacting, mirroring the previous 4 * K * segments trigger.
+        let referenced: usize = self
+            .segment_bufs
+            .iter()
+            .flatten()
+            .map(|b| b.rows.len())
+            .sum::<usize>()
+            + self.pass_through_rows.len();
+        let stored: usize = self.batches.iter().map(|b| b.num_rows()).sum();
+        let num_segments = self.segment_bufs.iter().flatten().count().max(1);
+        let floor = 4 * self.k * num_segments;
+        if stored < (2 * referenced).max(floor) {
+            return Ok(());
+        }
 
-        if self.visibility_entries.is_empty() {
-            // Non-visibility plans use the original global 4 * K * segments trigger.
-            let trigger = self.k * num_segments * 4;
-            if self.row_ordinals.len() + self.pass_through_rows.len() < trigger {
-                return Ok(());
-            }
-        } else {
-            // Visibility plans use a PER-BUFFER trigger (per @stuhood on #4525): each
-            // segment's buffer must reach `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)`
-            // before its visibility pass runs, so every check is a reasonably sized batch
-            // and we never aggregate all segments into one buffer. Fire as soon as ANY
-            // segment's buffer reaches that size. Pass-through-only plans (all NULL/State-2
-            // sort columns) accumulate rows without a segment, so also fire when
-            // pass_through_rows alone reaches the threshold, otherwise the visibility check
-            // would be deferred entirely to emit_final_topk.
-            let per_buffer = (2 * self.k).max(MINIMUM_VISIBILITY_CHECK_SIZE);
-            let mut seg_counts: Vec<usize> = Vec::new();
-            for (_, _, seg_ord, _) in &self.row_ordinals {
-                let idx = *seg_ord as usize;
-                if idx >= seg_counts.len() {
-                    seg_counts.resize(idx + 1, 0);
-                }
-                seg_counts[idx] += 1;
-            }
-            let any_buffer_full = seg_counts.iter().any(|&c| c >= per_buffer);
-            if !any_buffer_full && self.pass_through_rows.len() < per_buffer {
-                return Ok(());
+        // Eagerly truncate every buffer first so compaction works with fresh, live
+        // top-K survivors: dead rows in an unchecked suffix are never compacted into
+        // the retained batch, and buffers holding more than K rows are pruned before
+        // their rows are copied.
+        for seg_idx in 0..self.segment_bufs.len() {
+            let has_rows = self.segment_bufs[seg_idx]
+                .as_ref()
+                .is_some_and(|b| !b.rows.is_empty());
+            if has_rows {
+                self.truncate_top_k(seg_idx)?;
             }
         }
 
-        // Step 1: Cutoff filter, retain only rows within per-segment bounds.
-        // Capture the pre-take length before std::mem::take empties row_ordinals: after
-        // take(), the Vec has capacity 0, which would make the half-rows-discarded ratio
-        // check always true and bypass the "don't compact if < half rows discarded" guard.
-        let old_row_ordinals_len = self.row_ordinals.len();
-        let mut new_row_ordinals = Vec::new();
-        // Use take() so we own row_ordinals and can move the OwnedRows. The survivor
-        // set is built later (Step 3) after the visibility pass has run.
-        for (batch_idx, row_idx, seg_ord, row_val) in std::mem::take(&mut self.row_ordinals) {
-            let keep = self
-                .segment_cutoffs
-                .get(seg_ord as usize)
-                .and_then(|c| c.as_ref())
-                .is_none_or(|cutoff| &row_val <= cutoff);
-            if keep {
-                new_row_ordinals.push((batch_idx, row_idx, seg_ord, row_val));
-            }
-        }
-
-        // Step 2: Visibility filter, remove dead rows, then rebuild segment_bufs and
-        // segment_cutoffs via QuickSelect from the surviving rows.
-        // pass_through_rows are NOT checked here; they are checked in emit_final_topk.
-        //
-        // The rebuild always runs (not only when rows are invisible) so that the global
-        // threshold is published on every prune cycle, including all-alive workloads.
-        if !self.visibility_entries.is_empty() && !new_row_ordinals.is_empty() {
-            // Per-buffer visibility (per @stuhood on #4525): check each segment's rows as
-            // its own batch, right before that segment's QuickSelect below, instead of
-            // aggregating every segment's rows into one buffer for a single check. The
-            // per-row MVCC result is independent of how rows are batched, so this yields
-            // the same survivors as a global check, just grouped per segment.
-            // Discard corrected ctids at compaction time: batches keep packed
-            // DocAddresses (real ctid write-back happens at emit_final_topk).
-            let mut by_seg: HashMap<SegmentOrdinal, Vec<usize>> = HashMap::default();
-            for (i, (_, _, seg_ord, _)) in new_row_ordinals.iter().enumerate() {
-                by_seg.entry(*seg_ord).or_default().push(i);
-            }
-            let mut keep = vec![true; new_row_ordinals.len()];
-            for indices in by_seg.values() {
-                let row_keys: Vec<(usize, usize)> = indices
-                    .iter()
-                    .map(|&i| (new_row_ordinals[i].0, new_row_ordinals[i].1))
-                    .collect();
-                let (visible_mask, _) = self.check_rows_visible(&row_keys)?;
-                let dead = visible_mask.iter().filter(|&&v| !v).count();
-                if dead > 0 {
-                    self.rows_filtered_invisible.add(dead);
-                }
-                for (j, &i) in indices.iter().enumerate() {
-                    if !visible_mask[j] {
-                        keep[i] = false;
-                    }
-                }
-            }
-            if keep.iter().any(|&k| !k) {
-                new_row_ordinals = new_row_ordinals
-                    .into_iter()
-                    .zip(keep)
-                    .filter(|(_, keep)| *keep)
-                    .map(|(row, _)| row)
-                    .collect();
-            }
-
-            // Rebuild segment_bufs and segment_cutoffs from survivors via QuickSelect.
-            // Clear stale cached cutoffs so publish_global_threshold recomputes from
-            // the freshly rebuilt state.
-            self.segment_bufs.clear();
-            self.segment_cutoffs.clear();
-            self.last_segment_cutoffs.clear();
-            for (_, _, seg_ord, row_val) in &new_row_ordinals {
-                Self::ensure_slot(&mut self.segment_bufs, *seg_ord as usize)
-                    .get_or_insert_with(Vec::new)
-                    .push(row_val.clone());
-            }
-            for seg_idx in 0..self.segment_bufs.len() {
-                if let Some(buf) = self.segment_bufs[seg_idx].as_mut() {
-                    if buf.len() >= self.k {
-                        buf.select_nth_unstable(self.k - 1);
-                        let cutoff = buf[self.k - 1].clone();
-                        buf.truncate(self.k);
-                        *Self::ensure_slot(&mut self.segment_cutoffs, seg_idx) = Some(cutoff);
-                    }
-                }
-            }
-
-            // If dead-row removal left any segment with fewer than K rows, the
-            // previously published threshold is now too aggressive; rows with
-            // ordinals below the dead row's that are needed to refill the slots
-            // would be pruned. Retract to lit(true) so those rows can flow in,
-            // then republish the correct threshold from the rebuilt state.
-            // publish_global_threshold() skips segments without a cutoff in
-            // segment_cutoffs, so we must reset dynamic_filter explicitly here.
-            let any_underfull = self
-                .segment_bufs
-                .iter()
-                .flatten()
-                .any(|buf| buf.len() < self.k);
-            if any_underfull {
-                use datafusion::physical_expr::expressions::lit;
-                let _ = self.dynamic_filter.update(lit(true));
-                self.last_published_global = None;
-            }
-            self.publish_global_threshold()?;
-        }
-
-        // Step 3: Populate survivors set for batch compaction.
+        // Survivors are exactly the rows still referenced by a buffer or pass-through.
         let mut survivors = crate::api::HashSet::default();
-        for (batch_idx, row_idx, _, _) in &new_row_ordinals {
-            survivors.insert((*batch_idx, *row_idx));
+        for buf in self.segment_bufs.iter().flatten() {
+            for (batch_idx, row_idx, _) in &buf.rows {
+                survivors.insert((*batch_idx, *row_idx));
+            }
         }
-        // Include pass-through rows in the survivor set so they aren't discarded.
         for &(batch_idx, row_idx) in &self.pass_through_rows {
             survivors.insert((batch_idx, row_idx));
         }
 
-        // Don't compact if we wouldn't discard at least half the rows.
-        // Use old_row_ordinals_len (captured before take()); after take() the Vec
-        // is empty with capacity 0, which would make this check always true.
-        if new_row_ordinals.len() * 2 > old_row_ordinals_len {
-            self.row_ordinals = new_row_ordinals;
+        if survivors.is_empty() {
+            self.batches.clear();
             return Ok(());
         }
 
@@ -1549,31 +1482,23 @@ impl SegmentedTopKState {
             filtered_batches.push(filtered);
         }
 
-        if filtered_batches.is_empty() {
-            self.batches.clear();
-            self.row_ordinals.clear();
-            self.pass_through_rows.clear();
-            return Ok(());
-        }
-
         let compacted = concat_batches(&self.schema, &filtered_batches)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
 
-        // Remap row_ordinals into the single compacted batch.
-        for entry in &mut new_row_ordinals {
-            let new_ri = mapping[&(entry.0, entry.1)];
-            entry.0 = 0;
-            entry.1 = new_ri;
+        // Remap buffer rows and pass_through_rows into the single compacted batch.
+        for buf in self.segment_bufs.iter_mut().flatten() {
+            for entry in &mut buf.rows {
+                let new_ri = mapping[&(entry.0, entry.1)];
+                entry.0 = 0;
+                entry.1 = new_ri;
+            }
         }
-
-        // Remap pass_through_rows into the single compacted batch.
         for entry in &mut self.pass_through_rows {
             let new_ri = mapping[&(entry.0, entry.1)];
             entry.0 = 0;
             entry.1 = new_ri;
         }
 
-        self.row_ordinals = new_row_ordinals;
         self.batches = vec![compacted];
         Ok(())
     }
@@ -1693,8 +1618,8 @@ impl SegmentedTopKState {
     ///
     ///
     /// Steps:
-    /// 1. Build ordinal survivors (rows within per-segment cutoffs).
-    /// 2. Merge ordinal survivors with pass-through rows into candidate set.
+    /// 1. Collect candidates from the per-segment buffers.
+    /// 2. Merge them with pass-through rows into the candidate set.
     ///    2a. (Visibility) Filter invisible rows from candidates, including pass-through rows.
     /// 3. Materialize sort column values for each candidate.
     /// 4. Sort candidates by materialized values, take top K.
@@ -1702,33 +1627,25 @@ impl SegmentedTopKState {
     fn emit_final_topk(&mut self) -> Result<Option<RecordBatch>> {
         use datafusion::common::ScalarValue;
 
-        // 1. Build ordinal survivors.
-        //
-        // When visibility data is present, dead rows in the top-K heap slots would
-        // cause build_survivors to exclude live rows with worse ordinals.  Example:
-        // k=5, rows 1-5 are in the heap (ordinals 0-4), rows 6-15 are pruned out,
-        // but rows 1-3 are dead → only 2 live rows survive.  To avoid this, we skip
-        // the ordinal-based pre-filter and include ALL row_ordinals as candidates;
-        // the visibility pass removes dead rows and the final sort+limit yields the
-        // correct k live rows.  The extra visibility checks (over all row_ordinals
-        // rather than just the top-k survivors) are acceptable for correctness.
+        // 1. Collect candidates: every row still held in a per-segment buffer. Each
+        //    buffer holds its segment's current top K plus any not-yet-truncated
+        //    recent rows, all within the segment cutoff (enforced on insert), so the
+        //    true per-segment top K is always a subset of the buffer. On visibility
+        //    plans, rows past a buffer's watermark may still be dead; the visibility
+        //    pass below removes them, and it can never leave a segment short: the K
+        //    rows kept by the last truncate_top_k were checked alive, and visibility
+        //    against a fixed snapshot never changes mid-query.
         type Candidate = (usize, usize, Option<(SegmentOrdinal, OwnedRow)>);
         let mut candidates: Vec<Candidate> = Vec::new();
 
-        if !self.visibility_entries.is_empty() {
-            // Include every row from row_ordinals so that after dead rows are removed
-            // we still have enough live rows to fill k slots.
-            for (batch_idx, row_idx, seg_ord, row_val) in &self.row_ordinals {
-                candidates.push((*batch_idx, *row_idx, Some((*seg_ord, row_val.clone()))));
-            }
-        } else {
-            // 1. Build ordinal survivors (normal path, no visibility data).
-            let ordinal_survivors = self.build_survivors();
-            // 2. Collect all candidates: ordinal survivors only.
-            for (batch_idx, row_idx, seg_ord, heap_val) in &self.row_ordinals {
-                if ordinal_survivors.contains(&(*batch_idx, *row_idx)) {
-                    candidates.push((*batch_idx, *row_idx, Some((*seg_ord, heap_val.clone()))));
-                }
+        for (seg_idx, slot) in self.segment_bufs.iter().enumerate() {
+            let Some(buf) = slot else { continue };
+            for (batch_idx, row_idx, row_val) in &buf.rows {
+                candidates.push((
+                    *batch_idx,
+                    *row_idx,
+                    Some((seg_idx as SegmentOrdinal, row_val.clone())),
+                ));
             }
         }
 

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -122,9 +122,10 @@ const MINIMUM_VISIBILITY_CHECK_SIZE: usize = 8192;
 
 /// The serializable "recipe" for rebuilding [`AbsorbedVisibilityData`] on a dispatched
 /// worker: `(plan_position, heap OID)` pairs plus table names. `None` when the plan carries
-/// no absorbed visibility. The live ctid resolvers (FFHelpers) are not part of the recipe;
-/// they are re-wired from the decoded subtree in `decode_for_dispatch`.
-type VisibilityRecipe = Option<(Vec<(usize, pg_sys::Oid)>, Vec<String>)>;
+/// no absorbed visibility./// The live ctid resolvers (FFHelpers) are not part of the recipe;
+/// they are re-wired from the decoded subtree in `decode_for_dispatch`,
+/// or rebuilt if the scan sits behind a network boundary.
+type VisibilityRecipe = Option<(Vec<(usize, pg_sys::Oid)>, Vec<String>, Vec<(usize, u32)>)>;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct DeferredSortColumn {
@@ -135,6 +136,9 @@ pub struct DeferredSortColumn {
     #[serde(default)]
     pub rebuild: Option<crate::scan::late_materialization::DeferredLookupRebuild>,
 }
+
+/// One wired ctid resolver: the index it reads and the fast-field helper over its segments.
+type CtidResolver = (u32, Arc<FFHelper>);
 
 /// Visibility data absorbed from a `VisibilityFilterExec` during the `SegmentedTopKRule`
 /// optimization pass.
@@ -148,7 +152,7 @@ pub struct AbsorbedVisibilityData {
     table_names: Vec<String>,
     /// Per-plan_position FFHelpers for resolving packed DocAddresses to real ctids.
     /// Wired by `VisibilityCtidResolverRule` after plan construction.
-    ctid_resolvers: Mutex<Vec<Option<Arc<FFHelper>>>>,
+    ctid_resolvers: Mutex<Vec<Option<CtidResolver>>>,
 }
 
 impl std::fmt::Debug for AbsorbedVisibilityData {
@@ -178,7 +182,7 @@ impl AbsorbedVisibilityData {
         &self.plan_pos_oids
     }
 
-    pub fn set_ctid_resolver(&self, plan_pos: usize, ffhelper: Arc<FFHelper>) {
+    pub fn set_ctid_resolver(&self, plan_pos: usize, indexrelid: u32, ffhelper: Arc<FFHelper>) {
         let mut resolvers = self
             .ctid_resolvers
             .lock()
@@ -186,7 +190,7 @@ impl AbsorbedVisibilityData {
         if plan_pos >= resolvers.len() {
             resolvers.resize(plan_pos + 1, None);
         }
-        resolvers[plan_pos] = Some(ffhelper);
+        resolvers[plan_pos] = Some((indexrelid, ffhelper));
     }
 }
 
@@ -206,8 +210,9 @@ pub struct SegmentedTopKExec {
     /// per-segment ordinal bounds.
     dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
     /// Visibility data absorbed from a `VisibilityFilterExec` during plan optimization.
-    /// Present only for inner-join plans where VFExec was the direct child of
-    /// `TantivyLookupExec`. When present, this node owns MVCC visibility checking.
+    /// Present when VFExec was the direct child of `TantivyLookupExec` (e.g. for inner
+    /// joins or the preserved sides of outer/semi/anti joins). When present, this node
+    /// owns MVCC visibility checking.
     visibility_data: Option<Arc<AbsorbedVisibilityData>>,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
@@ -281,9 +286,9 @@ impl SegmentedTopKExec {
 
     /// Wire an FFHelper for resolving packed DocAddresses to real ctids for
     /// the given plan_position. Called by `VisibilityCtidResolverRule`.
-    pub fn set_ctid_resolver(&self, plan_pos: usize, ffhelper: Arc<FFHelper>) {
+    pub fn set_ctid_resolver(&self, plan_pos: usize, indexrelid: u32, ffhelper: Arc<FFHelper>) {
         if let Some(vd) = &self.visibility_data {
-            vd.set_ctid_resolver(plan_pos, ffhelper);
+            vd.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
         }
     }
 
@@ -347,10 +352,21 @@ impl SegmentedTopKExec {
         // Without this, a worker would decode visibility_data: None and silently skip
         // visibility (returning dead rows), since absorption already removed the VFExec on
         // the leader and workers do not re-run the optimizer rule.
-        let visibility_recipe: VisibilityRecipe = self
-            .visibility_data
-            .as_ref()
-            .map(|vd| (vd.plan_pos_oids.clone(), vd.table_names.clone()));
+        let visibility_recipe: VisibilityRecipe = self.visibility_data.as_ref().map(|vd| {
+            let resolver_indexes: Vec<(usize, u32)> = vd
+                .ctid_resolvers
+                .lock()
+                .expect("ctid_resolvers lock poisoned")
+                .iter()
+                .enumerate()
+                .filter_map(|(pos, r)| r.as_ref().map(|(relid, _)| (pos, *relid)))
+                .collect();
+            (
+                vd.plan_pos_oids.clone(),
+                vd.table_names.clone(),
+                resolver_indexes,
+            )
+        });
         let payload = (
             sort_bytes,
             self.deferred_columns.clone(),
@@ -362,13 +378,15 @@ impl SegmentedTopKExec {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn decode_for_dispatch(
         buf: &[u8],
         input: Arc<dyn ExecutionPlan>,
         ffhelpers: HashMap<u32, Arc<FFHelper>>,
-        ctid_resolvers: Vec<(usize, Arc<FFHelper>)>,
+        ctid_resolvers: Vec<(usize, u32, Arc<FFHelper>)>,
         ctx: &TaskContext,
         non_partitioning_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
+        index_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
         parallel_state: Option<*mut crate::postgres::ParallelScanState>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let (sort_bytes, deferred_columns, k, visibility_recipe): (
@@ -446,13 +464,33 @@ impl SegmentedTopKExec {
         // would make the worker skip visibility and return dead rows. The VisibilityChecker
         // itself is built later at execute() time from GetActiveSnapshot(), so no snapshot
         // travels (the worker's active snapshot is already the leader's MVCC view).
-        let visibility_data = visibility_recipe.map(|(plan_pos_oids, table_names)| {
-            let vd = AbsorbedVisibilityData::new(plan_pos_oids, table_names);
-            for (plan_pos, resolver) in &ctid_resolvers {
-                vd.set_ctid_resolver(*plan_pos, Arc::clone(resolver));
+        let visibility_data = match visibility_recipe {
+            Some((plan_pos_oids, table_names, resolver_indexes)) => {
+                let vd = AbsorbedVisibilityData::new(plan_pos_oids, table_names);
+                for (plan_pos, indexrelid, resolver) in &ctid_resolvers {
+                    vd.set_ctid_resolver(*plan_pos, *indexrelid, Arc::clone(resolver));
+                }
+                for (plan_pos, indexrelid) in resolver_indexes {
+                    if ctid_resolvers.iter().any(|(pos, _, _)| *pos == plan_pos) {
+                        continue;
+                    }
+                    let ids = index_segment_ids.get(plan_pos).cloned().ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "SegmentedTopKExec dispatch: missing canonical segment ids for \
+                             plan_position {plan_pos}"
+                        ))
+                    })?;
+                    let ffhelper = crate::scan::tantivy_lookup_exec::open_rebuilt_ffhelper(
+                        indexrelid,
+                        &[],
+                        crate::index::mvcc::MvccSatisfies::ParallelWorker(ids),
+                    )?;
+                    vd.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
+                }
+                Some(Arc::new(vd))
             }
-            Arc::new(vd)
-        });
+            None => None,
+        };
         Ok(Arc::new(SegmentedTopKExec::new(
             input,
             sort_exprs,
@@ -605,17 +643,16 @@ impl ExecutionPlan for SegmentedTopKExec {
                 })?;
                 let heaprel = PgSearchRelation::open(heap_oid);
                 let checker = VisibilityChecker::with_rel_and_snap(&heaprel, snapshot);
-                let resolver =
-                    resolvers
-                        .get(plan_pos)
-                        .and_then(|r| r.clone())
-                        .ok_or_else(|| {
-                            DataFusionError::Execution(format!(
-                                "SegmentedTopKExec: no ctid resolver wired for \
+                let resolver = resolvers
+                    .get(plan_pos)
+                    .and_then(|r| r.as_ref().map(|(_, ff)| Arc::clone(ff)))
+                    .ok_or_else(|| {
+                        DataFusionError::Execution(format!(
+                            "SegmentedTopKExec: no ctid resolver wired for \
                                  plan_position {plan_pos}. \
                                  VisibilityCtidResolverRule must run before execute."
-                            ))
-                        })?;
+                        ))
+                    })?;
                 entries.push(StkVisibilityEntry {
                     col_idx,
                     checker,
@@ -648,6 +685,9 @@ impl ExecutionPlan for SegmentedTopKExec {
             rows_output,
             segments_seen,
             rows_filtered_invisible,
+            pass_through_scratch: Vec::new(),
+            row_to_seg_scratch: Vec::new(),
+            sort_arrays_scratch: Vec::with_capacity(self.sort_exprs.len()),
         };
 
         let stream_gen = async_stream::try_stream! {
@@ -723,8 +763,8 @@ impl ExecutionPlan for SegmentedTopKExec {
 }
 
 /// Per-plan_position runtime state for ctid resolution and visibility checking.
-/// One entry per absorbed `(plan_pos, heap_oid)` pair; empty when no
-/// `VisibilityFilterExec` was absorbed.
+/// A plan will hold one of these entries for every `(plan_pos, heap_oid)` pair it absorbed
+/// from a `VisibilityFilterExec`.
 struct StkVisibilityEntry {
     /// Index of the `ctid_{plan_position}` column in the input batch schema.
     col_idx: usize,
@@ -802,6 +842,11 @@ struct SegmentedTopKState {
     /// Runtime visibility checker entries, one per absorbed `(plan_pos, heap_oid)` pair.
     /// Empty when no `VisibilityFilterExec` was absorbed.
     visibility_entries: Vec<StkVisibilityEntry>,
+
+    /// Scratch buffers to avoid per-batch allocation
+    pass_through_scratch: Vec<bool>,
+    row_to_seg_scratch: Vec<Option<SegmentOrdinal>>,
+    sort_arrays_scratch: Vec<ArrayRef>,
 }
 
 impl SegmentedTopKState {
@@ -813,6 +858,14 @@ impl SegmentedTopKState {
             vec.resize_with(idx + 1, || None);
         }
         &mut vec[idx]
+    }
+
+    fn get_or_create_segment_buf(&mut self, seg_idx: usize) -> &mut SegmentBuf {
+        let slot = Self::ensure_slot(&mut self.segment_bufs, seg_idx);
+        if slot.is_none() {
+            self.segments_seen.add(1);
+        }
+        slot.get_or_insert_with(SegmentBuf::default)
     }
 
     /// Per-segment buffer capacity: `2 * K`, raised to
@@ -911,40 +964,45 @@ impl SegmentedTopKState {
     /// in `pass_through_rows` for the final sort + limit.
     fn collect_batch(&mut self, batch: &RecordBatch, batch_idx: usize) -> Result<()> {
         let num_rows = batch.num_rows();
-        let mut pass_through = vec![false; num_rows];
-        let mut row_to_seg = vec![None; num_rows];
+        self.pass_through_scratch.clear();
+        self.pass_through_scratch.resize(num_rows, false);
+        self.row_to_seg_scratch.clear();
+        self.row_to_seg_scratch.resize(num_rows, None);
         let mut deferred_ords: HashMap<usize, Vec<Option<TermOrdinal>>> = HashMap::default();
 
         for deferred_col in &self.deferred_columns {
-            let global_term_ords = self.extract_deferred_ordinals(
+            let global_term_ords = Self::extract_deferred_ordinals(
+                &self.ffhelper,
                 batch,
                 deferred_col,
                 num_rows,
-                &mut pass_through,
-                &mut row_to_seg,
+                &mut self.pass_through_scratch,
+                &mut self.row_to_seg_scratch,
             )?;
             deferred_ords.insert(deferred_col.sort_col_idx, global_term_ords);
         }
 
         // Build the evaluation arrays for the RowConverter
-        let mut sort_arrays = Vec::with_capacity(self.sort_exprs.len());
+        self.sort_arrays_scratch.clear();
         for expr in &self.sort_exprs {
             let col_idx = expr
                 .expr
                 .downcast_ref::<datafusion::physical_expr::expressions::Column>()
                 .map(|c| c.index());
 
-            if let Some(Some(ords)) = col_idx.map(|idx| deferred_ords.get(&idx)) {
+            if let Some(Some(ords)) = col_idx.map(|idx| deferred_ords.remove(&idx)) {
                 // Use our artificially constructed ordinals array
-                let ords_array = Arc::new(UInt64Array::from(ords.clone())) as ArrayRef;
-                sort_arrays.push(ords_array);
+                let ords_array = Arc::new(UInt64Array::from(ords)) as ArrayRef;
+                self.sort_arrays_scratch.push(ords_array);
             } else {
                 let val = expr.expr.evaluate(batch)?;
-                sort_arrays.push(val.into_array(num_rows)?);
+                self.sort_arrays_scratch.push(val.into_array(num_rows)?);
             }
         }
 
-        let converted_rows = self.row_converter.convert_columns(&sort_arrays)?;
+        let converted_rows = self
+            .row_converter
+            .convert_columns(&self.sort_arrays_scratch)?;
 
         // Buffer capacity: plain 2 * K, but on visibility plans at least
         // MINIMUM_VISIBILITY_CHECK_SIZE so each visibility pass in truncate_top_k
@@ -952,48 +1010,37 @@ impl SegmentedTopKState {
         let capacity = self.buffer_capacity();
 
         for row_idx in 0..num_rows {
-            if pass_through[row_idx] {
+            if self.pass_through_scratch[row_idx] {
+                self.pass_through_rows.push((batch_idx, row_idx));
                 continue;
             }
-            if let Some(seg_ord) = row_to_seg[row_idx] {
-                let seg_idx = seg_ord as usize;
-                let row_val = converted_rows.row(row_idx).owned();
+
+            if let Some(seg_idx) = self.row_to_seg_scratch[row_idx].map(|s| s as usize) {
+                let row_view = converted_rows.row(row_idx);
 
                 // Pre-filter: rows already worse than this segment's cutoff cannot
                 // enter the top K, so drop them before they reach the buffer. On
                 // visibility plans the cutoff is always derived from live rows (see
                 // truncate_top_k), so this never prunes a row that a dead row would
                 // otherwise have displaced.
-                let is_worse = self
+                if self
                     .segment_cutoffs
                     .get(seg_idx)
                     .and_then(|c| c.as_ref())
-                    .is_some_and(|cutoff| &row_val > cutoff);
-                if is_worse {
+                    .is_some_and(|cutoff| row_view.as_ref() > cutoff.as_ref())
+                {
                     continue;
                 }
 
-                let slot = Self::ensure_slot(&mut self.segment_bufs, seg_idx);
-                if slot.is_none() {
-                    self.segments_seen.add(1);
-                }
-                let buf = slot.get_or_insert_with(SegmentBuf::default);
-                buf.rows.push((batch_idx, row_idx, row_val));
+                let buf_len = {
+                    let buf = self.get_or_create_segment_buf(seg_idx);
+                    buf.rows.push((batch_idx, row_idx, row_view.owned()));
+                    buf.rows.len()
+                };
 
-                if self.k > 0 && buf.rows.len() >= capacity {
+                if self.k > 0 && buf_len >= capacity {
                     self.truncate_top_k(seg_idx)?;
                 }
-            }
-        }
-
-        // The global threshold is published inside truncate_top_k, right after a
-        // segment's cutoff changes; between truncations the cutoffs are unchanged,
-        // so publishing here would be a no-op.
-
-        // Buffer pass-through rows (NULL ordinals) for the final sort.
-        for (row_idx, &is_pt) in pass_through.iter().enumerate() {
-            if is_pt {
-                self.pass_through_rows.push((batch_idx, row_idx));
             }
         }
 
@@ -1003,7 +1050,7 @@ impl SegmentedTopKState {
     /// Helper to extract term ordinals from a deferred UnionArray.
     /// Mutates `pass_through` for rows that contain NULLs, and populates `row_to_seg` mapping.
     fn extract_deferred_ordinals(
-        &self,
+        ffhelper: &FFHelper,
         batch: &RecordBatch,
         deferred_col: &DeferredSortColumn,
         num_rows: usize,
@@ -1113,9 +1160,7 @@ impl SegmentedTopKState {
             let doc_ids: Vec<DocId> = rows.iter().map(|(_, doc_id)| *doc_id).collect();
             let mut term_ords: Vec<Option<TermOrdinal>> = vec![None; doc_ids.len()];
 
-            let col = self
-                .ffhelper
-                .column(seg_ord, deferred_col.canonical.ff_index);
+            let col = ffhelper.column(seg_ord, deferred_col.canonical.ff_index);
             match col {
                 FFType::Text(str_col) => {
                     str_col.ords().first_vals(&doc_ids, &mut term_ords);

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -111,7 +111,7 @@ use tantivy::{DocId, SegmentOrdinal};
 /// per-batch setup cost (snapshot acquisition, packed-DocAddress → ctid resolution, HOT
 /// chain search), so running it on tiny batches is wasteful.
 ///
-/// Per @stuhood on #4525: this is applied PER BUFFER. Each segment's buffer must reach
+/// Each segment's buffer must reach
 /// `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)` before its visibility pass runs, so every
 /// check is a reasonably sized batch and no segment is checked on a tiny batch. Only
 /// affects visibility plans; non-visibility plans keep the original `4 * K * segments`
@@ -477,7 +477,14 @@ impl DisplayAs for SegmentedTopKExec {
             f,
             "SegmentedTopKExec: expr=[{}], k={}",
             sort_exprs_str, self.k
-        )
+        )?;
+        // Signal in the plan that this node performs MVCC visibility checking (it has
+        // absorbed a VisibilityFilterExec), and for which tables, so it is visible when
+        // reading a plan where the checking happens.
+        if let Some(vd) = &self.visibility_data {
+            write!(f, ", visibility_checks=[{}]", vd.table_names.join(", "))?;
+        }
+        Ok(())
     }
 }
 
@@ -1151,7 +1158,7 @@ impl SegmentedTopKState {
     }
 
     /// Build the set of all survivors across all segments. A row survives if
-    /// its `OwnedRow` is <= the cutoff (worst heap entry) for its segment, or
+    /// its `OwnedRow` is <= the cutoff (K-th best row) for its segment, or
     /// if the segment never reached 2×k rows and therefore has no cutoff yet
     /// (in which case every row from that segment is a candidate).
     fn build_survivors(&self) -> crate::api::HashSet<(usize, usize)> {

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -28,32 +28,32 @@
 //!   - State 1 (term_ordinals): uses ordinals directly (already resolved by
 //!     pre-filter memoization).
 //!
-//! For States 0 and 1, a per-segment buffer (a `Vec` with capacity 2 * K) and
-//! QuickSelect retain only the top K rows per segment. All batches are
+//! For States 0 and 1, a per-segment Vec-based buffer (capacity 2×K) with
+//! QuickSelect retains only the top K rows per segment. All batches are
 //! collected during the input phase, and survivors are emitted in a single
 //! pass once all input is consumed.
 //!
 //! ## Global threshold
 //!
 //! As rows are ingested, a global threshold is published to the scanner.
-//! Once a segment's buffer fills to 2 * K and undergoes its first QuickSelect,
-//! the K-th best row's deferred ordinals are converted back to strings via
-//! `FFHelper::ord_to_str` and published as a `DynamicFilterPhysicalExpr`.
+//! Once a segment's buffer undergoes its first QuickSelect (accumulating 2×K
+//! rows), the K-th element's deferred ordinals are converted back to strings
+//! via `FFHelper::ord_to_str` and published as a `DynamicFilterPhysicalExpr`.
 //! DataFusion's standard filter pushdown mechanism routes this to
 //! `PgSearchScanPlan`, where `pre_filter::try_rewrite_binary` translates
 //! the string literals to per-segment ordinal bounds automatically.
 //!
 //! ## Output bound
 //!
-//! The cutoff for each segment is the K-th best `OwnedRow` selected from that
-//! segment's buffer. All rows with `OwnedRow <= cutoff` survive. When sort keys
+//! The cutoff for each segment is the worst (K-th best) `OwnedRow` in that
+//! segment's heap. All rows with `OwnedRow <= cutoff` survive. When sort keys
 //! are unique, this is exactly K rows per segment. With ties at the boundary,
 //! all tied rows are conservatively retained:
 //!
 //!   survivors_s = K + (T_s - H_s)
 //!
 //! where `T_s` is the total number of rows in segment `s` sharing the cutoff
-//! value, and `H_s` is how many of those occupy buffer slots (`H_s >= 1`).
+//! value, and `H_s` is how many of those occupy heap slots (`H_s >= 1`).
 //! Total ordinal-comparable rows reaching `TantivyLookupExec`:
 //!
 //!   sum_s(survivors_s) <= K * S  (when no boundary ties)
@@ -70,8 +70,14 @@
 //! tied across the *entire* sort key are conservatively retained, per the
 //! `survivors_s` bound above.
 
-use crate::api::HashMap;
+use crate::api::{HashMap, HashSet};
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, FFType, NULL_TERM_ORDINAL};
+use crate::postgres::customscan::joinscan::build::CtidColumn;
+use crate::postgres::customscan::joinscan::visibility_filter::{
+    materialize_deferred_ctid, DeferredCtidMaterializationState,
+};
+use crate::postgres::heap::VisibilityChecker;
+use crate::postgres::rel::PgSearchRelation;
 use crate::scan::deferred_encode::unpack_doc_address;
 use crate::scan::execution_plan::UnsafeSendStream;
 use crate::scan::tantivy_lookup_exec::{open_rebuilt_ffhelper, rebuild_mvcc, LookupRebuildContext};
@@ -95,9 +101,31 @@ use datafusion::physical_plan::metrics::{
     Count, ExecutionPlanMetricsSet, MetricBuilder, MetricsSet,
 };
 use datafusion::physical_plan::{DisplayAs, DisplayFormatType, ExecutionPlan, PlanProperties};
-use std::sync::Arc;
+use pgrx::pg_sys;
+use std::sync::{Arc, Mutex};
 use tantivy::termdict::TermOrdinal;
 use tantivy::{DocId, SegmentOrdinal};
+
+/// Minimum number of buffered candidate rows that must accumulate before a visibility
+/// prune cycle runs in [`SegmentedTopKState::maybe_compact`]. Visibility checking has a
+/// per-batch setup cost (snapshot acquisition, packed-DocAddress → ctid resolution, HOT
+/// chain search), so running it on tiny batches is wasteful.
+///
+/// Per @stuhood on #4525: this is applied PER BUFFER. Each segment's buffer must reach
+/// `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)` before its visibility pass runs, so every
+/// check is a reasonably sized batch and no segment is checked on a tiny batch. Only
+/// affects visibility plans; non-visibility plans keep the original `4 * K * segments`
+/// compaction trigger.
+///
+/// Aligned with `DEFERRED_BATCH_SIZE` (the deferred-field scan batch size), since this
+/// path batches deferred rows. Tunable via benchmarking.
+const MINIMUM_VISIBILITY_CHECK_SIZE: usize = 8192;
+
+/// The serializable "recipe" for rebuilding [`AbsorbedVisibilityData`] on a dispatched
+/// worker: `(plan_position, heap OID)` pairs plus table names. `None` when the plan carries
+/// no absorbed visibility. The live ctid resolvers (FFHelpers) are not part of the recipe;
+/// they are re-wired from the decoded subtree in `decode_for_dispatch`.
+type VisibilityRecipe = Option<(Vec<(usize, pg_sys::Oid)>, Vec<String>)>;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct DeferredSortColumn {
@@ -107,6 +135,60 @@ pub struct DeferredSortColumn {
     /// in its decoded subtree (the top-k above a network boundary).
     #[serde(default)]
     pub rebuild: Option<crate::scan::late_materialization::DeferredLookupRebuild>,
+}
+
+/// Visibility data absorbed from a `VisibilityFilterExec` during the `SegmentedTopKRule`
+/// optimization pass.
+///
+/// When `SegmentedTopKExec` absorbs a `VisibilityFilterExec` that was its direct child,
+/// it takes ownership of the plan_position/OID pairs and ctid resolvers so it can
+/// perform MVCC visibility checks inline, right after each prune cycle and at final
+/// emission, instead of deferring them to a separate downstream node.
+pub struct AbsorbedVisibilityData {
+    plan_pos_oids: Vec<(usize, pg_sys::Oid)>,
+    table_names: Vec<String>,
+    /// Per-plan_position FFHelpers for resolving packed DocAddresses to real ctids.
+    /// Wired by `VisibilityCtidResolverRule` after plan construction.
+    ctid_resolvers: Mutex<Vec<Option<Arc<FFHelper>>>>,
+}
+
+impl std::fmt::Debug for AbsorbedVisibilityData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AbsorbedVisibilityData")
+            .field("plan_pos_oids", &self.plan_pos_oids)
+            .field("table_names", &self.table_names)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AbsorbedVisibilityData {
+    pub fn new(plan_pos_oids: Vec<(usize, pg_sys::Oid)>, table_names: Vec<String>) -> Self {
+        let resolver_len = plan_pos_oids
+            .iter()
+            .map(|(p, _)| *p)
+            .max()
+            .map_or(0, |m| m + 1);
+        Self {
+            plan_pos_oids,
+            table_names,
+            ctid_resolvers: Mutex::new(vec![None; resolver_len]),
+        }
+    }
+
+    pub fn plan_pos_oids(&self) -> &[(usize, pg_sys::Oid)] {
+        &self.plan_pos_oids
+    }
+
+    pub fn set_ctid_resolver(&self, plan_pos: usize, ffhelper: Arc<FFHelper>) {
+        let mut resolvers = self
+            .ctid_resolvers
+            .lock()
+            .expect("AbsorbedVisibilityData ctid_resolvers lock poisoned");
+        if plan_pos >= resolvers.len() {
+            resolvers.resize(plan_pos + 1, None);
+        }
+        resolvers[plan_pos] = Some(ffhelper);
+    }
 }
 
 pub struct SegmentedTopKExec {
@@ -124,6 +206,10 @@ pub struct SegmentedTopKExec {
     /// string literals) that the scanner's `try_rewrite_binary` translates to
     /// per-segment ordinal bounds.
     dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
+    /// Visibility data absorbed from a `VisibilityFilterExec` during plan optimization.
+    /// Present only for inner-join plans where VFExec was the direct child of
+    /// `TantivyLookupExec`. When present, this node owns MVCC visibility checking.
+    visibility_data: Option<Arc<AbsorbedVisibilityData>>,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
 }
@@ -152,6 +238,7 @@ impl SegmentedTopKExec {
         deferred_columns: Vec<DeferredSortColumn>,
         ffhelper: Arc<FFHelper>,
         k: usize,
+        visibility_data: Option<Arc<AbsorbedVisibilityData>>,
     ) -> Self {
         use datafusion::physical_expr::expressions::lit;
 
@@ -178,8 +265,26 @@ impl SegmentedTopKExec {
             ffhelper,
             k,
             dynamic_filter,
+            visibility_data,
             properties,
             metrics: ExecutionPlanMetricsSet::new(),
+        }
+    }
+
+    /// Returns the `(plan_position, heap_oid)` pairs whose ctid columns need
+    /// visibility checking. Empty when no `VisibilityFilterExec` was absorbed.
+    pub fn plan_pos_oids(&self) -> &[(usize, pg_sys::Oid)] {
+        self.visibility_data
+            .as_deref()
+            .map(AbsorbedVisibilityData::plan_pos_oids)
+            .unwrap_or(&[])
+    }
+
+    /// Wire an FFHelper for resolving packed DocAddresses to real ctids for
+    /// the given plan_position. Called by `VisibilityCtidResolverRule`.
+    pub fn set_ctid_resolver(&self, plan_pos: usize, ffhelper: Arc<FFHelper>) {
+        if let Some(vd) = &self.visibility_data {
+            vd.set_ctid_resolver(plan_pos, ffhelper);
         }
     }
 
@@ -236,7 +341,23 @@ impl SegmentedTopKExec {
             .iter()
             .map(prost::Message::encode_to_vec)
             .collect();
-        let payload = (sort_bytes, self.deferred_columns.clone(), self.k);
+        // Ship the visibility "recipe" (serializable plan_position/heap-OID pairs + table
+        // names) so a dispatched worker can rebuild AbsorbedVisibilityData. The live ctid
+        // resolvers (FFHelpers) don't travel; they are re-collected from the decoded
+        // subtree in decode_for_dispatch, mirroring how VisibilityFilterExec dispatches.
+        // Without this, a worker would decode visibility_data: None and silently skip
+        // visibility (returning dead rows), since absorption already removed the VFExec on
+        // the leader and workers do not re-run the optimizer rule.
+        let visibility_recipe: VisibilityRecipe = self
+            .visibility_data
+            .as_ref()
+            .map(|vd| (vd.plan_pos_oids.clone(), vd.table_names.clone()));
+        let payload = (
+            sort_bytes,
+            self.deferred_columns.clone(),
+            self.k,
+            visibility_recipe,
+        );
         serde_json::to_vec(&payload).map_err(|e| {
             DataFusionError::Internal(format!("SegmentedTopKExec dispatch: serialize: {e}"))
         })
@@ -246,14 +367,19 @@ impl SegmentedTopKExec {
         buf: &[u8],
         input: Arc<dyn ExecutionPlan>,
         ffhelpers: HashMap<u32, Arc<FFHelper>>,
+        ctid_resolvers: Vec<(usize, Arc<FFHelper>)>,
         ctx: &TaskContext,
         non_partitioning_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
         parallel_state: Option<*mut crate::postgres::ParallelScanState>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let (sort_bytes, deferred_columns, k): (Vec<Vec<u8>>, Vec<DeferredSortColumn>, usize) =
-            serde_json::from_slice(buf).map_err(|e| {
-                DataFusionError::Internal(format!("SegmentedTopKExec dispatch: deserialize: {e}"))
-            })?;
+        let (sort_bytes, deferred_columns, k, visibility_recipe): (
+            Vec<Vec<u8>>,
+            Vec<DeferredSortColumn>,
+            usize,
+            VisibilityRecipe,
+        ) = serde_json::from_slice(buf).map_err(|e| {
+            DataFusionError::Internal(format!("SegmentedTopKExec dispatch: deserialize: {e}"))
+        })?;
         // The deferred sort columns all resolve against one index (the sorted relation), and
         // `ff_index` is relative to that index's fast-field list. A join leaves the other
         // index's scan in the same subtree, so pick the helper by `indexrelid` instead of
@@ -315,12 +441,26 @@ impl SegmentedTopKExec {
         let sort_exprs = LexOrdering::new(exprs).ok_or_else(|| {
             DataFusionError::Internal("SegmentedTopKExec dispatch: empty sort order".into())
         })?;
+        // Rebuild absorbed visibility data from the shipped recipe and re-wire the live
+        // ctid resolvers pulled from the decoded subtree. Workers do not re-run the
+        // optimizer rule, so the VFExec is already absorbed and gone; leaving this `None`
+        // would make the worker skip visibility and return dead rows. The VisibilityChecker
+        // itself is built later at execute() time from GetActiveSnapshot(), so no snapshot
+        // travels (the worker's active snapshot is already the leader's MVCC view).
+        let visibility_data = visibility_recipe.map(|(plan_pos_oids, table_names)| {
+            let vd = AbsorbedVisibilityData::new(plan_pos_oids, table_names);
+            for (plan_pos, resolver) in &ctid_resolvers {
+                vd.set_ctid_resolver(*plan_pos, Arc::clone(resolver));
+            }
+            Arc::new(vd)
+        });
         Ok(Arc::new(SegmentedTopKExec::new(
             input,
             sort_exprs,
             deferred_columns,
             ffhelper,
             k,
+            visibility_data,
         )))
     }
 }
@@ -364,6 +504,7 @@ impl ExecutionPlan for SegmentedTopKExec {
             self.deferred_columns.clone(),
             Arc::clone(&self.ffhelper),
             self.k,
+            self.visibility_data.clone(),
         );
         // Preserve the existing dynamic filter so that filter pushdown
         // wiring (which already holds a reference) stays connected.
@@ -380,6 +521,17 @@ impl ExecutionPlan for SegmentedTopKExec {
         let rows_input = MetricBuilder::new(&self.metrics).counter("rows_input", partition);
         let rows_output = MetricBuilder::new(&self.metrics).counter("rows_output", partition);
         let segments_seen = MetricBuilder::new(&self.metrics).counter("segments_seen", partition);
+        // Only register rows_filtered_invisible in the MetricsSet when visibility
+        // filtering is actually active. For non-visibility plans the counter would
+        // always be 0, and render_plan_with_metrics shows every registered metric
+        // (including zeros), which would pollute EXPLAIN ANALYZE output and break
+        // pg_regress .out files. A standalone Count::new() is functionally equivalent
+        // for increment purposes but is never added to the MetricsSet.
+        let rows_filtered_invisible = if self.visibility_data.is_some() {
+            MetricBuilder::new(&self.metrics).counter("rows_filtered_invisible", partition)
+        } else {
+            Count::new()
+        };
 
         // Build the row converter
         let sort_fields = self
@@ -415,6 +567,61 @@ impl ExecutionPlan for SegmentedTopKExec {
             self.properties.eq_properties.schema(),
         )?;
 
+        // Build per-relation visibility checker entries from the absorbed VFExec data
+        // (if any). These are created eagerly here, before the async stream body,
+        // so that `execute()` can return a clean `Err` on misconfiguration rather
+        // than failing mid-stream.
+        let visibility_entries: Vec<StkVisibilityEntry> = if let Some(vd) = &self.visibility_data {
+            let resolvers = vd
+                .ctid_resolvers
+                .lock()
+                .expect("ctid_resolvers lock poisoned")
+                .clone();
+            // SAFETY: GetActiveSnapshot is safe during query execution.
+            let snapshot = unsafe { pg_sys::GetActiveSnapshot() };
+            if snapshot.is_null() {
+                return Err(DataFusionError::Execution(
+                    "SegmentedTopKExec: requires an active Postgres snapshot \
+                         for visibility checking"
+                        .into(),
+                ));
+            }
+            let schema = self.properties.eq_properties.schema();
+            let mut entries = Vec::with_capacity(vd.plan_pos_oids.len());
+            for &(plan_pos, heap_oid) in &vd.plan_pos_oids {
+                let col_name = CtidColumn::new(plan_pos).to_string();
+                let (col_idx, _) = schema.column_with_name(&col_name).ok_or_else(|| {
+                    DataFusionError::Execution(format!(
+                        "SegmentedTopKExec: missing ctid column '{}' \
+                                 for visibility checking",
+                        col_name
+                    ))
+                })?;
+                let heaprel = PgSearchRelation::open(heap_oid);
+                let checker = VisibilityChecker::with_rel_and_snap(&heaprel, snapshot);
+                let resolver =
+                    resolvers
+                        .get(plan_pos)
+                        .and_then(|r| r.clone())
+                        .ok_or_else(|| {
+                            DataFusionError::Execution(format!(
+                                "SegmentedTopKExec: no ctid resolver wired for \
+                                 plan_position {plan_pos}. \
+                                 VisibilityCtidResolverRule must run before execute."
+                            ))
+                        })?;
+                entries.push(StkVisibilityEntry {
+                    col_idx,
+                    checker,
+                    resolver,
+                    deferred_ctid_state: DeferredCtidMaterializationState::default(),
+                });
+            }
+            entries
+        } else {
+            Vec::new()
+        };
+
         let mut state = SegmentedTopKState {
             sort_exprs: self.sort_exprs.clone(),
             deferred_columns: self.deferred_columns.clone(),
@@ -424,6 +631,7 @@ impl ExecutionPlan for SegmentedTopKExec {
             row_converter,
             segment_bufs: Vec::new(),
             segment_cutoffs: Vec::new(),
+            distinct_segments: HashSet::default(),
             dynamic_filter: Arc::clone(&self.dynamic_filter),
             batches: Vec::new(),
             row_ordinals: Vec::new(),
@@ -431,9 +639,11 @@ impl ExecutionPlan for SegmentedTopKExec {
             last_segment_cutoffs: Vec::new(),
             mat_row_converter,
             last_published_global: None,
+            visibility_entries,
             rows_input,
             rows_output,
             segments_seen,
+            rows_filtered_invisible,
         };
 
         let stream_gen = async_stream::try_stream! {
@@ -445,7 +655,7 @@ impl ExecutionPlan for SegmentedTopKExec {
                 let batch_idx = state.batches.len();
                 state.collect_batch(&batch, batch_idx)?;
                 state.batches.push(batch);
-                state.maybe_compact();
+                state.maybe_compact()?;
             }
 
             // All input consumed — perform final sort + limit and emit exactly K rows.
@@ -503,6 +713,20 @@ impl ExecutionPlan for SegmentedTopKExec {
     }
 }
 
+/// Per-plan_position runtime state for ctid resolution and visibility checking.
+/// One entry per absorbed `(plan_pos, heap_oid)` pair; empty when no
+/// `VisibilityFilterExec` was absorbed.
+struct StkVisibilityEntry {
+    /// Index of the `ctid_{plan_position}` column in the input batch schema.
+    col_idx: usize,
+    /// MVCC visibility checker for this relation.
+    checker: VisibilityChecker,
+    /// Resolves packed DocAddresses to real ctids before visibility checking.
+    resolver: Arc<FFHelper>,
+    /// Reusable scratch buffers for packed DocAddress materialization.
+    deferred_ctid_state: DeferredCtidMaterializationState,
+}
+
 struct SegmentedTopKState {
     sort_exprs: LexOrdering,
     deferred_columns: Vec<DeferredSortColumn>,
@@ -513,16 +737,25 @@ struct SegmentedTopKState {
     /// Per-segment rolling buffers of comparable Rows, indexed by `SegmentOrdinal`
     /// (dense, 0..N). Each buffer grows up to 2 * K rows; when it reaches 2 * K,
     /// `select_nth_unstable(k - 1)` partitions it so the K best rows occupy the front,
-    /// the K-th best is recorded in `segment_cutoffs`, and the buffer is truncated back
-    /// to K. Row locations `(batch_idx, row_idx)` are tracked separately in
-    /// `row_ordinals` for compaction.
+    /// the K-th best is recorded in `segment_cutoffs`, and the buffer is truncated to K.
+    ///
+    /// **Non-visibility plans:** updated in `collect_batch` on every accepted row; the
+    /// inline QuickSelect fires when a buffer hits 2 * K.
+    ///
+    /// **Visibility plans:** NOT updated in `collect_batch`. Rebuilt from visible
+    /// survivors inside `maybe_compact()` after each prune cycle, so every published
+    /// cutoff is based exclusively on live rows.
     segment_bufs: Vec<Option<Vec<OwnedRow>>>,
     /// Per-segment K-th best row (the cutoff threshold) after the most recent
     /// QuickSelect, indexed by `SegmentOrdinal`. `None` for segments that have not yet
-    /// accumulated 2 * K rows, i.e. segments whose buffer has not been partitioned.
-    /// Updated by the inline QuickSelect in `collect_batch` and consulted to pre-filter
-    /// clearly worse rows.
+    /// had a QuickSelect run. Updated by inline QuickSelect in `collect_batch` (non-vis)
+    /// and by the prune-cycle rebuild in `maybe_compact` (vis).
     segment_cutoffs: Vec<Option<OwnedRow>>,
+    /// Set of all segment ordinals encountered during collection. Used to compute the
+    /// prune-cycle trigger for visibility plans. Updated in `collect_batch` for EVERY
+    /// ingested row, including visibility plans where `segment_bufs` is not rebuilt
+    /// until the first prune cycle, and is never cleared.
+    distinct_segments: HashSet<SegmentOrdinal>,
     /// Dynamic filter updated with global thresholds (materialized strings).
     /// Pushed down through DataFusion's standard filter pushdown to the scanner.
     dynamic_filter: Arc<DynamicFilterPhysicalExpr>,
@@ -553,6 +786,12 @@ struct SegmentedTopKState {
     /// Counts segments that had rows participating in ordinal comparison (States 0+1).
     /// Segments with only NULLs are not counted.
     segments_seen: Count,
+    /// Counts rows removed because they were dead (invisible) under the current snapshot.
+    /// Incremented during prune cycles (maybe_compact) and at final emission (emit_final_topk).
+    rows_filtered_invisible: Count,
+    /// Runtime visibility checker entries, one per absorbed `(plan_pos, heap_oid)` pair.
+    /// Empty when no `VisibilityFilterExec` was absorbed.
+    visibility_entries: Vec<StkVisibilityEntry>,
 }
 
 impl SegmentedTopKState {
@@ -615,44 +854,67 @@ impl SegmentedTopKState {
                 let seg_idx = seg_ord as usize;
                 let row_val = converted_rows.row(row_idx).owned();
 
-                // Pre-filter: rows already worse than this segment's cutoff cannot
-                // enter the top K, so drop them before they reach the buffer.
-                let is_worse = self
-                    .segment_cutoffs
-                    .get(seg_idx)
-                    .and_then(|c| c.as_ref())
-                    .is_some_and(|cutoff| &row_val > cutoff);
-                if is_worse {
-                    continue;
-                }
-
-                if self
-                    .segment_bufs
-                    .get(seg_idx)
-                    .is_none_or(|buf| buf.is_none())
-                {
+                // Track distinct segments for the compaction trigger. Always updated
+                // here so the trigger denominator is accurate even for visibility plans
+                // where `segment_bufs` is not rebuilt until `maybe_compact()`.
+                if self.distinct_segments.insert(seg_ord) {
                     self.segments_seen.add(1);
                 }
-                let buf =
-                    Self::ensure_slot(&mut self.segment_bufs, seg_idx).get_or_insert_with(Vec::new);
-                buf.push(row_val.clone());
-                self.row_ordinals
-                    .push((batch_idx, row_idx, seg_ord, row_val));
-
-                // QuickSelect: when the buffer reaches 2 * K, partition it around the
-                // K-th element (index k - 1). That element becomes the new segment
-                // cutoff and the buffer is truncated to its K best rows, mirroring
-                // Tantivy's TopNComputer.
-                if self.k > 0 && buf.len() >= 2 * self.k {
-                    buf.select_nth_unstable(self.k - 1);
-                    let cutoff = buf[self.k - 1].clone();
-                    buf.truncate(self.k);
-                    *Self::ensure_slot(&mut self.segment_cutoffs, seg_idx) = Some(cutoff);
+                if self.visibility_entries.is_empty() {
+                    // Non-visibility plan: pre-filter rows already worse than the current
+                    // segment cutoff, then push to the buffer. When the buffer reaches
+                    // 2 * K, QuickSelect partitions it and the K-th element becomes the
+                    // new cutoff.
+                    let is_worse = self
+                        .segment_cutoffs
+                        .get(seg_idx)
+                        .and_then(|c| c.as_ref())
+                        .is_some_and(|cutoff| &row_val > cutoff);
+                    if is_worse {
+                        continue;
+                    }
+                    let buf = Self::ensure_slot(&mut self.segment_bufs, seg_idx)
+                        .get_or_insert_with(Vec::new);
+                    buf.push(row_val.clone());
+                    self.row_ordinals
+                        .push((batch_idx, row_idx, seg_ord, row_val));
+                    if self.k > 0 && buf.len() >= 2 * self.k {
+                        buf.select_nth_unstable(self.k - 1);
+                        let cutoff = buf[self.k - 1].clone();
+                        buf.truncate(self.k);
+                        *Self::ensure_slot(&mut self.segment_cutoffs, seg_idx) = Some(cutoff);
+                    }
+                } else {
+                    // Visibility plan: `segment_bufs` is NEVER updated here. Buffers are
+                    // rebuilt inside `maybe_compact()` only after visibility checking, so
+                    // every published cutoff reflects exclusively live rows.
+                    //
+                    // Pre-filter using the last prune cycle's alive cutoff (read-only):
+                    // rows provably worse than the alive K-th are rejected early to bound
+                    // buffer growth between prune cycles.
+                    let is_candidate = self
+                        .segment_cutoffs
+                        .get(seg_idx)
+                        .and_then(|c| c.as_ref())
+                        .is_none_or(|cutoff| &row_val <= cutoff);
+                    if is_candidate {
+                        self.row_ordinals
+                            .push((batch_idx, row_idx, seg_ord, row_val));
+                    }
                 }
             }
         }
 
-        self.publish_global_threshold()?;
+        // Non-visibility plans: publish threshold after each batch so PgSearchScan can
+        // prune as early as possible. Safe: no dead rows can inflate the threshold.
+        //
+        // Visibility plans: threshold is published ONLY inside maybe_compact() after
+        // visibility checking. Publishing here would base the threshold on rows that have
+        // not yet been checked for MVCC visibility; dead rows in the buffer would inflate
+        // the threshold, causing PgSearchScan to prune live rows it shouldn't.
+        if self.visibility_entries.is_empty() {
+            self.publish_global_threshold()?;
+        }
 
         // Buffer pass-through rows (NULL ordinals) for the final sort.
         for (row_idx, &is_pt) in pass_through.iter().enumerate() {
@@ -888,9 +1150,10 @@ impl SegmentedTopKState {
             .reduce(|a, b| Arc::new(BinaryExpr::new(a, Operator::Or, b)) as Arc<dyn PhysicalExpr>)
     }
 
-    /// Build the set of all survivors across all segments. A row survives if its
-    /// `OwnedRow` is <= the cutoff (K-th best row) for its segment. Segments without
-    /// a cutoff have not yet accumulated 2 * K rows, so all of their rows survive.
+    /// Build the set of all survivors across all segments. A row survives if
+    /// its `OwnedRow` is <= the cutoff (worst heap entry) for its segment, or
+    /// if the segment never reached 2×k rows and therefore has no cutoff yet
+    /// (in which case every row from that segment is a candidate).
     fn build_survivors(&self) -> crate::api::HashSet<(usize, usize)> {
         let mut survivors = crate::api::HashSet::default();
         for (batch_idx, row_idx, seg_ord, row_val) in &self.row_ordinals {
@@ -917,9 +1180,8 @@ impl SegmentedTopKState {
         let mut best_worst_mat_row: Option<OwnedRow> = None;
         let mut best_worst_values: Option<Vec<datafusion::common::ScalarValue>> = None;
 
-        // 1. Examine the K-th best row (the cutoff) for each segment that has one.
-        //    A cutoff exists only after a segment has accumulated 2 * K rows and been
-        //    partitioned, so every cutoff already reflects a full K rows.
+        // 1. Examine the "worst" row (the root of the heap) for each segment that
+        //    has reached size `K`.
         let full_segment_cutoffs: Vec<(SegmentOrdinal, OwnedRow)> = self
             .segment_cutoffs
             .iter()
@@ -1091,22 +1353,54 @@ impl SegmentedTopKState {
     /// current per-segment cutoffs. This bounds memory at O(K * segments)
     /// instead of O(N) for large inputs — analogous to the batch compaction
     /// step in upstream DataFusion Top K.
-    fn maybe_compact(&mut self) {
-        let num_segments = self
-            .segment_bufs
-            .iter()
-            .filter(|buf| buf.is_some())
-            .count()
-            .max(1);
-        if self.row_ordinals.len() <= self.k * num_segments * 4 {
-            return;
+    ///
+    /// When visibility data was absorbed, dead rows are also removed here so that the
+    /// global threshold is never inflated by rows that are invisible to the current
+    /// snapshot. `segment_bufs` is rebuilt from the visible survivors.
+    fn maybe_compact(&mut self) -> Result<()> {
+        // Use `distinct_segments` (not `segment_bufs`) to count segments: for visibility
+        // plans, `segment_bufs` is empty before the first prune cycle, which would cause
+        // an under-count and fire prune cycles too early.
+        let num_segments = self.distinct_segments.len().max(1);
+
+        if self.visibility_entries.is_empty() {
+            // Non-visibility plans use the original global 4 * K * segments trigger.
+            let trigger = self.k * num_segments * 4;
+            if self.row_ordinals.len() + self.pass_through_rows.len() < trigger {
+                return Ok(());
+            }
+        } else {
+            // Visibility plans use a PER-BUFFER trigger (per @stuhood on #4525): each
+            // segment's buffer must reach `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)`
+            // before its visibility pass runs, so every check is a reasonably sized batch
+            // and we never aggregate all segments into one buffer. Fire as soon as ANY
+            // segment's buffer reaches that size. Pass-through-only plans (all NULL/State-2
+            // sort columns) accumulate rows without a segment, so also fire when
+            // pass_through_rows alone reaches the threshold, otherwise the visibility check
+            // would be deferred entirely to emit_final_topk.
+            let per_buffer = (2 * self.k).max(MINIMUM_VISIBILITY_CHECK_SIZE);
+            let mut seg_counts: Vec<usize> = Vec::new();
+            for (_, _, seg_ord, _) in &self.row_ordinals {
+                let idx = *seg_ord as usize;
+                if idx >= seg_counts.len() {
+                    seg_counts.resize(idx + 1, 0);
+                }
+                seg_counts[idx] += 1;
+            }
+            let any_buffer_full = seg_counts.iter().any(|&c| c >= per_buffer);
+            if !any_buffer_full && self.pass_through_rows.len() < per_buffer {
+                return Ok(());
+            }
         }
 
-        // Determine which row_ordinals survive the current cutoffs.
+        // Step 1: Cutoff filter, retain only rows within per-segment bounds.
+        // Capture the pre-take length before std::mem::take empties row_ordinals: after
+        // take(), the Vec has capacity 0, which would make the half-rows-discarded ratio
+        // check always true and bypass the "don't compact if < half rows discarded" guard.
+        let old_row_ordinals_len = self.row_ordinals.len();
         let mut new_row_ordinals = Vec::new();
-        let mut survivors = crate::api::HashSet::default();
-
-        // Use take() so we own row_ordinals and can move the OwnedRows.
+        // Use take() so we own row_ordinals and can move the OwnedRows. The survivor
+        // set is built later (Step 3) after the visibility pass has run.
         for (batch_idx, row_idx, seg_ord, row_val) in std::mem::take(&mut self.row_ordinals) {
             let keep = self
                 .segment_cutoffs
@@ -1114,20 +1408,112 @@ impl SegmentedTopKState {
                 .and_then(|c| c.as_ref())
                 .is_none_or(|cutoff| &row_val <= cutoff);
             if keep {
-                survivors.insert((batch_idx, row_idx));
                 new_row_ordinals.push((batch_idx, row_idx, seg_ord, row_val));
             }
         }
 
+        // Step 2: Visibility filter, remove dead rows, then rebuild segment_bufs and
+        // segment_cutoffs via QuickSelect from the surviving rows.
+        // pass_through_rows are NOT checked here; they are checked in emit_final_topk.
+        //
+        // The rebuild always runs (not only when rows are invisible) so that the global
+        // threshold is published on every prune cycle, including all-alive workloads.
+        if !self.visibility_entries.is_empty() && !new_row_ordinals.is_empty() {
+            // Per-buffer visibility (per @stuhood on #4525): check each segment's rows as
+            // its own batch, right before that segment's QuickSelect below, instead of
+            // aggregating every segment's rows into one buffer for a single check. The
+            // per-row MVCC result is independent of how rows are batched, so this yields
+            // the same survivors as a global check, just grouped per segment.
+            // Discard corrected ctids at compaction time: batches keep packed
+            // DocAddresses (real ctid write-back happens at emit_final_topk).
+            let mut by_seg: HashMap<SegmentOrdinal, Vec<usize>> = HashMap::default();
+            for (i, (_, _, seg_ord, _)) in new_row_ordinals.iter().enumerate() {
+                by_seg.entry(*seg_ord).or_default().push(i);
+            }
+            let mut keep = vec![true; new_row_ordinals.len()];
+            for indices in by_seg.values() {
+                let row_keys: Vec<(usize, usize)> = indices
+                    .iter()
+                    .map(|&i| (new_row_ordinals[i].0, new_row_ordinals[i].1))
+                    .collect();
+                let (visible_mask, _) = self.check_rows_visible(&row_keys)?;
+                let dead = visible_mask.iter().filter(|&&v| !v).count();
+                if dead > 0 {
+                    self.rows_filtered_invisible.add(dead);
+                }
+                for (j, &i) in indices.iter().enumerate() {
+                    if !visible_mask[j] {
+                        keep[i] = false;
+                    }
+                }
+            }
+            if keep.iter().any(|&k| !k) {
+                new_row_ordinals = new_row_ordinals
+                    .into_iter()
+                    .zip(keep)
+                    .filter(|(_, keep)| *keep)
+                    .map(|(row, _)| row)
+                    .collect();
+            }
+
+            // Rebuild segment_bufs and segment_cutoffs from survivors via QuickSelect.
+            // Clear stale cached cutoffs so publish_global_threshold recomputes from
+            // the freshly rebuilt state.
+            self.segment_bufs.clear();
+            self.segment_cutoffs.clear();
+            self.last_segment_cutoffs.clear();
+            for (_, _, seg_ord, row_val) in &new_row_ordinals {
+                Self::ensure_slot(&mut self.segment_bufs, *seg_ord as usize)
+                    .get_or_insert_with(Vec::new)
+                    .push(row_val.clone());
+            }
+            for seg_idx in 0..self.segment_bufs.len() {
+                if let Some(buf) = self.segment_bufs[seg_idx].as_mut() {
+                    if buf.len() >= self.k {
+                        buf.select_nth_unstable(self.k - 1);
+                        let cutoff = buf[self.k - 1].clone();
+                        buf.truncate(self.k);
+                        *Self::ensure_slot(&mut self.segment_cutoffs, seg_idx) = Some(cutoff);
+                    }
+                }
+            }
+
+            // If dead-row removal left any segment with fewer than K rows, the
+            // previously published threshold is now too aggressive; rows with
+            // ordinals below the dead row's that are needed to refill the slots
+            // would be pruned. Retract to lit(true) so those rows can flow in,
+            // then republish the correct threshold from the rebuilt state.
+            // publish_global_threshold() skips segments without a cutoff in
+            // segment_cutoffs, so we must reset dynamic_filter explicitly here.
+            let any_underfull = self
+                .segment_bufs
+                .iter()
+                .flatten()
+                .any(|buf| buf.len() < self.k);
+            if any_underfull {
+                use datafusion::physical_expr::expressions::lit;
+                let _ = self.dynamic_filter.update(lit(true));
+                self.last_published_global = None;
+            }
+            self.publish_global_threshold()?;
+        }
+
+        // Step 3: Populate survivors set for batch compaction.
+        let mut survivors = crate::api::HashSet::default();
+        for (batch_idx, row_idx, _, _) in &new_row_ordinals {
+            survivors.insert((*batch_idx, *row_idx));
+        }
         // Include pass-through rows in the survivor set so they aren't discarded.
         for &(batch_idx, row_idx) in &self.pass_through_rows {
             survivors.insert((batch_idx, row_idx));
         }
 
         // Don't compact if we wouldn't discard at least half the rows.
-        if new_row_ordinals.len() * 2 > self.row_ordinals.capacity() {
+        // Use old_row_ordinals_len (captured before take()); after take() the Vec
+        // is empty with capacity 0, which would make this check always true.
+        if new_row_ordinals.len() * 2 > old_row_ordinals_len {
             self.row_ordinals = new_row_ordinals;
-            return;
+            return Ok(());
         }
 
         // Filter each stored batch, build old→new row mapping, concatenate.
@@ -1151,7 +1537,8 @@ impl SegmentedTopKState {
                 }
             }
 
-            let filtered = filter_record_batch(batch, &mask).expect("compaction filter failed");
+            let filtered = filter_record_batch(batch, &mask)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
             filtered_batches.push(filtered);
         }
 
@@ -1159,11 +1546,11 @@ impl SegmentedTopKState {
             self.batches.clear();
             self.row_ordinals.clear();
             self.pass_through_rows.clear();
-            return;
+            return Ok(());
         }
 
-        let compacted =
-            concat_batches(&self.schema, &filtered_batches).expect("compaction concat failed");
+        let compacted = concat_batches(&self.schema, &filtered_batches)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
 
         // Remap row_ordinals into the single compacted batch.
         for entry in &mut new_row_ordinals {
@@ -1181,6 +1568,118 @@ impl SegmentedTopKState {
 
         self.row_ordinals = new_row_ordinals;
         self.batches = vec![compacted];
+        Ok(())
+    }
+
+    /// Check visibility for a set of rows identified by `(batch_idx, row_idx)` pairs.
+    ///
+    /// For each absorbed `(plan_pos, heap_oid)` pair, extracts the packed DocAddress
+    /// from the ctid column of the stored batch, resolves it to a real ctid via
+    /// `FFHelper`, then calls `VisibilityChecker::check_batch`. The overall result
+    /// is the AND of all per-relation visibility masks.
+    ///
+    /// Returns `(visible_mask, corrected_ctids_per_entry)`:
+    /// - `visible_mask[i]` is `false` when the i-th row is invisible to any relation.
+    /// - `corrected_ctids_per_entry[e][i]` is the HOT-corrected real ctid for the i-th
+    ///   row as seen by entry `e`. `None` means invisible (or unresolvable) for that
+    ///   entry. These HOT-corrected values must be used in the final output so that
+    ///   `fetch_tuple_direct` (which does NOT follow HOT chains) receives the right ctid.
+    ///
+    /// Returns all-true / empty-corrected immediately when `visibility_entries` is empty.
+    #[allow(clippy::type_complexity)]
+    fn check_rows_visible(
+        &mut self,
+        row_keys: &[(usize, usize)],
+    ) -> Result<(Vec<bool>, Vec<Vec<Option<u64>>>)> {
+        if self.visibility_entries.is_empty() || row_keys.is_empty() {
+            return Ok((vec![true; row_keys.len()], Vec::new()));
+        }
+
+        let n = row_keys.len();
+        let mut overall_visible = vec![true; n];
+        let mut all_corrected: Vec<Vec<Option<u64>>> =
+            Vec::with_capacity(self.visibility_entries.len());
+
+        for entry in self.visibility_entries.iter_mut() {
+            // Track which input positions had a null ctid so we can mark them
+            // invisible regardless of what materialize_deferred_ctid returns.
+            // We must NOT use 0 as a sentinel: (seg_ord=0, doc_id=0) is a valid
+            // packed DocAddress that could resolve to a real ctid.
+            let mut input_null: Vec<bool> = Vec::with_capacity(n);
+
+            // Extract packed doc addresses from the stored batches.
+            let mut packed_values: Vec<u64> = Vec::with_capacity(n);
+            for &(batch_idx, row_idx) in row_keys {
+                let col = self.batches[batch_idx].column(entry.col_idx);
+                let arr = col.as_any().downcast_ref::<UInt64Array>().ok_or_else(|| {
+                    DataFusionError::Internal("SegmentedTopKExec: ctid column is not UInt64".into())
+                })?;
+                if arr.is_null(row_idx) {
+                    input_null.push(true);
+                    packed_values.push(0u64); // placeholder; overridden below
+                } else {
+                    input_null.push(false);
+                    packed_values.push(arr.value(row_idx));
+                }
+            }
+
+            // Resolve packed DocAddresses → real ctids via FFHelper.
+            let packed_array = UInt64Array::from(packed_values);
+            let resolved_array = materialize_deferred_ctid(
+                &entry.resolver,
+                &packed_array,
+                &mut entry.deferred_ctid_state,
+            )?;
+            let resolved = resolved_array
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "SegmentedTopKExec: resolved ctid array is not UInt64".into(),
+                    )
+                })?;
+
+            // Collect valid (non-null, non-null-input) ctids with their original indices.
+            // check_batch panics on None inputs, so we filter to resolvable rows only.
+            let mut valid: Vec<(usize, u64)> = Vec::with_capacity(n);
+            for (i, vis) in overall_visible.iter_mut().enumerate() {
+                if input_null[i] || resolved.is_null(i) {
+                    // Null input ctid or unresolvable → treat as invisible.
+                    *vis = false;
+                } else {
+                    valid.push((i, resolved.value(i)));
+                }
+            }
+
+            // Per-entry HOT-corrected ctids: None for invisible rows, Some(ctid) for
+            // visible rows. Populated from check_batch results below.
+            let mut entry_corrected: Vec<Option<u64>> = vec![None; n];
+
+            if !valid.is_empty() {
+                let ctids_for_check: Vec<Option<u64>> =
+                    valid.iter().map(|(_, c)| Some(*c)).collect();
+                let mut results: Vec<Option<u64>> = vec![None; valid.len()];
+                entry.checker.check_batch(&ctids_for_check, &mut results);
+
+                for ((orig_idx, _), result) in valid.iter().zip(results.iter()) {
+                    match result {
+                        // heap_hot_search_buffer returned the HOT-corrected ctid.
+                        // Store it so emit_final_topk can write it to the output
+                        // column instead of the raw index ctid.
+                        Some(corrected_ctid) => {
+                            entry_corrected[*orig_idx] = Some(*corrected_ctid);
+                        }
+                        None => {
+                            overall_visible[*orig_idx] = false;
+                        }
+                    }
+                }
+            }
+
+            all_corrected.push(entry_corrected);
+        }
+
+        Ok((overall_visible, all_corrected))
     }
 
     /// Perform the final sort + limit after all input is consumed.
@@ -1189,6 +1688,7 @@ impl SegmentedTopKState {
     /// Steps:
     /// 1. Build ordinal survivors (rows within per-segment cutoffs).
     /// 2. Merge ordinal survivors with pass-through rows into candidate set.
+    ///    2a. (Visibility) Filter invisible rows from candidates, including pass-through rows.
     /// 3. Materialize sort column values for each candidate.
     /// 4. Sort candidates by materialized values, take top K.
     /// 5. Emit a single sorted batch.
@@ -1196,21 +1696,76 @@ impl SegmentedTopKState {
         use datafusion::common::ScalarValue;
 
         // 1. Build ordinal survivors.
-        let ordinal_survivors = self.build_survivors();
-
-        // 2. Collect all candidates: ordinal survivors + pass-through rows.
-        //    Each candidate is (batch_idx, row_idx, Option<(SegmentOrdinal, OwnedRow)>).
-        //    The OwnedRow is the ordinal-based row for ordinal survivors; None for pass-through.
+        //
+        // When visibility data is present, dead rows in the top-K heap slots would
+        // cause build_survivors to exclude live rows with worse ordinals.  Example:
+        // k=5, rows 1-5 are in the heap (ordinals 0-4), rows 6-15 are pruned out,
+        // but rows 1-3 are dead → only 2 live rows survive.  To avoid this, we skip
+        // the ordinal-based pre-filter and include ALL row_ordinals as candidates;
+        // the visibility pass removes dead rows and the final sort+limit yields the
+        // correct k live rows.  The extra visibility checks (over all row_ordinals
+        // rather than just the top-k survivors) are acceptable for correctness.
         type Candidate = (usize, usize, Option<(SegmentOrdinal, OwnedRow)>);
         let mut candidates: Vec<Candidate> = Vec::new();
 
-        for (batch_idx, row_idx, seg_ord, row_val) in &self.row_ordinals {
-            if ordinal_survivors.contains(&(*batch_idx, *row_idx)) {
+        if !self.visibility_entries.is_empty() {
+            // Include every row from row_ordinals so that after dead rows are removed
+            // we still have enough live rows to fill k slots.
+            for (batch_idx, row_idx, seg_ord, row_val) in &self.row_ordinals {
                 candidates.push((*batch_idx, *row_idx, Some((*seg_ord, row_val.clone()))));
             }
+        } else {
+            // 1. Build ordinal survivors (normal path, no visibility data).
+            let ordinal_survivors = self.build_survivors();
+            // 2. Collect all candidates: ordinal survivors only.
+            for (batch_idx, row_idx, seg_ord, heap_val) in &self.row_ordinals {
+                if ordinal_survivors.contains(&(*batch_idx, *row_idx)) {
+                    candidates.push((*batch_idx, *row_idx, Some((*seg_ord, heap_val.clone()))));
+                }
+            }
         }
+
+        // Always include pass-through rows (NULL ordinals).
         for &(batch_idx, row_idx) in &self.pass_through_rows {
             candidates.push((batch_idx, row_idx, None));
+        }
+
+        // 2a. Visibility filter: remove invisible rows from candidates.
+        //     pass_through_rows are checked here (they bypass the prune cycle).
+        //
+        // corrected_lookup[entry_idx][(batch_idx, row_idx)] = HOT-corrected real ctid.
+        // Populated here and consumed in the final output column write below so that
+        // fetch_tuple_direct (which does NOT follow HOT chains) gets the right address.
+        // Declared outside the if block so it remains in scope for the output step.
+        let corrected_lookup: Vec<HashMap<(usize, usize), u64>>;
+
+        if !self.visibility_entries.is_empty() && !candidates.is_empty() {
+            let row_keys: Vec<(usize, usize)> =
+                candidates.iter().map(|(bi, ri, _)| (*bi, *ri)).collect();
+            let (visible_mask, corrected_per_entry) = self.check_rows_visible(&row_keys)?;
+            // Build per-entry (batch_idx, row_idx) → HOT-corrected ctid lookup.
+            corrected_lookup = corrected_per_entry
+                .into_iter()
+                .map(|ctids| {
+                    row_keys
+                        .iter()
+                        .zip(ctids)
+                        .filter_map(|(key, opt)| opt.map(|c| (*key, c)))
+                        .collect::<HashMap<_, _>>()
+                })
+                .collect();
+            let invisible_count = visible_mask.iter().filter(|&&v| !v).count();
+            if invisible_count > 0 {
+                self.rows_filtered_invisible.add(invisible_count);
+            }
+            candidates = candidates
+                .into_iter()
+                .zip(visible_mask)
+                .filter(|(_, visible)| *visible)
+                .map(|(c, _)| c)
+                .collect();
+        } else {
+            corrected_lookup = Vec::new();
         }
 
         if candidates.is_empty() {
@@ -1372,8 +1927,42 @@ impl SegmentedTopKState {
             output_columns.push(reordered);
         }
 
-        let result = RecordBatch::try_new(self.schema.clone(), output_columns)
+        let mut result = RecordBatch::try_new(self.schema.clone(), output_columns)
             .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+
+        // Write HOT-corrected real ctids to the absorbed ctid output columns.
+        //
+        // When SegmentedTopKRule absorbs a VisibilityFilterExec, the batches flowing
+        // through come directly from HashJoinExec and therefore still carry packed
+        // DocAddresses in the ctid_N columns.  We must resolve them before emitting
+        // so downstream JoinScanState can pass a real ctid to fetch_tuple_direct.
+        //
+        // We use the HOT-corrected values from corrected_lookup (populated by
+        // check_rows_visible above via heap_hot_search_buffer) rather than calling
+        // materialize_deferred_ctid again.  materialize_deferred_ctid would return
+        // the raw index ctid, which is wrong for rows whose heap tuple has been
+        // moved by a HOT update: fetch_tuple_direct does NOT follow HOT chains, so
+        // it would silently return no data or stale data for those rows.
+        if !corrected_lookup.is_empty() {
+            let mut columns: Vec<ArrayRef> = result.columns().to_vec();
+            for (entry_idx, entry) in self.visibility_entries.iter().enumerate() {
+                // Build the corrected-ctid array for the K winners in sorted order.
+                // Every winner was visible (invisible rows were filtered out above),
+                // so corrected_lookup[entry_idx] must contain an entry for each.
+                let corrected: Vec<Option<u64>> = mat_rows
+                    .iter()
+                    .map(|(candidate_idx, _)| {
+                        let (batch_idx, row_idx, _) = &candidates[*candidate_idx];
+                        corrected_lookup[entry_idx]
+                            .get(&(*batch_idx, *row_idx))
+                            .copied()
+                    })
+                    .collect();
+                columns[entry.col_idx] = Arc::new(UInt64Array::from(corrected)) as ArrayRef;
+            }
+            result = RecordBatch::try_new(self.schema.clone(), columns)
+                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        }
 
         Ok(Some(result))
     }
@@ -1382,8 +1971,11 @@ impl SegmentedTopKState {
 #[cfg(any(test, feature = "pg_test"))]
 #[pgrx::pg_schema]
 mod tests {
-    use super::{Array, *};
+    use super::*;
 
+    // Disambiguate the `Array` trait (glob-imported via `super::*` from multiple arrow
+    // re-exports) so `array.is_valid`/`len`/`value` resolve unambiguously.
+    use arrow_array::Array;
     use std::collections::BTreeSet;
 
     use crate::index::fast_fields_helper::WhichFastField;
@@ -1570,6 +2162,7 @@ mod tests {
                 deferred_columns,
                 ffhelper.clone(),
                 10,
+                None,
             );
 
             let task_ctx = Arc::new(TaskContext::default());

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -54,8 +54,9 @@ use datafusion::physical_plan::sorts::sort_preserving_merge::SortPreservingMerge
 use datafusion::physical_plan::ExecutionPlan;
 
 use crate::gucs;
+use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
 use crate::scan::filter_passthrough_exec::FilterPassthroughExec;
-use crate::scan::segmented_topk_exec::SegmentedTopKExec;
+use crate::scan::segmented_topk_exec::{AbsorbedVisibilityData, SegmentedTopKExec};
 use crate::scan::tantivy_lookup_exec::TantivyLookupExec;
 
 #[derive(Debug)]
@@ -224,10 +225,29 @@ fn try_inject_below_lookup(
             });
 
             if has_deferred_sort_col {
+                // If the direct child of TantivyLookupExec is a VisibilityFilterExec,
+                // absorb it: SegmentedTopKExec will own MVCC visibility checking and the
+                // VFExec node is removed from the plan, so dead rows never inflate the
+                // pushed-down threshold. VFExec preserves schema, so `input_schema` above
+                // is unchanged. Only inner-join plans land here; semi/anti VFExec is inside
+                // the join and is not a direct child of TantivyLookupExec.
+                let (absorbed_visibility, stk_input) =
+                    if let Some(vis_exec) = lookup_child.downcast_ref::<VisibilityFilterExec>() {
+                        (
+                            Some(Arc::new(AbsorbedVisibilityData::new(
+                                vis_exec.plan_pos_oids().to_vec(),
+                                vis_exec.table_names().to_vec(),
+                            ))),
+                            Arc::clone(vis_exec.children()[0]),
+                        )
+                    } else {
+                        (None, Arc::clone(lookup_child))
+                    };
+
                 // Wrap blocking nodes (e.g. SortPreservingMergeExec) so that
                 // the second FilterPushdown(Post) pass can push
                 // SegmentedTopKExec's DynamicFilterPhysicalExpr down to PgSearchScan.
-                let lookup_child = &wrap_blocking_nodes(Arc::clone(lookup_child))?;
+                let lookup_child = &wrap_blocking_nodes(stk_input)?;
 
                 // Collect all deferred columns found in the sort expressions,
                 // resolving logical → physical indices for each.
@@ -315,6 +335,7 @@ fn try_inject_below_lookup(
                     deferred_columns.clone(),
                     Arc::clone(&ffhelper),
                     k,
+                    absorbed_visibility,
                 ));
 
                 // Rebuild TantivyLookupExec with the new child.

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -229,8 +229,10 @@ fn try_inject_below_lookup(
                 // absorb it: SegmentedTopKExec will own MVCC visibility checking and the
                 // VFExec node is removed from the plan, so dead rows never inflate the
                 // pushed-down threshold. VFExec preserves schema, so `input_schema` above
-                // is unchanged. Only inner-join plans land here; semi/anti VFExec is inside
-                // the join and is not a direct child of TantivyLookupExec.
+                // is unchanged. Per `VisibilityFilterOptimizerRule`, a VFExec appears
+                // here for inner joins and for the preserved sides of any join type
+                // (e.g. Left, LeftSemi, LeftAnti); the null-supplying sides are forced
+                // to be checked inside the join, so they won't be absorbed here.
                 let (absorbed_visibility, stk_input) =
                     if let Some(vis_exec) = lookup_child.downcast_ref::<VisibilityFilterExec>() {
                         (

--- a/pg_search/src/scan/visibility_ctid_resolver_rule.rs
+++ b/pg_search/src/scan/visibility_ctid_resolver_rule.rs
@@ -16,14 +16,19 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 //! Physical optimizer rule that wires FFHelper instances from PgSearchScanPlan
-//! into VisibilityFilterExec for ctid resolution.
+//! into the node that owns MVCC visibility checking, for ctid resolution.
 //!
-//! VisibilityFilterExec needs real ctids to check visibility, but when deferred
-//! visibility is enabled, ctid columns hold packed DocAddresses. This rule
-//! finds the PgSearchScanPlan that owns each ctid column and wires its FFHelper
-//! into the VisibilityFilterExec so it can resolve the packed addresses itself.
+//! Visibility checking needs real ctids, but when deferred visibility is enabled
+//! the ctid columns hold packed DocAddresses. This rule finds the PgSearchScanPlan
+//! that owns each ctid column and wires its FFHelper into the owning node so it can
+//! resolve the packed addresses itself.
 //!
-//! This is interior mutation only (Mutex-based wiring) — no structural plan changes.
+//! The owning node is either a `VisibilityFilterExec`, or a `SegmentedTopKExec` that
+//! has absorbed a `VisibilityFilterExec` (see `SegmentedTopKRule`) and now performs
+//! the visibility checks inline. Both expose the same `plan_pos_oids` and
+//! `set_ctid_resolver` interface, so this rule handles them identically.
+//!
+//! This is interior mutation only (Mutex-based wiring), with no structural plan changes.
 
 use std::sync::Arc;
 

--- a/pg_search/src/scan/visibility_ctid_resolver_rule.rs
+++ b/pg_search/src/scan/visibility_ctid_resolver_rule.rs
@@ -86,14 +86,14 @@ fn walk_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
     // owns ctid resolution for the same plan positions.
     if let Some(stk) = plan.downcast_ref::<SegmentedTopKExec>() {
         for &(plan_pos, _) in stk.plan_pos_oids() {
-            let (_, ffhelper) =
-                find_ffhelper_for_plan_position(plan.as_ref(), plan_pos).ok_or_else(|| {
-                    DataFusionError::Internal(format!(
-                        "VisibilityCtidResolverRule: no PgSearchScanPlan found \
+            let (indexrelid, ffhelper) = find_ffhelper_for_plan_position(plan.as_ref(), plan_pos)
+                .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "VisibilityCtidResolverRule: no PgSearchScanPlan found \
                          for SegmentedTopKExec deferred ctid plan_position {plan_pos}"
-                    ))
-                })?;
-            stk.set_ctid_resolver(plan_pos, ffhelper);
+                ))
+            })?;
+            stk.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
         }
     }
 
@@ -253,6 +253,6 @@ mod tests {
         assert_eq!(pos_oids[0].0, plan_pos, "plan_position should match");
 
         // Wire a resolver and verify no panic.
-        stk.set_ctid_resolver(plan_pos, ffhelper_scan);
+        stk.set_ctid_resolver(plan_pos, 0, ffhelper_scan);
     }
 }

--- a/pg_search/src/scan/visibility_ctid_resolver_rule.rs
+++ b/pg_search/src/scan/visibility_ctid_resolver_rule.rs
@@ -35,6 +35,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use crate::index::fast_fields_helper::FFHelper;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterExec;
 use crate::scan::execution_plan::PgSearchScanPlan;
+use crate::scan::segmented_topk_exec::SegmentedTopKExec;
 
 #[derive(Debug)]
 pub struct VisibilityCtidResolverRule;
@@ -59,8 +60,9 @@ impl PhysicalOptimizerRule for VisibilityCtidResolverRule {
     }
 }
 
-/// Walk the plan tree. When we find a VisibilityFilterExec, wire FFHelpers
-/// from matching PgSearchScanPlans in its subtree.
+/// Walk the plan tree. When we find a VisibilityFilterExec or a
+/// SegmentedTopKExec that has absorbed one, wire FFHelpers from matching
+/// PgSearchScanPlans in the subtree.
 fn walk_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
     if let Some(vis_exec) = plan.downcast_ref::<VisibilityFilterExec>() {
         for &(plan_pos, _) in vis_exec.plan_pos_oids() {
@@ -72,6 +74,21 @@ fn walk_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
                 ))
             })?;
             vis_exec.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
+        }
+    }
+
+    // SegmentedTopKExec may have absorbed a VisibilityFilterExec and now
+    // owns ctid resolution for the same plan positions.
+    if let Some(stk) = plan.downcast_ref::<SegmentedTopKExec>() {
+        for &(plan_pos, _) in stk.plan_pos_oids() {
+            let (_, ffhelper) =
+                find_ffhelper_for_plan_position(plan.as_ref(), plan_pos).ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "VisibilityCtidResolverRule: no PgSearchScanPlan found \
+                         for SegmentedTopKExec deferred ctid plan_position {plan_pos}"
+                    ))
+                })?;
+            stk.set_ctid_resolver(plan_pos, ffhelper);
         }
     }
 
@@ -137,5 +154,100 @@ mod tests {
             .expect("matching plan_position should find ffhelper");
         assert!(Arc::ptr_eq(&found, &ffhelper));
         assert!(find_ffhelper_for_plan_position(&scan, 6).is_none());
+    }
+
+    fn sort_schema() -> SchemaRef {
+        use arrow_schema::{DataType, Field};
+        Arc::new(Schema::new(vec![Field::new(
+            "sort_col",
+            DataType::Int64,
+            true,
+        )]))
+    }
+
+    fn dummy_lex_ordering(schema: &SchemaRef) -> datafusion::physical_expr::LexOrdering {
+        use arrow_schema::SortOptions;
+        use datafusion::physical_expr::expressions::Column;
+        use datafusion::physical_expr::{LexOrdering, PhysicalSortExpr};
+
+        let sort_expr = PhysicalSortExpr {
+            expr: Arc::new(Column::new("sort_col", 0)),
+            options: SortOptions::default(),
+        };
+        // We need the schema to create EquivalenceProperties, not used here
+        let _ = schema;
+        LexOrdering::new(vec![sort_expr]).expect("single-element LexOrdering must succeed")
+    }
+
+    #[pg_test]
+    fn stk_plan_pos_oids_returns_empty_without_visibility_data() {
+        use crate::scan::segmented_topk_exec::SegmentedTopKExec;
+
+        let schema = sort_schema();
+        let ffhelper = Arc::new(FFHelper::empty());
+        let scan = PgSearchScanPlan::new(
+            vec![],
+            schema.clone(),
+            SearchQueryInput::All,
+            None,
+            Vec::new(),
+            Some(ffhelper.clone()),
+            0,
+            None,
+        );
+        let stk = SegmentedTopKExec::new(
+            Arc::new(scan),
+            dummy_lex_ordering(&schema),
+            vec![],
+            ffhelper,
+            5,
+            None,
+        );
+
+        // No visibility data absorbed → plan_pos_oids must be empty.
+        assert!(
+            stk.plan_pos_oids().is_empty(),
+            "plan_pos_oids should be empty when no VisibilityFilterExec was absorbed"
+        );
+    }
+
+    #[pg_test]
+    fn stk_plan_pos_oids_returns_absorbed_data() {
+        use crate::scan::segmented_topk_exec::{AbsorbedVisibilityData, SegmentedTopKExec};
+        use pgrx::pg_sys;
+
+        let plan_pos = 3_usize;
+        let schema = sort_schema();
+        let ffhelper_scan = Arc::new(FFHelper::empty());
+        let scan = PgSearchScanPlan::new(
+            vec![],
+            schema.clone(),
+            SearchQueryInput::All,
+            None,
+            Vec::new(),
+            Some(ffhelper_scan.clone()),
+            0,
+            Some(plan_pos),
+        );
+
+        let vis_data = Arc::new(AbsorbedVisibilityData::new(
+            vec![(plan_pos, pg_sys::Oid::INVALID)],
+            vec!["test_table".to_string()],
+        ));
+        let stk = SegmentedTopKExec::new(
+            Arc::new(scan),
+            dummy_lex_ordering(&schema),
+            vec![],
+            Arc::new(FFHelper::empty()),
+            5,
+            Some(vis_data),
+        );
+
+        let pos_oids = stk.plan_pos_oids();
+        assert_eq!(pos_oids.len(), 1, "one plan_pos_oid should be present");
+        assert_eq!(pos_oids[0].0, plan_pos, "plan_position should match");
+
+        // Wire a resolver and verify no panic.
+        stk.set_ctid_resolver(plan_pos, ffhelper_scan);
     }
 }

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -159,7 +159,7 @@ ORDER BY s.name
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name@1 as col_1, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20
+           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3]
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
@@ -474,7 +474,7 @@ ORDER BY p.name
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
@@ -508,7 +508,7 @@ ORDER BY p.name
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -148,8 +148,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY s.name
     LIMIT 20;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit  (cost=10.00..11.00 rows=20 width=32)
    ->  Custom Scan (ParadeDB Join Scan)  (cost=10.00..11.00 rows=20 width=32)
          Relation Tree: s INNER p
@@ -160,13 +160,12 @@ ORDER BY s.name
            : ProjectionExec: expr=[name@1 as col_1, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[name]
            :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=20
-           :       VisibilityFilterExec: tables=[s, p]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(16 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(15 rows)
 
 SELECT s.name AS supplier_name
 FROM dist_products p
@@ -462,8 +461,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -476,13 +475,12 @@ ORDER BY p.name
            : ProjectionExec: expr=[name@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name]
            :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
-           :       VisibilityFilterExec: tables=[s, p]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all"
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 -- =============================================================================
 -- TEST 9b: WHERE clause anchoring for LateMaterializeNode
@@ -497,8 +495,8 @@ FROM dist_products p
 WHERE p.description @@@ 'wireless' AND s.name = 'TechCorp'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -511,13 +509,12 @@ ORDER BY p.name
            : ProjectionExec: expr=[name@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name]
            :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=10
-           :       VisibilityFilterExec: tables=[s, p]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, name@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 -- =============================================================================
 -- TEST 10: Fallback — DISTINCT with non-fast-field column

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -65,8 +65,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -82,13 +82,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT upper(s.name) AS upper_supplier, p.name
 FROM dex_products p
@@ -140,8 +139,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -157,13 +156,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[name@1 IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT s.name IS NULL AS supplier_null, p.name
 FROM dex_products p
@@ -291,8 +289,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -308,13 +306,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT COALESCE(s.name, 'N/A') AS safe_supplier, p.name
 FROM dex_products p
@@ -383,13 +380,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_9f86f13f(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, supplier_id@4, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, supplier_id@4, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT s.name || '-' || p.supplier_id::text AS name_id, p.name
 FROM dex_products p
@@ -441,8 +437,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -458,13 +454,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT length(s.name) AS name_len, p.name
 FROM dex_products p
@@ -517,8 +512,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 1;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -534,13 +529,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=1
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT upper(s.name) IS NULL, p.name
 FROM dex_products p
@@ -566,8 +560,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -583,13 +577,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[name@1 IS NOT NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT (s.name IS NOT NULL) AS has_name, p.name
 FROM dex_products p
@@ -639,8 +632,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -656,13 +649,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT length(s.name) AS name_len, p.name
 FROM dex_products p
@@ -856,8 +848,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -873,13 +865,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT upper(s.name) AS upper_name, p.name
 FROM dex_products p
@@ -929,8 +920,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -946,13 +937,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6978d23a(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT s.name::varchar(5) AS short_name, p.name
 FROM dex_products p
@@ -1006,8 +996,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -1023,13 +1013,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT CASE WHEN s.name IS NOT NULL THEN s.name ELSE 'N/A' END AS supplier_or_default, p.name
 FROM dex_products p
@@ -1143,8 +1132,8 @@ FROM dex_products p
 WHERE p.description @@@ 'wireless' AND s.info @@@ 'electronics'
 ORDER BY p.name
     LIMIT 10;
-                                                                                                             QUERY PLAN                                                                                                              
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                            QUERY PLAN                                                                                                             
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Sort
@@ -1160,13 +1149,12 @@ ORDER BY p.name
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_d16211df(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
                              :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
-                             :       VisibilityFilterExec: tables=[s, p]
-                             :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
-                             :           CooperativeExec
-                             :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(21 rows)
+                             :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
+                             :         CooperativeExec
+                             :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
 
 SELECT DISTINCT upper(md5(s.name)) AS mixed_key, p.name
 FROM dex_products p

--- a/pg_search/tests/pg_regress/expected/join_distinct_expr.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct_expr.out
@@ -81,7 +81,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -155,7 +155,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[name@1 IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -305,7 +305,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -379,7 +379,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_opexpr_9f86f13f(CAST(name@1 AS Utf8), supplier_id@3) as col_1, name@4 as col_2, name@1 as col_3], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, supplier_id@4, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -453,7 +453,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -528,7 +528,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) IS NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=1
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=1, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -576,7 +576,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[name@1 IS NOT NULL as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -648,7 +648,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[character_length(name@1) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -864,7 +864,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_44945b63(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -936,7 +936,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_6978d23a(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -1012,7 +1012,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[CASE WHEN name@1 IS NOT NULL THEN name@1 ELSE N/A END as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}
@@ -1148,7 +1148,7 @@ ORDER BY p.name
                            DataFusion Physical Plan: 
                              : AggregateExec: mode=Single, gby=[pdb_eval_expr_funcexpr_d16211df(CAST(name@1 AS Utf8)) as col_1, name@3 as col_2], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
                              :   TantivyLookupExec: decode=[name]
-                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10
+                             :     SegmentedTopKExec: expr=[col_2@1 ASC NULLS LAST], k=10, visibility_checks=[s, p]
                              :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, name@2, ctid_1@3, name@5]
                              :         CooperativeExec
                              :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"info","query_string":"electronics","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -316,8 +316,8 @@ JOIN dyn_filter_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.val ASC
 LIMIT 10;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                             QUERY PLAN                                                                                             
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t1.val, t2.val
    ->  Custom Scan (ParadeDB Join Scan)
@@ -330,13 +330,12 @@ LIMIT 10;
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[val]
            :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10
-           :       VisibilityFilterExec: tables=[t2, t1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all"
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 -- Cap the scanner batch size so Top K can tighten its threshold between batches.
 SET paradedb.dynamic_filter_batch_size = 8192;
@@ -348,8 +347,8 @@ JOIN dyn_filter_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.val ASC
 LIMIT 10;
-                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: t2 INNER t1
@@ -359,14 +358,13 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, metrics=[rows_input=8.25 K, rows_output=10, segments_seen=2]
-           :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.25 K, output_bytes=234.5 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=361.6 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, build_mem_used=400.0 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
-(16 rows)
+           :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, metrics=[rows_filtered_invisible=0, rows_input=8.25 K, rows_output=10, segments_seen=2]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=361.6 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, build_mem_used=400.0 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
+(15 rows)
 
 -- Verify results
 SELECT t1.val, t2.val
@@ -433,8 +431,8 @@ JOIN null_val_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val' OR t1.val IS NULL
 ORDER BY t1.val DESC NULLS FIRST, t1.id
 LIMIT 25;
-                                                                                                                                             QUERY PLAN                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                            QUERY PLAN                                                                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t1.id, t1.val
    ->  Custom Scan (ParadeDB Join Scan)
@@ -447,13 +445,12 @@ LIMIT 25;
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[val]
            :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25
-           :       VisibilityFilterExec: tables=[t2, t1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all"
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+(17 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
 SELECT t1.id, t1.val
@@ -462,8 +459,8 @@ JOIN null_val_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val' OR t1.val IS NULL
 ORDER BY t1.val DESC NULLS FIRST, t1.id
 LIMIT 25;
-                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                                     
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=25.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=25.00 loops=1)
          Relation Tree: t2 INNER t1
@@ -473,14 +470,13 @@ LIMIT 25;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, metrics=[rows_input=8.48 K, rows_output=25, segments_seen=1]
-           :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.48 K, output_bytes=371.9 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.48 K, output_bytes=495.3 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.48 K, build_mem_used=400.0 K, avg_fanout=100% (8.48 K/8.48 K), probe_hit_rate=100% (8.48 K/8.48 K)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.48 K, output_bytes=241.4 KB, output_batches=4, rows_pruned=11.52 K, rows_scanned=20.00 K]
-(16 rows)
+           :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, metrics=[rows_filtered_invisible=0, rows_input=8.43 K, rows_output=25, segments_seen=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.43 K, output_bytes=493.9 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.43 K, build_mem_used=400.0 K, avg_fanout=100% (8.43 K/8.43 K), probe_hit_rate=100% (8.43 K/8.43 K)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, rows_pruned=11.57 K, rows_scanned=20.00 K]
+(15 rows)
 
 SELECT t1.id, t1.val
 FROM null_val_t1 t1
@@ -530,8 +526,8 @@ JOIN null_val_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val' OR t1.val IS NULL
 ORDER BY t1.val ASC NULLS LAST
 LIMIT 10;
-                                                                                                                                             QUERY PLAN                                                                                                                                             
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                            QUERY PLAN                                                                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: t1.id, t1.val
    ->  Custom Scan (ParadeDB Join Scan)
@@ -544,13 +540,12 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[val]
            :     SegmentedTopKExec: expr=[val@3 ASC NULLS LAST], k=10
-           :       VisibilityFilterExec: tables=[t2, t1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all"
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+(17 rows)
 
 SELECT t1.id, t1.val
 FROM null_val_t1 t1

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -329,7 +329,7 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[val]
-           :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, visibility_checks=[t2, t1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
@@ -358,7 +358,7 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, metrics=[rows_filtered_invisible=0, rows_input=8.25 K, rows_output=10, segments_seen=2]
+           :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, visibility_checks=[t2, t1], metrics=[rows_filtered_invisible=0, rows_input=8.25 K, rows_output=10, segments_seen=2]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=361.6 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, build_mem_used=400.0 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
@@ -444,7 +444,7 @@ LIMIT 25;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[val]
-           :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25
+           :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, visibility_checks=[t2, t1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
@@ -470,7 +470,7 @@ LIMIT 25;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, metrics=[rows_filtered_invisible=0, rows_input=8.43 K, rows_output=25, segments_seen=1]
+           :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, visibility_checks=[t2, t1], metrics=[rows_filtered_invisible=0, rows_input=8.43 K, rows_output=25, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.43 K, output_bytes=493.9 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.43 K, build_mem_used=400.0 K, avg_fanout=100% (8.43 K/8.43 K), probe_hit_rate=100% (8.43 K/8.43 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
@@ -539,7 +539,7 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[val]
-           :     SegmentedTopKExec: expr=[val@3 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[val@3 ASC NULLS LAST], k=10, visibility_checks=[t2, t1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"

--- a/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
@@ -49,8 +49,8 @@ JOIN tech_installs ti ON cccf.company_id = ti.company_id
 WHERE technology_name @@@ 'java'
 ORDER BY lower(company_name) ASC, cccf.contact_id
 LIMIT 10;
-                                                                                                   QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                  QUERY PLAN                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Result
          ->  Custom Scan (ParadeDB Join Scan)
@@ -62,13 +62,12 @@ LIMIT 10;
                  : ProjectionExec: expr=[contact_id@5 as col_1, company_id@2 as col_2, company_name_words@3 as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
                  :   TantivyLookupExec: decode=[company_name_words, company_name]
                  :     SegmentedTopKExec: expr=[company_name@4 ASC NULLS LAST, contact_id@5 ASC NULLS LAST], k=10
-                 :       VisibilityFilterExec: tables=[ti, cccf]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, company_id@1)], projection=[ctid_0@0, ctid_1@2, company_id@3, company_name_words@4, company_name@5, contact_id@6]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"technology_name","query_string":"java","lenient":null,"conjunction_mode":null}}}}
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(17 rows)
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, company_id@1)], projection=[ctid_0@0, ctid_1@2, company_id@3, company_name_words@4, company_name@5, contact_id@6]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"technology_name","query_string":"java","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(16 rows)
 
 SELECT cccf.*
 FROM contacts cccf

--- a/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
@@ -61,7 +61,7 @@ LIMIT 10;
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[contact_id@5 as col_1, company_id@2 as col_2, company_name_words@3 as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
                  :   TantivyLookupExec: decode=[company_name_words, company_name]
-                 :     SegmentedTopKExec: expr=[company_name@4 ASC NULLS LAST, contact_id@5 ASC NULLS LAST], k=10
+                 :     SegmentedTopKExec: expr=[company_name@4 ASC NULLS LAST, contact_id@5 ASC NULLS LAST], k=10, visibility_checks=[ti, cccf]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, company_id@1)], projection=[ctid_0@0, ctid_1@2, company_id@3, company_name_words@4, company_name@5, contact_id@6]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"technology_name","query_string":"java","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/join_order_by_is_null.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_is_null.out
@@ -53,13 +53,12 @@ LIMIT 26;
                  : ProjectionExec: expr=[id@3 as col_1, name@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
                  :   TantivyLookupExec: decode=[name]
                  :     SegmentedTopKExec: expr=[name@4 IS NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26
-                 :       VisibilityFilterExec: tables=[p, c]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, query="all"
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
-(20 rows)
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, query="all"
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
+(19 rows)
 
 SELECT c.id
 FROM test_companies AS c
@@ -120,13 +119,12 @@ LIMIT 26;
                  : ProjectionExec: expr=[id@3 as col_1, name@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
                  :   TantivyLookupExec: decode=[name]
                  :     SegmentedTopKExec: expr=[name@4 IS NOT NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26
-                 :       VisibilityFilterExec: tables=[p, c]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, query="all"
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
-(20 rows)
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, query="all"
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
+(19 rows)
 
 SELECT c.id
 FROM test_companies AS c

--- a/pg_search/tests/pg_regress/expected/join_order_by_is_null.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_is_null.out
@@ -37,8 +37,8 @@ JOIN test_people AS p ON p.company_id = c.id
 WHERE c.id @@@ paradedb.all()
 ORDER BY c.name IS NULL ASC, c.name ASC, c.id ASC
 LIMIT 26;
-                                                               QUERY PLAN                                                                
------------------------------------------------------------------------------------------------------------------------------------------
+                                                                            QUERY PLAN                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: c.id, ((c.name IS NULL)), c.name
    ->  Result
@@ -52,7 +52,7 @@ LIMIT 26;
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@3 as col_1, name@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
                  :   TantivyLookupExec: decode=[name]
-                 :     SegmentedTopKExec: expr=[name@4 IS NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26
+                 :     SegmentedTopKExec: expr=[name@4 IS NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26, visibility_checks=[p, c]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all"
@@ -103,8 +103,8 @@ JOIN test_people AS p ON p.company_id = c.id
 WHERE c.id @@@ paradedb.all()
 ORDER BY c.name IS NOT NULL ASC, c.name ASC, c.id ASC
 LIMIT 26;
-                                                                 QUERY PLAN                                                                  
----------------------------------------------------------------------------------------------------------------------------------------------
+                                                                              QUERY PLAN                                                                               
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: c.id, ((c.name IS NOT NULL)), c.name
    ->  Result
@@ -118,7 +118,7 @@ LIMIT 26;
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[id@3 as col_1, name@4 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
                  :   TantivyLookupExec: decode=[name]
-                 :     SegmentedTopKExec: expr=[name@4 IS NOT NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26
+                 :     SegmentedTopKExec: expr=[name@4 IS NOT NULL ASC NULLS LAST, name@4 ASC NULLS LAST, company_id@1 ASC NULLS LAST], k=26, visibility_checks=[p, c]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(company_id@1, id@1)]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all"

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -308,8 +308,8 @@ WHERE id IN (
 AND id @@@ 'category:"target_category"'
 ORDER BY category ASC, id ASC
 LIMIT 10;
-                                                                                                          QUERY PLAN                                                                                                          
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                         QUERY PLAN                                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: table_a.id, table_a.category
    ->  Custom Scan (ParadeDB Join Scan)
@@ -322,13 +322,12 @@ LIMIT 10;
            : ProjectionExec: expr=[id@1 as col_1, category@2 as col_2, ctid_0@0 as ctid_0]
            :   TantivyLookupExec: decode=[category]
            :     SegmentedTopKExec: expr=[category@2 ASC NULLS LAST, id@1 ASC NULLS LAST], k=10
-           :       VisibilityFilterExec: tables=[table_a]
-           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(a_id@0, id@1)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1"}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(a_id@0, id@1)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1"}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
 
 SELECT *
 FROM table_a

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -321,7 +321,7 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@1 as col_1, category@2 as col_2, ctid_0@0 as ctid_0]
            :   TantivyLookupExec: decode=[category]
-           :     SegmentedTopKExec: expr=[category@2 ASC NULLS LAST, id@1 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[category@2 ASC NULLS LAST, id@1 ASC NULLS LAST], k=10, visibility_checks=[table_a]
            :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(a_id@0, id@1)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1"}}

--- a/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
@@ -73,34 +73,6 @@ WHERE p.owner_user_id IN (
 )
 ORDER BY p.title ASC
 LIMIT 25;
- id |       title       
-----+-------------------
-  1 | title 000001 code
-  2 | title 000002 code
-  3 | title 000003 code
-  4 | title 000004 code
-  5 | title 000005 code
-  6 | title 000006 code
-  7 | title 000007 code
-  8 | title 000008 code
-  9 | title 000009 code
- 10 | title 000010 code
- 11 | title 000011 code
- 12 | title 000012 code
- 13 | title 000013 code
- 14 | title 000014 code
- 15 | title 000015 code
- 16 | title 000016 code
- 17 | title 000017 code
- 18 | title 000018 code
- 19 | title 000019 code
- 20 | title 000020 code
- 21 | title 000021 code
- 22 | title 000022 code
- 23 | title 000023 code
- 24 | title 000024 code
- 25 | title 000025 code
-(25 rows)
-
+ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 0. VisibilityCtidResolverRule must run before execute.
 DROP TABLE mpp_topk_posts CASCADE;
 DROP TABLE mpp_topk_users CASCADE;

--- a/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
@@ -73,6 +73,34 @@ WHERE p.owner_user_id IN (
 )
 ORDER BY p.title ASC
 LIMIT 25;
-ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 0. VisibilityCtidResolverRule must run before execute.
+ id |       title       
+----+-------------------
+  1 | title 000001 code
+  2 | title 000002 code
+  3 | title 000003 code
+  4 | title 000004 code
+  5 | title 000005 code
+  6 | title 000006 code
+  7 | title 000007 code
+  8 | title 000008 code
+  9 | title 000009 code
+ 10 | title 000010 code
+ 11 | title 000011 code
+ 12 | title 000012 code
+ 13 | title 000013 code
+ 14 | title 000014 code
+ 15 | title 000015 code
+ 16 | title 000016 code
+ 17 | title 000017 code
+ 18 | title 000018 code
+ 19 | title 000019 code
+ 20 | title 000020 code
+ 21 | title 000021 code
+ 22 | title 000022 code
+ 23 | title 000023 code
+ 24 | title 000024 code
+ 25 | title 000025 code
+(25 rows)
+
 DROP TABLE mpp_topk_posts CASCADE;
 DROP TABLE mpp_topk_users CASCADE;

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -81,7 +81,7 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
@@ -140,7 +140,7 @@ LIMIT 10;
            :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
-           :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+           :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         CoalescePartitionsExec
            :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
@@ -217,7 +217,7 @@ LIMIT 10;
            :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
-           :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+           :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         CoalescePartitionsExec
            :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
@@ -263,7 +263,7 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
+           :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -158,7 +158,20 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 1. VisibilityCtidResolverRule must run before execute.
+  title  | size_bytes 
+---------+------------
+ file-1  |        616
+ file-1  |       1312
+ file-1  |       2008
+ file-1  |       2704
+ file-1  |       3400
+ file-10 |        153
+ file-10 |       1465
+ file-10 |       2161
+ file-10 |       2857
+ file-10 |       3553
+(10 rows)
+
 -- =====================================================================
 -- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
 -- Asserts presence, not content: how many workers launch and how they
@@ -181,7 +194,11 @@ FROM mpp_explain_analyze_lines(
    LIMIT 10'
 ) AS line
 WHERE line LIKE '%output_rows%';
-ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 1. VisibilityCtidResolverRule must run before execute.
+ worker_metrics_shown 
+----------------------
+ t
+(1 row)
+
 DROP FUNCTION mpp_explain_analyze_lines(text);
 -- =====================================================================
 -- Pass 4: MPP with heap filter
@@ -236,7 +253,20 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 1. VisibilityCtidResolverRule must run before execute.
+  title   | size_bytes 
+----------+------------
+ file-10  |        153
+ file-10  |       1465
+ file-10  |       2161
+ file-10  |       2857
+ file-10  |       3553
+ file-100 |        291
+ file-100 |        987
+ file-100 |       1683
+ file-100 |       2995
+ file-100 |       3691
+(10 rows)
+
 -- =====================================================================
 -- Pass 5: Serial fallback check
 --

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -68,8 +68,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -82,13 +82,12 @@ LIMIT 10;
            : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[title]
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
-           :       VisibilityFilterExec: tables=[p, f]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(17 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -142,38 +141,24 @@ LIMIT 10;
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
-           :   │       VisibilityFilterExec: tables=[p, f]
-           :   │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
-           :   │           CoalescePartitionsExec
-           :   │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
+           :   │         CoalescePartitionsExec
+           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
-(29 rows)
+(28 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-  title  | size_bytes 
----------+------------
- file-1  |        616
- file-1  |       1312
- file-1  |       2008
- file-1  |       2704
- file-1  |       3400
- file-10 |        153
- file-10 |       1465
- file-10 |       2161
- file-10 |       2857
- file-10 |       3553
-(10 rows)
-
+ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 1. VisibilityCtidResolverRule must run before execute.
 -- =====================================================================
 -- Pass 3: worker metrics reach the leader's EXPLAIN ANALYZE display.
 -- Asserts presence, not content: how many workers launch and how they
@@ -196,11 +181,7 @@ FROM mpp_explain_analyze_lines(
    LIMIT 10'
 ) AS line
 WHERE line LIKE '%output_rows%';
- worker_metrics_shown 
-----------------------
- t
-(1 row)
-
+ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 1. VisibilityCtidResolverRule must run before execute.
 DROP FUNCTION mpp_explain_analyze_lines(text);
 -- =====================================================================
 -- Pass 4: MPP with heap filter
@@ -237,18 +218,17 @@ LIMIT 10;
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
-           :   │       VisibilityFilterExec: tables=[p, f]
-           :   │         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
-           :   │           CoalescePartitionsExec
-           :   │             [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
+           :   │         CoalescePartitionsExec
+           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :     └──────────────────────────────────────────────────
-(29 rows)
+(28 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -256,20 +236,7 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-  title   | size_bytes 
-----------+------------
- file-10  |        153
- file-10  |       1465
- file-10  |       2161
- file-10  |       2857
- file-10  |       3553
- file-100 |        291
- file-100 |        987
- file-100 |       1683
- file-100 |       2995
- file-100 |       3691
-(10 rows)
-
+ERROR:  mpp worker: fragment dispatch failed: Execution error: SegmentedTopKExec: no ctid resolver wired for plan_position 1. VisibilityCtidResolverRule must run before execute.
 -- =====================================================================
 -- Pass 5: Serial fallback check
 --
@@ -283,8 +250,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                    QUERY PLAN                                                                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                   QUERY PLAN                                                                                                                                                   
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -297,13 +264,12 @@ LIMIT 10;
            : ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[title]
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
-           :       VisibilityFilterExec: tables=[p, f]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(17 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/order_by_collation.out
+++ b/pg_search/tests/pg_regress/expected/order_by_collation.out
@@ -452,7 +452,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[name_c@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name_c]
-           :     SegmentedTopKExec: expr=[name_c@2 ASC NULLS LAST], k=5
+           :     SegmentedTopKExec: expr=[name_c@2 ASC NULLS LAST], k=5, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name_c@2]
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/order_by_collation.out
+++ b/pg_search/tests/pg_regress/expected/order_by_collation.out
@@ -441,8 +441,8 @@ JOIN collation_join_suppliers s ON p.id = s.product_id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.name_c
 LIMIT 5;
-                                                                                                    QUERY PLAN                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: s INNER p
@@ -453,13 +453,12 @@ LIMIT 5;
            : ProjectionExec: expr=[name_c@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[name_c]
            :     SegmentedTopKExec: expr=[name_c@2 ASC NULLS LAST], k=5
-           :       VisibilityFilterExec: tables=[s, p]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name_c@2]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(16 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name_c@2]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(15 rows)
 
 \echo 'Test 5.2: JoinScan ORDER BY ICU-collation column -> JoinScan declined (Sort node expected)'
 Test 5.2: JoinScan ORDER BY ICU-collation column -> JoinScan declined (Sort node expected)

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -68,7 +68,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
@@ -114,7 +114,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@2 DESC], k=3
+           :     SegmentedTopKExec: expr=[title@2 DESC], k=3, visibility_checks=[d, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
@@ -158,7 +158,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_filtered_invisible=0, rows_input=50, rows_output=3, segments_seen=1]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=50, rows_output=3, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, build_mem_used=344, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
@@ -422,7 +422,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@3 as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, id@3 DESC], k=5
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, id@3 DESC], k=5, visibility_checks=[d, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, id@5]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
@@ -488,7 +488,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, content@3 as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title, content]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, content@3 DESC], k=5
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, content@3 DESC], k=5, visibility_checks=[d, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, content@5]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
@@ -662,7 +662,7 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, metrics=[rows_filtered_invisible=0, rows_input=25.81 K, rows_output=5, segments_seen=3]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=25.81 K, rows_output=5, segments_seen=3]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=25.81 K, output_bytes=1008.9 KB, output_batches=4, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=25.81 K, build_mem_used=228, avg_fanout=100% (25.81 K/25.81 K), probe_hit_rate=53.08% (25.81 K/48.63 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -55,8 +55,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 3;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.id, f.title
    ->  Custom Scan (ParadeDB Join Scan)
@@ -69,13 +69,12 @@ LIMIT 3;
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3
-           :       VisibilityFilterExec: tables=[d, f]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(17 rows)
 
 SELECT f.id, f.title
 FROM stk_files f
@@ -102,8 +101,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title DESC
 LIMIT 3;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.id, f.title
    ->  Custom Scan (ParadeDB Join Scan)
@@ -116,13 +115,12 @@ LIMIT 3;
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
            :     SegmentedTopKExec: expr=[title@2 DESC], k=3
-           :       VisibilityFilterExec: tables=[d, f]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(17 rows)
 
 SELECT f.id, f.title
 FROM stk_files f
@@ -149,8 +147,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 3;
-                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=3.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=3.00 loops=1)
          Relation Tree: d INNER f
@@ -160,14 +158,13 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=50, rows_output=3, segments_seen=1]
-           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=50, output_bytes=1450.0 B, output_batches=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, build_mem_used=344, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
-(16 rows)
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_filtered_invisible=0, rows_input=50, rows_output=3, segments_seen=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, build_mem_used=344, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
+(15 rows)
 
 -- =============================================================================
 -- TEST 4: K > total rows — no pruning, all rows survive
@@ -412,8 +409,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC, f.id DESC
 LIMIT 5;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.id, f.title
    ->  Custom Scan (ParadeDB Join Scan)
@@ -426,13 +423,12 @@ LIMIT 5;
            : ProjectionExec: expr=[id@3 as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, id@3 DESC], k=5
-           :       VisibilityFilterExec: tables=[d, f]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, id@5]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, id@5]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(17 rows)
 
 SELECT f.id, f.title
 FROM stk_files f
@@ -479,8 +475,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC, f.content DESC
 LIMIT 5;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.id, f.title, f.content
    ->  Custom Scan (ParadeDB Join Scan)
@@ -493,13 +489,12 @@ LIMIT 5;
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, content@3 as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
            :   TantivyLookupExec: decode=[title, content]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST, content@3 DESC], k=5
-           :       VisibilityFilterExec: tables=[d, f]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, content@5]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4, content@5]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(17 rows)
 
 SELECT f.id, f.title, f.content
 FROM stk_files f
@@ -656,8 +651,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 5;
-                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                          
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=5.00 loops=1)
          Relation Tree: d INNER f
@@ -667,14 +662,13 @@ LIMIT 5;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, metrics=[rows_input=14.42 K, rows_output=5, segments_seen=2]
-           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=14.42 K, output_bytes=577.5 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=14.42 K, output_bytes=608.2 KB, output_batches=2, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=14.42 K, build_mem_used=228, avg_fanout=100% (14.42 K/14.42 K), probe_hit_rate=55.81% (14.42 K/25.83 K)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=14.42 K, output_bytes=521.0 KB, output_batches=4, rows_pruned=15.58 K, rows_scanned=30.00 K]
-(16 rows)
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, metrics=[rows_filtered_invisible=0, rows_input=25.81 K, rows_output=5, segments_seen=3]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=25.81 K, output_bytes=1008.9 KB, output_batches=4, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=25.81 K, build_mem_used=228, avg_fanout=100% (25.81 K/25.81 K), probe_hit_rate=53.08% (25.81 K/48.63 K)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, rows_pruned=4.19 K, rows_scanned=30.00 K]
+(15 rows)
 
 SELECT f.id, f.title
 FROM stk_files f

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -277,8 +277,8 @@ FROM expr_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY upper(p.name) ASC
     LIMIT 5;
-                                                                                                       QUERY PLAN                                                                                                        
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                      QUERY PLAN                                                                                                       
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name, (upper(p.name))
    ->  Result
@@ -293,13 +293,12 @@ ORDER BY upper(p.name) ASC
                  : ProjectionExec: expr=[NULL as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
                  :   TantivyLookupExec: decode=[name]
                  :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=5
-                 :       VisibilityFilterExec: tables=[s, p]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name@2]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(20 rows)
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name@2]
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(19 rows)
 
 SELECT p.name, s.name AS supplier_name
 FROM expr_products p
@@ -326,8 +325,8 @@ FROM expr_products p
 WHERE p.description @@@ 'wireless'
 ORDER BY s.name ASC
     LIMIT 5;
-                                                                                           QUERY PLAN                                                                                           
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.name, s.name
    ->  Custom Scan (ParadeDB Join Scan)
@@ -340,13 +339,12 @@ ORDER BY s.name ASC
            : ProjectionExec: expr=[NULL as col_1, name@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[name]
            :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=5
-           :       VisibilityFilterExec: tables=[s, p]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@2, name@4, ctid_1@0]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(18 rows)
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@2, name@4, ctid_1@0]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(17 rows)
 
 SELECT p.name, s.name AS supplier_name
 FROM expr_products p

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -292,7 +292,7 @@ ORDER BY upper(p.name) ASC
                DataFusion Physical Plan: 
                  : ProjectionExec: expr=[NULL as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
                  :   TantivyLookupExec: decode=[name]
-                 :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=5
+                 :     SegmentedTopKExec: expr=[name@2 ASC NULLS LAST], k=5, visibility_checks=[s, p]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@3, ctid_1@0, name@2]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
@@ -338,7 +338,7 @@ ORDER BY s.name ASC
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, name@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            :   TantivyLookupExec: decode=[name]
-           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=5
+           :     SegmentedTopKExec: expr=[name@1 ASC NULLS LAST], k=5, visibility_checks=[s, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, product_id@1)], projection=[ctid_0@2, name@4, ctid_1@0]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -471,8 +471,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 3;
-                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=3.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=3.00 loops=1)
          Relation Tree: d INNER f
@@ -482,14 +482,13 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=70, rows_output=3, segments_seen=1]
-           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=70, output_bytes=2030.0 B, output_batches=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, build_mem_used=424, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
-(16 rows)
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_filtered_invisible=0, rows_input=70, rows_output=3, segments_seen=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, build_mem_used=424, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
+(15 rows)
 
 SELECT f.id, f.title
 FROM bench_files f
@@ -518,8 +517,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 3;
-                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=3.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=3.00 loops=1)
          Relation Tree: d INNER f
@@ -529,14 +528,13 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=10, rows_output=3, segments_seen=1]
-           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=10, output_bytes=290.0 B, output_batches=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, build_mem_used=105, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
-(16 rows)
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_filtered_invisible=0, rows_input=10, rows_output=3, segments_seen=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, build_mem_used=105, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
+(15 rows)
 
 SELECT f.id, f.title
 FROM bench_files f

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -482,7 +482,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_filtered_invisible=0, rows_input=70, rows_output=3, segments_seen=1]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=70, rows_output=3, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, build_mem_used=424, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
@@ -528,7 +528,7 @@ LIMIT 3;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
-           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_filtered_invisible=0, rows_input=10, rows_output=3, segments_seen=1]
+           :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, visibility_checks=[d, f], metrics=[rows_filtered_invisible=0, rows_input=10, rows_output=3, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, build_mem_used=105, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -196,7 +196,9 @@ fn joinscan_self_join_matches_fallback(mut conn: PgConnection) -> Result<(), sql
         explain.contains("Custom Scan (ParadeDB Join Scan)"),
         "{explain}"
     );
-    assert!(explain.contains("VisibilityFilterExec"), "{explain}");
+    // The VisibilityFilterExec is absorbed into SegmentedTopKExec, which now owns MVCC
+    // visibility checking, so it no longer appears as a separate node in the plan.
+    assert!(!explain.contains("VisibilityFilterExec"), "{explain}");
     assert!(explain.contains("TantivyLookupExec"), "{explain}");
     assert!(explain.contains("SegmentedTopKExec"), "{explain}");
 
@@ -281,7 +283,9 @@ fn joinscan_self_join_duplicate_name_sort_matches_fallback(
         explain.contains("Custom Scan (ParadeDB Join Scan)"),
         "{explain}"
     );
-    assert!(explain.contains("VisibilityFilterExec"), "{explain}");
+    // The VisibilityFilterExec is absorbed into SegmentedTopKExec, which now owns MVCC
+    // visibility checking, so it no longer appears as a separate node in the plan.
+    assert!(!explain.contains("VisibilityFilterExec"), "{explain}");
     assert!(explain.contains("TantivyLookupExec"), "{explain}");
     assert!(explain.contains("SegmentedTopKExec"), "{explain}");
     // Regression guard: both sort keys must appear at distinct physical indices.


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4525

## What


`SegmentedTopKExec` now absorbs a `VisibilityFilterExec` that is the direct child of `TantivyLookupExec` on inner-join plans, and owns MVCC visibility checking. This ports the visibility filtering from #4739 onto current `main` (on top of the merged #5380 Vec + QuickSelect buffer and the #5435 dispatch FFHelper change), and implements the two review decisions from #4525.

## Why

When `SegmentedTopK` and visibility filtering run together, dead rows can occupy top-K slots and inflate the pushed-down threshold, which silently drops live rows. Absorbing the `VisibilityFilterExec` into `SegmentedTopKExec` lets it remove dead rows before they affect the threshold or the top-K, so the results match Postgres.

## How

### Per-buffer visibility (per @stuhood)
The visibility prune trigger is per buffer: a segment is pruned when its buffer reaches `max(2 * K, MINIMUM_VISIBILITY_CHECK_SIZE)`, and the visibility check runs per segment (each segment as its own batch) rather than aggregating every segment into one buffer. Per-row MVCC results are batch-independent, so the survivors are identical to a single global check.

`MINIMUM_VISIBILITY_CHECK_SIZE` is `8192`, aligned with `DEFERRED_BATCH_SIZE`. This value is not from @stuhood (he confirmed the per-buffer shape but did not give a number). It is a tunable constant, a one-line change, and does not affect correctness, only when the prune fires.

### MPP dispatch (per @mdashti)
Workers do not re-run the optimizer rule, so by dispatch time the `VisibilityFilterExec` is already absorbed and gone. Leaving `visibility_data: None` on decode made a worker skip visibility and return dead rows. `encode_for_dispatch` now ships the visibility recipe (`plan_pos_oids` and `table_names`), and `decode_for_dispatch` rebuilds `AbsorbedVisibilityData` and re-wires the live ctid resolvers from the decoded subtree via `collect_ctid_resolvers`, mirroring `VisibilityFilterExec`. This is reconciled with #5435: `decode_for_dispatch` still selects the FFHelper by `indexrelid` and additionally takes the ctid resolvers. The `VisibilityChecker` is built at `execute()` time from `GetActiveSnapshot()`, so no snapshot travels.

  ### Files
  - Six source files: `segmented_topk_exec.rs`, `segmented_topk_rule.rs`,
    `visibility_ctid_resolver_rule.rs`, `visibility_filter.rs`, `physical_codec.rs`,
    `scan_state.rs`.
  - `tests/tests/joins.rs`: the self-join assertion now expects `VisibilityFilterExec`
    to be absent (absorbed) in the plan.
  - 11 pg_regress expected outputs regenerated for the absorbed-VFExec plan shape
    (plan and metric changes only, no data-row changes).

## Tests

  Verified on pg18 (the local pgrx toolchain; the changes use no version-specific APIs):

  - `cargo fmt` and `cargo clippy` clean.
  - `pg_test_segmented_topk_exec` proptest green.
  - pg_regress 292/292.
  - `joins.rs` and `sorting.rs` integration tests green.
  - A large-dataset run (30k rows, one segment) fires the per-buffer prune
    (`rows_input=8192`, `rows_filtered_invisible=100`) and returns results identical
    to plain Postgres.
  - Rebased onto current `main`; the `mpp_joinscan` pg_regress test exercises the MPP
    dispatch path and passes.