### PR TITLE
fix: Set `rm_decode` to `None`

### DIFF
--- a/pg_search/src/postgres/storage/custom_rmgr.rs
+++ b/pg_search/src/postgres/storage/custom_rmgr.rs
@@ -64,13 +64,6 @@ unsafe extern "C-unwind" fn rm_mask(
 ) {
 }
 
-#[pg_guard]
-unsafe extern "C-unwind" fn rm_decode(
-    _ctx: *mut pg_sys::LogicalDecodingContext,
-    _buf: *mut pg_sys::XLogRecordBuffer,
-) {
-}
-
 pub fn emit_init_record() {
     // XLogRegisterData's signature varies across Postgres versions
     // (data is `*mut c_char` on pg15-17 vs `*const c_void` on pg18, and len is `c_int`
@@ -94,7 +87,9 @@ pub fn register() {
         rm_startup: Some(rm_startup),
         rm_cleanup: Some(rm_cleanup),
         rm_mask: Some(rm_mask),
-        rm_decode: Some(rm_decode),
+        // Postgres decode.c line 77: every record's xid needs to be processed by reorderbuffer
+        // If this is set to none, Postgres will invoke reorderbuffer for us
+        rm_decode: None,
     };
 
     unsafe {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

According to Postgres doc comments I believe we should be setting `rm_decode` to `None` instead of a no-op function. The reason is Postgres says `rm_decode` should invoke `ReorderBufferProcessXid` if implemented, but if set to `None` Postgres will call it for us.

This isn't causing any bugs for us because `ReorderBufferProcessXid` only does actual work if the txid has never been seen before, and the txid where we fire our rmgr's WAL record would have been seen already, but is technically more correct.

## Why

## How

## Tests
