### PR TITLE
fix(pg_search): exclude mutable segments from parallel worker checkout pool

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -446,6 +446,7 @@ impl SearchIndexReader {
             total_segment_count,
             total_docs,
             schema,
+            mutable_segment_ids,
         } = components;
 
         let index_created_by_version = index_relation.created_by_version();
@@ -488,7 +489,7 @@ impl SearchIndexReader {
             total_docs,
             index_created_by_version,
             segment_ordinal_by_id: segment_ord_by_id,
-            mutable_segment_ids: components.mutable_segment_ids,
+            mutable_segment_ids,
             _cleanup_lock: cleanup_lock,
         })
     }

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 
 use crate::aggregate::mvcc_collector::MVCCFilterCollector;
 use crate::api::version::Version;
-use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, SortDirection};
+use crate::api::{FieldName, HashMap, HashSet, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::scorer::{DeferredScorer, ScorerIter};
 use crate::index::setup_tokenizers;
@@ -300,6 +300,12 @@ pub struct SearchIndexReader {
     index_created_by_version: Option<Version>,
     segment_ordinal_by_id: HashMap<SegmentId, SegmentOrdinal>,
 
+    /// Segment IDs that correspond to mutable (in-memory) segments.
+    /// Used by parallel scan coordination to exclude these from the DSM checkout
+    /// pool and have the leader handle them directly, avoiding expensive
+    /// per-worker materialization. See: https://github.com/paradedb/paradedb/issues/4497
+    mutable_segment_ids: HashSet<SegmentId>,
+
     // [`PinnedBuffer`] has a Drop impl, so we hold onto it but don't otherwise use it
     //
     // also, it's an Arc b/c if we're clone'd (we do derive it, after all), we only want this
@@ -328,6 +334,7 @@ impl Clone for SearchIndexReader {
             total_docs: self.total_docs,
             index_created_by_version: self.index_created_by_version,
             segment_ordinal_by_id: self.segment_ordinal_by_id.clone(),
+            mutable_segment_ids: self.mutable_segment_ids.clone(),
             _cleanup_lock: self._cleanup_lock.clone(),
         }
     }
@@ -341,6 +348,7 @@ struct IndexComponents {
     total_segment_count: usize,
     total_docs: u64,
     schema: SearchIndexSchema,
+    mutable_segment_ids: HashSet<SegmentId>,
 }
 
 impl SearchIndexReader {
@@ -370,6 +378,17 @@ impl SearchIndexReader {
             .try_into()?;
         let searcher = reader.searcher();
 
+        // Identify mutable segments so parallel scan coordination can exclude
+        // them from the worker checkout pool. This avoids the expensive
+        // index_memory_segment() materialization in every parallel worker.
+        // See: https://github.com/paradedb/paradedb/issues/4497
+        let mutable_segment_ids: HashSet<SegmentId> = searcher
+            .segment_readers()
+            .iter()
+            .filter(|sr| directory.is_mutable(&sr.segment_id()))
+            .map(|sr| sr.segment_id())
+            .collect();
+
         Ok(IndexComponents {
             cleanup_lock,
             index,
@@ -378,6 +397,7 @@ impl SearchIndexReader {
             total_segment_count,
             total_docs,
             schema,
+            mutable_segment_ids,
         })
     }
 
@@ -468,6 +488,7 @@ impl SearchIndexReader {
             total_docs,
             index_created_by_version,
             segment_ordinal_by_id: segment_ord_by_id,
+            mutable_segment_ids: components.mutable_segment_ids,
             _cleanup_lock: cleanup_lock,
         })
     }
@@ -478,6 +499,13 @@ impl SearchIndexReader {
             .iter()
             .map(|r| r.segment_id())
             .collect()
+    }
+
+    /// Returns the set of segment IDs that correspond to mutable (in-memory) segments.
+    /// These segments require expensive heap-scan materialization at read time.
+    /// Used by parallel scan coordination to exclude them from the worker checkout pool.
+    pub fn mutable_segment_ids(&self) -> &HashSet<SegmentId> {
+        &self.mutable_segment_ids
     }
 
     pub fn need_scores(&self) -> bool {

--- a/pg_search/src/postgres/parallel.rs
+++ b/pg_search/src/postgres/parallel.rs
@@ -114,7 +114,7 @@ pub unsafe fn maybe_init_parallel_scan(
     scan: pg_sys::IndexScanDesc,
     searcher: &SearchIndexReader,
 ) -> Option<i32> {
-    if unsafe { (*scan).parallel_scan.is_null() } {
+    if (*scan).parallel_scan.is_null() {
         // not a parallel scan, so there's nothing to initialize
         return None;
     }
@@ -153,7 +153,7 @@ pub unsafe fn maybe_init_parallel_scan(
             .collect();
         state.populate(&[&immutable_readers], 0, &[], false);
     }
-    Some(unsafe { pg_sys::ParallelWorkerNumber })
+    Some(pg_sys::ParallelWorkerNumber)
 }
 
 /// Claim a segment from the shared pool.

--- a/pg_search/src/postgres/parallel.rs
+++ b/pg_search/src/postgres/parallel.rs
@@ -113,7 +113,7 @@ unsafe fn bm25_shared_state(
 pub unsafe fn maybe_init_parallel_scan(
     scan: pg_sys::IndexScanDesc,
     searcher: &SearchIndexReader,
-) -> Option<(i32, Vec<SegmentId>)> {
+) -> Option<i32> {
     if unsafe { (*scan).parallel_scan.is_null() } {
         // not a parallel scan, so there's nothing to initialize
         return None;
@@ -125,8 +125,6 @@ pub unsafe fn maybe_init_parallel_scan(
     let state = get_bm25_scan_state(scan)?;
 
     let _mutex = state.acquire_mutex();
-
-    let mutable_ids: Vec<SegmentId> = searcher.mutable_segment_ids().iter().copied().collect();
 
     if !state.is_initialized() {
         // If concurrent writes created more segments than the DSM can hold, fall back to serial
@@ -147,14 +145,15 @@ pub unsafe fn maybe_init_parallel_scan(
         // Workers will never see or claim these — the leader handles them directly.
         // This prevents the expensive per-worker index_memory_segment() materialization
         // that caused issue #4497.
-        let immutable_readers: Vec<&SegmentReader> = searcher
+        let immutable_readers: Vec<SegmentReader> = searcher
             .segment_readers()
             .iter()
             .filter(|sr| !searcher.mutable_segment_ids().contains(&sr.segment_id()))
+            .cloned()
             .collect();
         state.populate(&[&immutable_readers], 0, &[], false);
     }
-    Some((unsafe { pg_sys::ParallelWorkerNumber }, mutable_ids))
+    Some(unsafe { pg_sys::ParallelWorkerNumber })
 }
 
 /// Claim a segment from the shared pool.

--- a/pg_search/src/postgres/parallel.rs
+++ b/pg_search/src/postgres/parallel.rs
@@ -19,6 +19,7 @@ use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::ParallelScanState;
 use pgrx::{pg_guard, pg_sys};
 use tantivy::index::SegmentId;
+use tantivy::SegmentReader;
 
 /// Safety margin for DSM allocation: actual segment count can exceed target_segment_count due to
 /// concurrent writes between plan and execute.
@@ -103,10 +104,16 @@ unsafe fn bm25_shared_state(
 /// snapshot-visible segments. Workers wait for this initialization and then
 /// use ParallelWorker visibility to see the same segments.
 /// Segments are NOT claimed here - they're claimed lazily in amgettuple/amgetbitmap.
+///
+/// Returns `Some((worker_number, mutable_segment_ids))` for parallel scans.
+/// Mutable segments are excluded from the DSM checkout pool so that workers
+/// never claim them — the leader handles them directly. This prevents
+/// every parallel worker from independently materializing the mutable segment
+/// (an expensive heap scan), which was the root cause of issue #4497.
 pub unsafe fn maybe_init_parallel_scan(
     scan: pg_sys::IndexScanDesc,
     searcher: &SearchIndexReader,
-) -> Option<i32> {
+) -> Option<(i32, Vec<SegmentId>)> {
     if unsafe { (*scan).parallel_scan.is_null() } {
         // not a parallel scan, so there's nothing to initialize
         return None;
@@ -118,6 +125,8 @@ pub unsafe fn maybe_init_parallel_scan(
     let state = get_bm25_scan_state(scan)?;
 
     let _mutex = state.acquire_mutex();
+
+    let mutable_ids: Vec<SegmentId> = searcher.mutable_segment_ids().iter().copied().collect();
 
     if !state.is_initialized() {
         // If concurrent writes created more segments than the DSM can hold, fall back to serial
@@ -133,9 +142,19 @@ pub unsafe fn maybe_init_parallel_scan(
             );
             return None;
         }
-        state.populate(&[searcher.segment_readers()], 0, &[], false);
+
+        // Exclude mutable segments from the DSM checkout pool.
+        // Workers will never see or claim these — the leader handles them directly.
+        // This prevents the expensive per-worker index_memory_segment() materialization
+        // that caused issue #4497.
+        let immutable_readers: Vec<&SegmentReader> = searcher
+            .segment_readers()
+            .iter()
+            .filter(|sr| !searcher.mutable_segment_ids().contains(&sr.segment_id()))
+            .collect();
+        state.populate(&[&immutable_readers], 0, &[], false);
     }
-    Some(unsafe { pg_sys::ParallelWorkerNumber })
+    Some((unsafe { pg_sys::ParallelWorkerNumber }, mutable_ids))
 }
 
 /// Claim a segment from the shared pool.

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -219,7 +219,7 @@ pub extern "C-unwind" fn amrescan(
 
         if is_parallel {
             let is_worker = pg_sys::ParallelWorkerNumber >= 0;
-            
+
             if !is_worker {
                 // Leader pre-searches mutable segments to prevent workers from independently materializing them
                 let mutable_ids = search_reader.mutable_segment_ids();

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -202,7 +202,9 @@ pub extern "C-unwind" fn amrescan(
             )
             .expect("amrescan: should be able to open a SearchIndexReader");
 
-            // For parallel scans, leader initializes shared state with its segment list
+            // For parallel scans, leader initializes shared state with its segment list.
+            // Mutable segments are excluded from the DSM checkout pool (workers never
+            // claim them), so the leader must handle them directly.
             if is_parallel {
                 parallel::maybe_init_parallel_scan(scan, &reader);
             }
@@ -216,9 +218,18 @@ pub extern "C-unwind" fn amrescan(
             // not a parallel scan - search all segments
             Some(search_reader.search())
         } else {
-            // parallel scan: DON'T claim segments here
-            // Segments will be claimed lazily in search_next_segment during amgettuple/amgetbitmap
-            None
+            // Parallel scan: the leader pre-searches any mutable segments that were
+            // excluded from the DSM checkout pool. Workers will handle immutable
+            // segments via checkout_segment() in search_next_segment().
+            //
+            // If there are no mutable segments, this is None and the leader also
+            // claims from the DSM pool like workers do.
+            let mutable_ids = search_reader.mutable_segment_ids();
+            if !mutable_ids.is_empty() {
+                Some(search_reader.search_segments(mutable_ids.iter().copied()))
+            } else {
+                None
+            }
         };
 
         let natts = (*(*scan).xs_hitupdesc).natts as usize;

--- a/pg_search/src/postgres/scan.rs
+++ b/pg_search/src/postgres/scan.rs
@@ -214,23 +214,23 @@ pub extern "C-unwind" fn amrescan(
     };
 
     unsafe {
-        let results = if (*scan).parallel_scan.is_null() {
-            // not a parallel scan - search all segments
-            Some(search_reader.search())
-        } else {
-            // Parallel scan: the leader pre-searches any mutable segments that were
-            // excluded from the DSM checkout pool. Workers will handle immutable
-            // segments via checkout_segment() in search_next_segment().
-            //
-            // If there are no mutable segments, this is None and the leader also
-            // claims from the DSM pool like workers do.
-            let mutable_ids = search_reader.mutable_segment_ids();
-            if !mutable_ids.is_empty() {
-                Some(search_reader.search_segments(mutable_ids.iter().copied()))
-            } else {
-                None
+        let mut results = None;
+        let is_parallel = !(*scan).parallel_scan.is_null();
+
+        if is_parallel {
+            let is_worker = pg_sys::ParallelWorkerNumber >= 0;
+            
+            if !is_worker {
+                // Leader pre-searches mutable segments to prevent workers from independently materializing them
+                let mutable_ids = search_reader.mutable_segment_ids();
+                if !mutable_ids.is_empty() {
+                    results = Some(search_reader.search_segments(mutable_ids.iter().copied()));
+                }
             }
-        };
+        } else {
+            // Serial scan searches all segments
+            results = Some(search_reader.search());
+        }
 
         let natts = (*(*scan).xs_hitupdesc).natts as usize;
         let scan_state = if (*scan).xs_want_itup {


### PR DESCRIPTION
Fixes #4497
When a BM25 index contains a visible mutable segment, every parallel worker independently materialized it via `index_memory_segment()` during Searcher construction — a full heap scan taking ~20 seconds per worker. This created a synchronization barrier where all workers stalled before any segment claiming could begin.
**Root cause:** The leader populated the DSM checkout pool with ALL segments (including mutable ones), and workers opened their Searcher with all segment IDs from DSM. Tantivy's `SegmentReader::open()` triggered `get_file_handle()` → `OnceLock::get_or_init()` → `index_memory_segment()` for the mutable segment in every worker process independently.
**Fix:** Three coordinated changes:
1. Track mutable segment IDs in `SearchIndexReader` during construction by querying `MVCCDirectory::is_mutable()` for each segment.
2. In `maybe_init_parallel_scan()`, filter mutable segment readers out of the DSM checkout pool. Workers never see mutable segment IDs in `wait_for_segment_ids()`, so their `ParallelWorker(ids)` set only contains immutable segments — no materialization occurs.
3. In `amrescan()`, the leader pre-searches mutable segments before entering the DSM claiming loop. Results from mutable segments are returned first, then the leader claims immutable segments from DSM like workers do.
This eliminates the 20s×N barrier (N = number of workers), reducing parallel query time from ~20s to sub-second for the immutable segment workers, while the leader alone materializes the mutable segment.