### PR TITLE
ci: re-enable logical-replication-merge stressgres benchmark

### DIFF
--- a/.github/workflows/benchmark-pg_search-stressgres.yml
+++ b/.github/workflows/benchmark-pg_search-stressgres.yml
@@ -319,17 +319,16 @@ jobs:
           slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
           pr_label: ${{ steps.pr_label.outputs.result }}
 
-      # Disabled pending https://github.com/paradedb/paradedb/issues/5076
-      # - name: Benchmark logical-replication-merge.toml
-      #   uses: ./.github/actions/benchmark-stressgres
-      #   with:
-      #     test_file: logical-replication-merge.toml
-      #     ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
-      #     github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
-      #     github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
-      #     slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
-      #     slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
-      #     pr_label: ${{ steps.pr_label.outputs.result }}
+      - name: Benchmark logical-replication-merge.toml
+        uses: ./.github/actions/benchmark-stressgres
+        with:
+          test_file: logical-replication-merge.toml
+          ref: ${{ steps.determine-ref.outputs.ref || steps.commit_info.outputs.short_commit }}
+          github_app_id: ${{ vars.PARADEDB_GITHUB_APP_CLIENT_ID }}
+          github_app_private_key: ${{ secrets.PARADEDB_GITHUB_APP_PRIVATE_KEY }}
+          slack_oauth_token: ${{ secrets.SLACK_OAUTH_TOKEN }}
+          slack_channel: ${{ secrets.SLACK_BENCHMARKS_CHANNEL_ID }}
+          pr_label: ${{ steps.pr_label.outputs.result }}
 
       - name: Notify Slack on Failure (push only)
         if: failure() && github.event_name == 'push'


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5076

## What

Re-enables the `logical-replication-merge.toml` Stressgres benchmark step in `.github/workflows/benchmark-pg_search-stressgres.yml`.

## Why

This suite was disabled pending #5076. Re-enabling it makes the Stressgres workflow exercise the original logical-replication merge coverage again, so the TOAST/mutable-segment regression path is validated in CI.

## Tests

- ParadeDB pre-commit checks passed:
  - Rust formatting
  - Clippy
  - unused dependency check
  - Cargo.toml formatting