### PR TITLE
feat: expose index build time via index_created_at()

### DIFF
--- a/pg_search/sql/pg_search--0.24.1--0.24.2.sql
+++ b/pg_search/sql/pg_search--0.24.1--0.24.2.sql
@@ -1,5 +1,13 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.24.2'" to load this file. \quit
 
+-- Expose the build-time creation timestamp stamped into an index's metadata page.
+CREATE FUNCTION "index_created_at"(
+	"index" regclass /* pgrx::rel::PgRelation */
+) RETURNS timestamp with time zone /* core::option::Option<pgrx::datum::time_stamp_with_timezone::TimestampWithTimeZone> */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'index_created_at_wrapper';
+
 -- Update boolean() overloads to add minimum_should_match parameter
 DROP FUNCTION IF EXISTS "boolean"(must searchqueryinput, should searchqueryinput, must_not searchqueryinput);
 CREATE OR REPLACE FUNCTION "boolean"(must searchqueryinput DEFAULT NULL, should searchqueryinput DEFAULT NULL, must_not searchqueryinput DEFAULT NULL, minimum_should_match pg_catalog.int8 DEFAULT NULL) RETURNS searchqueryinput AS 'MODULE_PATHNAME', 'boolean_singles_wrapper' IMMUTABLE LANGUAGE c PARALLEL SAFE;

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -193,6 +193,16 @@ pub unsafe fn combined_layer_sizes(index: PgRelation) -> Vec<AnyNumeric> {
     sizes.into_iter().collect()
 }
 
+/// Returns the wall-clock time the given bm25 index was built, or NULL for indices created
+/// before build-time stamping was added.
+#[pg_extern]
+pub fn index_created_at(index: PgRelation) -> Option<pgrx::datum::TimestampWithTimeZone> {
+    let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
+    MetaPage::open(&index)
+        .created_at()
+        .and_then(|ts| pgrx::datum::TimestampWithTimeZone::try_from(ts).ok())
+}
+
 #[pg_extern]
 unsafe fn merge_info(
     index: PgRelation,

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -403,6 +403,7 @@ unsafe fn bgmerger_state(
 #[pgrx::pg_schema]
 mod tests {
     use super::*;
+    use pgrx::datum::TimestampWithTimeZone;
     use pgrx::prelude::*;
 
     #[pg_test]
@@ -431,7 +432,9 @@ mod tests {
 
     #[pg_test]
     fn created_at_is_stamped_at_index_build() {
-        let before: i64 = Spi::get_one("SELECT now()::timestamptz")
+        // `GetCurrentTimestamp()` is wall-clock time, so bound the build with `clock_timestamp()`
+        // (which advances within the transaction) rather than the fixed `now()`.
+        let before: TimestampWithTimeZone = Spi::get_one("SELECT clock_timestamp()")
             .expect("spi should succeed")
             .unwrap();
 
@@ -439,7 +442,7 @@ mod tests {
         Spi::run("INSERT INTO t (data) VALUES ('hello');").unwrap();
         Spi::run("CREATE INDEX t_idx ON t USING bm25(id, data) WITH (key_field = 'id');").unwrap();
 
-        let after: i64 = Spi::get_one("SELECT now()::timestamptz")
+        let after: TimestampWithTimeZone = Spi::get_one("SELECT clock_timestamp()")
             .expect("spi should succeed")
             .unwrap();
 
@@ -449,19 +452,23 @@ mod tests {
                 .unwrap();
         let indexrel = PgSearchRelation::open(index_oid);
 
-        let created_at = MetaPage::open(&indexrel)
-            .created_at()
-            .expect("freshly built index should be timestamp-stamped");
+        let created_at = TimestampWithTimeZone::try_from(
+            MetaPage::open(&indexrel)
+                .created_at()
+                .expect("freshly built index should be timestamp-stamped"),
+        )
+        .unwrap();
 
         assert!(
             created_at >= before && created_at <= after,
-            "created_at {created_at} should fall within [{before}, {after}]"
+            "created_at {created_at:?} should fall within [{before:?}, {after:?}]"
         );
 
         // The UDF should surface the same instant.
-        let via_udf: i64 = Spi::get_one("SELECT paradedb.index_created_at('t_idx')::timestamptz")
-            .expect("spi should succeed")
-            .unwrap();
+        let via_udf: TimestampWithTimeZone =
+            Spi::get_one("SELECT paradedb.index_created_at('t_idx')")
+                .expect("spi should succeed")
+                .unwrap();
         assert_eq!(via_udf, created_at);
     }
 }

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -83,6 +83,8 @@ pub struct MetaPageData {
     created_by_version_major: u16,
     created_by_version_minor: u16,
     created_by_version_patch: u16,
+
+    created_at: pg_sys::TimestampTz,
 }
 
 /// Provides read access to the metadata page
@@ -127,6 +129,8 @@ impl MetaPage {
                 const { parse_version_component(env!("CARGO_PKG_VERSION_MINOR")) };
             metadata.created_by_version_patch =
                 const { parse_version_component(env!("CARGO_PKG_VERSION_PATCH")) };
+
+            metadata.created_at = pg_sys::GetCurrentTimestamp();
         }
     }
 
@@ -261,6 +265,17 @@ impl MetaPage {
                 minor,
                 patch,
             })
+        }
+    }
+
+    /// The wall-clock time this index was built, as a `TimestampTz`. Returns `None` for indices
+    /// created before build-time stamping was added (the on-disk field reads as zero).
+    pub fn created_at(&self) -> Option<pg_sys::TimestampTz> {
+        let created_at = self.data.created_at;
+        if created_at == 0 {
+            None
+        } else {
+            Some(created_at)
         }
     }
 
@@ -412,5 +427,41 @@ mod tests {
             env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
         );
         assert_eq!(stamped, expected);
+    }
+
+    #[pg_test]
+    fn created_at_is_stamped_at_index_build() {
+        let before: i64 = Spi::get_one("SELECT now()::timestamptz")
+            .expect("spi should succeed")
+            .unwrap();
+
+        Spi::run("CREATE TABLE t (id SERIAL, data TEXT);").unwrap();
+        Spi::run("INSERT INTO t (data) VALUES ('hello');").unwrap();
+        Spi::run("CREATE INDEX t_idx ON t USING bm25(id, data) WITH (key_field = 'id');").unwrap();
+
+        let after: i64 = Spi::get_one("SELECT now()::timestamptz")
+            .expect("spi should succeed")
+            .unwrap();
+
+        let index_oid: pg_sys::Oid =
+            Spi::get_one("SELECT oid FROM pg_class WHERE relname = 't_idx' AND relkind = 'i';")
+                .expect("spi should succeed")
+                .unwrap();
+        let indexrel = PgSearchRelation::open(index_oid);
+
+        let created_at = MetaPage::open(&indexrel)
+            .created_at()
+            .expect("freshly built index should be timestamp-stamped");
+
+        assert!(
+            created_at >= before && created_at <= after,
+            "created_at {created_at} should fall within [{before}, {after}]"
+        );
+
+        // The UDF should surface the same instant.
+        let via_udf: i64 = Spi::get_one("SELECT paradedb.index_created_at('t_idx')::timestamptz")
+            .expect("spi should succeed")
+            .unwrap();
+        assert_eq!(via_udf, created_at);
     }
 }


### PR DESCRIPTION
## What

Stores the wall-clock time a `bm25` index is built and exposes it through a new UDF, `paradedb.index_created_at(regclass)`.

```sql
SELECT paradedb.index_created_at('my_idx');
--        index_created_at
-- ------------------------------
--  2026-07-02 14:31:07.442218+00
```

Returns `NULL` for indexes built before this change.