### PR TITLE
fix: drain the MPP mesh before joining the producer workers

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -641,20 +641,23 @@ impl CustomScan for AggregateScan {
             if let Some(leader) = df_state.mpp.as_ref() {
                 leader.release_control_senders();
             }
-            if let Some(leader) = df_state.mpp.as_mut() {
-                if let Some(finish) = leader.finish.as_mut() {
-                    let _ = finish.recv();
-                }
-            }
-            // PG destroys the parallel DSM right after this hook, so drain the workers' metrics
-            // frames off the mesh now (the EXPLAIN hook runs after teardown and only reads the
-            // store).
+            // Drain the workers' metrics frames off the mesh BEFORE joining the workers. On an
+            // early-terminated query the rings still hold data the leader will never read; a
+            // worker's bounded metrics send spins on the full ring until the leader frees slots.
+            // Draining here is what frees them, so the `recv` below returns immediately instead
+            // of waiting out the workers' full spin bound. PG destroys the parallel DSM right
+            // after this hook (the EXPLAIN hook runs after teardown and only reads the store).
             if let Some(leader) = df_state.mpp.as_ref() {
                 if let Some(plan) = df_state.physical_plan.as_ref() {
                     crate::postgres::customscan::mpp::glue::drain_worker_metrics(
                         plan,
                         &leader.mesh,
                     );
+                }
+            }
+            if let Some(leader) = df_state.mpp.as_mut() {
+                if let Some(finish) = leader.finish.as_mut() {
+                    let _ = finish.recv();
                 }
             }
         }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1617,21 +1617,22 @@ impl CustomScan for JoinScan {
         if let Some(leader) = state.custom_state().mpp.as_ref() {
             leader.release_control_senders();
         }
-        // Wait for the producer workers to finish and flush their `TaskMetrics` before draining:
-        // `recv` blocks until every worker detaches its completion queue, which it does only after
-        // sending metrics. PG's parallel teardown joins Gather-spawned workers here; the
-        // builder-launched workers need this explicit join so the metrics land before the EXPLAIN
-        // render (which runs before end_custom_scan, where the context is finally destroyed).
-        if let Some(leader) = state.custom_state_mut().mpp.as_mut() {
-            if let Some(finish) = leader.finish.as_mut() {
-                let _ = finish.recv();
-            }
-        }
-        // The EXPLAIN hook runs after teardown and only reads the store, so drain the workers'
-        // metrics frames off the mesh now.
+        // Drain the workers' metrics frames off the mesh BEFORE joining the workers. On an
+        // early-terminated query the rings still hold data the leader will never read; a worker's
+        // bounded metrics send spins on the full ring until the leader frees slots. Draining here
+        // is what frees them: the sends land on the next try, the workers detach, and the `recv`
+        // below returns immediately instead of waiting out the workers' full spin bound.
         if let Some(leader) = state.custom_state().mpp.as_ref() {
             if let Some(plan) = state.custom_state().physical_plan.as_ref() {
                 crate::postgres::customscan::mpp::glue::drain_worker_metrics(plan, &leader.mesh);
+            }
+        }
+        // Join the producer workers so their metrics land before the EXPLAIN render (which runs
+        // before end_custom_scan, where the context is finally destroyed). A worker error is
+        // re-raised from inside `recv`.
+        if let Some(leader) = state.custom_state_mut().mpp.as_mut() {
+            if let Some(finish) = leader.finish.as_mut() {
+                let _ = finish.recv();
             }
         }
     }


### PR DESCRIPTION
## What

This PR drains the MPP worker metrics off the ring mesh before the leader joins its producer workers, instead of after.

## Why

An early-terminated query stalled for hundreds of milliseconds in teardown. When the leader satisfies a `LIMIT` before the workers finish, it drops the stream and leaves unread rows in the rings. Each worker's bounded metrics send then spins against a full ring that only the leader drains. The old order joined the workers first, so `recv` blocked until every worker gave up its spin, which is a fixed stall the query never needs to pay.

`join_hierarchical_small` with `LIMIT 5` showed it: about 444ms, almost all of it teardown, against ~23ms for the serial plan.

## How

In `shutdown_custom_scan`, `drain_worker_metrics` now runs before `finish.recv()`. Draining frees the ring slots, so the workers' metrics sends land on the next try and the workers detach right away. `recv` then returns at once. The same reorder applies to `JoinScan` and `AggregateScan`, since they share the teardown shape.

The control-sender release still happens first, so a worker error is re-raised from `recv` after the mesh is already drained.

## Tests

Re-timed the `LIMIT` join shapes with `paradedb.enable_mpp` on: `join_hierarchical_small` dropped from ~444ms to ~84ms.