### PR TITLE
perf: batch convert rows and columns during candidate materialization

### DIFF
--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -1772,8 +1772,6 @@ impl SegmentedTopKState {
             .collect();
 
         let mat_row_converter = RowConverter::new(materialized_sort_fields)?;
-
-        
         // Batch-convert all ordinal survivors' rows in a single convert_rows call.
         let ord_entries: Vec<(usize, SegmentOrdinal, OwnedRow)> = candidates
             .iter()

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -1773,12 +1773,40 @@ impl SegmentedTopKState {
 
         let mat_row_converter = RowConverter::new(materialized_sort_fields)?;
 
-        // For each candidate, resolve materialized ScalarValues and convert to OwnedRow.
-        let mut mat_rows: Vec<(usize, OwnedRow)> = Vec::with_capacity(candidates.len());
+        
+        // Batch-convert all ordinal survivors' rows in a single convert_rows call.
+        let ord_entries: Vec<(usize, SegmentOrdinal, OwnedRow)> = candidates
+            .iter()
+            .enumerate()
+            .filter_map(|(cand_idx, (_, _, ord_info))| {
+                ord_info
+                    .as_ref()
+                    .map(|(seg_ord, row_val)| (cand_idx, *seg_ord, row_val.clone()))
+            })
+            .collect();
+
+        let all_ord_arrays: Option<Vec<ArrayRef>> = if !ord_entries.is_empty() {
+            Some(
+                self.row_converter
+                    .convert_rows(ord_entries.iter().map(|(_, _, r)| r.row()))
+                    .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
+            )
+        } else {
+            None
+        };
+
+        // Map candidate index → position in ord_entries for O(1) lookup.
+        let mut cand_ord_idx: Vec<Option<usize>> = vec![None; candidates.len()];
+        for (ord_pos, (cand_idx, _, _)) in ord_entries.iter().enumerate() {
+            cand_ord_idx[*cand_idx] = Some(ord_pos);
+        }
+
+        // Build column-major ScalarValues and batch-convert all candidates at once.
+        let mut column_values: Vec<Vec<ScalarValue>> = (0..self.sort_exprs.len())
+            .map(|_| Vec::with_capacity(candidates.len()))
+            .collect();
 
         for (idx, (batch_idx, row_idx, ord_info)) in candidates.iter().enumerate() {
-            let mut values = Vec::with_capacity(self.sort_exprs.len());
-
             for (i, sort_expr) in self.sort_exprs.iter().enumerate() {
                 let is_deferred = sort_expr
                     .expr
@@ -1790,16 +1818,17 @@ impl SegmentedTopKState {
                     });
 
                 let value = if let Some(deferred) = is_deferred {
-                    if let Some((seg_ord, ord_row)) = ord_info {
-                        // Ordinal survivor: convert ordinal back to string.
-                        let arrays = self
-                            .row_converter
-                            .convert_rows(std::iter::once(ord_row.row()))
-                            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+                    if let Some((seg_ord, _)) = ord_info {
+                        // Ordinal survivor: use pre-batched arrays.
+                        let ord_pos = cand_ord_idx[idx]
+                            .expect("ordinal survivor candidate not in cand_ord_idx");
+                        let arrays = all_ord_arrays
+                            .as_ref()
+                            .expect("all_ord_arrays is None for ordinal survivor");
                         let term_ord = arrays[i]
                             .as_any()
                             .downcast_ref::<UInt64Array>()
-                            .map(|a| a.value(0));
+                            .map(|a| a.value(ord_pos));
                         if let Some(term_ord) = term_ord {
                             let col = self.ffhelper.column(*seg_ord, deferred.canonical.ff_index);
                             match col {
@@ -1836,18 +1865,21 @@ impl SegmentedTopKState {
                     ScalarValue::try_from_array(&arr, *row_idx)
                         .unwrap_or(ScalarValue::Utf8View(None))
                 };
-                values.push(value);
+                column_values[i].push(value);
             }
+        }
 
-            // Convert ScalarValues to arrays and then to an OwnedRow.
-            let arrays: Vec<ArrayRef> = values
-                .iter()
-                .map(|v| v.to_array())
-                .collect::<Result<Vec<_>>>()?;
-            let converted = mat_row_converter
-                .convert_columns(&arrays)
-                .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
-            mat_rows.push((idx, converted.row(0).owned()));
+        // Batch convert all candidates in a single convert_columns call.
+        let arrays: Vec<ArrayRef> = column_values
+            .into_iter()
+            .map(|col| ScalarValue::iter_to_array(col.into_iter()))
+            .collect::<Result<Vec<_>>>()?;
+        let converted = mat_row_converter
+            .convert_columns(&arrays)
+            .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?;
+        let mut mat_rows: Vec<(usize, OwnedRow)> = Vec::with_capacity(candidates.len());
+        for idx in 0..candidates.len() {
+            mat_rows.push((idx, converted.row(idx).owned()));
         }
 
         // 4. Sort candidates by materialized OwnedRow and take top K.

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -1773,38 +1773,29 @@ impl SegmentedTopKState {
 
         let mat_row_converter = RowConverter::new(materialized_sort_fields)?;
         // Batch-convert all ordinal survivors' rows in a single convert_rows call.
-        let ord_entries: Vec<(usize, SegmentOrdinal, OwnedRow)> = candidates
+        // We collect `Row<'_>` directly to avoid cloning `OwnedRow`.
+        let ord_rows: Vec<_> = candidates
             .iter()
-            .enumerate()
-            .filter_map(|(cand_idx, (_, _, ord_info))| {
-                ord_info
-                    .as_ref()
-                    .map(|(seg_ord, row_val)| (cand_idx, *seg_ord, row_val.clone()))
-            })
+            .filter_map(|(_, _, ord_info)| ord_info.as_ref().map(|(_, row_val)| row_val.row()))
             .collect();
 
-        let all_ord_arrays: Option<Vec<ArrayRef>> = if !ord_entries.is_empty() {
+        let all_ord_arrays: Option<Vec<ArrayRef>> = if !ord_rows.is_empty() {
             Some(
                 self.row_converter
-                    .convert_rows(ord_entries.iter().map(|(_, _, r)| r.row()))
+                    .convert_rows(ord_rows)
                     .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))?,
             )
         } else {
             None
         };
 
-        // Map candidate index → position in ord_entries for O(1) lookup.
-        let mut cand_ord_idx: Vec<Option<usize>> = vec![None; candidates.len()];
-        for (ord_pos, (cand_idx, _, _)) in ord_entries.iter().enumerate() {
-            cand_ord_idx[*cand_idx] = Some(ord_pos);
-        }
-
         // Build column-major ScalarValues and batch-convert all candidates at once.
         let mut column_values: Vec<Vec<ScalarValue>> = (0..self.sort_exprs.len())
             .map(|_| Vec::with_capacity(candidates.len()))
             .collect();
 
-        for (idx, (batch_idx, row_idx, ord_info)) in candidates.iter().enumerate() {
+        let mut ord_pos = 0;
+        for (batch_idx, row_idx, ord_info) in candidates.iter() {
             for (i, sort_expr) in self.sort_exprs.iter().enumerate() {
                 let is_deferred = sort_expr
                     .expr
@@ -1817,9 +1808,7 @@ impl SegmentedTopKState {
 
                 let value = if let Some(deferred) = is_deferred {
                     if let Some((seg_ord, _)) = ord_info {
-                        // Ordinal survivor: use pre-batched arrays.
-                        let ord_pos = cand_ord_idx[idx]
-                            .expect("ordinal survivor candidate not in cand_ord_idx");
+                        // Ordinal survivor: use pre-batched arrays with our sequential counter.
                         let arrays = all_ord_arrays
                             .as_ref()
                             .expect("all_ord_arrays is None for ordinal survivor");
@@ -1865,12 +1854,16 @@ impl SegmentedTopKState {
                 };
                 column_values[i].push(value);
             }
+
+            if ord_info.is_some() {
+                ord_pos += 1;
+            }
         }
 
         // Batch convert all candidates in a single convert_columns call.
         let arrays: Vec<ArrayRef> = column_values
             .into_iter()
-            .map(|col| ScalarValue::iter_to_array(col.into_iter()))
+            .map(|col| ScalarValue::iter_to_array(col))
             .collect::<Result<Vec<_>>>()?;
         let converted = mat_row_converter
             .convert_columns(&arrays)


### PR DESCRIPTION
… in segmented_topk_exec

# Ticket(s) Closed

- Closes #5467

## What

Batch Arrow `RowConverter` calls in `SegmentedTopKExec::emit_final_topk` so that both:

- Ordinal → materialized conversions (`row_converter.convert_rows`), and
- Materialized sort-key conversions (`mat_row_converter.convert_columns`)

are performed in a few batched calls instead of once per candidate.

## Why

Previously, `emit_final_topk` did Arrow conversion per candidate:

1. Ordinal → materialized conversion (`row_converter.convert_rows`):
   - Called once per deferred column per candidate (e.g. 3 deferred columns × 200 survivors = 600 calls).
   - Each call builds a single-row Arrow array, re-validates schemas, and dispatches Arrow kernels.

2. Materialized sort-key conversion (`mat_row_converter.convert_columns`):
   - Called once per candidate (e.g. 200 calls).
   - Same per-call overhead pattern.

On top‑K workloads with deferred (string/bytes) sort columns, these tiny, repeated Arrow conversions dominate the post‑scan top‑K assembly time, even after the segments have been scanned.

Batching both stages turns many small Arrow calls into a small number of batched calls, which is more cache- and allocator-friendly.

## How

**Phase 1 — Batch ordinal conversion**

- Collect all ordinal survivors into a single `Vec<(usize, SegmentOrdinal, OwnedRow)>` (`ord_entries`).
- Call `self.row_converter.convert_rows()` once with an iterator over `ord_entries.iter().map(|(_, _, r)| r.row())`.
- Build `cand_ord_idx: Vec<Option<usize>>` mapping candidate index → position in `ord_entries`.
- In the inner loop, for ordinal survivors, use:
  - `cand_ord_idx[idx]` to get the ordinal position.
  - The pre-batched `all_ord_arrays` to look up the term ordinal and resolve it via `ffhelper`.

This reduces `row_converter.convert_rows` from `O(D × N_ord)` calls to `O(1)` per `emit_final_topk`.

**Phase 2 — Batch materialized sort-key conversion**

- While iterating candidates, build `column_values: Vec<Vec<ScalarValue>>` in column-major layout:
  - For each sort expression `i`, append the candidate’s `ScalarValue` into `column_values[i]`.
- After the candidate loop:
  - Convert each `column_values[i]` into an `ArrayRef` via `ScalarValue::iter_to_array`.
  - Call `mat_row_converter.convert_columns(&arrays)` once.
  - Build `mat_rows: Vec<(usize, OwnedRow)>` by taking `converted.row(idx).owned()` for each candidate index.

This reduces `mat_row_converter.convert_columns` from `O(N_candidates)` calls to `O(1)`.

Semantics are unchanged:

- Same ranking and LIMIT behavior.
- No changes to the public API or external behavior.

## Tests

- `cargo check`
- Existing `segmented_topk_exec` tests (unchanged, all passing)
- Manual verification on deferred-sort workloads that:
  - Results are identical before/after this change.
  - Profiles show reduced time in:
    - `RowConverter::convert_rows`
    - `RowConverter::convert_columns`
