### PR TITLE
fix: forget the DSM control senders on abort instead of dropping them

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/join_semi_filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_semi_filter.sql
@@ -7,6 +7,10 @@
 -- - 'David John Alex' selectivity on users.display_name: ~2%
 -- - combined selectivity on users (about_me ||| 'java' AND display_name ||| 'David John Alex'): <1%
 
+-- TODO: the two "Sortedness enabled" blocks now run the same SQL as their "Sortedness disabled"
+-- twins, since the sort toggle that separated them is gone. Drop them on the next pass that can
+-- reset the benchmark baseline (removing alternatives renumbers the stored history).
+
 SET paradedb.enable_join_custom_scan TO off; SELECT
     p.id,
     p.title,

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -217,12 +217,27 @@ pub unsafe fn leader_setup(
     // Hand the senders to the mesh too, so its early-termination cancel can reach the producers.
     // The mesh shares this `Arc`, so clearing it below releases both views before the DSM unmaps.
     mesh.set_cancel_senders(Arc::clone(&control_senders));
-    // On abort, PG detaches the DSM before the portal contexts (and the scan state inside them)
-    // are cleaned up; release the DSM-backed senders while the mapping is still alive.
-    let on_abort = Arc::clone(&control_senders);
-    pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::Abort, move || {
-        on_abort.lock().unwrap().clear();
-    });
+    // Forget these senders instead of dropping them: `AbortTransaction` unmaps the DSM before the
+    // xact callbacks run, so a sender's drop would write its detach signal into a freed ring
+    // header. The signal has no audience anyway, since the abort already terminated the workers.
+    // `PreCommit` covers a subtransaction rollback where no abort fires; a populated vec at either
+    // event means the mapping is already gone (the success path clears it in `shutdown_custom_scan`).
+    let forget_senders = |senders: &Arc<std::sync::Mutex<Vec<Option<MppSender>>>>| {
+        let senders = Arc::clone(senders);
+        move || {
+            for sender in senders.lock().unwrap().drain(..).flatten() {
+                std::mem::forget(sender);
+            }
+        }
+    };
+    pgrx::register_xact_callback(
+        pgrx::PgXactCallbackEvent::Abort,
+        forget_senders(&control_senders),
+    );
+    pgrx::register_xact_callback(
+        pgrx::PgXactCallbackEvent::PreCommit,
+        forget_senders(&control_senders),
+    );
     Ok(MppLeaderState {
         mesh,
         control_senders,

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -219,11 +219,15 @@ pub unsafe fn leader_setup(
     mesh.set_cancel_senders(Arc::clone(&control_senders));
     // Forget these senders instead of dropping them: `AbortTransaction` unmaps the DSM before the
     // xact callbacks run, so a sender's drop would write its detach signal into a freed ring
-    // header. Nothing arms the ring's detach-liveness flag on the leader, so the drop can't tell
-    // the mapping is gone and skip that write. The signal has no audience anyway, since the abort
-    // already terminated the workers. `PreCommit` covers a subtransaction rollback where no abort
-    // fires; a populated vec at either event means the mapping is already gone (the success path
-    // clears it in `shutdown_custom_scan`).
+    // header. This DF-D rev has no ring liveness flag, so the drop can't tell the mapping is gone
+    // and guard itself. The signal has no audience anyway, since the abort already terminated the
+    // workers. `PreCommit` covers a subtransaction rollback where no abort fires; a populated vec
+    // at either event means the mapping is already gone (the success path clears it in
+    // `shutdown_custom_scan`).
+    //
+    // TODO: once the DF-D pin has `MppMesh::mark_detached` / `detached_flag`, flip that
+    // process-local flag here and drop the senders normally, so their own `Drop` skips the
+    // freed-ring write and frees their heap instead of leaking it.
     let forget_senders = |senders: &Arc<std::sync::Mutex<Vec<Option<MppSender>>>>| {
         let senders = Arc::clone(senders);
         move || {

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -219,9 +219,11 @@ pub unsafe fn leader_setup(
     mesh.set_cancel_senders(Arc::clone(&control_senders));
     // Forget these senders instead of dropping them: `AbortTransaction` unmaps the DSM before the
     // xact callbacks run, so a sender's drop would write its detach signal into a freed ring
-    // header. The signal has no audience anyway, since the abort already terminated the workers.
-    // `PreCommit` covers a subtransaction rollback where no abort fires; a populated vec at either
-    // event means the mapping is already gone (the success path clears it in `shutdown_custom_scan`).
+    // header. Nothing arms the ring's detach-liveness flag on the leader, so the drop can't tell
+    // the mapping is gone and skip that write. The signal has no audience anyway, since the abort
+    // already terminated the workers. `PreCommit` covers a subtransaction rollback where no abort
+    // fires; a populated vec at either event means the mapping is already gone (the success path
+    // clears it in `shutdown_custom_scan`).
     let forget_senders = |senders: &Arc<std::sync::Mutex<Vec<Option<MppSender>>>>| {
         let senders = Arc::clone(senders);
         move || {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR forgets the MPP control senders on transaction abort instead of dropping them.

## Why

A worker error, or any abort, mid-query would segfault the leader. `AbortTransaction` destroys the parallel contexts, which unmaps the DSM, before it runs the xact callbacks. The old `Abort` callback then dropped the DSM-backed control senders, and a sender's drop writes its detach signal into the ring header. That header lives in the DSM that's already unmapped, so the write faults.

## How

`leader_setup` now registers callbacks that `std::mem::forget` the senders instead of dropping them. The detach signal has no audience anyway: the abort already terminated the workers, and the ring is gone. Forgetting leaks a few heap bytes per sender, and only on aborted MPP queries.

It also registers a `PreCommit` callback for the same disposal. That covers a subtransaction rollback of the scan, where no top-level abort fires and the senders would otherwise sit populated until pgrx drops the unused abort closure at commit, past the DSM's lifetime. A non-empty vec at either event means the mapping is already gone, since the success path clears it in `shutdown_custom_scan`.

## Tests

Reproduced the crash by forcing a worker error mid-execution so the leader aborts with live senders, and confirmed the backend no longer segfaults on teardown.