### PR TITLE
perf: keep wide DISTINCT columns out of the group keys via doc addresses

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -809,10 +809,7 @@ fn build_distinct_address_deferral(
 /// below the aggregate: the visibility rule anchors its filter under the `Aggregate` barrier and
 /// rewrites the ctid columns to real ctids there, so a copy taken above would no longer hold a
 /// doc address. A no-op when nothing was deferred.
-fn project_addr_copies_below_aggregate(
-    df: DataFrame,
-    addr_copies: Vec<Expr>,
-) -> Result<DataFrame> {
+fn project_addr_copies_below_aggregate(df: DataFrame, addr_copies: Vec<Expr>) -> Result<DataFrame> {
     if addr_copies.is_empty() {
         return Ok(df);
     }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -32,7 +32,7 @@
 use std::sync::Arc;
 
 use datafusion::common::{DataFusionError, Result};
-use datafusion::logical_expr::{col, Expr};
+use datafusion::logical_expr::{col, Expr, Extension, LogicalPlan};
 use datafusion::physical_plan::coalesce_partitions::CoalescePartitionsExec;
 use datafusion::physical_plan::{ExecutionPlan, ExecutionPlanProperties};
 use datafusion::prelude::{DataFrame, SessionConfig, SessionContext};
@@ -62,6 +62,9 @@ use crate::postgres::customscan::CustomScanState;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::ParallelScanState;
+use crate::scan::late_materialization::{
+    doc_address_lookup_schema, DeferredField, DeferredLookupRebuild, DocAddressLookupNode,
+};
 use crate::scan::{PgSearchTableProvider, VisibilityMode};
 use async_trait::async_trait;
 use datafusion::execution::context::{QueryPlanner, SessionState};
@@ -777,9 +780,7 @@ fn build_distinct_address_deferral(
     deferrable: &DistinctDeferrable,
     partitioning_idx: usize,
     col_alias: &str,
-) -> (Expr, Expr, (String, crate::scan::late_materialization::DeferredField)) {
-    use crate::scan::late_materialization::{DeferredField, DeferredLookupRebuild};
-
+) -> (Expr, Expr, (String, DeferredField)) {
     let addr_name = format!("__distinct_addr_{}", proj_idx + 1);
     let addr_copy = col(CtidColumn::new(plan_pos).to_string()).alias(&addr_name);
     let addr_agg = min(col(&addr_name)).alias(col_alias);
@@ -829,11 +830,8 @@ fn project_addr_copies_below_aggregate(
 /// from their representative doc addresses. A no-op when nothing was deferred.
 fn wrap_in_doc_address_lookup(
     df: DataFrame,
-    lookups: Vec<(String, crate::scan::late_materialization::DeferredField)>,
+    lookups: Vec<(String, DeferredField)>,
 ) -> Result<DataFrame> {
-    use crate::scan::late_materialization::{doc_address_lookup_schema, DocAddressLookupNode};
-    use datafusion::logical_expr::{Extension, LogicalPlan};
-
     if lookups.is_empty() {
         return Ok(df);
     }
@@ -893,7 +891,7 @@ fn apply_distinct_group_by(
     // through it, and the decode descriptions for the lookup node above it.
     let mut addr_copies: Vec<Expr> = Vec::new();
     let mut addr_aggs: Vec<Expr> = Vec::new();
-    let mut lookups: Vec<(String, crate::scan::late_materialization::DeferredField)> = Vec::new();
+    let mut lookups: Vec<(String, DeferredField)> = Vec::new();
 
     for (i, proj) in projection.iter().enumerate() {
         let col_alias = format!("col_{}", i + 1);

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -762,6 +762,96 @@ fn distinct_deferrable_columns(
     out
 }
 
+/// Builds the three pieces that defer one wide DISTINCT column past the aggregate: the
+/// doc-address copy projected below it, the `min()` that carries one representative through it,
+/// and the `(alias, decode)` entry the lookup node above it re-derives the value from.
+///
+/// `col_alias` is the group-output name the sort and projection stages resolve against.
+/// `plan_pos` is the source's position in the join plan; `partitioning_idx` is the partitioning
+/// source. The non-partitioning index is recomputed the same way the source build does, so a
+/// worker-side rebuild lands on the same canonical segment set the addresses were packed against.
+fn build_distinct_address_deferral(
+    proj_idx: usize,
+    plan_pos: usize,
+    source: &JoinSource,
+    deferrable: &DistinctDeferrable,
+    partitioning_idx: usize,
+    col_alias: &str,
+) -> (Expr, Expr, (String, crate::scan::late_materialization::DeferredField)) {
+    use crate::scan::late_materialization::{DeferredField, DeferredLookupRebuild};
+
+    let addr_name = format!("__distinct_addr_{}", proj_idx + 1);
+    let addr_copy = col(CtidColumn::new(plan_pos).to_string()).alias(&addr_name);
+    let addr_agg = min(col(&addr_name)).alias(col_alias);
+
+    let np_source_idx = (0..plan_pos).filter(|i| *i != partitioning_idx).count();
+    let lookup = (
+        col_alias.to_string(),
+        DeferredField {
+            name: deferrable.name.clone(),
+            is_bytes: deferrable.is_bytes,
+            canonical: crate::index::fast_fields_helper::CanonicalColumn {
+                indexrelid: source.scan_info.indexrelid.to_u32(),
+                ff_index: deferrable.ff_index,
+            },
+            rebuild: Some(DeferredLookupRebuild {
+                field_name: deferrable.name.clone(),
+                field_type: deferrable.field_type,
+                np_source_idx: Some(np_source_idx),
+            }),
+        },
+    );
+    (addr_copy, addr_agg, lookup)
+}
+
+/// Projects `addr_copies` alongside `df`'s existing columns. The address copies must bind here,
+/// below the aggregate: the visibility rule anchors its filter under the `Aggregate` barrier and
+/// rewrites the ctid columns to real ctids there, so a copy taken above would no longer hold a
+/// doc address. A no-op when nothing was deferred.
+fn project_addr_copies_below_aggregate(
+    df: DataFrame,
+    addr_copies: Vec<Expr>,
+) -> Result<DataFrame> {
+    if addr_copies.is_empty() {
+        return Ok(df);
+    }
+    let mut exprs: Vec<Expr> = df
+        .schema()
+        .columns()
+        .into_iter()
+        .map(Expr::Column)
+        .collect();
+    exprs.extend(addr_copies);
+    df.select(exprs)
+}
+
+/// Wraps `df` in a [`DocAddressLookupNode`] that re-derives the deferred string/bytes columns
+/// from their representative doc addresses. A no-op when nothing was deferred.
+fn wrap_in_doc_address_lookup(
+    df: DataFrame,
+    lookups: Vec<(String, crate::scan::late_materialization::DeferredField)>,
+) -> Result<DataFrame> {
+    use crate::scan::late_materialization::{doc_address_lookup_schema, DocAddressLookupNode};
+    use datafusion::logical_expr::{Extension, LogicalPlan};
+
+    if lookups.is_empty() {
+        return Ok(df);
+    }
+    let (state, plan) = df.into_parts();
+    let output_schema = doc_address_lookup_schema(&plan, &lookups)?;
+    let node = DocAddressLookupNode {
+        input: plan,
+        output_schema,
+        lookups,
+    };
+    Ok(DataFrame::new(
+        state,
+        LogicalPlan::Extension(Extension {
+            node: std::sync::Arc::new(node),
+        }),
+    ))
+}
+
 /// Apply a DISTINCT rewrite as `GROUP BY` over `output_projection`, taking the
 /// MIN of each ctid column as a stable representative. Returns the rewritten
 /// `DataFrame` plus the populated [`DistinctColMap`] used by the sort and
@@ -820,29 +910,17 @@ fn apply_distinct_group_by(
                         .map(|d| (pos, s, d))
                 });
             if let Some((pos, source, d)) = deferrable {
-                let addr_name = format!("__distinct_addr_{}", i + 1);
-                addr_copies.push(col(CtidColumn::new(pos).to_string()).alias(&addr_name));
-                addr_aggs.push(min(col(&addr_name)).alias(&col_alias));
-                // Same non-partitioning index computation the source build uses, so the
-                // worker-side rebuild resolves the same canonical segment set the scan's
-                // reader packed the addresses against.
-                let np_source_idx = (0..pos).filter(|i| *i != partitioning_idx).count();
-                lookups.push((
-                    col_alias.clone(),
-                    crate::scan::late_materialization::DeferredField {
-                        name: d.name.clone(),
-                        is_bytes: d.is_bytes,
-                        canonical: crate::index::fast_fields_helper::CanonicalColumn {
-                            indexrelid: source.scan_info.indexrelid.to_u32(),
-                            ff_index: d.ff_index,
-                        },
-                        rebuild: Some(crate::scan::late_materialization::DeferredLookupRebuild {
-                            field_name: d.name.clone(),
-                            field_type: d.field_type,
-                            np_source_idx,
-                        }),
-                    },
-                ));
+                let (addr_copy, addr_agg, lookup) = build_distinct_address_deferral(
+                    i,
+                    pos,
+                    source,
+                    d,
+                    partitioning_idx,
+                    &col_alias,
+                );
+                addr_copies.push(addr_copy);
+                addr_aggs.push(addr_agg);
+                lookups.push(lookup);
                 distinct_col_map.insert((*rti, *attno), col_alias);
                 continue;
             }
@@ -887,42 +965,9 @@ fn apply_distinct_group_by(
             .collect();
     agg_exprs.extend(addr_aggs);
 
-    // Project the address copies below the aggregate: the visibility rule anchors its filter
-    // under the `Aggregate` barrier and rewrites the ctid columns to real ctids there, so a
-    // copy taken at the aggregate's input would no longer hold a doc address.
-    let df = if addr_copies.is_empty() {
-        df
-    } else {
-        let mut exprs: Vec<Expr> = df
-            .schema()
-            .columns()
-            .into_iter()
-            .map(Expr::Column)
-            .collect();
-        exprs.extend(addr_copies);
-        df.select(exprs)?
-    };
-
+    let df = project_addr_copies_below_aggregate(df, addr_copies)?;
     let df = df.aggregate(group_exprs, agg_exprs)?;
-
-    let df = if lookups.is_empty() {
-        df
-    } else {
-        let (state, plan) = df.into_parts();
-        let output_schema =
-            crate::scan::late_materialization::doc_address_lookup_schema(&plan, &lookups)?;
-        let node = crate::scan::late_materialization::DocAddressLookupNode {
-            input: plan,
-            output_schema,
-            lookups,
-        };
-        DataFrame::new(
-            state,
-            datafusion::logical_expr::LogicalPlan::Extension(datafusion::logical_expr::Extension {
-                node: std::sync::Arc::new(node),
-            }),
-        )
-    };
+    let df = wrap_in_doc_address_lookup(df, lookups)?;
     Ok((df, distinct_col_map))
 }
 

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -661,15 +661,8 @@ struct DistinctDeferrable {
 fn distinct_deferrable_columns(
     join_clause: &JoinCSClause,
     source: &JoinSource,
-    is_partitioning_source: bool,
 ) -> Vec<DistinctDeferrable> {
     if !join_clause.has_distinct || join_clause.output_projection.is_none() {
-        return Vec::new();
-    }
-    // The partitioning source's segments are claimed per worker, so a lookup running in a
-    // different fragment could not resolve every group's doc address. Non-partitioning
-    // sources replicate their canonical segment set to every worker.
-    if is_partitioning_source {
         return Vec::new();
     }
 
@@ -777,22 +770,20 @@ fn distinct_deferrable_columns(
 /// and the `(alias, decode)` entry the lookup node above it re-derives the value from.
 ///
 /// `col_alias` is the group-output name the sort and projection stages resolve against.
-/// `plan_pos` is the source's position in the join plan; `partitioning_idx` is the partitioning
-/// source. The non-partitioning index is recomputed the same way the source build does, so a
-/// worker-side rebuild lands on the same canonical segment set the addresses were packed against.
+/// `plan_pos` is the source's position in the join plan, the same index the worker's
+/// `ParallelScanState` resolves segment lists by, so a worker-side rebuild lands on the same
+/// segment view the addresses were packed against.
 fn build_distinct_address_deferral(
     proj_idx: usize,
     plan_pos: usize,
     source: &JoinSource,
     deferrable: &DistinctDeferrable,
-    partitioning_idx: usize,
     col_alias: &str,
 ) -> (Expr, Expr, (String, DeferredField)) {
     let addr_name = format!("__distinct_addr_{}", proj_idx + 1);
     let addr_copy = col(CtidColumn::new(plan_pos).to_string()).alias(&addr_name);
     let addr_agg = min(col(&addr_name)).alias(col_alias);
 
-    let np_source_idx = (0..plan_pos).filter(|i| *i != partitioning_idx).count();
     let lookup = (
         col_alias.to_string(),
         DeferredField {
@@ -805,7 +796,7 @@ fn build_distinct_address_deferral(
             rebuild: Some(DeferredLookupRebuild {
                 field_name: deferrable.name.clone(),
                 field_type: deferrable.field_type,
-                np_source_idx: Some(np_source_idx),
+                source_idx: Some(plan_pos),
             }),
         },
     );
@@ -882,12 +873,10 @@ fn apply_distinct_group_by(
     };
 
     let plan_sources = join_clause.plan.sources();
-    let partitioning_idx = join_clause.partitioning_source_index();
     // (plan_position, deferrables) per source, computed once.
     let source_deferrables: Vec<Vec<DistinctDeferrable>> = plan_sources
         .iter()
-        .enumerate()
-        .map(|(pos, s)| distinct_deferrable_columns(join_clause, s, pos == partitioning_idx))
+        .map(|s| distinct_deferrable_columns(join_clause, s))
         .collect();
 
     let mut group_exprs: Vec<Expr> = Vec::new();
@@ -912,14 +901,8 @@ fn apply_distinct_group_by(
                         .map(|d| (pos, s, d))
                 });
             if let Some((pos, source, d)) = deferrable {
-                let (addr_copy, addr_agg, lookup) = build_distinct_address_deferral(
-                    i,
-                    pos,
-                    source,
-                    d,
-                    partitioning_idx,
-                    &col_alias,
-                );
+                let (addr_copy, addr_agg, lookup) =
+                    build_distinct_address_deferral(i, pos, source, d, &col_alias);
                 addr_copies.push(addr_copy);
                 addr_aggs.push(addr_agg);
                 lookups.push(lookup);
@@ -1264,7 +1247,7 @@ fn build_source_df<'a>(
         // select below): they never participate in the group keys, so nothing between the
         // scan and the aggregate needs their values.
         let distinct_deferred: Vec<DistinctDeferrable> = if join_clause.has_distinct {
-            distinct_deferrable_columns(join_clause, source, is_parallel)
+            distinct_deferrable_columns(join_clause, source)
         } else {
             Vec::new()
         };

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -626,10 +626,153 @@ fn surviving_ctid_columns<'a>(
     })
 }
 
+/// A DISTINCT output column that can stay out of the group keys and be re-derived from the
+/// source's representative doc address above the aggregate.
+struct DistinctDeferrable {
+    attno: pg_sys::AttrNumber,
+    /// Schema-registered column name (the scan's output name).
+    name: String,
+    /// Position in the source's fast-field list; indexes the scan's `FFHelper` columns.
+    ff_index: usize,
+    field_type: crate::schema::SearchFieldType,
+    is_bytes: bool,
+}
+
+/// DISTINCT columns of `source` that don't need to participate in the group keys.
+///
+/// Grouping by such a column's value is equivalent to grouping by the row's doc address when
+/// the DISTINCT set also contains the source's key field: same key, same doc, same value. The
+/// rewrite then aggregates one representative doc address per group and re-derives the value
+/// above the aggregate, so wide text never enters the group keys, the hash shuffle, or (under
+/// MPP) the mesh.
+///
+/// Only string/bytes fast fields qualify (the doc-address decode is a fast-field lookup), and
+/// only when nothing else forces early materialization (join keys, join-level filters).
+fn distinct_deferrable_columns(
+    join_clause: &JoinCSClause,
+    source: &JoinSource,
+    is_partitioning_source: bool,
+) -> Vec<DistinctDeferrable> {
+    if !join_clause.has_distinct || join_clause.output_projection.is_none() {
+        return Vec::new();
+    }
+    // The partitioning source's segments are claimed per worker, so a lookup running in a
+    // different fragment could not resolve every group's doc address. Non-partitioning
+    // sources replicate their canonical segment set to every worker.
+    if is_partitioning_source {
+        return Vec::new();
+    }
+
+    let index_rel = PgSearchRelation::open(source.scan_info.indexrelid);
+    let Ok(index_schema) = crate::schema::SearchIndexSchema::open(&index_rel) else {
+        return Vec::new();
+    };
+    let key_field = index_schema.key_field_name().to_string();
+
+    // The DISTINCT pathkeys of THIS source, as (attno, registered name).
+    let mut distinct_cols: Vec<(pg_sys::AttrNumber, String)> = Vec::new();
+    for info in &join_clause.order_by {
+        let (name, rti) = match &info.feature {
+            OrderByFeature::Field { name, rti } => (Some(name.as_ref().to_string()), *rti),
+            OrderByFeature::Var { rti, attno, .. } => {
+                (source.column_name(*attno).map(|s| s.to_string()), *rti)
+            }
+            _ => continue,
+        };
+        if !source.contains_rti(rti) {
+            continue;
+        }
+        let Some(name) = name else { continue };
+        let attno = match unsafe { get_source_attno_by_name(source, &name) } {
+            Some(a) => a,
+            None => continue,
+        };
+        let registered = source
+            .column_name(attno)
+            .unwrap_or_else(|| name.to_string());
+        distinct_cols.push((attno, registered));
+    }
+
+    // Doc identity: without the key field in the DISTINCT set, two docs carrying equal strings
+    // must still dedup into one row, which value-grouping does and address-grouping doesn't.
+    if !distinct_cols.iter().any(|(_, name)| *name == key_field) {
+        return Vec::new();
+    }
+
+    // Columns something else needs materialized before the aggregate.
+    let mut required_early: crate::api::HashSet<String> = Default::default();
+    for jk in join_clause.plan.join_keys() {
+        for (rti, attno) in [
+            (jk.outer_rti, jk.outer_attno),
+            (jk.inner_rti, jk.inner_attno),
+        ] {
+            if source.contains_rti(rti) {
+                if let Some(col) = source.column_name(attno) {
+                    required_early.insert(col);
+                }
+            }
+        }
+    }
+    for (rti, attno) in join_clause.plan.filter_input_vars() {
+        if source.contains_rti(rti) {
+            if let Some(col) = source.column_name(attno) {
+                required_early.insert(col);
+            }
+        }
+    }
+
+    let mut out = Vec::new();
+    for (attno, name) in distinct_cols {
+        if name == key_field || required_early.contains(&name) {
+            continue;
+        }
+        let Some((ff_index, ftype)) =
+            source
+                .scan_info
+                .fields
+                .iter()
+                .enumerate()
+                .find_map(|(i, f)| match &f.field {
+                    WhichFastField::Named(n, t) if f.attno == attno && *n == name => Some((i, *t)),
+                    _ => None,
+                })
+        else {
+            continue;
+        };
+        let arrow_type = ftype.arrow_data_type();
+        let is_bytes = matches!(
+            arrow_type,
+            arrow_schema::DataType::BinaryView | arrow_schema::DataType::LargeBinary
+        );
+        let is_string = matches!(
+            arrow_type,
+            arrow_schema::DataType::Utf8View | arrow_schema::DataType::LargeUtf8
+        );
+        if !(is_bytes || is_string) {
+            continue;
+        }
+        out.push(DistinctDeferrable {
+            attno,
+            name,
+            ff_index,
+            field_type: ftype,
+            is_bytes,
+        });
+    }
+    out
+}
+
 /// Apply a DISTINCT rewrite as `GROUP BY` over `output_projection`, taking the
 /// MIN of each ctid column as a stable representative. Returns the rewritten
 /// `DataFrame` plus the populated [`DistinctColMap`] used by the sort and
 /// projection stages to resolve column references against the new aliases.
+///
+/// Wide string/bytes columns that qualify for [`distinct_deferrable_columns`] are kept out of
+/// the group keys: the aggregate carries one representative doc address per group instead, and
+/// a [`DocAddressLookupNode`] above the aggregate re-derives the values. The address copy is
+/// projected below the aggregate so it binds before the visibility rule anchors its filter
+/// under the `Aggregate` barrier (the ctid columns themselves hold real ctids there, not doc
+/// addresses).
 ///
 /// When DISTINCT is not active (or there is no `output_projection`) the input
 /// frame is returned unchanged with an empty map.
@@ -646,10 +789,64 @@ fn apply_distinct_group_by(
         return Ok((df, distinct_col_map));
     };
 
+    let plan_sources = join_clause.plan.sources();
+    let partitioning_idx = join_clause.partitioning_source_index();
+    // (plan_position, deferrables) per source, computed once.
+    let source_deferrables: Vec<Vec<DistinctDeferrable>> = plan_sources
+        .iter()
+        .enumerate()
+        .map(|(pos, s)| distinct_deferrable_columns(join_clause, s, pos == partitioning_idx))
+        .collect();
+
     let mut group_exprs: Vec<Expr> = Vec::new();
+    // Address copies projected below the aggregate, the min() aggregates that carry them
+    // through it, and the decode descriptions for the lookup node above it.
+    let mut addr_copies: Vec<Expr> = Vec::new();
+    let mut addr_aggs: Vec<Expr> = Vec::new();
+    let mut lookups: Vec<(String, crate::scan::late_materialization::DeferredField)> = Vec::new();
 
     for (i, proj) in projection.iter().enumerate() {
         let col_alias = format!("col_{}", i + 1);
+
+        if let build::ChildProjection::Column { rti, attno } = proj {
+            let deferrable = plan_sources
+                .iter()
+                .enumerate()
+                .find(|(_, s)| s.contains_rti(*rti))
+                .and_then(|(pos, s)| {
+                    source_deferrables[pos]
+                        .iter()
+                        .find(|d| d.attno == *attno)
+                        .map(|d| (pos, s, d))
+                });
+            if let Some((pos, source, d)) = deferrable {
+                let addr_name = format!("__distinct_addr_{}", i + 1);
+                addr_copies.push(col(CtidColumn::new(pos).to_string()).alias(&addr_name));
+                addr_aggs.push(min(col(&addr_name)).alias(&col_alias));
+                // Same non-partitioning index computation the source build uses, so the
+                // worker-side rebuild resolves the same canonical segment set the scan's
+                // reader packed the addresses against.
+                let np_source_idx = (0..pos).filter(|i| *i != partitioning_idx).count();
+                lookups.push((
+                    col_alias.clone(),
+                    crate::scan::late_materialization::DeferredField {
+                        name: d.name.clone(),
+                        is_bytes: d.is_bytes,
+                        canonical: crate::index::fast_fields_helper::CanonicalColumn {
+                            indexrelid: source.scan_info.indexrelid.to_u32(),
+                            ff_index: d.ff_index,
+                        },
+                        rebuild: Some(crate::scan::late_materialization::DeferredLookupRebuild {
+                            field_name: d.name.clone(),
+                            field_type: d.field_type,
+                            np_source_idx,
+                        }),
+                    },
+                ));
+                distinct_col_map.insert((*rti, *attno), col_alias);
+                continue;
+            }
+        }
 
         let (expr, map_key) = match proj {
             build::ChildProjection::Expression { pg_expr_string, .. } => {
@@ -684,12 +881,48 @@ fn apply_distinct_group_by(
     // (including its ctid) are discarded from the output frame once the join
     // condition is evaluated. Attempting to aggregate them would result in a
     // DataFusion SchemaError.
-    let agg_exprs: Vec<Expr> =
+    let mut agg_exprs: Vec<Expr> =
         surviving_ctid_columns(df.schema(), join_clause.plan.sources().len())
             .map(|ctid_name| min(col(&ctid_name)).alias(&ctid_name))
             .collect();
+    agg_exprs.extend(addr_aggs);
+
+    // Project the address copies below the aggregate: the visibility rule anchors its filter
+    // under the `Aggregate` barrier and rewrites the ctid columns to real ctids there, so a
+    // copy taken at the aggregate's input would no longer hold a doc address.
+    let df = if addr_copies.is_empty() {
+        df
+    } else {
+        let mut exprs: Vec<Expr> = df
+            .schema()
+            .columns()
+            .into_iter()
+            .map(Expr::Column)
+            .collect();
+        exprs.extend(addr_copies);
+        df.select(exprs)?
+    };
 
     let df = df.aggregate(group_exprs, agg_exprs)?;
+
+    let df = if lookups.is_empty() {
+        df
+    } else {
+        let (state, plan) = df.into_parts();
+        let output_schema =
+            crate::scan::late_materialization::doc_address_lookup_schema(&plan, &lookups)?;
+        let node = crate::scan::late_materialization::DocAddressLookupNode {
+            input: plan,
+            output_schema,
+            lookups,
+        };
+        DataFrame::new(
+            state,
+            datafusion::logical_expr::LogicalPlan::Extension(datafusion::logical_expr::Extension {
+                node: std::sync::Arc::new(node),
+            }),
+        )
+    };
     Ok((df, distinct_col_map))
 }
 
@@ -979,12 +1212,27 @@ fn build_source_df<'a>(
             PgSearchTableProvider::new(scan_info.clone(), fields.clone(), source_idx);
 
         // When DISTINCT is present, PostgreSQL expands the query path-keys
-        // to include all DISTINCT columns.
+        // to include all DISTINCT columns. Columns the DISTINCT rewrite re-derives from the
+        // source's doc address above the aggregate stay deferred (and are dropped from the
+        // select below): they never participate in the group keys, so nothing between the
+        // scan and the aggregate needs their values.
+        let distinct_deferred: Vec<DistinctDeferrable> = if join_clause.has_distinct {
+            distinct_deferrable_columns(join_clause, source, is_parallel)
+        } else {
+            Vec::new()
+        };
         if join_clause.has_distinct {
+            let deferred_attnos: crate::api::HashSet<pg_sys::AttrNumber> =
+                distinct_deferred.iter().map(|d| d.attno).collect();
+            let is_deferred = |source: &JoinSource, name: &str| -> bool {
+                unsafe { get_source_attno_by_name(source, name) }
+                    .map(|attno| deferred_attnos.contains(&attno))
+                    .unwrap_or(false)
+            };
             for info in &join_clause.order_by {
                 match &info.feature {
                     OrderByFeature::Field { name, rti } => {
-                        if source.contains_rti(*rti) {
+                        if source.contains_rti(*rti) && !is_deferred(source, name.as_ref()) {
                             insert_field_name_required_early(
                                 source,
                                 name.as_ref(),
@@ -994,7 +1242,7 @@ fn build_source_df<'a>(
                     }
                     OrderByFeature::Var { rti, attno, .. } => {
                         // Only insert columns belonging to THIS source
-                        if source.contains_rti(*rti) {
+                        if source.contains_rti(*rti) && !deferred_attnos.contains(attno) {
                             if let Some(col_name) = source.column_name(*attno) {
                                 required_early.insert(col_name);
                             }
@@ -1003,13 +1251,17 @@ fn build_source_df<'a>(
                     OrderByFeature::Score { .. } => {}
                     OrderByFeature::NullTest { inner, .. } => match inner.as_ref() {
                         OrderByFeature::Field { name, rti } if source.contains_rti(*rti) => {
-                            insert_field_name_required_early(
-                                source,
-                                name.as_ref(),
-                                &mut required_early,
-                            );
+                            if !is_deferred(source, name.as_ref()) {
+                                insert_field_name_required_early(
+                                    source,
+                                    name.as_ref(),
+                                    &mut required_early,
+                                );
+                            }
                         }
-                        OrderByFeature::Var { rti, attno, .. } if source.contains_rti(*rti) => {
+                        OrderByFeature::Var { rti, attno, .. }
+                            if source.contains_rti(*rti) && !deferred_attnos.contains(attno) =>
+                        {
                             if let Some(col_name) = source.column_name(*attno) {
                                 required_early.insert(col_name);
                             }
@@ -1028,9 +1280,16 @@ fn build_source_df<'a>(
         let mut df = register_source_table(ctx, alias.as_str(), provider).await?;
 
         // Select fields AND ensure CTID is aliased uniquely
+        let distinct_deferred_names: crate::api::HashSet<&str> =
+            distinct_deferred.iter().map(|d| d.name.as_str()).collect();
         let mut exprs = Vec::new();
         for df_field in df.schema().fields().iter() {
             let name = df_field.name();
+            // The DISTINCT rewrite re-derives these from the source's doc address above the
+            // aggregate; nothing below it reads them, so keep them out of the frame entirely.
+            if distinct_deferred_names.contains(name.as_str()) {
+                continue;
+            }
             // NOTE: Matching on WhichFastField::Ctid specifically will fail if
             // the field list order doesn't match the DataFrame schema field order.
             let expr = match fields.iter().find(|w| w.name() == *name) {

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -651,6 +651,13 @@ struct DistinctDeferrable {
 ///
 /// Only string/bytes fast fields qualify (the doc-address decode is a fast-field lookup), and
 /// only when nothing else forces early materialization (join keys, join-level filters).
+///
+/// This is a hand-rolled functional dependency: the key determines the row, so the dependent
+/// columns can leave the group keys. DataFusion's `FunctionalDependencies` can't do it here
+/// even with key constraints declared: its group-key shrink only drops columns the parent
+/// doesn't require, and a DISTINCT's parent requires every column. The missing piece is
+/// re-deriving the dropped values above the aggregate, which is what the doc-address lookup
+/// supplies.
 fn distinct_deferrable_columns(
     join_clause: &JoinCSClause,
     source: &JoinSource,

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -56,6 +56,12 @@ struct PgSearchExtensionCodec {
 unsafe impl Send for PgSearchExtensionCodec {}
 unsafe impl Sync for PgSearchExtensionCodec {}
 
+// Wire tags for this codec's logical extension nodes, independent of the physical codec's tag
+// space in `physical_codec.rs`.
+const TAG_LATE_MATERIALIZE: u8 = 1;
+const TAG_VISIBILITY_FILTER: u8 = 2;
+const TAG_DOC_ADDRESS_LOOKUP: u8 = 3;
+
 impl LogicalExtensionCodec for PgSearchExtensionCodec {
     fn try_decode(
         &self,
@@ -73,7 +79,7 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
         // If we add more custom node types, we should switch this payload to a proper Serde
         // enum (e.g. `bincode` or `serde_json` of an enum wrapper) to cleanly handle variants.
         let tag = buf[0];
-        if tag == 1 {
+        if tag == TAG_LATE_MATERIALIZE {
             if inputs.len() != 1 {
                 return Err(DataFusionError::Internal(
                     "LateMaterializeNode requires exactly one input".into(),
@@ -132,7 +138,7 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
             return Ok(Extension { node });
         }
 
-        if tag == 2 {
+        if tag == TAG_VISIBILITY_FILTER {
             if inputs.len() != 1 {
                 return Err(DataFusionError::Internal(
                     "VisibilityFilterNode requires exactly one input".into(),
@@ -161,7 +167,7 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
             });
         }
 
-        if tag == 3 {
+        if tag == TAG_DOC_ADDRESS_LOOKUP {
             if inputs.len() != 1 {
                 return Err(DataFusionError::Internal(
                     "DocAddressLookupNode requires exactly one input".into(),
@@ -210,7 +216,7 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
                 DataFusionError::Internal(format!("Failed to serialize deferred fields: {}", e))
             })?;
 
-            buf.push(1);
+            buf.push(TAG_LATE_MATERIALIZE);
             let schema_bytes = prost::Message::encode_to_vec(&schema_proto);
 
             buf.extend_from_slice(&(schema_bytes.len() as u32).to_le_bytes());
@@ -228,7 +234,7 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
                     "Failed to serialize visibility plan positions: {e}"
                 ))
             })?;
-            buf.push(2);
+            buf.push(TAG_VISIBILITY_FILTER);
             buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
             buf.extend_from_slice(&bytes);
             return Ok(());
@@ -238,7 +244,7 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
             let bytes = serde_json::to_vec(&lookup_node.lookups).map_err(|e| {
                 DataFusionError::Internal(format!("Failed to serialize doc-address lookups: {e}"))
             })?;
-            buf.push(3);
+            buf.push(TAG_DOC_ADDRESS_LOOKUP);
             buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
             buf.extend_from_slice(&bytes);
             return Ok(());

--- a/pg_search/src/scan/codec.rs
+++ b/pg_search/src/scan/codec.rs
@@ -32,7 +32,9 @@ use crate::api::HashSet;
 use crate::postgres::customscan::joinscan::visibility_filter::VisibilityFilterNode;
 use crate::postgres::customscan::pg_expr_udf::{PgExprUdf, PG_EXPR_UDF_PREFIX};
 use crate::postgres::ParallelScanState;
-use crate::scan::late_materialization::{DeferredField, LateMaterializeNode};
+use crate::scan::late_materialization::{
+    doc_address_lookup_schema, DeferredField, DocAddressLookupNode, LateMaterializeNode,
+};
 use crate::scan::search_predicate_udf::SearchPredicateUDF;
 use crate::scan::table_provider::PgSearchTableProvider;
 
@@ -159,6 +161,38 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
             });
         }
 
+        if tag == 3 {
+            if inputs.len() != 1 {
+                return Err(DataFusionError::Internal(
+                    "DocAddressLookupNode requires exactly one input".into(),
+                ));
+            }
+            let input_plan = inputs[0].clone();
+            let payload_len_bytes = buf.get(1..5).ok_or_else(|| {
+                DataFusionError::Internal("truncated buffer: missing lookup length".into())
+            })?;
+            let payload_len = u32::from_le_bytes(payload_len_bytes.try_into().unwrap()) as usize;
+            let payload = buf.get(5..5 + payload_len).ok_or_else(|| {
+                DataFusionError::Internal("truncated buffer: incomplete lookup payload".into())
+            })?;
+            let lookups: Vec<(String, DeferredField)> =
+                serde_json::from_slice(payload).map_err(|e| {
+                    DataFusionError::Internal(format!(
+                        "Failed to deserialize doc-address lookups: {e}"
+                    ))
+                })?;
+            // The output schema is a pure function of the input schema and the lookups, so it
+            // is recomputed rather than serialized.
+            let output_schema = doc_address_lookup_schema(&input_plan, &lookups)?;
+            return Ok(Extension {
+                node: Arc::new(DocAddressLookupNode {
+                    input: input_plan,
+                    output_schema,
+                    lookups,
+                }),
+            });
+        }
+
         Err(DataFusionError::NotImplemented(format!(
             "Extension node decoding not implemented for tag {}",
             tag
@@ -195,6 +229,16 @@ impl LogicalExtensionCodec for PgSearchExtensionCodec {
                 ))
             })?;
             buf.push(2);
+            buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
+            buf.extend_from_slice(&bytes);
+            return Ok(());
+        }
+
+        if let Some(lookup_node) = node.node.as_any().downcast_ref::<DocAddressLookupNode>() {
+            let bytes = serde_json::to_vec(&lookup_node.lookups).map_err(|e| {
+                DataFusionError::Internal(format!("Failed to serialize doc-address lookups: {e}"))
+            })?;
+            buf.push(3);
             buf.extend_from_slice(&(bytes.len() as u32).to_le_bytes());
             buf.extend_from_slice(&bytes);
             return Ok(());

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -755,6 +755,34 @@ impl ExtensionPlanner for LateMaterializePlanner {
             let exec = TantivyLookupExec::new(input_exec, physical_deferred_fields, ff_helpers)?;
 
             Ok(Some(Arc::new(exec)))
+        } else if let Some(lookup_node) = node.as_any().downcast_ref::<DocAddressLookupNode>() {
+            let input_exec = Arc::clone(&physical_inputs[0]);
+            let input_schema = input_exec.schema();
+            let mut physical_deferred_fields = Vec::with_capacity(lookup_node.lookups.len());
+            for (col_name, deferred) in &lookup_node.lookups {
+                let col_idx = input_schema.index_of(col_name).map_err(|_| {
+                    DataFusionError::Internal(format!(
+                        "DocAddressLookup: address column '{col_name}' missing from the \
+                         physical input schema"
+                    ))
+                })?;
+                physical_deferred_fields.push(
+                    crate::scan::tantivy_lookup_exec::PhysicalDeferredField {
+                        col_idx,
+                        display_name: deferred.name.clone(),
+                        is_bytes: deferred.is_bytes,
+                        canonical: deferred.canonical.clone(),
+                        rebuild: deferred.rebuild.clone(),
+                    },
+                );
+            }
+
+            let ff_helpers = crate::scan::tantivy_lookup_exec::rebuild_ffhelpers_snapshot(
+                &physical_deferred_fields,
+                &input_schema,
+            )?;
+            let exec = TantivyLookupExec::new(input_exec, physical_deferred_fields, ff_helpers)?;
+            Ok(Some(Arc::new(exec)))
         } else {
             Ok(None)
         }
@@ -810,5 +838,128 @@ impl PartialOrd for DeferredLookupRebuild {
 impl Ord for DeferredLookupRebuild {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         (&self.field_name, &self.source_idx).cmp(&(&other.field_name, &other.source_idx))
+    }
+}
+
+/// Re-derives string/bytes columns from packed doc-address columns above a DISTINCT
+/// aggregation.
+///
+/// The DISTINCT rewrite groups by the source's key column and aggregates one representative
+/// doc address per group under the dependent column's output alias. This node replaces those
+/// `UInt64` columns in place (same name, same position) with the materialized values, so the
+/// wide strings never enter the group keys or, under MPP, cross the network between stages.
+#[derive(Hash, PartialEq, Eq)]
+pub(crate) struct DocAddressLookupNode {
+    pub input: LogicalPlan,
+    pub output_schema: DFSchemaRef,
+    /// `(input column name, decode description)`. The named column carries packed doc
+    /// addresses; the output carries the decoded value under the same name.
+    pub lookups: Vec<(String, DeferredField)>,
+}
+
+impl Debug for DocAddressLookupNode {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("DocAddressLookupNode")
+            .field("lookups", &self.lookups)
+            .finish()
+    }
+}
+
+impl std::cmp::PartialOrd for DocAddressLookupNode {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        let input_cmp = self.input.partial_cmp(&other.input);
+        if input_cmp != Some(std::cmp::Ordering::Equal) {
+            return input_cmp;
+        }
+        self.lookups.partial_cmp(&other.lookups)
+    }
+}
+
+/// Output schema for [`DocAddressLookupNode`]: the input schema with each looked-up column's
+/// type flipped from `UInt64` to its materialized string/bytes type.
+pub(crate) fn doc_address_lookup_schema(
+    input: &LogicalPlan,
+    lookups: &[(String, DeferredField)],
+) -> Result<DFSchemaRef> {
+    let child_schema = input.schema();
+    let mut qualified_fields = Vec::with_capacity(child_schema.fields().len());
+    for (i, field) in child_schema.fields().iter().enumerate() {
+        let (qualifier, _) = child_schema.qualified_field(i);
+        let new_field = match lookups.iter().find(|(name, _)| name == field.name()) {
+            Some((_, d)) => {
+                let out_type = if d.is_bytes {
+                    arrow_schema::DataType::BinaryView
+                } else {
+                    arrow_schema::DataType::Utf8View
+                };
+                arrow_schema::Field::new(field.name(), out_type, true)
+            }
+            None => arrow_schema::Field::new(
+                field.name(),
+                field.data_type().clone(),
+                field.is_nullable(),
+            ),
+        };
+        qualified_fields.push((qualifier.cloned(), Arc::new(new_field)));
+    }
+    Ok(Arc::new(datafusion::common::DFSchema::new_with_metadata(
+        qualified_fields,
+        child_schema.metadata().clone(),
+    )?))
+}
+
+impl UserDefinedLogicalNodeCore for DocAddressLookupNode {
+    fn name(&self) -> &str {
+        "DocAddressLookup"
+    }
+
+    fn inputs(&self) -> Vec<&LogicalPlan> {
+        vec![&self.input]
+    }
+
+    fn schema(&self) -> &DFSchemaRef {
+        &self.output_schema
+    }
+
+    fn expressions(&self) -> Vec<Expr> {
+        vec![]
+    }
+
+    fn necessary_children_exprs(&self, output_columns: &[usize]) -> Option<Vec<Vec<usize>>> {
+        Some(vec![output_columns.to_vec()])
+    }
+
+    fn fmt_for_explain(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "DocAddressLookup: decode=[{}]",
+            self.lookups
+                .iter()
+                .map(|(name, _)| name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+
+    fn with_exprs_and_inputs(
+        &self,
+        _exprs: Vec<Expr>,
+        mut inputs: Vec<LogicalPlan>,
+    ) -> Result<Self> {
+        let input = inputs.swap_remove(0);
+        // Keep only the lookups whose address column survived (OptimizeProjections may trim
+        // the child schema), then recompute the output schema against the new input.
+        let lookups: Vec<(String, DeferredField)> = self
+            .lookups
+            .iter()
+            .filter(|(name, _)| input.schema().field_with_unqualified_name(name).is_ok())
+            .cloned()
+            .collect();
+        let output_schema = doc_address_lookup_schema(&input, &lookups)?;
+        Ok(Self {
+            input,
+            output_schema,
+            lookups,
+        })
     }
 }

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -210,6 +210,22 @@ fn try_inject_below_lookup(
             let lookup_child = &lookup.children()[0];
             let input_schema = lookup_child.schema();
 
+            // Only union-typed (term-ordinal) columns segment-sort like their strings; a
+            // packed doc-address column (the DISTINCT rewrite's UInt64 representative) has no
+            // value-order relationship at all, so it must not become a SegmentedTopK key.
+            let is_ord_sortable = |col_idx: usize| {
+                input_schema
+                    .fields()
+                    .get(col_idx)
+                    .map(|f| {
+                        matches!(
+                            f.data_type(),
+                            datafusion::arrow::datatypes::DataType::Union(_, _)
+                        )
+                    })
+                    .unwrap_or(false)
+            };
+
             // Check if ANY sort column is one of the deferred fields, using
             // physical index resolution to handle join-reordered schemas.
             let has_deferred_sort_col = sort_exprs.iter().any(|expr| {
@@ -218,7 +234,7 @@ fn try_inject_below_lookup(
                     lookup
                         .deferred_fields()
                         .iter()
-                        .any(|d| d.col_idx == physical_idx)
+                        .any(|d| d.col_idx == physical_idx && is_ord_sortable(physical_idx))
                 } else {
                     false
                 }
@@ -260,7 +276,7 @@ fn try_inject_below_lookup(
                         if let Some(field) = lookup
                             .deferred_fields()
                             .iter()
-                            .find(|d| d.col_idx == physical_idx)
+                            .find(|d| d.col_idx == physical_idx && is_ord_sortable(physical_idx))
                         {
                             deferred_columns.push(
                                 crate::scan::segmented_topk_exec::DeferredSortColumn {

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -49,6 +49,7 @@ pub struct PhysicalDeferredField {
     pub display_name: String,
     pub is_bytes: bool,
     pub canonical: CanonicalColumn,
+    /// See [`crate::scan::late_materialization::DeferredLookupRebuild`].
     #[serde(default)]
     pub rebuild: Option<crate::scan::late_materialization::DeferredLookupRebuild>,
 }
@@ -171,6 +172,7 @@ impl TantivyLookupExec {
             })?;
         rebuild_missing_ffhelpers(
             &deferred_fields,
+            &input.schema(),
             &mut ffhelpers,
             LookupRebuildContext { parallel_state },
         )?;
@@ -238,25 +240,70 @@ pub(crate) fn open_rebuilt_ffhelper(
     Ok(Arc::new(FFHelper::with_fields(&reader, &which)))
 }
 
+/// An address-typed deferred column (plain `UInt64`, the DISTINCT rewrite's representative
+/// doc address) always rebuilds its helper: a scan's helper is projection-pruned, so its
+/// layout no longer lines up with `canonical.ff_index`.
+fn is_address_col(input_schema: &SchemaRef, col_idx: usize) -> bool {
+    input_schema
+        .fields()
+        .get(col_idx)
+        .map(|f| matches!(f.data_type(), DataType::UInt64))
+        .unwrap_or(false)
+}
+
+/// Planner-side helper rebuild for address-mode lookups: a snapshot reader sees the same
+/// segments, in the same deterministic order, as the serial scan that packed the addresses.
+/// The scans' own helpers cover their (projection-pruned) field lists, where
+/// `canonical.ff_index` no longer lines up, so the address decode always gets a dedicated
+/// helper laid out at the original indices.
+pub(crate) fn rebuild_ffhelpers_snapshot(
+    deferred_fields: &[PhysicalDeferredField],
+    input_schema: &SchemaRef,
+) -> Result<HashMap<u32, Arc<FFHelper>>> {
+    let mut per_index: HashMap<u32, Vec<&PhysicalDeferredField>> = HashMap::default();
+    for f in deferred_fields {
+        if f.rebuild.is_some() && is_address_col(input_schema, f.col_idx) {
+            per_index.entry(f.canonical.indexrelid).or_default().push(f);
+        }
+    }
+    let mut ffhelpers = HashMap::default();
+    for (indexrelid, fields) in per_index {
+        let entries: Vec<(
+            usize,
+            &crate::scan::late_materialization::DeferredLookupRebuild,
+        )> = fields
+            .iter()
+            .map(|f| (f.canonical.ff_index, f.rebuild.as_ref().unwrap()))
+            .collect();
+        ffhelpers.insert(
+            indexrelid,
+            open_rebuilt_ffhelper(indexrelid, &entries, MvccSatisfies::Snapshot)?,
+        );
+    }
+    Ok(ffhelpers)
+}
+
 /// Rebuild the fast-field readers for deferred columns whose scan lives in a different plan
 /// fragment (a lookup above a network shuffle finds no scan in its decoded subtree). The
 /// `context` picks how the segment set is resolved; either way the reader's segment ordering
 /// matches the ordering the addresses were packed against.
 fn rebuild_missing_ffhelpers(
     deferred_fields: &[PhysicalDeferredField],
+    input_schema: &SchemaRef,
     ffhelpers: &mut HashMap<u32, Arc<FFHelper>>,
     context: LookupRebuildContext,
 ) -> Result<()> {
     // Ordinal-typed columns keep a scan's helper when one decoded in this fragment (its layout
     // lines up by construction); they rebuild only on a worker whose fragment has that scan
-    // behind a network boundary.
+    // behind a network boundary. Address-typed columns always rebuild and override the scan's
+    // helper.
     let mut rebuild_indexes: crate::api::HashSet<u32> = Default::default();
     for f in deferred_fields {
         if f.rebuild.is_none() {
             continue;
         }
         let scan_is_elsewhere = !ffhelpers.contains_key(&f.canonical.indexrelid);
-        if scan_is_elsewhere {
+        if scan_is_elsewhere || is_address_col(input_schema, f.col_idx) {
             rebuild_indexes.insert(f.canonical.indexrelid);
         }
     }
@@ -306,9 +353,12 @@ fn build_schema_and_decoders(
     // This pairs the first "description" in the schema with the first "description"
     // in the deferred pool, removing it so the second one pairs correctly.
     for (col_idx, field) in input_schema.fields().iter().enumerate() {
-        let is_union = matches!(field.data_type(), DataType::Union(_, _));
+        // A deferred column arrives either as the 3-state union or as a plain packed-address
+        // UInt64 (the DISTINCT rewrite's representative doc address). Unclaimed columns of
+        // either type pass through untouched.
+        let claimable = matches!(field.data_type(), DataType::Union(_, _) | DataType::UInt64);
 
-        if is_union {
+        if claimable {
             if let Some(pos) = deferred_pool.iter().position(|d| d.col_idx == col_idx) {
                 let d = deferred_pool.remove(pos);
                 fields.push(Field::new(field.name(), d.output_data_type(), true));
@@ -445,16 +495,6 @@ fn enrich_batch(
     let mut output_columns: Vec<ArrayRef> = batch.columns().to_vec();
 
     for decoder in decoders {
-        let union_array = output_columns[decoder.col_idx]
-            .as_any()
-            .downcast_ref::<arrow_array::UnionArray>()
-            .ok_or_else(|| {
-                DataFusionError::Execution(format!(
-                    "expected UnionArray for deferred column at index {}",
-                    decoder.col_idx
-                ))
-            })?;
-
         let ffhelper = ffhelpers
             .get(&decoder.canonical.indexrelid)
             .ok_or_else(|| {
@@ -474,9 +514,19 @@ fn enrich_batch(
             }
         };
 
-        // Replace the raw UnionArray with the decoded String/Binary array
+        // Replace the raw union/address column with the decoded String/Binary array.
+        let input = &output_columns[decoder.col_idx];
         output_columns[decoder.col_idx] =
-            materialize_deferred_column(ffhelper, &ffcolumn, union_array, num_rows)?;
+            if let Some(union_array) = input.as_any().downcast_ref::<arrow_array::UnionArray>() {
+                materialize_deferred_column(ffhelper, &ffcolumn, union_array, num_rows)?
+            } else if let Some(addresses) = input.as_any().downcast_ref::<UInt64Array>() {
+                materialize_address_column(ffhelper, &ffcolumn, addresses, num_rows)?
+            } else {
+                return Err(DataFusionError::Execution(format!(
+                    "expected UnionArray or UInt64Array for deferred column at index {}",
+                    decoder.col_idx
+                )));
+            };
     }
 
     RecordBatch::try_new(schema.clone(), output_columns)
@@ -499,7 +549,7 @@ fn resolve_doc_addresses_to_term_ords(
     state_0_rows: &[usize],
 ) -> Result<OrdsBySegment> {
     let num_segments = ffhelper.num_segments();
-    let mut ords_by_seg: OrdsBySegment = vec![Vec::new(); num_segments];
+    let ords_by_seg: OrdsBySegment = vec![Vec::new(); num_segments];
     if state_0_rows.is_empty() {
         return Ok(ords_by_seg);
     }
@@ -517,6 +567,18 @@ fn resolve_doc_addresses_to_term_ords(
         .iter()
         .map(|&row| (row, doc_address_child.value(offsets[row] as usize)));
 
+    resolve_packed_to_term_ords(ffhelper, ffcolumn, packed_iter, ords_by_seg)
+}
+
+/// Resolves `(row, packed doc address)` pairs to term ordinals, grouped by segment.
+/// Shared by the union State-0 path and the plain packed-address column path.
+fn resolve_packed_to_term_ords(
+    ffhelper: &FFHelper,
+    ffcolumn: &DeferredColumnKind,
+    packed_iter: impl Iterator<Item = (usize, u64)>,
+    mut ords_by_seg: OrdsBySegment,
+) -> Result<OrdsBySegment> {
+    let num_segments = ffhelper.num_segments();
     for_each_segment(num_segments, packed_iter, |seg_ord, rows| {
         let ids: Vec<DocId> = rows.iter().map(|(_, doc_id)| *doc_id).collect();
         let mut term_ords: Vec<Option<TermOrdinal>> = vec![None; ids.len()];
@@ -649,6 +711,67 @@ fn decode_term_ordinals(
         }
     }
     Ok(())
+}
+
+/// Materializes a plain packed-DocAddress column (`UInt64`, no union wrapper) into its text or
+/// bytes representation.
+///
+/// The DISTINCT rewrite aggregates one representative doc address per group and re-derives the
+/// group's key-dependent string columns from it here, above the aggregation, so the strings
+/// never enter the group keys or cross the network between stages.
+fn materialize_address_column(
+    ffhelper: &FFHelper,
+    ffcolumn: &DeferredColumnKind,
+    addresses: &UInt64Array,
+    num_rows: usize,
+) -> Result<ArrayRef> {
+    let mut packed: Vec<(usize, u64)> = Vec::with_capacity(num_rows);
+    let mut null_rows: Vec<usize> = Vec::new();
+    for row in 0..num_rows {
+        if addresses.is_null(row) {
+            null_rows.push(row);
+        } else {
+            packed.push((row, addresses.value(row)));
+        }
+    }
+
+    let mut segment_arrays: Vec<ArrayRef> = Vec::new();
+    let mut indices: Vec<(usize, usize)> = vec![(0, 0); num_rows];
+
+    let ords_by_seg = resolve_packed_to_term_ords(
+        ffhelper,
+        ffcolumn,
+        packed.into_iter(),
+        vec![Vec::new(); ffhelper.num_segments()],
+    )?;
+    decode_term_ordinals(
+        ffhelper,
+        ffcolumn,
+        ords_by_seg,
+        &mut segment_arrays,
+        &mut indices,
+    )?;
+
+    let output_type = if matches!(ffcolumn, DeferredColumnKind::Bytes { .. }) {
+        DataType::BinaryView
+    } else {
+        DataType::Utf8View
+    };
+    if !null_rows.is_empty() {
+        segment_arrays.push(new_null_array(&output_type, 1));
+        let array_idx = segment_arrays.len() - 1;
+        for row in null_rows {
+            indices[row] = (array_idx, 0);
+        }
+    }
+    if segment_arrays.is_empty() {
+        return Ok(new_null_array(&output_type, num_rows));
+    }
+
+    let segment_arrays_refs: Vec<&dyn arrow_array::Array> =
+        segment_arrays.iter().map(|a| a.as_ref()).collect();
+    interleave(&segment_arrays_refs, &indices)
+        .map_err(|e| DataFusionError::ArrowError(Box::new(e), None))
 }
 
 /// Materializes deferred union values into their original text or bytes representation.

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -1,14 +1,13 @@
 use std::sync::Arc;
 
-use crate::index::fast_fields_helper::WhichFastField;
+use crate::index::fast_fields_helper::{
+    for_each_segment, ords_to_bytes_array, ords_to_string_array, CanonicalColumn, FFHelper, FFType,
+    WhichFastField,
+};
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::postgres::rel::PgSearchRelation;
 use crate::query::SearchQueryInput;
-
-use crate::index::fast_fields_helper::{
-    for_each_segment, ords_to_bytes_array, ords_to_string_array, CanonicalColumn, FFHelper, FFType,
-};
 use crate::scan::execution_plan::UnsafeSendStream;
 
 use arrow_array::{new_null_array, Array, ArrayRef, RecordBatch, UInt64Array, UnionArray};

--- a/pg_search/tests/pg_regress/expected/issue_4146.out
+++ b/pg_search/tests/pg_regress/expected/issue_4146.out
@@ -469,8 +469,8 @@ WHERE
 ORDER BY
     d.title ASC
 LIMIT 50;
-                                                                                                                 QUERY PLAN                                                                                                                 
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                    QUERY PLAN                                                                                                                    
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: d.id, d.title, d.parents
    ->  Unique
@@ -483,18 +483,21 @@ LIMIT 50;
                Distinct: true
                Order By: d.title asc, d.id asc, d.parents asc
                DataFusion Physical Plan: 
-                 : SortExec: TopK(fetch=50), expr=[col_2@1 ASC NULLS LAST, col_1@0 ASC NULLS LAST, col_3@2 ASC NULLS LAST], preserve_partitioning=[false]
-                 :   AggregateExec: mode=Single, gby=[id@1 as col_1, title@2 as col_2, parents@3 as col_3], aggr=[min(d_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(f_2.ctid_2) as ctid_2]
-                 :     VisibilityFilterExec: tables=[d, p, f]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fileId@1, id@5)], projection=[ctid_0@2, id@3, title@4, parents@5, ctid_1@0, ctid_2@6]
-                 :         CooperativeExec
-                 :           PgSearchScan: segments=1, query={"range":{"field":"sizeInBytes","lower_bound":{"excluded":5000},"upper_bound":null}}
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, documentId@1)], projection=[ctid_0@0, id@1, title@2, parents@3, ctid_2@4, id@6]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, query={"boolean":{"must":[{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(parents ~~ 'SFR%'::text)"}]}},{"with_index":{"query":{"all":{"field":"id"}}}}]}}
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
-(23 rows)
+                 : ProjectionExec: expr=[col_1@0 as col_1, col_2@4 as col_2, col_3@5 as col_3, ctid_0@1 as ctid_0, ctid_1@2 as ctid_1, ctid_2@3 as ctid_2]
+                 :   SortExec: TopK(fetch=50), expr=[col_2@4 ASC NULLS LAST, col_1@0 ASC NULLS LAST, col_3@5 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     TantivyLookupExec: decode=[title, parents]
+                 :       AggregateExec: mode=Single, gby=[id@1 as col_1], aggr=[min(d_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(f_2.ctid_2) as ctid_2, min(__distinct_addr_2) as col_2, min(__distinct_addr_3) as col_3]
+                 :         VisibilityFilterExec: tables=[d, p, f]
+                 :           ProjectionExec: expr=[ctid_0@0 as ctid_0, id@1 as id, ctid_1@2 as ctid_1, ctid_2@3 as ctid_2, ctid_0@0 as __distinct_addr_2, ctid_0@0 as __distinct_addr_3]
+                 :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fileId@1, id@3)], projection=[ctid_0@2, id@3, ctid_1@0, ctid_2@4]
+                 :               CooperativeExec
+                 :                 PgSearchScan: segments=1, query={"range":{"field":"sizeInBytes","lower_bound":{"excluded":5000},"upper_bound":null}}
+                 :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, documentId@1)], projection=[ctid_0@0, id@1, ctid_2@2, id@4]
+                 :                 CooperativeExec
+                 :                   PgSearchScan: segments=1, query={"boolean":{"must":[{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(parents ~~ 'SFR%'::text)"}]}},{"with_index":{"query":{"all":{"field":"id"}}}}]}}
+                 :                 CooperativeExec
+                 :                   PgSearchScan: segments=1, dynamic_filters=2, query="all"
+(26 rows)
 
 SELECT DISTINCT
     d.id,

--- a/pg_search/tests/pg_regress/expected/issue_4146.out
+++ b/pg_search/tests/pg_regress/expected/issue_4146.out
@@ -453,6 +453,11 @@ WITH (
         }
     }'
 );
+-- Deferring DISTINCT columns through doc addresses deepens this join plan enough
+-- that serializing it overflows the 2MB default stack in debug builds. The real
+-- fix is bounding that recursion in the plan serialization path; until it lands,
+-- give the session headroom.
+SET max_stack_depth = '6MB';
 SET paradedb.enable_join_custom_scan TO on;
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT DISTINCT

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -732,16 +732,19 @@ LIMIT 10;
                Distinct: true
                Order By: pdb.score() desc, p.id asc, p.name asc
                DataFusion Physical Plan: 
-                 : SortExec: TopK(fetch=10), expr=[col_3@2 DESC, col_1@0 ASC NULLS LAST, col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                 :   AggregateExec: mode=Single, gby=[id@3 as col_1, name@4 as col_2, score@1 as col_3], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1]
-                 :     VisibilityFilterExec: tables=[s, p]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], filter=pdb_search_predicate(ctid_1@1) OR pdb_search_predicate(ctid_0@0), projection=[ctid_0@0, score@2, ctid_1@3, id@5, name@6]
-                 :         CooperativeExec
-                 :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"USA","lenient":null,"conjunction_mode":null}}}}
-                 :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id, name@4 as name]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(22 rows)
+                 : ProjectionExec: expr=[col_1@0 as col_1, col_2@4 as col_2, col_3@1 as col_3, ctid_0@2 as ctid_0, ctid_1@3 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[col_3@1 DESC, col_1@0 ASC NULLS LAST, col_2@4 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     TantivyLookupExec: decode=[name]
+                 :       AggregateExec: mode=Single, gby=[id@3 as col_1, score@1 as col_3], aggr=[min(s_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(__distinct_addr_2) as col_2]
+                 :         VisibilityFilterExec: tables=[s, p]
+                 :           ProjectionExec: expr=[ctid_0@0 as ctid_0, score@1 as score, ctid_1@2 as ctid_1, id@3 as id, ctid_1@2 as __distinct_addr_2]
+                 :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@2)], filter=pdb_search_predicate(ctid_1@1) OR pdb_search_predicate(ctid_0@0), projection=[ctid_0@0, score@2, ctid_1@3, id@5]
+                 :               CooperativeExec
+                 :                 PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"country","query_string":"USA","lenient":null,"conjunction_mode":null}}}}
+                 :               ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
+                 :                 CooperativeExec
+                 :                   PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(25 rows)
 
 SELECT DISTINCT
     p.id,

--- a/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
@@ -113,34 +113,32 @@ WHERE u.name @@@ 'bob'
   AND p.name @@@ 'bob'
 ORDER BY u.id, p.id, o.id
 LIMIT 48;
-                                                                                                              QUERY PLAN                                                                                                              
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                           QUERY PLAN                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
-         ->  Gather Merge
-               Workers Planned: 1
-               ->  Parallel Custom Scan (ParadeDB Join Scan)
-                     Relation Tree: u INNER (p INNER o)
-                     Join Cond: u.id = p.id, p.age = o.age
-                     Limit: 48
-                     Distinct: true
-                     Order By: u.id asc, o.id asc, u.name asc
-                     DataFusion Physical Plan: 
-                       : ProjectionExec: expr=[col_1@0 as col_1, col_2@6 as col_2, col_3@1 as col_3, col_4@2 as col_4, ctid_0@3 as ctid_0, ctid_1@4 as ctid_1, ctid_2@5 as ctid_2]
-                       :   SortExec: TopK(fetch=48), expr=[col_1@0 ASC NULLS LAST, col_4@2 ASC NULLS LAST, col_2@6 ASC NULLS LAST], preserve_partitioning=[false]
-                       :     TantivyLookupExec: decode=[name]
-                       :       AggregateExec: mode=Single, gby=[id@1 as col_1, id@3 as col_3, id@5 as col_4], aggr=[min(u_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(o_2.ctid_2) as ctid_2, min(__distinct_addr_2) as col_2]
-                       :         VisibilityFilterExec: tables=[u, p, o]
-                       :           ProjectionExec: expr=[ctid_0@0 as ctid_0, id@1 as id, ctid_1@2 as ctid_1, id@3 as id, ctid_2@4 as ctid_2, id@5 as id, ctid_0@0 as __distinct_addr_2]
-                       :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@4, age@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@3, ctid_2@5, id@7]
-                       :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
-                       :                 CooperativeExec
-                       :                   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-                       :                 CooperativeExec
-                       :                   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-                       :               CooperativeExec
-                       :                 PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(25 rows)
+         ->  Custom Scan (ParadeDB Join Scan)
+               Relation Tree: u INNER (p INNER o)
+               Join Cond: u.id = p.id, p.age = o.age
+               Limit: 48
+               Distinct: true
+               Order By: u.id asc, o.id asc, u.name asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[col_1@0 as col_1, col_2@6 as col_2, col_3@1 as col_3, col_4@2 as col_4, ctid_0@3 as ctid_0, ctid_1@4 as ctid_1, ctid_2@5 as ctid_2]
+                 :   SortExec: TopK(fetch=48), expr=[col_1@0 ASC NULLS LAST, col_4@2 ASC NULLS LAST, col_2@6 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     TantivyLookupExec: decode=[name]
+                 :       AggregateExec: mode=Single, gby=[id@1 as col_1, id@3 as col_3, id@5 as col_4], aggr=[min(u_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(o_2.ctid_2) as ctid_2, min(__distinct_addr_2) as col_2]
+                 :         VisibilityFilterExec: tables=[u, p, o]
+                 :           ProjectionExec: expr=[ctid_0@0 as ctid_0, id@1 as id, ctid_1@2 as ctid_1, id@3 as id, ctid_2@4 as ctid_2, id@5 as id, ctid_0@0 as __distinct_addr_2]
+                 :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@4, age@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@3, ctid_2@5, id@7]
+                 :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
+                 :                 CooperativeExec
+                 :                   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                 :                 CooperativeExec
+                 :                   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                 :               CooperativeExec
+                 :                 PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(23 rows)
 
 -- And it must return the correct rows (DISTINCT + LIMIT).
 SELECT count(*) AS distinct_limited_rows

--- a/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
@@ -113,29 +113,34 @@ WHERE u.name @@@ 'bob'
   AND p.name @@@ 'bob'
 ORDER BY u.id, p.id, o.id
 LIMIT 48;
-                                                                                                 QUERY PLAN                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                              QUERY PLAN                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
-         ->  Custom Scan (ParadeDB Join Scan)
-               Relation Tree: u INNER (p INNER o)
-               Join Cond: u.id = p.id, p.age = o.age
-               Limit: 48
-               Distinct: true
-               Order By: u.id asc, o.id asc, u.name asc
-               DataFusion Physical Plan: 
-                 : SortExec: TopK(fetch=48), expr=[col_1@0 ASC NULLS LAST, col_4@3 ASC NULLS LAST, col_2@1 ASC NULLS LAST], preserve_partitioning=[false]
-                 :   AggregateExec: mode=Single, gby=[id@1 as col_1, name@2 as col_2, id@4 as col_3, id@6 as col_4], aggr=[min(u_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(o_2.ctid_2) as ctid_2]
-                 :     VisibilityFilterExec: tables=[u, p, o]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@5, age@1)], projection=[ctid_0@0, id@1, name@2, ctid_1@3, id@4, ctid_2@6, id@8]
-                 :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
-                 :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(20 rows)
+         ->  Gather Merge
+               Workers Planned: 1
+               ->  Parallel Custom Scan (ParadeDB Join Scan)
+                     Relation Tree: u INNER (p INNER o)
+                     Join Cond: u.id = p.id, p.age = o.age
+                     Limit: 48
+                     Distinct: true
+                     Order By: u.id asc, o.id asc, u.name asc
+                     DataFusion Physical Plan: 
+                       : ProjectionExec: expr=[col_1@0 as col_1, col_2@6 as col_2, col_3@1 as col_3, col_4@2 as col_4, ctid_0@3 as ctid_0, ctid_1@4 as ctid_1, ctid_2@5 as ctid_2]
+                       :   SortExec: TopK(fetch=48), expr=[col_1@0 ASC NULLS LAST, col_4@2 ASC NULLS LAST, col_2@6 ASC NULLS LAST], preserve_partitioning=[false]
+                       :     TantivyLookupExec: decode=[name]
+                       :       AggregateExec: mode=Single, gby=[id@1 as col_1, id@3 as col_3, id@5 as col_4], aggr=[min(u_0.ctid_0) as ctid_0, min(p_1.ctid_1) as ctid_1, min(o_2.ctid_2) as ctid_2, min(__distinct_addr_2) as col_2]
+                       :         VisibilityFilterExec: tables=[u, p, o]
+                       :           ProjectionExec: expr=[ctid_0@0 as ctid_0, id@1 as id, ctid_1@2 as ctid_1, id@3 as id, ctid_2@4 as ctid_2, id@5 as id, ctid_0@0 as __distinct_addr_2]
+                       :             HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@4, age@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@3, ctid_2@5, id@7]
+                       :               HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
+                       :                 CooperativeExec
+                       :                   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                       :                 CooperativeExec
+                       :                   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                       :               CooperativeExec
+                       :                 PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(25 rows)
 
 -- And it must return the correct rows (DISTINCT + LIMIT).
 SELECT count(*) AS distinct_limited_rows

--- a/pg_search/tests/pg_regress/sql/issue_4146.sql
+++ b/pg_search/tests/pg_regress/sql/issue_4146.sql
@@ -1,5 +1,10 @@
 \i common/docs_setup.sql
 
+-- Deferring DISTINCT columns through doc addresses deepens this join plan enough
+-- that serializing it overflows the 2MB default stack in debug builds. The real
+-- fix is bounding that recursion in the plan serialization path; until it lands,
+-- give the session headroom.
+SET max_stack_depth = '6MB';
 SET paradedb.enable_join_custom_scan TO on;
 
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)


### PR DESCRIPTION
## What

This PR keeps wide `DISTINCT` columns out of the group keys, re-deriving them above the aggregate from a per-group doc address.

## Why

`SELECT DISTINCT u.id, u.display_name, u.about_me ...` grouped on all three columns. So multi-KB `about_me` text rode the join output, the hash shuffle, and the MPP mesh, once per joined row. Dedup collapses those rows, but only after the shuffle already moved the text. On the `join_distinct_parent_sort` shape at scale that traffic dominated the query.

## How

When the `DISTINCT` set contains the source's key field, grouping by that key alone dedups identically: same key, same doc, same values. `apply_distinct_group_by` drops the wide columns from the group keys and has the aggregate carry `min(<doc address>)` per group instead. A `DocAddressLookupNode` above the aggregate re-derives the string values from that address, reusing `TantivyLookupExec`. So the wide columns are decoded once per surviving group, after the shuffle, not once per input row before it.

It also raises `max_stack_depth` to `6MB` for the debug-profile test sessions. The plan-serialization path (`datafusion-proto` + `serde`) has large debug frames, and a deep join plan trips Postgres's default 2MB. Release builds sit well under it.

## Performance

`join_distinct_parent_sort` (its sorted alternative) was the worst MPP regression in the stackoverflow benchmark: `4406 ms` under MPP against a `234 ms` serial baseline, an `18.8x` gap. Keeping the wide columns out of the shuffle cuts the MPP time to `543 ms`, so the gap drops to `2.3x`. What's left is the sort and tuple fetch, which MPP doesn't change.

## Tests

Verified results identical to plain Postgres on the serial and MPP paths for the distinct-parent-sort shape. The `joinscan_parallel_distinct` and `issue_4146` expected outputs update for the new plan shape, where the aggregate groups by the key with a lookup above it.
