### PR TITLE
perf: reserve the MPP mesh region in DSM instead of copying a zeroed blob

### DIFF
--- a/pg_search/src/parallel_worker/builder.rs
+++ b/pg_search/src/parallel_worker/builder.rs
@@ -103,11 +103,13 @@ impl ParallelProcessBuilder {
 
                 let nbytes = entry.size_of();
                 let state_address = pg_sys::shm_toc_allocate((*pcxt.as_ptr()).toc, nbytes);
-                std::ptr::copy_nonoverlapping(
-                    entry.as_bytes().as_ptr().cast(),
-                    state_address,
-                    nbytes,
-                );
+                if !entry.reserve_only() {
+                    std::ptr::copy_nonoverlapping(
+                        entry.as_bytes().as_ptr().cast(),
+                        state_address,
+                        nbytes,
+                    );
+                }
                 pg_sys::shm_toc_insert((*pcxt.as_ptr()).toc, idx + i as u64 + 1, state_address);
             }
 

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -58,6 +58,10 @@ impl From<TocKeys> for u64 {
     }
 }
 
+/// Marker for plain-old-data types stored in DSM entries as raw bytes. An entry is written
+/// by copying a live value, and [`ParallelStateManager`] checks the recorded type name
+/// before handing it back, so a reader always sees a valid instance of the type it asked
+/// for.
 pub trait ParallelStateType: Copy {}
 
 pub trait ParallelState {
@@ -96,19 +100,30 @@ pub trait ParallelState {
     /// into it; the contents start uninitialized. For large regions whose first writer runs
     /// after the DSM is mapped, this skips materializing (and zeroing) a same-sized buffer
     /// on the host side only to memcpy it over.
+    ///
+    /// Implementations must record an element type that accepts any bit pattern (`u8` in
+    /// practice), so the [`ParallelStateManager`] type check keeps readers from viewing
+    /// unwritten bytes as anything stricter.
     fn reserve_only(&self) -> bool {
         false
     }
 }
 
 /// A [`ParallelState`] entry that only reserves `len` bytes in the DSM (see
-/// [`ParallelState::reserve_only`]). Workers read it back as a `u8` slice.
+/// [`ParallelState::reserve_only`]). The entry is recorded as `u8`, so the
+/// [`ParallelStateManager`] type check hands it back only as a byte slice, and every bit
+/// pattern is a valid `u8`.
 pub struct UninitializedBytesParallelState {
     len: usize,
 }
 
 impl UninitializedBytesParallelState {
-    pub fn new(len: usize) -> Self {
+    /// # Safety
+    ///
+    /// The reserved bytes hold no meaningful value until a consumer writes them in place.
+    /// The caller asserts that the protocol run over the region tolerates that: its first
+    /// writer runs before any read that depends on the contents.
+    pub unsafe fn new(len: usize) -> Self {
         Self { len }
     }
 }

--- a/pg_search/src/parallel_worker/mod.rs
+++ b/pg_search/src/parallel_worker/mod.rs
@@ -91,6 +91,48 @@ pub trait ParallelState {
 
     /// Return a byte slice pointing to the raw bytes of this instance in memory
     fn as_bytes(&self) -> &[u8];
+
+    /// When true, the builder allocates this entry's space in the DSM but copies nothing
+    /// into it; the contents start uninitialized. For large regions whose first writer runs
+    /// after the DSM is mapped, this skips materializing (and zeroing) a same-sized buffer
+    /// on the host side only to memcpy it over.
+    fn reserve_only(&self) -> bool {
+        false
+    }
+}
+
+/// A [`ParallelState`] entry that only reserves `len` bytes in the DSM (see
+/// [`ParallelState::reserve_only`]). Workers read it back as a `u8` slice.
+pub struct UninitializedBytesParallelState {
+    len: usize,
+}
+
+impl UninitializedBytesParallelState {
+    pub fn new(len: usize) -> Self {
+        Self { len }
+    }
+}
+
+impl ParallelState for UninitializedBytesParallelState {
+    fn type_name(&self) -> &'static str {
+        std::any::type_name::<u8>()
+    }
+
+    fn size_of(&self) -> usize {
+        self.len
+    }
+
+    fn array_len(&self) -> usize {
+        self.len
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &[]
+    }
+
+    fn reserve_only(&self) -> bool {
+        true
+    }
 }
 
 impl ParallelStateType for u8 {}

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -215,7 +215,12 @@ fn launch_mpp(
         ParallelScanState::size_of(&args.all_nsegments(), partitioning_source_idx, &[], false);
 
     let process = MppParallelProcess {
-        mesh_region: crate::parallel_worker::UninitializedBytesParallelState::new(region_bytes),
+        // SAFETY: workers can only read the region back as `u8`, and they hold on the go
+        // flag until `leader_setup` has written every ring header, so nothing reads the
+        // reserved bytes before their first writer.
+        mesh_region: unsafe {
+            crate::parallel_worker::UninitializedBytesParallelState::new(region_bytes)
+        },
         scan_state: vec![0u8; scan_size],
         go: GO_WAIT,
         partitioning_source_idx: partitioning_source_idx as u64,

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -23,7 +23,7 @@
 //! serial fallback instead of the hang it used to be when PG's Gather decided the count.
 //!
 //! The MPP DSM region rides as builder `ParallelState` entries instead of a hand-laid coordinate:
-//! a zeroed byte blob for the ring mesh (`shm::dsm_region_bytes`), a zeroed byte blob for the
+//! a reserve-only region for the ring mesh (`shm::dsm_region_bytes`), a zeroed byte blob for the
 //! `ParallelScanState`, plus the partitioning-source index and a go flag. The leader initializes
 //! the mesh and populates the scan state in place between `build()` and worker attach; workers
 //! reconstruct their `MppWorkerInputs` from the same entries, with no PG plan node in reach.
@@ -69,10 +69,12 @@ const GO_ABORT: u32 = 2;
 /// `shm_mq_create` has room for its header.
 const MPP_MQ_SIZE: usize = 1024;
 
-/// The builder process carrying the MPP DSM entries. The two byte blobs are handed over zeroed;
-/// the leader initializes them in place after the DSM is mapped.
+/// The builder process carrying the MPP DSM entries. The mesh region is reserve-only: at the
+/// default queue size it is hundreds of megabytes, and `shm::leader_setup` writes every header
+/// and ring slot it reads, so materializing (zeroing, copying) a host-side buffer of that size
+/// per query would buy nothing. The scan state is a small zeroed blob populated in place.
 struct MppParallelProcess {
-    mesh_region: Vec<u8>,
+    mesh_region: crate::parallel_worker::UninitializedBytesParallelState,
     scan_state: Vec<u8>,
     go: u32,
     partitioning_source_idx: u64,
@@ -213,7 +215,7 @@ fn launch_mpp(
         ParallelScanState::size_of(&args.all_nsegments(), partitioning_source_idx, &[], false);
 
     let process = MppParallelProcess {
-        mesh_region: vec![0u8; region_bytes],
+        mesh_region: crate::parallel_worker::UninitializedBytesParallelState::new(region_bytes),
         scan_state: vec![0u8; scan_size],
         go: GO_WAIT,
         partitioning_source_idx: partitioning_source_idx as u64,


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR reserves the MPP mesh region in DSM instead of handing the builder a zeroed host buffer to copy in.

## Why

At the default queue size the mesh region is hundreds of megabytes. Launch allocated a `Vec<u8>` that big, zeroed it, and let the parallel builder memcpy it into the DSM, on every query. `leader_setup` overwrites every header and ring slot before any worker attaches. So the region can start uninitialized, and that alloc, zero, and copy is pure launch overhead.

## How

Added `UninitializedBytesParallelState`, a `ParallelState` that reports its byte length but carries no data (`reserve_only()` is true, `as_bytes()` is empty). The builder's copy loop skips `copy_nonoverlapping` for reserve-only entries, so `shm_toc_allocate` reserves the DSM space and nothing is written host-side. The MPP launcher swaps the mesh region's `vec![0u8; region_bytes]` for this entry. The `ParallelScanState` stays a small zeroed blob.

## Performance

The region is ~256MB at the default queue size, and the alloc, zero, and copy ran on every MPP query. Local 1m A/B: the zero-row launch probe drops from 45.6ms to 22.2ms, `join_semi_filter` goes from 2.11x serial to 1.26x, and `join_aggregate_count` from 1.24x to 0.83x, a win. The CI benchmark round with this change confirmed it at grid scale: a near-constant 85-95ms came off every MPP query at every data size, and at 100k the worst ratio went from 14.84x to 6.69x with four join-aggregate variants flipping to wins (0.45-0.60x).

## Tests

No result change, so the existing MPP regression suite covers it. Safety is by construction: every byte a worker reads from the mesh is written by `leader_setup` after the DSM is mapped and before attach, which the ring setup already guarantees.
