### PR TITLE
perf(mpp): restore dynamic-filter pushdown in dispatched fragments

### DIFF
--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -378,8 +378,11 @@ pub fn deserialize_physical_plan_with_runtime(
     })?;
     let plan = proto.try_into_physical_plan(ctx, &codec)?;
     // Dynamic filters (hash-join keys, top-k bounds) are process-local Arcs shared between a
-    // node and the scans below it; serialization drops them. Re-running the post-optimization
-    // pushdown pass on the decoded fragment re-creates the links, so this task's probe scans
-    // prune against its build side instead of scanning every segment.
+    // node and the scans below it; the proto layer snapshots them into static expressions, so
+    // the shared link can't ride the wire. Re-running the post-optimization pushdown pass on
+    // the decoded fragment re-creates the links, so this task's probe scans prune against its
+    // own build side instead of scanning every segment. The relink is possible only because a
+    // fragment keeps an operator and its probe scans in the same process; a link that crossed
+    // fragments would need the filter values shipped between processes.
     FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())
 }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -384,5 +384,12 @@ pub fn deserialize_physical_plan_with_runtime(
     // own build side instead of scanning every segment. The relink is possible only because a
     // fragment keeps an operator and its probe scans in the same process; a link that crossed
     // fragments would need the filter values shipped between processes.
+    //
+    // Prior art: the same pass was proposed for datafusion-distributed
+    // (https://github.com/datafusion-contrib/datafusion-distributed/pull/348) and closed in
+    // favor of fixing it in DataFusion proper, by serializing and deduping dynamic filters so
+    // decode re-shares one instance (https://github.com/apache/datafusion/pull/20416, design
+    // discussion in https://github.com/apache/datafusion/issues/21207). Once DataFusion
+    // round-trips the filters natively, this pass can go.
     FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())
 }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -30,6 +30,8 @@ use datafusion::common::tree_node::{Transformed, TreeNode};
 use datafusion::common::{DataFusionError, Result};
 use datafusion::execution::TaskContext;
 use datafusion::logical_expr::ScalarUDF;
+use datafusion::physical_optimizer::filter_pushdown::FilterPushdown;
+use datafusion::physical_optimizer::PhysicalOptimizerRule;
 use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::DistributedCodec;
 use datafusion_proto::physical_plan::{
@@ -374,5 +376,10 @@ pub fn deserialize_physical_plan_with_runtime(
     let proto = <PhysicalPlanNode as prost::Message>::decode(bytes).map_err(|e| {
         DataFusionError::Internal(format!("Failed to decode dispatched PhysicalPlanNode: {e}"))
     })?;
-    proto.try_into_physical_plan(ctx, &codec)
+    let plan = proto.try_into_physical_plan(ctx, &codec)?;
+    // Dynamic filters (hash-join keys, top-k bounds) are process-local Arcs shared between a
+    // node and the scans below it; serialization drops them. Re-running the post-optimization
+    // pushdown pass on the decoded fragment re-creates the links, so this task's probe scans
+    // prune against its build side instead of scanning every segment.
+    FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())
 }


### PR DESCRIPTION
## What

This PR re-runs DataFusion's post-optimization filter-pushdown pass on MPP plan fragments after a worker decodes them.

## Why

Dynamic filters (hash-join key sets, top-k bounds) are process-local `Arc`s shared between an operator and the scans below it. The leader wires them up during physical optimization, but they can't travel through the dispatch codec, so every worker's probe scan ran without them and scanned all of its segments. The clearest case is `join_semi_filter`: at 20m rows in CI it runs 363ms under MPP vs 62ms serial, because the serial plan prunes the posts scan with the semi-join's dynamic filter (term-set index lookups) while the MPP workers scanned all 20m rows.

## How

The joins and their probe scans live in the same fragment (build sides are broadcast), so re-running `FilterPushdown(Post)` on the decoded fragment re-creates the same links the leader had, worker-locally. `PgSearchScanPlan`, `SegmentedTopKExec`, `TantivyLookupExec`, and `VisibilityFilterExec` already implement the pushdown handshake, and the rule is the same one the leader session runs, so no new plumbing is needed.

## Performance

With this change, `EXPLAIN (ANALYZE)` on `join_semi_filter` at 1m shows the workers' probe scan drop from `output_rows=1.00 M` (27.8 MB into the repartition) to `output_rows=1.11 K`, with `probe_hit_rate` going from 0.11% to 100%.

Local microbenchmarks (1m rows, M-series, `enable_mpp` off vs on, same build; ratios below 1.0 are MPP wins):

| query | serial ms | mpp ms | ratio |
|---|---|---|---|
| zero-row probe (pure launch) | 21.0 | 20.9 | 0.99 |
| `join_semi_filter` | 27.3 | 33.5 | 1.23 |
| `join_foreign_filter_local_sort` | 78.7 | 55.6 | 0.71 |
| `join_hierarchical_small` | 152.7 | 126.9 | 0.83 |
| `join_permissioned_search` | 112.7 | 142.9 | 1.27 |
| `join_distinct_parent_sort` | 319.5 | 303.3 | 0.95 |
| `join_aggregate_count` | 56.6 | 46.0 | 0.81 |
| `aggregate_topk_count` | 72.8 | 51.2 | 0.70 |
| `join_aggregate_sort` | 170.9 | 132.6 | 0.78 |

The 1m numbers barely move for `join_semi_filter` itself because at this scale the pushed filter's `linear` strategy costs about as much as the full scan it replaces; the win comes at larger scales where the strategy flips to term-set lookups.

## Tests

Existing tests.