### PR TITLE
perf(mpp): plan once and derive the dispatch payload from the leader's plan

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -50,6 +50,7 @@ use datafusion_distributed::shm::MppMesh;
 
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
+use crate::postgres::customscan::mpp::launch::MppLifecycle;
 
 use crate::api::agg_funcoid;
 use crate::api::SortDirection;
@@ -404,9 +405,7 @@ impl CustomScan for AggregateScan {
                     current_batch: None,
                     batch_row_idx: 0,
                     group_df_indices: Vec::new(),
-                    mpp: None,
-                    mpp_prep: None,
-                    mpp_plan_bytes: None,
+                    mpp: MppLifecycle::Inactive,
                 });
                 builder.build()
             }
@@ -557,11 +556,10 @@ impl CustomScan for AggregateScan {
                 );
                 state.custom_state_mut().scan_slot = Some(scan_slot);
             }
-            // MPP: serialize the logical plan so estimate_dsm/initialize_dsm
-            // can write it into the DSM region. Only the leader runs
-            // this branch (`ParallelWorkerNumber == -1` in the leader
-            // backend); workers read the bytes back from DSM in
-            // initialize_worker_custom_scan.
+            // MPP: serialize the logical plan now, while the source manifests are alive, so
+            // the first-exec prepare can size the DSM payload region before the physical plan
+            // exists. Only the leader runs this branch (`ParallelWorkerNumber == -1` in the
+            // leader backend).
             if mpp_is_active() && unsafe { pg_sys::ParallelWorkerNumber } == -1 {
                 Self::stash_mpp_plan_bytes(state);
             }
@@ -639,7 +637,7 @@ impl CustomScan for AggregateScan {
             // longjmps out of this hook; a release placed after it would never run, leaving the
             // senders to drop at xact commit, past the DSM's lifetime, where their `fetch_sub`
             // faults. The query is done producing here, so the senders aren't needed.
-            if let Some(leader) = df_state.mpp.as_ref() {
+            if let Some(leader) = df_state.mpp.leader() {
                 leader.release_control_senders();
             }
             // Drain the workers' metrics frames off the mesh BEFORE joining the workers. On an
@@ -648,7 +646,7 @@ impl CustomScan for AggregateScan {
             // Draining here is what frees them, so the `recv` below returns immediately instead
             // of waiting out the workers' full spin bound. PG destroys the parallel DSM right
             // after this hook (the EXPLAIN hook runs after teardown and only reads the store).
-            if let Some(leader) = df_state.mpp.as_ref() {
+            if let Some(leader) = df_state.mpp.leader() {
                 if let Some(plan) = df_state.physical_plan.as_ref() {
                     crate::postgres::customscan::mpp::glue::drain_worker_metrics(
                         plan,
@@ -656,7 +654,7 @@ impl CustomScan for AggregateScan {
                     );
                 }
             }
-            if let Some(leader) = df_state.mpp.as_mut() {
+            if let Some(leader) = df_state.mpp.leader_mut() {
                 if let Some(finish) = leader.finish.as_mut() {
                     let _ = finish.recv();
                 }
@@ -672,7 +670,7 @@ impl CustomScan for AggregateScan {
             // Pull the builder handle out so we can join the workers and destroy the parallel
             // context once nothing references the ring mesh anymore. The leader value (and its
             // own mesh handle) drops at the end of this match arm.
-            let finish = match df_state.mpp.take() {
+            let finish = match df_state.mpp.take_leader() {
                 Some(mut leader) => leader.finish.take(),
                 _ => None,
             };
@@ -815,11 +813,10 @@ impl AggregateScan {
             .unwrap_or(0)
     }
 
-    /// Serialize the leader's logical plan (already on `df_state`) and stash
-    /// the bytes on `df_state.mpp_plan_bytes`. `estimate_dsm_custom_scan`
-    /// reads the length to size the DSM region; `initialize_dsm_custom_scan`
-    /// hands the bytes to `glue::leader_setup` which copies them into DSM
-    /// for workers.
+    /// Serialize the leader's logical plan (already on `df_state`) and move the MPP lifecycle
+    /// to `PlanBytes`. The first-exec prepare uses the byte length to size the DSM payload
+    /// region; the dispatched stage plans themselves are derived later, from the leader's
+    /// physical plan.
     fn stash_mpp_plan_bytes(state: &mut CustomScanStateWrapper<Self>) {
         // Capture source manifests + partitioning_source_idx BEFORE building
         // the logical plan. Each `PgSearchTableProvider` needs to know whether
@@ -883,12 +880,12 @@ impl AggregateScan {
                 return;
             }
         };
-        df_state.mpp_plan_bytes = Some(bytes.to_vec());
+        df_state.mpp = MppLifecycle::PlanBytes(bytes.to_vec());
     }
 
     /// First-exec MPP launch. The leader spawns its producer workers through the builder and, on
     /// success, installs the leader state so the consumer plan reads from the mesh. A short launch
-    /// (or any setup fallback) leaves `mpp` unset and the query runs serially.
+    /// (or any setup fallback) leaves the lifecycle `Inactive` and the query runs serially.
     fn maybe_prepare_mpp(state: &mut CustomScanStateWrapper<Self>) {
         if !mpp_is_active() {
             return;
@@ -897,7 +894,7 @@ impl AggregateScan {
             .custom_state_mut()
             .datafusion_state
             .as_mut()
-            .and_then(|d| d.mpp_plan_bytes.take())
+            .and_then(|d| d.mpp.take_plan_bytes())
         else {
             return;
         };
@@ -931,7 +928,7 @@ impl AggregateScan {
             return;
         };
         if let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() {
-            df_state.mpp_prep = Some(prep);
+            df_state.mpp = MppLifecycle::Prepared(prep);
         }
     }
 
@@ -1025,7 +1022,7 @@ impl AggregateScan {
         let Some(plan) = df_state.physical_plan.clone() else {
             return;
         };
-        let rendered = match (df_state.mpp.as_ref(), df_state.runtime.as_ref()) {
+        let rendered = match (df_state.mpp.leader(), df_state.runtime.as_ref()) {
             (Some(_), Some(_runtime)) => {
                 match crate::postgres::customscan::mpp::glue::merge_worker_metrics(&plan) {
                     Some(merged) => display_plan_ascii(merged.as_ref(), true),
@@ -1553,7 +1550,7 @@ impl AggregateScan {
             // aggregate profile so `create_physical_plan` produces a `DistributedExec`. The
             // mesh and the dispatch source are execute-time concerns; the exec session below
             // carries them once the workers are committed.
-            let prep = df_state.mpp_prep.take();
+            let prep = df_state.mpp.take_prep();
             let plan_ctx = if prep.is_some() {
                 Self::build_mpp_session_context(None)
             } else {
@@ -1618,7 +1615,7 @@ impl AggregateScan {
                             }
                             let exec_ctx =
                                 Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)));
-                            df_state.mpp = Some(leader);
+                            df_state.mpp = MppLifecycle::Launched(leader);
                             (exec_ctx, physical_plan)
                         }
                         None => {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -405,6 +405,7 @@ impl CustomScan for AggregateScan {
                     batch_row_idx: 0,
                     group_df_indices: Vec::new(),
                     mpp: None,
+                    mpp_prep: None,
                     mpp_plan_bytes: None,
                 });
                 builder.build()
@@ -888,7 +889,7 @@ impl AggregateScan {
     /// First-exec MPP launch. The leader spawns its producer workers through the builder and, on
     /// success, installs the leader state so the consumer plan reads from the mesh. A short launch
     /// (or any setup fallback) leaves `mpp` unset and the query runs serially.
-    fn maybe_launch_mpp(state: &mut CustomScanStateWrapper<Self>) {
+    fn maybe_prepare_mpp(state: &mut CustomScanStateWrapper<Self>) {
         if !mpp_is_active() {
             return;
         }
@@ -922,15 +923,15 @@ impl AggregateScan {
             with_aggregates: false,
         };
 
-        let Some(leader) = crate::postgres::customscan::mpp::launch::launch_mpp_aggregate(
-            plan_bytes,
+        let Some(prep) = crate::postgres::customscan::mpp::launch::prepare_mpp_aggregate(
+            plan_bytes.len(),
             args,
             partitioning_idx,
         ) else {
             return;
         };
         if let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() {
-            df_state.mpp = Some(leader);
+            df_state.mpp_prep = Some(prep);
         }
     }
 
@@ -1521,17 +1522,19 @@ impl AggregateScan {
         let ps = state.planstate();
         let runtime_planstate = (!ps.is_null()).then_some(ps);
 
-        // First exec call: the leader launches its producer workers and picks the count, so a
-        // short launch falls back to serial instead of hanging the query. Done before the
-        // df_state borrow below because it needs `state` for the source manifests.
+        // First exec call: build the MPP DSM before planning. The workers launch only after
+        // the leader's plan is built and its stages serialize (`launch_mpp_commit` below).
+        // Done before the df_state borrow below because it needs `state` for the source
+        // manifests.
         let first_call = state
             .custom_state()
             .datafusion_state
             .as_ref()
             .is_some_and(|d| d.runtime.is_none());
         if first_call {
-            Self::maybe_launch_mpp(state);
+            Self::maybe_prepare_mpp(state);
         }
+        let mpp_partitioning_idx = state.custom_state().mpp_partitioning_source_idx;
 
         let df_state = state
             .custom_state_mut()
@@ -1546,50 +1549,86 @@ impl AggregateScan {
                 .build()
                 .unwrap_or_else(|e| pgrx::error!("Failed to create tokio runtime: {}", e));
 
-            // MPP leader: install the mesh + DF-D fork's distributed planner so
-            // `create_physical_plan` produces a `DistributedExec` whose
-            // `NetworkShuffleExec`s use our `ShmMqWorkerTransport` to read
-            // from worker queues at execute time. Otherwise: existing serial
-            // session context.
-            let ctx = match df_state.mpp.as_ref() {
-                Some(leader) => {
-                    // Workers are launched and draining their inboxes (the launcher already
-                    // verified the full producer set came up, else it fell back to serial); ship
-                    // each fragment's plan frame now.
-                    if let Err(e) =
-                        crate::postgres::customscan::mpp::glue::deliver_set_plans(leader)
-                    {
-                        pgrx::error!("mpp aggregate: plan delivery failed: {e}");
-                    }
-                    Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
-                }
-                _ => create_aggregate_session_context(),
+            // When the MPP DSM is prepared, layer the DF-D fork's distributed planner over the
+            // aggregate profile so `create_physical_plan` produces a `DistributedExec`. The
+            // mesh and the dispatch source are execute-time concerns; the exec session below
+            // carries them once the workers are committed.
+            let prep = df_state.mpp_prep.take();
+            let plan_ctx = if prep.is_some() {
+                Self::build_mpp_session_context(None)
+            } else {
+                create_aggregate_session_context()
             };
 
             let custom_exprs = df_state.custom_exprs;
             let custom_scan_tlist = df_state.custom_scan_tlist;
-            let physical_plan = runtime.block_on(async {
-                let (logical, group_df_indices) = build_join_aggregate_plan(
-                    &df_state.plan,
-                    &df_state.targetlist,
-                    df_state.topk.as_ref(),
-                    &df_state.join_level_predicates,
-                    custom_exprs,
-                    custom_scan_tlist,
-                    df_state.having_filter.as_ref(),
-                    &ctx,
-                    runtime_expr_context,
-                    runtime_planstate,
-                    None,
-                )
-                .await?;
-                df_state.group_df_indices = group_df_indices;
-                build_physical_plan(&ctx, logical).await
+            // `mpp_ctx` marks the partitioning source and stamps each provider's per-source
+            // dispatch metadata (`is_parallel`, `non_partitioning_index`). The worker-bound
+            // stage encodes carry that metadata, so it must be present on the plan the
+            // dispatch payload is derived from; the serial fallback plans without it.
+            let mut build_plan =
+                |ctx: &datafusion::prelude::SessionContext, mpp_ctx: Option<MppPlanContext>| {
+                    let built = runtime.block_on(async {
+                        let (logical, group_df_indices) = build_join_aggregate_plan(
+                            &df_state.plan,
+                            &df_state.targetlist,
+                            df_state.topk.as_ref(),
+                            &df_state.join_level_predicates,
+                            custom_exprs,
+                            custom_scan_tlist,
+                            df_state.having_filter.as_ref(),
+                            ctx,
+                            runtime_expr_context,
+                            runtime_planstate,
+                            mpp_ctx,
+                        )
+                        .await?;
+                        df_state.group_df_indices = group_df_indices;
+                        build_physical_plan(ctx, logical).await
+                    });
+                    match built {
+                        Ok(p) => p,
+                        Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+                    }
+                };
+            let plan_mpp_ctx = prep.as_ref().and_then(|_| {
+                mpp_partitioning_idx.map(|idx| MppPlanContext {
+                    partitioning_plan_position: idx,
+                })
             });
+            let physical_plan = build_plan(&plan_ctx, plan_mpp_ctx);
 
-            let physical_plan = match physical_plan {
-                Ok(p) => p,
-                Err(e) => pgrx::error!("Failed to build DataFusion aggregate plan: {}", e),
+            // Commit the MPP launch against the built plan: serialize its producer stages,
+            // spawn the workers, and hand the coordinator the same stages to dispatch. On a
+            // short launch the workers are gone and the `DistributedExec` shape has no mesh to
+            // read from, so replan serially.
+            let (ctx, physical_plan) = match prep {
+                Some(prep) => {
+                    match crate::postgres::customscan::mpp::launch::launch_mpp_commit(
+                        prep,
+                        &physical_plan,
+                    ) {
+                        Some(leader) => {
+                            // Workers are attaching and draining after the commit; ship each
+                            // fragment's plan frame now, before anything pulls from the mesh.
+                            if let Err(e) =
+                                crate::postgres::customscan::mpp::glue::deliver_set_plans(&leader)
+                            {
+                                pgrx::error!("mpp aggregate: plan delivery failed: {e}");
+                            }
+                            let exec_ctx =
+                                Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)));
+                            df_state.mpp = Some(leader);
+                            (exec_ctx, physical_plan)
+                        }
+                        None => {
+                            let serial_ctx = create_aggregate_session_context();
+                            let plan = build_plan(&serial_ctx, None);
+                            (serial_ctx, plan)
+                        }
+                    }
+                }
+                None => (plan_ctx, physical_plan),
             };
 
             let task_ctx = build_task_context(

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -84,6 +84,9 @@ pub struct DataFusionAggState {
     /// the leader; builder-launched workers reconstruct their state from DSM
     /// and never carry this.
     pub mpp: Option<crate::postgres::customscan::mpp::glue::MppLeaderState>,
+    /// The prepared-but-unlaunched MPP DSM. Set on the first exec call before planning; consumed
+    /// by `launch_mpp_commit` once the leader's plan is built, in the same call.
+    pub mpp_prep: Option<crate::postgres::customscan::mpp::launch::MppLaunchPrep>,
     /// Serialized logical-plan bytes that the leader writes into DSM and
     /// workers read back. Computed by `begin_custom_scan` when MPP is
     /// active; consulted by `estimate_dsm_custom_scan` and

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -79,19 +79,11 @@ pub struct DataFusionAggState {
     /// output RecordBatch. Needed because DataFusion deduplicates grouping
     /// expressions (e.g. metadata.brand).
     pub group_df_indices: Vec<usize>,
-    /// MPP-specific state. `Some` only when `paradedb.enable_mpp = on` and
-    /// the query qualifies (binary join + supported aggregate). Held only by
-    /// the leader; builder-launched workers reconstruct their state from DSM
-    /// and never carry this.
-    pub mpp: Option<crate::postgres::customscan::mpp::glue::MppLeaderState>,
-    /// The prepared-but-unlaunched MPP DSM. Set on the first exec call before planning; consumed
-    /// by `launch_mpp_commit` once the leader's plan is built, in the same call.
-    pub mpp_prep: Option<crate::postgres::customscan::mpp::launch::MppLaunchPrep>,
-    /// Serialized logical-plan bytes that the leader writes into DSM and
-    /// workers read back. Computed by `begin_custom_scan` when MPP is
-    /// active; consulted by `estimate_dsm_custom_scan` and
-    /// `initialize_dsm_custom_scan`.
-    pub mpp_plan_bytes: Option<Vec<u8>>,
+    /// Where MPP sits in its launch lifecycle for this scan: plan bytes stashed at begin,
+    /// prepared on first exec before planning, launched once the plan's stages are committed.
+    /// Stays `Inactive` on the serial path. Applies only when `paradedb.enable_mpp = on` and
+    /// the query qualifies (binary join + supported aggregate).
+    pub mpp: crate::postgres::customscan::mpp::launch::MppLifecycle,
 }
 
 /// State for projecting wrapped aggregate expressions through Postgres' own

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1007,10 +1007,11 @@ impl JoinScan {
         )
     }
 
-    /// First-exec MPP launch. The leader spawns its producer workers through the builder and, on
-    /// success, installs the leader state so the consumer plan reads from the mesh. A short launch
-    /// (or any setup fallback) leaves `mpp` unset and the query runs serially.
-    fn maybe_launch_mpp(state: &mut CustomScanStateWrapper<Self>) {
+    /// First-exec MPP prepare. Builds the DSM (mesh region + shared scan state) but launches no
+    /// workers yet: the leader plans first, and `launch_mpp_commit` spawns the producers only
+    /// once the plan's stages serialize. Any fallback here leaves `mpp_prep` unset and the query
+    /// runs serially.
+    fn maybe_prepare_mpp(state: &mut CustomScanStateWrapper<Self>) {
         if !mpp_is_active()
             || Self::source_queries_have_parameters(&state.custom_state().join_clause)
         {
@@ -1033,16 +1034,20 @@ impl JoinScan {
             query: vec![],
             with_aggregates: false,
         };
-        if let Some(leader) = crate::postgres::customscan::mpp::launch::launch_mpp_join(
-            plan_bytes,
+        if let Some(prep) = crate::postgres::customscan::mpp::launch::prepare_mpp_join(
+            plan_bytes.len(),
             args,
             partitioning_idx,
         ) {
             // The leader runs the top fragment itself. When a non-partitioning source lands there
             // (the SEMI/ANTI broadcast strategy), its scan claims per-source segments against the
             // same shared state the workers use, so the codec needs this pointer to install it.
-            state.custom_state_mut().parallel_state = Some(leader.parallel_state);
-            state.custom_state_mut().mpp = Some(leader);
+            // The canonical per-source segment sets feed the same deserialize the worker-bound
+            // stages are serialized from.
+            state.custom_state_mut().parallel_state = Some(prep.scan_ptr);
+            state.custom_state_mut().non_partitioning_segments =
+                prep.non_partitioning_segments.clone();
+            state.custom_state_mut().mpp_prep = Some(prep);
         }
     }
 }
@@ -1435,10 +1440,10 @@ impl CustomScan for JoinScan {
 
     fn exec_custom_scan(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
         if state.custom_state().datafusion_stream.is_none() {
-            // First exec call: the leader launches its MPP producer workers via the builder
-            // (leader-chosen count, with a serial fallback on a short launch). Done before the
-            // consumer plan is built below.
-            Self::maybe_launch_mpp(state);
+            // First exec call: build the MPP DSM before planning. The workers launch only after
+            // the leader's plan is built and its stages serialize (`launch_mpp_commit` below),
+            // so every planning fallback is a serial run with no workers to abort.
+            Self::maybe_prepare_mpp(state);
         }
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
@@ -1480,66 +1485,121 @@ impl CustomScan for JoinScan {
                 let index_segment_ids =
                     Self::build_index_segment_ids(state, &join_clause, &plan_sources);
 
-                // Leader session context: when MPP is active and we're the leader, layer the
-                // DF-D fork's distributed-planner knobs over the Join profile so the resulting
-                // physical plan is a `DistributedExec`. Without this, the leader builds a serial
-                // plan and the worker fragments would have nothing to consume from.
-                let ctx = match state.custom_state().mpp.as_ref() {
-                    Some(leader) => {
-                        // Workers are launched and draining (the launcher verified the full producer
-                        // set came up, else it fell back to serial); ship each fragment's plan now.
-                        if let Err(e) =
-                            crate::postgres::customscan::mpp::glue::deliver_set_plans(leader)
-                        {
-                            pgrx::error!("mpp join: plan delivery failed: {e}");
-                        }
-                        Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
-                    }
-                    _ => create_datafusion_session_context(SessionContextProfile::Join),
-                };
-                let logical_plan = deserialize_logical_plan_with_runtime(
-                    &plan_bytes,
-                    &ctx.task_ctx(),
-                    state.custom_state().parallel_state,
-                    Some(state.runtime_context),
-                    Some(planstate),
-                    state.custom_state().non_partitioning_segments.clone(),
-                    index_segment_ids,
-                )
-                .expect("Failed to deserialize logical plan");
-
-                // For parameterized LIMIT/OFFSET, the planning-time logical
-                // plan has no Limit node. Inject one now (before physical
-                // planning) so SegmentedTopKRule can detect SortExec(fetch=K)
-                // and apply its TopK optimization. Static cases were already
-                // pushed in `build_clause_df`.
-                let needs_runtime_limit = join_clause
-                    .limit_offset
-                    .as_ref()
-                    .map(|lo| lo.has_any_param())
-                    .unwrap_or(false);
-                let logical_plan = if needs_runtime_limit {
-                    use datafusion::logical_expr::LogicalPlanBuilder;
-                    let lo = join_clause.limit_offset.as_mut().unwrap();
+                // For parameterized LIMIT/OFFSET, the planning-time logical plan has no Limit
+                // node. Resolve the fetch once; each planning pass below injects it (before
+                // physical planning) so SegmentedTopKRule can detect SortExec(fetch=K) and
+                // apply its TopK optimization. Static cases were already pushed in
+                // `build_clause_df`.
+                let runtime_fetch = {
                     let estate = state.csstate.ss.ps.state;
-                    let fetch = lo
-                        .resolve_mut(estate)
-                        .expect("LIMIT must be resolvable from EState")
-                        .static_fetch()
-                        .expect("static_fetch must succeed after resolve_mut");
-                    LogicalPlanBuilder::from(logical_plan)
-                        .limit(0, Some(fetch))
-                        .expect("failed to add Limit to logical plan")
-                        .build()
-                        .expect("failed to build logical plan with Limit")
-                } else {
-                    logical_plan
+                    join_clause
+                        .limit_offset
+                        .as_mut()
+                        .filter(|lo| lo.has_any_param())
+                        .map(|lo| {
+                            lo.resolve_mut(estate)
+                                .expect("LIMIT must be resolvable from EState")
+                                .static_fetch()
+                                .expect("static_fetch must succeed after resolve_mut")
+                        })
                 };
 
-                // Convert logical plan to physical plan
-                let plan = runtime
-                    .block_on(build_physical_plan(&ctx, logical_plan))
-                    .expect("Failed to create execution plan");
+                // Raw pointers precomputed so the planning closure below never borrows `state`.
+                let runtime_context = state.runtime_context;
+                let build_plan = |ctx: &datafusion::prelude::SessionContext,
+                                  parallel_state: Option<*mut ParallelScanState>,
+                                  non_partitioning_segments: Vec<
+                    crate::api::HashSet<tantivy::index::SegmentId>,
+                >|
+                 -> Arc<dyn ExecutionPlan> {
+                    let logical_plan = deserialize_logical_plan_with_runtime(
+                        &plan_bytes,
+                        &ctx.task_ctx(),
+                        parallel_state,
+                        Some(runtime_context),
+                        Some(planstate),
+                        non_partitioning_segments,
+                        index_segment_ids.clone(),
+                    )
+                    .expect("Failed to deserialize logical plan");
+                    let logical_plan = match runtime_fetch {
+                        Some(fetch) => {
+                            use datafusion::logical_expr::LogicalPlanBuilder;
+                            LogicalPlanBuilder::from(logical_plan)
+                                .limit(0, Some(fetch))
+                                .expect("failed to add Limit to logical plan")
+                                .build()
+                                .expect("failed to build logical plan with Limit")
+                        }
+                        None => logical_plan,
+                    };
+                    runtime
+                        .block_on(build_physical_plan(ctx, logical_plan))
+                        .expect("Failed to create execution plan")
+                };
+
+                // Leader session context: when the MPP DSM is prepared, layer the DF-D fork's
+                // distributed-planner knobs over the Join profile so the resulting physical
+                // plan is a `DistributedExec`. The mesh and the dispatch source are
+                // execute-time concerns; the exec session below carries them once the workers
+                // are committed.
+                let plan_ctx = if state.custom_state().mpp_prep.is_some() {
+                    Self::build_mpp_session_context(None)
+                } else {
+                    create_datafusion_session_context(SessionContextProfile::Join)
+                };
+                // A rescan after an MPP run replans serially: the launched generation's
+                // workers have already claimed the shared scan state, so binding the fresh
+                // plan to it would leave the leader with nothing to scan.
+                let plan_parallel_state = if state.custom_state().mpp.is_some()
+                    && state.custom_state().mpp_prep.is_none()
+                {
+                    None
+                } else {
+                    state.custom_state().parallel_state
+                };
+                let plan = build_plan(
+                    &plan_ctx,
+                    plan_parallel_state,
+                    state.custom_state().non_partitioning_segments.clone(),
+                );
+
+                // Commit the MPP launch against the built plan: serialize its producer stages,
+                // spawn the workers, and hand the coordinator the same stages to dispatch. On a
+                // short launch the workers are gone and the `DistributedExec` shape has no mesh
+                // to read from, so replan serially.
+                let (ctx, plan) = match state.custom_state_mut().mpp_prep.take() {
+                    Some(prep) => {
+                        match crate::postgres::customscan::mpp::launch::launch_mpp_commit(
+                            prep, &plan,
+                        ) {
+                            Some(leader) => {
+                                // Workers are attaching and draining after the commit; ship each
+                                // fragment's plan frame now, before anything pulls from the mesh.
+                                if let Err(e) =
+                                    crate::postgres::customscan::mpp::glue::deliver_set_plans(
+                                        &leader,
+                                    )
+                                {
+                                    pgrx::error!("mpp join: plan delivery failed: {e}");
+                                }
+                                let exec_ctx =
+                                    Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)));
+                                state.custom_state_mut().mpp = Some(leader);
+                                (exec_ctx, plan)
+                            }
+                            None => {
+                                state.custom_state_mut().parallel_state = None;
+                                state.custom_state_mut().non_partitioning_segments = Vec::new();
+                                let serial_ctx =
+                                    create_datafusion_session_context(SessionContextProfile::Join);
+                                let plan = build_plan(&serial_ctx, None, Vec::new());
+                                (serial_ctx, plan)
+                            }
+                        }
+                    }
+                    None => (plan_ctx, plan),
+                };
 
                 let task_ctx = build_task_context(
                     &ctx,

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -179,6 +179,7 @@ use crate::postgres::customscan::joinscan::planning::distinct_columns_are_fast_f
 use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::{mpp_is_active, producer_worker_count};
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
+use crate::postgres::customscan::mpp::launch::MppLifecycle;
 use datafusion_distributed::shm::MppMesh;
 
 use crate::postgres::customscan::parallel::compute_nworkers;
@@ -1009,15 +1010,15 @@ impl JoinScan {
 
     /// First-exec MPP prepare. Builds the DSM (mesh region + shared scan state) but launches no
     /// workers yet: the leader plans first, and `launch_mpp_commit` spawns the producers only
-    /// once the plan's stages serialize. Any fallback here leaves `mpp_prep` unset and the query
-    /// runs serially.
+    /// once the plan's stages serialize. Any fallback here leaves the lifecycle `Inactive` and
+    /// the query runs serially.
     fn maybe_prepare_mpp(state: &mut CustomScanStateWrapper<Self>) {
         if !mpp_is_active()
             || Self::source_queries_have_parameters(&state.custom_state().join_clause)
         {
             return;
         }
-        let Some(plan_bytes) = state.custom_state_mut().mpp_plan_bytes.take() else {
+        let Some(plan_bytes) = state.custom_state_mut().mpp.take_plan_bytes() else {
             return;
         };
         Self::ensure_source_manifests(state);
@@ -1047,7 +1048,7 @@ impl JoinScan {
             state.custom_state_mut().parallel_state = Some(prep.scan_ptr);
             state.custom_state_mut().non_partitioning_segments =
                 prep.non_partitioning_segments.clone();
-            state.custom_state_mut().mpp_prep = Some(prep);
+            state.custom_state_mut().mpp = MppLifecycle::Prepared(prep);
         }
     }
 }
@@ -1332,7 +1333,7 @@ impl CustomScan for JoinScan {
                 // they exited; fold them in so the stage boxes show more than the leader's
                 // own nodes.
                 let merged = match (
-                    state.custom_state().mpp.as_ref(),
+                    state.custom_state().mpp.leader(),
                     state.custom_state().runtime.as_ref(),
                 ) {
                     (Some(_), Some(_runtime)) => {
@@ -1425,7 +1426,7 @@ impl CustomScan for JoinScan {
                 && unsafe { pg_sys::ParallelWorkerNumber } == -1
             {
                 if let Some(bytes) = state.custom_state().logical_plan.clone() {
-                    state.custom_state_mut().mpp_plan_bytes = Some(bytes.to_vec());
+                    state.custom_state_mut().mpp = MppLifecycle::PlanBytes(bytes.to_vec());
                     let partitioning_idx =
                         state.custom_state().join_clause.partitioning_source_index();
                     state.custom_state_mut().mpp_partitioning_source_idx = Some(partitioning_idx);
@@ -1543,7 +1544,7 @@ impl CustomScan for JoinScan {
                 // plan is a `DistributedExec`. The mesh and the dispatch source are
                 // execute-time concerns; the exec session below carries them once the workers
                 // are committed.
-                let plan_ctx = if state.custom_state().mpp_prep.is_some() {
+                let plan_ctx = if state.custom_state().mpp.is_prepared() {
                     Self::build_mpp_session_context(None)
                 } else {
                     create_datafusion_session_context(SessionContextProfile::Join)
@@ -1551,9 +1552,7 @@ impl CustomScan for JoinScan {
                 // A rescan after an MPP run replans serially: the launched generation's
                 // workers have already claimed the shared scan state, so binding the fresh
                 // plan to it would leave the leader with nothing to scan.
-                let plan_parallel_state = if state.custom_state().mpp.is_some()
-                    && state.custom_state().mpp_prep.is_none()
-                {
+                let plan_parallel_state = if state.custom_state().mpp.is_launched() {
                     None
                 } else {
                     state.custom_state().parallel_state
@@ -1568,7 +1567,7 @@ impl CustomScan for JoinScan {
                 // spawn the workers, and hand the coordinator the same stages to dispatch. On a
                 // short launch the workers are gone and the `DistributedExec` shape has no mesh
                 // to read from, so replan serially.
-                let (ctx, plan) = match state.custom_state_mut().mpp_prep.take() {
+                let (ctx, plan) = match state.custom_state_mut().mpp.take_prep() {
                     Some(prep) => {
                         match crate::postgres::customscan::mpp::launch::launch_mpp_commit(
                             prep, &plan,
@@ -1585,7 +1584,7 @@ impl CustomScan for JoinScan {
                                 }
                                 let exec_ctx =
                                     Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)));
-                                state.custom_state_mut().mpp = Some(leader);
+                                state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
                                 (exec_ctx, plan)
                             }
                             None => {
@@ -1674,7 +1673,7 @@ impl CustomScan for JoinScan {
         // out of this hook; a release placed after it would never run, leaving the senders to drop
         // at xact commit, past the DSM's lifetime, where their `fetch_sub` faults. The query is
         // done producing here, so the senders aren't needed, and the drop runs while DSM is mapped.
-        if let Some(leader) = state.custom_state().mpp.as_ref() {
+        if let Some(leader) = state.custom_state().mpp.leader() {
             leader.release_control_senders();
         }
         // Drain the workers' metrics frames off the mesh BEFORE joining the workers. On an
@@ -1682,7 +1681,7 @@ impl CustomScan for JoinScan {
         // bounded metrics send spins on the full ring until the leader frees slots. Draining here
         // is what frees them: the sends land on the next try, the workers detach, and the `recv`
         // below returns immediately instead of waiting out the workers' full spin bound.
-        if let Some(leader) = state.custom_state().mpp.as_ref() {
+        if let Some(leader) = state.custom_state().mpp.leader() {
             if let Some(plan) = state.custom_state().physical_plan.as_ref() {
                 crate::postgres::customscan::mpp::glue::drain_worker_metrics(plan, &leader.mesh);
             }
@@ -1690,7 +1689,7 @@ impl CustomScan for JoinScan {
         // Join the producer workers so their metrics land before the EXPLAIN render (which runs
         // before end_custom_scan, where the context is finally destroyed). A worker error is
         // re-raised from inside `recv`.
-        if let Some(leader) = state.custom_state_mut().mpp.as_mut() {
+        if let Some(leader) = state.custom_state_mut().mpp.leader_mut() {
             if let Some(finish) = leader.finish.as_mut() {
                 let _ = finish.recv();
             }
@@ -1701,7 +1700,7 @@ impl CustomScan for JoinScan {
         // Join the MPP producer workers and destroy the parallel context once nothing references
         // the ring mesh. Take the leader out first (its mesh handle drops with it), then drop the
         // stream/plan/runtime (all carry mesh references) before wait_for_finish destroys the DSM.
-        let finish = match state.custom_state_mut().mpp.take() {
+        let finish = match state.custom_state_mut().mpp.take_leader() {
             Some(mut leader) => leader.finish.take(),
             _ => None,
         };

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -249,17 +249,10 @@ pub struct JoinScanState {
     /// before workers can open them.
     pub source_manifests: Vec<SearchIndexManifest>,
 
-    /// MPP-specific state. `Some` only when `paradedb.enable_mpp = on` and the query qualifies.
-    /// Held only by the leader; builder-launched workers reconstruct their state from DSM and
-    /// never carry this.
-    pub mpp: Option<crate::postgres::customscan::mpp::glue::MppLeaderState>,
-    /// The prepared-but-unlaunched MPP DSM. Set on the first exec call before planning; consumed
-    /// by `launch_mpp_commit` once the leader's plan is built, in the same call.
-    pub mpp_prep: Option<crate::postgres::customscan::mpp::launch::MppLaunchPrep>,
-    /// Serialized logical-plan bytes that the leader writes into DSM and workers read back.
-    /// Stashed in `begin_custom_scan` when MPP is active; consumed by `estimate_dsm` /
-    /// `initialize_dsm`.
-    pub mpp_plan_bytes: Option<Vec<u8>>,
+    /// Where MPP sits in its launch lifecycle for this scan: plan bytes stashed at begin,
+    /// prepared on first exec before planning, launched once the plan's stages are committed.
+    /// Stays `Inactive` on the serial path.
+    pub mpp: crate::postgres::customscan::mpp::launch::MppLifecycle,
     /// Which entry in `plan.sources()` is the partitioning source. Stamped into the DSM header
     /// by the leader; read back by workers in `exec_mpp_worker` to key `index_segment_ids`.
     pub mpp_partitioning_source_idx: Option<usize>,

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -253,6 +253,9 @@ pub struct JoinScanState {
     /// Held only by the leader; builder-launched workers reconstruct their state from DSM and
     /// never carry this.
     pub mpp: Option<crate::postgres::customscan::mpp::glue::MppLeaderState>,
+    /// The prepared-but-unlaunched MPP DSM. Set on the first exec call before planning; consumed
+    /// by `launch_mpp_commit` once the leader's plan is built, in the same call.
+    pub mpp_prep: Option<crate::postgres::customscan::mpp::launch::MppLaunchPrep>,
     /// Serialized logical-plan bytes that the leader writes into DSM and workers read back.
     /// Stashed in `begin_custom_scan` when MPP is active; consumed by `estimate_dsm` /
     /// `initialize_dsm`.

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -32,21 +32,16 @@
 use std::sync::Arc;
 
 use datafusion::common::{DataFusionError, Result};
+use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::SessionContext;
-use tantivy::index::SegmentId;
 
 use datafusion_distributed::shm::{proc_for_task, MppMesh};
 
-use crate::api::HashSet;
 use crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context;
 use crate::postgres::customscan::mpp::worker_fragments::{
     collect_dispatched_stages, FragmentAssignment, FragmentRouting,
 };
-use crate::postgres::utils::ExprContextGuard;
-use crate::scan::codec::deserialize_logical_plan_with_runtime;
-use crate::scan::physical_codec::{
-    deserialize_physical_plan_with_runtime, serialize_physical_plan,
-};
+use crate::scan::physical_codec::serialize_physical_plan;
 
 /// One stage of the dispatch blob: the metadata a worker needs to route a stage's output.
 /// Shared by all workers; each selects the `task_idx` slots it owns. The stage's plan arrives
@@ -132,60 +127,23 @@ fn unframe_dispatch_payload(body: &[u8]) -> Result<&[u8]> {
     })
 }
 
-/// Build the dispatch blob on the leader at DSM-init: deserialize the leader's logical plan, build
-/// the distributed physical plan once, and serialize each producer stage's subplan.
+/// Build the dispatch payload from the leader's own execution plan: collect every producer
+/// stage, serialize each subplan, and frame the routing blob to `capacity`.
 ///
-/// This is a structure-only build: no `parallel_state` is injected, so the leader never claims
-/// segments while planning (a throttled sorted scan would otherwise checkout the workers' segments
-/// against the shared state here; with no state it falls to an eager scan that the codec declines,
-/// dropping the query to serial with the real state intact). Lazy scans ship source indices, and
-/// each worker injects its own `ParallelScanState` + segments on decode. `mesh = None` keeps the
-/// build off the transport; the stage numbering matches the consumer plan the leader builds at exec.
-///
-/// The logical bytes predate exec-time rewrites: joinscan injects a runtime `Limit` for
-/// parameterized LIMIT/OFFSET only at exec, after this build. Workers re-planned from these same
-/// bytes before dispatch existed, so the producer-stage shapes here match that precedent.
-pub fn build_dispatch_blob(
-    logical_bytes: &[u8],
-    seed: SessionContext,
+/// The leader executes the same plan object it serialized from, so stage numbering and routing
+/// cannot drift from what the coordinator dispatches. Scan encodes are context-free recipes;
+/// each worker injects its own `ParallelScanState` + segment view on decode, and re-runs the
+/// pushdown pass to re-link dynamic filters.
+pub fn dispatch_payload_from_plan(
+    physical: &Arc<dyn ExecutionPlan>,
     n_workers: u32,
-    runtime: &tokio::runtime::Runtime,
-    non_partitioning_segments: &[HashSet<SegmentId>],
+    capacity: usize,
 ) -> Result<(Vec<u8>, Vec<StagePlan>)> {
-    let expr_context_guard = ExprContextGuard::new();
-    let logical = deserialize_logical_plan_with_runtime(
-        logical_bytes,
-        &seed.task_ctx(),
-        None,
-        Some(expr_context_guard.as_ptr()),
-        None,
-        Vec::new(),
-        Vec::new(),
-    )?;
-    let session = build_mpp_session_context(seed, None);
-    let physical =
-        runtime.block_on(async { session.state().create_physical_plan(&logical).await })?;
-
-    let stages = collect_dispatched_stages(&physical, n_workers)?;
+    let stages = collect_dispatched_stages(physical, n_workers)?;
     let mut dispatched = Vec::with_capacity(stages.len());
     let mut stage_plans = Vec::with_capacity(stages.len());
-    let decode_ctx = session.task_ctx();
     for stage in stages {
         let plan_proto = serialize_physical_plan(stage.plan)?;
-        // Encode can succeed while decode fails (a codec gap). The first decode otherwise
-        // happens in a worker, where failure is a hard query error instead of the serial
-        // fallback this Result feeds; one extra decode per stage (readers released with the
-        // init context) buys the fallback. With no ParallelScanState, a non-partitioning scan
-        // resolves its MVCC view from these canonical sets by its `non_partitioning_index`;
-        // `index_segment_ids` stays empty, which skips the UDF injection without failing it.
-        deserialize_physical_plan_with_runtime(
-            &plan_proto,
-            &decode_ctx,
-            None,
-            non_partitioning_segments.to_vec(),
-            Vec::new(),
-            Some(expr_context_guard.as_ptr()),
-        )?;
         dispatched.push(DispatchedStage {
             stage_num: stage.stage_num,
             task_count: stage.task_count,
@@ -200,7 +158,8 @@ pub fn build_dispatch_blob(
     }
     let blob = bincode::serde::encode_to_vec(&dispatched, blob_config())
         .map_err(|e| DataFusionError::Internal(format!("mpp dispatch: blob encode: {e}")))?;
-    Ok((blob, stage_plans))
+    let payload = frame_dispatch_payload(&blob, capacity)?;
+    Ok((payload, stage_plans))
 }
 
 /// Decode the dispatch blob from the framed DSM payload a worker copied out of DSM.
@@ -230,31 +189,6 @@ fn push_owned_tasks(
             });
         }
     }
-}
-
-/// Builds and frames the dispatch payload for the DSM plan region: a single-thread runtime for
-/// the planning pass, the per-stage blob, then the fixed-capacity frame. One `Err` covers the
-/// whole pipeline so a caller warns once and falls back to serial. Capacity is derived from
-/// `logical_bytes.len()`, the same input `estimate_dsm` sized the region with.
-pub fn build_dispatch_payload(
-    logical_bytes: &[u8],
-    seed: SessionContext,
-    n_workers: u32,
-    non_partitioning_segments: &[HashSet<SegmentId>],
-) -> Result<(Vec<u8>, Vec<StagePlan>)> {
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| DataFusionError::Internal(format!("mpp dispatch: runtime build: {e}")))?;
-    let (blob, stage_plans) = build_dispatch_blob(
-        logical_bytes,
-        seed,
-        n_workers,
-        &runtime,
-        non_partitioning_segments,
-    )?;
-    let payload = frame_dispatch_payload(&blob, dispatch_plan_capacity(logical_bytes.len()))?;
-    Ok((payload, stage_plans))
 }
 
 /// Expand the dispatch blob body into this worker's fragment assignments: the `(stage, task)`

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -133,11 +133,12 @@ pub struct MppLeaderState {
     /// in [`leader_setup`]) clears them on the error path, both before PG detaches the DSM.
     /// The scan state's own drop runs after detach and must find this empty.
     pub control_senders: Arc<std::sync::Mutex<Vec<Option<MppSender>>>>,
-    /// Plans for [`deliver_set_plans`], which runs at exec time when the launched workers are
-    /// draining their inboxes. Sending from the init callback instead could fill a small ring
-    /// with no drainer behind it and wedge the leader. Kept (not drained) so a parallel rescan
-    /// can re-deliver to relaunched workers, the frame analog of the plan blob persisting in
-    /// DSM. Mutex because the exec hook only sees a shared borrow of the scan state.
+    /// The producer-stage subplans serialized from the leader's own execution plan, for
+    /// [`deliver_set_plans`], which runs at exec time when the launched workers are draining
+    /// their inboxes. Sending from the init callback instead could fill a small ring with no
+    /// drainer behind it and wedge the leader. Kept (not drained) so a parallel rescan can
+    /// re-deliver to relaunched workers, the frame analog of the plan blob persisting in DSM.
+    /// Mutex because the exec hook only sees a shared borrow of the scan state.
     pub stage_plans: std::sync::Mutex<Vec<StagePlan>>,
     /// One delivery per worker generation: set by [`deliver_set_plans`], reset by the rescan
     /// path before workers relaunch.

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -218,6 +218,86 @@ pub struct MppLaunchPrep {
     payload_capacity: usize,
 }
 
+/// Where MPP sits in a scan's launch lifecycle. Every transition consumes the previous stage,
+/// so a scan is in exactly one stage at a time; a single field keeps the impossible
+/// combinations (prepared and launched at once, say) unrepresentable. Held only by the leader;
+/// builder-launched workers reconstruct their state from DSM and never carry this.
+#[derive(Default)]
+pub enum MppLifecycle {
+    /// Serial execution: the query didn't qualify, a fallback abandoned the launch, or
+    /// teardown already reclaimed the leader state.
+    #[default]
+    Inactive,
+    /// Serialized logical-plan bytes, stashed at begin time. Prepare uses their length to size
+    /// the DSM payload region before the physical plan exists.
+    PlanBytes(Vec<u8>),
+    /// The DSM is built and the producer workers are spawned, parked on the go flag while the
+    /// leader plans.
+    Prepared(MppLaunchPrep),
+    /// The workers are running dispatched fragments; carries the leader's mesh and finish
+    /// handles until teardown.
+    Launched(MppLeaderState),
+}
+
+impl MppLifecycle {
+    /// Consume the stashed plan bytes. Leaves `Inactive`, so a prepare fallback reads as the
+    /// serial path from then on.
+    pub fn take_plan_bytes(&mut self) -> Option<Vec<u8>> {
+        match std::mem::take(self) {
+            MppLifecycle::PlanBytes(bytes) => Some(bytes),
+            other => {
+                *self = other;
+                None
+            }
+        }
+    }
+
+    /// Consume the prepared launch. Leaves `Inactive`; [`launch_mpp_commit`] decides whether
+    /// the scan moves to `Launched` or stays serial.
+    pub fn take_prep(&mut self) -> Option<MppLaunchPrep> {
+        match std::mem::take(self) {
+            MppLifecycle::Prepared(prep) => Some(prep),
+            other => {
+                *self = other;
+                None
+            }
+        }
+    }
+
+    /// Consume the leader state at teardown, leaving `Inactive`.
+    pub fn take_leader(&mut self) -> Option<MppLeaderState> {
+        match std::mem::take(self) {
+            MppLifecycle::Launched(leader) => Some(leader),
+            other => {
+                *self = other;
+                None
+            }
+        }
+    }
+
+    pub fn leader(&self) -> Option<&MppLeaderState> {
+        match self {
+            MppLifecycle::Launched(leader) => Some(leader),
+            _ => None,
+        }
+    }
+
+    pub fn leader_mut(&mut self) -> Option<&mut MppLeaderState> {
+        match self {
+            MppLifecycle::Launched(leader) => Some(leader),
+            _ => None,
+        }
+    }
+
+    pub fn is_prepared(&self) -> bool {
+        matches!(self, MppLifecycle::Prepared(_))
+    }
+
+    pub fn is_launched(&self) -> bool {
+        matches!(self, MppLifecycle::Launched(_))
+    }
+}
+
 /// Build the MPP DSM (mesh region, `ParallelScanState`, go flag) and spawn the workers parked
 /// on the go flag. `None` covers the fallbacks that must not deploy MPP: DSM too large, or no
 /// parallel context available.

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -27,6 +27,12 @@
 //! `ParallelScanState`, plus the partitioning-source index and a go flag. The leader initializes
 //! the mesh and populates the scan state in place between `build()` and worker attach; workers
 //! reconstruct their `MppWorkerInputs` from the same entries, with no PG plan node in reach.
+//!
+//! The launch is split around the leader's planning pass: [`launch_mpp_prepare`] builds the DSM
+//! and spawns the workers parked on the go flag, so worker process startup overlaps the
+//! leader's planning; [`launch_mpp_commit`] derives the dispatch payload from the leader's plan
+//! and releases them. One plan serves both dispatch and the leader's own execution, and every
+//! planning fallback aborts the parked workers before they touch the mesh.
 
 use std::ffi::c_void;
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -45,7 +51,9 @@ use crate::postgres::customscan::aggregatescan::datafusion_exec::create_aggregat
 use crate::postgres::customscan::joinscan::scan_state::{
     create_datafusion_session_context, SessionContextProfile,
 };
-use crate::postgres::customscan::mpp::dispatch::{build_dispatch_payload, dispatch_plan_capacity};
+use crate::postgres::customscan::mpp::dispatch::{
+    dispatch_payload_from_plan, dispatch_plan_capacity,
+};
 use crate::postgres::customscan::mpp::exec_worker::{run_mpp_worker, MppWorkerInputs};
 use crate::postgres::customscan::mpp::glue::{
     estimate_dsm_size, leader_setup, producer_worker_count, worker_setup, MppLeaderState,
@@ -102,7 +110,7 @@ unsafe fn go_flag(sm: &ParallelStateManager) -> &'static AtomicU32 {
 }
 
 /// AggregateScan worker entry point. PG resolves this symbol by name (passed to
-/// `ParallelProcessBuilder::build`), so the name must match the string in [`launch_mpp_aggregate`].
+/// `ParallelProcessBuilder::build`), so the name must match the string in [`prepare_mpp_aggregate`].
 #[no_mangle]
 #[pgrx::pg_guard]
 pub unsafe extern "C-unwind" fn mpp_launched_worker_agg(
@@ -116,7 +124,7 @@ pub unsafe extern "C-unwind" fn mpp_launched_worker_agg(
 }
 
 /// JoinScan worker entry point. PG resolves this symbol by name; it must match the string in
-/// [`launch_mpp_join`].
+/// [`prepare_mpp_join`].
 #[no_mangle]
 #[pgrx::pg_guard]
 pub unsafe extern "C-unwind" fn mpp_launched_worker_join(
@@ -134,13 +142,20 @@ pub unsafe extern "C-unwind" fn mpp_launched_worker_join(
 /// per-shape serial session context used only for plan deserialization.
 fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> SessionContext) {
     let go = unsafe { go_flag(&state_manager) };
+    // The wait spans the leader's planning pass, so back off to sleeping after a burst of
+    // yields; spinning here would steal cores from the planner.
+    let mut spins = 0u32;
     loop {
         check_for_interrupts!();
         match go.load(Ordering::Acquire) {
             GO_RUN => break,
             // Short launch: the leader ran the query serially. Exit before touching the mesh.
             GO_ABORT => return,
-            _ => std::thread::yield_now(),
+            _ if spins < 1000 => {
+                spins += 1;
+                std::thread::yield_now();
+            }
+            _ => unsafe { pg_sys::pg_usleep(100) },
         }
     }
 
@@ -190,21 +205,32 @@ fn run_launched_worker(state_manager: ParallelStateManager, seed_ctx: fn() -> Se
     run_mpp_worker(inputs, seed_ctx(), &runtime);
 }
 
-/// Launch the producer workers and return the leader's mesh state, or `None` to run serially.
-///
-/// `None` covers every fallback that must not deploy MPP: DSM too large, or the machine couldn't
-/// give us the full producer set. A `pgrx::error!` is reserved for setup that already committed a
-/// launched worker to the mesh, where a silent serial fallback would hide a real bug.
-fn launch_mpp(
-    plan_bytes: Vec<u8>,
+/// DSM prepared for an MPP launch, before the leader has planned. The workers are already
+/// spawned but parked on the go flag: their process startup (library load, backend init)
+/// overlaps the leader's planning pass, while the go flag keeps them off the mesh until the
+/// payload exists. The leader plans against `scan_ptr`, then hands the physical plan to
+/// [`launch_mpp_commit`].
+pub struct MppLaunchPrep {
+    attach: crate::parallel_worker::builder::ParallelProcessAttach,
+    pub scan_ptr: *mut ParallelScanState,
+    pub non_partitioning_segments: Vec<crate::api::HashSet<tantivy::index::SegmentId>>,
+    producer_count: u32,
+    payload_capacity: usize,
+}
+
+/// Build the MPP DSM (mesh region, `ParallelScanState`, go flag) and spawn the workers parked
+/// on the go flag. `None` covers the fallbacks that must not deploy MPP: DSM too large, or no
+/// parallel context available.
+fn launch_mpp_prepare(
+    plan_bytes_len: usize,
     args: ParallelScanArgs,
     partitioning_source_idx: usize,
-    seed_for_dispatch: SessionContext,
     worker_entrypoint: &'static str,
-) -> Option<MppLeaderState> {
+) -> Option<MppLaunchPrep> {
     let producer_count = producer_worker_count();
+    let payload_capacity = dispatch_plan_capacity(plan_bytes_len);
 
-    let region_bytes = match estimate_dsm_size(dispatch_plan_capacity(plan_bytes.len())) {
+    let region_bytes = match estimate_dsm_size(payload_capacity) {
         Ok(sz) => sz,
         Err(e) => {
             pgrx::warning!("mpp: estimate_dsm failed: {e}; running serially");
@@ -235,7 +261,8 @@ fn launch_mpp(
     )?;
 
     // Populate the ParallelScanState in place while the DSM is mapped and the leader still holds
-    // the source manifests `args` borrows. Done before launch so workers find it initialized.
+    // the source manifests `args` borrows. Done before planning so the leader's plan (the same
+    // one the dispatch payload is derived from) binds to the shared state the workers will use.
     let scan_ptr = match launcher.state_manager().slice_mut::<u8>(SCAN_IDX) {
         Ok(Some(s)) => s.as_mut_ptr() as *mut ParallelScanState,
         _ => pgrx::error!("mpp: parallel scan state region missing"),
@@ -243,21 +270,45 @@ fn launch_mpp(
     unsafe { (*scan_ptr).create_and_populate(args) };
     let non_partitioning_segments = unsafe { (*scan_ptr).non_partitioning_segment_ids() };
 
-    // Build the per-stage subplans once. A failure here is a hard error, matching the pre-cutover
-    // path: a serial fallback on a serialization gap would hide a codec bug behind a slow plan.
-    let (payload, stage_plans) = match build_dispatch_payload(
-        &plan_bytes,
-        seed_for_dispatch,
-        producer_count,
-        &non_partitioning_segments,
-    ) {
-        Ok(p) => p,
-        Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
-    };
-
-    // Spawn the workers. They block on the go flag before attaching, so a short launch is aborted
-    // without any worker reaching the mesh.
+    // Spawn the workers before the leader plans: their process startup overlaps the planning
+    // pass, and the go flag keeps them off the mesh until the payload is written.
     let attach = launcher.launch()?;
+
+    Some(MppLaunchPrep {
+        attach,
+        scan_ptr,
+        non_partitioning_segments,
+        producer_count,
+        payload_capacity,
+    })
+}
+
+/// Serialize the leader's plan into the dispatch payload, release the workers, and return the
+/// leader's mesh state, or `None` to run serially (the machine couldn't give us the full
+/// producer set, or the plan has nothing to distribute). A `pgrx::error!` is reserved for setup
+/// that already committed a launched worker to the mesh, where a silent serial fallback would
+/// hide a real bug.
+pub fn launch_mpp_commit(
+    prep: MppLaunchPrep,
+    physical: &std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+) -> Option<MppLeaderState> {
+    let MppLaunchPrep {
+        attach,
+        scan_ptr,
+        non_partitioning_segments: _,
+        producer_count,
+        payload_capacity,
+    } = prep;
+
+    // Derive the per-stage subplans from the plan the leader itself will execute. A failure
+    // here is a hard error: a serialization gap is a codec bug, and the parked workers die
+    // with the transaction.
+    let (payload, stage_plans) =
+        match dispatch_payload_from_plan(physical, producer_count, payload_capacity) {
+            Ok(p) => p,
+            Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
+        };
+
     let finish = attach.wait_for_attach()?;
     let launched = finish.launched_workers() as u32;
 
@@ -272,6 +323,15 @@ fn launch_mpp(
         pgrx::warning!(
             "mpp: launched {launched} of {producer_count} requested workers; running serially"
         );
+        return None;
+    }
+
+    // A plan with no producer stages has nothing to distribute; the workers would only exit
+    // with no fragments while the leader runs a plan whose per-source scans aren't executable
+    // without a worker's state. Release the workers and let the caller replan serially.
+    if stage_plans.is_empty() {
+        go.store(GO_ABORT, Ordering::Release);
+        finish.wait_for_finish();
         return None;
     }
 
@@ -294,32 +354,30 @@ fn launch_mpp(
     Some(leader)
 }
 
-/// AggregateScan launch entry: aggregate seed context + aggregate worker symbol.
-pub fn launch_mpp_aggregate(
-    plan_bytes: Vec<u8>,
+/// AggregateScan prepare entry: aggregate worker symbol.
+pub fn prepare_mpp_aggregate(
+    plan_bytes_len: usize,
     args: ParallelScanArgs,
     partitioning_source_idx: usize,
-) -> Option<MppLeaderState> {
-    launch_mpp(
-        plan_bytes,
+) -> Option<MppLaunchPrep> {
+    launch_mpp_prepare(
+        plan_bytes_len,
         args,
         partitioning_source_idx,
-        create_aggregate_session_context(),
         "mpp_launched_worker_agg",
     )
 }
 
-/// JoinScan launch entry: join seed context + join worker symbol.
-pub fn launch_mpp_join(
-    plan_bytes: Vec<u8>,
+/// JoinScan prepare entry: join worker symbol.
+pub fn prepare_mpp_join(
+    plan_bytes_len: usize,
     args: ParallelScanArgs,
     partitioning_source_idx: usize,
-) -> Option<MppLeaderState> {
-    launch_mpp(
-        plan_bytes,
+) -> Option<MppLaunchPrep> {
+    launch_mpp_prepare(
+        plan_bytes_len,
         args,
         partitioning_source_idx,
-        create_datafusion_session_context(SessionContextProfile::Join),
         "mpp_launched_worker_join",
     )
 }


### PR DESCRIPTION
## What

This PR makes the MPP leader plan each query once, deriving the dispatch payload from the plan it executes.

## Why

The launch ran a structure-only planning pass (`build_dispatch_payload`: logical deserialize, `create_physical_plan`, plus a validation decode per stage) to fill the DSM routing blob and the coordinator's stage plans, and the leader then planned a second time for its own execution. The two passes had to agree on stage numbering by convention. In addition, the dispatch pass planned from logical bytes that predate exec-time rewrites, so worker fragments missed the runtime `Limit` on parameterized LIMIT/OFFSET queries.

## How

The launch is split around the single planning pass:

1. `launch_mpp_prepare` builds the DSM (mesh region + shared `ParallelScanState`) and spawns the workers parked on the go flag, so their process startup overlaps the leader's planning. The wait loop backs off to sleeping so parked workers don't steal cores from the planner. The go flag keeps them off the mesh until the payload exists.
2. The leader plans once, against the shared scan state, under the distributed-planner session. JoinScan injects the runtime `Limit` before physical planning. AggregateScan plans with `MppPlanContext` so the worker-bound stage encodes carry each provider's dispatch metadata (`is_parallel`, `non_partitioning_index`); without it the workers open the wrong segment sets.
3. `launch_mpp_commit` serializes the producer stages of that plan into the dispatch payload (`dispatch_payload_from_plan`) and raises the go flag. The leader executes the same plan object, and the coordinator ships those same stages to the workers, so stage numbering and routing agree with the executed plan by construction.

Fallbacks stay serial-safe: a short launch and a plan with no producer stages both release the parked workers (they never touched the mesh) and the query replans serially. A rescan after an MPP run also replans serially, without binding to the launched generation's already-claimed scan state.

## Performance

Measured with interleaved A/B rounds (same machine, flipping the installed `pg_search.dylib` between this branch and its base within each round; local 1m stackoverflow, M-series, warm). MPP times, two rounds each:

| query | base ms | this PR ms |
|---|---|---|
| zero-row probe (pure launch + plan) | 23.2 / 21.8 | 19.7 / 19.8 |
| `join_semi_filter` | 35.5 / 33.7 | 32.8 / 32.9 |
| `join_aggregate_count` | 47.5 / 46.7 | 44.9 / 45.1 |
| `join_hierarchical_small` | 137.6 / 132.6 | 137.0 / 135.7 |

The saving is one warm planning pass (~2-3ms at this plan size and CPU). The CI runners plan the same shapes several times slower, so the expected saving there is a larger slice of the ~60-70ms fixed floor the 100k benchmarks show.

## Tests

Existing tests pass
