### PR TITLE
perf: gate join InList pushdown to index-driven term-set strategies

### DIFF
--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -859,6 +859,11 @@ fn try_convert_in_list_to_query(
     // multi-column threshold is used because the column's docs-per-term isn't known here; a
     // unique-keyed column between the two thresholds still lands on `LinearScan`, an
     // accepted residual since either path is inexpensive in that band.
+    // A per-segment exact decision needs doc counts and doc_freqs only tantivy's weight
+    // sees. A `TermSetStrategyConfig` flag meaning "a consumer above rechecks membership"
+    // would let each segment fall back to match-all instead of `LinearScan`, and this
+    // planner-side prediction would go away; until then the largest segment stands in for
+    // all of them.
     let linear_fallback_possible = field.is_fast()
         && !field.is_text()
         && !(crate::gucs::term_set_gallop_enabled() && sorted_by_field == Some(col.name()));

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -791,21 +791,38 @@ fn extract_in_list_exprs<'a>(
     }
 }
 
+/// Outcome of trying to convert one join-derived `InList` predicate.
+enum InListPushdown {
+    /// AND the converted term-set query into the tantivy search.
+    Query(Box<dyn Query>),
+    /// Drop the predicate: evaluating it in the scan costs more per row than the hash
+    /// join above, which re-checks the same keys against its build table anyway.
+    Skip,
+    /// Not convertible; keep it as a batch-level pre-filter.
+    Keep,
+}
+
 fn try_convert_in_list_to_query(
     in_list: &InListExpr,
     schema: &crate::schema::SearchIndexSchema,
     index_created_by_version: Option<crate::api::version::Version>,
     strategy_sink: Option<Arc<std::sync::atomic::AtomicU8>>,
-) -> Option<Box<dyn Query>> {
+    max_segment_docs: u32,
+    sorted_by_field: Option<&str>,
+) -> InListPushdown {
     if in_list.negated() {
-        return None;
+        return InListPushdown::Keep;
     }
 
-    let col = in_list.expr().downcast_ref::<Column>()?;
-    let field = schema.search_field(col.name())?;
+    let Some(col) = in_list.expr().downcast_ref::<Column>() else {
+        return InListPushdown::Keep;
+    };
+    let Some(field) = schema.search_field(col.name()) else {
+        return InListPushdown::Keep;
+    };
 
     if field.is_text() && !field.is_keyword() {
-        return None;
+        return InListPushdown::Keep;
     }
 
     let field_type = field.field_type();
@@ -819,18 +836,41 @@ fn try_convert_in_list_to_query(
     // gucs::HASH_JOIN_INLIST_PUSHDOWN_MAX_DISTINCT_VALUES doc for the
     // reasoning and trade-off. Set to 0 to disable pushdown.
     if in_list.list().len() > max_distinct {
-        return None;
+        return InListPushdown::Keep;
     }
 
     // Estimate size: this is a rough estimate based on the number of elements
     // and their typical size.
     let estimated_size = in_list.list().len() * 32; // Assume ~32 bytes per element
     if estimated_size > max_size {
-        return None;
+        return InListPushdown::Keep;
+    }
+
+    // Integrating the term set only pays when the segments admit an index-driven strategy.
+    // Past its density gate tantivy's planner falls back to `LinearScan`, a per-candidate
+    // fast-field probe that re-does the membership test the hash join above performs against
+    // its build table anyway, at a far higher per-row cost than the join's own vectorized
+    // probe — so the predicate is dropped rather than kept. The gate only guards that
+    // fallback: a keyword column or one without a fast representation routes to the FST
+    // automaton, and a column the segments are sorted by routes to gallop, both index-driven
+    // at any density.
+    // Gate on the largest segment: the big segments carry the linear cost, and a small
+    // segment's linear scan is cheap even when it misses its own bitset gate. The looser
+    // multi-column threshold is used because the column's docs-per-term isn't known here; a
+    // unique-keyed column between the two thresholds still lands on `LinearScan`, an
+    // accepted residual since either path is inexpensive in that band.
+    let linear_fallback_possible = field.is_fast()
+        && !field.is_text()
+        && !(crate::gucs::term_set_gallop_enabled() && sorted_by_field == Some(col.name()));
+    let density = in_list.list().len() as f64 / max_segment_docs.max(1) as f64;
+    if linear_fallback_possible && density > crate::gucs::term_set_bitset_max_density_multi() {
+        return InListPushdown::Skip;
     }
 
     let tantivy_schema = schema.tantivy_schema();
-    let tantivy_field = tantivy_schema.get_field(col.name()).ok()?;
+    let Ok(tantivy_field) = tantivy_schema.get_field(col.name()) else {
+        return InListPushdown::Keep;
+    };
     let tantivy_field_type = tantivy_schema.get_field_entry(tantivy_field).field_type();
 
     let terms: Option<Vec<Term>> = in_list
@@ -850,9 +890,11 @@ fn try_convert_in_list_to_query(
         })
         .collect();
 
-    let terms = terms?;
+    let Some(terms) = terms else {
+        return InListPushdown::Keep;
+    };
     if terms.is_empty() {
-        return None;
+        return InListPushdown::Keep;
     }
 
     // Build a strategy config from the paradedb.term_set_* GUCs so the
@@ -874,7 +916,7 @@ fn try_convert_in_list_to_query(
 
     let term_set_query = TermSetQuery::new(terms).with_strategy_config(cfg);
     let const_score_query = ConstScoreQuery::new(Box::new(term_set_query), 0.0);
-    Some(Box::new(const_score_query) as Box<dyn Query>)
+    InListPushdown::Query(Box::new(const_score_query) as Box<dyn Query>)
 }
 
 /// Try to push down `InList` expressions from `dynamic_filters` into the search query.
@@ -900,6 +942,13 @@ pub fn try_dynamic_filter_pushdown(
     let mut pushed_down_pointers = HashSet::default();
     let schema = reader.schema();
     let index_created_by_version = reader.index_created_by_version();
+    let max_segment_docs = reader
+        .segment_readers()
+        .iter()
+        .map(|sr| sr.num_docs())
+        .max()
+        .unwrap_or(0);
+    let sorted_by_field = reader.sort_order().map(|s| s.field_name.to_string());
 
     for df in dynamic_filters {
         let Some(dynamic) = df.downcast_ref::<DynamicFilterPhysicalExpr>() else {
@@ -915,14 +964,22 @@ pub fn try_dynamic_filter_pushdown(
         for in_list_arc in extracted_in_lists {
             let in_list = in_list_arc.downcast_ref::<InListExpr>().unwrap();
 
-            if let Some(query) = try_convert_in_list_to_query(
+            match try_convert_in_list_to_query(
                 in_list,
                 schema,
                 index_created_by_version,
                 strategy_sink.clone(),
+                max_segment_docs,
+                sorted_by_field.as_deref(),
             ) {
-                pushed_down_queries.push(query);
-                pushed_down_pointers.insert(Arc::as_ptr(in_list_arc) as *const () as usize);
+                InListPushdown::Query(query) => {
+                    pushed_down_queries.push(query);
+                    pushed_down_pointers.insert(Arc::as_ptr(in_list_arc) as *const () as usize);
+                }
+                InListPushdown::Skip => {
+                    pushed_down_pointers.insert(Arc::as_ptr(in_list_arc) as *const () as usize);
+                }
+                InListPushdown::Keep => {}
             }
         }
 

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -52,7 +52,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
+                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
 (16 rows)
 
 SELECT t1.val, t2.val
@@ -139,7 +139,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
 (16 rows)
 
 SELECT t1.val, t2.val

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -222,14 +222,14 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 509], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[t2_a, t1, t2_b], metrics=[output_rows=601, output_bytes=78.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4], metrics=[output_rows=601, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=297.0 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4], metrics=[output_rows=601, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=297.0 K, avg_fanout=100% (601/601), probe_hit_rate=54.64% (601/1.10 K)]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_b@4, id@5], metrics=[output_rows=1.10 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
 (18 rows)
 
 SET paradedb.term_set_gallop_enabled = OFF;
@@ -302,17 +302,17 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2, ctid_3@4 as ctid_3], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 809], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[t2_a, t1, t2_b, t2_c], metrics=[output_rows=301, output_bytes=73.4 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_c@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4, ctid_3@5], metrics=[output_rows=301, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=601, input_batches=1, input_rows=301, build_mem_used=345.1 K, avg_fanout=100% (301/301), probe_hit_rate=100% (301/301)]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@3, fk@1)], projection=[ctid_0@0, ctid_1@1, fk_c@2, id@4, ctid_2@5], metrics=[output_rows=601, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=362.6 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_c@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4, ctid_3@5], metrics=[output_rows=301, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=601, input_batches=1, input_rows=1.09 K, build_mem_used=345.1 K, avg_fanout=100% (301/301), probe_hit_rate=27.51% (301/1.09 K)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@3, fk@1)], projection=[ctid_0@0, ctid_1@1, fk_c@2, id@4, ctid_2@5], metrics=[output_rows=601, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=362.6 K, avg_fanout=100% (601/601), probe_hit_rate=54.64% (601/1.10 K)]
            :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_c@4, fk_b@5, id@6], metrics=[output_rows=1.10 K, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
            :             CooperativeExec
            :               PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :             CooperativeExec
            :               PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=301, output_bytes=4.7 KB, output_batches=1, rows_pruned=0, rows_scanned=301]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.09 K, output_bytes=17.1 KB, output_batches=1, rows_pruned=6, rows_scanned=1.10 K]
 (21 rows)
 
 SET paradedb.term_set_gallop_enabled = OFF;

--- a/pg_search/tests/pg_regress/expected/term_set_dispatch.out
+++ b/pg_search/tests/pg_regress/expected/term_set_dispatch.out
@@ -277,12 +277,12 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
-           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=1, input_rows=6.00 K, build_mem_used=1.20 K, avg_fanout=100% (6.00 K/6.00 K), probe_hit_rate=100% (6.00 K/6.00 K)]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.92 K, output_bytes=153.8 KB, output_batches=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.92 K, output_bytes=153.8 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=2, input_rows=4.92 K, build_mem_used=1.20 K, avg_fanout=100% (4.92 K/4.92 K), probe_hit_rate=100% (4.92 K/4.92 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":60}}}]}}, metrics=[output_rows=60, output_bytes=960.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6.00 K, output_bytes=140.6 KB, output_batches=1, rows_pruned=0, rows_scanned=6.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=4.92 K, output_bytes=115.3 KB, output_batches=2, rows_pruned=5.08 K, rows_scanned=10.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_multi.id
@@ -439,11 +439,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.00 K, output_bytes=190.5 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=1, input_rows=4.00 K, build_mem_used=800, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=2, input_rows=4.00 K, build_mem_used=800, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":40}}}]}}, metrics=[output_rows=40, output_bytes=640.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4.00 K, output_bytes=93.8 KB, output_batches=1, rows_pruned=0, rows_scanned=4.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=4.00 K, output_bytes=93.8 KB, output_batches=2, rows_pruned=6.00 K, rows_scanned=10.00 K]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_multi;

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -167,7 +167,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=16.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=6, output_bytes=160.0 B, output_batches=1, rows_pruned=24, rows_scanned=30]
 (15 rows)
 
 -- =============================================================================


### PR DESCRIPTION
## What

This PR stops pushing dense join-key `InList` filters into the tantivy query.

## Why

When a hash join's key set is dense relative to segment size, tantivy's term-set planner falls back to `LinearScan`: a per-candidate fast-field probe that re-does the membership test the join above performs against its build table anyway, at roughly 700ns/doc versus the join's ~50ns/row vectorized probe. Its work also runs regardless of demand, so a `LIMIT` above the join can't exit early.

The mechanism, isolated with GUCs on `join_hierarchical_small` (local 1m, K≈9.5k):

| variant | serial ms | mpp ms |
|---|---|---|
| integrate (linear fires) | 152.4 | 128.1 |
| drop the InList | 20.3 | 38.2 |
| force bitset admission | 255.0 | 165.7 |

Note: this has no MPP dependency; it applies to serial JoinScan too (`join_hierarchical` serial time at 1m has the same linear-scan cost).x 

## How

The gate predicts the per-segment strategy from `K / max_segment_docs` against the existing `paradedb.term_set_bitset_max_density_multi` threshold and drops the predicate when only `LinearScan` could fire; the join re-checks the same keys, so dropping is safe. Index-driven strategies keep integrating: sparse sets (bitset), columns the segments are sorted by (gallop), and keyword or non-fast columns (automaton).

## Performance

Benchmark on the gated build (local 1m, serial / mpp, versus the base branch):

| query | base | gated |
|---|---|---|
| `join_hierarchical_small` | 157 / 148 | **22 / 41** |
| `join_permissioned_search` | 135 / 158 | **60 / 143** |
| `join_foreign_filter_local_sort` | 26 / 60 | 27 / **30** |
| `join_semi_filter` | 30 / 35 | 28 / 30 |
| `join_distinct_parent_sort` | 346 / 378 | 306 / 323 |

`join_semi_filter` at 20m is unaffected: its 560-key set against ~417k-doc segments stays under the density threshold and keeps the bitset path.

## Tests

Expected-output updates.