### PR TITLE
chore: upgrade pgvector to 0.8.4

### DIFF
--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -120,7 +120,7 @@ jobs:
       # Needed for hybrid search unit tests
       - name: Install pgvector
         run: |
-          git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
           cd pgvector/
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -153,7 +153,7 @@ jobs:
       - name: Install pgvector (system)
         if: matrix.pg_impl == 'system'
         run: |
-          git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
           cd pgvector/
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make -j
           sudo PG_CONFIG=/usr/lib/postgresql/${{ matrix.pg_version }}/bin/pg_config make install -j
@@ -161,7 +161,7 @@ jobs:
       - name: Install pgvector (pgrx)
         if: matrix.pg_impl == 'pgrx'
         run: |
-          git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
+          git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
           cd pgvector/
           PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make -j
           PG_CONFIG=~/.pgrx/${{ matrix.pg_version }}.*/pgrx-install/bin/pg_config make install -j

--- a/docker/Dockerfile.antithesis-18
+++ b/docker/Dockerfile.antithesis-18
@@ -38,7 +38,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-18-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-18-cron=1.6.7-2.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-15
+++ b/docker/Dockerfile.official-15
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-15-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-15-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-15-cron=1.6.7-2.pgdg13+1 \
     postgresql-15-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-16
+++ b/docker/Dockerfile.official-16
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-16-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-16-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-16-cron=1.6.7-2.pgdg13+1 \
     postgresql-16-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-17
+++ b/docker/Dockerfile.official-17
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-17-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-17-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-17-cron=1.6.7-2.pgdg13+1 \
     postgresql-17-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.official-18
+++ b/docker/Dockerfile.official-18
@@ -31,7 +31,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-18-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-18-cron=1.6.7-2.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-15
+++ b/docker/Dockerfile.paradedb-15
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-15-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-15-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-15-cron=1.6.7-2.pgdg13+1 \
     postgresql-15-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-15-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-16
+++ b/docker/Dockerfile.paradedb-16
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-16-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-16-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-16-cron=1.6.7-2.pgdg13+1 \
     postgresql-16-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-16-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-17
+++ b/docker/Dockerfile.paradedb-17
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-17-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-17-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-17-cron=1.6.7-2.pgdg13+1 \
     postgresql-17-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-17-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.paradedb-18
+++ b/docker/Dockerfile.paradedb-18
@@ -45,7 +45,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-18-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-18-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-18-cron=1.6.7-2.pgdg13+1 \
     postgresql-18-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-18-postgis-$POSTGIS_VERSION_MAJOR \

--- a/docker/Dockerfile.template
+++ b/docker/Dockerfile.template
@@ -58,7 +58,7 @@ RUN apt-get update \
     && echo "deb [ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] https://apt-archive.postgresql.org/pub/repos/apt trixie-pgdg-archive main" > /etc/apt/sources.list.d/pgdg-archive.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
-    postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.2-1.pgdg13+1 \
+    postgresql-@@PG_VERSION_MAJOR@@-pgvector=0.8.4-1.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-cron=1.6.7-2.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-pg-ivm=1.13-1.pgdg13+1 \
     postgresql-@@PG_VERSION_MAJOR@@-postgis-$POSTGIS_VERSION_MAJOR \

--- a/pg_search/README.md
+++ b/pg_search/README.md
@@ -47,7 +47,7 @@ cargo pgrx init
 `pgvector` is needed for hybrid search integration tests. To build it against the pgrx-managed Postgres install (replace `18.3` with the version under `~/.pgrx/`):
 
 ```bash
-git clone --branch v0.8.2 https://github.com/pgvector/pgvector.git
+git clone --branch v0.8.4 https://github.com/pgvector/pgvector.git
 cd pgvector/
 
 PG_CONFIG=~/.pgrx/18.3/pgrx-install/bin/pg_config make


### PR DESCRIPTION
## What

Upgrades pgvector from `0.8.2` to `0.8.4` everywhere it is pinned:

- **Docker images** (`docker/Dockerfile.{paradedb,official}-{15,16,17,18}`, `Dockerfile.antithesis-18`, `Dockerfile.template`): apt package pin `0.8.2-1.pgdg13+1` → `0.8.4-1.pgdg13+1`.
- **CI workflows** (`test-pg_search.yml`, `test-pg_search-upgrade.yml`): `git clone --branch v0.8.2` → `v0.8.4`.
- **`pg_search/README.md`**: build-from-source instructions bumped to `v0.8.4`.

## Notes

- `tests/Cargo.toml`'s `pgvector = "0.4.1"` is the Rust sqlx client crate, unrelated to the extension version — left untouched.
- pgvector 0.8.4 was released 2026-06-30.