### PR TITLE
ci: fix Jammy Ubuntu package publishing

### DIFF
--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -45,63 +45,72 @@ jobs:
         include:
           # Ubuntu 22.04
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
+            runner_image: ubuntu22-full-x64
             pg_version: 15
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
+            runner_image: ubuntu22-full-arm64
             pg_version: 15
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
+            runner_image: ubuntu22-full-x64
             pg_version: 16
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
+            runner_image: ubuntu22-full-arm64
             pg_version: 16
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
+            runner_image: ubuntu22-full-x64
             pg_version: 17
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
+            runner_image: ubuntu22-full-arm64
             pg_version: 17
             arch: arm64
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
-            runner_image: ubuntu24-full-x64
+            runner_image: ubuntu22-full-x64
             pg_version: 18
             arch: amd64
           - name: Ubuntu 22.04 (Jammy)
+            os_codename: jammy
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
-            runner_image: ubuntu24-full-arm64
+            runner_image: ubuntu22-full-arm64
             pg_version: 18
             arch: arm64
           # Ubuntu 24.04
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
@@ -109,6 +118,7 @@ jobs:
             pg_version: 15
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
@@ -116,6 +126,7 @@ jobs:
             pg_version: 15
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
@@ -123,6 +134,7 @@ jobs:
             pg_version: 16
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
@@ -130,6 +142,7 @@ jobs:
             pg_version: 16
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
@@ -137,6 +150,7 @@ jobs:
             pg_version: 17
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
@@ -144,6 +158,7 @@ jobs:
             pg_version: 17
             arch: arm64
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7a+c7i
@@ -151,6 +166,7 @@ jobs:
             pg_version: 18
             arch: amd64
           - name: Ubuntu 24.04 (Noble)
+            os_codename: noble
             cpu: 8
             ram: 16
             runner_family: c7g+c8g
@@ -198,6 +214,10 @@ jobs:
 
           OS_VERSION="$(lsb_release -cs)"
           echo "OS Version: $OS_VERSION"
+          if [[ "$OS_VERSION" != "${{ matrix.os_codename }}" ]]; then
+            echo "Expected Ubuntu codename '${{ matrix.os_codename }}' for ${{ matrix.name }}, but runner reports '$OS_VERSION'"
+            exit 1
+          fi
           echo "os_version=$OS_VERSION" >> $GITHUB_OUTPUT
 
       - name: Install & Configure Supported PostgreSQL Version
@@ -225,7 +245,7 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.cargo/bin/cargo-pgrx
-          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}-ubuntu
+          key: cargo-pgrx-${{ steps.pgrx.outputs.version }}-${{ runner.os }}-${{ runner.arch }}-${{ matrix.os_codename }}-ubuntu
 
       - name: Install pgrx
         if: steps.cache-pgrx.outputs.cache-hit != 'true'


### PR DESCRIPTION
## What changed

- Point the Ubuntu 22.04 publish matrix entries at `ubuntu22-full-x64` and `ubuntu22-full-arm64` RunsOn images instead of Ubuntu 24 images.
- Add an `os_codename` matrix value and fail early if `lsb_release -cs` does not match the matrix entry.
- Include the Ubuntu codename in the `cargo-pgrx` cache key so Jammy and Noble do not share a cached binary built on the other OS release.

## Why

The Jammy publish jobs were named `Ubuntu 22.04 (Jammy)` but were running on `ubuntu24-full-*`. The workflow derives package filenames from `lsb_release -cs`, so those jobs uploaded `noble` assets and overwrote the actual Noble builds instead of producing `jammy` assets.

## Validation

- `npx --yes prettier --check .github/workflows/publish-pg_search-ubuntu.yml`
- Ruby YAML parse check
- `git diff --check`
- commit pre-commit hooks