### PR TITLE
chore(benchmarks): log executed plans and the MPP launch floor

### DIFF
--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1415,12 +1415,16 @@ async fn execute_query_multiple_times(
     let stats_query = format!("SELECT max_exec_time, max_plan_time, rows FROM pg_stat_statements WHERE queryid = {query_id};");
 
     // Log the plan the timings will measure, so a benchmark run's logs show which execution
-    // path (serial, PG-parallel Gather, MPP DistributedExec) each query took. The compound
-    // statement runs once first so the plan reflects the query's own GUC prefix.
+    // path (serial, PG-parallel Gather, MPP DistributedExec) each query took. ANALYZE makes
+    // the render reflect the EXECUTED plan: launch-time fallbacks (the MPP size gate, a short
+    // worker launch) replan after the plain-EXPLAIN render would have shown a distributed
+    // shape. The compound statement runs once first so the plan reflects the query's own GUC
+    // prefix.
     {
         use sqlx::Row;
         sqlx::raw_sql(query).execute(&mut conn).await.ok();
-        let explain = format!("EXPLAIN (COSTS OFF) {measured_query}");
+        let explain =
+            format!("EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) {measured_query}");
         match sqlx::raw_sql(&explain).fetch_all(&mut conn).await {
             Ok(rows) => {
                 println!("plan for `{query_type}`:");

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1414,6 +1414,27 @@ async fn execute_query_multiple_times(
     let query_id = get_query_id(measured_query, &mut conn).await?;
     let stats_query = format!("SELECT max_exec_time, max_plan_time, rows FROM pg_stat_statements WHERE queryid = {query_id};");
 
+    // Log the plan the timings will measure, so a benchmark run's logs show which execution
+    // path (serial, PG-parallel Gather, MPP DistributedExec) each query took. The compound
+    // statement runs once first so the plan reflects the query's own GUC prefix.
+    {
+        use sqlx::Row;
+        sqlx::raw_sql(query).execute(&mut conn).await.ok();
+        let explain = format!("EXPLAIN (COSTS OFF) {measured_query}");
+        match sqlx::raw_sql(&explain).fetch_all(&mut conn).await {
+            Ok(rows) => {
+                println!("plan for `{query_type}`:");
+                for row in rows {
+                    match row.try_get::<String, _>(0) {
+                        Ok(line) => println!("    {line}"),
+                        Err(e) => println!("    <row decode failed: {e}>"),
+                    }
+                }
+            }
+            Err(e) => println!("plan for `{query_type}`: EXPLAIN failed: {e}"),
+        }
+    }
+
     // run until run-to-run variance is sub-0.1% (query is warmed) or
     // until 10 runs have passed, then take the next sample_count results
     let mut runs_completed = 0;

--- a/benchmarks/src/main.rs
+++ b/benchmarks/src/main.rs
@@ -1423,8 +1423,11 @@ async fn execute_query_multiple_times(
     {
         use sqlx::Row;
         sqlx::raw_sql(query).execute(&mut conn).await.ok();
-        let explain =
-            format!("EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, SUMMARY OFF) {measured_query}");
+        // VERBOSE because the JoinScan renderer only includes per-node `elapsed_compute`
+        // timing for verbose EXPLAINs.
+        let explain = format!(
+            "EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF) {measured_query}"
+        );
         match sqlx::raw_sql(&explain).fetch_all(&mut conn).await {
             Ok(rows) => {
                 println!("plan for `{query_type}`:");

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1381,6 +1381,27 @@ impl CustomScan for JoinScan {
                     explainer.add_text("  ", line);
                 }
             }
+
+            // The MPP launch floor (worker spawn, ring attach, plan dispatch) lives outside the
+            // DataFusion plan, so surface its per-phase breakdown separately when the query ran
+            // distributed.
+            if let Some(t) = state.custom_state().launch_timing {
+                explainer.add_text(
+                    "MPP Launch",
+                    format!(
+                        "workers={} prepare={}us plan={}us payload={}us attach={}us \
+                         leader_setup={}us exec={}us first_frame={}us",
+                        t.workers,
+                        t.prepare_us,
+                        t.plan_us,
+                        t.payload_us,
+                        t.attach_us,
+                        t.leader_setup_us,
+                        t.exec_us,
+                        t.first_frame_us,
+                    ),
+                );
+            }
         } else if let Some(ref logical_plan) = state.custom_state().logical_plan {
             // Plain EXPLAIN reconstructs the physical plan by deserializing the logical
             // plan and calling PgSearchTableProvider::scan(), but without executor state
@@ -1472,11 +1493,14 @@ impl CustomScan for JoinScan {
     }
 
     fn exec_custom_scan(state: &mut CustomScanStateWrapper<Self>) -> *mut pg_sys::TupleTableSlot {
+        let mut launch_us = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
         if state.custom_state().datafusion_stream.is_none() {
             // First exec call: build the MPP DSM before planning. The workers launch only after
             // the leader's plan is built and its stages serialize (`launch_mpp_commit` below),
             // so every planning fallback is a serial run with no workers to abort.
+            let t_prepare = std::time::Instant::now();
             Self::maybe_prepare_mpp(state);
+            launch_us.prepare_us = t_prepare.elapsed().as_micros() as u64;
         }
         unsafe {
             if state.custom_state().datafusion_stream.is_none() {
@@ -1589,11 +1613,13 @@ impl CustomScan for JoinScan {
                 } else {
                     state.custom_state().parallel_state
                 };
+                let t_plan = std::time::Instant::now();
                 let plan = build_plan(
                     &plan_ctx,
                     plan_parallel_state,
                     state.custom_state().non_partitioning_segments.clone(),
                 );
+                launch_us.plan_us = t_plan.elapsed().as_micros() as u64;
 
                 // Commit the MPP launch against the built plan: serialize its producer stages,
                 // spawn the workers, and hand the coordinator the same stages to dispatch. On a
@@ -1609,6 +1635,10 @@ impl CustomScan for JoinScan {
                                 let exec_ctx =
                                     Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
                                         .with_distributed_dispatch_plan_source(source);
+                                launch_us.payload_us = leader.timing.payload_us;
+                                launch_us.attach_us = leader.timing.attach_us;
+                                launch_us.leader_setup_us = leader.timing.leader_setup_us;
+                                launch_us.workers = leader.timing.workers;
                                 state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
                                 (exec_ctx, plan)
                             }
@@ -1631,13 +1661,21 @@ impl CustomScan for JoinScan {
                     pg_sys::work_mem as usize * 1024,
                     pg_sys::hash_mem_multiplier,
                 );
+                let t_exec = std::time::Instant::now();
                 let stream = {
                     let _guard = runtime.enter();
                     plan.execute(0, task_ctx)
                         .expect("Failed to execute DataFusion plan")
                 };
+                launch_us.exec_us = t_exec.elapsed().as_micros() as u64;
 
-                // Retain the executed plan so EXPLAIN ANALYZE can extract metrics.
+                // Retain the executed plan so EXPLAIN ANALYZE can extract metrics. Record the
+                // launch timing only when the query actually ran distributed (workers attached);
+                // a serial fallback never reaches `Launched` and leaves `workers` at zero.
+                if state.custom_state().mpp.is_launched() {
+                    state.custom_state_mut().launch_timing = Some(launch_us);
+                    state.custom_state_mut().stream_built_at = Some(std::time::Instant::now());
+                }
                 state.custom_state_mut().physical_plan = Some(plan.clone());
 
                 let schema = plan.schema();
@@ -1678,6 +1716,16 @@ impl CustomScan for JoinScan {
 
                 match next_batch {
                     Some(Ok(batch)) => {
+                        // First distributed batch out: fold the worker decode, first scan, and
+                        // network hop into the launch timing.
+                        if let Some(built) = state.custom_state().stream_built_at {
+                            if let Some(t) = state.custom_state_mut().launch_timing.as_mut() {
+                                if t.first_frame_us == 0 {
+                                    t.first_frame_us = built.elapsed().as_micros() as u64;
+                                }
+                            }
+                            state.custom_state_mut().stream_built_at = None;
+                        }
                         state.custom_state_mut().current_batch = Some(batch);
                         state.custom_state_mut().batch_index = 0;
                     }

--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -221,6 +221,14 @@ pub struct JoinScanState {
     /// Retained executed physical plan for EXPLAIN ANALYZE metrics extraction.
     pub physical_plan: Option<Arc<dyn ExecutionPlan>>,
 
+    /// Per-phase MPP launch timing, filled during exec when the query runs distributed, for
+    /// `EXPLAIN ANALYZE`. `None` when the query ran serially (no launch).
+    pub launch_timing: Option<crate::postgres::customscan::mpp::glue::MppLaunchTiming>,
+
+    /// When the distributed stream was built, used to time the first batch out (worker decode
+    /// plus first scan plus the network hop to the leader).
+    pub stream_built_at: Option<std::time::Instant>,
+
     /// Shared state for parallel execution.
     /// This is set by either `initialize_dsm_custom_scan` (in the leader) or
     /// `initialize_worker_custom_scan` (in a worker), and then consumed in

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -107,6 +107,31 @@ pub fn producer_worker_count() -> u32 {
     mpp_worker_count() - 1
 }
 
+/// Leader-observable per-phase timing of an MPP launch, in microseconds. Populated so
+/// `EXPLAIN ANALYZE` can show where the launch floor goes. Zero means unmeasured. The
+/// worker-side cost the leader can't see directly is captured indirectly: `attach_us` is the
+/// spawn-plus-fork-plus-ring-attach wait, and `first_frame_us` folds in the workers' plan
+/// decode and first scan.
+#[derive(Default, Clone, Copy, Debug)]
+pub struct MppLaunchTiming {
+    /// DSM alloc and scan-state populate, before the dispatch payload is built.
+    pub prepare_us: u64,
+    /// Leader physical planning.
+    pub plan_us: u64,
+    /// Dispatch-payload serialization from the leader's own plan.
+    pub payload_us: u64,
+    /// Wait for every worker to fork and attach to the ring mesh.
+    pub attach_us: u64,
+    /// Leader ring-mesh init (`leader_setup`).
+    pub leader_setup_us: u64,
+    /// `plan.execute` stream construction.
+    pub exec_us: u64,
+    /// First batch out (worker decode, first scan, and network hop to the leader).
+    pub first_frame_us: u64,
+    /// Producer workers that attached.
+    pub workers: u32,
+}
+
 /// Returned to the leader from [`leader_setup`]. The customscan stashes this on its execution
 /// state and consults it during `exec_custom_scan`.
 ///
@@ -138,6 +163,8 @@ pub struct MppLeaderState {
     /// stashes it on its custom state so the codec installs it into those providers. Null until
     /// `launch` sets it.
     pub parallel_state: *mut ParallelScanState,
+    /// Per-phase launch timing the leader fills in as it commits, for `EXPLAIN ANALYZE`.
+    pub timing: MppLaunchTiming,
 }
 
 /// The `(pgprocno, pid)` of this backend, packed into the receiver token the transport stores so a
@@ -222,6 +249,7 @@ pub unsafe fn leader_setup(
         control_senders,
         finish: None,
         parallel_state: std::ptr::null_mut(),
+        timing: MppLaunchTiming::default(),
     })
 }
 

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -380,17 +380,24 @@ pub fn launch_mpp_commit(
         payload_capacity,
     } = prep;
 
+    let mut timing = crate::postgres::customscan::mpp::glue::MppLaunchTiming::default();
+
     // Derive the per-stage subplans from the plan the leader itself will execute. A failure
     // here is a hard error: a serialization gap is a codec bug, and the parked workers die
     // with the transaction.
+    let t_payload = std::time::Instant::now();
     let (payload, stage_count) =
         match dispatch_payload_from_plan(physical, producer_count, payload_capacity) {
             Ok(p) => p,
             Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
         };
+    timing.payload_us = t_payload.elapsed().as_micros() as u64;
 
+    let t_attach = std::time::Instant::now();
     let finish = attach.wait_for_attach()?;
+    timing.attach_us = t_attach.elapsed().as_micros() as u64;
     let launched = finish.launched_workers() as u32;
+    timing.workers = launched;
 
     let go = unsafe { go_flag(finish.state_manager()) };
 
@@ -421,10 +428,13 @@ pub fn launch_mpp_commit(
         Ok(Some(s)) => s.as_mut_ptr() as *mut c_void,
         _ => pgrx::error!("mpp: mesh region missing"),
     };
+    let t_setup = std::time::Instant::now();
     let mut leader = match unsafe { leader_setup(mesh_ptr, payload) } {
         Ok(l) => l,
         Err(e) => pgrx::error!("mpp: leader_setup failed: {e}"),
     };
+    timing.leader_setup_us = t_setup.elapsed().as_micros() as u64;
+    leader.timing = timing;
 
     // Release the workers into ring attach + plan wait.
     go.store(GO_RUN, Ordering::Release);


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

This PR logs each benchmark query's executed plan into the run output, and adds per-phase MPP launch timings to the JoinScan's `EXPLAIN (ANALYZE)`.

## Why

The summary tables give only timings. Round 9 on #5474 left one number that resists local reproduction (`join_permissioned_search` at 100k: 152ms vs main's 38ms, with the size gate expected to force it serial), and settling it needs to know which execution path the CI run actually took: serial JoinScan, PG-parallel Gather, or MPP `DistributedExec`. In addition, the MPP launch floor (worker spawn, ring attach, plan dispatch) sits outside the DataFusion plan, so no plan render showed where it goes.

## How

The benchmark runner prints one `EXPLAIN (ANALYZE, VERBOSE, COSTS OFF, TIMING OFF, SUMMARY OFF)` per query type, after applying the query's GUC prefix. `ANALYZE` because launch-time fallbacks (the size gate, a short worker launch) replan after plain `EXPLAIN`'s render, which would show a distributed shape for queries that ran serially. `VERBOSE` because the JoinScan renderer emits per-node `elapsed_compute` only there. The JoinScan's `EXPLAIN (ANALYZE)` output gains the launch phases, so a run shows where the fixed floor goes for every query at every scale.

## Tests

Log-only change; nothing asserts on the output. Please note it adds one extra execution of each compound statement per query type (to apply its `SET` prefix before `EXPLAIN`), which is noise-level next to the 10-run warmup.
