### PR TITLE
perf: keep dense join-key InLists integrated under full-consumption plans

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/joinscan/scan_state.rs
@@ -436,6 +436,10 @@ pub async fn build_physical_plan(
         .create_physical_plan(&plan, &state)
         .await?;
 
+    // After the optimizer passes: filter pushdown rebuilds scan nodes, which would drop an
+    // earlier mark.
+    crate::scan::execution_plan::mark_full_consumption_scans(plan.as_ref());
+
     if plan.output_partitioning().partition_count() > 1 {
         Ok(Arc::new(CoalescePartitionsExec::new(plan)) as Arc<dyn ExecutionPlan>)
     } else {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -171,6 +171,13 @@ pub struct PgSearchScanPlan {
     /// this scan to write a tag — the EXPLAIN renderer falls back to
     /// `=true` in that case.
     dynamic_filter_strategy: Arc<AtomicU8>,
+    /// Set when a full-consumption operator (a sort or an aggregate) sits above this scan,
+    /// so a `LIMIT` at the plan root cannot stop the scan early. Dropping a dense join-key
+    /// `InList` is only worthwhile when early exit is possible; under full consumption the
+    /// integrated term set prunes rows before they are decoded and probed, which is where
+    /// the benchmark grid shows the win. Marked by [`mark_full_consumption_scans`] after the
+    /// final plan exists; the default (false) preserves the drop.
+    full_consumption: Arc<AtomicBool>,
 }
 
 impl std::fmt::Debug for PgSearchScanPlan {
@@ -253,11 +260,16 @@ impl PgSearchScanPlan {
             dynamic_filter_pushdown: Arc::new(AtomicBool::new(false)),
             sort_order: sort_order.cloned(),
             dynamic_filter_strategy: Arc::new(AtomicU8::new(0)),
+            full_consumption: Arc::new(AtomicBool::new(false)),
         }
     }
 
     pub fn has_deferred_fields(&self) -> bool {
         !self.deferred_fields.is_empty()
+    }
+
+    fn mark_full_consumption(&self) {
+        self.full_consumption.store(true, Ordering::Relaxed);
     }
 
     pub fn ffhelper(&self) -> Option<Arc<FFHelper>> {
@@ -659,6 +671,7 @@ impl ExecutionPlan for PgSearchScanPlan {
         // Capture self-references for the async block
         let dynamic_filter_pushdown = self.dynamic_filter_pushdown.clone();
         let dynamic_filter_strategy = self.dynamic_filter_strategy.clone();
+        let full_consumption = self.full_consumption.clone();
 
         let stream_gen = async_stream::try_stream! {
             // Optimized Search Integration:
@@ -671,6 +684,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                     &mut reader,
                     &mut dynamic_filters,
                     Some(dynamic_filter_strategy.clone()),
+                    full_consumption.load(Ordering::Relaxed),
                 )
             {
                 dynamic_filter_pushdown.store(true, Ordering::Relaxed);
@@ -813,6 +827,9 @@ impl ExecutionPlan for PgSearchScanPlan {
                 dynamic_filter_strategy: Arc::new(AtomicU8::new(
                     self.dynamic_filter_strategy.load(Ordering::Relaxed),
                 )),
+                full_consumption: Arc::new(AtomicBool::new(
+                    self.full_consumption.load(Ordering::Relaxed),
+                )),
             });
             Ok(
                 FilterPushdownPropagation::with_parent_pushdown_result(filters)
@@ -822,6 +839,32 @@ impl ExecutionPlan for PgSearchScanPlan {
             Ok(FilterPushdownPropagation::if_all(child_pushdown_result))
         }
     }
+}
+
+/// Marks every [`PgSearchScanPlan`] that sits below a full-consumption operator (a sort,
+/// an aggregate, or a segmented Top K), meaning a `LIMIT` at the plan root cannot stop the
+/// scan early. The flag steers the dense join-key `InList` decision: with early exit
+/// possible the predicate is dropped (its up-front evaluation is demand-blind), without it
+/// the term set integrates into the tantivy query so rows are pruned before decode.
+///
+/// Call on the final plan, after the filter-pushdown pass: that pass rebuilds scan nodes,
+/// which would discard an earlier mark.
+pub fn mark_full_consumption_scans(plan: &dyn ExecutionPlan) {
+    fn walk(node: &dyn ExecutionPlan, under_barrier: bool) {
+        let under_barrier = under_barrier
+            || node.is::<datafusion::physical_plan::sorts::sort::SortExec>()
+            || node.is::<datafusion::physical_plan::aggregates::AggregateExec>()
+            || node.is::<crate::scan::segmented_topk_exec::SegmentedTopKExec>();
+        if under_barrier {
+            if let Some(scan) = node.downcast_ref::<PgSearchScanPlan>() {
+                scan.mark_full_consumption();
+            }
+        }
+        for child in node.children() {
+            walk(child.as_ref(), under_barrier);
+        }
+    }
+    walk(plan, false);
 }
 
 /// Evaluate the current dynamic filter expressions and convert them into

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -386,5 +386,10 @@ pub fn deserialize_physical_plan_with_runtime(
     // node and the scans below it; serialization drops them. Re-running the post-optimization
     // pushdown pass on the decoded fragment re-creates the links, so this task's probe scans
     // prune against its build side instead of scanning every segment.
-    FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())
+    let plan =
+        FilterPushdown::new_post_optimization().optimize(plan, ctx.session_config().options())?;
+    // The consumption mark doesn't ride the wire either; re-derive it from the decoded
+    // fragment's shape.
+    crate::scan::execution_plan::mark_full_consumption_scans(plan.as_ref());
+    Ok(plan)
 }

--- a/pg_search/src/scan/pre_filter.rs
+++ b/pg_search/src/scan/pre_filter.rs
@@ -686,6 +686,7 @@ fn try_convert_in_list_to_query(
     strategy_sink: Option<Arc<std::sync::atomic::AtomicU8>>,
     max_segment_docs: u32,
     sorted_by_field: Option<&str>,
+    full_consumption: bool,
 ) -> InListPushdown {
     if in_list.negated() {
         return InListPushdown::Keep;
@@ -736,11 +737,19 @@ fn try_convert_in_list_to_query(
     // multi-column threshold is used because the column's docs-per-term isn't known here; a
     // unique-keyed column between the two thresholds still lands on `LinearScan`, an
     // accepted residual since either path is inexpensive in that band.
+    //
+    // The drop only pays under a plan that can exit early: linear's up-front, demand-blind
+    // scan is then wasted work a `LIMIT` never amortizes. Under full consumption every
+    // candidate is decoded and probed anyway, and integration prunes rows before that cost,
+    // which beats re-checking them in the join above.
     let linear_fallback_possible = field.is_fast()
         && !field.is_text()
         && !(crate::gucs::term_set_gallop_enabled() && sorted_by_field == Some(col.name()));
     let density = in_list.list().len() as f64 / max_segment_docs.max(1) as f64;
-    if linear_fallback_possible && density > crate::gucs::term_set_bitset_max_density_multi() {
+    if linear_fallback_possible
+        && !full_consumption
+        && density > crate::gucs::term_set_bitset_max_density_multi()
+    {
         return InListPushdown::Skip;
     }
 
@@ -814,6 +823,7 @@ pub fn try_dynamic_filter_pushdown(
     reader: &mut crate::index::reader::index::SearchIndexReader,
     dynamic_filters: &mut [Arc<dyn PhysicalExpr>],
     strategy_sink: Option<Arc<std::sync::atomic::AtomicU8>>,
+    full_consumption: bool,
 ) -> bool {
     let mut pushed_down_queries: Vec<Box<dyn Query>> = Vec::new();
     let mut pushed_down_pointers = HashSet::default();
@@ -848,6 +858,7 @@ pub fn try_dynamic_filter_pushdown(
                 strategy_sink.clone(),
                 max_segment_docs,
                 sorted_by_field.as_deref(),
+                full_consumption,
             ) {
                 InListPushdown::Query(query) => {
                     pushed_down_queries.push(query);

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -52,7 +52,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
+                 :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
 (16 rows)
 
 SELECT t1.val, t2.val
@@ -139,7 +139,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
+                 :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=2.00 K, output_bytes=31.2 KB, output_batches=1, rows_pruned=0, rows_scanned=2.00 K]
 (16 rows)
 
 SELECT t1.val, t2.val

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -222,14 +222,14 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 509], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[t2_a, t1, t2_b], metrics=[output_rows=601, output_bytes=78.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4], metrics=[output_rows=601, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=297.0 K, avg_fanout=100% (601/601), probe_hit_rate=54.64% (601/1.10 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4], metrics=[output_rows=601, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=297.0 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
            :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_b@4, id@5], metrics=[output_rows=1.10 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
 (18 rows)
 
 SET paradedb.term_set_gallop_enabled = OFF;
@@ -302,17 +302,17 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2, ctid_3@4 as ctid_3], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 809], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[t2_a, t1, t2_b, t2_c], metrics=[output_rows=301, output_bytes=73.4 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_c@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4, ctid_3@5], metrics=[output_rows=301, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=601, input_batches=1, input_rows=1.09 K, build_mem_used=345.1 K, avg_fanout=100% (301/301), probe_hit_rate=27.51% (301/1.09 K)]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@3, fk@1)], projection=[ctid_0@0, ctid_1@1, fk_c@2, id@4, ctid_2@5], metrics=[output_rows=601, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=362.6 K, avg_fanout=100% (601/601), probe_hit_rate=54.64% (601/1.10 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_c@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4, ctid_3@5], metrics=[output_rows=301, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=601, input_batches=1, input_rows=301, build_mem_used=345.1 K, avg_fanout=100% (301/301), probe_hit_rate=100% (301/301)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@3, fk@1)], projection=[ctid_0@0, ctid_1@1, fk_c@2, id@4, ctid_2@5], metrics=[output_rows=601, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=362.6 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
            :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_c@4, fk_b@5, id@6], metrics=[output_rows=1.10 K, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
            :             CooperativeExec
            :               PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :             CooperativeExec
            :               PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=1.09 K, output_bytes=17.1 KB, output_batches=1, rows_pruned=6, rows_scanned=1.10 K]
+           :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=301, output_bytes=4.7 KB, output_batches=1, rows_pruned=0, rows_scanned=301]
 (21 rows)
 
 SET paradedb.term_set_gallop_enabled = OFF;

--- a/pg_search/tests/pg_regress/expected/term_set_dispatch.out
+++ b/pg_search/tests/pg_regress/expected/term_set_dispatch.out
@@ -277,12 +277,12 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
-           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.92 K, output_bytes=153.8 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.92 K, output_bytes=153.8 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=2, input_rows=4.92 K, build_mem_used=1.20 K, avg_fanout=100% (4.92 K/4.92 K), probe_hit_rate=100% (4.92 K/4.92 K)]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=1, input_rows=6.00 K, build_mem_used=1.20 K, avg_fanout=100% (6.00 K/6.00 K), probe_hit_rate=100% (6.00 K/6.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":60}}}]}}, metrics=[output_rows=60, output_bytes=960.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=4.92 K, output_bytes=115.3 KB, output_batches=2, rows_pruned=5.08 K, rows_scanned=10.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6.00 K, output_bytes=140.6 KB, output_batches=1, rows_pruned=0, rows_scanned=6.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_multi.id
@@ -439,11 +439,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.00 K, output_bytes=190.5 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=2, input_rows=4.00 K, build_mem_used=800, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=1, input_rows=4.00 K, build_mem_used=800, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":40}}}]}}, metrics=[output_rows=40, output_bytes=640.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=4.00 K, output_bytes=93.8 KB, output_batches=2, rows_pruned=6.00 K, rows_scanned=10.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4.00 K, output_bytes=93.8 KB, output_batches=1, rows_pruned=0, rows_scanned=4.00 K]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_multi;

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -167,7 +167,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=16.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all", metrics=[output_rows=6, output_bytes=160.0 B, output_batches=1, rows_pruned=24, rows_scanned=30]
+           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
 (15 rows)
 
 -- =============================================================================


### PR DESCRIPTION
This PR keeps dense join-key `InList` predicates integrated into the tantivy query when the plan consumes the scan fully.

The density gate (#5474) drops a dense `InList` on the assumption that early exit makes tantivy's `LinearScan` fallback wasteful. That holds for a plain `LIMIT` above the join, but not when a sort or aggregate drains the probe. `join_semi_filter` at 1m is the clear case: its `SegmentedTopKExec` consumes the whole join, and with the predicate dropped the posts probe feeds 1.01M rows into the hash join at a 0.1% hit rate. Integrating the term set prunes those rows in tantivy before they are decoded and probed.

The discriminator is whether a `LIMIT` can stop the scan early. After the physical plan exists, a walker marks every `PgSearchScan` below a full-consumption operator (`SortExec`, `AggregateExec`, `SegmentedTopKExec`); the density gate now only drops the predicate for unmarked scans. MPP workers re-derive the mark from their decoded fragment, next to the existing dynamic-filter re-link. `join_hierarchical_small`, the shape the drop was built for, has a plain `LIMIT` and no barrier, so it keeps the drop and its win.

Expected-output updates: `join_hash`, `join_hash_dynamic_filters_sparse`, `term_set_dispatch`, and `topk_dynamic_filter` assert integration (`dynamic_filter_pushdown=linear`) again on their sort/aggregate shapes; query results are unchanged. Verified locally that `join_hierarchical_small` keeps the drop (timings unchanged) and that permissioned/semi results are identical across plain Postgres, serial JoinScan, and MPP.

Please note that `join_permissioned_search`'s 100k regression is a separate cost (the scored hash-build scan, addressed in the PR above this one) and is not expected to move much here; its `InList` sits on the cheap users probe.
