### PR TITLE
perf: share one scored weight across a search's segments

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -27,7 +27,7 @@ use crate::api::version::Version;
 use crate::api::{FieldName, HashMap, OrderByFeature, OrderByInfo, SortDirection};
 use crate::index::fast_fields_helper::FFHelper;
 use crate::index::mvcc::MvccSatisfies;
-use crate::index::reader::scorer::{DeferredScorer, ScorerIter};
+use crate::index::reader::scorer::{DeferredScorer, LazyWeight, ScorerIter};
 use crate::index::setup_tokenizers;
 use crate::postgres::heap::VisibilityChecker;
 use crate::postgres::options::{SortByDirection, SortByField};
@@ -667,16 +667,16 @@ impl SearchIndexReader {
         &self,
         segment_ids: impl Iterator<Item = SegmentId>,
     ) -> MultiSegmentSearchResults {
+        let weight = Arc::new(LazyWeight::new(
+            self.query().box_clone(),
+            self.need_scores,
+            self.searcher.clone(),
+        ));
         let iterators = self
             .segment_readers_in_segments(segment_ids)
             .map(|(segment_ord, segment_reader)| {
                 ScorerIter::new(
-                    DeferredScorer::new(
-                        self.query().box_clone(),
-                        self.need_scores,
-                        segment_reader.clone(),
-                        self.searcher.clone(),
-                    ),
+                    DeferredScorer::new(Arc::clone(&weight), segment_reader.clone()),
                     segment_ord,
                     segment_reader.clone(),
                 )
@@ -738,8 +738,11 @@ impl SearchIndexReader {
             source_idx,
         };
         let searcher = self.searcher.clone();
-        let query = self.query.box_clone();
-        let need_scores = self.need_scores;
+        let weight = Arc::new(LazyWeight::new(
+            self.query.box_clone(),
+            self.need_scores,
+            searcher.clone(),
+        ));
 
         let lazy_iterators = segment_ids.map(move |segment_id| {
             let (segment_ord, segment_reader) = searcher
@@ -751,12 +754,7 @@ impl SearchIndexReader {
             let segment_ord = segment_ord as SegmentOrdinal;
 
             ScorerIter::new(
-                DeferredScorer::new(
-                    query.box_clone(),
-                    need_scores,
-                    segment_reader.clone(),
-                    searcher.clone(),
-                ),
+                DeferredScorer::new(Arc::clone(&weight), segment_reader.clone()),
                 segment_ord,
                 segment_reader.clone(),
             )

--- a/pg_search/src/index/reader/scorer.rs
+++ b/pg_search/src/index/reader/scorer.rs
@@ -16,30 +16,55 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
 use crate::index::reader::index::enable_scoring;
-use std::sync::OnceLock;
-use tantivy::query::{PruningScorer, Query, Scorer};
+use std::sync::{Arc, OnceLock};
+use tantivy::query::{PruningScorer, Query, Scorer, Weight};
 use tantivy::{DocAddress, DocId, DocSet, Score, Searcher, SegmentOrdinal, SegmentReader};
 
-pub struct DeferredScorer {
+/// Lazily builds one [`Weight`] and shares it across a search's segments.
+///
+/// A scored weight aggregates corpus-level term statistics: `doc_freq` walks every
+/// segment's term dictionary. Building the weight per segment therefore costs
+/// segments² dictionary lookups per query, which dominates scored scans on
+/// many-segment indexes.
+pub struct LazyWeight {
     query: Box<dyn Query>,
     need_scores: bool,
-    segment_reader: SegmentReader,
     searcher: Searcher,
+    weight: OnceLock<Box<dyn Weight>>,
+}
+
+impl LazyWeight {
+    pub fn new(query: Box<dyn Query>, need_scores: bool, searcher: Searcher) -> Self {
+        Self {
+            query,
+            need_scores,
+            searcher,
+            weight: Default::default(),
+        }
+    }
+
+    fn get(&self) -> &dyn Weight {
+        self.weight
+            .get_or_init(|| {
+                self.query
+                    .weight(enable_scoring(self.need_scores, &self.searcher))
+                    .expect("weight should be constructable")
+            })
+            .as_ref()
+    }
+}
+
+pub struct DeferredScorer {
+    weight: Arc<LazyWeight>,
+    segment_reader: SegmentReader,
     scorer: OnceLock<Box<dyn PruningScorer>>,
 }
 
 impl DeferredScorer {
-    pub fn new(
-        query: Box<dyn Query>,
-        need_scores: bool,
-        segment_reader: SegmentReader,
-        searcher: Searcher,
-    ) -> Self {
+    pub fn new(weight: Arc<LazyWeight>, segment_reader: SegmentReader) -> Self {
         Self {
-            query,
-            need_scores,
+            weight,
             segment_reader,
-            searcher,
             scorer: Default::default(),
         }
     }
@@ -57,12 +82,8 @@ impl DeferredScorer {
     #[inline(always)]
     fn scorer(&self) -> &dyn PruningScorer {
         self.scorer.get_or_init(|| {
-            let weight = self
-                .query
-                .weight(enable_scoring(self.need_scores, &self.searcher))
-                .expect("weight should be constructable");
-
-            weight
+            self.weight
+                .get()
                 .pruning_scorer(&self.segment_reader, 1.0, Score::MIN)
                 .expect("pruning scorer should be constructable")
         })


### PR DESCRIPTION
## What

This PR builds a scored search's tantivy `Weight` once and shares it across the search's segments.

## Why

A BM25 `Weight` carries corpus-level term statistics: constructing it walks every segment's term dictionary to sum `doc_freq`. `search_segments` and `search_lazy` built a fresh `Weight` per segment, so a scored scan on an N-segment index paid N times that N-segment walk, an O(N²) cost that was paid entirely on the scan's first rows.

join_permissioned_search` at 100k builds its hash side from a scored `title` scan over 48 segments; that scan's `elapsed_compute` is 140ms for 10.2K rows and is on the join's critical path (`build_time=141ms`), which is the whole 4x regression versus single-threaded single-weight base scan. The cost is masked on few-segment indexes, so it only surfaces at the benchmark's segment count under the per-query cache clear.

Note this has no MPP dependency; it helps any scored multi-segment scan (serial base scan, JoinScan, MPP worker).

## How

The weight build is wrapped in a `LazyWeight` (a `OnceLock` behind an `Arc`) that every segment's `DeferredScorer` shares; the per-segment `scorer(segment_reader)` call is unchanged. This is tantivy's own `Searcher::search` pattern.

## Performance

Local A/B on a 10-segment index (the effect grows with segment count, so 48 is larger): the scored build scan's `elapsed_compute` drops from 5.4ms to 1.7ms warm and from 22.5ms to 2.3ms cold. The CI benchmark round with this change confirmed it: `join_permissioned_search` at 100k went from 153.7ms (4.01x vs serial execution) to 70.6ms (1.84x).

## Tests

Existing tests.
