### PR TITLE
docs: document paradedb.index_created_at

### DIFF
--- a/docs/documentation/indexing/verify-index.mdx
+++ b/docs/documentation/indexing/verify-index.mdx
@@ -890,6 +890,22 @@ await dbContext.Database
  app        | articles    | articles_idx  |      16448 |            2 |      10000
 ```
 
+## Index Build Time
+
+To see the wall-clock time a BM25 index was built:
+
+```sql SQL
+SELECT paradedb.index_created_at('search_idx');
+```
+
+```
+       index_created_at
+------------------------------
+ 2026-07-02 14:31:07.442218+00
+```
+
+This returns `NULL` for indexes built before build-time stamping was added.
+
 ## Function Reference
 
 ### `pdb.verify_index`
@@ -952,3 +968,13 @@ Returns:
 | `indexrelid`   | oid    | OID of the index                    |
 | `num_segments` | int    | Number of Tantivy segments          |
 | `total_docs`   | bigint | Total documents across all segments |
+
+### `paradedb.index_created_at`
+
+Returns the wall-clock time the given BM25 index was built, or `NULL` for indexes built before build-time stamping was added.
+
+| Parameter | Type     | Default    | Description          |
+| --------- | -------- | ---------- | -------------------- |
+| `index`   | regclass | (required) | The index to inspect |
+
+Returns a `timestamp with time zone`.

--- a/docs/documentation/indexing/verify-index.mdx
+++ b/docs/documentation/indexing/verify-index.mdx
@@ -892,7 +892,7 @@ await dbContext.Database
 
 ## Index Build Time
 
-To see the wall-clock time a BM25 index was built:
+To see the wall-clock time a BM25 index was built at:
 
 ```sql SQL
 SELECT paradedb.index_created_at('search_idx');

--- a/docs/documentation/indexing/verify-index.mdx
+++ b/docs/documentation/indexing/verify-index.mdx
@@ -904,7 +904,7 @@ SELECT paradedb.index_created_at('search_idx');
  2026-07-02 14:31:07.442218+00
 ```
 
-This returns `NULL` for indexes built before build-time stamping was added.
+Build-time stamping is supported on ParadeDB `0.24.2` and up. Indexes created before upgrading to `0.24.2` will return `NULL`.
 
 ## Function Reference
 
@@ -971,7 +971,7 @@ Returns:
 
 ### `paradedb.index_created_at`
 
-Returns the wall-clock time the given BM25 index was built, or `NULL` for indexes built before build-time stamping was added.
+Returns the wall-clock time the given BM25 index was built. Supported on ParadeDB `0.24.2` and up; indexes created before upgrading to `0.24.2` return `NULL`.
 
 | Parameter | Type     | Default    | Description          |
 | --------- | -------- | ---------- | -------------------- |


### PR DESCRIPTION
## What

Documents the new `paradedb.index_created_at(regclass)` UDF (added in #5465) on the [Verify Index Integrity](https://docs.paradedb.com/documentation/indexing/verify-index) page.

Adds an **Index Build Time** usage section and a **Function Reference** entry under the existing function reference.