### PR TITLE
perf(mpp): lower the default ring size to 8MB

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -148,19 +148,20 @@ static MPP_TRACE: GucSetting<bool> = GucSetting::<bool>::new(false);
 /// at exec time, so users in constrained environments see fewer.
 static MPP_WORKER_COUNT: GucSetting<i32> = GucSetting::<i32>::new(4);
 
-/// Per-edge shm_mq queue size in bytes. Each MPP query allocates
-/// `num_meshes × N×(N-1) × mpp_queue_size` of dynamic shared memory: at
-/// N=4 with 3 meshes (group-by aggregate's worst case) the default 64 MiB
-/// produces ~2.3 GiB per query, sized so a ~100 MiB Partial-aggregate burst
-/// on the post-agg mesh fits without backpressure. Operators on memory-
-/// constrained boxes will want to dial this down; that's the explicit
-/// reason it's exposed instead of held as a `pub const`.
+/// Per-inbox ring size in bytes. Each MPP query lays out one MPSC inbox per proc
+/// (leader plus workers), so the mesh region is about `N × mpp_queue_size`, and
+/// Postgres commits the whole region on creation (`posix_fallocate` in the Linux
+/// DSM path, to avoid a later SIGBUS under overcommit), so the region size is a
+/// fixed per-query launch cost. The default keeps that cost inside Docker's
+/// default 64 MiB `/dev/shm` with room to spare: at N=4 it reserves ~32 MiB per
+/// query. Frames larger than a ring stream through it in chunks, so the size
+/// bounds backpressure granularity and launch cost, not what a query can carry.
+/// The runtime tuning reach is the reason it's a GUC instead of a `pub const`.
 ///
-/// This is a foundation-era knob and may be replaced once mesh
-/// multiplexing lands (one queue carrying tagged messages from N stages
-/// instead of N meshes), at which point the right user knob is more
-/// likely a per-query DSM cap than a raw per-edge byte count.
-static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(64 * 1024 * 1024);
+/// The inboxes already multiplex tagged frames from every stage; if this knob
+/// changes shape, the right user knob is more likely a per-query DSM cap than
+/// a raw per-inbox byte count.
+static MPP_QUEUE_SIZE: GucSetting<i32> = GucSetting::<i32>::new(8 * 1024 * 1024);
 
 /// The maximum size of an InList that can be pushed down to a TermSet Query.
 static HASH_JOIN_INLIST_PUSHDOWN_MAX_SIZE: GucSetting<i32> =
@@ -649,14 +650,14 @@ pub fn init() {
 
     GucRegistry::define_int_guc(
         c"paradedb.mpp_queue_size",
-        c"Per-edge shm_mq queue size for MPP shuffles",
-        c"Sets the per-edge shm_mq queue size for MPP shuffles. Accepts standard \
-          Postgres byte units (e.g. '64MB', '1GB', '512kB'). Total DSM per query is \
-          `num_meshes × N×(N-1) × mpp_queue_size`; at the default 64MB and N=4 with \
-          3 meshes that is ~2.3GB per query. Lower this on memory-constrained boxes; \
-          raise it only if a single shuffle batch routinely backs up the queue. \
-          Foundation-era knob — likely to be replaced by a per-query DSM cap once \
-          mesh multiplexing lands.",
+        c"Per-inbox ring size for MPP shuffles",
+        c"Sets the per-inbox ring size for MPP shuffles. Accepts standard \
+          Postgres byte units (e.g. '64MB', '1GB', '512kB'). Each query lays out \
+          one inbox per proc, so total DSM per query is about `N x mpp_queue_size`; \
+          at the default 8MB and N=4 that is ~32MB per query, within Docker's \
+          default 64MB /dev/shm. Frames larger than a ring stream through it in \
+          chunks. Lower this on memory-constrained boxes; raise it when shuffle \
+          batches routinely back up the ring.",
         &MPP_QUEUE_SIZE,
         64 * 1024,
         1024 * 1024 * 1024,

--- a/pg_search/tests/pg_regress/expected/mpp_smoke.out
+++ b/pg_search/tests/pg_regress/expected/mpp_smoke.out
@@ -30,7 +30,7 @@ SHOW paradedb.mpp_worker_count;
 SHOW paradedb.mpp_queue_size;
  paradedb.mpp_queue_size 
 -------------------------
- 64MB
+ 8MB
 (1 row)
 
 -- Defaults: the debug knob stays off.
@@ -49,7 +49,7 @@ SELECT current_setting('paradedb.mpp_worker_count')::int AS worker_count_default
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_default;
  queue_size_default 
 --------------------
- 64MB
+ 8MB
 (1 row)
 
 -- Toggle the boolean GUCs and verify they stick.
@@ -107,11 +107,11 @@ SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_1gb;
  1GB
 (1 row)
 
-SET paradedb.mpp_queue_size TO '64MB';
+SET paradedb.mpp_queue_size TO '8MB';
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_back_to_default;
  queue_size_back_to_default 
 ----------------------------
- 64MB
+ 8MB
 (1 row)
 
 -- Out-of-range queue size must fail (GUC min=64kB, max=1GB).

--- a/pg_search/tests/pg_regress/sql/mpp_smoke.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_smoke.sql
@@ -59,7 +59,7 @@ SET paradedb.mpp_queue_size TO '32MB';
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_32mb;
 SET paradedb.mpp_queue_size TO '1GB';
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_after_1gb;
-SET paradedb.mpp_queue_size TO '64MB';
+SET paradedb.mpp_queue_size TO '8MB';
 SELECT current_setting('paradedb.mpp_queue_size') AS queue_size_back_to_default;
 
 -- Out-of-range queue size must fail (GUC min=64kB, max=1GB).


### PR DESCRIPTION
## What

This PR lowers the default `paradedb.mpp_queue_size` from 64MB to 8MB and fixes the DSM math in the GUC docs.

## Why

Postgres commits the whole mesh region when it creates the segment (`posix_fallocate` on the Linux DSM path, to avoid a later `SIGBUS` under overcommit). So the region is a fixed launch cost, paid before any rows move: ~256MB and ~45ms of `prepare` per query at the old default with N=4. On the light join shapes that's more than half the runtime.

The reservation is also a hard failure where `/dev/shm` is small: Docker's default 64MiB can't fit ~257MB, which is #5748. At 8MB the request drops to ~33MB and fits a stock container.

The old default wasn't picked for throughput. Small rings were a correctness ceiling: a frame must fit its ring whole, and operators emit slices whose arrow-ipc encoding balloons to the full accumulated-state size, so wide `GROUP BY` and `DISTINCT` shapes failed with the frame-too-large error. paradedb/datafusion-distributed#51 removed that ceiling: the send path compacts an over-cap batch and streams whatever is still too large through the ring in chunks, so frame size is never an error. It rides in on the `snapshot-main-2026-07-30-083335` pin `main` already carries, so this PR is only the GUC change.

## How

One GUC change plus a doc fix. The old docs claimed `num_meshes × N×(N-1) × mpp_queue_size` of DSM per query, a leftover from the pairwise-ring topology. The actual layout is one inbox per proc, about `N × mpp_queue_size`.

## Performance

The smaller reservation drops `prepare` from ~45ms to ~12ms per MPP query (local A/B via the launch timer). In the CI benchmark round that measured 16MB rings: the last two 100k regressions cleared, `join_semi_filter` at 1m went from 3.70x to 2.52x vs serial (its variant from 2.18x to 1.45x), and `join_hierarchical` at 20m dropped to parity. An earlier flat-16MB attempt without the fix is what the benchmarks rejected (the wide-bio `DISTINCT` hit the frame-too-large error); with it pinned, the benchmark round on this branch passes. Those rounds ran at 16MB rings; the default here is 8MB to fit Docker, and tuning it back up rides the #5734 benchmarking.

## Tests

`mpp_smoke` pins the default; its expectations moved to 8MB. The MPP suites pass at the new default. The streaming itself is covered in the fork: unit tests (compaction, chunk reassembly, a single row bigger than the whole ring, the `Utf8View` gc case) and an end-to-end wide `max(s)` `GROUP BY` over 64KiB rings.


