### PR TITLE
ci: tolerate paradedb faults in antithesis stressgres

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -386,9 +386,9 @@ jobs:
       # custom.container_faults_{stop,kill}_exclusion_patterns exempts containers from stop/kill faults for two reasons:
       #   - infra ParadeDB doesn't develop, always exempt: the cloudnative-pg operator and
       #     logical-replication-publisher (a vanilla Postgres container)
-      #   - the paradedb container, but only on proptests: proptests is a differential-correctness oracle with no
+      #   - the paradedb pod(s) under proptests: proptests is a differential-correctness oracle with no
       #     reconnect resilience, so a stopped/killed paradedb there is spurious query-failure noise rather than
-      #     exercised recovery. On stressgres, paradedb is left subject to the faults.
+      #     exercised recovery
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.12
         with:

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -383,11 +383,12 @@ jobs:
       # antithesis.duration is in minutes, 360 minutes = 6 hours
       # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
       # antithesis.source ensures Community and Enteprise have separate histories
-      # custom.container_faults_{stop,kill}_exclusion_patterns spares from stop/kill faults the infra ParadeDB doesn't develop:
-      #   - the cloudnative-pg operator
-      #   - logical-replication-publisher (a vanilla Postgres container)
-      #   - the paradedb container(s) on proptests — a differential-correctness oracle with no reconnect
-      #     resilience, where a killed paradedb is spurious query-failure noise instead of exercised recovery
+      # custom.container_faults_{stop,kill}_exclusion_patterns exempts containers from stop/kill faults for two reasons:
+      #   - infra ParadeDB doesn't develop, always exempt: the cloudnative-pg operator and
+      #     logical-replication-publisher (a vanilla Postgres container)
+      #   - the paradedb container, but only on proptests: proptests is a differential-correctness oracle with no
+      #     reconnect resilience, so a stopped/killed paradedb there is spurious query-failure noise rather than
+      #     exercised recovery. On stressgres, paradedb is left subject to the faults.
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.12
         with:

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -386,9 +386,8 @@ jobs:
       # custom.container_faults_{stop,kill}_exclusion_patterns exempts containers from stop/kill faults for two reasons:
       #   - infra ParadeDB doesn't develop, always exempt: the cloudnative-pg operator and
       #     logical-replication-publisher (a vanilla Postgres container)
-      #   - the paradedb pod(s) under proptests: proptests is a differential-correctness oracle with no
-      #     reconnect resilience, so a stopped/killed paradedb there is spurious query-failure noise rather than
-      #     exercised recovery
+      #   - the paradedb pod(s) under proptests: proptests is a differential-correctness oracle with no reconnect
+      #     resilience, so a stopped/killed paradedb there is spurious query-failure noise rather than exercised recovery
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.12
         with:

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -383,8 +383,7 @@ jobs:
       # antithesis.duration is in minutes, 360 minutes = 6 hours
       # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
       # antithesis.source ensures Community and Enteprise have separate histories
-      # custom.container_faults_{stop,kill}_exclusion_patterns spares from stop/kill faults the infra
-      # ParadeDB doesn't develop:
+      # custom.container_faults_{stop,kill}_exclusion_patterns spares from stop/kill faults the infra ParadeDB doesn't develop:
       #   - the cloudnative-pg operator
       #   - logical-replication-publisher (a vanilla Postgres container)
       #   - the paradedb container(s) on proptests — a differential-correctness oracle with no reconnect

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -400,8 +400,8 @@ jobs:
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb
             custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }}
-            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg,logical-replication-publisher
-            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg,logical-replication-publisher
+            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},cloudnative-pg,logical-replication-publisher
+            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},cloudnative-pg,logical-replication-publisher
 
   # Ping Slack if any of the nightly (scheduled) jobs failed. Scheduled runs only execute on
   # paradedb-enterprise (see the `if` on `setup`), so this notification only fires there.

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -383,6 +383,10 @@ jobs:
       # antithesis.duration is in minutes, 360 minutes = 6 hours
       # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
       # antithesis.source ensures Community and Enteprise have separate histories
+      # custom.container_faults_{stop,kill}_exclusion_patterns spares infra ParadeDB doesn't develop from
+      #   stop/kill faults: the cloudnative-pg operator and logical-replication-publisher (a vanilla Postgres
+      #   container), plus the paradedb container(s) on proptests — a differential-correctness oracle with no
+      #   reconnect resilience, where a killed paradedb is spurious query-failure noise instead of exercised recovery
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.12
         with:
@@ -400,8 +404,8 @@ jobs:
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb
             custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }}
-            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},cloudnative-pg,logical-replication-publisher
-            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},cloudnative-pg,logical-replication-publisher
+            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
+            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
 
   # Ping Slack if any of the nightly (scheduled) jobs failed. Scheduled runs only execute on
   # paradedb-enterprise (see the `if` on `setup`), so this notification only fires there.

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -383,10 +383,12 @@ jobs:
       # antithesis.duration is in minutes, 360 minutes = 6 hours
       # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
       # antithesis.source ensures Community and Enteprise have separate histories
-      # custom.container_faults_{stop,kill}_exclusion_patterns spares infra ParadeDB doesn't develop from
-      #   stop/kill faults: the cloudnative-pg operator and logical-replication-publisher (a vanilla Postgres
-      #   container), plus the paradedb container(s) on proptests — a differential-correctness oracle with no
-      #   reconnect resilience, where a killed paradedb is spurious query-failure noise instead of exercised recovery
+      # custom.container_faults_{stop,kill}_exclusion_patterns spares from stop/kill faults the infra
+      # ParadeDB doesn't develop:
+      #   - the cloudnative-pg operator
+      #   - logical-replication-publisher (a vanilla Postgres container)
+      #   - the paradedb container(s) on proptests — a differential-correctness oracle with no reconnect
+      #     resilience, where a killed paradedb is spurious query-failure noise instead of exercised recovery
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.12
         with:

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,7 +16,7 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
-- Run headless mode tolerating transient database faults (e.g. under Antithesis) with `--reconnect-grace-ms`, how long to reconnect before a fault fails the run (default `0` = fail immediately):
+- Run headless mode tolerating transient database faults (e.g. under Antithesis)
 
 ```bash
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace-ms=30000

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,7 +16,7 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
-- Run headless mode tolerating transient database faults (e.g. under Antithesis)
+- Run headless mode tolerating transient database faults (e.g. under Antithesis). The grace window is per continuous outage and resets after a successful reconnect.
 
 ```bash
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace-ms=30000

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -24,6 +24,17 @@ cargo run -- auto /path/to/pg_config suites/vanilla-postgres.toml /tmp/stressgre
 
 Suites are TOML files in `suites/`. The `vanilla-postgres.toml` suite exercises baseline Postgres features and works with any PostgreSQL-compatible server.
 
+### Tolerating transient database faults
+
+By default any error (including a dropped connection) fails the run immediately. Under
+fault injection (e.g. Antithesis stopping/killing/partitioning the database container)
+that isn't desired — the workload should ride out the fault and keep exercising recovery
+code, leaving bug detection to Antithesis properties / postgres-side checks. Pass
+`--reconnect-grace-ms <MS>` (on `headless` or `ui`) to keep reconnecting through transient
+connectivity faults for that long before declaring the connection dropped; real
+logical/SQL errors and assertion failures still fail immediately regardless. The
+Antithesis singleton drivers pass `--reconnect-grace-ms 30000`.
+
 ## Docker
 
 To run Stressgres from within Docker, use:

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,7 +16,7 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
-- Run headless mode tolerating transient database faults (e.g. under Antithesis). The grace window is per continuous outage and resets after a successful reconnect.
+- Run headless mode tolerating transient database faults (e.g. under Antithesis); grace window is per continuous outage and resets after a successful reconnect
 
 ```bash
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace-ms=30000

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,7 +16,7 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
-- Run headless mode tolerating transient database faults (e.g. under Antithesis, which stops/kills/partitions the database container). `--reconnect-grace-ms` is how long to keep reconnecting through a fault before failing; it defaults to `0` (any error fails the run immediately):
+- Run headless mode tolerating transient database faults (e.g. under Antithesis) with `--reconnect-grace-ms`, how long to reconnect before a fault fails the run (default `0` = fail immediately):
 
 ```bash
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace-ms=30000

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,6 +16,12 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
+- Run headless mode tolerating transient database faults (e.g. under Antithesis, which stops/kills/partitions the database container). `--reconnect-grace-ms` is how long to keep reconnecting through a fault before failing; it defaults to `0` (any error fails the run immediately):
+
+```bash
+cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace-ms=30000
+```
+
 - Run a suite against a throwaway Postgres cluster built from a given `pg_config`:
 
 ```bash
@@ -23,17 +29,6 @@ cargo run -- auto /path/to/pg_config suites/vanilla-postgres.toml /tmp/stressgre
 ```
 
 Suites are TOML files in `suites/`. The `vanilla-postgres.toml` suite exercises baseline Postgres features and works with any PostgreSQL-compatible server.
-
-### Tolerating transient database faults
-
-By default any error (including a dropped connection) fails the run immediately. Under
-fault injection (e.g. Antithesis stopping/killing/partitioning the database container)
-that isn't desired — the workload should ride out the fault and keep exercising recovery
-code, leaving bug detection to Antithesis properties / postgres-side checks. Pass
-`--reconnect-grace-ms <MS>` (on `headless` or `ui`) to keep reconnecting through transient
-connectivity faults for that long before declaring the connection dropped; real
-logical/SQL errors and assertion failures still fail immediately regardless. The
-Antithesis singleton drivers pass `--reconnect-grace-ms 30000`.
 
 ## Docker
 

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,7 +16,7 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
-- Run headless mode tolerating transient database faults (e.g. under Antithesis); grace window is per continuous outage and resets after a successful reconnect
+- Run headless mode tolerating transient database faults (e.g. under Antithesis)
 
 ```bash
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace-ms=30000

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -60,6 +60,14 @@ pub struct UiArgs {
     /// PostgreSQL version to use (pg15, pg16, pg17, or pg18).
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
+
+    /// How long (in milliseconds) to tolerate transient database connectivity
+    /// faults (dropped/refused sockets, server restarting) by reconnecting before
+    /// failing the run. Defaults to 0, i.e. any error fails the run immediately.
+    /// Set this (e.g. under Antithesis, which stops/kills/partitions the database
+    /// container) so the workload rides out the fault instead of failing.
+    #[arg(long, default_value = "0")]
+    pub reconnect_grace_ms: u64,
 }
 
 /// Arguments for running the suite in headless mode.
@@ -80,6 +88,13 @@ pub struct HeadlessArgs {
     /// PostgreSQL version to use (pg15, pg16, pg17, or pg18).
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
+    /// How long (in milliseconds) to tolerate transient database connectivity
+    /// faults (dropped/refused sockets, server restarting) by reconnecting before
+    /// failing the run. Defaults to 0, i.e. any error fails the run immediately.
+    /// Set this (e.g. under Antithesis, which stops/kills/partitions the database
+    /// container) so the workload rides out the fault instead of failing.
+    #[arg(long, default_value = "0")]
+    pub reconnect_grace_ms: u64,
 }
 
 /// Arguments for parsing a log file and generating the desired charts.

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -61,11 +61,12 @@ pub struct UiArgs {
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
 
-    /// How long (in milliseconds) to tolerate transient database connectivity
-    /// faults (dropped/refused sockets, server restarting) by reconnecting before
-    /// failing the run. Defaults to 0, i.e. any error fails the run immediately.
-    /// Set this (e.g. under Antithesis, which stops/kills/partitions the database
-    /// container) so the workload rides out the fault instead of failing.
+    /// How long (in milliseconds) to tolerate one continuous transient database
+    /// fault (dropped/refused sockets, server restarting) by reconnecting before
+    /// failing the run. The grace window resets after a successful reconnect.
+    /// Defaults to 0, i.e. any error fails the run immediately. Set this (e.g.
+    /// under Antithesis, which stops/kills/partitions the database container) so
+    /// the workload rides out the fault instead of failing.
     #[arg(long, default_value = "0")]
     pub reconnect_grace_ms: u64,
 }
@@ -88,11 +89,12 @@ pub struct HeadlessArgs {
     /// PostgreSQL version to use (pg15, pg16, pg17, or pg18).
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
-    /// How long (in milliseconds) to tolerate transient database connectivity
-    /// faults (dropped/refused sockets, server restarting) by reconnecting before
-    /// failing the run. Defaults to 0, i.e. any error fails the run immediately.
-    /// Set this (e.g. under Antithesis, which stops/kills/partitions the database
-    /// container) so the workload rides out the fault instead of failing.
+    /// How long (in milliseconds) to tolerate one continuous transient database
+    /// fault (dropped/refused sockets, server restarting) by reconnecting before
+    /// failing the run. The grace window resets after a successful reconnect.
+    /// Defaults to 0, i.e. any error fails the run immediately. Set this (e.g.
+    /// under Antithesis, which stops/kills/partitions the database container) so
+    /// the workload rides out the fault instead of failing.
     #[arg(long, default_value = "0")]
     pub reconnect_grace_ms: u64,
 }

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -107,11 +107,26 @@ fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
     }
 }
 
+#[derive(Default)]
+pub(crate) struct TransientProgress {
+    recovered: bool,
+}
+
+impl TransientProgress {
+    /// Mark that this retry attempt reached the database. If the attempt later
+    /// fails with another transient error, it starts a fresh grace window.
+    pub(crate) fn mark_recovered(&mut self) {
+        self.recovered = true;
+    }
+}
+
 /// Runs `op`, tolerating transient connectivity faults for up to `grace`: while `op`
 /// keeps failing with a transient error (a dropped/refused socket, server restarting,
 /// etc.) it is retried with capped backoff. A real (non-transient) error is returned
 /// immediately. The connection is only declared dropped — and the error surfaced —
-/// once it has stayed broken for `grace` continuously.
+/// once it has stayed broken for `grace` continuously. If `op` calls
+/// [`TransientProgress::mark_recovered`] before returning a later transient error,
+/// the grace window is restarted because the database recovered between faults.
 ///
 /// With `grace == 0` (the default outside Antithesis) any error fails immediately,
 /// preserving the historical "an error fails the run" behaviour.
@@ -125,17 +140,22 @@ fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
 pub(crate) fn tolerate_transient<T>(
     alive: &AtomicBool,
     grace: Duration,
-    mut op: impl FnMut() -> Result<T>,
+    mut op: impl FnMut(&mut TransientProgress) -> Result<T>,
 ) -> Result<Option<T>> {
     let mut backoff = INITIAL_RECONNECT_BACKOFF;
     let mut down_since: Option<Instant> = None;
     loop {
-        match op() {
+        let mut progress = TransientProgress::default();
+        match op(&mut progress) {
             Ok(value) => return Ok(Some(value)),
             Err(e) if !is_transient_error(&e) => return Err(e),
             Err(e) => {
                 if !alive.load(Ordering::Relaxed) {
                     return Ok(None);
+                }
+                if progress.recovered {
+                    down_since = None;
+                    backoff = INITIAL_RECONNECT_BACKOFF;
                 }
                 let down_since = *down_since.get_or_insert_with(Instant::now);
                 if down_since.elapsed() >= grace {
@@ -203,5 +223,27 @@ mod tests {
     fn io_errors_are_transient() {
         let err = anyhow::Error::new(io::Error::new(io::ErrorKind::ConnectionReset, "reset"));
         assert!(is_transient_error(&err));
+    }
+
+    #[test]
+    fn recovery_marker_restarts_grace_window() {
+        let alive = AtomicBool::new(true);
+        let mut attempts = 0;
+
+        let result = tolerate_transient(&alive, Duration::from_millis(250), |progress| {
+            attempts += 1;
+            match attempts {
+                1 => Err(anyhow!("connection closed")),
+                2 => {
+                    progress.mark_recovered();
+                    Err(anyhow!("connection closed"))
+                }
+                _ => Ok("ok"),
+            }
+        })
+        .unwrap();
+
+        assert_eq!(result, Some("ok"));
+        assert_eq!(attempts, 3);
     }
 }

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -23,8 +23,8 @@
 //! *real* logical/SQL error (which must surface), and provides [`tolerate_transient`]
 //! to retry an operation through transient faults for a bounded grace window.
 //!
-//! Bug detection is expected to come from Antithesis properties / postgres-side
-//! checks, not from stressgres exit codes — so tolerating these faults is by design.
+//! When this is enabled, bug detection is expected to come from Antithesis properties / postgres-side
+//! checks, not from stressgres exit codes.
 
 use anyhow::Result;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -56,7 +56,6 @@ const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
     "(sqlstate: 57p03", // cannot_connect_now
 ];
 
-/// Does this error message look like a transient connectivity failure?
 fn message_looks_transient(msg: &str) -> bool {
     let msg = msg.to_ascii_lowercase();
     TRANSIENT_ERROR_NEEDLES
@@ -98,7 +97,6 @@ fn is_transient_error(err: &anyhow::Error) -> bool {
     message_looks_transient(&err.to_string())
 }
 
-/// Sleep for `dur`, returning early if `alive` becomes false.
 fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
     let start = Instant::now();
     while start.elapsed() < dur {
@@ -142,7 +140,7 @@ pub(crate) fn tolerate_transient<T>(
                 let down_since = *down_since.get_or_insert_with(Instant::now);
                 if down_since.elapsed() >= grace {
                     // Grace window exhausted (immediate when grace == 0): the fault is
-                    // no longer "transient" as far as the run is concerned — fail.
+                    // no longer "transient" as far as the run is concerned and we should fail.
                     return Err(if grace.is_zero() {
                         e
                     } else {

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -48,6 +48,7 @@ const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
     "terminating connection",
     "error connecting to server",
     "error communicating with the server",
+    "error performing tls handshake",
     "unexpected eof",
     "os error 101",     // ENETUNREACH
     "(sqlstate: 08",    // connection exception class
@@ -65,18 +66,29 @@ fn message_looks_transient(msg: &str) -> bool {
 
 /// Classifies a `postgres::Error` as a transient connectivity failure (as opposed
 /// to a logical/SQL error, which represents a real bug we want to surface).
+///
+/// The discriminator is whether the error carries a SQLSTATE, not what its message
+/// says. A SQLSTATE means the statement actually reached the server and it answered,
+/// so only the connection-class codes are transient and everything else is a real
+/// logical/SQL error. No SQLSTATE means the failure happened in the client/transport
+/// before the server answered — connect refused/reset, socket dropped, a TLS
+/// handshake against a server that is down or restarting, protocol desync on a dying
+/// connection — which under fault injection are exactly the faults we ride out. This
+/// keys off the transport-vs-server distinction rather than string-matching each new
+/// libpq/driver phrasing (e.g. "error performing TLS handshake", which has no
+/// SQLSTATE and no `is_closed()` signal, so needle matching alone would miss it).
 fn is_transient_connection_error(e: &postgres::Error) -> bool {
-    if let Some(db) = e.as_db_error() {
-        let code = db.code().code();
-        // Class 08 = connection exception; 57P0x = operator/crash shutdown and
-        // "cannot connect now" (server starting up / shutting down).
-        return code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05");
+    match e.as_db_error() {
+        Some(db) => {
+            let code = db.code().code();
+            // Class 08 = connection exception; 57P0x = operator/crash shutdown and
+            // "cannot connect now" (server starting up / shutting down).
+            code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05")
+        }
+        // Client-side/transport failure: no answer from the server, so it never got
+        // far enough to be a logical bug. Treat it as transient.
+        None => true,
     }
-
-    // No SQLSTATE => a client-side/transport failure. If the driver reports the
-    // connection as closed, or the message looks like a connectivity problem,
-    // treat it as transient.
-    e.is_closed() || message_looks_transient(&e.to_string())
 }
 
 /// Classifies an `anyhow::Error` as a transient connectivity failure by walking its
@@ -192,6 +204,9 @@ mod tests {
             "connection reset by peer",
             "db error: FATAL: terminating connection due to administrator command (SQLState: 57P01)",
             "error: could not receive data from server (SQLState: 08006)",
+            // No SQLSTATE, no `is_closed()` signal: only the transport-level phrasing
+            // marks this as connectivity noise (server down/restarting mid-handshake).
+            "error performing TLS handshake: unexpected EOF",
         ] {
             assert!(message_looks_transient(msg), "should be transient: {msg}");
         }

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -23,6 +23,7 @@ mod csv;
 mod graph;
 mod headless;
 mod metrics;
+mod resilience;
 mod runner;
 mod sqlscanner;
 mod suite;

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -96,7 +96,9 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, None, Some(&args)).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(suite, false)?;
+            // `auto` is a local-dev command with no fault injection, so fail fast
+            // (grace 0) rather than tolerating transient connectivity faults.
+            let suite_runner = SuiteRunner::new(suite, false, Duration::ZERO)?;
             headless::run(
                 suite_runner,
                 args.log_path.clone(),

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -20,10 +20,10 @@
 mod auto;
 mod cli;
 mod csv;
+mod fault_tolerance;
 mod graph;
 mod headless;
 mod metrics;
-mod resilience;
 mod runner;
 mod sqlscanner;
 mod suite;
@@ -73,11 +73,8 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(
-                suite,
-                false,
-                Duration::from_millis(args.reconnect_grace_ms),
-            )?;
+            let suite_runner =
+                SuiteRunner::new(suite, false, Duration::from_millis(args.reconnect_grace_ms))?;
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -59,7 +59,11 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(suite, args.paused)?;
+            let suite_runner = SuiteRunner::new(
+                suite,
+                args.paused,
+                Duration::from_millis(args.reconnect_grace_ms),
+            )?;
             tui::run(suite_runner)?;
         }
 
@@ -68,7 +72,11 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(suite, false)?;
+            let suite_runner = SuiteRunner::new(
+                suite,
+                false,
+                Duration::from_millis(args.reconnect_grace_ms),
+            )?;
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {

--- a/stressgres/src/resilience.rs
+++ b/stressgres/src/resilience.rs
@@ -1,0 +1,209 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Tolerance for transient database connectivity faults.
+//!
+//! Under Antithesis the `paradedb` container is stopped, killed, and network-
+//! partitioned mid-run. This module classifies an error as either a *transient*
+//! connectivity fault (which the workload should ride out by reconnecting) or a
+//! *real* logical/SQL error (which must surface), and provides [`tolerate_transient`]
+//! to retry an operation through transient faults for a bounded grace window.
+//!
+//! Bug detection is expected to come from Antithesis properties / postgres-side
+//! checks, not from stressgres exit codes — so tolerating these faults is by design.
+
+use anyhow::Result;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Backoff bounds for retries within the reconnect grace window.
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Substrings that identify a transient connectivity failure when all we have is a
+/// stringified error (e.g. one already flattened by `format_postgres_error`).
+const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
+    "network is unreachable",
+    "no route to host",
+    "connection refused",
+    "connection reset",
+    "connection closed",
+    "broken pipe",
+    "server closed the connection",
+    "terminating connection",
+    "error connecting to server",
+    "error communicating with the server",
+    "unexpected eof",
+    "os error 101",     // ENETUNREACH
+    "(sqlstate: 08",    // connection exception class
+    "(sqlstate: 57p01", // admin_shutdown
+    "(sqlstate: 57p02", // crash_shutdown
+    "(sqlstate: 57p03", // cannot_connect_now
+];
+
+/// Does this error message look like a transient connectivity failure?
+fn message_looks_transient(msg: &str) -> bool {
+    let msg = msg.to_ascii_lowercase();
+    TRANSIENT_ERROR_NEEDLES
+        .iter()
+        .any(|needle| msg.contains(needle))
+}
+
+/// Classifies a `postgres::Error` as a transient connectivity failure (as opposed
+/// to a logical/SQL error, which represents a real bug we want to surface).
+fn is_transient_connection_error(e: &postgres::Error) -> bool {
+    if let Some(db) = e.as_db_error() {
+        let code = db.code().code();
+        // Class 08 = connection exception; 57P0x = operator/crash shutdown and
+        // "cannot connect now" (server starting up / shutting down).
+        return code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05");
+    }
+
+    // No SQLSTATE => a client-side/transport failure. If the driver reports the
+    // connection as closed, or the message looks like a connectivity problem,
+    // treat it as transient.
+    e.is_closed() || message_looks_transient(&e.to_string())
+}
+
+/// Classifies an `anyhow::Error` as a transient connectivity failure by walking its
+/// cause chain for a `postgres::Error`/IO error, falling back to string matching for
+/// errors that have already been flattened to a message.
+fn is_transient_error(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(pg) = cause.downcast_ref::<postgres::Error>() {
+            return is_transient_connection_error(pg);
+        }
+        if let Some(pg) = cause.downcast_ref::<Arc<postgres::Error>>() {
+            return is_transient_connection_error(pg);
+        }
+        if cause.downcast_ref::<std::io::Error>().is_some() {
+            return true;
+        }
+    }
+    message_looks_transient(&err.to_string())
+}
+
+/// Sleep for `dur`, returning early if `alive` becomes false.
+fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < dur {
+        if !alive.load(Ordering::Relaxed) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Runs `op`, tolerating transient connectivity faults for up to `grace`: while `op`
+/// keeps failing with a transient error (a dropped/refused socket, server restarting,
+/// etc.) it is retried with capped backoff. A real (non-transient) error is returned
+/// immediately. The connection is only declared dropped — and the error surfaced —
+/// once it has stayed broken for `grace` continuously.
+///
+/// With `grace == 0` (the default outside Antithesis) any error fails immediately,
+/// preserving the historical "an error fails the run" behaviour.
+///
+/// This is the single place reconnection lives. Callers express *what* to do (probe
+/// the version, run setup, run one job iteration); reopening a dead connection is
+/// the caller's job inside `op`, and re-running the whole `op` is what makes this
+/// safe for transactional work — a lost transaction is simply replayed from scratch.
+///
+/// Returns `Ok(None)` if `alive` went false while we were waiting out a fault.
+pub(crate) fn tolerate_transient<T>(
+    alive: &AtomicBool,
+    grace: Duration,
+    mut op: impl FnMut() -> Result<T>,
+) -> Result<Option<T>> {
+    let mut backoff = INITIAL_RECONNECT_BACKOFF;
+    let mut down_since: Option<Instant> = None;
+    loop {
+        match op() {
+            Ok(value) => return Ok(Some(value)),
+            Err(e) if !is_transient_error(&e) => return Err(e),
+            Err(e) => {
+                if !alive.load(Ordering::Relaxed) {
+                    return Ok(None);
+                }
+                let down_since = *down_since.get_or_insert_with(Instant::now);
+                if down_since.elapsed() >= grace {
+                    // Grace window exhausted (immediate when grace == 0): the fault is
+                    // no longer "transient" as far as the run is concerned — fail.
+                    return Err(if grace.is_zero() {
+                        e
+                    } else {
+                        e.context(format!(
+                            "database unreachable for {:?}, past the {grace:?} grace window",
+                            down_since.elapsed()
+                        ))
+                    });
+                }
+                eprintln!("stressgres: transient database fault, retrying: {e:#}");
+                interruptible_sleep(alive, backoff);
+                backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use std::io;
+
+    #[test]
+    fn message_matching_flags_connectivity_faults() {
+        for msg in [
+            "error connecting to server: Network is unreachable (os error 101)",
+            "server closed the connection unexpectedly",
+            "connection reset by peer",
+            "db error: FATAL: terminating connection due to administrator command (SQLState: 57P01)",
+            "error: could not receive data from server (SQLState: 08006)",
+        ] {
+            assert!(message_looks_transient(msg), "should be transient: {msg}");
+        }
+    }
+
+    #[test]
+    fn message_matching_ignores_real_errors() {
+        for msg in [
+            "ERROR: division by zero (SQLState: 22012)",
+            "duplicate key value violates unique constraint (SQLState: 23505)",
+            "ERROR: relation \"foo\" does not exist (SQLState: 42P01)",
+            "Job assertion failed: expected 5 but got 3",
+        ] {
+            assert!(!message_looks_transient(msg), "should be real: {msg}");
+        }
+    }
+
+    #[test]
+    fn anyhow_string_errors_are_classified() {
+        assert!(is_transient_error(&anyhow!(
+            "error connecting to server: Network is unreachable (os error 101)"
+        )));
+        assert!(!is_transient_error(&anyhow!(
+            "Job assertion failed: expected 5 but got 3"
+        )));
+    }
+
+    #[test]
+    fn io_errors_are_transient() {
+        let err = anyhow::Error::new(io::Error::new(io::ErrorKind::ConnectionReset, "reset"));
+        assert!(is_transient_error(&err));
+    }
+}

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -368,10 +368,15 @@ impl SuiteRunner {
             sys: Arc::new(RwLock::new(System::new_all())),
         };
 
-        runner.pgver = Conn::open(&suite, &Job::default())?
-            .first_client()
-            .query_one("SELECT version()", &[])?
-            .get(0);
+        // Probe the server version, riding out any transient connectivity fault
+        // (e.g. Antithesis stopping/killing/partitioning the container) at startup.
+        let default_job = Job::default();
+        runner.pgver = tolerate_transient(&runner.alive, || {
+            let mut conn = Conn::open(&suite, &default_job)?;
+            let version: String = conn.first_client().query_one("SELECT version()", &[])?.get(0);
+            Ok(version)
+        })?
+        .unwrap_or_else(|| String::from("<unknown>"));
 
         runner.init()?;
         let suite_runner = Arc::new(runner);
@@ -420,7 +425,12 @@ impl SuiteRunner {
                 self.alive.clone(),
                 self.sys.clone(),
             )?;
-            setup_runner.run(&mut Conn::open(&self.suite, &setup_runner.job)?)?;
+            // Run setup on a fresh connection, replaying it in full if a transient
+            // fault interrupts it (safe because setup re-runs from scratch).
+            tolerate_transient(&self.alive, || {
+                let mut conn = Conn::open(&self.suite, &setup_runner.job)?;
+                setup_runner.run(&mut conn)
+            })?;
         }
 
         // setup and start the monitors
@@ -527,13 +537,13 @@ impl SuiteRunner {
             .map(|info| (info, RuntimeStats::default()))
             .collect();
 
-        let mut conn = if job_runner.job.atomic_connection {
-            None
-        } else {
-            Some(Conn::open(&job_runner.suite, &job_runner.job)?)
-        };
-
         let alive = job_runner.alive.clone();
+
+        // A normal job keeps a persistent connection; an `atomic_connection` job
+        // opens a fresh one each iteration. Either way it is (re)opened lazily inside
+        // the `tolerate_transient` closure, so a dropped socket just reconnects.
+        let mut conn: Option<Conn> = None;
+
         while alive.load(Ordering::Relaxed) {
             // If paused, sleep until unpaused
             while paused.load(Ordering::Relaxed) && alive.load(Ordering::Relaxed) {
@@ -543,11 +553,26 @@ impl SuiteRunner {
                 break;
             }
 
-            let conn = match &mut conn {
-                Some(conn) => conn,
-                None => &mut Conn::open(&job_runner.suite, &job_runner.job)?,
-            };
-            job_runner.run(conn)?;
+            if job_runner.job.atomic_connection {
+                conn = None;
+            }
+
+            // Run one iteration, riding out transient faults. On any error we drop the
+            // (possibly poisoned) connection so the next attempt reconnects; replaying
+            // the whole iteration keeps transactional jobs correct.
+            let outcome = tolerate_transient(&alive, || {
+                if conn.is_none() {
+                    conn = Some(Conn::open(&job_runner.suite, &job_runner.job)?);
+                }
+                let result = job_runner.run(conn.as_mut().unwrap());
+                if result.is_err() {
+                    conn = None;
+                }
+                result
+            })?;
+            if outcome.is_none() {
+                break; // `alive` went false while waiting out a fault
+            }
 
             if refresh_ms.as_millis() <= 1000 {
                 // if the refresh interval is less than a second, just sleep for that amount of time
@@ -701,6 +726,135 @@ pub const HARDCODED_IGNORE_ERRORS: &[&str] = &[
     "canceling statement due to conflict with recovery",
     "(SQLState: 57014)", // query_canceled
 ];
+
+/// How long a database operation may keep failing with transient connectivity
+/// errors before we give up and treat the connection as genuinely dropped.
+///
+/// Antithesis can stop, kill, or partition the `paradedb` container mid-run. Rather
+/// than failing the whole test the instant a socket dies, we keep retrying (with
+/// backoff) for this long; a killed container plus CloudNativePG failover normally
+/// recovers well within the window. Only if connectivity stays broken for the full
+/// window do we surface the error as real.
+const RECONNECT_GRACE: Duration = Duration::from_secs(30);
+/// Backoff bounds for retries within the grace window.
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Substrings that identify a transient connectivity failure when all we have is a
+/// stringified error (e.g. one already flattened by `format_postgres_error`).
+const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
+    "network is unreachable",
+    "no route to host",
+    "connection refused",
+    "connection reset",
+    "connection closed",
+    "broken pipe",
+    "server closed the connection",
+    "terminating connection",
+    "error connecting to server",
+    "error communicating with the server",
+    "unexpected eof",
+    "os error 101",     // ENETUNREACH
+    "(sqlstate: 08",    // connection exception class
+    "(sqlstate: 57p01", // admin_shutdown
+    "(sqlstate: 57p02", // crash_shutdown
+    "(sqlstate: 57p03", // cannot_connect_now
+];
+
+/// Classifies a `postgres::Error` as a transient connectivity failure (as opposed
+/// to a logical/SQL error, which represents a real bug we want to surface).
+fn is_transient_connection_error(e: &postgres::Error) -> bool {
+    if let Some(db) = e.as_db_error() {
+        let code = db.code().code();
+        // Class 08 = connection exception; 57P0x = operator/crash shutdown and
+        // "cannot connect now" (server starting up / shutting down).
+        return code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05");
+    }
+
+    // No SQLSTATE => a client-side/transport failure. If the driver reports the
+    // connection as closed, or the message looks like a connectivity problem,
+    // treat it as transient.
+    if e.is_closed() {
+        return true;
+    }
+    let msg = e.to_string().to_ascii_lowercase();
+    TRANSIENT_ERROR_NEEDLES
+        .iter()
+        .any(|needle| msg.contains(needle))
+}
+
+/// Classifies an `anyhow::Error` as a transient connectivity failure by walking its
+/// cause chain for a `postgres::Error`/IO error, falling back to string matching for
+/// errors that have already been flattened to a message.
+fn is_transient_error(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(pg) = cause.downcast_ref::<postgres::Error>() {
+            return is_transient_connection_error(pg);
+        }
+        if let Some(pg) = cause.downcast_ref::<Arc<postgres::Error>>() {
+            return is_transient_connection_error(pg);
+        }
+        if cause.downcast_ref::<std::io::Error>().is_some() {
+            return true;
+        }
+    }
+    let msg = err.to_string().to_ascii_lowercase();
+    TRANSIENT_ERROR_NEEDLES
+        .iter()
+        .any(|needle| msg.contains(needle))
+}
+
+/// Sleep for `dur`, returning early if `alive` becomes false.
+fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < dur {
+        if !alive.load(Ordering::Relaxed) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// Runs `op`, tolerating transient connectivity faults: while `op` keeps failing
+/// with a transient error (a dropped/refused socket, server restarting, etc.) it is
+/// retried with capped backoff. A real (non-transient) error is returned
+/// immediately. The connection is only declared dropped — and the error surfaced —
+/// once it has stayed broken for `RECONNECT_GRACE` continuously.
+///
+/// This is the single place reconnection lives. Callers express *what* to do (probe
+/// the version, run setup, run one job iteration); reopening a dead connection is
+/// the caller's job inside `op`, and re-running the whole `op` is what makes this
+/// safe for transactional work — a lost transaction is simply replayed from scratch.
+///
+/// Returns `Ok(None)` if `alive` went false while we were waiting out a fault.
+fn tolerate_transient<T>(
+    alive: &AtomicBool,
+    mut op: impl FnMut() -> Result<T>,
+) -> Result<Option<T>> {
+    let mut backoff = INITIAL_RECONNECT_BACKOFF;
+    let mut down_since: Option<Instant> = None;
+    loop {
+        match op() {
+            Ok(value) => return Ok(Some(value)),
+            Err(e) if !is_transient_error(&e) => return Err(e),
+            Err(e) => {
+                if !alive.load(Ordering::Relaxed) {
+                    return Ok(None);
+                }
+                let down_since = *down_since.get_or_insert_with(Instant::now);
+                if down_since.elapsed() >= RECONNECT_GRACE {
+                    return Err(e.context(format!(
+                        "database unreachable for {:?}, past the {RECONNECT_GRACE:?} grace window",
+                        down_since.elapsed()
+                    )));
+                }
+                eprintln!("stressgres: transient database fault, retrying: {e:#}");
+                interruptible_sleep(alive, backoff);
+                backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
+            }
+        }
+    }
+}
 
 type Index = usize;
 

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::resilience::tolerate_transient;
+use crate::fault_tolerance::tolerate_transient;
 use crate::sqlscanner::StatementDestination;
 use crate::suite::{Job, Server, ServerStyle, Suite};
 use anyhow::{anyhow, Result};
@@ -375,7 +375,10 @@ impl SuiteRunner {
         let default_job = Job::default();
         runner.pgver = tolerate_transient(&runner.alive, runner.reconnect_grace, || {
             let mut conn = Conn::open(&suite, &default_job)?;
-            let version: String = conn.first_client().query_one("SELECT version()", &[])?.get(0);
+            let version: String = conn
+                .first_client()
+                .query_one("SELECT version()", &[])?
+                .get(0);
             Ok(version)
         })?
         .unwrap_or_else(|| String::from("<unknown>"));

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -345,6 +345,9 @@ pub struct SuiteRunner {
     runners: Vec<Arc<JobRunner>>,
     have_error: Arc<AtomicBool>,
     first_error_duration_bits: Arc<AtomicU64>,
+    /// How long to tolerate transient connectivity faults before failing (0 = fail
+    /// immediately on the first error, the default outside Antithesis).
+    reconnect_grace: Duration,
 
     monitors: Vec<Arc<JobRunner>>,
     sys: Arc<RwLock<System>>,
@@ -352,7 +355,7 @@ pub struct SuiteRunner {
 
 impl SuiteRunner {
     /// Create a new SuiteRunner, run the `setup` job, then spawn threads for each job + monitor.
-    pub fn new(suite: Suite, paused: bool) -> Result<Arc<Self>> {
+    pub fn new(suite: Suite, paused: bool, reconnect_grace: Duration) -> Result<Arc<Self>> {
         let suite = Arc::new(suite);
         let mut runner = Self {
             suite: suite.clone(),
@@ -363,6 +366,7 @@ impl SuiteRunner {
             runners: Default::default(),
             have_error: Arc::new(AtomicBool::new(false)),
             first_error_duration_bits: Default::default(),
+            reconnect_grace,
 
             monitors: Default::default(),
             sys: Arc::new(RwLock::new(System::new_all())),
@@ -371,7 +375,7 @@ impl SuiteRunner {
         // Probe the server version, riding out any transient connectivity fault
         // (e.g. Antithesis stopping/killing/partitioning the container) at startup.
         let default_job = Job::default();
-        runner.pgver = tolerate_transient(&runner.alive, || {
+        runner.pgver = tolerate_transient(&runner.alive, runner.reconnect_grace, || {
             let mut conn = Conn::open(&suite, &default_job)?;
             let version: String = conn.first_client().query_one("SELECT version()", &[])?.get(0);
             Ok(version)
@@ -427,7 +431,7 @@ impl SuiteRunner {
             )?;
             // Run setup on a fresh connection, replaying it in full if a transient
             // fault interrupts it (safe because setup re-runs from scratch).
-            tolerate_transient(&self.alive, || {
+            tolerate_transient(&self.alive, self.reconnect_grace, || {
                 let mut conn = Conn::open(&self.suite, &setup_runner.job)?;
                 setup_runner.run(&mut conn)
             })?;
@@ -499,12 +503,13 @@ impl SuiteRunner {
 
         let job_runner = Arc::new(job_runner);
         let refresh_ms = Duration::from_millis(job_runner.job.refresh_ms as u64);
+        let reconnect_grace = self.reconnect_grace;
 
         // The actual thread loop
         let handle = {
             let job_runner = job_runner.clone();
             std::thread::spawn(move || {
-                match Self::job_runner_worker(paused, refresh_ms, &job_runner) {
+                match Self::job_runner_worker(paused, refresh_ms, reconnect_grace, &job_runner) {
                     Ok(()) => Ok(()),
                     Err(e) => {
                         job_runner.running.store(false, Ordering::Relaxed);
@@ -530,6 +535,7 @@ impl SuiteRunner {
     fn job_runner_worker(
         paused: Arc<AtomicBool>,
         refresh_ms: Duration,
+        reconnect_grace: Duration,
         job_runner: &Arc<JobRunner>,
     ) -> Result<(), anyhow::Error> {
         *job_runner.runtime_stats.write() = Conn::make_infos(&job_runner.suite, &job_runner.job)
@@ -560,7 +566,7 @@ impl SuiteRunner {
             // Run one iteration, riding out transient faults. On any error we drop the
             // (possibly poisoned) connection so the next attempt reconnects; replaying
             // the whole iteration keeps transactional jobs correct.
-            let outcome = tolerate_transient(&alive, || {
+            let outcome = tolerate_transient(&alive, reconnect_grace, || {
                 if conn.is_none() {
                     conn = Some(Conn::open(&job_runner.suite, &job_runner.job)?);
                 }
@@ -693,7 +699,13 @@ impl SuiteRunner {
                 self.alive.clone(),
                 self.sys.clone(),
             )?;
-            teardown_runner.run(&mut Conn::open(&self.suite, &teardown_runner.job)?)?;
+            // Best-effort teardown: ride out a transient fault, and if connectivity
+            // is gone during shutdown (`alive` is already false here) skip it rather
+            // than panicking the shutdown thread.
+            tolerate_transient(&self.alive, self.reconnect_grace, || {
+                let mut conn = Conn::open(&self.suite, &teardown_runner.job)?;
+                teardown_runner.run(&mut conn)
+            })?;
         }
 
         for job in &self.runners {
@@ -727,16 +739,7 @@ pub const HARDCODED_IGNORE_ERRORS: &[&str] = &[
     "(SQLState: 57014)", // query_canceled
 ];
 
-/// How long a database operation may keep failing with transient connectivity
-/// errors before we give up and treat the connection as genuinely dropped.
-///
-/// Antithesis can stop, kill, or partition the `paradedb` container mid-run. Rather
-/// than failing the whole test the instant a socket dies, we keep retrying (with
-/// backoff) for this long; a killed container plus CloudNativePG failover normally
-/// recovers well within the window. Only if connectivity stays broken for the full
-/// window do we surface the error as real.
-const RECONNECT_GRACE: Duration = Duration::from_secs(30);
-/// Backoff bounds for retries within the grace window.
+/// Backoff bounds for retries within the reconnect grace window.
 const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
 const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
 
@@ -815,11 +818,14 @@ fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
     }
 }
 
-/// Runs `op`, tolerating transient connectivity faults: while `op` keeps failing
-/// with a transient error (a dropped/refused socket, server restarting, etc.) it is
-/// retried with capped backoff. A real (non-transient) error is returned
+/// Runs `op`, tolerating transient connectivity faults for up to `grace`: while `op`
+/// keeps failing with a transient error (a dropped/refused socket, server restarting,
+/// etc.) it is retried with capped backoff. A real (non-transient) error is returned
 /// immediately. The connection is only declared dropped — and the error surfaced —
-/// once it has stayed broken for `RECONNECT_GRACE` continuously.
+/// once it has stayed broken for `grace` continuously.
+///
+/// With `grace == 0` (the default outside Antithesis) any error fails immediately,
+/// preserving the historical "an error fails the run" behaviour.
 ///
 /// This is the single place reconnection lives. Callers express *what* to do (probe
 /// the version, run setup, run one job iteration); reopening a dead connection is
@@ -829,6 +835,7 @@ fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
 /// Returns `Ok(None)` if `alive` went false while we were waiting out a fault.
 fn tolerate_transient<T>(
     alive: &AtomicBool,
+    grace: Duration,
     mut op: impl FnMut() -> Result<T>,
 ) -> Result<Option<T>> {
     let mut backoff = INITIAL_RECONNECT_BACKOFF;
@@ -842,11 +849,17 @@ fn tolerate_transient<T>(
                     return Ok(None);
                 }
                 let down_since = *down_since.get_or_insert_with(Instant::now);
-                if down_since.elapsed() >= RECONNECT_GRACE {
-                    return Err(e.context(format!(
-                        "database unreachable for {:?}, past the {RECONNECT_GRACE:?} grace window",
-                        down_since.elapsed()
-                    )));
+                if down_since.elapsed() >= grace {
+                    // Grace window exhausted (immediate when grace == 0): the fault is
+                    // no longer "transient" as far as the run is concerned — fail.
+                    return Err(if grace.is_zero() {
+                        e
+                    } else {
+                        e.context(format!(
+                            "database unreachable for {:?}, past the {grace:?} grace window",
+                            down_since.elapsed()
+                        ))
+                    });
                 }
                 eprintln!("stressgres: transient database fault, retrying: {e:#}");
                 interruptible_sleep(alive, backoff);

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::resilience::tolerate_transient;
 use crate::sqlscanner::StatementDestination;
 use crate::suite::{Job, Server, ServerStyle, Suite};
 use anyhow::{anyhow, Result};
@@ -735,136 +736,6 @@ pub const HARDCODED_IGNORE_ERRORS: &[&str] = &[
     "canceling statement due to conflict with recovery",
     "(SQLState: 57014)", // query_canceled
 ];
-
-/// Backoff bounds for retries within the reconnect grace window.
-const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
-const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
-
-/// Substrings that identify a transient connectivity failure when all we have is a
-/// stringified error (e.g. one already flattened by `format_postgres_error`).
-const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
-    "network is unreachable",
-    "no route to host",
-    "connection refused",
-    "connection reset",
-    "connection closed",
-    "broken pipe",
-    "server closed the connection",
-    "terminating connection",
-    "error connecting to server",
-    "error communicating with the server",
-    "unexpected eof",
-    "os error 101",     // ENETUNREACH
-    "(sqlstate: 08",    // connection exception class
-    "(sqlstate: 57p01", // admin_shutdown
-    "(sqlstate: 57p02", // crash_shutdown
-    "(sqlstate: 57p03", // cannot_connect_now
-];
-
-/// Classifies a `postgres::Error` as a transient connectivity failure (as opposed
-/// to a logical/SQL error, which represents a real bug we want to surface).
-fn is_transient_connection_error(e: &postgres::Error) -> bool {
-    if let Some(db) = e.as_db_error() {
-        let code = db.code().code();
-        // Class 08 = connection exception; 57P0x = operator/crash shutdown and
-        // "cannot connect now" (server starting up / shutting down).
-        return code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05");
-    }
-
-    // No SQLSTATE => a client-side/transport failure. If the driver reports the
-    // connection as closed, or the message looks like a connectivity problem,
-    // treat it as transient.
-    if e.is_closed() {
-        return true;
-    }
-    let msg = e.to_string().to_ascii_lowercase();
-    TRANSIENT_ERROR_NEEDLES
-        .iter()
-        .any(|needle| msg.contains(needle))
-}
-
-/// Classifies an `anyhow::Error` as a transient connectivity failure by walking its
-/// cause chain for a `postgres::Error`/IO error, falling back to string matching for
-/// errors that have already been flattened to a message.
-fn is_transient_error(err: &anyhow::Error) -> bool {
-    for cause in err.chain() {
-        if let Some(pg) = cause.downcast_ref::<postgres::Error>() {
-            return is_transient_connection_error(pg);
-        }
-        if let Some(pg) = cause.downcast_ref::<Arc<postgres::Error>>() {
-            return is_transient_connection_error(pg);
-        }
-        if cause.downcast_ref::<std::io::Error>().is_some() {
-            return true;
-        }
-    }
-    let msg = err.to_string().to_ascii_lowercase();
-    TRANSIENT_ERROR_NEEDLES
-        .iter()
-        .any(|needle| msg.contains(needle))
-}
-
-/// Sleep for `dur`, returning early if `alive` becomes false.
-fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
-    let start = Instant::now();
-    while start.elapsed() < dur {
-        if !alive.load(Ordering::Relaxed) {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(50));
-    }
-}
-
-/// Runs `op`, tolerating transient connectivity faults for up to `grace`: while `op`
-/// keeps failing with a transient error (a dropped/refused socket, server restarting,
-/// etc.) it is retried with capped backoff. A real (non-transient) error is returned
-/// immediately. The connection is only declared dropped — and the error surfaced —
-/// once it has stayed broken for `grace` continuously.
-///
-/// With `grace == 0` (the default outside Antithesis) any error fails immediately,
-/// preserving the historical "an error fails the run" behaviour.
-///
-/// This is the single place reconnection lives. Callers express *what* to do (probe
-/// the version, run setup, run one job iteration); reopening a dead connection is
-/// the caller's job inside `op`, and re-running the whole `op` is what makes this
-/// safe for transactional work — a lost transaction is simply replayed from scratch.
-///
-/// Returns `Ok(None)` if `alive` went false while we were waiting out a fault.
-fn tolerate_transient<T>(
-    alive: &AtomicBool,
-    grace: Duration,
-    mut op: impl FnMut() -> Result<T>,
-) -> Result<Option<T>> {
-    let mut backoff = INITIAL_RECONNECT_BACKOFF;
-    let mut down_since: Option<Instant> = None;
-    loop {
-        match op() {
-            Ok(value) => return Ok(Some(value)),
-            Err(e) if !is_transient_error(&e) => return Err(e),
-            Err(e) => {
-                if !alive.load(Ordering::Relaxed) {
-                    return Ok(None);
-                }
-                let down_since = *down_since.get_or_insert_with(Instant::now);
-                if down_since.elapsed() >= grace {
-                    // Grace window exhausted (immediate when grace == 0): the fault is
-                    // no longer "transient" as far as the run is concerned — fail.
-                    return Err(if grace.is_zero() {
-                        e
-                    } else {
-                        e.context(format!(
-                            "database unreachable for {:?}, past the {grace:?} grace window",
-                            down_since.elapsed()
-                        ))
-                    });
-                }
-                eprintln!("stressgres: transient database fault, retrying: {e:#}");
-                interruptible_sleep(alive, backoff);
-                backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
-            }
-        }
-    }
-}
 
 type Index = usize;
 

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -352,6 +352,41 @@ pub struct SuiteRunner {
     sys: Arc<RwLock<System>>,
 }
 
+/// Run `op` against a live [`Conn`], tolerating transient connectivity faults.
+///
+/// The connection lives in `conn` and is (re)opened lazily: whenever it is `None`
+/// — the first call, or after a prior error dropped it — a fresh one is opened and
+/// the reconnect grace window is reset (the fault-tolerance layer's `mark_recovered`).
+/// On any error from `op` the connection is dropped so the next attempt reconnects;
+/// replaying the whole `op` is what keeps transactional work correct.
+///
+/// One-shot callers (version probe, setup, teardown) pass a throwaway `&mut None`;
+/// the job worker passes a long-lived slot so its connection persists across
+/// iterations. This is the single place the open / `mark_recovered` / drop-on-error
+/// dance lives, so callers only have to say what to do with the connection.
+///
+/// Returns `Ok(None)` if `alive` went false while waiting out a fault.
+fn with_reconnect<T>(
+    alive: &AtomicBool,
+    grace: Duration,
+    conn: &mut Option<Conn>,
+    suite: &Suite,
+    job: &Job,
+    mut op: impl FnMut(&mut Conn) -> Result<T>,
+) -> Result<Option<T>> {
+    tolerate_transient(alive, grace, |progress| {
+        if conn.is_none() {
+            *conn = Some(Conn::open(suite, job)?);
+            progress.mark_recovered();
+        }
+        let result = op(conn.as_mut().unwrap());
+        if result.is_err() {
+            *conn = None;
+        }
+        result
+    })
+}
+
 impl SuiteRunner {
     /// Create a new SuiteRunner, run the `setup` job, then spawn threads for each job + monitor.
     pub fn new(suite: Suite, paused: bool, reconnect_grace: Duration) -> Result<Arc<Self>> {
@@ -373,15 +408,21 @@ impl SuiteRunner {
 
         // Probe the server version, riding out any transient connectivity fault
         let default_job = Job::default();
-        runner.pgver = tolerate_transient(&runner.alive, runner.reconnect_grace, |progress| {
-            let mut conn = Conn::open(&suite, &default_job)?;
-            progress.mark_recovered();
-            let version: String = conn
-                .first_client()
-                .query_one("SELECT version()", &[])?
-                .get(0);
-            Ok(version)
-        })?
+        let mut conn = None;
+        runner.pgver = with_reconnect(
+            &runner.alive,
+            runner.reconnect_grace,
+            &mut conn,
+            &suite,
+            &default_job,
+            |conn| {
+                let version: String = conn
+                    .first_client()
+                    .query_one("SELECT version()", &[])?
+                    .get(0);
+                Ok(version)
+            },
+        )?
         .unwrap_or_else(|| String::from("<unknown>"));
 
         runner.init()?;
@@ -432,12 +473,20 @@ impl SuiteRunner {
                 self.sys.clone(),
             )?;
             // Run setup on a fresh connection, replaying it in full if a transient
-            // fault interrupts it (safe because setup re-runs from scratch).
-            tolerate_transient(&self.alive, self.reconnect_grace, |progress| {
-                let mut conn = Conn::open(&self.suite, &setup_runner.job)?;
-                progress.mark_recovered();
-                setup_runner.run(&mut conn)
-            })?;
+            // fault interrupts it. Replay is safe because setup is idempotent (every
+            // statement is DROP ... IF EXISTS / CREATE OR REPLACE), so re-running from
+            // the top rebuilds state no matter how far a partial attempt got — not
+            // because it runs in one transaction (it can't: it issues ALTER SYSTEM /
+            // pg_reload_conf, which are disallowed inside a transaction block).
+            let mut conn = None;
+            with_reconnect(
+                &self.alive,
+                self.reconnect_grace,
+                &mut conn,
+                &self.suite,
+                &setup_runner.job,
+                |conn| setup_runner.run(conn),
+            )?;
         }
 
         // setup and start the monitors
@@ -549,8 +598,8 @@ impl SuiteRunner {
         let alive = job_runner.alive.clone();
 
         // A normal job keeps a persistent connection; an `atomic_connection` job
-        // opens a fresh one each iteration. Either way it is (re)opened lazily inside
-        // the `tolerate_transient` closure, so a dropped socket just reconnects.
+        // opens a fresh one each iteration. Either way it is (re)opened lazily by
+        // `with_reconnect`, so a dropped socket just reconnects.
         let mut conn: Option<Conn> = None;
 
         while alive.load(Ordering::Relaxed) {
@@ -566,20 +615,17 @@ impl SuiteRunner {
                 conn = None;
             }
 
-            // Run one iteration, riding out transient faults. On any error we drop the
-            // (possibly poisoned) connection so the next attempt reconnects; replaying
-            // the whole iteration keeps transactional jobs correct.
-            let outcome = tolerate_transient(&alive, reconnect_grace, |progress| {
-                if conn.is_none() {
-                    conn = Some(Conn::open(&job_runner.suite, &job_runner.job)?);
-                    progress.mark_recovered();
-                }
-                let result = job_runner.run(conn.as_mut().unwrap());
-                if result.is_err() {
-                    conn = None;
-                }
-                result
-            })?;
+            // Run one iteration, riding out transient faults. `with_reconnect` drops
+            // the (possibly poisoned) connection on error so the next attempt
+            // reconnects; replaying the whole iteration keeps transactional jobs correct.
+            let outcome = with_reconnect(
+                &alive,
+                reconnect_grace,
+                &mut conn,
+                &job_runner.suite,
+                &job_runner.job,
+                |conn| job_runner.run(conn),
+            )?;
             if outcome.is_none() {
                 break; // `alive` went false while waiting out a fault
             }
@@ -706,11 +752,15 @@ impl SuiteRunner {
             // Best-effort teardown: ride out a transient fault, and if connectivity
             // is gone during shutdown (`alive` is already false here) skip it rather
             // than panicking the shutdown thread.
-            tolerate_transient(&self.alive, self.reconnect_grace, |progress| {
-                let mut conn = Conn::open(&self.suite, &teardown_runner.job)?;
-                progress.mark_recovered();
-                teardown_runner.run(&mut conn)
-            })?;
+            let mut conn = None;
+            with_reconnect(
+                &self.alive,
+                self.reconnect_grace,
+                &mut conn,
+                &self.suite,
+                &teardown_runner.job,
+                |conn| teardown_runner.run(conn),
+            )?;
         }
 
         for job in &self.runners {

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -373,8 +373,9 @@ impl SuiteRunner {
 
         // Probe the server version, riding out any transient connectivity fault
         let default_job = Job::default();
-        runner.pgver = tolerate_transient(&runner.alive, runner.reconnect_grace, || {
+        runner.pgver = tolerate_transient(&runner.alive, runner.reconnect_grace, |progress| {
             let mut conn = Conn::open(&suite, &default_job)?;
+            progress.mark_recovered();
             let version: String = conn
                 .first_client()
                 .query_one("SELECT version()", &[])?
@@ -432,8 +433,9 @@ impl SuiteRunner {
             )?;
             // Run setup on a fresh connection, replaying it in full if a transient
             // fault interrupts it (safe because setup re-runs from scratch).
-            tolerate_transient(&self.alive, self.reconnect_grace, || {
+            tolerate_transient(&self.alive, self.reconnect_grace, |progress| {
                 let mut conn = Conn::open(&self.suite, &setup_runner.job)?;
+                progress.mark_recovered();
                 setup_runner.run(&mut conn)
             })?;
         }
@@ -567,9 +569,10 @@ impl SuiteRunner {
             // Run one iteration, riding out transient faults. On any error we drop the
             // (possibly poisoned) connection so the next attempt reconnects; replaying
             // the whole iteration keeps transactional jobs correct.
-            let outcome = tolerate_transient(&alive, reconnect_grace, || {
+            let outcome = tolerate_transient(&alive, reconnect_grace, |progress| {
                 if conn.is_none() {
                     conn = Some(Conn::open(&job_runner.suite, &job_runner.job)?);
+                    progress.mark_recovered();
                 }
                 let result = job_runner.run(conn.as_mut().unwrap());
                 if result.is_err() {
@@ -703,8 +706,9 @@ impl SuiteRunner {
             // Best-effort teardown: ride out a transient fault, and if connectivity
             // is gone during shutdown (`alive` is already false here) skip it rather
             // than panicking the shutdown thread.
-            tolerate_transient(&self.alive, self.reconnect_grace, || {
+            tolerate_transient(&self.alive, self.reconnect_grace, |progress| {
                 let mut conn = Conn::open(&self.suite, &teardown_runner.job)?;
+                progress.mark_recovered();
                 teardown_runner.run(&mut conn)
             })?;
         }

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -345,8 +345,6 @@ pub struct SuiteRunner {
     runners: Vec<Arc<JobRunner>>,
     have_error: Arc<AtomicBool>,
     first_error_duration_bits: Arc<AtomicU64>,
-    /// How long to tolerate transient connectivity faults before failing (0 = fail
-    /// immediately on the first error, the default outside Antithesis).
     reconnect_grace: Duration,
 
     monitors: Vec<Arc<JobRunner>>,
@@ -373,7 +371,6 @@ impl SuiteRunner {
         };
 
         // Probe the server version, riding out any transient connectivity fault
-        // (e.g. Antithesis stopping/killing/partitioning the container) at startup.
         let default_job = Job::default();
         runner.pgver = tolerate_transient(&runner.alive, runner.reconnect_grace, || {
             let mut conn = Conn::open(&suite, &default_job)?;

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -13,7 +13,10 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
+# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
+# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -13,9 +13,6 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
-# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
-# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
-# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -13,6 +13,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
+# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
+# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
+# the run ends on its own runtime. Keep grace > runtime if you change either.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -13,10 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
-# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
-# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
-# the run ends on its own runtime. Keep grace > runtime if you change either.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -13,6 +13,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
+# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
+# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
+# the run ends on its own runtime. Keep grace > runtime if you change either.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -13,10 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
-# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
-# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
-# the run ends on its own runtime. Keep grace > runtime if you change either.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -13,9 +13,6 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
-# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
-# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
-# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -13,7 +13,10 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
+# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
+# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -20,9 +20,6 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
-# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
-# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -20,6 +20,9 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
+# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
+# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
+# the run ends on its own runtime. Keep grace > runtime if you change either.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -20,10 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
-# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
-# the run ends on its own runtime. Keep grace > runtime if you change either.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -20,7 +20,10 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
+# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
+# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -20,7 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -20,7 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -20,7 +20,10 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
+# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
+# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -20,7 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -20,10 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
-# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
-# the run ends on its own runtime. Keep grace > runtime if you change either.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -20,9 +20,6 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
-# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
-# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -20,6 +20,9 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
+# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
+# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
+# the run ends on its own runtime. Keep grace > runtime if you change either.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -20,7 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -13,7 +13,10 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
+# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
+# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -13,6 +13,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
+# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
+# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
+# the run ends on its own runtime. Keep grace > runtime if you change either.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -13,10 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
-# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
-# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
-# the run ends on its own runtime. Keep grace > runtime if you change either.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -13,9 +13,6 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
-# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
-# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
-# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -13,9 +13,6 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
-# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
-# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
-# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -13,7 +13,10 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
+# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
+# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -13,6 +13,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
+# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
+# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
+# the run ends on its own runtime. Keep grace > runtime if you change either.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -13,10 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
-# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
-# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
-# the run ends on its own runtime. Keep grace > runtime if you change either.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -13,6 +13,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
+# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
+# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
+# the run ends on its own runtime. Keep grace > runtime if you change either.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -13,7 +13,10 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
+# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
+# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -13,10 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
-# --reconnect-grace-ms is deliberately larger than --runtime so a transient DB fault
-# (Antithesis stop/kill/partition) is tolerated for the whole run instead of failing it;
-# the run ends on its own runtime. Keep grace > runtime if you change either.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 300000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 30000
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -13,9 +13,6 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
-# reconnect-grace resets after each successful reconnect, so it only needs to exceed the
-# longest single outage: a paradedb node kill + CloudNativePG pod recovery can take ~75s,
-# so 180s (also > --runtime) leaves margin. Keep it above --runtime if that ever changes.
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace-ms 180000
 
 echo ""

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -114,12 +114,19 @@ sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where message ||| 'cheese';
 """
 
+# A grouped, unlimited scan is emitted as a serial custom path that PostgreSQL may
+# swap for its own scan of the BM25 index: the two cost within ~0.4% of each other,
+# inside PostgreSQL's fuzzy-cost factor, and the custom path is not forced (see
+# `hook::add_path`). Which one wins then turns on how much the concurrent writer jobs
+# have grown the index, so disable the native scans to pin the plan we mean to test.
 [[jobs]]
 refresh_ms = 5
 title = "Normal Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_aggregate_custom_scan = off;
+SET enable_indexscan = off;
+SET enable_indexonlyscan = off;
 SELECT assert_plan_contains(
     $q$ SELECT count(*) FROM test where message ||| 'wine' $q$,
     'NormalScanExecState'

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -50,6 +50,26 @@ BEGIN
 END;
 $$;
 
+CREATE OR REPLACE FUNCTION assert_plan_contains(
+    p_query text,
+    p_expected_text text
+) RETURNS boolean AS $$
+DECLARE
+    plan_line text;
+BEGIN
+    -- Loop through each line of the EXPLAIN output
+    FOR plan_line IN EXECUTE 'EXPLAIN ' || p_query LOOP
+        -- Check if the current line contains the expected text
+        IF plan_line ILIKE '%' || p_expected_text || '%' THEN
+            RETURN true;
+        END IF;
+    END LOOP;
+
+    RAISE EXCEPTION 'Plan assertion failed: Expected text "%" not found in plan for query: %', p_expected_text, p_query;
+END;
+$$ LANGUAGE plpgsql;
+
+
 ALTER SYSTEM SET autovacuum_naptime = '1s';
 SELECT pg_reload_conf();
 """
@@ -81,6 +101,10 @@ log_tps = true
 on_connect = """
 SET paradedb.enable_custom_scan = off;
 SET paradedb.enable_aggregate_custom_scan = off;
+SELECT assert_plan_contains(
+    $q$ SELECT count(*) FROM test where message ||| 'cheese' $q$,
+    'Index Only Scan'
+);
 """
 sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where message ||| 'cheese';
@@ -92,6 +116,10 @@ title = "Normal Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_aggregate_custom_scan = off;
+SELECT assert_plan_contains(
+    $q$ SELECT count(*) FROM test where message ||| 'wine' $q$,
+    'NormalScanExecState'
+);
 """
 sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where message ||| 'wine';
@@ -103,6 +131,10 @@ title = "Columnar Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_columnar_exec = on;
+SELECT assert_plan_contains(
+    $q$ SELECT id, category FROM test WHERE message ||| 'beer' $q$,
+    'ColumnarExecState'
+);
 """
 sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM (SELECT id, category FROM test WHERE message ||| 'beer') sub;
@@ -114,6 +146,10 @@ title = "Aggregate Custom Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_aggregate_custom_scan = on;
+SELECT assert_plan_contains(
+    $q$ SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb) FROM test WHERE message ||| 'beer' $q$,
+    'ParadeDB Aggregate Scan'
+);
 """
 sql = """
 SELECT assert((pdb.agg('{"value_count": {"field": "id"}}'::jsonb)->>'value')::numeric::bigint, 8::bigint) FROM test WHERE message ||| 'beer';

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -114,11 +114,6 @@ sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where message ||| 'cheese';
 """
 
-# A grouped, unlimited scan is emitted as a serial custom path that PostgreSQL may
-# swap for its own scan of the BM25 index: the two cost within ~0.4% of each other,
-# inside PostgreSQL's fuzzy-cost factor, and the custom path is not forced (see
-# `hook::add_path`). Which one wins then turns on how much the concurrent writer jobs
-# have grown the index, so disable the native scans to pin the plan we mean to test.
 [[jobs]]
 refresh_ms = 5
 title = "Normal Scan"

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -56,16 +56,20 @@ CREATE OR REPLACE FUNCTION assert_plan_contains(
 ) RETURNS boolean AS $$
 DECLARE
     plan_line text;
+    full_plan text := '';
 BEGIN
-    -- Loop through each line of the EXPLAIN output
-    FOR plan_line IN EXECUTE 'EXPLAIN ' || p_query LOOP
+    -- Accumulate the EXPLAIN output as we go so we can show the plan we actually
+    -- got if the assertion fails (invaluable when a fault-injection run flips the plan).
+    FOR plan_line IN EXECUTE 'EXPLAIN (VERBOSE) ' || p_query LOOP
+        full_plan := full_plan || plan_line || chr(10);
         -- Check if the current line contains the expected text
         IF plan_line ILIKE '%' || p_expected_text || '%' THEN
             RETURN true;
         END IF;
     END LOOP;
 
-    RAISE EXCEPTION 'Plan assertion failed: Expected text "%" not found in plan for query: %', p_expected_text, p_query;
+    RAISE EXCEPTION 'Plan assertion failed: expected "%" not found in plan for query: %. Actual plan:%',
+        p_expected_text, p_query, chr(10) || full_plan;
 END;
 $$ LANGUAGE plpgsql;
 

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -50,26 +50,6 @@ BEGIN
 END;
 $$;
 
-CREATE OR REPLACE FUNCTION assert_plan_contains(
-    p_query text,
-    p_expected_text text
-) RETURNS boolean AS $$
-DECLARE
-    plan_line text;
-BEGIN
-    -- Loop through each line of the EXPLAIN output
-    FOR plan_line IN EXECUTE 'EXPLAIN ' || p_query LOOP
-        -- Check if the current line contains the expected text
-        IF plan_line ILIKE '%' || p_expected_text || '%' THEN
-            RETURN true;
-        END IF;
-    END LOOP;
-
-    RAISE EXCEPTION 'Plan assertion failed: Expected text "%" not found in plan for query: %', p_expected_text, p_query;
-END;
-$$ LANGUAGE plpgsql;
-
-
 ALTER SYSTEM SET autovacuum_naptime = '1s';
 SELECT pg_reload_conf();
 """
@@ -101,10 +81,6 @@ log_tps = true
 on_connect = """
 SET paradedb.enable_custom_scan = off;
 SET paradedb.enable_aggregate_custom_scan = off;
-SELECT assert_plan_contains(
-    $q$ SELECT count(*) FROM test where message ||| 'cheese' $q$,
-    'Index Only Scan'
-);
 """
 sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where message ||| 'cheese';
@@ -116,10 +92,6 @@ title = "Normal Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_aggregate_custom_scan = off;
-SELECT assert_plan_contains(
-    $q$ SELECT count(*) FROM test where message ||| 'wine' $q$,
-    'NormalScanExecState'
-);
 """
 sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM test where message ||| 'wine';
@@ -131,10 +103,6 @@ title = "Columnar Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_columnar_exec = on;
-SELECT assert_plan_contains(
-    $q$ SELECT id, category FROM test WHERE message ||| 'beer' $q$,
-    'ColumnarExecState'
-);
 """
 sql = """
 SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM (SELECT id, category FROM test WHERE message ||| 'beer') sub;
@@ -146,10 +114,6 @@ title = "Aggregate Custom Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_aggregate_custom_scan = on;
-SELECT assert_plan_contains(
-    $q$ SELECT pdb.agg('{"value_count": {"field": "id"}}'::jsonb) FROM test WHERE message ||| 'beer' $q$,
-    'ParadeDB Aggregate Scan'
-);
 """
 sql = """
 SELECT assert((pdb.agg('{"value_count": {"field": "id"}}'::jsonb)->>'value')::numeric::bigint, 8::bigint) FROM test WHERE message ||| 'beer';


### PR DESCRIPTION
## What

- Enables `paradedb` stop/kill faults for Antithesis `stressgres` runs while keeping them excluded for `proptests`.
- Adds opt-in `--reconnect-grace-ms` handling to stressgres. Antithesis uses `30000` ms per continuous outage, and the timer resets after a successful reconnect.
- Keeps the stressgres `single-server` plan-shape assertions, but makes `assert_plan_contains` dump the plan it actually got, and pins the `Normal Scan` job's plan so the assertion stops racing the cost model. See the comment below for why it was failing.

## Verification

- `cargo test -p stressgres fault_tolerance`
- `cargo check -p stressgres`
- Antithesis reruns: proptests pass; later stressgres failures were addressed by the reconnect grace reset and the pinned `Normal Scan` plan.
