### PR TITLE
feat(stressgres): wire up the `auto` subcommand

### DIFF
--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,8 +16,7 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
-- Run a suite headless against an arbitrary Postgres build (spins up a throwaway
-  cluster from the given `pg_config`, or two for logical-replication suites):
+- Run a suite headless against a throwaway cluster
 
 ```bash
 cargo run -- auto /path/to/pg_config suites/vanilla-postgres.toml /tmp/stressgres-data --runtime 300000

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,6 +16,13 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
+- Run a suite headless against an arbitrary Postgres build (spins up a throwaway
+  cluster from the given `pg_config`, or two for logical-replication suites):
+
+```bash
+cargo run -- auto /path/to/pg_config suites/vanilla-postgres.toml /tmp/stressgres-data --runtime 300000
+```
+
 Suites are TOML files in `suites/`. The `vanilla-postgres.toml` suite exercises baseline Postgres features and works with any PostgreSQL-compatible server.
 
 ## Docker

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,7 +16,7 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
-- Run a suite headless against a throwaway cluster
+- Run a suite against a throwaway Postgres cluster built from a given `pg_config`:
 
 ```bash
 cargo run -- auto /path/to/pg_config suites/vanilla-postgres.toml /tmp/stressgres-data --runtime 300000

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -117,9 +117,6 @@ pub struct AutoArgs {
     #[arg(value_name = "PG_DATA")]
     pub pg_data_base: PathBuf,
 
-    #[arg(long, default_value = "false")]
-    pub logical_replication: bool,
-
     /// Path to the log file produced by a headless run.
     #[arg(long)]
     pub log_path: Option<PathBuf>,

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -175,20 +175,6 @@ fn load_suite<P: AsRef<Path>>(
                 ),
             }
         }
-
-        // The suite itself decides the topology (a Subscriber server ⇒ logical
-        // replication); warn if `--logical-replication` disagrees rather than
-        // silently overriding the suite.
-        let has_subscriber = definition.servers.iter().any(|s| s.is_subscriber());
-        if auto.logical_replication != has_subscriber {
-            eprintln!(
-                "warning: --logical-replication={} but suite `{}` {} a Subscriber server; \
-                 using the suite's topology",
-                auto.logical_replication,
-                path.as_ref().display(),
-                if has_subscriber { "has" } else { "has no" },
-            );
-        }
     }
 
     eprintln!("{definition:#?}");

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -30,7 +30,7 @@ mod table_helper;
 mod tui;
 
 use crate::auto::{setup_server, ServerHandler};
-use crate::cli::{Cli, Command};
+use crate::cli::{AutoArgs, Cli, Command};
 use crate::runner::SuiteRunner;
 use crate::suite::{PgConfigStyle, PgVersion, ServerStyle, Suite, SuiteDefinition};
 use anyhow::Context;
@@ -56,7 +56,7 @@ fn main() -> anyhow::Result<()> {
     match cli.command {
         // When using the "ui" subcommand.
         Command::Ui(args) => {
-            let suite = load_suite(&args.suite_path, args.pgversion).with_context(|| {
+            let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
             let suite_runner = SuiteRunner::new(suite, args.paused)?;
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
 
         // When using the "headless" subcommand.
         Command::Headless(args) => {
-            let suite = load_suite(&args.suite_path, args.pgversion).with_context(|| {
+            let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
             let suite_runner = SuiteRunner::new(suite, false)?;
@@ -83,6 +83,22 @@ fn main() -> anyhow::Result<()> {
             )?;
         }
 
+        // When using the "auto" subcommand: spin up a throwaway Postgres cluster
+        // (or two, for logical replication) from the given `pg_config` and run the
+        // suite headless against it.
+        Command::Auto(args) => {
+            let suite = load_suite(&args.suite_path, None, Some(&args)).with_context(|| {
+                format!("Failed to load suite file: {}", args.suite_path.display())
+            })?;
+            let suite_runner = SuiteRunner::new(suite, false)?;
+            headless::run(
+                suite_runner,
+                args.log_path.clone(),
+                1000,
+                Some(args.runtime as u128),
+            )?;
+        }
+
         // When using the "graph" subcommand.
         Command::Graph(graph_args) => {
             graph::run(&graph_args)?;
@@ -91,15 +107,22 @@ fn main() -> anyhow::Result<()> {
         Command::Csv(csv_args) => {
             csv::run(&csv_args)?;
         }
-
-        other => panic!("Unrecognized command: {:?}", other),
     }
 
     Ok(())
 }
 
 /// Loads the Suite (TOML) from the provided path.
-fn load_suite<P: AsRef<Path>>(path: P, pgversion: Option<PgVersion>) -> anyhow::Result<Suite> {
+///
+/// When `auto` is provided (the `auto` subcommand), every `Automatic` server is
+/// pointed at the supplied `pg_config` binary and given a data directory under the
+/// supplied base path, so a suite can be run against an arbitrary Postgres build
+/// without editing its TOML.
+fn load_suite<P: AsRef<Path>>(
+    path: P,
+    pgversion: Option<PgVersion>,
+    auto: Option<&AutoArgs>,
+) -> anyhow::Result<Suite> {
     eprintln!("Loading Suite: {}", path.as_ref().display());
     let file = std::fs::read_to_string(path.as_ref())?;
     let mut definition = toml::from_str::<SuiteDefinition>(&file)?;
@@ -121,6 +144,50 @@ fn load_suite<P: AsRef<Path>>(path: P, pgversion: Option<PgVersion>) -> anyhow::
                     // For other server styles, we don't override
                 }
             }
+        }
+    }
+
+    // Override every server to use the `auto`-provided pg_config binary and a data
+    // directory under the requested base path.
+    if let Some(auto) = auto {
+        std::fs::create_dir_all(&auto.pg_data_base).with_context(|| {
+            format!(
+                "Failed to create data directory base {}",
+                auto.pg_data_base.display()
+            )
+        })?;
+        for server in &mut definition.servers {
+            let name = server.name.clone();
+            match &mut server.style {
+                ServerStyle::Automatic {
+                    pg_config,
+                    pgdata,
+                    log_path,
+                    ..
+                } => {
+                    *pg_config = PgConfigStyle::Path(auto.pg_config.clone());
+                    *pgdata = Some(auto.pg_data_base.join(format!("{name}.data")));
+                    *log_path = Some(auto.pg_data_base.join(format!("{name}.log")));
+                }
+                style => anyhow::bail!(
+                    "`stressgres auto` requires `[server.style.Automatic]` servers, \
+                     but server `{name}` is {style:?}"
+                ),
+            }
+        }
+
+        // The suite itself decides the topology (a Subscriber server ⇒ logical
+        // replication); warn if `--logical-replication` disagrees rather than
+        // silently overriding the suite.
+        let has_subscriber = definition.servers.iter().any(|s| s.is_subscriber());
+        if auto.logical_replication != has_subscriber {
+            eprintln!(
+                "warning: --logical-replication={} but suite `{}` {} a Subscriber server; \
+                 using the suite's topology",
+                auto.logical_replication,
+                path.as_ref().display(),
+                if has_subscriber { "has" } else { "has no" },
+            );
         }
     }
 


### PR DESCRIPTION
## What

`stressgres` defines an `auto` subcommand (`Command::Auto` / `AutoArgs`) but it was
**never wired up** — running `stressgres auto ...` fell through to
`other => panic!("Unrecognized command")` in `main.rs`. It's been dead since the
original Stressgres PR (#3821). This implements it.

`auto` runs a suite headless against a **throwaway Postgres cluster built from a given
`pg_config` binary**, instead of the pgrx-managed Postgres that the `Automatic` server
style defaults to. Useful for exercising a suite against an arbitrary/local Postgres
build without editing the suite TOML.

```bash
stressgres auto /path/to/pg_config suites/vanilla-postgres.toml /tmp/stressgres-data --runtime 300000
```

## How

- `load_suite` gains an optional `auto` override. When present, every `Automatic`
  server is pointed at the provided `pg_config` (`PgConfigStyle::Path`) and given a
  data directory under the provided base path (`create_dir_all`'d first). The
  existing setup/teardown machinery (`setup_server`) then spins up the cluster(s) —
  including the two-node publisher/subscriber case for logical-replication suites.
- Non-`Automatic` servers are rejected with a clear error rather than silently
  mishandled.
- Removes the now-unreachable `other => panic!` arm; the match is exhaustive over all
  five subcommands.

## Dead-code cleanup

- Dropped the `auto --logical-replication` flag. It only existed on this
  (never-wired) subcommand and carried no information: topology is determined by the
  suite's servers (a `Subscriber` server ⇒ logical replication) in every mode, so the
  flag could only ever agree-or-contradict the suite. Removed it entirely.

## Status / verification

Separate from the Antithesis fault-tolerance work — branched off `main`.

I could **not** build/test locally. Verified statically: all three `load_suite`
callers pass the new arg, the `match` is exhaustive, and the `ServerStyle::Automatic`
destructure matches the enum fields. **CI is the gate** (`cargo build` + `cargo clippy`
for the crate). Kept as a **draft** until it's confirmed green and someone sanity-runs
`stressgres auto` against a real `pg_config`.
