### PR TITLE
fix: Allow BMW to be used for compound `ORDER BY` with a score prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -895,7 +895,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1784,7 +1784,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.117",
 ]
 
@@ -5310,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6192,7 +6191,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7809,7 +7808,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7864,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "bitpacking",
 ]
@@ -7872,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7887,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7920,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7932,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7945,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7982,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?rev=0056e2d8ed624211ccc37742e8b28ecb32bdf6b6#0056e2d8ed624211ccc37742e8b28ecb32bdf6b6"
+source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
 dependencies = [
  "serde",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5309,7 +5309,7 @@ dependencies = [
 [[package]]
 name = "ownedbytes"
 version = "0.9.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -7808,7 +7808,7 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 [[package]]
 name = "tantivy"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "aho-corasick",
  "arc-swap",
@@ -7863,7 +7863,7 @@ dependencies = [
 [[package]]
 name = "tantivy-bitpacker"
 version = "0.10.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "bitpacking",
 ]
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "tantivy-columnar"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "downcast-rs",
  "fastdivide",
@@ -7886,7 +7886,7 @@ dependencies = [
 [[package]]
 name = "tantivy-common"
 version = "0.11.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7919,7 +7919,7 @@ dependencies = [
 [[package]]
 name = "tantivy-query-grammar"
 version = "0.26.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "fnv",
  "nom 7.1.3",
@@ -7931,7 +7931,7 @@ dependencies = [
 [[package]]
 name = "tantivy-sstable"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "futures-util",
  "itertools 0.14.0",
@@ -7944,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "tantivy-stacker"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "fixedbitset",
  "murmurhash32",
@@ -7981,7 +7981,7 @@ dependencies = [
 [[package]]
 name = "tantivy-tokenizer-api"
 version = "0.7.0"
-source = "git+https://github.com/paradedb/tantivy.git?branch=stuhood.compound-score-bmw#af74b9331aad5511a966f34e0fd0ea19733ca877"
+source = "git+https://github.com/paradedb/tantivy.git?rev=5c652e151199a703e4dc81b2f12da4897c323b7c#5c652e151199a703e4dc81b2f12da4897c323b7c"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "0056e2d8ed624211ccc37742e8b28ecb32bdf6b6", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.compound-score-bmw", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -44,7 +44,7 @@ pgrx-tests = "=0.19.0"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "0056e2d8ed624211ccc37742e8b28ecb32bdf6b6" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.compound-score-bmw" }
 
 # datafusion 54.0.0 + the null-aware anti-join dynamic-filter fix (paradedb/datafusion PR #2, backported
 # to a 54.0.0 branch so it stays on arrow 58). Patch every datafusion crate, or two `datafusion-common`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ inherits = "release"
 debug = true
 
 [workspace.dependencies]
-tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", branch = "stuhood.compound-score-bmw", features = [
+tantivy = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy", rev = "5c652e151199a703e4dc81b2f12da4897c323b7c", features = [
   "columnar-zstd-compression",
   "lz4-compression",
   "paradedb",
@@ -44,7 +44,7 @@ pgrx-tests = "=0.19.0"
 tantivy-jieba = "0.20.0"
 
 [patch.crates-io]
-tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", branch = "stuhood.compound-score-bmw" }
+tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "5c652e151199a703e4dc81b2f12da4897c323b7c" }
 
 # datafusion 54.0.0 + the null-aware anti-join dynamic-filter fix (paradedb/datafusion PR #2, backported
 # to a 54.0.0 branch so it stays on arrow 58). Patch every datafusion crate, or two `datafusion-common`

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-tQoddWgHHdbqX88ImexER7r5qKraoKHP/73wvVkMhUQ=";
+  cargoHash = "sha256-98nsCm43nVa67DI382QbOISZmDdtVeH6Djgspi9FQ6U=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -776,11 +776,11 @@ impl SearchIndexReader {
     /// Mirrors the sort-shape branch in `search_top_k_in_segments`.
     pub(crate) fn orderby_uses_score_desc_topk_collector(orderby_info: &[OrderByInfo]) -> bool {
         matches!(
-            orderby_info,
-            [OrderByInfo {
+            orderby_info.first(),
+            Some(OrderByInfo {
                 feature: OrderByFeature::Score { .. },
                 direction,
-            }] if !direction.is_asc()
+            }) if !direction.is_asc()
         )
     }
 

--- a/pg_search/src/postgres/customscan/basescan/cost.rs
+++ b/pg_search/src/postgres/customscan/basescan/cost.rs
@@ -61,7 +61,7 @@ fn parallel_tuple_cost() -> f64 {
 /// the branch, not the serial-vs-parallel outcome (the plan shape shows that).
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub(super) enum WorkerDecisionReason {
-    /// Prunable score-DESC single term: Block-WAND keeps serial scoring sublinear (#4664), so
+    /// Prunable primarily score-DESC ordering: Block-WAND keeps serial scoring sublinear (#4664), so
     /// workers would only add overhead.
     BlockWandPrunable,
     /// Costable scan, no effective LIMIT: pg_search offered both paths and let PostgreSQL choose. (A
@@ -251,8 +251,8 @@ pub(super) unsafe fn topk_can_prune_for_method(
         return TopKPrunability::NotPrunable;
     }
 
-    // A clean ordered TopK: a prunable candidate only when ordered by score DESC (the one direction
-    // Block-WAND prunes to sublinear). Score ASC / field sort are ordered but not prunable.
+    // A clean ordered TopK: a prunable candidate only when ordered primarily by score DESC (the one
+    // direction Block-WAND prunes to sublinear). Score ASC / field sort are ordered but not prunable.
     if SearchIndexReader::orderby_uses_score_desc_topk_collector(orderby_info) {
         TopKPrunability::PrunableCandidate
     } else {
@@ -364,7 +364,7 @@ pub(super) unsafe fn decide_scan_parallelism(inputs: ScanParallelismInputs) -> W
         has_grouping,
     } = inputs;
 
-    // 1. Prunable short-circuit -> serial only. Block-WAND keeps a score-DESC single term sublinear
+    // 1. Prunable short-circuit -> serial only. Block-WAND keeps primarily score-DESC ordered top-k sublinear
     //    (#4664), so workers would only add overhead. A hard gate: the cost model can't see
     //    Block-WAND, and the predicate must actually prune, not just look like a term.
     if matches!(prunability, TopKPrunability::PrunableCandidate) && query.is_topk_prunable() {

--- a/pg_search/src/postgres/shared_threshold.rs
+++ b/pg_search/src/postgres/shared_threshold.rs
@@ -234,25 +234,6 @@ impl SharedThreshold<tantivy::Score> for PgAtomicSharedScoreThreshold {
             }
         }
     }
-
-    /// # Tie-breaking determinism
-    /// Tantivy's fast-path WAND scorer uses a strict inequality (`score > threshold`) to prune documents.
-    /// When our segment is supposed to WIN a global tie-breaker (`segment_ord < threshold_ord`), we must
-    /// accept documents with a score *equal* to the threshold.
-    /// To do this mathematically against a strict `>` operator, we artificially lower the threshold by
-    /// one float epsilon (`next_down()`), ensuring `score > threshold_minus_epsilon` evaluates to `true`.
-    fn competitive_threshold(
-        &self,
-        value: tantivy::Score,
-        threshold_ord: u32,
-        segment_ord: u32,
-    ) -> tantivy::Score {
-        if segment_ord < threshold_ord {
-            value.next_down()
-        } else {
-            value
-        }
-    }
 }
 
 pub fn new_score_threshold(

--- a/pg_search/tests/pg_regress/expected/issue_5108.out
+++ b/pg_search/tests/pg_regress/expected/issue_5108.out
@@ -478,26 +478,23 @@ WITH matched AS (
 SELECT m.body, d.filename, m.s
 FROM matched m JOIN issue_5108_docs d ON d.id = m.doc_id
 ORDER BY m.s DESC, m.id;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Nested Loop
    Output: issue_5108_chunks.body, d.filename, (pdb.score(issue_5108_chunks.id)), issue_5108_chunks.id
    Inner Unique: true
    ->  Limit
          Output: issue_5108_chunks.id, issue_5108_chunks.body, issue_5108_chunks.doc_id, (pdb.score(issue_5108_chunks.id))
-         ->  Gather Merge
-               Output: issue_5108_chunks.id, issue_5108_chunks.body, issue_5108_chunks.doc_id, (pdb.score(issue_5108_chunks.id))
-               Workers Planned: 1
-               ->  Parallel Custom Scan (ParadeDB Base Scan) on public.issue_5108_chunks
-                     Output: issue_5108_chunks.id, issue_5108_chunks.body, issue_5108_chunks.doc_id, pdb.score(issue_5108_chunks.id)
-                     Table: issue_5108_chunks
-                     Index: issue_5108_chunks_bm25
-                     Worker Selection: Cost model
-                     Exec Method: TopKScanExecState
-                     Scores: true
-                        TopK Order By: pdb.score() desc, id asc
-                        TopK Limit: 100
-                     Tantivy Query: {"with_index":{"query":{"match":{"field":"body","value":"healthcare","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
+         ->  Custom Scan (ParadeDB Base Scan) on public.issue_5108_chunks
+               Output: issue_5108_chunks.id, issue_5108_chunks.body, issue_5108_chunks.doc_id, pdb.score(issue_5108_chunks.id)
+               Table: issue_5108_chunks
+               Index: issue_5108_chunks_bm25
+               Worker Selection: Prunable top-K
+               Exec Method: TopKScanExecState
+               Scores: true
+                  TopK Order By: pdb.score() desc, id asc
+                  TopK Limit: 100
+               Tantivy Query: {"with_index":{"query":{"match":{"field":"body","value":"healthcare","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
    ->  Memoize
          Output: d.filename, d.id
          Cache Key: issue_5108_chunks.doc_id
@@ -505,7 +502,7 @@ ORDER BY m.s DESC, m.id;
          ->  Index Scan using issue_5108_docs_pkey on public.issue_5108_docs d
                Output: d.filename, d.id
                Index Cond: (d.id = issue_5108_chunks.doc_id)
-(25 rows)
+(22 rows)
 
 WITH matched AS (
     SELECT id, body, doc_id, pdb.score(id) AS s

--- a/pg_search/tests/pg_regress/expected/parallel_small_segments.out
+++ b/pg_search/tests/pg_regress/expected/parallel_small_segments.out
@@ -138,24 +138,21 @@ SELECT id, name FROM items
 WHERE name @@@ pdb.match('item')
 ORDER BY paradedb.score(id) DESC, id
 LIMIT 10;
-                                                                                              QUERY PLAN                                                                                              
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                           QUERY PLAN                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: id, name, (paradedb.score(id))
-   ->  Gather Merge
-         Output: id, name, (paradedb.score(id))
-         Workers Planned: 2
-         ->  Parallel Custom Scan (ParadeDB Base Scan) on public.items
-               Output: id, name, paradedb.score(id)
-               Table: items
-               Index: items_bm25_idx
-               Worker Selection: Cost model (LIMIT)
-               Exec Method: TopKScanExecState
-               Scores: true
-                  TopK Order By: pdb.score() desc, id asc
-                  TopK Limit: 10
-               Tantivy Query: {"with_index":{"query":{"match":{"field":"name","value":"item","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
-(15 rows)
+   ->  Custom Scan (ParadeDB Base Scan) on public.items
+         Output: id, name, paradedb.score(id)
+         Table: items
+         Index: items_bm25_idx
+         Worker Selection: Prunable top-K
+         Exec Method: TopKScanExecState
+         Scores: true
+            TopK Order By: pdb.score() desc, id asc
+            TopK Limit: 10
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"name","value":"item","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":null}}}}
+(12 rows)
 
 SELECT id, name FROM items
 WHERE name @@@ pdb.match('item')

--- a/tests/tests/parallel_topk.rs
+++ b/tests/tests/parallel_topk.rs
@@ -360,6 +360,12 @@ fn cost_based_topk_plan_shapes(mut conn: PgConnection) {
                     ORDER BY paradedb.score(id) DESC LIMIT 1000",
             expected_workers: None,
         },
+        PlanCase {
+            name: "secondary_sort_key_is_serial",
+            query: "SELECT id FROM topk_desc_large WHERE body @@@ 'alpha'
+                    ORDER BY paradedb.score(id) DESC, id ASC LIMIT 10",
+            expected_workers: None,
+        },
     ] {
         assert_plan_case(&mut conn, case);
     }
@@ -420,12 +426,6 @@ fn cost_based_topk_plan_shapes(mut conn: PgConnection) {
             name: "field_sort_large_match_parallelizes",
             query: "SELECT id FROM topk_desc_large WHERE body @@@ 'gamma'
                     ORDER BY id ASC LIMIT 10",
-            expected_workers: Some(2),
-        },
-        PlanCase {
-            name: "secondary_sort_key_parallelizes",
-            query: "SELECT id FROM topk_desc_large WHERE body @@@ 'alpha'
-                    ORDER BY paradedb.score(id) DESC, id ASC LIMIT 10",
             expected_workers: Some(2),
         },
         PlanCase {


### PR DESCRIPTION
## What

Incorporate https://github.com/paradedb/tantivy/pull/167 to allow Block-Max WAND to be used for a compound `ORDER BY` with a score prefix.

## Why

While Tantivy and Lucene generally lean on `Score` ordering itself being deterministic (by implicitly including the `DocAddress` during Top-K), this is insufficient for `pg_search` for a few reasons:
1. when parallel workers or deeper query paths are used, Postgres will introduce additional sorts on the `Score`, which will be oblivious to the `DocAddress`
2. the `DocAddress` for a tuple will change due to compaction and merging of segments

## Tests

Benchmarks show [a ~2x speedup for `top_k-score-desc-tiebreaker`](https://github.com/paradedb/paradedb/pull/5496#pullrequestreview-4657963818), demonstrating the use of BMW.