### PR TITLE
ci: pin regress parallelism and fail the step on baseline drift

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -291,10 +291,10 @@ jobs:
         if: matrix.pg_impl == 'pgrx'
         run: |
           set -e
-          if ! cargo pgrx regress --package pg_search pg${{ matrix.pg_version }} --auto; then
-            git diff
-            exit 1
-          fi
+          cargo pgrx regress --package pg_search pg${{ matrix.pg_version }} --auto
+          # `--auto` promotes any output diff into the working tree, so a zero exit code
+          # doesn't mean the baselines matched. Fail if anything was promoted.
+          git diff --exit-code
 
       - name: Stop PostgreSQL to flush coverage data (pgrx)
         if: matrix.pg_impl == 'pgrx' && always()

--- a/pg_search/tests/pg_regress/expected/setup.out
+++ b/pg_search/tests/pg_regress/expected/setup.out
@@ -1,7 +1,7 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
--- Whether MPP engages depends on `max_parallel_workers_per_gather`, so pin it for the regress
--- cluster. Otherwise the plans differ between a stock cluster and a developer's MPP-tuned one.
--- Tests that exercise MPP raise it themselves.
+-- Pin parallelism so regress plans don't depend on the local cluster's worker config. The value
+-- drives how much a query parallelizes, MPP or not, so a stock cluster and a tuned one would
+-- otherwise produce different plans. Tests that want more workers raise it themselves.
 ALTER SYSTEM SET max_parallel_workers_per_gather = 2;
 SELECT pg_reload_conf();
  pg_reload_conf 

--- a/pg_search/tests/pg_regress/expected/setup.out
+++ b/pg_search/tests/pg_regress/expected/setup.out
@@ -1,4 +1,14 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
+-- Whether MPP engages depends on `max_parallel_workers_per_gather`, so pin it for the regress
+-- cluster. Otherwise the plans differ between a stock cluster and a developer's MPP-tuned one.
+-- Tests that exercise MPP raise it themselves.
+ALTER SYSTEM SET max_parallel_workers_per_gather = 2;
+SELECT pg_reload_conf();
+ pg_reload_conf 
+----------------
+ t
+(1 row)
+
 DROP TABLE IF EXISTS mock_items_issue_2528;
 CALL paradedb.create_bm25_test_table(
   schema_name => 'public',

--- a/pg_search/tests/pg_regress/sql/setup.sql
+++ b/pg_search/tests/pg_regress/sql/setup.sql
@@ -1,8 +1,8 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
--- Whether MPP engages depends on `max_parallel_workers_per_gather`, so pin it for the regress
--- cluster. Otherwise the plans differ between a stock cluster and a developer's MPP-tuned one.
--- Tests that exercise MPP raise it themselves.
+-- Pin parallelism so regress plans don't depend on the local cluster's worker config. The value
+-- drives how much a query parallelizes, MPP or not, so a stock cluster and a tuned one would
+-- otherwise produce different plans. Tests that want more workers raise it themselves.
 ALTER SYSTEM SET max_parallel_workers_per_gather = 2;
 SELECT pg_reload_conf();
 

--- a/pg_search/tests/pg_regress/sql/setup.sql
+++ b/pg_search/tests/pg_regress/sql/setup.sql
@@ -1,5 +1,11 @@
 CREATE EXTENSION IF NOT EXISTS pg_search;
 
+-- Whether MPP engages depends on `max_parallel_workers_per_gather`, so pin it for the regress
+-- cluster. Otherwise the plans differ between a stock cluster and a developer's MPP-tuned one.
+-- Tests that exercise MPP raise it themselves.
+ALTER SYSTEM SET max_parallel_workers_per_gather = 2;
+SELECT pg_reload_conf();
+
 DROP TABLE IF EXISTS mock_items_issue_2528;
 CALL paradedb.create_bm25_test_table(
   schema_name => 'public',


### PR DESCRIPTION
This PR makes the `pg_search` regress suite deterministic and able to catch baseline drift.

Context: #5430 (MPP on by default) merged without the regress suite running (a base retarget is an `edited` event, which `test-pg_search.yml` doesn't trigger on). Digging into it turned up two gaps that let that slip through, plus a leftover from the first version of this PR.

## Pin `max_parallel_workers_per_gather` in `setup.sql`

Whether MPP engages depends on it: `mpp_is_active()` needs `producer_count <= max_parallel_workers_per_gather`, which is `3` at the default `mpp_worker_count`. Tests that don't set it inherited the local cluster's value, so a stock cluster ran them serial while an MPP-tuned one (a dev box, or a CI runner with more workers) ran them through MPP and got different plans. `ALTER SYSTEM` pins it for the whole run. Tests that exercise MPP raise it themselves.

## Fail the regress step on drift

The step ran `cargo pgrx regress --auto`, which promotes any output diff into the runner's working tree and returns `0`. So the `if ! ... ; then git diff; exit 1` guard only fired on a hard crash, never on baseline drift, the promoted files just got thrown away with the runner. It now runs `--auto` and then `git diff --exit-code`, so any promotion fails the job.

## Drop the `max_stack_depth = 6MB` PGOPTIONS

Added in the first version of this PR. The deep join plan that trips Postgres's 2MB limit in the plan-serialization path only shows up under MPP, which the pin keeps off in the general tests, so `main` doesn't need it.
