### PR TITLE
chore: Enable the `large_futures` lint to check for potential stack overflows.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,3 +82,6 @@ datafusion-proto-common = { git = "https://github.com/paradedb/datafusion", rev 
 datafusion-pruning = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
 datafusion-session = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
 datafusion-sql = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
+
+[workspace.lints.clippy]
+large_futures = "warn"

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -5,6 +5,9 @@ version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 clap = { version = "4.6.1", features = ["derive", "env"] }
 anyhow = "1.0"

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -5,6 +5,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lints]
+workspace = true
+
 [lib]
 proc-macro = true
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -5,6 +5,9 @@ version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["cdylib"]
 

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -5,6 +5,9 @@ version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.102"
 clap = { version = "4.6", features = ["derive"] }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -5,6 +5,9 @@ version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 
+[lints]
+workspace = true
+
 [lib]
 crate-type = ["rlib"]
 

--- a/tokenizers/Cargo.toml
+++ b/tokenizers/Cargo.toml
@@ -5,6 +5,9 @@ version = { workspace = true }
 edition = { workspace = true }
 license = { workspace = true }
 
+[lints]
+workspace = true
+
 [dependencies]
 anyhow = "1.0.102"
 lindera = { version = "1.5.1", features = [


### PR DESCRIPTION
## What

Enable the `clippy` `large_futures` lint, to help guard against stack overflows.

## Why

A stack overflow causes an abort at runtime.

## Tests

No existing large futures were detected. But temporarily introducing them triggers a warning like the following:
```
warning: large future with a size of 30002 bytes
   --> pg_search/src/lib.rs:187:5
    |
187 |     my_large_future().await;
    |     ^^^^^^^^^^^^^^^^^ help: consider `Box::pin` on it: `Box::pin(my_large_future())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.96.0/index.html#large_futures
    = note: requested on the command line with `-W clippy::large-futures`

warning: `pg_search` (lib) generated 1 warning
```