### PR TITLE
chore: Add a compound BMW benchmark.

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/top_k-score-desc-tiebreaker.sql
+++ b/benchmarks/datasets/stackoverflow/queries/top_k-score-desc-tiebreaker.sql
@@ -1,3 +1,10 @@
+-- Shape: TopK Score with Tiebreaker (Single Table, BM25)
+-- Description: BM25 score ordered DESC with a primary key tiebreaker and LIMIT 10.
+-- This tests that the Block-Max WAND optimization is able to trigger when a score
+-- is used as a prefix in the ORDER BY clause along with a tiebreaker.
+--
+-- Query Info (statistics from 1M dataset; larger datasets may have different values):
+-- - 'javascript' selectivity on stackoverflow_posts.body: ~4%
 SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) DESC, id LIMIT 10;
 
 -- force single worker

--- a/benchmarks/datasets/stackoverflow/queries/top_k-score-desc-tiebreaker.sql
+++ b/benchmarks/datasets/stackoverflow/queries/top_k-score-desc-tiebreaker.sql
@@ -1,0 +1,4 @@
+SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) DESC, id LIMIT 10;
+
+-- force single worker
+SET max_parallel_workers_per_gather=0; SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) DESC, id LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/top_k-score-desc.sql
+++ b/benchmarks/datasets/stackoverflow/queries/top_k-score-desc.sql
@@ -1,3 +1,9 @@
+-- Shape: TopK Score (Single Table, BM25)
+-- Description: BM25 score ordered DESC and LIMIT 10.
+-- This tests the standard Block-Max WAND optimization without tiebreakers.
+--
+-- Query Info (statistics from 1M dataset; larger datasets may have different values):
+-- - 'javascript' selectivity on stackoverflow_posts.body: ~4%
 SELECT *, pdb.score(id) FROM stackoverflow_posts WHERE body ||| 'javascript' ORDER BY pdb.score(id) DESC LIMIT 10;
 
 -- force single worker


### PR DESCRIPTION
## What

Add a pure-Top-K query with a tiebreaker. 

## Why

#5496 adds support for using BMW on compound scores, but that optimization is difficult to track semantically: it is easier to track via benchmarks.