### PR TITLE
fix: don't spawn a docstore compressor thread when materializing a mutable segment

### DIFF
--- a/pg_search/src/index/mod.rs
+++ b/pg_search/src/index/mod.rs
@@ -24,3 +24,25 @@ pub mod writer;
 
 pub use directory::*;
 pub use search::*;
+
+use crate::postgres::options::BM25IndexOptions;
+use crate::schema::SearchIndexSchema;
+use tantivy::columnar::CodecType;
+use tantivy::IndexSettings;
+
+/// The [`IndexSettings`] used for every tantivy index pg_search creates.
+///
+/// `docstore_compress_dedicated_thread` must remain `false`: a dedicated compressor thread
+/// receives process-directed signals, and pgrx's background worker signal handlers call into
+/// Postgres FFI, which panics off the main thread. Compress inline instead.
+pub fn index_settings(
+    options: &BM25IndexOptions,
+    schema: &tantivy::schema::Schema,
+) -> IndexSettings {
+    IndexSettings {
+        sort_by_field: SearchIndexSchema::build_sort_by_field(&options.sort_by(), schema),
+        docstore_compress_dedicated_thread: false,
+        codec_types: vec![CodecType::Bitpacked, CodecType::BlockwiseLinearV2],
+        ..IndexSettings::default()
+    }
+}

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -175,6 +175,10 @@ impl SerialIndexWriter {
             SearchIndexSchema::build_sort_by_field(&options.sort_by(), &tantivy_schema);
         let settings = IndexSettings {
             sort_by_field,
+            // A dedicated compressor thread would receive process-directed signals, and pgrx's
+            // background worker signal handlers call into Postgres FFI, which panics off the
+            // main thread. Compress inline instead.
+            docstore_compress_dedicated_thread: false,
             codec_types: vec![
                 tantivy::columnar::CodecType::Bitpacked,
                 tantivy::columnar::CodecType::BlockwiseLinearV2,

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -23,13 +23,13 @@ use tantivy::index::SegmentId;
 use tantivy::indexer::{AddOperation, IndexWriterOptions, SegmentWriter};
 use tantivy::schema::Field;
 use tantivy::{
-    directory::RamDirectory, Directory, Index, IndexMeta, IndexSettings, IndexWriter, Opstamp,
-    Segment, SegmentMeta, TantivyDocument,
+    directory::RamDirectory, Directory, Index, IndexMeta, IndexWriter, Opstamp, Segment,
+    SegmentMeta, TantivyDocument,
 };
 use thiserror::Error;
 
 use crate::index::mvcc::{MVCCDirectory, MvccSatisfies};
-use crate::index::setup_tokenizers;
+use crate::index::{index_settings, setup_tokenizers};
 use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::block::SegmentMetaEntry;
 use crate::{postgres::types::TantivyValueError, schema::SearchIndexSchema};
@@ -169,22 +169,7 @@ impl SerialIndexWriter {
         let schema = index_relation.schema()?;
         let tantivy_schema: tantivy::schema::Schema = schema.clone().into();
 
-        // Build IndexSettings from rd_options (same source as build.rs:create_index)
-        let options = index_relation.options();
-        let sort_by_field =
-            SearchIndexSchema::build_sort_by_field(&options.sort_by(), &tantivy_schema);
-        let settings = IndexSettings {
-            sort_by_field,
-            // A dedicated compressor thread would receive process-directed signals, and pgrx's
-            // background worker signal handlers call into Postgres FFI, which panics off the
-            // main thread. Compress inline instead.
-            docstore_compress_dedicated_thread: false,
-            codec_types: vec![
-                tantivy::columnar::CodecType::Bitpacked,
-                tantivy::columnar::CodecType::BlockwiseLinearV2,
-            ],
-            ..IndexSettings::default()
-        };
+        let settings = index_settings(index_relation.options(), &tantivy_schema);
         let mut index = Index::create(directory, tantivy_schema, settings)?;
         setup_tokenizers(index_relation, &mut index)?;
         let ctid_field = schema.ctid_field();

--- a/pg_search/src/postgres/build.rs
+++ b/pg_search/src/postgres/build.rs
@@ -17,6 +17,7 @@
 
 use crate::api::version::VersionInfo;
 use crate::api::FieldName;
+use crate::index::index_settings;
 use crate::index::mvcc::MvccSatisfies;
 use crate::postgres::build_parallel::build_index;
 use crate::postgres::options::BM25IndexOptions;
@@ -24,11 +25,11 @@ use crate::postgres::rel::PgSearchRelation;
 use crate::postgres::storage::custom_rmgr;
 use crate::postgres::storage::metadata::MetaPage;
 use crate::postgres::utils::{extract_field_attributes, ExtractedFieldAttribute};
-use crate::schema::{SearchFieldConfig, SearchFieldType, SearchIndexSchema};
+use crate::schema::{SearchFieldConfig, SearchFieldType};
 use anyhow::Result;
 use pgrx::*;
 use tantivy::schema::Schema;
-use tantivy::{Index, IndexSettings};
+use tantivy::Index;
 use tokenizers::SearchTokenizer;
 
 #[pg_guard]
@@ -340,18 +341,7 @@ fn create_index(index_relation: &PgSearchRelation) -> Result<()> {
     let schema = builder.build();
     let directory = MvccSatisfies::Snapshot.directory(index_relation);
 
-    // Configure sort_by for segment sorting
-    let sort_by_field = SearchIndexSchema::build_sort_by_field(&options.sort_by(), &schema);
-
-    let settings = IndexSettings {
-        sort_by_field,
-        docstore_compress_dedicated_thread: false,
-        codec_types: vec![
-            tantivy::columnar::CodecType::Bitpacked,
-            tantivy::columnar::CodecType::BlockwiseLinearV2,
-        ],
-        ..IndexSettings::default()
-    };
+    let settings = index_settings(options, &schema);
     let _ = Index::create(directory, schema, settings)?;
     Ok(())
 }
@@ -362,9 +352,11 @@ mod tests {
     use super::*;
     use crate::api::FieldName;
     use crate::postgres::options::{SortByDirection, SortByField};
+    use crate::schema::SearchIndexSchema;
     use pgrx::pg_test;
     use tantivy::index::Order;
     use tantivy::schema::{NumericOptions, Schema, FAST};
+    use tantivy::IndexSettings;
 
     #[pg_test]
     fn test_build_sort_by_field_empty() {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5504

## What

Set `docstore_compress_dedicated_thread: false` in `SerialIndexWriter::in_memory`, so that materializing a mutable segment no longer spawns a tantivy `docstore-compressor-thread` inside the Postgres process.

## Why

`SerialIndexWriter::in_memory` built its `IndexSettings` from `IndexSettings::default()`, which leaves `docstore_compress_dedicated_thread: true` (tantivy `index_meta.rs:347`). That flows through `PendingSegment::with_id` → `SegmentWriter::for_segment` → `SegmentSerializer::for_segment` → `StoreWriter::new(..., dedicated_thread: true)` → `BlockCompressor::new`, which spawns a thread.

When the postmaster `SIGTERM`s pg_search's background merge worker, the process-directed signal can land on that thread — it inherited an empty signal mask at spawn. pgrx's `worker_spi_sigterm` handler (installed at `pg_search/src/postgres/merge.rs:340`) then calls `SetLatch` through `pg_guard_ffi_boundary`, whose `check_active_thread()` panics off the main thread:

```
thread 'docstore-compressor-thread' (2036) panicked at pgrx-0.19.0/src/bgworkers.rs:365:5:
  postgres FFI may not be called from multiple threads.
```

The compressor thread dies, and the in-flight merge fails with:

```
ERROR:  XX000: Failed to index mutable segment.: An IO error occurred: 'Compressing thread panicked.'
```

Both production sites in `build.rs` (`build.rs:348`, `build.rs:482`) already disable the dedicated thread for exactly this reason. `in_memory` was the one production site that missed it.

Found by Antithesis (`stressgres` workload, `background-merge` suite) on commit `7f5a551` — see #5504 for the full trace.

## How

One-line settings change, plus a comment recording the constraint.

Note that `index_memory_segment` is also reached from `MVCCDirectory::file_entry` on the read path, so this additionally removes a thread spawn/join from every query that materializes a mutable segment. The panic itself only fires in the background merge worker, because that is the only place pg_search installs pgrx's signal handlers — ordinary client backends use Postgres's own C `die()` handler, which is not pgrx-guarded.

## Tests

`cargo check -p pg_search --features pg17 --no-default-features` passes.

Verified behaviourally by building the extension both ways against a real PG17 and sampling the backend's threads while it materialized a mutable segment (9,000 rows of ~4.8KB each, re-materialized 40 times in one session).

Before, two threads:

```
4602 Thread_3671802   DispatchQueue_1: com.apple.main-thread  (serial)
4602 Thread_3671806: docstore-compressor-thread
       thread_start  (in libsystem_pthread.dylib)
         _pthread_start
           std::sys::thread::unix::Thread::new::thread_start  (in pg_search.dylib)
```

After, one:

```
4599 Thread_3645769   DispatchQueue_1: com.apple.main-thread  (serial)
```

Both samples contain `index_memory_segment`, `SerialIndexWriter::insert` and `StoreWriter::store` frames, confirming the probe was catching the materialization path rather than an idle backend.
