### PR TITLE
fix: prevent heap filters from tripping assert on aggregate scan

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -749,7 +749,7 @@ pub fn index_memory_segment(
                     heap_fetch_state.scan,
                     &mut ipd,
                     fetch_snapshot,
-                    heap_fetch_state.slot(),
+                    heap_fetch_state.buffer_heap_slot(),
                     // call_again: This parameter will be set to true if this `ctid` points to multiple
                     // tuples as part of a HOT chain. We must attempt to find one live version of the
                     // tuple, and it may not be the first one in the chain.
@@ -814,7 +814,7 @@ pub fn index_memory_segment(
                     // table_index_fetch_tuple stored this dead tuple in a buffer-backed slot. Since
                     // this branch skips the tuple, clear the slot before any HOT-chain retry or ctid
                     // skip so the slot releases its buffer pin.
-                    pg_sys::ExecClearTuple(heap_fetch_state.slot());
+                    pg_sys::ExecClearTuple(heap_fetch_state.buffer_heap_slot());
 
                     // This copy of the tuple is no longer visible to any transaction. Are there
                     // more in the HOT chain?
@@ -844,7 +844,7 @@ pub fn index_memory_segment(
             // heap tuple and deleting its TOAST chunks while we read them below.
             // See: https://github.com/paradedb/paradedb/issues/5076
             let htup = pg_sys::ExecFetchSlotHeapTuple(
-                heap_fetch_state.slot(),
+                heap_fetch_state.buffer_heap_slot(),
                 false,
                 std::ptr::null_mut(),
             );
@@ -871,7 +871,7 @@ pub fn index_memory_segment(
                 }
             }
 
-            let expr_results = expression_state.evaluate(heap_fetch_state.slot());
+            let expr_results = expression_state.evaluate(heap_fetch_state.buffer_heap_slot());
 
             let mut doc = tantivy::TantivyDocument::new();
 
@@ -929,7 +929,7 @@ pub fn index_memory_segment(
             // stay held until the next table_index_fetch_tuple call (which
             // replaces the slot contents) or until HeapFetchState is dropped at
             // end-of-query, unnecessarily blocking VACUUM on this buffer.
-            pg_sys::ExecClearTuple(heap_fetch_state.slot());
+            pg_sys::ExecClearTuple(heap_fetch_state.buffer_heap_slot());
         }
     }
 

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -749,7 +749,7 @@ pub fn index_memory_segment(
                     heap_fetch_state.scan,
                     &mut ipd,
                     fetch_snapshot,
-                    heap_fetch_state.buffer_heap_slot(),
+                    heap_fetch_state.slot(),
                     // call_again: This parameter will be set to true if this `ctid` points to multiple
                     // tuples as part of a HOT chain. We must attempt to find one live version of the
                     // tuple, and it may not be the first one in the chain.
@@ -777,10 +777,10 @@ pub fn index_memory_segment(
                 }
 
                 let mut htsv_result = {
-                    let buffer = (*heap_fetch_state.buffer_slot()).buffer;
+                    let buffer = (*heap_fetch_state.buffer_heap_slot()).buffer;
                     let _lock = BorrowedBuffer::from_pg(buffer);
                     HeapTupleSatisfiesVacuum(
-                        (*heap_fetch_state.buffer_slot()).base.tuple,
+                        (*heap_fetch_state.buffer_heap_slot()).base.tuple,
                         oldest_xmin,
                         buffer,
                     )
@@ -800,10 +800,10 @@ pub fn index_memory_segment(
                     let fresh_oldest_xmin =
                         pg_sys::GetOldestNonRemovableTransactionId(heaprel.as_ptr());
                     if fresh_oldest_xmin != oldest_xmin {
-                        let buffer = (*heap_fetch_state.buffer_slot()).buffer;
+                        let buffer = (*heap_fetch_state.buffer_heap_slot()).buffer;
                         let _lock = BorrowedBuffer::from_pg(buffer);
                         htsv_result = HeapTupleSatisfiesVacuum(
-                            (*heap_fetch_state.buffer_slot()).base.tuple,
+                            (*heap_fetch_state.buffer_heap_slot()).base.tuple,
                             fresh_oldest_xmin,
                             buffer,
                         );
@@ -814,7 +814,7 @@ pub fn index_memory_segment(
                     // table_index_fetch_tuple stored this dead tuple in a buffer-backed slot. Since
                     // this branch skips the tuple, clear the slot before any HOT-chain retry or ctid
                     // skip so the slot releases its buffer pin.
-                    pg_sys::ExecClearTuple(heap_fetch_state.buffer_heap_slot());
+                    pg_sys::ExecClearTuple(heap_fetch_state.slot());
 
                     // This copy of the tuple is no longer visible to any transaction. Are there
                     // more in the HOT chain?
@@ -844,7 +844,7 @@ pub fn index_memory_segment(
             // heap tuple and deleting its TOAST chunks while we read them below.
             // See: https://github.com/paradedb/paradedb/issues/5076
             let htup = pg_sys::ExecFetchSlotHeapTuple(
-                heap_fetch_state.buffer_heap_slot(),
+                heap_fetch_state.slot(),
                 false,
                 std::ptr::null_mut(),
             );
@@ -871,7 +871,7 @@ pub fn index_memory_segment(
                 }
             }
 
-            let expr_results = expression_state.evaluate(heap_fetch_state.buffer_heap_slot());
+            let expr_results = expression_state.evaluate(heap_fetch_state.slot());
 
             let mut doc = tantivy::TantivyDocument::new();
 
@@ -929,7 +929,7 @@ pub fn index_memory_segment(
             // stay held until the next table_index_fetch_tuple call (which
             // replaces the slot contents) or until HeapFetchState is dropped at
             // end-of-query, unnecessarily blocking VACUUM on this buffer.
-            pg_sys::ExecClearTuple(heap_fetch_state.buffer_heap_slot());
+            pg_sys::ExecClearTuple(heap_fetch_state.slot());
         }
     }
 

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -414,7 +414,7 @@ impl BaseScanState {
 
         let tuple_desc = PgTupleDesc::from_pg_unchecked(heaprel.rd_att);
         let mut should_free = false;
-        let htup = pg_sys::ExecFetchSlotHeapTuple(state.slot(), true, &mut should_free);
+        let htup = pg_sys::ExecFetchSlotHeapTuple(state.buffer_heap_slot(), true, &mut should_free);
 
         let result = (|| {
             let heap_tuple = PgHeapTuple::from_heap_tuple(tuple_desc.clone(), &mut *htup);

--- a/pg_search/src/postgres/customscan/basescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/basescan/scan_state.rs
@@ -414,7 +414,7 @@ impl BaseScanState {
 
         let tuple_desc = PgTupleDesc::from_pg_unchecked(heaprel.rd_att);
         let mut should_free = false;
-        let htup = pg_sys::ExecFetchSlotHeapTuple(state.buffer_heap_slot(), true, &mut should_free);
+        let htup = pg_sys::ExecFetchSlotHeapTuple(state.slot(), true, &mut should_free);
 
         let result = (|| {
             let heap_tuple = PgHeapTuple::from_heap_tuple(tuple_desc.clone(), &mut *htup);

--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -326,24 +326,24 @@ impl HeapFetchState {
         }
     }
 
-    /// The buffer-heap slot that holds the most recently fetched tuple, as the
-    /// generic `TupleTableSlot` type that executor APIs accept.
+    /// The slot that holds the most recently fetched tuple, as the generic
+    /// `TupleTableSlot` type that executor APIs accept.
     ///
     /// This is the raw storage slot: it is the target of the heap fetch and keeps
-    /// the heap buffer pinned. [`Self::buffer_slot`] returns the *same* slot as its
-    /// concrete `BufferHeapTupleTableSlot` type, for reading buffer-heap-only
-    /// fields. To evaluate a PostgreSQL expression against a fetched tuple, use
-    /// [`Self::fetch_eval_slot`] instead, which presents the tuple as a virtual
-    /// slot the executor can always consume.
-    pub fn buffer_heap_slot(&self) -> *mut pg_sys::TupleTableSlot {
+    /// the heap buffer pinned. [`Self::buffer_heap_slot`] returns the *same* slot
+    /// as its concrete `BufferHeapTupleTableSlot` type, for reading
+    /// buffer-heap-only fields. To evaluate a PostgreSQL expression against a
+    /// fetched tuple, use [`Self::fetch_eval_slot`] instead, which presents the
+    /// tuple as a virtual slot the executor can always consume.
+    pub fn slot(&self) -> *mut pg_sys::TupleTableSlot {
         self.slot.cast()
     }
 
-    /// The same slot as [`Self::buffer_heap_slot`], but as its concrete
+    /// The same slot as [`Self::slot`], but as its concrete
     /// `BufferHeapTupleTableSlot` type so callers can read buffer-heap-only fields
     /// such as `buffer` and `base.tuple`. (Rust raw pointers don't upcast
     /// implicitly, so we expose both rather than casting at every call site.)
-    pub fn buffer_slot(&self) -> *mut pg_sys::BufferHeapTupleTableSlot {
+    pub fn buffer_heap_slot(&self) -> *mut pg_sys::BufferHeapTupleTableSlot {
         self.slot
     }
 
@@ -361,6 +361,11 @@ impl HeapFetchState {
         ctid: &mut pg_sys::ItemPointerData,
         snapshot: pg_sys::Snapshot,
     ) -> Option<*mut pg_sys::TupleTableSlot> {
+        // `call_again`/`all_dead` are only meaningful when walking a HOT chain
+        // for every matching tuple (e.g. a SnapshotAny scan). Callers pass an MVCC
+        // snapshot, for which `table_index_fetch_tuple` returns the single visible
+        // version directly, so we take that one and ignore both -- as the
+        // query-visible path in `mvcc.rs` does.
         let mut call_again = false;
         let mut all_dead = false;
         if !self.fetch_tuple(ctid, snapshot, &mut call_again, &mut all_dead) {
@@ -374,7 +379,7 @@ impl HeapFetchState {
         // `HeapFetchState` still holds the buffer pin. We deliberately avoid
         // `ExecCopySlot`, which would materialize (palloc + copy) every varlena
         // column on every row.
-        let src = self.buffer_heap_slot();
+        let src = self.slot();
         let dst = self.virtual_slot;
 
         pg_sys::ExecClearTuple(dst);
@@ -412,7 +417,7 @@ impl HeapFetchState {
             self.scan,
             ctid,
             snapshot,
-            self.buffer_heap_slot(),
+            self.slot(),
             call_again,
             all_dead,
         )

--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -295,6 +295,9 @@ impl VisibilityChecker {
 pub struct HeapFetchState {
     pub scan: *mut pg_sys::IndexFetchTableData,
     slot: *mut pg_sys::BufferHeapTupleTableSlot,
+    // A virtual view of the fetched tuple, handed to expression evaluation by
+    // `fetch_eval_slot`. See that method for why a virtual slot is required.
+    virtual_slot: *mut pg_sys::TupleTableSlot,
     // Hold a reference to the heap relation to keep it open for the lifetime of the scan.
     // The scan stores an internal pointer to the relation, so it must not be closed early.
     _heaprel: PgSearchRelation,
@@ -310,23 +313,78 @@ impl HeapFetchState {
         unsafe {
             let scan = pg_sys::table_index_fetch_begin(heaprel.as_ptr());
             let slot = pg_sys::MakeTupleTableSlot(heaprel.rd_att, &pg_sys::TTSOpsBufferHeapTuple);
+            let virtual_slot = pg_sys::MakeTupleTableSlot(heaprel.rd_att, &pg_sys::TTSOpsVirtual);
             let nblocks =
                 pg_sys::RelationGetNumberOfBlocksInFork(heaprel.as_ptr(), heaprel.fork_number());
             Self {
                 scan,
                 slot: slot.cast(),
+                virtual_slot,
                 _heaprel: heaprel.clone(),
                 nblocks,
             }
         }
     }
 
-    pub fn slot(&self) -> *mut pg_sys::TupleTableSlot {
+    /// The buffer-heap slot that holds the most recently fetched tuple, as the
+    /// generic `TupleTableSlot` type that executor APIs accept.
+    ///
+    /// This is the raw storage slot: it is the target of the heap fetch and keeps
+    /// the heap buffer pinned. [`Self::buffer_slot`] returns the *same* slot as its
+    /// concrete `BufferHeapTupleTableSlot` type, for reading buffer-heap-only
+    /// fields. To evaluate a PostgreSQL expression against a fetched tuple, use
+    /// [`Self::fetch_eval_slot`] instead, which presents the tuple as a virtual
+    /// slot the executor can always consume.
+    pub fn buffer_heap_slot(&self) -> *mut pg_sys::TupleTableSlot {
         self.slot.cast()
     }
 
+    /// The same slot as [`Self::buffer_heap_slot`], but as its concrete
+    /// `BufferHeapTupleTableSlot` type so callers can read buffer-heap-only fields
+    /// such as `buffer` and `base.tuple`. (Rust raw pointers don't upcast
+    /// implicitly, so we expose both rather than casting at every call site.)
     pub fn buffer_slot(&self) -> *mut pg_sys::BufferHeapTupleTableSlot {
         self.slot
+    }
+
+    /// Fetch the tuple at `ctid` and return it as a virtual slot ready for
+    /// PostgreSQL expression evaluation, or `None` if it is not visible.
+    ///
+    /// The executor may compile a scan `Var` into the `ExecJustScanVarVirt` fast
+    /// path (which requires a virtual slot) when the owning plan node advertises
+    /// virtual scan-slot ops, as the aggregate custom scan does. Handing it the
+    /// buffer-heap fetch slot there trips `Assert(TTS_IS_VIRTUAL(slot))`. A
+    /// virtual slot is accepted by both the fast and generic evaluation paths, so
+    /// we always present one here.
+    pub unsafe fn fetch_eval_slot(
+        &self,
+        ctid: &mut pg_sys::ItemPointerData,
+        snapshot: pg_sys::Snapshot,
+    ) -> Option<*mut pg_sys::TupleTableSlot> {
+        let mut call_again = false;
+        let mut all_dead = false;
+        if !self.fetch_tuple(ctid, snapshot, &mut call_again, &mut all_dead) {
+            return None;
+        }
+
+        // Present the fetched tuple through the virtual slot. Deform it and
+        // shallow-copy the resulting value/null arrays into the virtual slot --
+        // byref values still point into the pinned heap buffer, which is sound
+        // because the caller evaluates the expression immediately, while this
+        // `HeapFetchState` still holds the buffer pin. We deliberately avoid
+        // `ExecCopySlot`, which would materialize (palloc + copy) every varlena
+        // column on every row.
+        let src = self.buffer_heap_slot();
+        let dst = self.virtual_slot;
+
+        pg_sys::ExecClearTuple(dst);
+        pg_sys::slot_getallattrs(src);
+
+        let natts = (*src).tts_nvalid as usize;
+        std::ptr::copy_nonoverlapping((*src).tts_values, (*dst).tts_values, natts);
+        std::ptr::copy_nonoverlapping((*src).tts_isnull, (*dst).tts_isnull, natts);
+
+        Some(pg_sys::ExecStoreVirtualTuple(dst))
     }
 
     /// Wrapper around `table_index_fetch_tuple` that guards against stale ctids
@@ -354,7 +412,7 @@ impl HeapFetchState {
             self.scan,
             ctid,
             snapshot,
-            self.slot(),
+            self.buffer_heap_slot(),
             call_again,
             all_dead,
         )
@@ -365,6 +423,7 @@ crate::impl_safe_drop!(HeapFetchState, |self| {
     unsafe {
         if crate::postgres::utils::IsTransactionState() {
             pg_sys::ExecDropSingleTupleTableSlot(self.slot.cast());
+            pg_sys::ExecDropSingleTupleTableSlot(self.virtual_slot);
             pg_sys::table_index_fetch_end(self.scan);
         }
     }

--- a/pg_search/src/query/heap_field_filter.rs
+++ b/pg_search/src/query/heap_field_filter.rs
@@ -109,27 +109,17 @@ impl HeapFieldFilter {
             .get_or_insert_with(|| HeapFetchState::new(relation));
         let econtext = expr_context.as_ptr();
 
-        let mut call_again = false;
-        let mut all_dead = false;
-        if !heap_fetch_state.fetch_tuple(
-            &mut *ctid,
-            pg_sys::GetActiveSnapshot(),
-            &mut call_again,
-            &mut all_dead,
-        ) {
+        // Fetch the tuple and present it as a virtual slot suitable for expression
+        // evaluation (see `HeapFetchState::fetch_eval_slot`).
+        let Some(eval_slot) =
+            heap_fetch_state.fetch_eval_slot(&mut *ctid, pg_sys::GetActiveSnapshot())
+        else {
             return false;
-        }
+        };
 
         // Store the original scan tuple to restore later if we're using a provided context
         let original_scan_tuple = (*econtext).ecxt_scantuple;
-
-        // Set the tuple slot in the expression context
-        (*econtext).ecxt_scantuple = heap_fetch_state.slot();
-
-        // Ensure all attributes in the slot are deformed (fetched from tuple storage)
-        // This is necessary because the expression might reference any attribute,
-        // and the slot's tts_nvalid must be >= the highest attribute number referenced
-        pg_sys::slot_getallattrs(heap_fetch_state.slot());
+        (*econtext).ecxt_scantuple = eval_slot;
 
         let eval_result = (|| {
             // Initialize the expression for execution with proper planstate for subquery support

--- a/pg_search/tests/pg_regress/expected/aggregate_heap_filter_bool.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_heap_filter_bool.out
@@ -1,0 +1,81 @@
+-- Regression test: aggregate custom scan over a bare boolean heap filter.
+--
+-- When a predicate references a column that is NOT in the bm25 index, the
+-- aggregate custom scan evaluates it as a "heap filter" against the fetched
+-- heap tuple. A bare boolean Var (e.g. `WHERE flag`) compiles to PostgreSQL's
+-- `ExecJustScanVarVirt` fast path, which requires a virtual scan slot. The
+-- aggregate scan advertises virtual scan-slot ops, so feeding it the buffer-heap
+-- fetch slot tripped `Assert(TTS_IS_VIRTUAL(slot))` and crashed the backend on
+-- assert-enabled builds. This test exercises those bare-boolean heap filters.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS agg_heap_bool;
+CREATE TABLE agg_heap_bool (
+    id       serial PRIMARY KEY,
+    category text,
+    flag     boolean
+);
+INSERT INTO agg_heap_bool (category, flag)
+SELECT (ARRAY['a', 'b'])[1 + (g % 2)], (g % 2 = 0)
+FROM generate_series(1, 500) g;
+-- `flag` is intentionally NOT indexed, so predicates on it become heap filters.
+CREATE INDEX agg_heap_bool_idx ON agg_heap_bool
+USING bm25 (id, category) WITH (key_field = 'id');
+SET paradedb.enable_aggregate_custom_scan TO on;
+-- Bare boolean Var heap filter (previously crashed).
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag;
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.agg_heap_bool
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: agg_heap_bool_idx
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"category","value":"a"}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"flag"}]}}]}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
+
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag;
+ count 
+-------
+   250
+(1 row)
+
+-- Boolean equality heap filter (previously crashed).
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag = false;
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.agg_heap_bool
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: agg_heap_bool_idx
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"category","value":"a"}}}},{"boolean":{"must":["all"],"must_not":[{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"flag"}]}}]}}]}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
+
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag = false;
+ count 
+-------
+     0
+(1 row)
+
+-- Negated bare boolean Var heap filter.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND NOT flag;
+                                                                                                              QUERY PLAN                                                                                                               
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.agg_heap_bool
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: agg_heap_bool_idx
+   Tantivy Query: {"boolean":{"must":[{"with_index":{"query":{"term":{"field":"category","value":"a"}}}},{"boolean":{"must":["all"],"must_not":[{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"flag"}]}}]}}]}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
+
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND NOT flag;
+ count 
+-------
+     0
+(1 row)
+
+DROP TABLE agg_heap_bool;

--- a/pg_search/tests/pg_regress/sql/aggregate_heap_filter_bool.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_heap_filter_bool.sql
@@ -1,0 +1,43 @@
+-- Regression test: aggregate custom scan over a bare boolean heap filter.
+--
+-- When a predicate references a column that is NOT in the bm25 index, the
+-- aggregate custom scan evaluates it as a "heap filter" against the fetched
+-- heap tuple. A bare boolean Var (e.g. `WHERE flag`) compiles to PostgreSQL's
+-- `ExecJustScanVarVirt` fast path, which requires a virtual scan slot. The
+-- aggregate scan advertises virtual scan-slot ops, so feeding it the buffer-heap
+-- fetch slot tripped `Assert(TTS_IS_VIRTUAL(slot))` and crashed the backend on
+-- assert-enabled builds. This test exercises those bare-boolean heap filters.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS agg_heap_bool;
+CREATE TABLE agg_heap_bool (
+    id       serial PRIMARY KEY,
+    category text,
+    flag     boolean
+);
+INSERT INTO agg_heap_bool (category, flag)
+SELECT (ARRAY['a', 'b'])[1 + (g % 2)], (g % 2 = 0)
+FROM generate_series(1, 500) g;
+
+-- `flag` is intentionally NOT indexed, so predicates on it become heap filters.
+CREATE INDEX agg_heap_bool_idx ON agg_heap_bool
+USING bm25 (id, category) WITH (key_field = 'id');
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+-- Bare boolean Var heap filter (previously crashed).
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag;
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag;
+
+-- Boolean equality heap filter (previously crashed).
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag = false;
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND flag = false;
+
+-- Negated bare boolean Var heap filter.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND NOT flag;
+SELECT count(*) FROM agg_heap_bool WHERE category === 'a' AND NOT flag;
+
+DROP TABLE agg_heap_bool;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

The aggregate custom scan creates its scan slot with virtual tuple ops. When a predicate references a non-indexed column it is evaluated as a heap filter, and Postgres compiles the expression against that virtual scan slot. `HeapFetchState` used a buffer heap slot instead of a virtual slot, which tripped `TTS_IS_VIRTUAL(slot)` inside `ExecJustScanVarVirt`.

Running the regress test crashes on `main`, passes here.

## Why

## How

## Tests
