### PR TITLE
feat: run MPP on the WorkerChannel-based datafusion-distributed fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2103,10 +2103,8 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=f2087994c4e7b8f742168762b2e1da5e9a9c13c1#f2087994c4e7b8f742168762b2e1da5e9a9c13c1"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=c58122ab6207e178d0a50dfb15f955282f9d52e4#c58122ab6207e178d0a50dfb15f955282f9d52e4"
 dependencies = [
- "arrow-ipc",
- "arrow-select",
  "async-stream",
  "async-trait",
  "bincode 1.3.3",
@@ -2122,6 +2120,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "moka",
+ "num-traits",
  "object_store",
  "pin-project",
  "prost",
@@ -2666,7 +2665,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2986,7 +2985,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3798,7 +3797,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4170,7 +4169,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5340,7 +5339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6230,7 +6229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6948,7 +6947,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7006,7 +7005,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7435,7 +7434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8064,7 +8063,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9043,7 +9042,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=c58122ab6207e178d0a50dfb15f955282f9d52e4#c58122ab6207e178d0a50dfb15f955282f9d52e4"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=53f2d469e6b06d5d31092321920b51346575957d#53f2d469e6b06d5d31092321920b51346575957d"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=53f2d469e6b06d5d31092321920b51346575957d#53f2d469e6b06d5d31092321920b51346575957d"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=4fd9283ea3ff369581459f53c145123a954f2874#4fd9283ea3ff369581459f53c145123a954f2874"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2103,7 +2103,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=4fd9283ea3ff369581459f53c145123a954f2874#4fd9283ea3ff369581459f53c145123a954f2874"
+source = "git+https://github.com/paradedb/datafusion-distributed?tag=snapshot-main-2026-07-15-173408#f35ee8e846013c9b0457788c6ef9a80ef81b43cd"
 dependencies = [
  "async-stream",
  "async-trait",

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-uj0YGiK9VP+UaF2vVWITEPUdOil86FPrg47ZpKdDC0w=";
+  cargoHash = "sha256-BxMcVWwvKGhgK3QkXO7zBEr9Yp8ctvVW7mOhYgKYrL0=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-eBowK124WtWobmtDn+diywMGNRp13oAjMf1pH+djWzY=";
+  cargoHash = "sha256-uj0YGiK9VP+UaF2vVWITEPUdOil86FPrg47ZpKdDC0w=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-BxMcVWwvKGhgK3QkXO7zBEr9Yp8ctvVW7mOhYgKYrL0=";
+  cargoHash = "sha256-NNxqCeBfREwUWdXm9JP2A2V8FE9SRZDwFH0/4GWxyik=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-NNxqCeBfREwUWdXm9JP2A2V8FE9SRZDwFH0/4GWxyik=";
+  cargoHash = "sha256-9Qzo3y90y3Yx7V2etMCjZSyT3EaQUrUcJsXu4fqWG4w=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -86,7 +86,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "54", default-features = false }
 datafusion-proto = { version = "54", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "4fd9283ea3ff369581459f53c145123a954f2874", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", tag = "snapshot-main-2026-07-15-173408", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -86,7 +86,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "54", default-features = false }
 datafusion-proto = { version = "54", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "f2087994c4e7b8f742168762b2e1da5e9a9c13c1", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "c58122ab6207e178d0a50dfb15f955282f9d52e4", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -86,7 +86,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "54", default-features = false }
 datafusion-proto = { version = "54", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "c58122ab6207e178d0a50dfb15f955282f9d52e4", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "53f2d469e6b06d5d31092321920b51346575957d", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -86,7 +86,7 @@ tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
 datafusion = { version = "54", default-features = false }
 datafusion-proto = { version = "54", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "53f2d469e6b06d5d31092321920b51346575957d", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "4fd9283ea3ff369581459f53c145123a954f2874", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -44,7 +44,9 @@ use crate::postgres::catalog::is_ltree_oid;
 
 use datafusion::execution::TaskContext;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedTaskContext};
+use datafusion_distributed::{
+    display_plan_ascii, DistributedExec, DistributedExt, DistributedTaskContext,
+};
 
 use datafusion_distributed::shm::MppMesh;
 
@@ -1606,15 +1608,11 @@ impl AggregateScan {
                         &physical_plan,
                     ) {
                         Some(leader) => {
-                            // Workers are attaching and draining after the commit; ship each
-                            // fragment's plan frame now, before anything pulls from the mesh.
-                            if let Err(e) =
-                                crate::postgres::customscan::mpp::glue::deliver_set_plans(&leader)
-                            {
-                                pgrx::error!("mpp aggregate: plan delivery failed: {e}");
-                            }
+                            let source =
+                                crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
                             let exec_ctx =
-                                Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)));
+                                Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
+                                    .with_distributed_dispatch_plan_source(source);
                             df_state.mpp = MppLifecycle::Launched(leader);
                             (exec_ctx, physical_plan)
                         }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -194,7 +194,7 @@ use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
 use datafusion::physical_plan::displayable;
 use datafusion::physical_plan::metrics::MetricValue;
 use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
-use datafusion_distributed::{display_plan_ascii, DistributedExec};
+use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedExt};
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
 use std::sync::Arc;
@@ -1573,17 +1573,10 @@ impl CustomScan for JoinScan {
                             prep, &plan,
                         ) {
                             Some(leader) => {
-                                // Workers are attaching and draining after the commit; ship each
-                                // fragment's plan frame now, before anything pulls from the mesh.
-                                if let Err(e) =
-                                    crate::postgres::customscan::mpp::glue::deliver_set_plans(
-                                        &leader,
-                                    )
-                                {
-                                    pgrx::error!("mpp join: plan delivery failed: {e}");
-                                }
+                                let source = crate::postgres::customscan::mpp::glue::StagePlanDispatchSource::default();
                                 let exec_ctx =
-                                    Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)));
+                                    Self::build_mpp_session_context(Some(Arc::clone(&leader.mesh)))
+                                        .with_distributed_dispatch_plan_source(source);
                                 state.custom_state_mut().mpp = MppLifecycle::Launched(leader);
                                 (exec_ctx, plan)
                             }

--- a/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
+++ b/pg_search/src/postgres/customscan/joinscan/visibility_filter.rs
@@ -681,6 +681,13 @@ impl ExtensionPlanner for VisibilityExtensionPlanner {
 // Physical Execution Plan
 // ---------------------------------------------------------------------------
 
+/// One wired ctid resolver: the index it reads and the fast-field helper over its segments.
+type CtidResolver = (u32, Arc<FFHelper>);
+
+/// The dispatch wire shape: `(plan_pos, heap_oid)` pairs, display names, and each wired
+/// resolver's `(plan_pos, indexrelid)`.
+type VisibilityDispatchPayload = (Vec<(usize, pg_sys::Oid)>, Vec<String>, Vec<(usize, u32)>);
+
 /// Physical plan node that resolves packed DocAddresses and performs batch
 /// visibility checking on ctid columns.
 ///
@@ -698,10 +705,12 @@ pub struct VisibilityFilterExec {
     table_names: Vec<String>,
     properties: Arc<PlanProperties>,
     metrics: ExecutionPlanMetricsSet,
-    /// Per-plan_position FFHelper for resolving packed DocAddresses to real ctids.
-    /// Wired by `VisibilityCtidResolverRule` after plan construction.
-    /// Indexed by plan_position (0, 1, 2...).
-    ctid_resolvers: Mutex<Vec<Option<Arc<FFHelper>>>>,
+    /// Per-plan_position `(indexrelid, FFHelper)` for resolving packed DocAddresses to real
+    /// ctids. Wired by `VisibilityCtidResolverRule` after plan construction. Indexed by
+    /// plan_position (0, 1, 2...). The relid rides along so the dispatch encode can tell a
+    /// worker which index to rebuild a resolver from when the scan sits behind a network
+    /// boundary.
+    ctid_resolvers: Mutex<Vec<Option<CtidResolver>>>,
 }
 
 impl fmt::Debug for VisibilityFilterExec {
@@ -750,7 +759,7 @@ impl VisibilityFilterExec {
     }
 
     /// Wire an FFHelper for resolving packed DocAddresses to real ctids for the given plan_position.
-    pub fn set_ctid_resolver(&self, plan_pos: usize, ffhelper: Arc<FFHelper>) {
+    pub fn set_ctid_resolver(&self, plan_pos: usize, indexrelid: u32, ffhelper: Arc<FFHelper>) {
         let mut resolvers = self
             .ctid_resolvers
             .lock()
@@ -758,7 +767,7 @@ impl VisibilityFilterExec {
         if plan_pos >= resolvers.len() {
             resolvers.resize(plan_pos + 1, None);
         }
-        resolvers[plan_pos] = Some(ffhelper);
+        resolvers[plan_pos] = Some((indexrelid, ffhelper));
     }
 
     pub fn plan_pos_oids(&self) -> &[(usize, pg_sys::Oid)] {
@@ -766,32 +775,60 @@ impl VisibilityFilterExec {
     }
 
     /// Serialize for leader dispatch. The `ctid_resolvers` are live `FFHelper`s wired by an
-    /// optimizer rule, so they don't travel; the receiving worker re-wires them from the scans in
-    /// its decoded subtree.
+    /// optimizer rule, so they don't travel; the worker re-wires them from the scans in its
+    /// decoded subtree, or rebuilds one from the shipped `(plan_position, indexrelid)` pairs
+    /// when a position's scan sits behind a network boundary.
     pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
-        let payload: (&[(usize, pg_sys::Oid)], &[String]) =
-            (&self.plan_pos_oids, &self.table_names);
+        let resolver_indexes: Vec<(usize, u32)> = self
+            .ctid_resolvers
+            .lock()
+            .expect("ctid_resolvers lock poisoned")
+            .iter()
+            .enumerate()
+            .filter_map(|(pos, r)| r.as_ref().map(|(relid, _)| (pos, *relid)))
+            .collect();
+        let payload = (&self.plan_pos_oids, &self.table_names, &resolver_indexes);
         serde_json::to_vec(&payload).map_err(|e| {
             DataFusionError::Internal(format!("VisibilityFilterExec dispatch: serialize: {e}"))
         })
     }
 
-    /// Rebuild from a dispatch descriptor, re-wiring the per-plan_position ctid resolvers from the
-    /// scans the worker decoded below this node.
+    /// Rebuild from a dispatch descriptor, re-wiring the per-plan_position ctid resolvers from
+    /// the scans the worker decoded below this node. A position whose scan sits behind a network
+    /// boundary rebuilds its resolver instead: a helper over that index's canonical segment view
+    /// resolves any address a producer packed (ctid access needs no field layout).
     pub(crate) fn decode_for_dispatch(
         buf: &[u8],
         input: Arc<dyn ExecutionPlan>,
-        ctid_resolvers: Vec<(usize, Arc<FFHelper>)>,
+        ctid_resolvers: Vec<(usize, u32, Arc<FFHelper>)>,
+        index_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        let (plan_pos_oids, table_names): (Vec<(usize, pg_sys::Oid)>, Vec<String>) =
+        let (plan_pos_oids, table_names, resolver_indexes): VisibilityDispatchPayload =
             serde_json::from_slice(buf).map_err(|e| {
                 DataFusionError::Internal(format!(
                     "VisibilityFilterExec dispatch: deserialize: {e}"
                 ))
             })?;
         let exec = VisibilityFilterExec::new(input, plan_pos_oids, table_names)?;
-        for (plan_pos, ffhelper) in ctid_resolvers {
-            exec.set_ctid_resolver(plan_pos, ffhelper);
+        for (plan_pos, indexrelid, ffhelper) in &ctid_resolvers {
+            exec.set_ctid_resolver(*plan_pos, *indexrelid, Arc::clone(ffhelper));
+        }
+        for (plan_pos, indexrelid) in resolver_indexes {
+            if ctid_resolvers.iter().any(|(pos, _, _)| *pos == plan_pos) {
+                continue;
+            }
+            let ids = index_segment_ids.get(plan_pos).cloned().ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "VisibilityFilterExec dispatch: missing canonical segment ids for \
+                     plan_position {plan_pos}"
+                ))
+            })?;
+            let ffhelper = crate::scan::tantivy_lookup_exec::open_rebuilt_ffhelper(
+                indexrelid,
+                &[],
+                crate::index::mvcc::MvccSatisfies::ParallelWorker(ids),
+            )?;
+            exec.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
         }
         Ok(Arc::new(exec))
     }
@@ -931,7 +968,7 @@ impl ExecutionPlan for VisibilityFilterExec {
             let visibility = VisibilityChecker::with_rel_and_snap(&heaprel, snapshot);
             let resolver = resolvers
                 .get(plan_pos)
-                .and_then(|r| r.clone())
+                .and_then(|r| r.as_ref().map(|(_, ff)| Arc::clone(ff)))
                 .ok_or_else(|| {
                     DataFusionError::Execution(format!(
                         "VisibilityFilterExec: no ctid resolver wired for plan_position {plan_pos}. \

--- a/pg_search/src/postgres/customscan/mpp/dispatch.rs
+++ b/pg_search/src/postgres/customscan/mpp/dispatch.rs
@@ -41,7 +41,6 @@ use crate::postgres::customscan::mpp::exec_worker::build_mpp_session_context;
 use crate::postgres::customscan::mpp::worker_fragments::{
     collect_dispatched_stages, FragmentAssignment, FragmentRouting,
 };
-use crate::scan::physical_codec::serialize_physical_plan;
 
 /// One stage of the dispatch blob: the metadata a worker needs to route a stage's output.
 /// Shared by all workers; each selects the `task_idx` slots it owns. The stage's plan arrives
@@ -51,17 +50,6 @@ struct DispatchedStage {
     stage_num: u32,
     task_count: usize,
     routing: FragmentRouting,
-}
-
-/// One stage's plan bytes, headed for per-task `SetPlan` frames. Stays leader-side: the leader
-/// stamps each task's `TaskKey` from `query_id`/`stage_num` and ships `plan_proto` once per task.
-#[derive(Clone)]
-pub struct StagePlan {
-    pub stage_num: u32,
-    pub query_id: Vec<u8>,
-    pub task_count: usize,
-    /// `PhysicalPlanNode`-encoded `stage.local_plan()` (via the combined codec).
-    pub plan_proto: Vec<u8>,
 }
 
 /// First byte of the DSM plan region. Only the dispatch blob is shipped today (every MPP
@@ -127,39 +115,32 @@ fn unframe_dispatch_payload(body: &[u8]) -> Result<&[u8]> {
     })
 }
 
-/// Build the dispatch payload from the leader's own execution plan: collect every producer
-/// stage, serialize each subplan, and frame the routing blob to `capacity`.
+/// Build the dispatch payload (the routing blob, framed to `capacity`) from the leader's own
+/// execution plan, and report how many producer stages it found. The stage subplans travel
+/// separately: the coordinator serializes each through the leader's
+/// [`crate::postgres::customscan::mpp::glue::StagePlanDispatchSource`] as it dispatches.
 ///
-/// The leader executes the same plan object it serialized from, so stage numbering and routing
-/// cannot drift from what the coordinator dispatches. Scan encodes are context-free recipes;
-/// each worker injects its own `ParallelScanState` + segment view on decode, and re-runs the
-/// pushdown pass to re-link dynamic filters.
+/// The leader executes the same plan object the routing derives from, so stage numbering and
+/// routing cannot drift from what the coordinator dispatches.
 pub fn dispatch_payload_from_plan(
     physical: &Arc<dyn ExecutionPlan>,
     n_workers: u32,
     capacity: usize,
-) -> Result<(Vec<u8>, Vec<StagePlan>)> {
+) -> Result<(Vec<u8>, usize)> {
     let stages = collect_dispatched_stages(physical, n_workers)?;
-    let mut dispatched = Vec::with_capacity(stages.len());
-    let mut stage_plans = Vec::with_capacity(stages.len());
-    for stage in stages {
-        let plan_proto = serialize_physical_plan(stage.plan)?;
-        dispatched.push(DispatchedStage {
+    let stage_count = stages.len();
+    let dispatched: Vec<DispatchedStage> = stages
+        .into_iter()
+        .map(|stage| DispatchedStage {
             stage_num: stage.stage_num,
             task_count: stage.task_count,
             routing: stage.routing,
-        });
-        stage_plans.push(StagePlan {
-            stage_num: stage.stage_num,
-            query_id: stage.query_id.as_bytes().to_vec(),
-            task_count: stage.task_count,
-            plan_proto,
-        });
-    }
+        })
+        .collect();
     let blob = bincode::serde::encode_to_vec(&dispatched, blob_config())
         .map_err(|e| DataFusionError::Internal(format!("mpp dispatch: blob encode: {e}")))?;
     let payload = frame_dispatch_payload(&blob, capacity)?;
-    Ok((payload, stage_plans))
+    Ok((payload, stage_count))
 }
 
 /// Decode the dispatch blob from the framed DSM payload a worker copied out of DSM.

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -36,8 +36,7 @@ use std::sync::Arc;
 use datafusion::execution::{SessionStateBuilder, TaskContext};
 use datafusion::prelude::SessionContext;
 use datafusion_distributed::{
-    DistributedConfig, DistributedExec, DistributedExt, DistributedTaskContext,
-    SessionStateBuilderExt,
+    DistributedConfig, DistributedExt, DistributedTaskContext, SessionStateBuilderExt,
 };
 use pgrx::pg_sys;
 use tantivy::index::SegmentId;
@@ -48,7 +47,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::shm::{
     collect_task_metrics, proc_for_task, run_worker_fragment, CooperativeDrainSet,
     InProcessWorkerResolver, MppFrameHeader, MppMesh, MppPartitionSink, MppSender,
-    ShmMqWorkerTransport,
+    ShmChannelResolver,
 };
 use datafusion_distributed::PartitionSink;
 
@@ -158,7 +157,7 @@ pub(crate) fn build_mpp_session_context(
     // opens a WorkerConnection, so the fork's default transport sits unused.
     if let Some(mesh) = mesh {
         state_builder =
-            state_builder.with_distributed_worker_transport(ShmMqWorkerTransport::new(mesh));
+            state_builder.with_distributed_channel_resolver(ShmChannelResolver::new(mesh));
     }
     let state_builder = state_builder
         // Broadcast-subtree cap. Chain order matters: this has to come before the leaf
@@ -168,9 +167,6 @@ pub(crate) fn build_mpp_session_context(
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
-        // No `with_distributed_user_codec(...)`: the leader serializes per-stage subplans through
-        // a combined codec built explicitly in `scan::physical_codec`, and each worker decodes
-        // the same way. Nothing drives the session's user-codec slot.
         .with_distributed_planner();
     SessionContext::new_with_state(state_builder.build())
 }
@@ -453,27 +449,12 @@ pub(crate) fn run_mpp_worker(
                     .with_runtime(build_runtime_env(memory_pool)),
             );
 
-            // Wrap the fragment's plan in a fresh `DistributedExec` and run `prepare_in_process_plan`
-            // to convert any nested boundaries' input stages from `Stage::Local` to
-            // `Stage::Remote`. Without this, a nested `NetworkShuffleExec` /
-            // `NetworkBroadcastExec` hitting `LocalStage::execute` errors when its task count
-            // exceeds 1; with the conversion, those boundaries dispatch through
-            // `ShmMqWorkerTransport` exactly like outer boundaries.
-            let plan = {
-                let dist = Arc::new(DistributedExec::new(Arc::clone(frag_plan)));
-                match dist.prepare_in_process_plan(&task_ctx) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        return Err(datafusion::common::DataFusionError::Internal(format!(
-                            "mpp worker: prepare_in_process_plan failed for fragment \
-                             (stage_id={}, task_idx={}): {e}",
-                            fragment.stage_id, fragment.task_idx
-                        )));
-                    }
-                }
-            };
+            // The fragment arrives ready-to-run: the leader serialized it with nested stages
+            // already `Remote`, so its boundary leaves read the mesh through the session's
+            // `ShmChannelResolver`. Nothing here converts or dispatches.
+            let plan = Arc::clone(frag_plan);
             // Kept for the post-run metrics frame: the executed nodes (and their metrics)
-            // live in this prepared plan.
+            // live in this plan.
             executed_fragments.push((
                 fragment.stage_id,
                 fragment.task_idx,

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -36,14 +36,8 @@ use std::sync::Arc;
 
 use pgrx::pg_sys;
 
-use datafusion_distributed::proto::SetPlanRequest;
-use datafusion_distributed::shm::{
-    self, proc_for_task, CooperativeDrainSet, Interrupt, MppFrameHeader, MppMesh, MppSender,
-    SendBatchStats, SetPlanFrame, Wakeup,
-};
+use datafusion_distributed::shm::{self, Interrupt, MppMesh, MppSender, Wakeup};
 use datafusion_distributed::TaskKey;
-
-use crate::postgres::customscan::mpp::dispatch::StagePlan;
 
 use crate::gucs::{
     enable_mpp, mpp_queue_size as gucs_mpp_queue_size, mpp_worker_count as gucs_mpp_worker_count,
@@ -120,7 +114,7 @@ pub fn producer_worker_count() -> u32 {
 /// producer fragment itself. Its outbound senders are dropped inside `leader_setup`.
 pub struct MppLeaderState {
     /// Runtime mesh handle. Install on the leader's `SessionContext` via
-    /// `with_extension(Arc::clone(&mesh))` so `ShmMqWorkerTransport` can find
+    /// `with_extension(Arc::clone(&mesh))` so `ShmChannelResolver` can find
     /// it at execute time.
     pub mesh: Arc<MppMesh>,
     /// The leader's outbound senders, one per peer inbox; the control-plane path for `SetPlan`
@@ -133,16 +127,6 @@ pub struct MppLeaderState {
     /// in [`leader_setup`]) clears them on the error path, both before PG detaches the DSM.
     /// The scan state's own drop runs after detach and must find this empty.
     pub control_senders: Arc<std::sync::Mutex<Vec<Option<MppSender>>>>,
-    /// The producer-stage subplans serialized from the leader's own execution plan, for
-    /// [`deliver_set_plans`], which runs at exec time when the launched workers are draining
-    /// their inboxes. Sending from the init callback instead could fill a small ring with no
-    /// drainer behind it and wedge the leader. Kept (not drained) so a parallel rescan can
-    /// re-deliver to relaunched workers, the frame analog of the plan blob persisting in DSM.
-    /// Mutex because the exec hook only sees a shared borrow of the scan state.
-    pub stage_plans: std::sync::Mutex<Vec<StagePlan>>,
-    /// One delivery per worker generation: set by [`deliver_set_plans`], reset by the rescan
-    /// path before workers relaunch.
-    pub plans_delivered: std::sync::atomic::AtomicBool,
     /// The builder handle owning the launched producer workers. The leader controls the launch, so
     /// it owns the teardown too: `end_custom_scan` takes this and calls `wait_for_finish` to join
     /// the workers and destroy the parallel context. `None` until `launch` installs it on the
@@ -180,7 +164,6 @@ unsafe fn self_receiver_token() -> u64 {
 pub unsafe fn leader_setup(
     coordinate: *mut c_void,
     plan_bytes: Vec<u8>,
-    stage_plans: Vec<StagePlan>,
 ) -> Result<MppLeaderState, String> {
     let wakeup: Arc<dyn Wakeup> = Arc::new(PgWakeup);
     let interrupt: Arc<dyn Interrupt> = Arc::new(PgInterrupt);
@@ -218,38 +201,25 @@ pub unsafe fn leader_setup(
     // Hand the senders to the mesh too, so its early-termination cancel can reach the producers.
     // The mesh shares this `Arc`, so clearing it below releases both views before the DSM unmaps.
     mesh.set_cancel_senders(Arc::clone(&control_senders));
-    // Forget these senders instead of dropping them: `AbortTransaction` unmaps the DSM before the
-    // xact callbacks run, so a sender's drop would write its detach signal into a freed ring
-    // header. This DF-D rev has no ring liveness flag, so the drop can't tell the mapping is gone
-    // and guard itself. The signal has no audience anyway, since the abort already terminated the
-    // workers. `PreCommit` covers a subtransaction rollback where no abort fires; a populated vec
-    // at either event means the mapping is already gone (the success path clears it in
-    // `shutdown_custom_scan`).
-    //
-    // TODO: once the DF-D pin has `MppMesh::mark_detached` / `detached_flag`, flip that
-    // process-local flag here and drop the senders normally, so their own `Drop` skips the
-    // freed-ring write and frees their heap instead of leaking it.
-    let forget_senders = |senders: &Arc<std::sync::Mutex<Vec<Option<MppSender>>>>| {
-        let senders = Arc::clone(senders);
+    // On abort, `AbortTransaction` unmaps the DSM before these callbacks run, so the senders must
+    // not touch their ring headers as they drop. The mesh's liveness flag is process-local, so
+    // flip it here (every ring handle reads it) and the senders' drop skips the freed-ring write
+    // while their heap is still freed. `PreCommit` covers a subtransaction rollback where no abort
+    // fires; the success path releases the senders in `shutdown_custom_scan` while the segment is
+    // still mapped, so the vec is empty by then.
+    let make_detacher = || {
+        let alive = mesh.detached_flag();
+        let senders = Arc::clone(&control_senders);
         move || {
-            for sender in senders.lock().unwrap().drain(..).flatten() {
-                std::mem::forget(sender);
-            }
+            alive.store(false, std::sync::atomic::Ordering::Release);
+            senders.lock().unwrap().clear();
         }
     };
-    pgrx::register_xact_callback(
-        pgrx::PgXactCallbackEvent::Abort,
-        forget_senders(&control_senders),
-    );
-    pgrx::register_xact_callback(
-        pgrx::PgXactCallbackEvent::PreCommit,
-        forget_senders(&control_senders),
-    );
+    pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::Abort, make_detacher());
+    pgrx::register_xact_callback(pgrx::PgXactCallbackEvent::PreCommit, make_detacher());
     Ok(MppLeaderState {
         mesh,
         control_senders,
-        stage_plans: std::sync::Mutex::new(stage_plans),
-        plans_delivered: std::sync::atomic::AtomicBool::new(false),
         finish: None,
         parallel_state: std::ptr::null_mut(),
     })
@@ -263,68 +233,38 @@ impl MppLeaderState {
     }
 }
 
-/// Ship every dispatched plan as `SetPlan` frames: one per `(stage, task)`, to the proc hosting
-/// the task, carrying the same `SetPlanRequest` Flight would put on its coordinator stream.
-///
-/// Runs at exec time, after the launched-worker check: the workers are attaching and draining by
-/// then, so a plan bigger than a ring drains through instead of wedging the send spin. One
-/// delivery per worker generation; re-execution without a relaunch is a no-op.
-pub fn deliver_set_plans(leader: &MppLeaderState) -> Result<(), String> {
-    if leader
-        .plans_delivered
-        .swap(true, std::sync::atomic::Ordering::SeqCst)
-    {
-        return Ok(());
-    }
-    let stage_plans = leader.stage_plans.lock().unwrap().clone();
-    if stage_plans.is_empty() {
-        return Ok(());
-    }
-    let runtime = tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .map_err(|e| format!("mpp: set-plan runtime build: {e}"))?;
-    let n_workers = leader.mesh.n_workers();
-    runtime.block_on(async {
-        let mut stats = SendBatchStats::default();
-        for sp in &stage_plans {
-            for task in 0..sp.task_count {
-                let dest = proc_for_task(n_workers, task as u32);
-                // Clone the sender out under the lock so the guard never spans the await below.
-                let sender = {
-                    let senders = leader.control_senders.lock().unwrap();
-                    let Some(base) = senders.get(dest as usize).and_then(|s| s.as_ref()) else {
-                        return Err(format!("mpp: no leader sender for proc {dest}"));
-                    };
-                    base.clone_with_header(MppFrameHeader::set_plan(sp.stage_num, task as u32, 0))
-                        .with_cooperative_drain(
-                            Arc::clone(&leader.mesh) as Arc<dyn CooperativeDrainSet>
-                        )
-                };
-                let frame = SetPlanFrame {
-                    set_plan: Some(SetPlanRequest {
-                        plan_proto: sp.plan_proto.clone(),
-                        task_count: sp.task_count as u64,
-                        task_key: Some(TaskKey {
-                            query_id: sp.query_id.clone(),
-                            stage_id: sp.stage_num as u64,
-                            task_number: task as u64,
-                        }),
-                        work_unit_feed_declarations: vec![],
-                        target_worker_url: String::new(),
-                        query_start_time_ns: 0,
-                    }),
-                    header_keys: vec![],
-                    header_values: vec![],
-                };
-                sender
-                    .send_set_plan_traced(&frame, &mut stats)
-                    .await
-                    .map_err(|e| format!("mpp: set-plan send failed: {e}"))?;
-            }
+/// Serializes each stage subplan the coordinator dispatches, with the pg codec
+/// (`serialize_physical_plan`): the config-level codec extension point cannot express the
+/// UDF-definition handling or the optimization-only wrapper strip, so the coordinator's own
+/// encode cannot produce these bytes. The coordinator hands over its ready-to-run per-task
+/// plan; scan encodes are context-free recipes, so the plan the leader runs is the plan the
+/// workers decode, and each worker specializes its own segment slice. Every task of a stage
+/// runs the same subplan here (nothing in a pg plan is task-specialized), so the encode is
+/// cached by stage.
+#[derive(Default)]
+pub struct StagePlanDispatchSource {
+    cache: std::sync::Mutex<std::collections::HashMap<usize, Vec<u8>>>,
+}
+
+impl datafusion_distributed::DispatchPlanSource for StagePlanDispatchSource {
+    fn dispatch_plan_proto(
+        &self,
+        task: &TaskKey,
+        specialized: &Arc<dyn datafusion::physical_plan::ExecutionPlan>,
+    ) -> Option<datafusion::common::Result<Vec<u8>>> {
+        // One source per query execution, so the query id never varies here.
+        let stage_id = task.stage_id;
+        if let Some(bytes) = self.cache.lock().unwrap().get(&stage_id) {
+            return Some(Ok(bytes.clone()));
         }
-        Ok(())
-    })
+        let bytes =
+            match crate::scan::physical_codec::serialize_physical_plan(Arc::clone(specialized)) {
+                Ok(bytes) => bytes,
+                Err(e) => return Some(Err(e)),
+            };
+        self.cache.lock().unwrap().insert(stage_id, bytes.clone());
+        Some(Ok(bytes))
+    }
 }
 
 /// Returned to a worker from [`worker_setup`]. The customscan reads the plan bytes, runs the
@@ -421,7 +361,7 @@ pub fn drain_worker_metrics(
     let _ = plan.apply(|node| {
         if let Some(nb) = node.as_network_boundary() {
             let stage = nb.input_stage();
-            query_id.get_or_insert_with(|| stage.query_id().as_bytes().to_vec());
+            query_id.get_or_insert_with(|| stage.query_id());
             expected += stage.task_count();
         }
         Ok(TreeNodeRecursion::Continue)
@@ -436,14 +376,18 @@ pub fn drain_worker_metrics(
     for _ in 0..100 {
         let _ = mesh.try_drain_pass();
         while let Ok((stage_id, task_number, metrics)) = rx.try_recv() {
-            store.insert(
-                datafusion_distributed::TaskKey {
-                    query_id: query_id.clone(),
-                    stage_id: stage_id as u64,
-                    task_number: task_number as u64,
-                },
-                metrics,
-            );
+            // The frames carry proto metrics; the store holds the decoded in-memory form the rewrite
+            // reads. A frame that fails to decode is still counted so the wait doesn't spin.
+            if let Ok(metrics) = datafusion_distributed::decode_task_metrics(metrics) {
+                store.insert(
+                    TaskKey {
+                        query_id,
+                        stage_id: stage_id as usize,
+                        task_number: task_number as usize,
+                    },
+                    metrics,
+                );
+            }
             got.insert((stage_id, task_number));
         }
         if got.len() >= expected {

--- a/pg_search/src/postgres/customscan/mpp/launch.rs
+++ b/pg_search/src/postgres/customscan/mpp/launch.rs
@@ -383,7 +383,7 @@ pub fn launch_mpp_commit(
     // Derive the per-stage subplans from the plan the leader itself will execute. A failure
     // here is a hard error: a serialization gap is a codec bug, and the parked workers die
     // with the transaction.
-    let (payload, stage_plans) =
+    let (payload, stage_count) =
         match dispatch_payload_from_plan(physical, producer_count, payload_capacity) {
             Ok(p) => p,
             Err(e) => pgrx::error!("mpp: dispatch payload build failed: {e}"),
@@ -409,7 +409,7 @@ pub fn launch_mpp_commit(
     // A plan with no producer stages has nothing to distribute; the workers would only exit
     // with no fragments while the leader runs a plan whose per-source scans aren't executable
     // without a worker's state. Release the workers and let the caller replan serially.
-    if stage_plans.is_empty() {
+    if stage_count == 0 {
         go.store(GO_ABORT, Ordering::Release);
         finish.wait_for_finish();
         return None;
@@ -421,7 +421,7 @@ pub fn launch_mpp_commit(
         Ok(Some(s)) => s.as_mut_ptr() as *mut c_void,
         _ => pgrx::error!("mpp: mesh region missing"),
     };
-    let mut leader = match unsafe { leader_setup(mesh_ptr, payload, stage_plans) } {
+    let mut leader = match unsafe { leader_setup(mesh_ptr, payload) } {
         Ok(l) => l,
         Err(e) => pgrx::error!("mpp: leader_setup failed: {e}"),
     };

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -21,9 +21,9 @@
 //!
 //! [`collect_dispatched_stages`] walks the distributed physical plan, visits every
 //! [`datafusion_distributed::NetworkBoundary`], and collects one [`StageEntry`]
-//! (`input_stage.num`, `task_count`, `routing`, `plan`) per boundary. The leader serializes each
-//! stage's plan and ships it; each worker later expands a stage into one [`FragmentAssignment`]
-//! per `task_idx` it owns under `proc_for_task`.
+//! (`input_stage.num`, `task_count`, `routing`) per boundary. The stage plans travel separately,
+//! serialized by the coordinator's dispatch; each worker later expands a stage into one
+//! [`FragmentAssignment`] per `task_idx` it owns under `proc_for_task`.
 //!
 //! The fork's coordinator has no equivalent of this walk: it dispatches one boundary at a time,
 //! when the consumer's `execute` opens connections, so routing is implicit in who pulls. These
@@ -103,27 +103,21 @@ pub enum FragmentRouting {
     },
 }
 
-/// One producer stage to dispatch. The leader serializes `plan` once per stage and ships it with
-/// its `task_count` and `routing`; each worker expands a stage into one [`FragmentAssignment`] per
-/// `task_idx` it owns under `proc_for_task`.
+/// One producer stage to dispatch: the routing metadata the blob carries. Each worker expands a
+/// stage into one [`FragmentAssignment`] per `task_idx` it owns under `proc_for_task`.
 pub struct StageEntry {
     /// `input_stage.num` of the boundary whose producer side this stage belongs to.
     pub stage_num: u32,
-    /// The query's id, carried so the leader can stamp each task's `TaskKey`.
-    pub query_id: uuid::Uuid,
     /// Total task count for the stage (= `input_stage.tasks.len()`).
     pub task_count: usize,
     /// How to route each output partition to a destination proc.
     pub routing: FragmentRouting,
-    /// The stage's `input_stage.plan` (nested boundaries left `Local`; the worker converts them
-    /// at run time via `prepare_in_process_plan`, same as before).
-    pub plan: Arc<dyn ExecutionPlan>,
 }
 
 /// Walk the distributed physical plan and collect every producer stage, once per boundary. The
-/// leader runs this (replacing the worker-side re-plan): it classifies routing from the boundary
-/// type and captures each stage's `local_plan` for serialization. Not filtered by proc; the blob
-/// is shared and each worker selects its own `(stage, task)` slots.
+/// leader runs this (replacing the worker-side re-plan) to classify routing from the boundary
+/// type. Not filtered by proc; the blob is shared and each worker selects its own
+/// `(stage, task)` slots.
 pub fn collect_dispatched_stages(
     root: &Arc<dyn ExecutionPlan>,
     n_workers: u32,
@@ -145,7 +139,7 @@ fn collect_stages(
         // Only the `mpp_log!` trace reads `p_c` (routing reads the crate's `route_partition`),
         // so it's gated to non-test builds to avoid the unused-variable warning.
         #[cfg(not(test))]
-        let p_c = nb.partitions_per_consumer_task();
+        let p_c = nb.properties().partitioning.partition_count();
         // `route_partition(q).consumer_task` for every producer output partition. Used by the
         // hash-partitioned boundaries (Shuffle / Broadcast) only; Coalesce routes by task instead.
         let route_consumer_tasks = || -> Result<Vec<u32>, DataFusionError> {
@@ -239,10 +233,8 @@ fn collect_stages(
         if let Some(stage_plan) = stage.local_plan() {
             out.push(StageEntry {
                 stage_num: stage_id,
-                query_id: stage.query_id(),
                 task_count,
                 routing,
-                plan: Arc::clone(stage_plan),
             });
             // Recurse into the stage's plan with `nested = true`. The boundary's `children()`
             // returns `[stage.plan]`, so descending through it would double-process every nested

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -735,6 +735,7 @@ impl ExtensionPlanner for LateMaterializePlanner {
                         display_name: deferred.name.clone(),
                         is_bytes: deferred.is_bytes,
                         canonical: deferred.canonical.clone(),
+                        rebuild: deferred.rebuild.clone(),
                     },
                 );
             }
@@ -769,4 +770,37 @@ pub struct DeferredField {
     pub name: String,
     pub is_bytes: bool,
     pub canonical: CanonicalColumn,
+    /// Worker-side `FFHelper` rebuild info for lookups whose fragment has no scan of this
+    /// index beneath them (a lookup above a network shuffle). `None` keeps the pre-existing
+    /// behavior of collecting the helper from the plan subtree.
+    #[serde(default)]
+    pub rebuild: Option<DeferredLookupRebuild>,
+}
+
+/// Everything a worker needs to rebuild the fast-field reader for a deferred column when the
+/// scan that would normally supply it lives in a different plan fragment: the registered field
+/// name/type at `canonical.ff_index`, and which segment view to open.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DeferredLookupRebuild {
+    pub field_name: String,
+    pub field_type: crate::schema::SearchFieldType,
+    /// The source's non-partitioning index, resolving the canonical segment set every worker
+    /// replicates. `None` means the partitioning source: its full segment list lives in the
+    /// worker's `ParallelScanState` (only the scan's runtime claiming divides it, so a reader
+    /// over the full list sees every address any producer packed).
+    pub np_source_idx: Option<usize>,
+}
+
+// `SearchFieldType` has no ordering; (name, np index) is enough for the opportunistic
+// plan-ordering these impls serve.
+impl PartialOrd for DeferredLookupRebuild {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for DeferredLookupRebuild {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (&self.field_name, self.np_source_idx).cmp(&(&other.field_name, other.np_source_idx))
+    }
 }

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -102,21 +102,41 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
             ),
             // The deferred execs (visibility ctid resolvers, tantivy lookup, segmented top-k)
             // carry live `FFHelper`s that can't travel. Decode is bottom-up, so the scans below
-            // are already rebuilt; pull their helpers out of the decoded subtree.
+            // are already rebuilt; pull their helpers out of the decoded subtree. A column whose
+            // scan sits behind a network boundary rebuilds its helper from the column's
+            // `DeferredLookupRebuild` instead.
             TAG_VISIBILITY_FILTER => {
                 let input = single_input(inputs)?;
                 let resolvers = collect_ctid_resolvers(&input);
-                VisibilityFilterExec::decode_for_dispatch(payload, input, resolvers)
+                VisibilityFilterExec::decode_for_dispatch(
+                    payload,
+                    input,
+                    resolvers,
+                    &self.index_segment_ids,
+                )
             }
             TAG_TANTIVY_LOOKUP => {
                 let input = single_input(inputs)?;
                 let ffhelpers = collect_ffhelpers_by_indexrelid(&input);
-                TantivyLookupExec::decode_for_dispatch(payload, input, ffhelpers)
+                TantivyLookupExec::decode_for_dispatch(
+                    payload,
+                    input,
+                    ffhelpers,
+                    &self.non_partitioning_segment_ids,
+                    self.parallel_state,
+                )
             }
             TAG_SEGMENTED_TOPK => {
                 let input = single_input(inputs)?;
                 let ffhelpers = collect_ffhelpers_by_indexrelid(&input);
-                SegmentedTopKExec::decode_for_dispatch(payload, input, ffhelpers, ctx)
+                SegmentedTopKExec::decode_for_dispatch(
+                    payload,
+                    input,
+                    ffhelpers,
+                    ctx,
+                    &self.non_partitioning_segment_ids,
+                    self.parallel_state,
+                )
             }
             other => Err(DataFusionError::NotImplemented(format!(
                 "PgSearchPhysicalExtensionCodec: unknown physical node tag {other}"
@@ -227,9 +247,11 @@ struct ScanRuntime {
     ctid_plan_position: Option<usize>,
 }
 
-/// Walk a decoded subtree collecting each `PgSearchScanPlan`'s runtime handles. Nested stages are
-/// still `Local` at decode time, so the walk descends into them. Binding a resolver to any reader
-/// it finds is fine: canonical segment sets give every proc the same `segment_ord` layout.
+/// Walk a decoded subtree collecting each `PgSearchScanPlan`'s runtime handles. Nested stages
+/// decode as `Remote` (no inline child), so the walk covers this fragment's own scans; columns
+/// whose scan lives in another fragment rebuild their helpers from `DeferredLookupRebuild`.
+/// Binding a resolver to any reader it finds is fine: canonical segment sets give every proc
+/// the same `segment_ord` layout.
 fn collect_scan_runtime(plan: &Arc<dyn ExecutionPlan>, out: &mut Vec<ScanRuntime>) {
     if let Some(scan) = plan.downcast_ref::<PgSearchScanPlan>() {
         out.push(ScanRuntime {
@@ -253,14 +275,15 @@ fn single_input(inputs: &[Arc<dyn ExecutionPlan>]) -> Result<Arc<dyn ExecutionPl
     }
 }
 
-/// `(plan_position, ffhelper)` for each scan that resolves deferred ctids, for the visibility exec.
-fn collect_ctid_resolvers(input: &Arc<dyn ExecutionPlan>) -> Vec<(usize, Arc<FFHelper>)> {
+/// `(plan_position, indexrelid, ffhelper)` for each scan that resolves deferred ctids, for the
+/// visibility exec.
+fn collect_ctid_resolvers(input: &Arc<dyn ExecutionPlan>) -> Vec<(usize, u32, Arc<FFHelper>)> {
     let mut scans = Vec::new();
     collect_scan_runtime(input, &mut scans);
     scans
         .into_iter()
         .filter_map(|s| match (s.ctid_plan_position, s.ffhelper) {
-            (Some(pos), Some(ff)) => Some((pos, ff)),
+            (Some(pos), Some(ff)) => Some((pos, s.indexrelid, ff)),
             _ => None,
         })
         .collect()

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -75,6 +75,7 @@ use crate::api::HashMap;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, FFType, NULL_TERM_ORDINAL};
 use crate::scan::deferred_encode::unpack_doc_address;
 use crate::scan::execution_plan::UnsafeSendStream;
+use crate::scan::tantivy_lookup_exec::{open_rebuilt_ffhelper, rebuild_mvcc, LookupRebuildContext};
 use arrow_array::{
     Array, ArrayRef, BooleanArray, RecordBatch, StructArray, UInt32Array, UInt64Array, UnionArray,
 };
@@ -103,6 +104,10 @@ use tantivy::{DocId, SegmentOrdinal};
 pub struct DeferredSortColumn {
     pub sort_col_idx: usize,
     pub canonical: CanonicalColumn,
+    /// How a dispatched fragment rebuilds the fast-field helper when the column's scan is not
+    /// in its decoded subtree (the top-k above a network boundary).
+    #[serde(default)]
+    pub rebuild: Option<crate::scan::late_materialization::DeferredLookupRebuild>,
 }
 
 pub struct SegmentedTopKExec {
@@ -243,6 +248,8 @@ impl SegmentedTopKExec {
         input: Arc<dyn ExecutionPlan>,
         ffhelpers: HashMap<u32, Arc<FFHelper>>,
         ctx: &TaskContext,
+        non_partitioning_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
+        parallel_state: Option<*mut crate::postgres::ParallelScanState>,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let (sort_bytes, deferred_columns, k): (Vec<Vec<u8>>, Vec<DeferredSortColumn>, usize) =
             serde_json::from_slice(buf).map_err(|e| {
@@ -251,17 +258,34 @@ impl SegmentedTopKExec {
         // The deferred sort columns all resolve against one index (the sorted relation), and
         // `ff_index` is relative to that index's fast-field list. A join leaves the other
         // index's scan in the same subtree, so pick the helper by `indexrelid` instead of
-        // grabbing whichever scan comes first.
+        // grabbing whichever scan comes first. When that scan is behind a network boundary
+        // (no helper in the subtree), rebuild one over the same segment view the scan's
+        // reader opens, so segment ordering matches the ordinals the producers packed.
         let ffhelper = match deferred_columns.first() {
-            Some(first) => ffhelpers
-                .get(&first.canonical.indexrelid)
-                .cloned()
-                .ok_or_else(|| {
-                    DataFusionError::Internal(format!(
-                        "SegmentedTopKExec dispatch: no ffhelper for indexrelid {}",
-                        first.canonical.indexrelid
-                    ))
-                })?,
+            Some(first) => match ffhelpers.get(&first.canonical.indexrelid).cloned() {
+                Some(helper) => helper,
+                None => {
+                    let entries: Vec<_> = deferred_columns
+                        .iter()
+                        .filter_map(|d| d.rebuild.as_ref().map(|rb| (d.canonical.ff_index, rb)))
+                        .collect();
+                    let (_, first_rb) = entries.first().ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "SegmentedTopKExec dispatch: no ffhelper for indexrelid {} and no \
+                             rebuild info",
+                            first.canonical.indexrelid
+                        ))
+                    })?;
+                    let mvcc = rebuild_mvcc(
+                        LookupRebuildContext::Worker {
+                            non_partitioning_segment_ids,
+                            parallel_state,
+                        },
+                        first_rb,
+                    )?;
+                    open_rebuilt_ffhelper(first.canonical.indexrelid, &entries, mvcc)?
+                }
+            },
             None => ffhelpers
                 .into_values()
                 .next()
@@ -1562,7 +1586,8 @@ mod tests {
                     canonical: crate::index::fast_fields_helper::CanonicalColumn {
                         indexrelid: index_oid.to_u32(),
                         ff_index: 0,
-                    }
+                    },
+                    rebuild: None,
                 }
             ];
 

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -277,7 +277,7 @@ impl SegmentedTopKExec {
                         ))
                     })?;
                     let mvcc = rebuild_mvcc(
-                        LookupRebuildContext::Worker {
+                        LookupRebuildContext {
                             non_partitioning_segment_ids,
                             parallel_state,
                         },

--- a/pg_search/src/scan/segmented_topk_rule.rs
+++ b/pg_search/src/scan/segmented_topk_rule.rs
@@ -244,6 +244,7 @@ fn try_inject_below_lookup(
                                 crate::scan::segmented_topk_exec::DeferredSortColumn {
                                     sort_col_idx: physical_idx,
                                     canonical: field.canonical.clone(),
+                                    rebuild: field.rebuild.clone(),
                                 },
                             );
                         }

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -328,6 +328,15 @@ impl PgSearchTableProvider {
                         indexrelid: self.scan_info.indexrelid.to_u32(),
                         ff_index,
                     },
+                    // Resolvable from any fragment: a non-partitioning source reads the
+                    // replicated canonical set, the partitioning source reads the full list in
+                    // the worker's `ParallelScanState` (claiming only divides the scan, not a
+                    // reader opened over the whole list).
+                    rebuild: Some(crate::scan::late_materialization::DeferredLookupRebuild {
+                        field_name: name.clone(),
+                        field_type: *field_type,
+                        np_source_idx: self.non_partitioning_index,
+                    }),
                 });
             }
         }

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use crate::index::mvcc::MvccSatisfies;
-use crate::postgres::rel::PgSearchRelation;
-use crate::index::reader::index::SearchIndexReader;
-use crate::query::SearchQueryInput;
 use crate::index::fast_fields_helper::WhichFastField;
+use crate::index::mvcc::MvccSatisfies;
+use crate::index::reader::index::SearchIndexReader;
+use crate::postgres::rel::PgSearchRelation;
+use crate::query::SearchQueryInput;
 
 use crate::index::fast_fields_helper::{
     for_each_segment, ords_to_bytes_array, ords_to_string_array, CanonicalColumn, FFHelper, FFType,
@@ -173,7 +173,7 @@ impl TantivyLookupExec {
         rebuild_missing_ffhelpers(
             &deferred_fields,
             &mut ffhelpers,
-            LookupRebuildContext::Worker {
+            LookupRebuildContext {
                 non_partitioning_segment_ids,
                 parallel_state,
             },
@@ -189,16 +189,12 @@ impl TantivyLookupExec {
 /// Which snapshot a rebuilt fast-field reader reads. Both decode paths reach the same segments
 /// in the same order the addresses were packed against, they just resolve the set differently.
 #[derive(Clone, Copy)]
-pub(crate) enum LookupRebuildContext<'a> {
-    /// Planner path (serial plan): a snapshot reader sees the scan's segments directly.
-    Snapshot,
+pub(crate) struct LookupRebuildContext<'a> {
     /// MPP worker path: a non-partitioning source reads its replicated canonical segment set;
     /// the partitioning source reads the full list in the worker's `ParallelScanState` (the
     /// same view its scan's reader opens, so segment ordering matches the packed addresses).
-    Worker {
-        non_partitioning_segment_ids: &'a [crate::api::HashSet<tantivy::index::SegmentId>],
-        parallel_state: Option<*mut crate::postgres::ParallelScanState>,
-    },
+    pub non_partitioning_segment_ids: &'a [crate::api::HashSet<tantivy::index::SegmentId>],
+    pub parallel_state: Option<*mut crate::postgres::ParallelScanState>,
 }
 
 /// Resolve the segment view a rebuilt helper opens for one deferred column's index.
@@ -206,35 +202,30 @@ pub(crate) fn rebuild_mvcc(
     context: LookupRebuildContext,
     rebuild: &crate::scan::late_materialization::DeferredLookupRebuild,
 ) -> Result<MvccSatisfies> {
-    match context {
-        LookupRebuildContext::Snapshot => Ok(MvccSatisfies::Snapshot),
-        LookupRebuildContext::Worker {
-            non_partitioning_segment_ids,
-            parallel_state,
-        } => match rebuild.np_source_idx {
-            Some(np_source_idx) => {
-                let ids = non_partitioning_segment_ids
-                    .get(np_source_idx)
-                    .cloned()
-                    .ok_or_else(|| {
-                        DataFusionError::Internal(format!(
-                            "ffhelper rebuild: missing canonical segment ids for \
-                             non-partitioning source {np_source_idx}"
-                        ))
-                    })?;
-                Ok(MvccSatisfies::ParallelWorker(ids))
-            }
-            None => {
-                let ps = parallel_state.ok_or_else(|| {
-                    DataFusionError::Internal(
-                        "ffhelper rebuild: partitioning source needs a ParallelScanState".into(),
-                    )
+    match rebuild.np_source_idx {
+        Some(np_source_idx) => {
+            let ids = context
+                .non_partitioning_segment_ids
+                .get(np_source_idx)
+                .cloned()
+                .ok_or_else(|| {
+                    DataFusionError::Internal(format!(
+                        "ffhelper rebuild: missing canonical segment ids for \
+                         non-partitioning source {np_source_idx}"
+                    ))
                 })?;
-                Ok(MvccSatisfies::ParallelWorker(unsafe {
-                    crate::postgres::customscan::parallel::list_segment_ids(ps)
-                }))
-            }
-        },
+            Ok(MvccSatisfies::ParallelWorker(ids))
+        }
+        None => {
+            let ps = context.parallel_state.ok_or_else(|| {
+                DataFusionError::Internal(
+                    "ffhelper rebuild: partitioning source needs a ParallelScanState".into(),
+                )
+            })?;
+            Ok(MvccSatisfies::ParallelWorker(unsafe {
+                crate::postgres::customscan::parallel::list_segment_ids(ps)
+            }))
+        }
     }
 }
 
@@ -285,8 +276,7 @@ fn rebuild_missing_ffhelpers(
         if f.rebuild.is_none() {
             continue;
         }
-        let scan_is_elsewhere = matches!(context, LookupRebuildContext::Worker { .. })
-            && !ffhelpers.contains_key(&f.canonical.indexrelid);
+        let scan_is_elsewhere = !ffhelpers.contains_key(&f.canonical.indexrelid);
         if scan_is_elsewhere {
             rebuild_indexes.insert(f.canonical.indexrelid);
         }

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -1,5 +1,11 @@
 use std::sync::Arc;
 
+use crate::index::mvcc::MvccSatisfies;
+use crate::postgres::rel::PgSearchRelation;
+use crate::index::reader::index::SearchIndexReader;
+use crate::query::SearchQueryInput;
+use crate::index::fast_fields_helper::WhichFastField;
+
 use crate::index::fast_fields_helper::{
     for_each_segment, ords_to_bytes_array, ords_to_string_array, CanonicalColumn, FFHelper, FFType,
 };
@@ -43,6 +49,8 @@ pub struct PhysicalDeferredField {
     pub display_name: String,
     pub is_bytes: bool,
     pub canonical: CanonicalColumn,
+    #[serde(default)]
+    pub rebuild: Option<crate::scan::late_materialization::DeferredLookupRebuild>,
 }
 
 impl PhysicalDeferredField {
@@ -152,7 +160,9 @@ impl TantivyLookupExec {
     pub(crate) fn decode_for_dispatch(
         buf: &[u8],
         input: Arc<dyn ExecutionPlan>,
-        ffhelpers: HashMap<u32, Arc<FFHelper>>,
+        mut ffhelpers: HashMap<u32, Arc<FFHelper>>,
+        non_partitioning_segment_ids: &[crate::api::HashSet<tantivy::index::SegmentId>],
+        parallel_state: Option<*mut crate::postgres::ParallelScanState>,
     ) -> datafusion::common::Result<Arc<dyn ExecutionPlan>> {
         let deferred_fields: Vec<PhysicalDeferredField> =
             serde_json::from_slice(buf).map_err(|e| {
@@ -160,6 +170,14 @@ impl TantivyLookupExec {
                     "TantivyLookupExec dispatch: deserialize: {e}"
                 ))
             })?;
+        rebuild_missing_ffhelpers(
+            &deferred_fields,
+            &mut ffhelpers,
+            LookupRebuildContext::Worker {
+                non_partitioning_segment_ids,
+                parallel_state,
+            },
+        )?;
         Ok(Arc::new(TantivyLookupExec::new(
             input,
             deferred_fields,
@@ -168,6 +186,138 @@ impl TantivyLookupExec {
     }
 }
 
+/// Which snapshot a rebuilt fast-field reader reads. Both decode paths reach the same segments
+/// in the same order the addresses were packed against, they just resolve the set differently.
+#[derive(Clone, Copy)]
+pub(crate) enum LookupRebuildContext<'a> {
+    /// Planner path (serial plan): a snapshot reader sees the scan's segments directly.
+    Snapshot,
+    /// MPP worker path: a non-partitioning source reads its replicated canonical segment set;
+    /// the partitioning source reads the full list in the worker's `ParallelScanState` (the
+    /// same view its scan's reader opens, so segment ordering matches the packed addresses).
+    Worker {
+        non_partitioning_segment_ids: &'a [crate::api::HashSet<tantivy::index::SegmentId>],
+        parallel_state: Option<*mut crate::postgres::ParallelScanState>,
+    },
+}
+
+/// Resolve the segment view a rebuilt helper opens for one deferred column's index.
+pub(crate) fn rebuild_mvcc(
+    context: LookupRebuildContext,
+    rebuild: &crate::scan::late_materialization::DeferredLookupRebuild,
+) -> Result<MvccSatisfies> {
+    match context {
+        LookupRebuildContext::Snapshot => Ok(MvccSatisfies::Snapshot),
+        LookupRebuildContext::Worker {
+            non_partitioning_segment_ids,
+            parallel_state,
+        } => match rebuild.np_source_idx {
+            Some(np_source_idx) => {
+                let ids = non_partitioning_segment_ids
+                    .get(np_source_idx)
+                    .cloned()
+                    .ok_or_else(|| {
+                        DataFusionError::Internal(format!(
+                            "ffhelper rebuild: missing canonical segment ids for \
+                             non-partitioning source {np_source_idx}"
+                        ))
+                    })?;
+                Ok(MvccSatisfies::ParallelWorker(ids))
+            }
+            None => {
+                let ps = parallel_state.ok_or_else(|| {
+                    DataFusionError::Internal(
+                        "ffhelper rebuild: partitioning source needs a ParallelScanState".into(),
+                    )
+                })?;
+                Ok(MvccSatisfies::ParallelWorker(unsafe {
+                    crate::postgres::customscan::parallel::list_segment_ids(ps)
+                }))
+            }
+        },
+    }
+}
+
+/// Open a fast-field helper for `indexrelid` with each rebuild entry laid out at its original
+/// `ff_index` (`Junk` fills the gaps), over the segment view `mvcc` picks.
+pub(crate) fn open_rebuilt_ffhelper(
+    indexrelid: u32,
+    entries: &[(
+        usize,
+        &crate::scan::late_materialization::DeferredLookupRebuild,
+    )],
+    mvcc: MvccSatisfies,
+) -> Result<Arc<FFHelper>> {
+    let index_rel = PgSearchRelation::open(pgrx::pg_sys::Oid::from(indexrelid));
+    let reader = SearchIndexReader::open_with_context(
+        &index_rel,
+        SearchQueryInput::All,
+        /* need_scores */ false,
+        mvcc,
+        None,
+        None,
+        /* needs_tokenizer_manager */ false,
+    )
+    .map_err(|e| DataFusionError::Internal(format!("ffhelper rebuild: open reader: {e}")))?;
+
+    let width = entries.iter().map(|(i, _)| i + 1).max().unwrap_or(0);
+    let mut which: Vec<WhichFastField> = vec![WhichFastField::Junk(String::new()); width];
+    for (ff_index, rb) in entries {
+        which[*ff_index] = WhichFastField::Named(rb.field_name.clone(), rb.field_type);
+    }
+    Ok(Arc::new(FFHelper::with_fields(&reader, &which)))
+}
+
+/// Rebuild the fast-field readers for deferred columns whose scan lives in a different plan
+/// fragment (a lookup above a network shuffle finds no scan in its decoded subtree). The
+/// `context` picks how the segment set is resolved; either way the reader's segment ordering
+/// matches the ordering the addresses were packed against.
+fn rebuild_missing_ffhelpers(
+    deferred_fields: &[PhysicalDeferredField],
+    ffhelpers: &mut HashMap<u32, Arc<FFHelper>>,
+    context: LookupRebuildContext,
+) -> Result<()> {
+    // Ordinal-typed columns keep a scan's helper when one decoded in this fragment (its layout
+    // lines up by construction); they rebuild only on a worker whose fragment has that scan
+    // behind a network boundary.
+    let mut rebuild_indexes: crate::api::HashSet<u32> = Default::default();
+    for f in deferred_fields {
+        if f.rebuild.is_none() {
+            continue;
+        }
+        let scan_is_elsewhere = matches!(context, LookupRebuildContext::Worker { .. })
+            && !ffhelpers.contains_key(&f.canonical.indexrelid);
+        if scan_is_elsewhere {
+            rebuild_indexes.insert(f.canonical.indexrelid);
+        }
+    }
+
+    // Group by index so two columns of the same index share one reader, and lay out every
+    // rebuildable column of a rebuilding index, not just the ones that triggered it: the
+    // rebuilt helper replaces the map entry, so it has to serve all of them.
+    let mut per_index: HashMap<u32, Vec<&PhysicalDeferredField>> = HashMap::default();
+    for f in deferred_fields {
+        if f.rebuild.is_some() && rebuild_indexes.contains(&f.canonical.indexrelid) {
+            per_index.entry(f.canonical.indexrelid).or_default().push(f);
+        }
+    }
+
+    for (indexrelid, fields) in per_index {
+        let mvcc = rebuild_mvcc(context, fields[0].rebuild.as_ref().unwrap())?;
+        let entries: Vec<(
+            usize,
+            &crate::scan::late_materialization::DeferredLookupRebuild,
+        )> = fields
+            .iter()
+            .map(|f| (f.canonical.ff_index, f.rebuild.as_ref().unwrap()))
+            .collect();
+        ffhelpers.insert(
+            indexrelid,
+            open_rebuilt_ffhelper(indexrelid, &entries, mvcc)?,
+        );
+    }
+    Ok(())
+}
 #[derive(Clone, Debug)]
 pub struct DecoderInfo {
     pub col_idx: usize,

--- a/pg_search/src/scan/visibility_ctid_resolver_rule.rs
+++ b/pg_search/src/scan/visibility_ctid_resolver_rule.rs
@@ -64,14 +64,14 @@ impl PhysicalOptimizerRule for VisibilityCtidResolverRule {
 fn walk_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
     if let Some(vis_exec) = plan.downcast_ref::<VisibilityFilterExec>() {
         for &(plan_pos, _) in vis_exec.plan_pos_oids() {
-            let ffhelper =
-                find_ffhelper_for_plan_position(plan.as_ref(), plan_pos).ok_or_else(|| {
-                    DataFusionError::Internal(format!(
-                        "VisibilityCtidResolverRule: no PgSearchScanPlan found \
+            let (indexrelid, ffhelper) = find_ffhelper_for_plan_position(plan.as_ref(), plan_pos)
+                .ok_or_else(|| {
+                DataFusionError::Internal(format!(
+                    "VisibilityCtidResolverRule: no PgSearchScanPlan found \
                      for deferred ctid plan_position {plan_pos}"
-                    ))
-                })?;
-            vis_exec.set_ctid_resolver(plan_pos, ffhelper);
+                ))
+            })?;
+            vis_exec.set_ctid_resolver(plan_pos, indexrelid, ffhelper);
         }
     }
 
@@ -82,14 +82,14 @@ fn walk_plan(plan: &Arc<dyn ExecutionPlan>) -> Result<()> {
 }
 
 /// Search the subtree for a PgSearchScanPlan whose deferred ctid metadata matches
-/// the given plan position. Returns its FFHelper if found.
+/// the given plan position. Returns its index relid and FFHelper if found.
 fn find_ffhelper_for_plan_position(
     plan: &dyn ExecutionPlan,
     plan_position: usize,
-) -> Option<Arc<FFHelper>> {
+) -> Option<(u32, Arc<FFHelper>)> {
     if let Some(scan) = plan.downcast_ref::<PgSearchScanPlan>() {
         if scan.deferred_ctid_plan_position() == Some(plan_position) {
-            return scan.ffhelper();
+            return scan.ffhelper().map(|ff| (scan.indexrelid, ff));
         }
     }
 
@@ -133,7 +133,7 @@ mod tests {
             Some(7),
         );
 
-        let found = find_ffhelper_for_plan_position(&scan, 7)
+        let (_, found) = find_ffhelper_for_plan_position(&scan, 7)
             .expect("matching plan_position should find ffhelper");
         assert!(Arc::ptr_eq(&found, &ffhelper));
         assert!(find_ffhelper_for_plan_position(&scan, 6).is_none());

--- a/pg_search/tests/pg_regress/expected/issue_4779.out
+++ b/pg_search/tests/pg_regress/expected/issue_4779.out
@@ -194,7 +194,7 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
          Limit: 10
          Order By: m.id desc
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : ┌───── DistributedExec
            : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
            : │   SortPreservingMergeExec: [id@1 DESC], fetch=10
            : │     SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
@@ -205,7 +205,7 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
            : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            : │             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 1 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   ┌───── Stage 1 ── tasks=3, partitions=9
            :   │ HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
            :   │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
            :   │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1

--- a/pg_search/tests/pg_regress/expected/issue_4910.out
+++ b/pg_search/tests/pg_regress/expected/issue_4910.out
@@ -88,12 +88,12 @@ LIMIT 25;
          Limit: 25
          Order By: cccf.revenue_rank desc nulls last, cccf.contact_id asc
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : ┌───── DistributedExec
            : │ ProjectionExec: expr=[contact_id@3 as col_1, company_id@1 as col_2, revenue_rank@2 as col_3, ctid_0@0 as ctid_0]
            : │   SortPreservingMergeExec: [revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], fetch=25
            : │     [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   ┌───── Stage 3 ── tasks=3, partitions=9
            :   │ SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[true]
            :   │   VisibilityFilterExec: tables=[cccf]
            :   │     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
@@ -105,11 +105,11 @@ LIMIT 25;
            :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :   │           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :     │   PgSearchScan: segments=1, query="all"
            :     └──────────────────────────────────────────────────
-           :     ┌───── Stage 2 ── Tasks: t0:[p0..p2]
+           :     ┌───── Stage 2 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :     │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -157,12 +157,12 @@ WHERE f.content @@@ 'Section';
    Indexes: mpp_files_idx (f), mpp_pages_idx (p)
    Aggregates: COUNT(*)
    DataFusion Physical Plan: 
-     : ┌───── DistributedExec ── Tasks: t0:[p0]
+     : ┌───── DistributedExec
      : │ AggregateExec: mode=Final, gby=[], aggr=[count(1) as agg_0]
      : │   CoalescePartitionsExec
      : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+     :   ┌───── Stage 2 ── tasks=3, partitions=9
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
@@ -170,7 +170,7 @@ WHERE f.content @@@ 'Section';
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+     :     ┌───── Stage 1 ── tasks=1, partitions=3
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
      :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
@@ -205,16 +205,16 @@ LIMIT 5;
                Group By: title
                Aggregates: COUNT(*), SUM(size_bytes)
                DataFusion Physical Plan: 
-                 : ┌───── DistributedExec ── Tasks: t0:[p0]
+                 : ┌───── DistributedExec
                  : │ SortPreservingMergeExec: [title@0 ASC NULLS LAST], fetch=5
                  : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
                  : └──────────────────────────────────────────────────
-                 :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                 :   ┌───── Stage 3 ── tasks=3, partitions=3
                  :   │ SortExec: TopK(fetch=5), expr=[title@0 ASC NULLS LAST], preserve_partitioning=[true]
                  :   │   AggregateExec: mode=FinalPartitioned, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :   │     [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
                  :   └──────────────────────────────────────────────────
-                 :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                 :     ┌───── Stage 2 ── tasks=3, partitions=9
                  :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
@@ -223,7 +223,7 @@ LIMIT 5;
                  :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                 :       ┌───── Stage 1 ── tasks=1, partitions=3
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
                  :       │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -104,15 +104,15 @@ ORDER BY f.category;
          Group By: category
          Aggregates: COUNT(*), SUM(size_bytes), MIN(size_bytes), MAX(size_bytes)
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : ┌───── DistributedExec
            : │ CoalescePartitionsExec
            : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+           :   ┌───── Stage 3 ── tasks=3, partitions=3
            :   │ AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1, min(p_1.size_bytes) as agg_2, max(p_1.size_bytes) as agg_3]
            :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+           :     ┌───── Stage 2 ── tasks=3, partitions=9
            :     │ RepartitionExec: partitioning=Hash([category@0], 9), input_partitions=3
            :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1, min(p_1.size_bytes) as agg_2, max(p_1.size_bytes) as agg_3]
            :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
@@ -121,7 +121,7 @@ ORDER BY f.category;
            :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-           :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :       ┌───── Stage 1 ── tasks=1, partitions=3
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
@@ -191,15 +191,15 @@ LIMIT 10;
                Group By: category, title
                Aggregates: COUNT(*)
                DataFusion Physical Plan: 
-                 : ┌───── DistributedExec ── Tasks: t0:[p0]
+                 : ┌───── DistributedExec
                  : │ CoalescePartitionsExec
                  : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
                  : └──────────────────────────────────────────────────
-                 :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                 :   ┌───── Stage 3 ── tasks=3, partitions=3
                  :   │ AggregateExec: mode=FinalPartitioned, gby=[category@0 as category, title@1 as title], aggr=[count(1) as agg_0]
                  :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
                  :   └──────────────────────────────────────────────────
-                 :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                 :     ┌───── Stage 2 ── tasks=3, partitions=9
                  :     │ RepartitionExec: partitioning=Hash([category@0, title@1], 9), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[category@1 as category, title@0 as title], aggr=[count(1) as agg_0]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, category@2]
@@ -208,7 +208,7 @@ LIMIT 10;
                  :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                 :       ┌───── Stage 1 ── tasks=1, partitions=3
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
                  :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
@@ -275,17 +275,17 @@ LIMIT 3;
                Group By: category
                Aggregates: COUNT(*), SUM(size_bytes)
                DataFusion Physical Plan: 
-                 : ┌───── DistributedExec ── Tasks: t0:[p0]
+                 : ┌───── DistributedExec
                  : │ SortPreservingMergeExec: [agg_1@2 DESC], fetch=3
                  : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
                  : └──────────────────────────────────────────────────
-                 :   ┌───── Stage 3 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+                 :   ┌───── Stage 3 ── tasks=3, partitions=3
                  :   │ SortExec: TopK(fetch=3), expr=[agg_1@2 DESC], preserve_partitioning=[true]
                  :   │   FilterExec: agg_0@1 > 100
                  :   │     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :   │       [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
                  :   └──────────────────────────────────────────────────
-                 :     ┌───── Stage 2 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+                 :     ┌───── Stage 2 ── tasks=3, partitions=9
                  :     │ RepartitionExec: partitioning=Hash([category@0], 9), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
@@ -294,7 +294,7 @@ LIMIT 3;
                  :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
                  :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+                 :       ┌───── Stage 1 ── tasks=1, partitions=3
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
                  :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
@@ -342,12 +342,12 @@ WHERE f.content @@@ 'Section';
    Indexes: mpp_postagg_files_idx (f), mpp_postagg_pages_idx (p)
    Aggregates: COUNT(*)
    DataFusion Physical Plan: 
-     : ┌───── DistributedExec ── Tasks: t0:[p0]
+     : ┌───── DistributedExec
      : │ AggregateExec: mode=Final, gby=[], aggr=[count(1) as agg_0]
      : │   CoalescePartitionsExec
      : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+     :   ┌───── Stage 2 ── tasks=3, partitions=9
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
@@ -355,7 +355,7 @@ WHERE f.content @@@ 'Section';
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
      :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+     :     ┌───── Stage 1 ── tasks=1, partitions=3
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
      :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
@@ -431,15 +431,15 @@ ORDER BY c.name;
          Group By: name
          Aggregates: COUNT(*), SUM(size_bytes)
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : ┌───── DistributedExec
            : │ CoalescePartitionsExec
            : │   [Stage 4] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 4 ── Tasks: t0:[p0..p2] t1:[p0..p2] t2:[p0..p2]
+           :   ┌───── Stage 4 ── tasks=3, partitions=3
            :   │ AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
            :   │   [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=3
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 3 ── Tasks: t0:[p0..p8] t1:[p0..p8] t2:[p0..p8]
+           :     ┌───── Stage 3 ── tasks=3, partitions=9
            :     │ RepartitionExec: partitioning=Hash([name@0], 9), input_partitions=3
            :     │   AggregateExec: mode=Partial, gby=[name@1 as name], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
            :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(name@0, category@0)], projection=[size_bytes@2, name@0]
@@ -451,11 +451,11 @@ ORDER BY c.name;
            :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :     │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-           :       ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :       ┌───── Stage 1 ── tasks=1, partitions=3
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :       │   PgSearchScan: segments=1, query="all"
            :       └──────────────────────────────────────────────────
-           :       ┌───── Stage 2 ── Tasks: t0:[p0..p2]
+           :       ┌───── Stage 2 ── tasks=1, partitions=3
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :       │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -133,12 +133,12 @@ LIMIT 10;
          Limit: 10
          Order By: f.title asc, p.size_bytes asc
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
            : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
@@ -149,7 +149,7 @@ LIMIT 10;
            :   │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :   │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
@@ -228,12 +228,12 @@ LIMIT 10;
          Limit: 10
          Order By: f.title asc, p.size_bytes asc
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec ── Tasks: t0:[p0]
+           : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
            : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── Tasks: t0:[p0..p2] t1:[p3..p5] t2:[p6..p8]
+           :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10
@@ -244,7 +244,7 @@ LIMIT 10;
            :   │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
            :   │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
+           :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
            :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :     └──────────────────────────────────────────────────


### PR DESCRIPTION
# Ticket(s) Closed

N/A

## What

This PR runs MPP on the `WorkerChannel`-based `datafusion-distributed` fork, with workers as passive executors of the plans the leader dispatches, and carries the fork pin. It absorbs #5448, so the whole migration lands as one reviewable unit at the top of the chain and nothing below depends on the fork rev.

## Why

The fork moved to the merged upstream `WorkerChannel` abstraction. A worker used to be a sub-coordinator: it wrapped every decoded fragment in a fresh `DistributedExec` and ran `prepare_in_process_plan`, spawning a per-fragment coordinator whose nested dispatch was discarded (`ShmDiscardedPlanCodec` existed to absorb those bytes). A gRPC worker never does any of this, because the coordinator's encode ships nested stages already `Remote`. The shm worker now works the same way.

## How

- The transport moves off the `WorkerTransport` umbrella onto the fork's channel protocol: `ShmChannelResolver` + `ShmWorkerChannel`, with the coordinator dispatching every stage itself. `SetPlan` frames routed over the mesh replace the out-of-band delivery.
- The coordinator hands its ready-to-run per-task plan (task-specialized, nested stages `Remote`) to the leader's `StagePlanDispatchSource`, which serializes it with the pg codec on demand. The worker executes the decoded fragment as-is; the `DistributedExec` wrap, `prepare_in_process_plan`, and `ShmDiscardedPlanCodec` are gone.
- Ready-to-run bytes carry no inline nested child plans, so the deferred execs become self-contained: `DeferredLookupRebuild` covers the partitioning source, `DeferredSortColumn` carries the rebuild info, and `TantivyLookupExec`, `SegmentedTopKExec`, and `VisibilityFilterExec` rebuild helpers and ctid resolvers over canonical segment views when a column's scan sits behind a network boundary.
- Teardown flips the mesh liveness flag so DSM-backed senders drop cleanly on abort.
- Pins `datafusion-distributed` to the reworked fork stack on the merged upstream `WorkerChannel` base, whose EXPLAIN task rendering re-blesses the affected expected files.

## Tests

The MPP regress suite passes on pg18; `mpp_join_topk_ffhelper` and `mpp_joinscan` exercise the cross-stage helper and resolver rebuilds. The fork's in-crate shm transport tests run the same passive-worker flow, including the dispatch handoff, with no Postgres.
