### PR TITLE
chore: Add docs for tiebreaking on score.

### DIFF
--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -277,13 +277,6 @@ await dbContext
 (3 rows)
 ```
 
-<Note>
-  When ordering by `pdb.score`, we recommend including a unique tiebreaker
-  column (such as the primary key) to guarantee deterministic results. See
-  [Deterministic Sorting](/documentation/sorting/score#deterministic-sorting)
-  for more information.
-</Note>
-
 ## Highlighting
 
 Finally, let's also [highlight](/documentation/full-text/highlight) the relevant portions of the documents that were matched.

--- a/docs/documentation/getting-started/queries.mdx
+++ b/docs/documentation/getting-started/queries.mdx
@@ -277,6 +277,13 @@ await dbContext
 (3 rows)
 ```
 
+<Note>
+  When ordering by `pdb.score`, we recommend including a unique tiebreaker
+  column (such as the primary key) to guarantee deterministic results. See
+  [Deterministic Sorting](/documentation/sorting/score#deterministic-sorting)
+  for more information.
+</Note>
+
 ## Highlighting
 
 Finally, let's also [highlight](/documentation/full-text/highlight) the relevant portions of the documents that were matched.

--- a/docs/documentation/sorting/score.mdx
+++ b/docs/documentation/sorting/score.mdx
@@ -242,7 +242,7 @@ LIMIT 5;
 
 ## Deterministic Sorting
 
-Ordering by `pdb.score` alone is not sufficient to guarantee deterministic query results when there are multiple documents with the same score (due to Postgres' internal sorting behavior and segment compactions).
+Ordering by `pdb.score` alone is not sufficient to guarantee deterministic query results when there are multiple documents with the same score.
 
 To ensure stable output, we recommend adding a tiebreaker column (such as the primary key) after the score:
 

--- a/docs/documentation/sorting/score.mdx
+++ b/docs/documentation/sorting/score.mdx
@@ -192,7 +192,7 @@ Next, let's compute a "combined BM25 score" over a join across both tables.
   Directly computing and ordering by the sum of scores across a join (e.g.
   `ORDER BY pdb.score(t1) + pdb.score(t2)`) is currently not efficient. For more
   details on implementing efficient support for this operation, please refer to
-  [Issue #5300](https://github.com/paradedb/paradedb/issues/5300).
+  [Issue #5301](https://github.com/paradedb/paradedb/issues/5301).
 </Note>
 
 The recommended approach for combining scores from multiple tables is to use [Reciprocal Rank Fusion (RRF)](https://www.paradedb.com/learn/search-concepts/reciprocal-rank-fusion). RRF combines the ranked results from separate queries into a single unified ranking.
@@ -239,6 +239,22 @@ LIMIT 5;
 ```
 
 </CodeGroup>
+
+## Deterministic Sorting
+
+Ordering by `pdb.score` alone is not sufficient to guarantee deterministic query results when there are multiple documents with the same score (due to Postgres' internal sorting behavior and segment compactions).
+
+To ensure stable output, we recommend adding a tiebreaker column (such as the primary key) after the score:
+
+```sql
+SELECT id, pdb.score(id)
+FROM mock_items
+WHERE description ||| 'shoes'
+ORDER BY pdb.score(id) DESC, id ASC
+LIMIT 5;
+```
+
+Note that to receive this [Top K optimization](/documentation/sorting/topk), all tiebreaker columns must be indexed.
 
 ## Score Refresh
 

--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -112,7 +112,9 @@ If any of the above conditions are not met, the query cannot be fully optimized 
 
 ## Tiebreaker Sorting
 
-To guarantee stable sorting in the event of a tie, additional columns can be provided to `ORDER BY`:
+To guarantee stable sorting in the event of a tie, additional columns can be provided to `ORDER BY`.
+
+This is particularly important when sorting by `pdb.score(...)`, as equal scores can result in non-deterministic orderings (due to Postgres' internal sorting behavior and segment compactions). As noted above, all tiebreaker columns must be indexed to receive the Top K optimization.
 
 <CodeGroup>
 ```sql SQL

--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -114,7 +114,7 @@ If any of the above conditions are not met, the query cannot be fully optimized 
 
 To guarantee stable sorting in the event of a tie, additional columns can be provided to `ORDER BY`.
 
-This is particularly important when sorting by `pdb.score(...)`, as equal scores can result in non-deterministic orderings (due to Postgres' internal sorting behavior and segment compactions). As noted above, all tiebreaker columns must be indexed to receive the Top K optimization.
+This is particularly important when sorting by `pdb.score(...)`, as equal scores can result in non-deterministic orderings. As noted above, all tiebreaker columns must be indexed to receive the Top K optimization.
 
 <CodeGroup>
 ```sql SQL


### PR DESCRIPTION
## What

Add recommendations around tiebreaking score sorts.

## Why

We have not previously recommended using tiebreakers with a score, in part because it used to impose a significant cost.

Now that #5496 is in, we're in a better position to recommend it.