### PR TITLE
test(stressgres): pin the Normal Scan plan instead of racing the cost model

### DIFF
--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -56,16 +56,20 @@ CREATE OR REPLACE FUNCTION assert_plan_contains(
 ) RETURNS boolean AS $$
 DECLARE
     plan_line text;
+    full_plan text := '';
 BEGIN
-    -- Loop through each line of the EXPLAIN output
-    FOR plan_line IN EXECUTE 'EXPLAIN ' || p_query LOOP
+    -- Accumulate the EXPLAIN output as we go so we can show the plan we actually
+    -- got if the assertion fails (invaluable when a fault-injection run flips the plan).
+    FOR plan_line IN EXECUTE 'EXPLAIN (VERBOSE) ' || p_query LOOP
+        full_plan := full_plan || plan_line || chr(10);
         -- Check if the current line contains the expected text
         IF plan_line ILIKE '%' || p_expected_text || '%' THEN
             RETURN true;
         END IF;
     END LOOP;
 
-    RAISE EXCEPTION 'Plan assertion failed: Expected text "%" not found in plan for query: %', p_expected_text, p_query;
+    RAISE EXCEPTION 'Plan assertion failed: expected "%" not found in plan for query: %. Actual plan:%',
+        p_expected_text, p_query, chr(10) || full_plan;
 END;
 $$ LANGUAGE plpgsql;
 
@@ -116,6 +120,8 @@ title = "Normal Scan"
 log_tps = true
 on_connect = """
 SET paradedb.enable_aggregate_custom_scan = off;
+SET enable_indexscan = off;
+SET enable_indexonlyscan = off;
 SELECT assert_plan_contains(
     $q$ SELECT count(*) FROM test where message ||| 'wine' $q$,
     'NormalScanExecState'


### PR DESCRIPTION
Split out of #5492, which it does not otherwise depend on.

## What

`count(*) ... WHERE message ||| 'wine'` groups with no `LIMIT`, so the custom path leaves `RowHeuristic` as `SerialOnly` with `force = false`. `hook::add_path` only clears the pathlist for forced paths, so Postgres' own BM25 index scan stays in the running and cost decides between them.

The two are ~0.4% apart, well inside the fuzzy-cost factor: the native cost is frozen at the `reltuples` that `CREATE INDEX` wrote, while the custom path's `drive_cost` grows as the writer jobs churn the index. Normally `on_connect` runs before the writers get far enough to flip it; under load it does not, and the job silently stops exercising `NormalScanExecState`. This is what @stuhood suspected in https://github.com/paradedb/paradedb/pull/5492#discussion_r2600756668 — real signal, not a fault-recovery bug. @carlsverre independently hit it too.

- Disable `enable_indexscan` / `enable_indexonlyscan` for the job, as its sibling scan jobs already do for their own alternatives (`Index Scan` disables the custom scan, `Columnar Scan` forces columnar exec). The custom path is then the only candidate — a seq scan cannot win, since `|||` has `procost = 1e9` — so the assertion checks that pg_search *produces* the path rather than that it wins a coin flip.
- Make `assert_plan_contains` accumulate and dump the plan it actually got, so the next time one of these flips we can see what it chose instead of guessing.

## Verification

- `python3 -c "import tomllib; tomllib.load(open('stressgres/suites/single-server.toml','rb'))"` — suite still parses.

## Follow-up

Left open from the original review, worth its own ticket: should the `RowHeuristic` / `SerialOnly` branch force the pathlist clear? On a real table where the native scan is the wrong pick, we would lose to it silently.

https://claude.ai/code/session_01VwnAbNJZ4HdTpc9hHgypkk