### PR TITLE
ci(antithesis): enable paradedb faults and assert recovery

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -383,6 +383,11 @@ jobs:
       # antithesis.duration is in minutes, 360 minutes = 6 hours
       # antithesis.is_ephemeral ensures runs triggered from PRs don't impact the history
       # antithesis.source ensures Community and Enteprise have separate histories
+      # custom.container_faults_{stop,kill}_exclusion_patterns exempts containers from stop/kill faults for two reasons:
+      #   - infra ParadeDB doesn't develop, always exempt: the cloudnative-pg operator and
+      #     logical-replication-publisher (a vanilla Postgres container)
+      #   - the paradedb pod(s) under proptests: proptests is a differential-correctness oracle with no reconnect
+      #     resilience, so a stopped/killed paradedb there is spurious query-failure noise rather than exercised recovery
       - name: Trigger Antithesis Test
         uses: antithesishq/antithesis-trigger-action@v0.12
         with:
@@ -400,8 +405,8 @@ jobs:
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb
             custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }}
-            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg,logical-replication-publisher
-            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }},paradedb,cloudnative-pg,logical-replication-publisher
+            custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
+            custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
 
   # Ping Slack if any of the nightly (scheduled) jobs failed. Scheduled runs only execute on
   # paradedb-enterprise (see the `if` on `setup`), so this notification only fires there.

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -191,7 +191,7 @@ jobs:
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -lvoidstar" \
           CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
-            cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH" --features antithesis
+            cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH" --features dst
 
       # Catch the broken-symbol case above before shipping to Antithesis.
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -404,7 +404,7 @@ jobs:
             antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '60') || '360' }}
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
             antithesis.source=paradedb
-            custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }}
+            custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }},logical-replication-publisher
             custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
             custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
 

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -191,7 +191,7 @@ jobs:
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -lvoidstar" \
           CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
-            cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH"
+            cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH" --features antithesis
 
       # Catch the broken-symbol case above before shipping to Antithesis.
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5503,6 +5503,7 @@ dependencies = [
 name = "pg_search"
 version = "0.24.3"
 dependencies = [
+ "antithesis_sdk",
  "anyhow",
  "arrow-array",
  "arrow-buffer",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -143,7 +143,23 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "antithesis_sdk"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08410fcac93669a476c006cd6c4512ac1e2b30fd117231a5d55d8a2c76599b82"
+dependencies = [
+ "libc",
+ "libloading",
+ "linkme",
+ "once_cell",
+ "rand 0.8.6",
+ "rustc_version_runtime",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -895,7 +911,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1784,6 +1800,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -2649,7 +2666,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2969,7 +2986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4153,7 +4170,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4683,6 +4700,26 @@ dependencies = [
  "rkyv 0.8.16",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "linkme"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83272d46373fb8decca684579ac3e7c8f3d71d4cc3aa693df8759e260ae41cf"
+dependencies = [
+ "linkme-impl",
+]
+
+[[package]]
+name = "linkme-impl"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32d59e20403c7d08fe62b4376edfe5c7fb2ef1e6b1465379686d0f21c8df444b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5303,7 +5340,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6191,7 +6228,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6863,6 +6900,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.37.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6899,7 +6946,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6957,7 +7004,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7386,7 +7433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7649,6 +7696,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 name = "stressgres"
 version = "0.24.3"
 dependencies = [
+ "antithesis_sdk",
  "anyhow",
  "clap",
  "csv",
@@ -7671,6 +7719,7 @@ dependencies = [
  "serde_json",
  "shutdown_hooks",
  "sysinfo 0.33.1",
+ "tempfile",
  "toml 0.8.23",
  "url",
 ]
@@ -8013,7 +8062,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8992,7 +9041,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -26,6 +26,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
     ca-certificates \
     postgresql-client \
     libpq5 \
+    util-linux \
     && rm -rf /var/lib/apt/lists/*
 
 # Create app user

--- a/docker/manifests/antithesis-paradedb.yaml
+++ b/docker/manifests/antithesis-paradedb.yaml
@@ -301,10 +301,11 @@ spec:
 ---
 # Vanilla Postgres publisher used by the logical-replication Stressgres suites.
 # Lives outside the CNPG cluster because real-world logical-replication
-# customers typically don't control the upstream primary. Network faults between
-# this pod and the paradedb cluster are intentionally still injected by
-# Antithesis; only container stop/kill faults on this pod are excluded (see the
-# trigger workflow).
+# customers typically don't control the upstream primary. Both network and
+# container stop/kill faults on this pod are excluded (see the trigger workflow):
+# partitioning or killing the publisher only stalls the WAL stream, so the
+# subscriber's row-count assertions fail on ordinary replication lag rather than
+# any ParadeDB defect.
 apiVersion: v1
 kind: Service
 metadata:

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-OI4sUd8UPVZGL9JaXp2o3+0zUA0VE0U+Dr7X0KDkBfg=";
+  cargoHash = "sha256-QRxvi8/v3ePepSqJ3bKHW8DCQjBtdR3t/0y9YwpjFWk=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-aVFRcY7oGJHxO+PGFKvXpmwTMquJyCxiGi/vPpNEUFo=";
+  cargoHash = "sha256-OI4sUd8UPVZGL9JaXp2o3+0zUA0VE0U+Dr7X0KDkBfg=";
 
   inherit cargo-pgrx postgresql;
 

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-QRxvi8/v3ePepSqJ3bKHW8DCQjBtdR3t/0y9YwpjFWk=";
+  cargoHash = "sha256-DPH15xkMHUsw0u51V3sdQ2xGTlgnEiUdIlaPi3jTHIA=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,9 +19,6 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = ["dep:proptest"]
 deferred_wal = []
-# Emit deterministic-simulation-testing (DST) assertions from bug-class code paths (e.g. a
-# background-merge crash), via the Antithesis SDK in `src/dst.rs`. Enabled only for the
-# instrumented build; a no-op everywhere else.
 dst = ["dep:antithesis_sdk"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 block_tracker = [] # for debugging when blocks are acquired and released

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,6 +19,9 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = ["dep:proptest"]
 deferred_wal = []
+# Emit Antithesis assertions from bug-class code paths (e.g. a background-merge crash).
+# Enabled only for the Antithesis-instrumented build; a no-op everywhere else.
+antithesis = ["dep:antithesis_sdk"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 block_tracker = [] # for debugging when blocks are acquired and released
 debug-logging = [
@@ -27,6 +30,9 @@ debug-logging = [
 
 [dependencies]
 async-trait = "0.1.89"
+antithesis_sdk = { version = "0.2.9", default-features = false, features = [
+  "full",
+], optional = true }
 stable_deref_trait = "1.2.1"
 anyhow = { version = "1.0.102", features = ["backtrace"] }
 arrow-array = "58.1.0"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,9 +19,10 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = ["dep:proptest"]
 deferred_wal = []
-# Emit Antithesis assertions from bug-class code paths (e.g. a background-merge crash).
-# Enabled only for the Antithesis-instrumented build; a no-op everywhere else.
-antithesis = ["dep:antithesis_sdk"]
+# Emit deterministic-simulation-testing (DST) assertions from bug-class code paths (e.g. a
+# background-merge crash), via the Antithesis SDK in `src/dst.rs`. Enabled only for the
+# instrumented build; a no-op everywhere else.
+dst = ["dep:antithesis_sdk"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 block_tracker = [] # for debugging when blocks are acquired and released
 debug-logging = [

--- a/pg_search/src/dst.rs
+++ b/pg_search/src/dst.rs
@@ -30,6 +30,18 @@
 #[cfg(feature = "dst")]
 use pgrx::pg_sys::panic::CaughtError;
 
+/// Register the DST assertion catalog for this process. The SDK requires this once per
+/// process that emits assertions; without it a never-hit `assert_unreachable!` passes
+/// vacuously instead of being reported. Called from `_PG_init`, so it runs in the
+/// postmaster and every forked backend/bgworker (`antithesis_init` is idempotent).
+#[cfg(feature = "dst")]
+pub(crate) fn init() {
+    antithesis_sdk::antithesis_init();
+}
+
+#[cfg(not(feature = "dst"))]
+pub(crate) fn init() {}
+
 /// The DST details payload for a background-merge worker crash, or `None` when `caught` is
 /// not a bug.
 ///

--- a/pg_search/src/dst.rs
+++ b/pg_search/src/dst.rs
@@ -1,0 +1,90 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Deterministic-simulation-testing (DST) hooks.
+//!
+//! The only module that talks to the DST vendor SDK (Antithesis), pulled in as
+//! the optional `antithesis_sdk` dependency.
+//!
+//! Built only under `--features dst` (the instrumented build); a no-op everywhere else,
+//! so production `pg_search` never links the SDK.
+//!
+//! [`report_merge_crash!`] is a forwarding macro, not a function, so the SDK captures the
+//! assertion's location at the call site (`background_merge`) rather than here. The
+//! bug-class classification stays in the `merge_crash_details` function.
+
+#[cfg(feature = "dst")]
+use pgrx::pg_sys::panic::CaughtError;
+
+/// The DST details payload for a background-merge worker crash, or `None` when `caught` is
+/// not a bug.
+///
+/// Returns `Some` only for bug-class errors — internal-error / corruption SQLSTATEs and
+/// Rust panics. An interrupt-driven cancellation is not a bug and never reaches here:
+/// `merge_index` downgrades it to a `warning!`, so the faults we deliberately inject do
+/// not trip the assertion.
+#[cfg(feature = "dst")]
+pub(crate) fn merge_crash_details(caught: &CaughtError) -> Option<serde_json::Value> {
+    use pgrx::PgSqlErrorCode::*;
+
+    let report = match caught {
+        // A Rust panic (a failed `expect`, or the `panic!("failed to merge…")` in
+        // `merge_index`) is always a bug.
+        CaughtError::RustPanic { ereport, .. } => ereport,
+        // A Postgres/ereport error is a bug only when it is an internal error or
+        // corruption; cancellations, shutdowns and connection faults are the chaos we
+        // are injecting, not defects.
+        CaughtError::PostgresError(report) | CaughtError::ErrorReport(report) => {
+            if !matches!(
+                report.sql_error_code(),
+                ERRCODE_INTERNAL_ERROR
+                    | ERRCODE_DATA_CORRUPTED
+                    | ERRCODE_INDEX_CORRUPTED
+                    | ERRCODE_ASSERT_FAILURE
+            ) {
+                return None;
+            }
+            report
+        }
+    };
+
+    Some(serde_json::json!({
+        "sqlstate": format!("{:?}", report.sql_error_code()),
+        "message": report.message(),
+    }))
+}
+
+/// Unreachable: surface a background-merge worker crash as an invariant violation so the
+/// run fails instead of silently passing on a crash that only ever reached the container's
+/// stdout.
+#[cfg(feature = "dst")]
+macro_rules! report_merge_crash {
+    ($caught:expr) => {
+        if let Some(details) = $crate::dst::merge_crash_details($caught) {
+            ::antithesis_sdk::assert_unreachable!("pg_search background merge crashed", &details);
+        }
+    };
+}
+
+#[cfg(not(feature = "dst"))]
+macro_rules! report_merge_crash {
+    ($caught:expr) => {{
+        let _ = $caught;
+    }};
+}
+
+pub(crate) use report_merge_crash;

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -19,6 +19,7 @@
 mod aggregate;
 mod api;
 mod bootstrap;
+mod dst;
 mod index;
 mod postgres;
 mod query;

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -123,6 +123,11 @@ pub unsafe extern "C-unwind" fn _PG_init() {
         error!("pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to shared_preload_libraries in postgresql.conf and restart Postgres.");
     }
 
+    // Register the DST assertion catalog for this process (a no-op outside `--features dst`).
+    // Runs here so every backend/bgworker that emits an Antithesis assertion has initialised
+    // the SDK; otherwise a never-hit assertion passes vacuously.
+    crate::dst::init();
+
     postgres::options::init();
     gucs::init();
 

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -123,9 +123,7 @@ pub unsafe extern "C-unwind" fn _PG_init() {
         error!("pg_search must be loaded via shared_preload_libraries. Add 'pg_search' to shared_preload_libraries in postgresql.conf and restart Postgres.");
     }
 
-    // Register the DST assertion catalog for this process (a no-op outside `--features dst`).
-    // Runs here so every backend/bgworker that emits an Antithesis assertion has initialised
-    // the SDK; otherwise a never-hit assertion passes vacuously.
+    // Register the DST assertion catalog for this process (a no-op outside `--features dst`)
     crate::dst::init();
 
     postgres::options::init();

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -393,9 +393,63 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
                 next_xid,
             )
         }))
+        // A crash here dies in this background worker: it never reaches a client
+        // connection, and Postgres logs only to the container's stdout, so nothing
+        // outside would fail on it. Report it to Antithesis before rethrowing so the
+        // fuzzer's run fails instead of silently passing. Rethrowing preserves the
+        // existing behaviour (Postgres logs the error and the worker exits).
+        .catch_others(|caught| {
+            report_background_merge_crash(&caught);
+            caught.rethrow()
+        })
         .execute();
     })
 }
+
+/// Under Antithesis, surface a background-merge crash as an assertion failure.
+///
+/// We fire only for bug-class errors — internal-error / corruption SQLSTATEs (class
+/// `XX`) and Rust panics. An interrupt-driven cancellation is not a bug and never
+/// reaches here: [`merge_index`] downgrades it to a `warning!` (see the
+/// `check_for_interrupts!` before it re-raises a merge error), so the faults we
+/// deliberately inject do not trip the assertion.
+#[cfg(feature = "antithesis")]
+fn report_background_merge_crash(caught: &pg_sys::panic::CaughtError) {
+    use pg_sys::panic::CaughtError;
+    use pgrx::PgSqlErrorCode::*;
+
+    let report = match caught {
+        // A Rust panic (a failed `expect`, or the `panic!("failed to merge…")` in
+        // `merge_index`) is always a bug.
+        CaughtError::RustPanic { ereport, .. } => ereport,
+        // A Postgres/ereport error is a bug only when it is an internal error or
+        // corruption; cancellations, shutdowns and connection faults are the chaos we
+        // are injecting, not defects.
+        CaughtError::PostgresError(report) | CaughtError::ErrorReport(report) => {
+            if !matches!(
+                report.sql_error_code(),
+                ERRCODE_INTERNAL_ERROR
+                    | ERRCODE_DATA_CORRUPTED
+                    | ERRCODE_INDEX_CORRUPTED
+                    | ERRCODE_ASSERT_FAILURE
+            ) {
+                return;
+            }
+            report
+        }
+    };
+
+    antithesis_sdk::assert_unreachable!(
+        "pg_search background merge crashed",
+        &serde_json::json!({
+            "sqlstate": format!("{:?}", report.sql_error_code()),
+            "message": report.message(),
+        })
+    );
+}
+
+#[cfg(not(feature = "antithesis"))]
+fn report_background_merge_crash(_caught: &pg_sys::panic::CaughtError) {}
 
 #[inline]
 #[allow(clippy::too_many_arguments)]

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -395,61 +395,16 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
         }))
         // A crash here dies in this background worker: it never reaches a client
         // connection, and Postgres logs only to the container's stdout, so nothing
-        // outside would fail on it. Report it to Antithesis before rethrowing so the
+        // outside would fail on it. Report it to the DST harness before rethrowing so the
         // fuzzer's run fails instead of silently passing. Rethrowing preserves the
         // existing behaviour (Postgres logs the error and the worker exits).
         .catch_others(|caught| {
-            report_background_merge_crash(&caught);
+            crate::dst::report_merge_crash!(&caught);
             caught.rethrow()
         })
         .execute();
     })
 }
-
-/// Under Antithesis, surface a background-merge crash as an assertion failure.
-///
-/// We fire only for bug-class errors — internal-error / corruption SQLSTATEs (class
-/// `XX`) and Rust panics. An interrupt-driven cancellation is not a bug and never
-/// reaches here: [`merge_index`] downgrades it to a `warning!` (see the
-/// `check_for_interrupts!` before it re-raises a merge error), so the faults we
-/// deliberately inject do not trip the assertion.
-#[cfg(feature = "antithesis")]
-fn report_background_merge_crash(caught: &pg_sys::panic::CaughtError) {
-    use pg_sys::panic::CaughtError;
-    use pgrx::PgSqlErrorCode::*;
-
-    let report = match caught {
-        // A Rust panic (a failed `expect`, or the `panic!("failed to merge…")` in
-        // `merge_index`) is always a bug.
-        CaughtError::RustPanic { ereport, .. } => ereport,
-        // A Postgres/ereport error is a bug only when it is an internal error or
-        // corruption; cancellations, shutdowns and connection faults are the chaos we
-        // are injecting, not defects.
-        CaughtError::PostgresError(report) | CaughtError::ErrorReport(report) => {
-            if !matches!(
-                report.sql_error_code(),
-                ERRCODE_INTERNAL_ERROR
-                    | ERRCODE_DATA_CORRUPTED
-                    | ERRCODE_INDEX_CORRUPTED
-                    | ERRCODE_ASSERT_FAILURE
-            ) {
-                return;
-            }
-            report
-        }
-    };
-
-    antithesis_sdk::assert_unreachable!(
-        "pg_search background merge crashed",
-        &serde_json::json!({
-            "sqlstate": format!("{:?}", report.sql_error_code()),
-            "message": report.message(),
-        })
-    );
-}
-
-#[cfg(not(feature = "antithesis"))]
-fn report_background_merge_crash(_caught: &pg_sys::panic::CaughtError) {}
 
 #[inline]
 #[allow(clippy::too_many_arguments)]

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -36,7 +36,9 @@ toml = "0.8.23"
 url = "2.5.8"
 postgres-openssl = "0.5.3"
 openssl = "0.10.78"
-antithesis_sdk = { version = "0.2.9", default-features = false, features = ["full"] }
+antithesis_sdk = { version = "0.2.9", default-features = false, features = [
+  "full",
+] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/stressgres/Cargo.toml
+++ b/stressgres/Cargo.toml
@@ -36,3 +36,7 @@ toml = "0.8.23"
 url = "2.5.8"
 postgres-openssl = "0.5.3"
 openssl = "0.10.78"
+antithesis_sdk = { version = "0.2.9", default-features = false, features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3.27.0"

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -15,9 +15,48 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::fault_tolerance::GraceWindow;
 use crate::suite::PgVersion;
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+use std::time::Duration;
+
+/// Reconnect-grace options, shared by the `ui` and `headless` subcommands.
+#[derive(Debug, Args)]
+pub struct ReconnectGraceArgs {
+    /// How long (in milliseconds) to tolerate one continuous transient database fault
+    /// (dropped/refused sockets, server restarting) by reconnecting before failing the
+    /// run. The window restarts after a successful reconnect. Defaults to 0, i.e. any
+    /// error fails the run immediately.
+    ///
+    /// Under fault injection set this longer than `--runtime`, so a connectivity fault
+    /// can never fail the run, and pair it with `--reconnect-grace-file`: any window
+    /// shorter than the run is one the fault injector can outlast, so liveness has to be
+    /// asserted while faults are healed rather than guessed at while they are active.
+    #[arg(long, default_value = "0")]
+    pub reconnect_grace: u64,
+
+    /// Path to a file whose contents (a count of milliseconds) override
+    /// `--reconnect-grace` for as long as it exists, re-read on every failed attempt.
+    ///
+    /// This is how an external supervisor narrows the window at runtime. Under Antithesis
+    /// the `anytime_recovery_liveness` command heals every fault and then writes a shorter
+    /// window here, so the run fails only if the database was provably reachable and the
+    /// workload still could not make progress.
+    #[arg(long)]
+    pub reconnect_grace_file: Option<PathBuf>,
+}
+
+impl ReconnectGraceArgs {
+    /// The grace window these options describe.
+    pub fn window(&self) -> GraceWindow {
+        let baseline = Duration::from_millis(self.reconnect_grace);
+        match self.reconnect_grace_file.clone() {
+            Some(file) => GraceWindow::pokeable(baseline, file),
+            None => GraceWindow::fixed(baseline),
+        }
+    }
+}
 
 /// Stress testing for ParadeDB/PostgreSQL
 #[derive(Debug, Parser)]
@@ -61,27 +100,8 @@ pub struct UiArgs {
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
 
-    /// How long (in milliseconds) to tolerate one continuous transient database fault
-    /// (dropped/refused sockets, server restarting) by reconnecting before failing the
-    /// run. The window restarts after a successful reconnect. Defaults to 0, i.e. any
-    /// error fails the run immediately.
-    ///
-    /// Under fault injection set this longer than `--runtime`, so a connectivity fault
-    /// can never fail the run, and pair it with `--reconnect-grace-file`: any window
-    /// shorter than the run is one the fault injector can outlast, so liveness has to be
-    /// asserted while faults are healed rather than guessed at while they are active.
-    #[arg(long, default_value = "0")]
-    pub reconnect_grace: u64,
-
-    /// Path to a file whose contents (a count of milliseconds) override
-    /// `--reconnect-grace` for as long as it exists, re-read on every failed attempt.
-    ///
-    /// This is how an external supervisor narrows the window at runtime. Under Antithesis
-    /// the `anytime_recovery_liveness` command heals every fault and then writes a shorter
-    /// window here, so the run fails only if the database was provably reachable and the
-    /// workload still could not make progress.
-    #[arg(long)]
-    pub reconnect_grace_file: Option<PathBuf>,
+    #[command(flatten)]
+    pub grace: ReconnectGraceArgs,
 }
 
 /// Arguments for running the suite in headless mode.
@@ -102,27 +122,8 @@ pub struct HeadlessArgs {
     /// PostgreSQL version to use (pg15, pg16, pg17, or pg18).
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
-    /// How long (in milliseconds) to tolerate one continuous transient database fault
-    /// (dropped/refused sockets, server restarting) by reconnecting before failing the
-    /// run. The window restarts after a successful reconnect. Defaults to 0, i.e. any
-    /// error fails the run immediately.
-    ///
-    /// Under fault injection set this longer than `--runtime`, so a connectivity fault
-    /// can never fail the run, and pair it with `--reconnect-grace-file`: any window
-    /// shorter than the run is one the fault injector can outlast, so liveness has to be
-    /// asserted while faults are healed rather than guessed at while they are active.
-    #[arg(long, default_value = "0")]
-    pub reconnect_grace: u64,
-
-    /// Path to a file whose contents (a count of milliseconds) override
-    /// `--reconnect-grace` for as long as it exists, re-read on every failed attempt.
-    ///
-    /// This is how an external supervisor narrows the window at runtime. Under Antithesis
-    /// the `anytime_recovery_liveness` command heals every fault and then writes a shorter
-    /// window here, so the run fails only if the database was provably reachable and the
-    /// workload still could not make progress.
-    #[arg(long)]
-    pub reconnect_grace_file: Option<PathBuf>,
+    #[command(flatten)]
+    pub grace: ReconnectGraceArgs,
 }
 
 /// Arguments for parsing a log file and generating the desired charts.

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -66,10 +66,22 @@ pub struct UiArgs {
     /// run. The window restarts after a successful reconnect. Defaults to 0, i.e. any
     /// error fails the run immediately.
     ///
-    /// Set this when the database is expected to go away and come back, e.g. under a
-    /// fault injector that stops, kills, or partitions its container.
+    /// Under fault injection set this longer than `--runtime`, so a connectivity fault
+    /// can never fail the run, and pair it with `--reconnect-grace-file`: any window
+    /// shorter than the run is one the fault injector can outlast, so liveness has to be
+    /// asserted while faults are healed rather than guessed at while they are active.
     #[arg(long, default_value = "0")]
     pub reconnect_grace: u64,
+
+    /// Path to a file whose contents (a count of milliseconds) override
+    /// `--reconnect-grace` for as long as it exists, re-read on every failed attempt.
+    ///
+    /// This is how an external supervisor narrows the window at runtime. Under Antithesis
+    /// the `anytime_recovery_liveness` command heals every fault and then writes a shorter
+    /// window here, so the run fails only if the database was provably reachable and the
+    /// workload still could not make progress.
+    #[arg(long)]
+    pub reconnect_grace_file: Option<PathBuf>,
 }
 
 /// Arguments for running the suite in headless mode.
@@ -95,10 +107,22 @@ pub struct HeadlessArgs {
     /// run. The window restarts after a successful reconnect. Defaults to 0, i.e. any
     /// error fails the run immediately.
     ///
-    /// Set this when the database is expected to go away and come back, e.g. under a
-    /// fault injector that stops, kills, or partitions its container.
+    /// Under fault injection set this longer than `--runtime`, so a connectivity fault
+    /// can never fail the run, and pair it with `--reconnect-grace-file`: any window
+    /// shorter than the run is one the fault injector can outlast, so liveness has to be
+    /// asserted while faults are healed rather than guessed at while they are active.
     #[arg(long, default_value = "0")]
     pub reconnect_grace: u64,
+
+    /// Path to a file whose contents (a count of milliseconds) override
+    /// `--reconnect-grace` for as long as it exists, re-read on every failed attempt.
+    ///
+    /// This is how an external supervisor narrows the window at runtime. Under Antithesis
+    /// the `anytime_recovery_liveness` command heals every fault and then writes a shorter
+    /// window here, so the run fails only if the database was provably reachable and the
+    /// workload still could not make progress.
+    #[arg(long)]
+    pub reconnect_grace_file: Option<PathBuf>,
 }
 
 /// Arguments for parsing a log file and generating the desired charts.

--- a/stressgres/src/dst.rs
+++ b/stressgres/src/dst.rs
@@ -1,0 +1,66 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Deterministic-simulation-testing (DST) hooks.
+//!
+//! The only module that talks to the DST vendor SDK (Antithesis), pulled in as
+//! `antithesis_sdk`.
+//!
+//! The assertion wrappers are forwarding macros, not functions, so the SDK captures each
+//! assertion's location at the real call site rather than here in `dst.rs`. The lifecycle
+//! calls carry no location, so they stay plain functions.
+//!
+//! Stressgres links the SDK unconditionally: it is test-only tooling, and the SDK is a
+//! runtime no-op outside the DST environment, so there is no feature gate here (unlike
+//! `pg_search`, which gates its equivalent module behind `--features dst`).
+
+use serde_json::json;
+
+/// Register the assertion catalog so the harness knows which sites exist but were never
+/// hit, instead of a never-reached assertion passing vacuously. Call once at startup.
+pub fn init() {
+    antithesis_sdk::antithesis_init();
+}
+
+/// Signal that setup finished and the workload is about to start. The harness holds fault
+/// injection until this fires, so every suite gets a clean startup and actually runs its
+/// workload rather than being killed mid-initialisation.
+pub fn setup_complete(suite: &str) {
+    antithesis_sdk::lifecycle::setup_complete(&json!({ "suite": suite }));
+}
+
+/// Reachability: mark that the workload retried and rode out a transient database fault.
+/// A run where this is never hit exercised no fault and proves nothing about recovery.
+macro_rules! retried_transient_fault {
+    () => {
+        ::antithesis_sdk::assert_reachable!("stressgres retried a transient database fault")
+    };
+}
+pub(crate) use retried_transient_fault;
+
+/// Sometimes: `$narrowed` is true when a recovery poke shrank the grace window during an
+/// active fault — the only situation in which the liveness check can actually fail, so it
+/// must hold true at least once across the fault search or the check proved nothing.
+macro_rules! poke_narrowed_window {
+    ($narrowed:expr) => {
+        ::antithesis_sdk::assert_sometimes!(
+            $narrowed,
+            "a recovery poke narrowed the grace window during an active database fault"
+        )
+    };
+}
+pub(crate) use poke_narrowed_window;

--- a/stressgres/src/dst.rs
+++ b/stressgres/src/dst.rs
@@ -21,26 +21,17 @@
 //! `antithesis_sdk`.
 //!
 //! The assertion wrappers are forwarding macros, not functions, so the SDK captures each
-//! assertion's location at the real call site rather than here in `dst.rs`. The lifecycle
-//! calls carry no location, so they stay plain functions.
+//! assertion's location at the real call site rather than here in `dst.rs`. [`init`] carries
+//! no location, so it stays a plain function.
 //!
 //! Stressgres links the SDK unconditionally: it is test-only tooling, and the SDK is a
 //! runtime no-op outside the DST environment, so there is no feature gate here (unlike
 //! `pg_search`, which gates its equivalent module behind `--features dst`).
 
-use serde_json::json;
-
 /// Register the assertion catalog so the harness knows which sites exist but were never
 /// hit, instead of a never-reached assertion passing vacuously. Call once at startup.
 pub fn init() {
     antithesis_sdk::antithesis_init();
-}
-
-/// Signal that setup finished and the workload is about to start. The harness holds fault
-/// injection until this fires, so every suite gets a clean startup and actually runs its
-/// workload rather than being killed mid-initialisation.
-pub fn setup_complete(suite: &str) {
-    antithesis_sdk::lifecycle::setup_complete(&json!({ "suite": suite }));
 }
 
 /// Reachability: mark that the workload retried and rode out a transient database fault.

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -36,7 +36,6 @@
 //! When a non-zero grace is enabled, bug detection is expected to come from Antithesis
 //! properties / postgres-side checks, not from stressgres exit codes.
 
-use antithesis_sdk::{assert_reachable, assert_sometimes};
 use anyhow::Result;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -255,12 +254,9 @@ pub(crate) fn tolerate_transient<T>(
 
                 // A narrower window means the supervisor healed the faults and started
                 // the recovery clock while we were down, which is the only situation in
-                // which the liveness check can actually fail. If Antithesis never
+                // which the liveness check can actually fail. If the harness never
                 // reaches it, the check passed vacuously and proved nothing.
-                assert_sometimes!(
-                    last_grace.is_some_and(|last| grace < last),
-                    "a recovery poke narrowed the grace window during an active database fault"
-                );
+                crate::dst::poke_narrowed_window!(last_grace.is_some_and(|last| grace < last));
                 // No symmetric "widened during a fault" assertion: the only widening is the
                 // supervisor restoring the baseline, which happens deep in the healed quiet
                 // period with no active fault to observe it. That path is pinned by the
@@ -280,7 +276,7 @@ pub(crate) fn tolerate_transient<T>(
                         down_since.elapsed()
                     )));
                 }
-                assert_reachable!("stressgres retried a transient database fault");
+                crate::dst::retried_transient_fault!();
                 eprintln!("stressgres: transient database fault, retrying: {e:#}");
                 interruptible_sleep(alive, backoff);
                 backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -210,30 +210,20 @@ impl TransientProgress {
 
 /// Runs `op`, tolerating transient connectivity faults for as long as `grace` allows:
 /// while `op` keeps failing with a transient error (a dropped/refused socket, server
-/// restarting, etc.) it is retried with capped backoff. A real (non-transient) error
-/// is returned immediately. The connection is only declared dropped — and the error
-/// surfaced — once it has stayed broken for the whole grace window continuously.
-///
-/// The connection is only declared dropped — and the error surfaced — once it has
-/// stayed broken for the whole window continuously.
+/// restarting, etc.) it is retried with capped backoff. A real (non-transient) error is
+/// returned immediately. The fault is only surfaced once the connection has stayed
+/// broken for the whole grace window continuously.
 ///
 /// The window is re-read on every failed attempt, and the clock restarts whenever it
-/// changes. That reset is what makes an external poke meaningful: a supervisor that
-/// heals all faults and *then* narrows the window is asking "can you reconnect within N
-/// seconds of now", not "were you already down N seconds ago", and without the reset a
-/// database that had been unreachable for ten minutes would fail on the very next
-/// attempt. The clock also restarts when `op` calls
-/// [`TransientProgress::mark_recovered`] before returning a later transient error,
-/// because the database recovered in between.
+/// changes or `op` calls [`TransientProgress::mark_recovered`]. That reset is what lets
+/// an external poke narrow the window mid-fault: it asks "can you reconnect within N
+/// seconds of now", not "were you already down N seconds ago".
 ///
-/// With a zero window, the default, any error fails the run immediately and unwrapped,
-/// exactly as it did before this module existed. A non-zero grace is opt-in via
-/// `--reconnect-grace`.
+/// With a zero window, the default, any error fails the run immediately, as it did
+/// before this module existed. A non-zero grace is opt-in via `--reconnect-grace`.
 ///
-/// This is the single place reconnection lives. Callers express *what* to do (probe
-/// the version, run setup, run one job iteration); reopening a dead connection is
-/// the caller's job inside `op`, and re-running the whole `op` is what makes this
-/// safe for transactional work — a lost transaction is simply replayed from scratch.
+/// Reopening a dead connection is the caller's job inside `op`; re-running the whole
+/// `op` is what keeps this safe for transactional work — a lost transaction is replayed.
 ///
 /// Returns `Ok(None)` if `alive` went false while we were waiting out a fault.
 pub(crate) fn tolerate_transient<T>(
@@ -553,6 +543,4 @@ mod tests {
         assert_eq!(result, Some("ok"));
         assert_eq!(attempts, 4);
     }
-
-    // appended temporarily to fault_tolerance.rs tests
 }

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -50,10 +50,8 @@ const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
 /// How long a continuous transient fault may last before the run fails.
 ///
 /// The window has a `baseline`, fixed at startup, and an optional `file` that overrides
-/// it for as long as the file exists. The file is how an external supervisor — under
-/// Antithesis, an `anytime_` test command that has just healed every fault — narrows
-/// the window to one the workload is actually expected to meet, turning an
-/// unfalsifiable timeout into a liveness assertion. Deleting the file restores the
+/// it for as long as the file exists — the poke channel an external supervisor uses to
+/// narrow the window at runtime (see the module docs). Deleting the file restores the
 /// baseline, so the supervisor never has to know what it was.
 ///
 /// It is only read on the error path, so a healthy run never touches it.
@@ -64,8 +62,8 @@ pub(crate) struct GraceWindow {
 }
 
 impl GraceWindow {
-    /// A window that never changes. `Duration::ZERO` is the default, under which any
-    /// error fails the run immediately.
+    /// A window that never changes. `Duration::ZERO` is the default (fail on the first
+    /// error).
     pub(crate) fn fixed(baseline: Duration) -> Self {
         Self {
             baseline,
@@ -113,6 +111,10 @@ impl GraceWindow {
 
 /// Substrings that identify a transient connectivity failure when all we have is a
 /// stringified error (e.g. one already flattened by `format_postgres_error`).
+///
+/// The `(sqlstate: ...` needles must mirror the connection-class codes in
+/// [`is_transient_connection_error`]; this is the fallback for errors that have lost
+/// their structured `postgres::Error`, so keep the two lists in sync.
 const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
     "network is unreachable",
     "no route to host",
@@ -131,6 +133,7 @@ const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
     "(sqlstate: 57p01", // admin_shutdown
     "(sqlstate: 57p02", // crash_shutdown
     "(sqlstate: 57p03", // cannot_connect_now
+    "(sqlstate: 57p05", // idle_session_timeout
 ];
 
 fn message_looks_transient(msg: &str) -> bool {
@@ -157,8 +160,9 @@ fn is_transient_connection_error(e: &postgres::Error) -> bool {
     match e.as_db_error() {
         Some(db) => {
             let code = db.code().code();
-            // Class 08 = connection exception; 57P0x = operator/crash shutdown and
-            // "cannot connect now" (server starting up / shutting down).
+            // Class 08 = connection exception; 57P0x = operator/crash shutdown,
+            // "cannot connect now" (server starting up / shutting down), and idle-session
+            // timeout — all cases where the connection is gone and reconnecting is right.
             code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05")
         }
         // Client-side/transport failure: no answer from the server, so it never got
@@ -219,9 +223,6 @@ impl TransientProgress {
 /// an external poke narrow the window mid-fault: it asks "can you reconnect within N
 /// seconds of now", not "were you already down N seconds ago".
 ///
-/// With a zero window, the default, any error fails the run immediately, as it did
-/// before this module existed. A non-zero grace is opt-in via `--reconnect-grace`.
-///
 /// Reopening a dead connection is the caller's job inside `op`; re-running the whole
 /// `op` is what keeps this safe for transactional work — a lost transaction is replayed.
 ///
@@ -260,12 +261,10 @@ pub(crate) fn tolerate_transient<T>(
                     last_grace.is_some_and(|last| grace < last),
                     "a recovery poke narrowed the grace window during an active database fault"
                 );
-                // There is deliberately no symmetric "widened during a fault" assertion.
-                // The window is only read here, on the error path, and the only widening is
-                // the supervisor restoring the baseline — which it does deep inside the healed
-                // quiet period, once the fault is long gone, so no active fault is ever riding
-                // out a widen for us to observe. The widen-resets-the-clock behaviour is pinned
-                // by the `widening_the_window_also_restarts_the_clock` test instead.
+                // No symmetric "widened during a fault" assertion: the only widening is the
+                // supervisor restoring the baseline, which happens deep in the healed quiet
+                // period with no active fault to observe it. That path is pinned by the
+                // `widening_the_window_also_restarts_the_clock` test instead.
                 if progress.recovered || last_grace.is_some_and(|last| last != grace) {
                     down_since = None;
                     backoff = INITIAL_RECONNECT_BACKOFF;

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -26,7 +26,7 @@
 //! The grace defaults to zero, under which any error fails the run, so this is inert
 //! unless a caller opts in with `--reconnect-grace`.
 //!
-//! Under fault injection the grace is set larger than the run itself, so a connectivity
+//! Under fault injection the grace should be set larger than the run itself, so a connectivity
 //! fault can never fail the run: Antithesis searches for the fault schedule that breaks
 //! us, so any window shorter than the run is one it can outlast. Liveness is instead
 //! asserted from the outside: the `anytime_recovery_liveness` test command heals every

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -260,12 +260,12 @@ pub(crate) fn tolerate_transient<T>(
                     last_grace.is_some_and(|last| grace < last),
                     "a recovery poke narrowed the grace window during an active database fault"
                 );
-                // The other direction: widening resets the clock too, so a quiet period
-                // ending mid-fault drops back to riding the fault out.
-                assert_sometimes!(
-                    last_grace.is_some_and(|last| grace > last),
-                    "a recovery poke widened the grace window during an active database fault"
-                );
+                // There is deliberately no symmetric "widened during a fault" assertion.
+                // The window is only read here, on the error path, and the only widening is
+                // the supervisor restoring the baseline — which it does deep inside the healed
+                // quiet period, once the fault is long gone, so no active fault is ever riding
+                // out a widen for us to observe. The widen-resets-the-clock behaviour is pinned
+                // by the `widening_the_window_also_restarts_the_clock` test instead.
                 if progress.recovered || last_grace.is_some_and(|last| last != grace) {
                     down_since = None;
                     backoff = INITIAL_RECONNECT_BACKOFF;

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -36,7 +36,7 @@
 //! When a non-zero grace is enabled, bug detection is expected to come from Antithesis
 //! properties / postgres-side checks, not from stressgres exit codes.
 
-use antithesis_sdk::assert_reachable;
+use antithesis_sdk::{assert_reachable, assert_sometimes};
 use anyhow::Result;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -255,12 +255,17 @@ pub(crate) fn tolerate_transient<T>(
                 // A narrower window means the supervisor healed the faults and started
                 // the recovery clock while we were down, which is the only situation in
                 // which the liveness check can actually fail. If Antithesis never
-                // reaches this, the check passed vacuously and proved nothing.
-                if last_grace.is_some_and(|last| grace < last) {
-                    assert_reachable!(
-                        "a recovery poke narrowed the grace window during an active database fault"
-                    );
-                }
+                // reaches it, the check passed vacuously and proved nothing.
+                assert_sometimes!(
+                    last_grace.is_some_and(|last| grace < last),
+                    "a recovery poke narrowed the grace window during an active database fault"
+                );
+                // The other direction: widening resets the clock too, so a quiet period
+                // ending mid-fault drops back to riding the fault out.
+                assert_sometimes!(
+                    last_grace.is_some_and(|last| grace > last),
+                    "a recovery poke widened the grace window during an active database fault"
+                );
                 if progress.recovered || last_grace.is_some_and(|last| last != grace) {
                     down_since = None;
                     backoff = INITIAL_RECONNECT_BACKOFF;

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -26,10 +26,19 @@
 //! The grace defaults to zero, under which any error fails the run, so this is inert
 //! unless a caller opts in with `--reconnect-grace`.
 //!
+//! Under fault injection the grace is set larger than the run itself, so a connectivity
+//! fault can never fail the run: Antithesis searches for the fault schedule that breaks
+//! us, so any window shorter than the run is one it can outlast. Liveness is instead
+//! asserted from the outside: the `anytime_recovery_liveness` test command heals every
+//! fault, then narrows the [`GraceWindow`] via its poke file to a window that *can*
+//! expire. See `stressgres/suites/antithesis/`.
+//!
 //! When a non-zero grace is enabled, bug detection is expected to come from Antithesis
 //! properties / postgres-side checks, not from stressgres exit codes.
 
+use antithesis_sdk::assert_reachable;
 use anyhow::Result;
+use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -37,6 +46,70 @@ use std::time::{Duration, Instant};
 /// Backoff bounds for retries within the reconnect grace window.
 const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
 const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+
+/// How long a continuous transient fault may last before the run fails.
+///
+/// The window has a `baseline`, fixed at startup, and an optional `file` that overrides
+/// it for as long as the file exists. The file is how an external supervisor — under
+/// Antithesis, an `anytime_` test command that has just healed every fault — narrows
+/// the window to one the workload is actually expected to meet, turning an
+/// unfalsifiable timeout into a liveness assertion. Deleting the file restores the
+/// baseline, so the supervisor never has to know what it was.
+///
+/// It is only read on the error path, so a healthy run never touches it.
+#[derive(Clone, Debug)]
+pub(crate) struct GraceWindow {
+    baseline: Duration,
+    file: Option<PathBuf>,
+}
+
+impl GraceWindow {
+    /// A window that never changes. `Duration::ZERO` is the default, under which any
+    /// error fails the run immediately.
+    pub(crate) fn fixed(baseline: Duration) -> Self {
+        Self {
+            baseline,
+            file: None,
+        }
+    }
+
+    /// A window that `file` may narrow or widen at any time. A missing, unreadable, or
+    /// malformed file falls back to `baseline` — a supervisor that has not run yet, or
+    /// a half-written file, must not be able to fail the run.
+    pub(crate) fn pokeable(baseline: Duration, file: PathBuf) -> Self {
+        Self {
+            baseline,
+            file: Some(file),
+        }
+    }
+
+    /// Parses a count of milliseconds, as written to the poke file.
+    fn parse_ms(s: &str) -> Result<Duration> {
+        let s = s.trim();
+        Ok(Duration::from_millis(s.parse::<u64>().map_err(|_| {
+            anyhow::anyhow!("expected a count of milliseconds, got `{s}`")
+        })?))
+    }
+
+    /// The window in force right now.
+    fn current(&self) -> Duration {
+        let Some(file) = self.file.as_ref() else {
+            return self.baseline;
+        };
+        match std::fs::read_to_string(file) {
+            Ok(contents) => Self::parse_ms(&contents).unwrap_or_else(|e| {
+                eprintln!(
+                    "stressgres: ignoring malformed grace file {}: {e:#}",
+                    file.display()
+                );
+                self.baseline
+            }),
+            // Absent (the supervisor has not run, or has restored the baseline), or we
+            // lost a race with its atomic rename.
+            Err(_) => self.baseline,
+        }
+    }
+}
 
 /// Substrings that identify a transient connectivity failure when all we have is a
 /// stringified error (e.g. one already flattened by `format_postgres_error`).
@@ -139,9 +212,23 @@ impl TransientProgress {
 /// while `op` keeps failing with a transient error (a dropped/refused socket, server
 /// restarting, etc.) it is retried with capped backoff. A real (non-transient) error
 /// is returned immediately. The connection is only declared dropped — and the error
-/// surfaced — once it has stayed broken for `grace` continuously. If `op` calls
-/// [`TransientProgress::mark_recovered`] before returning a later transient error, the
-/// window restarts, because the database recovered in between.
+/// surfaced — once it has stayed broken for the whole grace window continuously.
+///
+/// The connection is only declared dropped — and the error surfaced — once it has
+/// stayed broken for the whole window continuously.
+///
+/// The window is re-read on every failed attempt, and the clock restarts whenever it
+/// changes. That reset is what makes an external poke meaningful: a supervisor that
+/// heals all faults and *then* narrows the window is asking "can you reconnect within N
+/// seconds of now", not "were you already down N seconds ago", and without the reset a
+/// database that had been unreachable for ten minutes would fail on the very next
+/// attempt. The clock also restarts when `op` calls
+/// [`TransientProgress::mark_recovered`] before returning a later transient error,
+/// because the database recovered in between.
+///
+/// With a zero window, the default, any error fails the run immediately and unwrapped,
+/// exactly as it did before this module existed. A non-zero grace is opt-in via
+/// `--reconnect-grace`.
 ///
 /// This is the single place reconnection lives. Callers express *what* to do (probe
 /// the version, run setup, run one job iteration); reopening a dead connection is
@@ -151,17 +238,19 @@ impl TransientProgress {
 /// Returns `Ok(None)` if `alive` went false while we were waiting out a fault.
 pub(crate) fn tolerate_transient<T>(
     alive: &AtomicBool,
-    grace: Duration,
+    grace: &GraceWindow,
     mut op: impl FnMut(&mut TransientProgress) -> Result<T>,
 ) -> Result<Option<T>> {
     let mut backoff = INITIAL_RECONNECT_BACKOFF;
     let mut down_since: Option<Instant> = None;
+    let mut last_grace: Option<Duration> = None;
     loop {
         let mut progress = TransientProgress::default();
         match op(&mut progress) {
             Ok(value) => return Ok(Some(value)),
             Err(e) if !is_transient_error(&e) => return Err(e),
             Err(e) => {
+                let grace = grace.current();
                 // Checked before `alive`, so that a zero grace fails the run on the
                 // first error even during shutdown. With a real grace we would rather
                 // abandon a fault we are waiting out than block teardown for the whole
@@ -172,10 +261,22 @@ pub(crate) fn tolerate_transient<T>(
                 if !alive.load(Ordering::Relaxed) {
                     return Ok(None);
                 }
-                if progress.recovered {
+
+                // A narrower window means the supervisor healed the faults and started
+                // the recovery clock while we were down, which is the only situation in
+                // which the liveness check can actually fail. If Antithesis never
+                // reaches this, the check passed vacuously and proved nothing.
+                if last_grace.is_some_and(|last| grace < last) {
+                    assert_reachable!(
+                        "a recovery poke narrowed the grace window during an active database fault"
+                    );
+                }
+                if progress.recovered || last_grace.is_some_and(|last| last != grace) {
                     down_since = None;
                     backoff = INITIAL_RECONNECT_BACKOFF;
                 }
+                last_grace = Some(grace);
+
                 let down_since = *down_since.get_or_insert_with(Instant::now);
                 if down_since.elapsed() >= grace {
                     // Grace window exhausted: the fault is no longer "transient" as far
@@ -185,6 +286,7 @@ pub(crate) fn tolerate_transient<T>(
                         down_since.elapsed()
                     )));
                 }
+                assert_reachable!("stressgres retried a transient database fault");
                 eprintln!("stressgres: transient database fault, retrying: {e:#}");
                 interruptible_sleep(alive, backoff);
                 backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
@@ -248,8 +350,8 @@ mod tests {
         let alive = AtomicBool::new(true);
         let mut attempts = 0;
 
-        let grace = Duration::from_millis(250);
-        let result = tolerate_transient(&alive, grace, |progress| {
+        let grace = fixed(Duration::from_millis(250));
+        let result = tolerate_transient(&alive, &grace, |progress| {
             attempts += 1;
             match attempts {
                 1 => Err(anyhow!("connection closed")),
@@ -269,10 +371,10 @@ mod tests {
     #[test]
     fn zero_grace_fails_on_the_first_transient_error() {
         let alive = AtomicBool::new(true);
-        let grace = Duration::ZERO;
+        let grace = fixed(Duration::ZERO);
         let mut attempts = 0;
 
-        let err = tolerate_transient(&alive, grace, |_| {
+        let err = tolerate_transient(&alive, &grace, |_| {
             attempts += 1;
             Err::<(), _>(anyhow!("connection refused"))
         })
@@ -287,13 +389,17 @@ mod tests {
     /// A grace no test will exhaust.
     const LONG_GRACE: Duration = Duration::from_secs(3600);
 
+    fn fixed(d: Duration) -> GraceWindow {
+        GraceWindow::fixed(d)
+    }
+
     #[test]
     fn a_long_grace_rides_out_transient_faults() {
         let alive = AtomicBool::new(true);
-        let grace = LONG_GRACE;
+        let grace = fixed(LONG_GRACE);
         let mut attempts = 0;
 
-        let result = tolerate_transient(&alive, grace, |_| {
+        let result = tolerate_transient(&alive, &grace, |_| {
             attempts += 1;
             if attempts < 4 {
                 Err(anyhow!("connection refused"))
@@ -311,9 +417,9 @@ mod tests {
     #[test]
     fn zero_grace_fails_even_once_the_suite_is_shutting_down() {
         let alive = AtomicBool::new(false);
-        let grace = Duration::ZERO;
+        let grace = fixed(Duration::ZERO);
 
-        let err = tolerate_transient(&alive, grace, |_| {
+        let err = tolerate_transient(&alive, &grace, |_| {
             Err::<(), _>(anyhow!("connection refused"))
         })
         .unwrap_err();
@@ -327,7 +433,7 @@ mod tests {
     fn a_long_grace_gives_up_once_the_suite_is_shutting_down() {
         let alive = AtomicBool::new(false);
 
-        let result = tolerate_transient(&alive, LONG_GRACE, |_| {
+        let result = tolerate_transient(&alive, &fixed(LONG_GRACE), |_| {
             Err::<(), _>(anyhow!("connection refused"))
         })
         .unwrap();
@@ -338,9 +444,9 @@ mod tests {
     #[test]
     fn real_errors_surface_through_a_long_grace() {
         let alive = AtomicBool::new(true);
-        let grace = LONG_GRACE;
+        let grace = fixed(LONG_GRACE);
 
-        let err = tolerate_transient(&alive, grace, |_| {
+        let err = tolerate_transient(&alive, &grace, |_| {
             Err::<(), _>(anyhow!(
                 "duplicate key value violates unique constraint (SQLState: 23505)"
             ))
@@ -349,4 +455,104 @@ mod tests {
 
         assert!(err.to_string().contains("duplicate key"));
     }
+
+    #[test]
+    fn poke_file_grammar_round_trips() {
+        assert_eq!(GraceWindow::parse_ms("0").unwrap(), Duration::ZERO);
+        assert_eq!(
+            GraceWindow::parse_ms("45000\n").unwrap(),
+            Duration::from_secs(45)
+        );
+        assert!(GraceWindow::parse_ms("").is_err());
+        assert!(GraceWindow::parse_ms("infinite").is_err());
+    }
+
+    #[test]
+    fn a_missing_or_malformed_poke_file_falls_back_to_the_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grace");
+
+        let grace = GraceWindow::pokeable(LONG_GRACE, path.clone());
+        assert_eq!(grace.current(), LONG_GRACE, "missing file");
+
+        std::fs::write(&path, "not-a-duration").unwrap();
+        assert_eq!(grace.current(), LONG_GRACE, "malformed file");
+
+        std::fs::write(&path, "45000").unwrap();
+        assert_eq!(grace.current(), Duration::from_secs(45), "valid file");
+
+        // The supervisor restores the baseline by removing the file, so it never has to
+        // know what the baseline was.
+        std::fs::remove_file(&path).unwrap();
+        assert_eq!(grace.current(), LONG_GRACE, "file removed");
+    }
+
+    /// The liveness check: faults are healed, the supervisor narrows the window, and the
+    /// run must fail if the workload cannot reconnect inside it — measured from the
+    /// poke, *not* from when the (arbitrarily long) fault began.
+    #[test]
+    fn a_poke_restarts_the_clock_rather_than_failing_on_a_stale_down_since() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grace");
+        let grace = GraceWindow::pokeable(LONG_GRACE, path.clone());
+
+        let alive = AtomicBool::new(true);
+        let mut attempts = 0;
+
+        let err = tolerate_transient(&alive, &grace, |_| {
+            attempts += 1;
+            // Ride out an arbitrarily long fault, then get poked down to 200ms. The
+            // backoff between attempts already exceeds 200ms, so had the poke not
+            // restarted the clock we would fail on attempt 3 — the very attempt that
+            // observes it — instead of being given a fresh window.
+            if attempts == 3 {
+                std::fs::write(&path, "200").unwrap();
+            }
+            Err::<(), _>(anyhow!("connection refused"))
+        })
+        .unwrap_err();
+
+        assert_eq!(
+            attempts, 4,
+            "the poke should grant a fresh window, failing only on the next attempt"
+        );
+        assert!(
+            err.to_string().contains("grace window"),
+            "expected the grace-exhausted context, got: {err:#}"
+        );
+    }
+
+    #[test]
+    fn widening_the_window_also_restarts_the_clock() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("grace");
+        std::fs::write(&path, "200").unwrap();
+        let grace = GraceWindow::pokeable(LONG_GRACE, path.clone());
+
+        let alive = AtomicBool::new(true);
+        let mut attempts = 0;
+
+        // The supervisor's quiet period ends and it restores the baseline while we are
+        // still down. By then we have been down longer than the 200ms window it is
+        // replacing, so only restarting the clock keeps us from failing on a window that
+        // is no longer in force.
+        let result = tolerate_transient(&alive, &grace, |_| {
+            attempts += 1;
+            match attempts {
+                1 => Err(anyhow!("connection refused")),
+                2 => {
+                    std::fs::remove_file(&path).unwrap();
+                    Err(anyhow!("connection refused"))
+                }
+                3 => Err(anyhow!("connection refused")),
+                _ => Ok("ok"),
+            }
+        })
+        .unwrap();
+
+        assert_eq!(result, Some("ok"));
+        assert_eq!(attempts, 4);
+    }
+
+    // appended temporarily to fault_tolerance.rs tests
 }

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -75,9 +75,14 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            // Cap startup at one runtime's worth of time: if we cannot even reach the
-            // database within that, this timeline has no server to test, so exit cleanly
-            // rather than riding the fault out for the whole reconnect grace.
+            // Cap startup (version probe + schema build) at one runtime's worth of time.
+            // Under fault injection the reconnect grace is set far longer than a run, so a
+            // fault straddling startup would otherwise pin the process for the whole grace
+            // window and the driver would never run to completion. If the database stays
+            // unreachable for a whole runtime we exit cleanly with no workload, so every
+            // driver reliably finishes. This is a stopgap: moving setup into an Antithesis
+            // `first_` command (which runs before any faults) removes the straddle and lets
+            // this bound go.
             let startup_timeout =
                 Duration::from_millis(u64::try_from(args.runtime).unwrap_or(u64::MAX));
             let suite_runner =
@@ -88,10 +93,6 @@ fn main() -> anyhow::Result<()> {
                 );
                 return Ok(());
             }
-            // Setup (schema build) is done and the workload is about to start; signal the
-            // DST harness, which holds fault injection until now so every suite gets a
-            // clean startup rather than being killed mid-initialisation.
-            dst::setup_complete(&args.suite_path.display().to_string());
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -87,6 +87,13 @@ fn main() -> anyhow::Result<()> {
                 );
                 return Ok(());
             }
+            // Setup (schema build) is done and the workload is about to start. Antithesis
+            // holds fault injection until this signal, so every suite gets a clean startup
+            // and actually runs its workload rather than being killed mid-initialisation.
+            // A no-op outside the Antithesis environment.
+            antithesis_sdk::lifecycle::setup_complete(&serde_json::json!({
+                "suite": args.suite_path.display().to_string(),
+            }));
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -51,16 +51,6 @@ pub struct MetricsLine {
     pub metrics: serde_json::Map<String, serde_json::Value>,
 }
 
-/// Builds the reconnect grace window from the CLI's baseline (in milliseconds) and
-/// optional poke file.
-fn grace_window(baseline_ms: u64, file: Option<std::path::PathBuf>) -> GraceWindow {
-    let baseline = Duration::from_millis(baseline_ms);
-    match file {
-        Some(file) => GraceWindow::pokeable(baseline, file),
-        None => GraceWindow::fixed(baseline),
-    }
-}
-
 /// Main entry point using subcommands.
 fn main() -> anyhow::Result<()> {
     // Registers the assertion catalog so Antithesis knows which `assert_reachable!`
@@ -75,12 +65,7 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(
-                suite,
-                args.paused,
-                grace_window(args.reconnect_grace, args.reconnect_grace_file),
-                None,
-            )?;
+            let suite_runner = SuiteRunner::new(suite, args.paused, args.grace.window(), None)?;
             tui::run(suite_runner)?;
         }
 
@@ -94,12 +79,8 @@ fn main() -> anyhow::Result<()> {
             // rather than riding the fault out for the whole reconnect grace.
             let startup_timeout =
                 Duration::from_millis(u64::try_from(args.runtime).unwrap_or(u64::MAX));
-            let suite_runner = SuiteRunner::new(
-                suite,
-                false,
-                grace_window(args.reconnect_grace, args.reconnect_grace_file.clone()),
-                Some(startup_timeout),
-            )?;
+            let suite_runner =
+                SuiteRunner::new(suite, false, args.grace.window(), Some(startup_timeout))?;
             if !suite_runner.alive() {
                 eprintln!(
                     "stressgres: database unreachable throughout startup, exiting without a workload"

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -32,6 +32,7 @@ mod tui;
 
 use crate::auto::{setup_server, ServerHandler};
 use crate::cli::{AutoArgs, Cli, Command};
+use crate::fault_tolerance::GraceWindow;
 use crate::runner::SuiteRunner;
 use crate::suite::{PgConfigStyle, PgVersion, ServerStyle, Suite, SuiteDefinition};
 use anyhow::Context;
@@ -50,8 +51,22 @@ pub struct MetricsLine {
     pub metrics: serde_json::Map<String, serde_json::Value>,
 }
 
+/// Builds the reconnect grace window from the CLI's baseline (in milliseconds) and
+/// optional poke file.
+fn grace_window(baseline_ms: u64, file: Option<std::path::PathBuf>) -> GraceWindow {
+    let baseline = Duration::from_millis(baseline_ms);
+    match file {
+        Some(file) => GraceWindow::pokeable(baseline, file),
+        None => GraceWindow::fixed(baseline),
+    }
+}
+
 /// Main entry point using subcommands.
 fn main() -> anyhow::Result<()> {
+    // Registers the assertion catalog so Antithesis knows which `assert_reachable!`
+    // sites exist but were never hit. A no-op outside the Antithesis environment.
+    antithesis_sdk::antithesis_init();
+
     let cli = Cli::parse();
 
     match cli.command {
@@ -63,7 +78,8 @@ fn main() -> anyhow::Result<()> {
             let suite_runner = SuiteRunner::new(
                 suite,
                 args.paused,
-                Duration::from_millis(args.reconnect_grace),
+                grace_window(args.reconnect_grace, args.reconnect_grace_file),
+                None,
             )?;
             tui::run(suite_runner)?;
         }
@@ -73,8 +89,23 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner =
-                SuiteRunner::new(suite, false, Duration::from_millis(args.reconnect_grace))?;
+            // Cap startup at one runtime's worth of time: if we cannot even reach the
+            // database within that, this timeline has no server to test, so exit cleanly
+            // rather than riding the fault out for the whole reconnect grace.
+            let startup_timeout =
+                Duration::from_millis(u64::try_from(args.runtime).unwrap_or(u64::MAX));
+            let suite_runner = SuiteRunner::new(
+                suite,
+                false,
+                grace_window(args.reconnect_grace, args.reconnect_grace_file.clone()),
+                Some(startup_timeout),
+            )?;
+            if !suite_runner.alive() {
+                eprintln!(
+                    "stressgres: database unreachable throughout startup, exiting without a workload"
+                );
+                return Ok(());
+            }
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {
@@ -98,7 +129,8 @@ fn main() -> anyhow::Result<()> {
             })?;
             // `auto` is a local-dev command with no fault injection, so fail fast
             // (grace 0) rather than tolerating transient connectivity faults.
-            let suite_runner = SuiteRunner::new(suite, false, Duration::ZERO)?;
+            let suite_runner =
+                SuiteRunner::new(suite, false, GraceWindow::fixed(Duration::ZERO), None)?;
             headless::run(
                 suite_runner,
                 args.log_path.clone(),

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -20,6 +20,7 @@
 mod auto;
 mod cli;
 mod csv;
+mod dst;
 mod fault_tolerance;
 mod graph;
 mod headless;
@@ -53,9 +54,9 @@ pub struct MetricsLine {
 
 /// Main entry point using subcommands.
 fn main() -> anyhow::Result<()> {
-    // Registers the assertion catalog so Antithesis knows which `assert_reachable!`
-    // sites exist but were never hit. A no-op outside the Antithesis environment.
-    antithesis_sdk::antithesis_init();
+    // Register the DST assertion catalog (see `dst`), so a never-hit reachability site is
+    // reported rather than passing vacuously. A no-op outside the DST environment.
+    dst::init();
 
     let cli = Cli::parse();
 
@@ -87,13 +88,10 @@ fn main() -> anyhow::Result<()> {
                 );
                 return Ok(());
             }
-            // Setup (schema build) is done and the workload is about to start. Antithesis
-            // holds fault injection until this signal, so every suite gets a clean startup
-            // and actually runs its workload rather than being killed mid-initialisation.
-            // A no-op outside the Antithesis environment.
-            antithesis_sdk::lifecycle::setup_complete(&serde_json::json!({
-                "suite": args.suite_path.display().to_string(),
-            }));
+            // Setup (schema build) is done and the workload is about to start; signal the
+            // DST harness, which holds fault injection until now so every suite gets a
+            // clean startup rather than being killed mid-initialisation.
+            dst::setup_complete(&args.suite_path.display().to_string());
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use crate::fault_tolerance::tolerate_transient;
+use crate::fault_tolerance::{tolerate_transient, GraceWindow};
 use crate::sqlscanner::StatementDestination;
 use crate::suite::{Job, Server, ServerStyle, Suite};
 use anyhow::{anyhow, Result};
@@ -346,7 +346,7 @@ pub struct SuiteRunner {
     runners: Vec<Arc<JobRunner>>,
     have_error: Arc<AtomicBool>,
     first_error_duration_bits: Arc<AtomicU64>,
-    reconnect_grace: Duration,
+    reconnect_grace: GraceWindow,
 
     monitors: Vec<Arc<JobRunner>>,
     sys: Arc<RwLock<System>>,
@@ -368,7 +368,7 @@ pub struct SuiteRunner {
 /// Returns `Ok(None)` if `alive` went false while waiting out a fault.
 fn with_reconnect<T>(
     alive: &AtomicBool,
-    grace: Duration,
+    grace: &GraceWindow,
     conn: &mut Option<Conn>,
     suite: &Suite,
     job: &Job,
@@ -395,7 +395,7 @@ impl SuiteRunner {
         let mut conn = None;
         with_reconnect(
             &self.alive,
-            self.reconnect_grace,
+            &self.reconnect_grace,
             &mut conn,
             &self.suite,
             job,
@@ -404,7 +404,20 @@ impl SuiteRunner {
     }
 
     /// Create a new SuiteRunner, run the `setup` job, then spawn threads for each job + monitor.
-    pub fn new(suite: Suite, paused: bool, reconnect_grace: Duration) -> Result<Arc<Self>> {
+    ///
+    /// `startup_timeout` caps the version-probe-plus-setup phase. Those run with the full
+    /// reconnect grace, which the fault suite sets far longer than a run, so a fault
+    /// straddling startup would otherwise pin the process for the whole grace window and
+    /// the driver would never finish. Pass `None` (ui, auto) to keep the old unbounded
+    /// behaviour; pass `Some(_)` under fault injection so a start that never reaches the
+    /// database gives up. When it lapses the returned runner is dormant (`alive()` is
+    /// false) and the caller should exit without a workload.
+    pub fn new(
+        suite: Suite,
+        paused: bool,
+        reconnect_grace: GraceWindow,
+        startup_timeout: Option<Duration>,
+    ) -> Result<Arc<Self>> {
         let suite = Arc::new(suite);
         let mut runner = Self {
             suite: suite.clone(),
@@ -421,6 +434,28 @@ impl SuiteRunner {
             sys: Arc::new(RwLock::new(System::new_all())),
         };
 
+        // Once the budget lapses with the database still unreachable, flip `alive` so the
+        // in-flight `tolerate_transient` returns `Ok(None)` instead of riding the fault out
+        // for the whole grace window. `startup_done` cancels the watchdog the moment setup
+        // finishes, so a healthy run keeps its full runtime.
+        let startup_done = Arc::new(AtomicBool::new(false));
+        if let Some(budget) = startup_timeout {
+            let alive = runner.alive.clone();
+            let startup_done = startup_done.clone();
+            std::thread::spawn(move || {
+                let start = Instant::now();
+                while start.elapsed() < budget {
+                    if startup_done.load(Ordering::Acquire) {
+                        return;
+                    }
+                    std::thread::sleep(Duration::from_millis(50));
+                }
+                if !startup_done.load(Ordering::Acquire) {
+                    alive.store(false, Ordering::Release);
+                }
+            });
+        }
+
         // Probe the server version, riding out any transient connectivity fault
         let default_job = Job::default();
         if let Some(version) = runner.run_once(&default_job, |conn| {
@@ -433,7 +468,12 @@ impl SuiteRunner {
             runner.pgver = version;
         }
 
-        runner.init()?;
+        // Skip setup (and, via the dormant runner, the workload) if the startup budget
+        // lapsed while the database was unreachable. `alive` is already false.
+        if runner.alive.load(Ordering::Relaxed) {
+            runner.init()?;
+        }
+        startup_done.store(true, Ordering::Release);
         let suite_runner = Arc::new(runner);
 
         // refresh sysinfo stats very frequently
@@ -486,7 +526,13 @@ impl SuiteRunner {
             // the top rebuilds state no matter how far a partial attempt got — not
             // because it runs in one transaction (it can't: it issues ALTER SYSTEM /
             // pg_reload_conf, which are disallowed inside a transaction block).
-            self.run_once(&setup_runner.job, |conn| setup_runner.run(conn))?;
+            if self
+                .run_once(&setup_runner.job, |conn| setup_runner.run(conn))?
+                .is_none()
+            {
+                // Startup budget lapsed mid-setup; stop before spawning any workers.
+                return Ok(());
+            }
         }
 
         // setup and start the monitors
@@ -555,7 +601,7 @@ impl SuiteRunner {
 
         let job_runner = Arc::new(job_runner);
         let refresh_ms = Duration::from_millis(job_runner.job.refresh_ms as u64);
-        let reconnect_grace = self.reconnect_grace;
+        let reconnect_grace = self.reconnect_grace.clone();
 
         // The actual thread loop
         let handle = {
@@ -587,7 +633,7 @@ impl SuiteRunner {
     fn job_runner_worker(
         paused: Arc<AtomicBool>,
         refresh_ms: Duration,
-        reconnect_grace: Duration,
+        reconnect_grace: GraceWindow,
         job_runner: &Arc<JobRunner>,
     ) -> Result<(), anyhow::Error> {
         *job_runner.runtime_stats.write() = Conn::make_infos(&job_runner.suite, &job_runner.job)
@@ -623,7 +669,7 @@ impl SuiteRunner {
             // reconnects; replaying the whole iteration keeps transactional jobs correct.
             let outcome = with_reconnect(
                 &alive,
-                reconnect_grace,
+                &reconnect_grace,
                 &mut conn,
                 &job_runner.suite,
                 &job_runner.job,

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -279,7 +279,7 @@ impl Conn {
             ServerStyle::With { .. } => server.connstr(),
             _ => format!("{} application_name={}", server.connstr(), sanitized),
         };
-        let mut conn = postgres::Client::connect(&connstr, {
+        let mut conn = postgres::Client::connect(&tokio_connstr(&connstr), {
             use openssl::ssl::{SslConnector, SslMethod};
             use postgres_openssl::MakeTlsConnector;
             let mut builder =
@@ -333,6 +333,19 @@ fn do_query_replacements(query: &str, server_lookup: &Arc<HashMap<String, Server
         query = query.replace(&key, &server.connstr());
     }
     query
+}
+
+/// Adapts a connection string for our tokio-postgres client.
+///
+/// Connection strings are written with libpq's canonical parameter names so the same
+/// string works both here and when it is inlined verbatim into SQL the server parses with
+/// libpq (e.g. `CREATE SUBSCRIPTION ... CONNECTION '...'`, via [`do_query_replacements`]).
+/// The two spellings agree on every keyword except the keepalive probe count, which libpq
+/// calls `keepalives_count` and tokio-postgres calls `keepalives_retries`; tokio-postgres
+/// rejects the libpq name outright. Translate just that one so the client accepts the
+/// libpq-canonical string. Names never used in-tree stay untranslated on purpose.
+fn tokio_connstr(connstr: &str) -> String {
+    connstr.replace("keepalives_count", "keepalives_retries")
 }
 
 /// Manages the entire suite: runs setup once, spawns each job's thread, optionally a monitor job,
@@ -1192,4 +1205,29 @@ fn is_ignorable_error(e: &postgres::Error, ignore_patterns: &[String]) -> bool {
     }
 
     false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::tokio_connstr;
+
+    #[test]
+    fn tokio_connstr_translates_only_the_keepalive_probe_count() {
+        // libpq's keepalives_count becomes tokio-postgres's keepalives_retries; every
+        // other keyword (including the identically-spelled keepalives_* and
+        // tcp_user_timeout) is left untouched.
+        assert_eq!(
+            tokio_connstr(
+                "postgresql://h:5432/db?connect_timeout=5&keepalives=1&keepalives_idle=5\
+                 &keepalives_interval=2&keepalives_count=3&tcp_user_timeout=15"
+            ),
+            "postgresql://h:5432/db?connect_timeout=5&keepalives=1&keepalives_idle=5\
+             &keepalives_interval=2&keepalives_retries=3&tcp_user_timeout=15"
+        );
+        // A string that never mentions the probe count is returned verbatim.
+        assert_eq!(
+            tokio_connstr("host=localhost port=5432 dbname=stressgres"),
+            "host=localhost port=5432 dbname=stressgres"
+        );
+    }
 }

--- a/stressgres/suites/antithesis/anytime_recovery_liveness.sh
+++ b/stressgres/suites/antithesis/anytime_recovery_liveness.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
 #
 # Antithesis "anytime" command: heal every fault, then require that the stressgres
-# processes running alongside us reconnect and make progress before faults resume.
+# processes running alongside us reconnect and make progress before faults resume. The
+# failure condition is "the database was provably reachable and stressgres still could
+# not make progress", which no fault schedule can fake.
 #
-# This is the liveness check that lets the singleton drivers run with a reconnect grace
-# longer than the run. A grace shorter than the run can be outlasted by a long enough
-# injected fault, so it reports a bug we don't have as soon as Antithesis finds the
-# schedule that exceeds it; raising the bound only moves the false positive into a rarer
-# rollout. Here the failure condition is instead "the database was provably reachable
-# and stressgres still could not make progress", which no fault schedule can fake.
-#
-# We poke the running processes rather than starting our own, because stressgres
-# spends its first 60s waiting for the cluster and then builds its schema, and
-# because an `eventually_` command would kill the drivers we want to observe
-# recovering. See https://github.com/paradedb/paradedb/issues/5501.
+# We poke the already-running drivers rather than starting our own, because stressgres
+# spends its first 60s waiting for the cluster and then builds its schema.
+# See https://github.com/paradedb/paradedb/issues/5501.
 
 set -Eeuo pipefail
 

--- a/stressgres/suites/antithesis/anytime_recovery_liveness.sh
+++ b/stressgres/suites/antithesis/anytime_recovery_liveness.sh
@@ -45,13 +45,6 @@ fi
 exec 9>"${LOCK_FILE}"
 flock -n 9 || exit 0
 
-# Absent when dry-running the test template locally, where there is no fault
-# injector to pause and therefore nothing to assert.
-if [ -z "${ANTITHESIS_STOP_FAULTS:-}" ]; then
-  echo "ANTITHESIS_STOP_FAULTS unset, skipping the recovery liveness check"
-  exit 0
-fi
-
 # Write via rename so a reader never observes a half-written window. Removing the file
 # restores whatever `--reconnect-grace` the driver was started with, so the baseline
 # lives in exactly one place.

--- a/stressgres/suites/antithesis/anytime_recovery_liveness.sh
+++ b/stressgres/suites/antithesis/anytime_recovery_liveness.sh
@@ -59,18 +59,18 @@ restore() { rm -f "${GRACE_FILE}" "${GRACE_FILE}.tmp"; }
 # Restore the baseline no matter how we leave, or the next fault would be measured
 # against a window that is no longer in force and fail the run. The EXIT trap covers a
 # normal exit, a `set -e` failure, and SIGTERM. Only SIGKILL would strand the short
-# window, and the stressgres container is named in
+# window, and the Stressgres container is named in
 # `container_faults_{stop,kill}_exclusion_patterns`, so the run never injects one.
 trap restore EXIT
 
-echo "recovery liveness: pausing faults for ${QUIET_SECONDS}s; stressgres must recover within ${RECOVER_SECONDS}s"
+echo "Recovery liveness: pausing faults for ${QUIET_SECONDS}s; Stressgres must recover within ${RECOVER_SECONDS}s"
 "${ANTITHESIS_STOP_FAULTS}" "${QUIET_SECONDS}"
 
 poke "$(( RECOVER_SECONDS * 1000 ))"
 sleep "${RECOVER_SECONDS}"
 restore
 
-echo "recovery liveness: stressgres survived the quiet period"
+echo "Recovery liveness: Stressgres survived the quiet period"
 
 # A nonzero exit here would report *this* command as the failure. The assertion
 # belongs to the driver: if it could not reconnect inside the window, it exits

--- a/stressgres/suites/antithesis/anytime_recovery_liveness.sh
+++ b/stressgres/suites/antithesis/anytime_recovery_liveness.sh
@@ -1,18 +1,19 @@
 #!/bin/bash
 #
 # Antithesis "anytime" command: heal every fault, then require that the Stressgres
-# processes running alongside us reconnect and make progress before faults resume. The
+# driver running alongside us reconnects and makes progress before faults resume. The
 # failure condition is "the database was provably reachable and stressgres still could
 # not make progress", which no fault schedule can fake.
 #
-# We poke the already-running drivers rather than starting our own, because Stressgres
+# We poke the already-running driver rather than starting our own, because Stressgres
 # spends its first 60s waiting for the cluster and then builds its schema.
 # See https://github.com/paradedb/paradedb/issues/5501.
 
 set -Eeuo pipefail
 
-# Shared with the `--reconnect-grace-file` passed by every singleton driver. Both
-# commands run in the Stressgres container, so this is a plain shared file.
+# The poke channel, shared via the Stressgres container's filesystem. Every singleton
+# driver is launched with this same `--reconnect-grace-file`, but Antithesis runs exactly
+# one of them per timeline, so at runtime the file has a single reader.
 GRACE_FILE=/tmp/stressgres-reconnect-grace
 LOCK_FILE=/tmp/stressgres-recovery-liveness.lock
 
@@ -31,9 +32,10 @@ TRIGGER_PERCENT=5
 sample=$(od -An -N2 -tu2 < /dev/urandom | tr -d '[:space:]')
 (( sample % 100 < TRIGGER_PERCENT )) || exit 0
 
-# Overlapping quiet periods merge into the longest interval, but overlapping pokes
-# would race: the first to finish would restore the baseline while the second is still
-# counting down, silently disarming the check.
+# Antithesis fires anytime commands concurrently (the drivers can't overlap — only one
+# singleton runs per timeline — but these can). Overlapping quiet periods merge into the
+# longest interval, but overlapping pokes would race: the first to finish would restore
+# the baseline while the second is still counting down, silently disarming the check.
 #
 # Check for flock(1) separately from taking the lock: a missing binary exits 127,
 # which `|| exit 0` would otherwise report as "another instance holds the lock" and
@@ -71,6 +73,6 @@ restore
 echo "recovery liveness: stressgres survived the quiet period"
 
 # A nonzero exit here would report *this* command as the failure. The assertion
-# belongs to the drivers: if one of them could not reconnect inside the window,
-# it exits nonzero and Antithesis attributes the failure to the workload.
+# belongs to the driver: if it could not reconnect inside the window, it exits
+# nonzero and Antithesis attributes the failure to the workload.
 exit 0

--- a/stressgres/suites/antithesis/anytime_recovery_liveness.sh
+++ b/stressgres/suites/antithesis/anytime_recovery_liveness.sh
@@ -23,12 +23,12 @@ LOCK_FILE=/tmp/stressgres-recovery-liveness.lock
 # primary, be promoted back into service before a connection can succeed. Too short and
 # the liveness check itself becomes the flake.
 QUIET_SECONDS=90
-RECOVER_SECONDS=75
+RECOVER_SECONDS=50
 
 # Antithesis schedules anytime commands aggressively, and a quiet period suppresses
 # exactly the faults this test exists to inject. Fire on a small fraction of
 # invocations so most of the run is spent under chaos.
-TRIGGER_PERCENT=5
+TRIGGER_PERCENT=10
 sample=$(od -An -N2 -tu2 < /dev/urandom | tr -d '[:space:]')
 (( sample % 100 < TRIGGER_PERCENT )) || exit 0
 

--- a/stressgres/suites/antithesis/anytime_recovery_liveness.sh
+++ b/stressgres/suites/antithesis/anytime_recovery_liveness.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+#
+# Antithesis "anytime" command: heal every fault, then require that the stressgres
+# processes running alongside us reconnect and make progress before faults resume.
+#
+# This is the liveness check that lets the singleton drivers run with a reconnect grace
+# longer than the run. A grace shorter than the run can be outlasted by a long enough
+# injected fault, so it reports a bug we don't have as soon as Antithesis finds the
+# schedule that exceeds it; raising the bound only moves the false positive into a rarer
+# rollout. Here the failure condition is instead "the database was provably reachable
+# and stressgres still could not make progress", which no fault schedule can fake.
+#
+# We poke the running processes rather than starting our own, because stressgres
+# spends its first 60s waiting for the cluster and then builds its schema, and
+# because an `eventually_` command would kill the drivers we want to observe
+# recovering. See https://github.com/paradedb/paradedb/issues/5501.
+
+set -Eeuo pipefail
+
+# Shared with the `--reconnect-grace-file` passed by every singleton driver. Both
+# commands run in the stressgres container, so this is a plain shared file.
+GRACE_FILE=/tmp/stressgres-reconnect-grace
+LOCK_FILE=/tmp/stressgres-recovery-liveness.lock
+
+# How long to hold faults off, and how much of that window stressgres gets to recover
+# in. The recovery window has to cover the worst fault we inject: a killed container,
+# restarted by k8s, whose Postgres then has to finish crash recovery and, for the CNPG
+# primary, be promoted back into service before a connection can succeed. Too short and
+# the liveness check itself becomes the flake. The remainder is slack, so the workload
+# is healthy again before faults resume.
+QUIET_SECONDS=90
+RECOVER_SECONDS=75
+
+# Antithesis schedules anytime commands aggressively, and a quiet period suppresses
+# exactly the faults this test exists to inject. Fire on a small fraction of
+# invocations so most of the run is spent under chaos.
+#
+# Sample /dev/urandom rather than $RANDOM: Antithesis controls the former, but bash
+# seeds its own PRNG for the latter, so a $RANDOM-gated command is invisible to the
+# fault scheduler's search.
+TRIGGER_PERCENT=5
+sample=$(od -An -N2 -tu2 < /dev/urandom | tr -d '[:space:]')
+(( sample % 100 < TRIGGER_PERCENT )) || exit 0
+
+# Overlapping quiet periods merge into the longest interval, but overlapping pokes
+# would race: the first to finish would restore the baseline while the second is still
+# counting down, silently disarming the check.
+#
+# Check for flock(1) separately from taking the lock: a missing binary exits 127,
+# which `|| exit 0` would otherwise report as "another instance holds the lock" and
+# skip every check for the whole run.
+if ! command -v flock >/dev/null 2>&1; then
+  echo "recovery liveness: flock(1) not found, refusing to run without single-flight" >&2
+  exit 1
+fi
+exec 9>"${LOCK_FILE}"
+flock -n 9 || exit 0
+
+# Absent when dry-running the test template locally, where there is no fault
+# injector to pause and therefore nothing to assert.
+if [ -z "${ANTITHESIS_STOP_FAULTS:-}" ]; then
+  echo "ANTITHESIS_STOP_FAULTS unset, skipping the recovery liveness check"
+  exit 0
+fi
+
+# Write via rename so a reader never observes a half-written window. Removing the file
+# restores whatever `--reconnect-grace` the driver was started with, so the baseline
+# lives in exactly one place.
+poke() {
+  printf '%s' "$1" > "${GRACE_FILE}.tmp"
+  mv "${GRACE_FILE}.tmp" "${GRACE_FILE}"
+}
+restore() { rm -f "${GRACE_FILE}" "${GRACE_FILE}.tmp"; }
+
+# Restore the baseline no matter how we leave, or the next fault would be measured
+# against a window that is no longer in force and fail the run. The EXIT trap covers a
+# normal exit, a `set -e` failure, and SIGTERM. Only SIGKILL would strand the short
+# window, and the stressgres container is named in
+# `container_faults_{stop,kill}_exclusion_patterns`, so the run never injects one.
+trap restore EXIT
+
+echo "recovery liveness: pausing faults for ${QUIET_SECONDS}s; stressgres must recover within ${RECOVER_SECONDS}s"
+"${ANTITHESIS_STOP_FAULTS}" "${QUIET_SECONDS}"
+
+poke "$(( RECOVER_SECONDS * 1000 ))"
+sleep "${RECOVER_SECONDS}"
+restore
+
+echo "recovery liveness: stressgres survived the quiet period"
+
+# A nonzero exit here would report *this* command as the failure. The assertion
+# belongs to the drivers: if one of them could not reconnect inside the window,
+# it exits nonzero and Antithesis attributes the failure to the workload.
+exit 0

--- a/stressgres/suites/antithesis/anytime_recovery_liveness.sh
+++ b/stressgres/suites/antithesis/anytime_recovery_liveness.sh
@@ -1,37 +1,32 @@
 #!/bin/bash
 #
-# Antithesis "anytime" command: heal every fault, then require that the stressgres
+# Antithesis "anytime" command: heal every fault, then require that the Stressgres
 # processes running alongside us reconnect and make progress before faults resume. The
 # failure condition is "the database was provably reachable and stressgres still could
 # not make progress", which no fault schedule can fake.
 #
-# We poke the already-running drivers rather than starting our own, because stressgres
+# We poke the already-running drivers rather than starting our own, because Stressgres
 # spends its first 60s waiting for the cluster and then builds its schema.
 # See https://github.com/paradedb/paradedb/issues/5501.
 
 set -Eeuo pipefail
 
 # Shared with the `--reconnect-grace-file` passed by every singleton driver. Both
-# commands run in the stressgres container, so this is a plain shared file.
+# commands run in the Stressgres container, so this is a plain shared file.
 GRACE_FILE=/tmp/stressgres-reconnect-grace
 LOCK_FILE=/tmp/stressgres-recovery-liveness.lock
 
-# How long to hold faults off, and how much of that window stressgres gets to recover
+# How long to hold faults off, and how much of that window Stressgres gets to recover
 # in. The recovery window has to cover the worst fault we inject: a killed container,
-# restarted by k8s, whose Postgres then has to finish crash recovery and, for the CNPG
+# restarted by K8s, whose Postgres then has to finish crash recovery and, for the CNPG
 # primary, be promoted back into service before a connection can succeed. Too short and
-# the liveness check itself becomes the flake. The remainder is slack, so the workload
-# is healthy again before faults resume.
+# the liveness check itself becomes the flake.
 QUIET_SECONDS=90
 RECOVER_SECONDS=75
 
 # Antithesis schedules anytime commands aggressively, and a quiet period suppresses
 # exactly the faults this test exists to inject. Fire on a small fraction of
 # invocations so most of the run is spent under chaos.
-#
-# Sample /dev/urandom rather than $RANDOM: Antithesis controls the former, but bash
-# seeds its own PRNG for the latter, so a $RANDOM-gated command is invisible to the
-# fault scheduler's search.
 TRIGGER_PERCENT=5
 sample=$(od -An -N2 -tu2 < /dev/urandom | tr -d '[:space:]')
 (( sample % 100 < TRIGGER_PERCENT )) || exit 0

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -5,8 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
-# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/background-merge.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/background-merge.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/background-merge.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connection..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/background-merge.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/background-merge.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -16,7 +16,6 @@ echo ""
 echo "Running Stressgres with suite background-merge.toml..."
 # Keep the runtime short: Antithesis explores by branching across many short timelines, so a
 # fast, self-contained run covers far more fault schedules per budget than one long scenario.
-# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -5,6 +5,8 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
+# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/background-merge.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_background-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_background-merge.sh
@@ -14,6 +14,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite background-merge.toml..."
+# Keep the runtime short: Antithesis explores by branching across many short timelines, so a
+# fast, self-contained run covers far more fault schedules per budget than one long scenario.
+# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/background-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -14,6 +14,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
+# Keep the runtime short: Antithesis explores by branching across many short timelines, so a
+# fast, self-contained run covers far more fault schedules per budget than one long scenario.
+# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -16,7 +16,6 @@ echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
 # Keep the runtime short: Antithesis explores by branching across many short timelines, so a
 # fast, self-contained run covers far more fault schedules per budget than one long scenario.
-# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -5,8 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
-# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/bulk-updates.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -5,6 +5,8 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
+# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/bulk-updates.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connection..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/bulk-updates.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/bulk-updates.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."

--- a/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
+++ b/stressgres/suites/antithesis/singleton_driver_bulk-updates.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/bulk-updates.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/bulk-updates.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite bulk-updates.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/bulk-updates.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -11,11 +11,8 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connections..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-# The Publisher string omits keepalives_retries: stressgres substitutes it verbatim into
-# CREATE SUBSCRIPTION, which libpq reparses, and libpq only knows keepalives_count and
-# rejects the tokio-postgres name (SQLSTATE 42601). tcp_user_timeout still bounds detection.
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -10,8 +10,7 @@ set -Eeuo pipefail
 # Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
 echo ""
 echo "Updating suite to use Antithesis connections..."
-# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
-# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -11,7 +11,10 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connections..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
+# The Publisher string omits keepalives_retries: stressgres substitutes it verbatim into
+# CREATE SUBSCRIPTION, which libpq reparses, and libpq only knows keepalives_count and
+# rejects the tokio-postgres name (SQLSTATE 42601). tcp_user_timeout still bounds detection.
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -22,7 +22,6 @@ echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Keep the runtime short: Antithesis explores by branching across many short timelines, so a
 # fast, self-contained run covers far more fault schedules per budget than one long scenario.
-# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -10,6 +10,8 @@ set -Eeuo pipefail
 # Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
 echo ""
 echo "Updating suite to use Antithesis connections..."
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
+# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -10,8 +10,8 @@ set -Eeuo pipefail
 # Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
 echo ""
 echo "Updating suite to use Antithesis connections..."
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres"|' /home/app/stressgres/suites/logical-replication-merge.toml
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/logical-replication-merge.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication-merge.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
@@ -20,7 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication-merge.sh
@@ -20,7 +20,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite logical-replication-merge.toml..."
-# Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
+# Keep the runtime short: Antithesis explores by branching across many short timelines, so a
+# fast, self-contained run covers far more fault schedules per budget than one long scenario.
+# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication-merge.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -22,7 +22,6 @@ echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Keep the runtime short: Antithesis explores by branching across many short timelines, so a
 # fast, self-contained run covers far more fault schedules per budget than one long scenario.
-# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -10,8 +10,7 @@ set -Eeuo pipefail
 # Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
 echo ""
 echo "Updating suite to use Antithesis connections..."
-# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
-# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -11,7 +11,10 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connections..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
+# The Publisher string omits keepalives_retries: stressgres substitutes it verbatim into
+# CREATE SUBSCRIPTION, which libpq reparses, and libpq only knows keepalives_count and
+# rejects the tokio-postgres name (SQLSTATE 42601). tcp_user_timeout still bounds detection.
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -10,8 +10,8 @@ set -Eeuo pipefail
 # Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
 echo ""
 echo "Updating suite to use Antithesis connections..."
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres"|' /home/app/stressgres/suites/logical-replication.toml
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/logical-replication.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
@@ -20,7 +20,7 @@ sleep 60
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
 # Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -20,7 +20,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite logical-replication.toml..."
-# Run for 100 seconds: running for 10 minutes causes a "All commands were run to completion at least once" error in Antithesis.
+# Keep the runtime short: Antithesis explores by branching across many short timelines, so a
+# fast, self-contained run covers far more fault schedules per budget than one long scenario.
+# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/logical-replication.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -10,6 +10,8 @@ set -Eeuo pipefail
 # Subscriber -> paradedb-rw (primary of the CNPG cluster, has pg_search).
 echo ""
 echo "Updating suite to use Antithesis connections..."
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
+# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 

--- a/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
+++ b/stressgres/suites/antithesis/singleton_driver_logical-replication.sh
@@ -11,11 +11,8 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connections..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-# The Publisher string omits keepalives_retries: stressgres substitutes it verbatim into
-# CREATE SUBSCRIPTION, which libpq reparses, and libpq only knows keepalives_count and
-# rejects the tokio-postgres name (SQLSTATE 42601). tcp_user_timeout still bounds detection.
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
-sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
+sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/logical-replication.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -5,6 +5,8 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
+# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/single-server.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -14,6 +14,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
+# Keep the runtime short: Antithesis explores by branching across many short timelines, so a
+# fast, self-contained run covers far more fault schedules per budget than one long scenario.
+# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -5,8 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
-# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/single-server.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connection..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/single-server.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/single-server.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -16,7 +16,6 @@ echo ""
 echo "Running Stressgres with suite single-server.toml..."
 # Keep the runtime short: Antithesis explores by branching across many short timelines, so a
 # fast, self-contained run covers far more fault schedules per budget than one long scenario.
-# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_single-server.sh
+++ b/stressgres/suites/antithesis/singleton_driver_single-server.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/single-server.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/single-server.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite single-server.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/single-server.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connection..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-sed -i 's|postgresql://postgres:postgres@localhost:5432/postgres|postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15|g' /home/app/stressgres/suites/vanilla-postgres.toml
+sed -i 's|postgresql://postgres:postgres@localhost:5432/postgres|postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15|g' /home/app/stressgres/suites/vanilla-postgres.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -16,7 +16,6 @@ echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
 # Keep the runtime short: Antithesis explores by branching across many short timelines, so a
 # fast, self-contained run covers far more fault schedules per budget than one long scenario.
-# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-sed -i 's|postgresql://postgres:postgres@localhost:5432/postgres|postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb|g' /home/app/stressgres/suites/vanilla-postgres.toml
+sed -i 's|postgresql://postgres:postgres@localhost:5432/postgres|postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15|g' /home/app/stressgres/suites/vanilla-postgres.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -5,8 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
-# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
 sed -i 's|postgresql://postgres:postgres@localhost:5432/postgres|postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15|g' /home/app/stressgres/suites/vanilla-postgres.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -5,6 +5,8 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
+# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
 sed -i 's|postgresql://postgres:postgres@localhost:5432/postgres|postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15|g' /home/app/stressgres/suites/vanilla-postgres.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
+++ b/stressgres/suites/antithesis/singleton_driver_vanilla-postgres.sh
@@ -14,6 +14,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite vanilla-postgres.toml..."
+# Keep the runtime short: Antithesis explores by branching across many short timelines, so a
+# fast, self-contained run covers far more fault schedules per budget than one long scenario.
+# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/vanilla-postgres.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -5,8 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
-# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/wide-table.toml
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -14,6 +14,9 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
+# Keep the runtime short: Antithesis explores by branching across many short timelines, so a
+# fast, self-contained run covers far more fault schedules per budget than one long scenario.
+# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -6,7 +6,7 @@ set -Eeuo pipefail
 echo ""
 echo "Updating suite to use Antithesis connection..."
 # The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned socket fail fast, so a recovery poke lands inside the reconnect-grace window
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/wide-table.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/wide-table.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -16,7 +16,6 @@ echo ""
 echo "Running Stressgres with suite wide-table.toml..."
 # Keep the runtime short: Antithesis explores by branching across many short timelines, so a
 # fast, self-contained run covers far more fault schedules per budget than one long scenario.
-# (A ~10-minute run also trips the Antithesis "all commands were run to completion" check.)
 /home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
-sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb"|' /home/app/stressgres/suites/wide-table.toml
+sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/wide-table.toml
 
 echo ""
 echo "Sleeping for 60 seconds to allow the ParadeDB cluster to initialize..."
@@ -13,7 +13,7 @@ sleep 60
 
 echo ""
 echo "Running Stressgres with suite wide-table.toml..."
-/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000
+/home/app/target/release/stressgres headless /home/app/stressgres/suites/wide-table.toml --runtime 100000 --log-interval-ms 10000 --reconnect-grace 3600000 --reconnect-grace-file /tmp/stressgres-reconnect-grace
 
 echo ""
 echo "Stressgres completed!"

--- a/stressgres/suites/antithesis/singleton_driver_wide-table.sh
+++ b/stressgres/suites/antithesis/singleton_driver_wide-table.sh
@@ -5,6 +5,8 @@ set -Eeuo pipefail
 # See stressgres/README.md about this connection string.
 echo ""
 echo "Updating suite to use Antithesis connection..."
+# The connect_timeout/keepalive/tcp_user_timeout params make a dropped or partitioned
+# socket fail fast instead of hanging ~130s, so a recovery poke lands inside the window.
 sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_retries=3\&tcp_user_timeout=15"|' /home/app/stressgres/suites/wide-table.toml
 
 echo ""


### PR DESCRIPTION
## Ticket(s) Closed

- Closes #5501

## What

Builds on the merged `--reconnect-grace` (#5524) to turn on `paradedb` faults for the stressgres workload and prove it recovers.

- Enables `paradedb` stop/kill faults for the stressgres workload (still excluded for proptests).
- Excludes the vanilla-Postgres logical-replication publisher from network faults too, not just stop/kill: partitioning it only stalls the WAL stream, so the subscriber's row-count assertions fail on ordinary replication lag rather than any ParadeDB defect.
- Antithesis drivers set `--reconnect-grace` longer than `--runtime`, so a connectivity fault alone can never fail a run. Real errors still do, since they carry a SQLSTATE.
- Adds a `--reconnect-grace-file` poke mechanism and `anytime_recovery_liveness.sh`, which heals every fault, then narrows the grace to a window that *can* expire. Removing the file restores the baseline.
- Adds liveness assertions (`assert_reachable!` / `assert_sometimes!`) plus `antithesis_init()`, so a never-hit site is reported instead of passing vacuously.
- Surfaces background-merge worker crashes: a new `antithesis` feature on `pg_search` reports an internal-error/corruption crash in the merge bgworker via `assert_unreachable!` before rethrowing, so a crash that only ever reached the container's stdout now fails the run. Interrupt-driven cancellations are exempt. Built only under `--features antithesis`; a no-op everywhere else.
- Gates fault injection on `setup_complete()`, so every suite builds its schema before faults start rather than being killed mid-initialisation.
- Adds `connect_timeout`, keepalives, and `tcp_user_timeout` to the Antithesis connection strings, so a black-holed socket fails fast enough for the grace window to mean anything.
- Bounds stressgres startup. The version probe and setup run with the full grace before the runtime clock starts, so a fault straddling startup could pin the process for the whole grace window and the driver would never finish. Now if one runtime passes with the database still unreachable it exits clean with no workload, so every driver reliably runs to completion. A real setup error still surfaces, so nothing is swallowed.

## Why

A green chaos run is only evidence if a timeout can actually expire somewhere faults are provably healed. Failing past a fixed grace doesn't work: Antithesis will always find a schedule that outlasts any bound we pick, turning it into a false positive. So connectivity never fails the run. Liveness is asserted from the outside, in the narrow window where faults are healed.

The startup bound comes from the same principle applied to completion rather than failure: a driver that can be pinned for the whole grace never runs to completion under an unlucky schedule, which an Antithesis spot test flagged. Capping startup makes drivers finish without letting connectivity fail the run.

## Tests

- `cargo test -p stressgres` (16 pass), `cargo clippy -p stressgres --all-targets -- -D warnings`, `shellcheck`.
- Drove the poke path with `ANTITHESIS_SDK_LOCAL_OUTPUT` set and confirmed both assertions register at init and then fire.

