### PR TITLE
fix(pg_search): EXPLAIN of aggregate join with heap filter no longer panics

### DIFF
--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -431,23 +431,21 @@ impl SearchIndexReader {
         let index_created_by_version = index_relation.created_by_version();
         let need_scores = need_scores || search_query_input.need_scores();
         let query = {
-            search_query_input
-                .into_tantivy_query(
-                    &schema,
-                    index_created_by_version,
-                    &|| {
-                        QueryParser::for_index(
-                            &index,
-                            schema.fields().map(|(field, _)| field).collect::<Vec<_>>(),
-                        )
-                    },
-                    &searcher,
-                    index_relation.oid(),
-                    index_relation.rel_oid(),
-                    expr_context,
-                    planstate,
-                )
-                .unwrap_or_else(|e| panic!("{e}"))
+            search_query_input.into_tantivy_query(
+                &schema,
+                index_created_by_version,
+                &|| {
+                    QueryParser::for_index(
+                        &index,
+                        schema.fields().map(|(field, _)| field).collect::<Vec<_>>(),
+                    )
+                },
+                &searcher,
+                index_relation.oid(),
+                index_relation.rel_oid(),
+                expr_context,
+                planstate,
+            )?
         };
         let segment_ord_by_id = searcher
             .segment_readers()

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -1442,8 +1442,14 @@ impl SearchQueryInput {
                 let (indexed_tantivy_query, opt_output) = B::split_for_parent(inner_output);
 
                 // Is initialized in `begin_custom_scan` if `has_heap_filters`.
-                let expr_context = expr_context
-                    .expect("An expression context must be provided when heap filtering.");
+                // During EXPLAIN-only mode, `begin_custom_scan` skips creating the expression
+                // context, so we return an Err here instead of panicking — the caller's error
+                // handler will display a graceful message in the EXPLAIN output.
+                let Some(expr_context) = expr_context else {
+                    return Err(anyhow::anyhow!(
+                        "No expression context available for heap filtering (EXPLAIN-only mode)"
+                    ));
+                };
 
                 // Create combined query with heap field filters
                 let query = Box::new(heap_field_filter::HeapFilterQuery::new(

--- a/tests/tests/aggregate_join.rs
+++ b/tests/tests/aggregate_join.rs
@@ -703,3 +703,22 @@ fn test_join_aggregate_cross_join_falls_back(mut conn: PgConnection) {
         "CROSS JOIN should produce same count whether DataFusion is ON or OFF"
     );
 }
+
+#[rstest]
+fn test_explain_aggregate_join_with_heap_filter(mut conn: PgConnection) {
+    setup_join_tables(&mut conn);
+    "SET paradedb.enable_join_custom_scan TO on".execute(&mut conn);
+
+    // EXPLAIN of an aggregate join query with a heap filter (ILIKE) used to panic with:
+    // "An expression context must be provided when heap filtering."
+    // because begin_custom_scan skips creating the expr context in EXPLAIN-only mode,
+    // but explain_custom_scan still tried to rebuild the full DataFusion physical plan.
+    r#"
+        EXPLAIN
+        SELECT COUNT(*)
+        FROM products p
+        JOIN tags t ON p.id = t.product_id
+        WHERE p.description @@@ 'laptop' AND p.description ILIKE '%laptop%'
+    "#
+    .execute(&mut conn);
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5514 

## What

Fix a panic that occurs when running `EXPLAIN` on an aggregate query over a join where the `WHERE` clause contains a predicate that cannot be pushed into the BM25 index (a heap filter, e.g. `ILIKE`).

## Why

`begin_custom_scan` intentionally skips creating the expression context when running in `EXPLAIN_ONLY` mode (no expressions need to be evaluated). However, `explain_custom_scan` calls `render_df_physical_plan`, which rebuilds the DataFusion physical plan from scratch to display it. When the plan contains a `HeapFilter`, it hits a hard `.expect()` / `.unwrap_or_else(panic)` on the missing context, crashing with:

```text
ERROR: XX000: An expression context must be provided when heap filtering.
```

Surfaced by Antithesis.

## How

Two changes:

1. **`query/mod.rs`** - Changed the `.expect()` in the `HeapFilter` branch of `SearchQueryInput::into_tantivy_query_generic` to return a proper `Err` instead of panicking. During `EXPLAIN`, `expr_context` is `None` by design, so returning an error allows it to propagate cleanly.

2. **`index/reader/index.rs`** - Changed `.unwrap_or_else(|e| panic!("{e}"))` on the `into_tantivy_query` call to `?` so the error bubbles up to `render_df_physical_plan`'s existing error handler, which gracefully displays:

```text
(rebuild failed during EXPLAIN: ...)
```

instead of crashing.

## Tests

Added `test_explain_aggregate_join_with_heap_filter` to `aggregate_join.rs`. The test reproduces the exact scenario from the bug report (BM25 filter + `ILIKE` heap filter over a join with both `enable_aggregate_custom_scan` and `enable_join_custom_scan` enabled) and asserts that `EXPLAIN` completes without error.