### PR TITLE
feat(stressgres): add an opt-in reconnect grace for transient database faults

### DIFF
--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -16,6 +16,22 @@ cargo run -- ui suites/vanilla-postgres.toml
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=logs/test.log
 ```
 
+- Run headless mode tolerating transient database faults (e.g. under Antithesis)
+
+```bash
+cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace=30000
+```
+
+By default (`--reconnect-grace=0`) any error fails the run. A larger value rides out
+transient connectivity faults — dropped or refused sockets, a restarting server — by
+reconnecting and replaying the operation, failing only once the database has stayed
+unreachable for the whole window. The window restarts after a successful reconnect.
+Real SQL errors always fail immediately, whatever the grace, because they carry a
+SQLSTATE and so mean the server answered.
+
+Set this when the database is expected to go away and come back, e.g. under a fault
+injector that stops, kills, or partitions its container.
+
 - Run a suite against a throwaway Postgres cluster built from a given `pg_config`:
 
 ```bash

--- a/stressgres/README.md
+++ b/stressgres/README.md
@@ -22,16 +22,6 @@ cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --log-file=l
 cargo run -- headless suites/vanilla-postgres.toml --runtime=300000 --reconnect-grace=30000
 ```
 
-By default (`--reconnect-grace=0`) any error fails the run. A larger value rides out
-transient connectivity faults — dropped or refused sockets, a restarting server — by
-reconnecting and replaying the operation, failing only once the database has stayed
-unreachable for the whole window. The window restarts after a successful reconnect.
-Real SQL errors always fail immediately, whatever the grace, because they carry a
-SQLSTATE and so mean the server answered.
-
-Set this when the database is expected to go away and come back, e.g. under a fault
-injector that stops, kills, or partitions its container.
-
 - Run a suite against a throwaway Postgres cluster built from a given `pg_config`:
 
 ```bash

--- a/stressgres/src/cli.rs
+++ b/stressgres/src/cli.rs
@@ -60,6 +60,16 @@ pub struct UiArgs {
     /// PostgreSQL version to use (pg15, pg16, pg17, or pg18).
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
+
+    /// How long (in milliseconds) to tolerate one continuous transient database fault
+    /// (dropped/refused sockets, server restarting) by reconnecting before failing the
+    /// run. The window restarts after a successful reconnect. Defaults to 0, i.e. any
+    /// error fails the run immediately.
+    ///
+    /// Set this when the database is expected to go away and come back, e.g. under a
+    /// fault injector that stops, kills, or partitions its container.
+    #[arg(long, default_value = "0")]
+    pub reconnect_grace: u64,
 }
 
 /// Arguments for running the suite in headless mode.
@@ -80,6 +90,15 @@ pub struct HeadlessArgs {
     /// PostgreSQL version to use (pg15, pg16, pg17, or pg18).
     #[arg(long, default_value = "pg18")]
     pub pgversion: Option<PgVersion>,
+    /// How long (in milliseconds) to tolerate one continuous transient database fault
+    /// (dropped/refused sockets, server restarting) by reconnecting before failing the
+    /// run. The window restarts after a successful reconnect. Defaults to 0, i.e. any
+    /// error fails the run immediately.
+    ///
+    /// Set this when the database is expected to go away and come back, e.g. under a
+    /// fault injector that stops, kills, or partitions its container.
+    #[arg(long, default_value = "0")]
+    pub reconnect_grace: u64,
 }
 
 /// Arguments for parsing a log file and generating the desired charts.

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -139,16 +139,13 @@ impl TransientProgress {
 /// while `op` keeps failing with a transient error (a dropped/refused socket, server
 /// restarting, etc.) it is retried with capped backoff. A real (non-transient) error
 /// is returned immediately. The connection is only declared dropped — and the error
-/// surfaced — once it has stayed broken for the whole grace window continuously.
-///
-/// The connection is only declared dropped — and the error surfaced — once it has
-/// stayed broken for `grace` continuously. If `op` calls
+/// surfaced — once it has stayed broken for `grace` continuously. If `op` calls
 /// [`TransientProgress::mark_recovered`] before returning a later transient error, the
 /// window restarts, because the database recovered in between.
 ///
-/// With `grace == 0`, the default, any error fails the run immediately and unwrapped,
-/// exactly as it did before this module existed. That is the only behaviour anything
-/// in-tree relies on today; a non-zero grace is opt-in via `--reconnect-grace`.
+/// With `grace == 0`, the default, any error fails the run immediately and unwrapped.
+/// That is the only behaviour anything in-tree relies on today; a non-zero grace is
+/// opt-in via `--reconnect-grace`.
 ///
 /// This is the single place reconnection lives. Callers express *what* to do (probe
 /// the version, run setup, run one job iteration); reopening a dead connection is
@@ -170,9 +167,9 @@ pub(crate) fn tolerate_transient<T>(
             Err(e) if !is_transient_error(&e) => return Err(e),
             Err(e) => {
                 // Checked before `alive`, so that a zero grace fails the run on the
-                // first error even during shutdown, as it did before this module. With
-                // a real grace we would rather abandon a fault we are waiting out than
-                // block teardown for the whole window.
+                // first error even during shutdown. With a real grace we would rather
+                // abandon a fault we are waiting out than block teardown for the whole
+                // window.
                 if grace.is_zero() {
                     return Err(e);
                 }

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -143,10 +143,6 @@ impl TransientProgress {
 /// [`TransientProgress::mark_recovered`] before returning a later transient error, the
 /// window restarts, because the database recovered in between.
 ///
-/// With `grace == 0`, the default, any error fails the run immediately and unwrapped.
-/// That is the only behaviour anything in-tree relies on today; a non-zero grace is
-/// opt-in via `--reconnect-grace`.
-///
 /// This is the single place reconnection lives. Callers express *what* to do (probe
 /// the version, run setup, run one job iteration); reopening a dead connection is
 /// the caller's job inside `op`, and re-running the whole `op` is what makes this

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -1,0 +1,359 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Tolerance for transient database connectivity faults.
+//!
+//! Under Antithesis the `paradedb` container is stopped, killed, and network-
+//! partitioned mid-run. This module classifies an error as either a *transient*
+//! connectivity fault (which the workload should ride out by reconnecting) or a
+//! *real* logical/SQL error (which must surface), and provides [`tolerate_transient`]
+//! to retry an operation through transient faults for a bounded grace window.
+//!
+//! The grace defaults to zero, under which any error fails the run, so this is inert
+//! unless a caller opts in with `--reconnect-grace`.
+//!
+//! When a non-zero grace is enabled, bug detection is expected to come from Antithesis
+//! properties / postgres-side checks, not from stressgres exit codes.
+
+use anyhow::Result;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+/// Backoff bounds for retries within the reconnect grace window.
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_millis(500);
+const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(5);
+
+/// Substrings that identify a transient connectivity failure when all we have is a
+/// stringified error (e.g. one already flattened by `format_postgres_error`).
+const TRANSIENT_ERROR_NEEDLES: &[&str] = &[
+    "network is unreachable",
+    "no route to host",
+    "connection refused",
+    "connection reset",
+    "connection closed",
+    "broken pipe",
+    "server closed the connection",
+    "terminating connection",
+    "error connecting to server",
+    "error communicating with the server",
+    "error performing tls handshake",
+    "unexpected eof",
+    "os error 101",     // ENETUNREACH
+    "(sqlstate: 08",    // connection exception class
+    "(sqlstate: 57p01", // admin_shutdown
+    "(sqlstate: 57p02", // crash_shutdown
+    "(sqlstate: 57p03", // cannot_connect_now
+];
+
+fn message_looks_transient(msg: &str) -> bool {
+    let msg = msg.to_ascii_lowercase();
+    TRANSIENT_ERROR_NEEDLES
+        .iter()
+        .any(|needle| msg.contains(needle))
+}
+
+/// Classifies a `postgres::Error` as a transient connectivity failure (as opposed
+/// to a logical/SQL error, which represents a real bug we want to surface).
+///
+/// The discriminator is whether the error carries a SQLSTATE, not what its message
+/// says. A SQLSTATE means the statement actually reached the server and it answered,
+/// so only the connection-class codes are transient and everything else is a real
+/// logical/SQL error. No SQLSTATE means the failure happened in the client/transport
+/// before the server answered — connect refused/reset, socket dropped, a TLS
+/// handshake against a server that is down or restarting, protocol desync on a dying
+/// connection — which under fault injection are exactly the faults we ride out. This
+/// keys off the transport-vs-server distinction rather than string-matching each new
+/// libpq/driver phrasing (e.g. "error performing TLS handshake", which has no
+/// SQLSTATE and no `is_closed()` signal, so needle matching alone would miss it).
+fn is_transient_connection_error(e: &postgres::Error) -> bool {
+    match e.as_db_error() {
+        Some(db) => {
+            let code = db.code().code();
+            // Class 08 = connection exception; 57P0x = operator/crash shutdown and
+            // "cannot connect now" (server starting up / shutting down).
+            code.starts_with("08") || matches!(code, "57P01" | "57P02" | "57P03" | "57P05")
+        }
+        // Client-side/transport failure: no answer from the server, so it never got
+        // far enough to be a logical bug. Treat it as transient.
+        None => true,
+    }
+}
+
+/// Classifies an `anyhow::Error` as a transient connectivity failure by walking its
+/// cause chain for a `postgres::Error`/IO error, falling back to string matching for
+/// errors that have already been flattened to a message.
+fn is_transient_error(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(pg) = cause.downcast_ref::<postgres::Error>() {
+            return is_transient_connection_error(pg);
+        }
+        if let Some(pg) = cause.downcast_ref::<Arc<postgres::Error>>() {
+            return is_transient_connection_error(pg);
+        }
+        if cause.downcast_ref::<std::io::Error>().is_some() {
+            return true;
+        }
+    }
+    message_looks_transient(&err.to_string())
+}
+
+fn interruptible_sleep(alive: &AtomicBool, dur: Duration) {
+    let start = Instant::now();
+    while start.elapsed() < dur {
+        if !alive.load(Ordering::Relaxed) {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+#[derive(Default)]
+pub(crate) struct TransientProgress {
+    recovered: bool,
+}
+
+impl TransientProgress {
+    /// Mark that this retry attempt reached the database. If the attempt later
+    /// fails with another transient error, it starts a fresh grace window.
+    pub(crate) fn mark_recovered(&mut self) {
+        self.recovered = true;
+    }
+}
+
+/// Runs `op`, tolerating transient connectivity faults for as long as `grace` allows:
+/// while `op` keeps failing with a transient error (a dropped/refused socket, server
+/// restarting, etc.) it is retried with capped backoff. A real (non-transient) error
+/// is returned immediately. The connection is only declared dropped — and the error
+/// surfaced — once it has stayed broken for the whole grace window continuously.
+///
+/// The connection is only declared dropped — and the error surfaced — once it has
+/// stayed broken for `grace` continuously. If `op` calls
+/// [`TransientProgress::mark_recovered`] before returning a later transient error, the
+/// window restarts, because the database recovered in between.
+///
+/// With `grace == 0`, the default, any error fails the run immediately and unwrapped,
+/// exactly as it did before this module existed. That is the only behaviour anything
+/// in-tree relies on today; a non-zero grace is opt-in via `--reconnect-grace`.
+///
+/// This is the single place reconnection lives. Callers express *what* to do (probe
+/// the version, run setup, run one job iteration); reopening a dead connection is
+/// the caller's job inside `op`, and re-running the whole `op` is what makes this
+/// safe for transactional work — a lost transaction is simply replayed from scratch.
+///
+/// Returns `Ok(None)` if `alive` went false while we were waiting out a fault.
+pub(crate) fn tolerate_transient<T>(
+    alive: &AtomicBool,
+    grace: Duration,
+    mut op: impl FnMut(&mut TransientProgress) -> Result<T>,
+) -> Result<Option<T>> {
+    let mut backoff = INITIAL_RECONNECT_BACKOFF;
+    let mut down_since: Option<Instant> = None;
+    loop {
+        let mut progress = TransientProgress::default();
+        match op(&mut progress) {
+            Ok(value) => return Ok(Some(value)),
+            Err(e) if !is_transient_error(&e) => return Err(e),
+            Err(e) => {
+                // Checked before `alive`, so that a zero grace fails the run on the
+                // first error even during shutdown, as it did before this module. With
+                // a real grace we would rather abandon a fault we are waiting out than
+                // block teardown for the whole window.
+                if grace.is_zero() {
+                    return Err(e);
+                }
+                if !alive.load(Ordering::Relaxed) {
+                    return Ok(None);
+                }
+                if progress.recovered {
+                    down_since = None;
+                    backoff = INITIAL_RECONNECT_BACKOFF;
+                }
+                let down_since = *down_since.get_or_insert_with(Instant::now);
+                if down_since.elapsed() >= grace {
+                    // Grace window exhausted: the fault is no longer "transient" as far
+                    // as the run is concerned and we should fail.
+                    return Err(e.context(format!(
+                        "database unreachable for {:?}, past the {grace:?} grace window",
+                        down_since.elapsed()
+                    )));
+                }
+                eprintln!("stressgres: transient database fault, retrying: {e:#}");
+                interruptible_sleep(alive, backoff);
+                backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use anyhow::anyhow;
+    use std::io;
+
+    #[test]
+    fn message_matching_flags_connectivity_faults() {
+        for msg in [
+            "error connecting to server: Network is unreachable (os error 101)",
+            "server closed the connection unexpectedly",
+            "connection reset by peer",
+            "db error: FATAL: terminating connection due to administrator command (SQLState: 57P01)",
+            "error: could not receive data from server (SQLState: 08006)",
+            // No SQLSTATE, no `is_closed()` signal: only the transport-level phrasing
+            // marks this as connectivity noise (server down/restarting mid-handshake).
+            "error performing TLS handshake: unexpected EOF",
+        ] {
+            assert!(message_looks_transient(msg), "should be transient: {msg}");
+        }
+    }
+
+    #[test]
+    fn message_matching_ignores_real_errors() {
+        for msg in [
+            "ERROR: division by zero (SQLState: 22012)",
+            "duplicate key value violates unique constraint (SQLState: 23505)",
+            "ERROR: relation \"foo\" does not exist (SQLState: 42P01)",
+            "Job assertion failed: expected 5 but got 3",
+        ] {
+            assert!(!message_looks_transient(msg), "should be real: {msg}");
+        }
+    }
+
+    #[test]
+    fn anyhow_string_errors_are_classified() {
+        assert!(is_transient_error(&anyhow!(
+            "error connecting to server: Network is unreachable (os error 101)"
+        )));
+        assert!(!is_transient_error(&anyhow!(
+            "Job assertion failed: expected 5 but got 3"
+        )));
+    }
+
+    #[test]
+    fn io_errors_are_transient() {
+        let err = anyhow::Error::new(io::Error::new(io::ErrorKind::ConnectionReset, "reset"));
+        assert!(is_transient_error(&err));
+    }
+
+    #[test]
+    fn recovery_marker_restarts_grace_window() {
+        let alive = AtomicBool::new(true);
+        let mut attempts = 0;
+
+        let grace = Duration::from_millis(250);
+        let result = tolerate_transient(&alive, grace, |progress| {
+            attempts += 1;
+            match attempts {
+                1 => Err(anyhow!("connection closed")),
+                2 => {
+                    progress.mark_recovered();
+                    Err(anyhow!("connection closed"))
+                }
+                _ => Ok("ok"),
+            }
+        })
+        .unwrap();
+
+        assert_eq!(result, Some("ok"));
+        assert_eq!(attempts, 3);
+    }
+
+    #[test]
+    fn zero_grace_fails_on_the_first_transient_error() {
+        let alive = AtomicBool::new(true);
+        let grace = Duration::ZERO;
+        let mut attempts = 0;
+
+        let err = tolerate_transient(&alive, grace, |_| {
+            attempts += 1;
+            Err::<(), _>(anyhow!("connection refused"))
+        })
+        .unwrap_err();
+
+        assert_eq!(attempts, 1);
+        // No `.context()` wrapping: the caller sees exactly the error it would have
+        // seen before fault tolerance existed.
+        assert_eq!(err.to_string(), "connection refused");
+    }
+
+    /// A grace no test will exhaust.
+    const LONG_GRACE: Duration = Duration::from_secs(3600);
+
+    #[test]
+    fn a_long_grace_rides_out_transient_faults() {
+        let alive = AtomicBool::new(true);
+        let grace = LONG_GRACE;
+        let mut attempts = 0;
+
+        let result = tolerate_transient(&alive, grace, |_| {
+            attempts += 1;
+            if attempts < 4 {
+                Err(anyhow!("connection refused"))
+            } else {
+                Ok("ok")
+            }
+        })
+        .unwrap();
+
+        assert_eq!(result, Some("ok"));
+    }
+
+    /// `main` propagates any error from a job, including one raised as the suite is
+    /// shutting down. The grace-0 default must not start swallowing those.
+    #[test]
+    fn zero_grace_fails_even_once_the_suite_is_shutting_down() {
+        let alive = AtomicBool::new(false);
+        let grace = Duration::ZERO;
+
+        let err = tolerate_transient(&alive, grace, |_| {
+            Err::<(), _>(anyhow!("connection refused"))
+        })
+        .unwrap_err();
+
+        assert_eq!(err.to_string(), "connection refused");
+    }
+
+    /// With a real grace we would rather abandon a fault we are riding out than block
+    /// teardown for the whole window.
+    #[test]
+    fn a_long_grace_gives_up_once_the_suite_is_shutting_down() {
+        let alive = AtomicBool::new(false);
+
+        let result = tolerate_transient(&alive, LONG_GRACE, |_| {
+            Err::<(), _>(anyhow!("connection refused"))
+        })
+        .unwrap();
+
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn real_errors_surface_through_a_long_grace() {
+        let alive = AtomicBool::new(true);
+        let grace = LONG_GRACE;
+
+        let err = tolerate_transient(&alive, grace, |_| {
+            Err::<(), _>(anyhow!(
+                "duplicate key value violates unique constraint (SQLState: 23505)"
+            ))
+        })
+        .unwrap_err();
+
+        assert!(err.to_string().contains("duplicate key"));
+    }
+}

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -20,6 +20,7 @@
 mod auto;
 mod cli;
 mod csv;
+mod fault_tolerance;
 mod graph;
 mod headless;
 mod metrics;
@@ -59,7 +60,11 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(suite, args.paused)?;
+            let suite_runner = SuiteRunner::new(
+                suite,
+                args.paused,
+                Duration::from_millis(args.reconnect_grace),
+            )?;
             tui::run(suite_runner)?;
         }
 
@@ -68,7 +73,8 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, args.pgversion, None).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(suite, false)?;
+            let suite_runner =
+                SuiteRunner::new(suite, false, Duration::from_millis(args.reconnect_grace))?;
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {
@@ -90,7 +96,9 @@ fn main() -> anyhow::Result<()> {
             let suite = load_suite(&args.suite_path, None, Some(&args)).with_context(|| {
                 format!("Failed to load suite file: {}", args.suite_path.display())
             })?;
-            let suite_runner = SuiteRunner::new(suite, false)?;
+            // `auto` is a local-dev command with no fault injection, so fail fast
+            // (grace 0) rather than tolerating transient connectivity faults.
+            let suite_runner = SuiteRunner::new(suite, false, Duration::ZERO)?;
             headless::run(
                 suite_runner,
                 args.log_path.clone(),

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -611,10 +611,9 @@ impl SuiteRunner {
                 break;
             }
 
-            // An `atomic_connection` job opens a fresh connection each iteration. It is
-            // dropped here rather than after `run`, matching the temporary that the
-            // previous `&mut Conn::open(..)` bound: both keep the connection open
-            // across the refresh sleep and close it before the next iteration opens.
+            // An `atomic_connection` job opens a fresh connection each iteration.
+            // Dropping it here rather than after `run` keeps it open across the refresh
+            // sleep and closes it before the next iteration reopens it.
             if job_runner.job.atomic_connection {
                 conn = None;
             }

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -388,6 +388,21 @@ fn with_reconnect<T>(
 }
 
 impl SuiteRunner {
+    /// [`with_reconnect`] for a one-shot job (version probe, setup, teardown): opens a
+    /// throwaway connection and fills in the runner's `alive` / grace / suite, so the
+    /// caller only supplies the job and what to do with the connection.
+    fn run_once<T>(&self, job: &Job, op: impl FnMut(&mut Conn) -> Result<T>) -> Result<Option<T>> {
+        let mut conn = None;
+        with_reconnect(
+            &self.alive,
+            self.reconnect_grace,
+            &mut conn,
+            &self.suite,
+            job,
+            op,
+        )
+    }
+
     /// Create a new SuiteRunner, run the `setup` job, then spawn threads for each job + monitor.
     pub fn new(suite: Suite, paused: bool, reconnect_grace: Duration) -> Result<Arc<Self>> {
         let suite = Arc::new(suite);
@@ -408,22 +423,15 @@ impl SuiteRunner {
 
         // Probe the server version, riding out any transient connectivity fault
         let default_job = Job::default();
-        let mut conn = None;
-        runner.pgver = with_reconnect(
-            &runner.alive,
-            runner.reconnect_grace,
-            &mut conn,
-            &suite,
-            &default_job,
-            |conn| {
-                let version: String = conn
-                    .first_client()
-                    .query_one("SELECT version()", &[])?
-                    .get(0);
-                Ok(version)
-            },
-        )?
-        .unwrap_or_else(|| String::from("<unknown>"));
+        if let Some(version) = runner.run_once(&default_job, |conn| {
+            let version: String = conn
+                .first_client()
+                .query_one("SELECT version()", &[])?
+                .get(0);
+            Ok(version)
+        })? {
+            runner.pgver = version;
+        }
 
         runner.init()?;
         let suite_runner = Arc::new(runner);
@@ -478,15 +486,7 @@ impl SuiteRunner {
             // the top rebuilds state no matter how far a partial attempt got — not
             // because it runs in one transaction (it can't: it issues ALTER SYSTEM /
             // pg_reload_conf, which are disallowed inside a transaction block).
-            let mut conn = None;
-            with_reconnect(
-                &self.alive,
-                self.reconnect_grace,
-                &mut conn,
-                &self.suite,
-                &setup_runner.job,
-                |conn| setup_runner.run(conn),
-            )?;
+            self.run_once(&setup_runner.job, |conn| setup_runner.run(conn))?;
         }
 
         // setup and start the monitors
@@ -756,15 +756,7 @@ impl SuiteRunner {
             // Best-effort teardown: ride out a transient fault, and if connectivity
             // is gone during shutdown (`alive` is already false here) skip it rather
             // than panicking the shutdown thread.
-            let mut conn = None;
-            with_reconnect(
-                &self.alive,
-                self.reconnect_grace,
-                &mut conn,
-                &self.suite,
-                &teardown_runner.job,
-                |conn| teardown_runner.run(conn),
-            )?;
+            self.run_once(&teardown_runner.job, |conn| teardown_runner.run(conn))?;
         }
 
         for job in &self.runners {

--- a/stressgres/src/runner.rs
+++ b/stressgres/src/runner.rs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
+use crate::fault_tolerance::tolerate_transient;
 use crate::sqlscanner::StatementDestination;
 use crate::suite::{Job, Server, ServerStyle, Suite};
 use anyhow::{anyhow, Result};
@@ -345,14 +346,50 @@ pub struct SuiteRunner {
     runners: Vec<Arc<JobRunner>>,
     have_error: Arc<AtomicBool>,
     first_error_duration_bits: Arc<AtomicU64>,
+    reconnect_grace: Duration,
 
     monitors: Vec<Arc<JobRunner>>,
     sys: Arc<RwLock<System>>,
 }
 
+/// Run `op` against a live [`Conn`], tolerating transient connectivity faults.
+///
+/// The connection lives in `conn` and is (re)opened lazily: whenever it is `None`
+/// — the first call, or after a prior error dropped it — a fresh one is opened and
+/// the reconnect grace window is reset (the fault-tolerance layer's `mark_recovered`).
+/// On any error from `op` the connection is dropped so the next attempt reconnects;
+/// replaying the whole `op` is what keeps transactional work correct.
+///
+/// One-shot callers (version probe, setup, teardown) pass a throwaway `&mut None`;
+/// the job worker passes a long-lived slot so its connection persists across
+/// iterations. This is the single place the open / `mark_recovered` / drop-on-error
+/// dance lives, so callers only have to say what to do with the connection.
+///
+/// Returns `Ok(None)` if `alive` went false while waiting out a fault.
+fn with_reconnect<T>(
+    alive: &AtomicBool,
+    grace: Duration,
+    conn: &mut Option<Conn>,
+    suite: &Suite,
+    job: &Job,
+    mut op: impl FnMut(&mut Conn) -> Result<T>,
+) -> Result<Option<T>> {
+    tolerate_transient(alive, grace, |progress| {
+        if conn.is_none() {
+            *conn = Some(Conn::open(suite, job)?);
+            progress.mark_recovered();
+        }
+        let result = op(conn.as_mut().unwrap());
+        if result.is_err() {
+            *conn = None;
+        }
+        result
+    })
+}
+
 impl SuiteRunner {
     /// Create a new SuiteRunner, run the `setup` job, then spawn threads for each job + monitor.
-    pub fn new(suite: Suite, paused: bool) -> Result<Arc<Self>> {
+    pub fn new(suite: Suite, paused: bool, reconnect_grace: Duration) -> Result<Arc<Self>> {
         let suite = Arc::new(suite);
         let mut runner = Self {
             suite: suite.clone(),
@@ -363,15 +400,30 @@ impl SuiteRunner {
             runners: Default::default(),
             have_error: Arc::new(AtomicBool::new(false)),
             first_error_duration_bits: Default::default(),
+            reconnect_grace,
 
             monitors: Default::default(),
             sys: Arc::new(RwLock::new(System::new_all())),
         };
 
-        runner.pgver = Conn::open(&suite, &Job::default())?
-            .first_client()
-            .query_one("SELECT version()", &[])?
-            .get(0);
+        // Probe the server version, riding out any transient connectivity fault
+        let default_job = Job::default();
+        let mut conn = None;
+        runner.pgver = with_reconnect(
+            &runner.alive,
+            runner.reconnect_grace,
+            &mut conn,
+            &suite,
+            &default_job,
+            |conn| {
+                let version: String = conn
+                    .first_client()
+                    .query_one("SELECT version()", &[])?
+                    .get(0);
+                Ok(version)
+            },
+        )?
+        .unwrap_or_else(|| String::from("<unknown>"));
 
         runner.init()?;
         let suite_runner = Arc::new(runner);
@@ -420,7 +472,21 @@ impl SuiteRunner {
                 self.alive.clone(),
                 self.sys.clone(),
             )?;
-            setup_runner.run(&mut Conn::open(&self.suite, &setup_runner.job)?)?;
+            // Run setup on a fresh connection, replaying it in full if a transient
+            // fault interrupts it. Replay is safe because setup is idempotent (every
+            // statement is DROP ... IF EXISTS / CREATE OR REPLACE), so re-running from
+            // the top rebuilds state no matter how far a partial attempt got — not
+            // because it runs in one transaction (it can't: it issues ALTER SYSTEM /
+            // pg_reload_conf, which are disallowed inside a transaction block).
+            let mut conn = None;
+            with_reconnect(
+                &self.alive,
+                self.reconnect_grace,
+                &mut conn,
+                &self.suite,
+                &setup_runner.job,
+                |conn| setup_runner.run(conn),
+            )?;
         }
 
         // setup and start the monitors
@@ -489,12 +555,13 @@ impl SuiteRunner {
 
         let job_runner = Arc::new(job_runner);
         let refresh_ms = Duration::from_millis(job_runner.job.refresh_ms as u64);
+        let reconnect_grace = self.reconnect_grace;
 
         // The actual thread loop
         let handle = {
             let job_runner = job_runner.clone();
             std::thread::spawn(move || {
-                match Self::job_runner_worker(paused, refresh_ms, &job_runner) {
+                match Self::job_runner_worker(paused, refresh_ms, reconnect_grace, &job_runner) {
                     Ok(()) => Ok(()),
                     Err(e) => {
                         job_runner.running.store(false, Ordering::Relaxed);
@@ -520,6 +587,7 @@ impl SuiteRunner {
     fn job_runner_worker(
         paused: Arc<AtomicBool>,
         refresh_ms: Duration,
+        reconnect_grace: Duration,
         job_runner: &Arc<JobRunner>,
     ) -> Result<(), anyhow::Error> {
         *job_runner.runtime_stats.write() = Conn::make_infos(&job_runner.suite, &job_runner.job)
@@ -527,13 +595,13 @@ impl SuiteRunner {
             .map(|info| (info, RuntimeStats::default()))
             .collect();
 
-        let mut conn = if job_runner.job.atomic_connection {
-            None
-        } else {
-            Some(Conn::open(&job_runner.suite, &job_runner.job)?)
-        };
-
         let alive = job_runner.alive.clone();
+
+        // A normal job keeps a persistent connection; an `atomic_connection` job
+        // opens a fresh one each iteration. Either way it is (re)opened lazily by
+        // `with_reconnect`, so a dropped socket just reconnects.
+        let mut conn: Option<Conn> = None;
+
         while alive.load(Ordering::Relaxed) {
             // If paused, sleep until unpaused
             while paused.load(Ordering::Relaxed) && alive.load(Ordering::Relaxed) {
@@ -543,11 +611,28 @@ impl SuiteRunner {
                 break;
             }
 
-            let conn = match &mut conn {
-                Some(conn) => conn,
-                None => &mut Conn::open(&job_runner.suite, &job_runner.job)?,
-            };
-            job_runner.run(conn)?;
+            // An `atomic_connection` job opens a fresh connection each iteration. It is
+            // dropped here rather than after `run`, matching the temporary that the
+            // previous `&mut Conn::open(..)` bound: both keep the connection open
+            // across the refresh sleep and close it before the next iteration opens.
+            if job_runner.job.atomic_connection {
+                conn = None;
+            }
+
+            // Run one iteration, riding out transient faults. `with_reconnect` drops
+            // the (possibly poisoned) connection on error so the next attempt
+            // reconnects; replaying the whole iteration keeps transactional jobs correct.
+            let outcome = with_reconnect(
+                &alive,
+                reconnect_grace,
+                &mut conn,
+                &job_runner.suite,
+                &job_runner.job,
+                |conn| job_runner.run(conn),
+            )?;
+            if outcome.is_none() {
+                break; // `alive` went false while waiting out a fault
+            }
 
             if refresh_ms.as_millis() <= 1000 {
                 // if the refresh interval is less than a second, just sleep for that amount of time
@@ -668,7 +753,18 @@ impl SuiteRunner {
                 self.alive.clone(),
                 self.sys.clone(),
             )?;
-            teardown_runner.run(&mut Conn::open(&self.suite, &teardown_runner.job)?)?;
+            // Best-effort teardown: ride out a transient fault, and if connectivity
+            // is gone during shutdown (`alive` is already false here) skip it rather
+            // than panicking the shutdown thread.
+            let mut conn = None;
+            with_reconnect(
+                &self.alive,
+                self.reconnect_grace,
+                &mut conn,
+                &self.suite,
+                &teardown_runner.job,
+                |conn| teardown_runner.run(conn),
+            )?;
         }
 
         for job in &self.runners {


### PR DESCRIPTION
## What

Adds `--reconnect-grace` to stressgres, in milliseconds, defaulting to 0. Above zero, a transient connectivity fault is retried with capped backoff, and only fails the run once the database has stayed unreachable for the whole window. The window restarts after a successful reconnect.

Nothing in-tree passes a non-zero grace, so this is inert. #5521 stacks on it to enable Antithesis container faults and assert recovery.

## Why

A stressgres job that loses its connection fails the run. That's right for local and CI runs, where the database going away is itself the bug. It's wrong under a fault injector that stops, kills, and partitions the database container on purpose, where reconnecting is the behaviour under test.

Transient is decided by whether the error carries a SQLSTATE, not by what its message says. A SQLSTATE means the statement reached the server and the server answered, so only the connection classes (08xxx, 57P0x) are transient and everything else is a real bug. No SQLSTATE means it failed in the client or the transport before the server answered, which is exactly the class we want to ride out. Keying off that rather than string-matching means we don't have to chase each new driver phrasing, e.g. "error performing TLS handshake", which carries no SQLSTATE and no `is_closed()` signal.

Reconnection is centralised in `with_reconnect`, which owns the open / `mark_recovered` / drop-on-error dance, per Stu's review on #5492. Replaying the whole operation is what keeps transactional work correct: a lost transaction is just re-run from scratch.

## Behaviour at the default is unchanged

`tolerate_transient` checks for a zero grace *before* it checks `alive`, so the first error fails the run unwrapped, with no added context, on every path, including during shutdown and teardown. Without that ordering, teardown would start swallowing errors that `main` propagates today. Both that and the shutdown behaviour a real grace needs are pinned by tests.

One deliberate difference: a non-`atomic_connection` job now opens its connection lazily on the first iteration rather than eagerly before the loop. Invisible in headless mode. In a TUI started with `--paused`, connections open on unpause rather than at startup. Undoing it would undo the `with_reconnect` centralisation.

I checked the `atomic_connection` path against `main` rather than assuming: `main` binds `&mut Conn::open(..)` in a `match` arm, and temporary lifetime extension keeps that connection alive to the end of the loop body, i.e. across the refresh sleep. The lazy `Option<Conn>` here drops it at the same point, so the two are equivalent.

## Tests

- `cargo test -p stressgres`. 11 pass, 8 new: the SQLSTATE classification, the zero-grace default including during shutdown, a long grace riding faults out and giving up on shutdown, real errors surfacing through a long grace, and the window restarting on reconnect.
- `cargo clippy -p stressgres --all-targets -- -D warnings`.

No `Cargo.lock` change, so no nix `cargoHash` regeneration.
