### PR TITLE
perf: cap index build worker memory at 1GB

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -689,15 +689,17 @@ pub fn global_enable_background_merging() -> bool {
     GLOBAL_ENABLE_BACKGROUND_MERGING.get()
 }
 
-// NB:  These limits come from [`tantivy::index_writer::MEMORY_BUDGET_NUM_BYTES_MAX`], which is not publicly exposed
+// NB:  MEMORY_BUDGET_NUM_BYTES_MIN comes from [`tantivy::index_writer::MEMORY_BUDGET_NUM_BYTES_MIN`], which is not publicly exposed
 mod limits {
     const MARGIN_IN_BYTES: usize = 1_000_000;
     // Size of the margin for the `memory_arena`. A segment is closed when the remaining memory
     // in the `memory_arena` goes below MARGIN_IN_BYTES.
     pub const MEMORY_BUDGET_NUM_BYTES_MIN: usize = 15 * MARGIN_IN_BYTES;
 
-    // We impose the memory per thread to be no greater than 4GB as that's tantivy's limit
-    pub const MEMORY_BUDGET_NUM_BYTES_MAX: usize = (4 * 1024 * 1024 * 1024) - MARGIN_IN_BYTES;
+    // We impose the memory per thread to be no greater than 1GB. Tantivy's hard limit is 4GB,
+    // but a single writer sees no meaningful throughput gains past ~1GB, so anything more is
+    // just wasted memory.
+    pub const MEMORY_BUDGET_NUM_BYTES_MAX: usize = 1024 * 1024 * 1024;
 }
 
 pub fn adjust_maintenance_work_mem(nlaunched: usize) -> NonZeroUsize {
@@ -721,7 +723,7 @@ pub fn adjust_maintenance_work_mem(nlaunched: usize) -> NonZeroUsize {
         );
     }
 
-    // clamp the per_thread_budget to the min/max values
+    // clamp the per_worker_budget to the min/max values
     let per_worker_budget = per_worker_budget.clamp(
         limits::MEMORY_BUDGET_NUM_BYTES_MIN,
         limits::MEMORY_BUDGET_NUM_BYTES_MAX - 1,
@@ -911,6 +913,17 @@ mod tests {
             1.0
         );
         assert!(std::panic::catch_unwind(|| adjust_maintenance_work_mem(128)).is_err());
+
+        // Each worker is capped at 1GB, so raising maintenance_work_mem beyond
+        // nlaunched * 1GB does not hand any single worker more than 1GB.
+        const ONE_GB: usize = 1024 * 1024 * 1024;
+        Spi::run("SET maintenance_work_mem = '8GB';").unwrap();
+        // 1 worker: 8GB budget clamped down to the 1GB per-worker cap.
+        assert_approx_eq!(adjust_maintenance_work_mem(1).get(), ONE_GB, 1.0);
+        // 2 workers: each capped at 1GB -> 2GB total.
+        assert_approx_eq!(adjust_maintenance_work_mem(2).get(), 2 * ONE_GB, 1.0);
+        // 8 workers: 8GB / 8 = 1GB each, exactly at the cap -> 8GB total.
+        assert_approx_eq!(adjust_maintenance_work_mem(8).get(), 8 * ONE_GB, 1.0);
     }
 
     #[pg_test]


### PR DESCRIPTION
## What

Lowers `MEMORY_BUDGET_NUM_BYTES_MAX` from ~4GB to **1GB**, capping the memory budget of an index-build worker. The reason is we don't see perf gains beyond this point, so we're just wasting memory.