### PR TITLE
feat: Add sql function to inspect index_created_by version

### DIFF
--- a/pg_search/sql/pg_search--0.24.2--0.24.3.sql
+++ b/pg_search/sql/pg_search--0.24.2--0.24.3.sql
@@ -1,1 +1,9 @@
 \echo Use "ALTER EXTENSION pg_search UPDATE TO '0.24.3'" to load this file. \quit
+
+-- Expose the pg_search version stamped into an index's metadata page at build time.
+CREATE FUNCTION "index_created_by"(
+	"index" regclass /* pgrx::rel::PgRelation */
+) RETURNS TEXT /* core::option::Option<alloc::string::String> */
+STRICT
+LANGUAGE c /* Rust */
+AS 'MODULE_PATHNAME', 'index_created_by_wrapper';

--- a/pg_search/src/api/admin.rs
+++ b/pg_search/src/api/admin.rs
@@ -203,6 +203,16 @@ pub fn index_created_at(index: PgRelation) -> Option<pgrx::datum::TimestampWithT
         .and_then(|ts| pgrx::datum::TimestampWithTimeZone::try_from(ts).ok())
 }
 
+/// Returns the pg_search version that created the given bm25 index, or NULL for indices
+/// created before version stamping was added.
+#[pg_extern]
+pub fn index_created_by(index: PgRelation) -> Option<String> {
+    let index = PgSearchRelation::with_lock(index.oid(), pg_sys::AccessShareLock as _);
+    MetaPage::open(&index)
+        .created_by_version()
+        .map(|version| version.to_string())
+}
+
 #[pg_extern]
 unsafe fn merge_info(
     index: PgRelation,

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -428,6 +428,12 @@ mod tests {
             env!("CARGO_PKG_VERSION_PATCH").parse().unwrap(),
         );
         assert_eq!(stamped, expected);
+
+        // The UDF should surface the same version.
+        let via_udf: String = Spi::get_one("SELECT paradedb.index_created_by('t_idx')")
+            .expect("spi should succeed")
+            .unwrap();
+        assert_eq!(via_udf, stamped.to_string());
     }
 
     #[pg_test]


### PR DESCRIPTION
## What
Adds a sql function that I should have added back in #5309 

