### PR TITLE
ci: surface Mintlify error body on failed publish

### DIFF
--- a/.github/workflows/publish-paradedb-docs.yml
+++ b/.github/workflows/publish-paradedb-docs.yml
@@ -25,12 +25,22 @@ jobs:
 
       - name: Publish Docs to Mintlify
         run: |
-          # -f makes curl exit non-zero on an HTTP 4xx/5xx so a failed deploy fails the step
-          # instead of silently reporting success.
-          curl -fsS -X POST \
+          # Capture the response body and HTTP status separately so a failed deploy
+          # surfaces Mintlify's error message instead of just an opaque curl exit code.
+          http_code=$(curl -sS -o response.txt -w "%{http_code}" -X POST \
             https://api.mintlify.com/v1/project/update/${{ secrets.MINTLIFY_PROJECT_ID }} \
             -H "Authorization: Bearer ${{ secrets.MINTLIFY_API_KEY }}" \
-            -H "Content-Type: application/json"
+            -H "Content-Type: application/json")
+
+          echo "HTTP status: ${http_code}"
+          echo "Response body:"
+          cat response.txt
+
+          # Fail the step on any non-2xx response.
+          if [ "${http_code}" -lt 200 ] || [ "${http_code}" -ge 300 ]; then
+            echo "::error::Mintlify deploy failed with HTTP ${http_code}"
+            exit 1
+          fi
 
       - name: Notify Slack on Failure
         if: failure()


### PR DESCRIPTION
The docs publish step used `curl -fsS`, which fails on any 4xx/5xx but discards the response body — a failed deploy showed only `curl: (22)` and the HTTP code, with no insight into *why* Mintlify rejected the request.

Recent runs ([#29127618896](https://github.com/paradedb/paradedb/actions/runs/29127618896), [#29128019150](https://github.com/paradedb/paradedb/actions/runs/29128019150)) have been returning **HTTP 401** even after rotating `MINTLIFY_API_KEY` and `MINTLIFY_PROJECT_ID`, and the suppressed body made root-causing impossible.

## Change
- Capture the response body (`-o response.txt`) and HTTP status (`-w %{http_code}`) separately.
- Print both to the log.
- Fail the step on any non-2xx.

## Next step after merge
Re-run the `Publish ParadeDB (Docs)` workflow via `workflow_dispatch` — the logged body will show the actual Mintlify error. Note their current [API docs](https://www.mintlify.com/docs/api/update/trigger) require an **admin** API key prefixed with `mint_`; a non-admin/legacy key returns 401.

https://claude.ai/code/session_01VKafSY9WpVb4LgVzMek2iB