### PR TITLE
chore: Update to a DataFusion `0.55.x` prerelease

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -202,19 +202,37 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "378530e55cd479eda3c14eb345310799717e6f76d0c332041e8487022166b471"
 dependencies = [
- "arrow-arith",
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
+ "arrow-arith 58.3.0",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-cast 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-row 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "arrow-string 58.3.0",
+]
+
+[[package]]
+name = "arrow"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b952ca5a8046ad741b60f142d6eca4aeebcad615694202bc64c5341f23e32c5b"
+dependencies = [
+ "arrow-arith 59.1.0",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-cast 59.1.0",
  "arrow-csv",
- "arrow-data",
+ "arrow-data 59.1.0",
  "arrow-ipc",
  "arrow-json",
- "arrow-ord",
- "arrow-row",
- "arrow-schema",
- "arrow-select",
- "arrow-string",
+ "arrow-ord 59.1.0",
+ "arrow-row 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
+ "arrow-string 59.1.0",
 ]
 
 [[package]]
@@ -223,10 +241,24 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0ab212d2c1886e802f51c5212d78ebbcbb0bec980fff9dadc1eb8d45cd0b738"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-arith"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a13b8d3008c4e9063c597a08f46446fe3fd5789277127672d6c0bdbb43b1ff"
+dependencies = [
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
  "chrono",
  "num-traits",
 ]
@@ -238,9 +270,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "chrono",
+ "half 2.7.1",
+ "hashbrown 0.17.1",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-array"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9486151b2f0785bafc6fa04fc5c99fcb4495455662e58787ea32eaaed33c4192"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
  "chrono",
  "chrono-tz",
  "half 2.7.1",
@@ -263,17 +313,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrow-buffer"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4776577a87794bfdf0b4e90e2ea12454fa7738ea2823c4be5b9d1851da7b434"
+dependencies = [
+ "bytes",
+ "half 2.7.1",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
 name = "arrow-cast"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c5aefb56a2c02e9e2b30746241058b85f8983f0fcff2ba0c6d09006e1cded7f"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-ord 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "atoi",
+ "base64",
+ "chrono",
+ "comfy-table",
+ "half 2.7.1",
+ "lexical-core",
+ "num-traits",
+ "ryu",
+]
+
+[[package]]
+name = "arrow-cast"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ad451ce4f98710828a455b96991b8f031deb2e67f5fcad6773f017e4a69c3a"
+dependencies = [
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-ord 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "atoi",
  "base64",
  "chrono",
@@ -286,13 +370,13 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94e8cf7e517657a52b91ea1263acf38c4ca62a84655d72458a3359b12ab97de"
+checksum = "8aa7bf96d6141a7bcca2eed57c7c9767d2a2175281857b8a7b68308992864784"
 dependencies = [
- "arrow-array",
- "arrow-cast",
- "arrow-schema",
+ "arrow-array 59.1.0",
+ "arrow-cast 59.1.0",
+ "arrow-schema 59.1.0",
  "chrono",
  "csv",
  "csv-core",
@@ -305,8 +389,21 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
 dependencies = [
- "arrow-buffer",
- "arrow-schema",
+ "arrow-buffer 58.3.0",
+ "arrow-schema 58.3.0",
+ "half 2.7.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38fe43e2e8704360f1464e6e8cc4fc381ef02cc4fb0192afa8df1aaa0115c66"
+dependencies = [
+ "arrow-buffer 59.1.0",
+ "arrow-schema 59.1.0",
  "half 2.7.1",
  "num-integer",
  "num-traits",
@@ -314,15 +411,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+checksum = "29dac499fcbc6ba74ee0324057821d381929a48526a3966bd9dffb44aa06d98c"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "flatbuffers",
  "lz4_flex",
  "zstd",
@@ -330,16 +427,16 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "205ca2119e6d679d5c133c6f30e68f027738d95ed948cf77677ea69c7800036b"
+checksum = "0fe05e916ddc50f4c7a363cd69c0ef5894fcee063517e9a0b8582f0c56746af6"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-cast",
- "arrow-ord",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-cast 59.1.0",
+ "arrow-ord 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "chrono",
  "half 2.7.1",
  "indexmap",
@@ -359,11 +456,24 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bffd8fd2579286a5d63bac898159873e5094a79009940bcb42bbfce4f19f1d0"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+]
+
+[[package]]
+name = "arrow-ord"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e13dbdc2a9c053c10c7baa6e30faee04a180aa7ce88e471835850ce37abd20b"
+dependencies = [
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
 ]
 
 [[package]]
@@ -372,10 +482,23 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bab5994731204603c73ba69267616c50f80780774c6bb0476f1f830625115e0c"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "half 2.7.1",
+]
+
+[[package]]
+name = "arrow-row"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d5a1f8c733d15260b305683472ee8ad89c62cbd706703ca873b90d051b41592"
+dependencies = [
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
  "half 2.7.1",
 ]
 
@@ -386,6 +509,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
  "bitflags 2.13.0",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9e4969dc350d571766247143ab36a5187d095d3d3690970408bc630d47c69e5"
+dependencies = [
  "serde_core",
  "serde_json",
 ]
@@ -397,10 +528,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-select"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402770dba90865359d98d1ef92ef16e23d75c0cca9c2c880c8a05468b7743bf9"
+dependencies = [
+ "ahash 0.8.12",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
  "num-traits",
 ]
 
@@ -410,11 +555,28 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29dd7cda3ab9692f43a2e4acc444d760cc17b12bb6d8232ddf64e9bab7c06b42"
 dependencies = [
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 58.3.0",
+ "arrow-buffer 58.3.0",
+ "arrow-data 58.3.0",
+ "arrow-schema 58.3.0",
+ "arrow-select 58.3.0",
+ "memchr",
+ "num-traits",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "arrow-string"
+version = "59.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b0afbb8b9016700938291123df30838b89decc3213dba00852021988b170d3"
+dependencies = [
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "memchr",
  "num-traits",
  "regex",
@@ -895,7 +1057,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -1191,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -1784,6 +1946,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.117",
 ]
 
@@ -1817,9 +1980,9 @@ checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -1832,10 +1995,10 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 59.1.0",
+ "arrow-schema 59.1.0",
  "async-trait",
  "chrono",
  "datafusion-catalog",
@@ -1880,9 +2043,9 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "async-trait",
  "dashmap",
  "datafusion-common",
@@ -1904,9 +2067,9 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -1926,11 +2089,11 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "arrow-ipc",
- "arrow-schema",
+ "arrow-schema 59.1.0",
  "chrono",
  "foldhash 0.2.0",
  "half 2.7.1",
@@ -1939,6 +2102,7 @@ dependencies = [
  "itertools 0.14.0",
  "libc",
  "log",
+ "num-traits",
  "object_store",
  "parquet",
  "sqlparser",
@@ -1950,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
  "futures",
  "log",
@@ -1960,9 +2124,9 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "async-trait",
  "bytes",
  "chrono",
@@ -1989,9 +2153,9 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "arrow-ipc",
  "async-trait",
  "bytes",
@@ -2012,9 +2176,9 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -2034,9 +2198,9 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -2056,9 +2220,10 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
+ "arrow-schema 59.1.0",
  "async-trait",
  "bytes",
  "datafusion-common",
@@ -2086,10 +2251,10 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=f2087994c4e7b8f742168762b2e1da5e9a9c13c1#f2087994c4e7b8f742168762b2e1da5e9a9c13c1"
+source = "git+https://github.com/paradedb/datafusion-distributed?rev=11d6c621287f0ff3e87c43ddde81492b230edf98#11d6c621287f0ff3e87c43ddde81492b230edf98"
 dependencies = [
  "arrow-ipc",
- "arrow-select",
+ "arrow-select 59.1.0",
  "async-stream",
  "async-trait",
  "bincode 1.3.3",
@@ -2120,15 +2285,15 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 59.1.0",
+ "arrow-buffer 59.1.0",
  "async-trait",
  "dashmap",
  "datafusion-common",
@@ -2146,10 +2311,10 @@ dependencies = [
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
- "arrow-schema",
+ "arrow 59.1.0",
+ "arrow-schema 59.1.0",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2167,9 +2332,9 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "indexmap",
  "itertools 0.14.0",
@@ -2178,10 +2343,10 @@ dependencies = [
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
- "arrow-buffer",
+ "arrow 59.1.0",
+ "arrow-buffer 59.1.0",
  "base64",
  "chrono",
  "chrono-tz",
@@ -2205,9 +2370,9 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2216,7 +2381,6 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "foldhash 0.2.0",
  "half 2.7.1",
  "log",
  "num-traits",
@@ -2225,9 +2389,9 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -2236,10 +2400,10 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
- "arrow-ord",
+ "arrow 59.1.0",
+ "arrow-ord 59.1.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2260,9 +2424,9 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -2275,9 +2439,9 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-expr",
@@ -2291,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2300,7 +2464,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2310,9 +2474,9 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -2328,14 +2492,15 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
  "datafusion-physical-expr-common",
+ "datafusion-proto-models",
  "half 2.7.1",
  "hashbrown 0.17.1",
  "indexmap",
@@ -2348,9 +2513,9 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-functions",
@@ -2362,12 +2527,13 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "chrono",
  "datafusion-common",
  "datafusion-expr-common",
+ "datafusion-proto-models",
  "hashbrown 0.17.1",
  "indexmap",
  "itertools 0.14.0",
@@ -2378,9 +2544,9 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -2395,13 +2561,13 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
- "arrow-data",
+ "arrow 59.1.0",
+ "arrow-data 59.1.0",
  "arrow-ipc",
- "arrow-ord",
- "arrow-schema",
+ "arrow-ord 59.1.0",
+ "arrow-schema 59.1.0",
  "async-trait",
  "datafusion-common",
  "datafusion-common-runtime",
@@ -2412,6 +2578,8 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
+ "datafusion-proto-common",
+ "datafusion-proto-models",
  "futures",
  "half 2.7.1",
  "hashbrown 0.17.1",
@@ -2421,15 +2589,16 @@ dependencies = [
  "num-traits",
  "parking_lot",
  "pin-project-lite",
+ "serde_json",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "chrono",
  "datafusion-catalog",
  "datafusion-catalog-listing",
@@ -2446,6 +2615,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-proto-common",
+ "datafusion-proto-models",
  "object_store",
  "prost",
 ]
@@ -2453,19 +2623,28 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
+ "prost",
+]
+
+[[package]]
+name = "datafusion-proto-models"
+version = "54.0.0"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+dependencies = [
+ "datafusion-proto-common",
  "prost",
 ]
 
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "datafusion-common",
  "datafusion-datasource",
  "datafusion-expr-common",
@@ -2478,7 +2657,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2491,9 +2670,9 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/paradedb/datafusion?rev=65a35ad658bfa93c871b000c0fcecf36793ffeb1#65a35ad658bfa93c871b000c0fcecf36793ffeb1"
+source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
 dependencies = [
- "arrow",
+ "arrow 59.1.0",
  "bigdecimal",
  "chrono",
  "datafusion-common",
@@ -2649,7 +2828,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2706,7 +2885,7 @@ version = "1.10502.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdc796383b176dd5a45353fbb5e64583c0ee4da12cb62c9e510b785324b2488"
 dependencies = [
- "arrow",
+ "arrow 58.3.0",
  "cast",
  "comfy-table",
  "fallible-iterator 0.3.0",
@@ -2969,7 +3148,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4093,12 +4272,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "interpolate_name"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4153,7 +4326,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4823,9 +4996,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -5271,15 +5444,6 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
-version = "2.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "ordered-float"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
@@ -5303,7 +5467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5354,17 +5518,17 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "58.3.0"
+version = "59.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+checksum = "5302d4da74d6596a1f11f9928767995b53bca657cbeea1e4e8c5074f8a1157dd"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array",
- "arrow-buffer",
- "arrow-data",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-data 59.1.0",
  "arrow-ipc",
- "arrow-schema",
- "arrow-select",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "base64",
  "brotli",
  "bytes",
@@ -5382,7 +5546,6 @@ dependencies = [
  "seq-macro",
  "simdutf8",
  "snap",
- "thrift",
  "tokio",
  "twox-hash",
  "zstd",
@@ -5467,10 +5630,10 @@ name = "pg_search"
 version = "0.24.3"
 dependencies = [
  "anyhow",
- "arrow-array",
- "arrow-buffer",
- "arrow-schema",
- "arrow-select",
+ "arrow-array 59.1.0",
+ "arrow-buffer 59.1.0",
+ "arrow-schema 59.1.0",
+ "arrow-select 59.1.0",
  "async-stream",
  "async-trait",
  "bincode 2.0.1",
@@ -6191,7 +6354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6899,7 +7062,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6957,7 +7120,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7386,7 +7549,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8013,7 +8176,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8100,17 +8263,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "thrift"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -8992,7 +9144,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,7 +132,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -143,7 +143,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1995,7 +1995,7 @@ dependencies = [
 [[package]]
 name = "datafusion"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-schema 59.1.0",
@@ -2028,7 +2028,7 @@ dependencies = [
  "datafusion-sql",
  "futures",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -2043,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "async-trait",
@@ -2057,7 +2057,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -2067,7 +2067,7 @@ dependencies = [
 [[package]]
 name = "datafusion-catalog-listing"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "async-trait",
@@ -2081,7 +2081,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
 ]
@@ -2089,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc",
@@ -2099,7 +2099,7 @@ dependencies = [
  "half 2.7.1",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "libc",
  "log",
  "num-traits",
@@ -2114,7 +2114,7 @@ dependencies = [
 [[package]]
 name = "datafusion-common-runtime"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "futures",
  "log",
@@ -2124,7 +2124,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "async-trait",
@@ -2141,7 +2141,7 @@ dependencies = [
  "datafusion-session",
  "futures",
  "glob",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -2153,7 +2153,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-arrow"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ipc",
@@ -2168,7 +2168,7 @@ dependencies = [
  "datafusion-physical-plan",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "object_store",
  "tokio",
 ]
@@ -2176,7 +2176,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-csv"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "async-trait",
@@ -2198,7 +2198,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-json"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "async-trait",
@@ -2220,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "datafusion-datasource-parquet"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-schema 59.1.0",
@@ -2240,7 +2240,7 @@ dependencies = [
  "datafusion-pruning",
  "datafusion-session",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "object_store",
  "parking_lot",
@@ -2251,7 +2251,7 @@ dependencies = [
 [[package]]
 name = "datafusion-distributed"
 version = "2.0.0"
-source = "git+https://github.com/paradedb/datafusion-distributed?rev=11d6c621287f0ff3e87c43ddde81492b230edf98#11d6c621287f0ff3e87c43ddde81492b230edf98"
+source = "git+https://github.com/paradedb/datafusion-distributed?branch=stuhood.datafusion-0.55.x-pre#bbcbfdf00556f02a47648fdd31db37e8fbf47268"
 dependencies = [
  "arrow-ipc",
  "arrow-select 59.1.0",
@@ -2285,16 +2285,17 @@ dependencies = [
 [[package]]
 name = "datafusion-doc"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 
 [[package]]
 name = "datafusion-execution"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-buffer 59.1.0",
  "async-trait",
+ "bytes",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
@@ -2305,13 +2306,15 @@ dependencies = [
  "parking_lot",
  "rand 0.9.4",
  "tempfile",
+ "tokio",
+ "tokio-util",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-schema 59.1.0",
@@ -2324,7 +2327,7 @@ dependencies = [
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "serde_json",
  "sqlparser",
 ]
@@ -2332,18 +2335,18 @@ dependencies = [
 [[package]]
 name = "datafusion-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-functions"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-buffer 59.1.0",
@@ -2358,7 +2361,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hex",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "memchr",
  "num-traits",
@@ -2370,7 +2373,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2389,7 +2392,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-aggregate-common"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2400,7 +2403,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-nested"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-ord 59.1.0",
@@ -2415,7 +2418,7 @@ dependencies = [
  "datafusion-macros",
  "datafusion-physical-expr-common",
  "hashbrown 0.17.1",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "itoa",
  "log",
  "memchr",
@@ -2424,7 +2427,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-table"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "async-trait",
@@ -2439,7 +2442,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2455,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "datafusion-functions-window-common"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
@@ -2464,7 +2467,7 @@ dependencies = [
 [[package]]
 name = "datafusion-macros"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "datafusion-doc",
  "quote",
@@ -2474,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "datafusion-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "chrono",
@@ -2483,7 +2486,7 @@ dependencies = [
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "regex",
  "regex-syntax",
@@ -2492,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2504,7 +2507,7 @@ dependencies = [
  "half 2.7.1",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "parking_lot",
  "petgraph",
  "tokio",
@@ -2513,7 +2516,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-expr-adapter"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2521,13 +2524,13 @@ dependencies = [
  "datafusion-functions",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
- "itertools 0.14.0",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-physical-expr-common"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "chrono",
@@ -2536,7 +2539,7 @@ dependencies = [
  "datafusion-proto-models",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "parking_lot",
  "pin-project",
 ]
@@ -2544,7 +2547,7 @@ dependencies = [
 [[package]]
 name = "datafusion-physical-optimizer"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2555,13 +2558,13 @@ dependencies = [
  "datafusion-physical-expr-common",
  "datafusion-physical-plan",
  "datafusion-pruning",
- "itertools 0.14.0",
+ "itertools 0.15.0",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "arrow-data 59.1.0",
@@ -2569,6 +2572,7 @@ dependencies = [
  "arrow-ord 59.1.0",
  "arrow-schema 59.1.0",
  "async-trait",
+ "bytes",
  "datafusion-common",
  "datafusion-common-runtime",
  "datafusion-execution",
@@ -2584,7 +2588,7 @@ dependencies = [
  "half 2.7.1",
  "hashbrown 0.17.1",
  "indexmap",
- "itertools 0.14.0",
+ "itertools 0.15.0",
  "log",
  "num-traits",
  "parking_lot",
@@ -2596,7 +2600,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "chrono",
@@ -2623,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-common"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2633,7 +2637,7 @@ dependencies = [
 [[package]]
 name = "datafusion-proto-models"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "datafusion-proto-common",
  "prost",
@@ -2642,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "datafusion-pruning"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "datafusion-common",
@@ -2657,7 +2661,7 @@ dependencies = [
 [[package]]
 name = "datafusion-session"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "async-trait",
  "datafusion-common",
@@ -2670,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "datafusion-sql"
 version = "54.0.0"
-source = "git+https://github.com/apache/datafusion?rev=bde8e5b24e772210885ea5272e5cb06b52c939c3#bde8e5b24e772210885ea5272e5cb06b52c939c3"
+source = "git+https://github.com/apache/datafusion?rev=63e25c15bc72e731c174ba03d1143b243cc1aaae#63e25c15bc72e731c174ba03d1143b243cc1aaae"
 dependencies = [
  "arrow 59.1.0",
  "bigdecimal",
@@ -2828,7 +2832,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3148,7 +3152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3960,7 +3964,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.57.0",
 ]
 
 [[package]]
@@ -4326,7 +4330,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4355,6 +4359,15 @@ name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -5467,7 +5480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6354,7 +6367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7062,7 +7075,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7120,7 +7133,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7549,7 +7562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8176,7 +8189,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9144,7 +9157,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,42 +46,5 @@ tantivy-jieba = "0.20.0"
 [patch.crates-io]
 tantivy-tokenizer-api = { git = "https://github.com/paradedb/tantivy.git", package = "tantivy-tokenizer-api", rev = "3c423758142d018d92f7e38d93fc5d23b94287d1" }
 
-# datafusion 54.0.0 + the null-aware anti-join dynamic-filter fix (paradedb/datafusion PR #2, backported
-# to a 54.0.0 branch so it stays on arrow 58). Patch every datafusion crate, or two `datafusion-common`
-# versions collide.
-datafusion = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-catalog = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-catalog-listing = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-common = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-common-runtime = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-datasource = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-datasource-arrow = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-datasource-csv = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-datasource-json = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-datasource-parquet = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-doc = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-execution = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-expr = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-expr-common = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-functions = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-functions-aggregate = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-functions-aggregate-common = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-functions-nested = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-functions-table = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-functions-window = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-functions-window-common = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-macros = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-optimizer = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-physical-expr = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-physical-expr-adapter = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-physical-expr-common = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-physical-optimizer = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-physical-plan = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-proto = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-proto-common = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-pruning = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-session = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-datafusion-sql = { git = "https://github.com/paradedb/datafusion", rev = "65a35ad658bfa93c871b000c0fcecf36793ffeb1" }
-
 [workspace.lints.clippy]
 large_futures = "warn"

--- a/nix/pg_search.nix
+++ b/nix/pg_search.nix
@@ -64,7 +64,7 @@ buildPgrxExtension (finalAttrs: {
   # If maintainers forget to do so, Nix will throw an error message that begins
   # like this and then provides the correct new hash:
   # error: hash mismatch in fixed-output derivation '...'
-  cargoHash = "sha256-aVFRcY7oGJHxO+PGFKvXpmwTMquJyCxiGi/vPpNEUFo=";
+  cargoHash = "sha256-LPcWtn/zX7RQ6obj5c1Sz0ce+7T/+Z4HGnsUu5dOzIk=";
 
   inherit cargo-pgrx postgresql;
 

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -29,10 +29,10 @@ debug-logging = [
 async-trait = "0.1.89"
 stable_deref_trait = "1.2.1"
 anyhow = { version = "1.0.102", features = ["backtrace"] }
-arrow-array = "58.1.0"
-arrow-buffer = "58.1.0"
-arrow-schema = "58.1.0"
-arrow-select = "58.1.0"
+arrow-array = "59.0.0"
+arrow-buffer = "59.0.0"
+arrow-schema = "59.0.0"
+arrow-select = "59.0.0"
 bitpacking = "0.9.3"
 chrono = "0.4.44"
 time = "0.3.47"
@@ -79,9 +79,9 @@ paste = "1.0.15"
 typetag = "0.2"
 tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
-datafusion = { version = "54", default-features = false }
-datafusion-proto = { version = "54", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "f2087994c4e7b8f742168762b2e1da5e9a9c13c1", default-features = false }
+datafusion = { git = "https://github.com/apache/datafusion", rev = "bde8e5b24e772210885ea5272e5cb06b52c939c3", default-features = false }
+datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "bde8e5b24e772210885ea5272e5cb06b52c939c3", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "11d6c621287f0ff3e87c43ddde81492b230edf98", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -79,9 +79,9 @@ paste = "1.0.15"
 typetag = "0.2"
 tokio = { version = "1", features = ["rt"] }
 bytes = { version = "1", features = ["serde"] }
-datafusion = { git = "https://github.com/apache/datafusion", rev = "bde8e5b24e772210885ea5272e5cb06b52c939c3", default-features = false }
-datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "bde8e5b24e772210885ea5272e5cb06b52c939c3", default-features = false }
-datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", rev = "11d6c621287f0ff3e87c43ddde81492b230edf98", default-features = false }
+datafusion = { git = "https://github.com/apache/datafusion", rev = "63e25c15bc72e731c174ba03d1143b243cc1aaae", default-features = false }
+datafusion-proto = { git = "https://github.com/apache/datafusion", rev = "63e25c15bc72e731c174ba03d1143b243cc1aaae", default-features = false }
+datafusion-distributed = { git = "https://github.com/paradedb/datafusion-distributed", branch = "stuhood.datafusion-0.55.x-pre", default-features = false }
 futures = "0.3"
 async-stream = "0.3.6"
 prost = "0.14.3"

--- a/pg_search/src/scan/physical_codec.rs
+++ b/pg_search/src/scan/physical_codec.rs
@@ -34,6 +34,7 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion_distributed::DistributedCodec;
 use datafusion_proto::physical_plan::{
     AsExecutionPlan, ComposedPhysicalExtensionCodec, PhysicalExtensionCodec,
+    PhysicalProtoConverterExtension,
 };
 use datafusion_proto::protobuf::PhysicalPlanNode;
 use tantivy::index::SegmentId;
@@ -85,6 +86,7 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         buf: &[u8],
         inputs: &[Arc<dyn ExecutionPlan>],
         ctx: &TaskContext,
+        _proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let Some((&tag, payload)) = buf.split_first() else {
             return Err(DataFusionError::Internal(
@@ -122,7 +124,12 @@ impl PhysicalExtensionCodec for PgSearchPhysicalExtensionCodec {
         }
     }
 
-    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
+    fn try_encode(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        buf: &mut Vec<u8>,
+        _proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<()> {
         if let Some(scan) = node.downcast_ref::<PgSearchScanPlan>() {
             buf.push(TAG_PG_SEARCH_SCAN);
             buf.extend_from_slice(&scan.encode_for_dispatch()?);
@@ -301,12 +308,18 @@ impl PhysicalExtensionCodec for DistributedCodecHostingPgSearchUdfs {
         buf: &[u8],
         inputs: &[Arc<dyn ExecutionPlan>],
         ctx: &TaskContext,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
     ) -> Result<Arc<dyn ExecutionPlan>> {
-        self.0.try_decode(buf, inputs, ctx)
+        PhysicalExtensionCodec::try_decode(&self.0, buf, inputs, ctx, proto_converter)
     }
 
-    fn try_encode(&self, node: Arc<dyn ExecutionPlan>, buf: &mut Vec<u8>) -> Result<()> {
-        self.0.try_encode(node, buf)
+    fn try_encode(
+        &self,
+        node: Arc<dyn ExecutionPlan>,
+        buf: &mut Vec<u8>,
+        proto_converter: &dyn PhysicalProtoConverterExtension,
+    ) -> Result<()> {
+        PhysicalExtensionCodec::try_encode(&self.0, node, buf, proto_converter)
     }
 
     fn try_encode_udf(&self, node: &ScalarUDF, _buf: &mut Vec<u8>) -> Result<()> {

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -1595,8 +1595,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                         QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (string_agg(t.tag_name, ', '::text ORDER BY t.tag_name))
    Backend: DataFusion
@@ -1605,10 +1605,10 @@ GROUP BY p.category;
    Aggregates: STRING_AGG(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[string_agg(t_1.tag_name, , ) ORDER BY [t_1.tag_name ASC NULLS LAST] as agg_0]
-     :   SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :       CooperativeExec
-     :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :     CooperativeExec
+     :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :     SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
      :       CooperativeExec
      :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (14 rows)
@@ -1664,8 +1664,8 @@ FROM agg_join_products p
 JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-                                                                                         QUERY PLAN                                                                                          
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                        QUERY PLAN                                                                                         
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: p.category, (array_agg(t.tag_name ORDER BY t.tag_name))
    Backend: DataFusion
@@ -1674,10 +1674,10 @@ GROUP BY p.category;
    Aggregates: ARRAY_AGG(tag_name)
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[array_agg(t_1.tag_name) ORDER BY [t_1.tag_name ASC NULLS LAST] as agg_0]
-     :   SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
-     :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
-     :       CooperativeExec
-     :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
+     :     CooperativeExec
+     :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :     SortExec: expr=[tag_name@1 ASC NULLS LAST], preserve_partitioning=[false]
      :       CooperativeExec
      :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (14 rows)

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -435,7 +435,7 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
          Group By: metadata.brand
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[metadata.brand@0 as metadata.brand], aggr=[]
-           :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[metadata.brand@1]
+           :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(category@0, category@0)], projection=[metadata.brand@1]
            :     CooperativeExec
            :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -180,7 +180,7 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[job_title@0 as job_title], aggr=[count(1) as agg_0]
            :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(contact_id@0, ldf_id@0)], projection=[job_title@1]
-           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(contact_id@0, ldf_id@0)], null_aware
            :       CooperativeExec
            :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"job_title","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
@@ -408,7 +408,7 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
          DataFusion Physical Plan: 
            : AggregateExec: mode=Single, gby=[label@0 as label], aggr=[count(1) as agg_0]
            :   HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@0, id@0)], projection=[label@1]
-           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, eid@0)]
+           :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, eid@0)], null_aware
            :       CooperativeExec
            :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"label","query_string":"Senior","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
@@ -425,9 +425,10 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
 GROUP BY label
 ORDER BY doc_count DESC, label;
 WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
- label | doc_count 
--------+-----------
-(0 rows)
+       label       | doc_count 
+-------------------+-----------
+ Senior Programmer |         4
+(1 row)
 
 -- Result parity with Postgres-only execution. Both should report zero
 -- rows because of the NULL in `asa_excl_inner.eid`.
@@ -659,10 +660,10 @@ WHERE a.id NOT IN (
    DataFusion Physical Plan: 
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0, sum(b_3.val) as agg_1]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, a_id@0)], filter=val@1 > threshold@0, projection=[val@3]
-     :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, aid@0)]
+     :     HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@0, aid@0)], null_aware
      :       CooperativeExec
      :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"outermatch","lenient":null,"conjunction_mode":null}}}}
-     :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, y_id@1)], projection=[aid@1]
+     :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, y_id@1)], projection=[aid@0]
      :         CooperativeExec
      :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"block","lenient":null,"conjunction_mode":null}}}}
      :         CooperativeExec

--- a/pg_search/tests/pg_regress/expected/columnar_queries_01_complex_join.out
+++ b/pg_search/tests/pg_regress/expected/columnar_queries_01_complex_join.out
@@ -201,7 +201,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"Receipt","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Socienty","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 \i common/columnar_queries_cleanup.sql

--- a/pg_search/tests/pg_regress/expected/filter_pushdown_datafusion.out
+++ b/pg_search/tests/pg_regress/expected/filter_pushdown_datafusion.out
@@ -93,7 +93,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -138,7 +138,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -231,7 +231,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -375,7 +375,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"must":["all",{"boolean":{"should":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}]}}}}]}}]}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":["all",{"boolean":{"should":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}]}}}}]}}]}}
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -421,7 +421,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology OR audio","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR headphones","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR headphones","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -468,7 +468,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"audio","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"technology","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"audio","lenient":null,"conjunction_mode":null}}}}]}}]}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}}]}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}},{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}}]}}
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -514,7 +514,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name

--- a/pg_search/tests/pg_regress/expected/issue_4531.out
+++ b/pg_search/tests/pg_regress/expected/issue_4531.out
@@ -101,7 +101,7 @@ ORDER BY p.id DESC LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id

--- a/pg_search/tests/pg_regress/expected/issue_4532.out
+++ b/pg_search/tests/pg_regress/expected/issue_4532.out
@@ -152,7 +152,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT p.id, p.description
@@ -227,7 +227,7 @@ LIMIT 10;
            :             CooperativeExec
            :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 SELECT p.id, p.description
@@ -289,7 +289,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Acme","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget","lenient":null,"conjunction_mode":null}}}}
 (15 rows)
 
 SELECT p.id, p.description
@@ -346,16 +346,16 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false]
            :     VisibilityFilterExec: tables=[p]
            :       HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, company_id@1)], projection=[ctid_0@0, id@2]
-           :         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@0, company_id@0)]
-           :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, region_id@1)], projection=[id@1]
+           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, id@0)]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Engineering","lenient":null,"conjunction_mode":null}}}}
+           :           HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(id@0, region_id@1)], projection=[id@0]
            :             CooperativeExec
            :               PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"America","lenient":null,"conjunction_mode":null}}}}
            :             CooperativeExec
-           :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
-           :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Engineering","lenient":null,"conjunction_mode":null}}}}
+           :               PgSearchScan: segments=1, dynamic_filters=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 SELECT p.id, p.description

--- a/pg_search/tests/pg_regress/expected/issue_4719.out
+++ b/pg_search/tests/pg_regress/expected/issue_4719.out
@@ -84,8 +84,8 @@ WHERE p.id NOT IN (
        OR p.company_id IN (SELECT c.id FROM issue_4719_companies c))
 ORDER BY p.id DESC
 LIMIT 26;
-                                                                                        QUERY PLAN                                                                                        
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id
    ->  Custom Scan (ParadeDB Join Scan)
@@ -101,11 +101,11 @@ LIMIT 26;
            :     FilterExec: mark@3 OR company_id@1 IS NULL, projection=[ctid_0@0, id@2]
            :       HashJoinExec: mode=CollectLeft, join_type=LeftMark, on=[(company_id@1, id@0)]
            :         VisibilityFilterExec: tables=[p]
-           :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(person_id@0, id@2)]
-           :             CooperativeExec
-           :               PgSearchScan: segments=1, query={"term_set":{"terms":[{"field":"company_id","value":10},{"field":"company_id","value":20},{"field":"company_id","value":50}]}}
+           :           HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@2, person_id@0)], null_aware
            :             CooperativeExec
            :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, dynamic_filters=1, query={"term_set":{"terms":[{"field":"company_id","value":10},{"field":"company_id","value":20},{"field":"company_id","value":50}]}}
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (22 rows)

--- a/pg_search/tests/pg_regress/expected/issue_4910.out
+++ b/pg_search/tests/pg_regress/expected/issue_4910.out
@@ -103,7 +103,7 @@ LIMIT 25;
            :   │         CoalescePartitionsExec
            :   │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
+           :   │           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── Tasks: t0:[p0..p2]
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
@@ -193,7 +193,7 @@ LIMIT 25;
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
 (18 rows)
 
 -- Native PG (JoinScan disabled) rows on the same data, parallel mode.

--- a/pg_search/tests/pg_regress/expected/join_deferred_visibility.out
+++ b/pg_search/tests/pg_regress/expected/join_deferred_visibility.out
@@ -157,7 +157,7 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"great","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=3, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless OR keyboard","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless OR keyboard","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
 
 SELECT i.id, i.name
@@ -289,7 +289,7 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"range":{"field":"rating","lower_bound":null,"upper_bound":{"excluded":4}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless OR mouse","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless OR mouse","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
 
 SELECT i.id, i.name

--- a/pg_search/tests/pg_regress/expected/join_distinct.out
+++ b/pg_search/tests/pg_regress/expected/join_distinct.out
@@ -481,7 +481,7 @@ ORDER BY p.name
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all"
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 -- =============================================================================
@@ -516,7 +516,7 @@ ORDER BY p.name
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(name = 'TechCorp'::text)"}]}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 -- =============================================================================
@@ -914,8 +914,8 @@ WHERE j.id @@@ paradedb.parse('title:developer')
 ORDER BY p.id
 LIMIT 50;
 WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a suboptimal parallel partitioning strategy for this query. See https://github.com/paradedb/paradedb/issues/4152
-                                                                                 QUERY PLAN                                                                                 
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Unique
          ->  Custom Scan (ParadeDB Join Scan)
@@ -931,11 +931,11 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(person_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, name@4]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:developer","lenient":null,"conjunction_mode":null}}}}
-                 :         HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(person_id@0, id@1)]
-                 :           CooperativeExec
-                 :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
+                 :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@1, person_id@0)], null_aware
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"title:recruiter","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
 
 SELECT DISTINCT p.id, p.name

--- a/pg_search/tests/pg_regress/expected/join_execution_limits.out
+++ b/pg_search/tests/pg_regress/expected/join_execution_limits.out
@@ -68,7 +68,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT lo.id, lo.description, ls.name AS supplier_name
@@ -412,7 +412,7 @@ LIMIT 20;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT hp.id, hp.description, hc.name AS category_name

--- a/pg_search/tests/pg_regress/expected/join_hash.out
+++ b/pg_search/tests/pg_regress/expected/join_hash.out
@@ -48,11 +48,11 @@ LIMIT 10;
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
                  :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
                  :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=1.00 K, output_bytes=79.6 KB, output_batches=1]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3], metrics=[output_rows=1.00 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.00 K, input_batches=1, input_rows=1.00 K, build_mem_used=20.00 K, avg_fanout=100% (1.00 K/1.00 K), probe_hit_rate=100% (1.00 K/1.00 K)]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3], metrics=[output_rows=1.00 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=19.5 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=1.00 K, input_batches=1, input_rows=1.00 K, avg_fanout=100% (1.00 K/1.00 K), probe_hit_rate=100% (1.00 K/1.00 K)]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.00 K, output_bytes=15.6 KB, output_batches=1, rows_pruned=0, rows_scanned=1.00 K]
 (16 rows)
 
 SELECT t1.val, t2.val
@@ -135,7 +135,7 @@ LIMIT 10;
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
                  :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
                  :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, build_mem_used=30.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=29.3 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :         CooperativeExec
@@ -185,7 +185,7 @@ LIMIT 10;
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
                  :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
                  :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, build_mem_used=30.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=29.3 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :         CooperativeExec
@@ -240,7 +240,7 @@ LIMIT 10;
                  : ProjectionExec: expr=[NULL as col_1, id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
                  :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 5], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=10]
                  :     VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=2.00 K, output_bytes=95.2 KB, output_batches=1]
-                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, build_mem_used=30.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, t1_id@1)], projection=[ctid_0@2, ctid_1@0, id@1], metrics=[output_rows=2.00 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=29.3 KB, array_map_created_count=1, build_input_batches=1, build_input_rows=1.50 K, input_batches=1, input_rows=2.00 K, avg_fanout=100% (2.00 K/2.00 K), probe_hit_rate=100% (2.00 K/2.00 K)]
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.50 K, output_bytes=23.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.50 K]
                  :         CooperativeExec

--- a/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
+++ b/pg_search/tests/pg_regress/expected/join_hash_dynamic_filters_sparse.out
@@ -133,8 +133,8 @@ JOIN t2_a ON t1.fk_a = t2_a.fk
 WHERE t1.body @@@ 'doc'
 ORDER BY t1.id
 LIMIT 10;
-                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: t2_a INNER t1
@@ -145,11 +145,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 10], metrics=[output_rows=10, output_bytes=240.0 B, output_batches=1, row_replacements=51]
            :     VisibilityFilterExec: tables=[t2_a, t1], metrics=[output_rows=1.10 K, output_bytes=81.2 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, id@4], metrics=[output_rows=1.10 K, output_bytes=192.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, id@4], metrics=[output_rows=1.10 K, output_bytes=192.0 KB, output_batches=1, build_mem_used=51.2 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=4, input_rows=30.00 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=3.67% (1.10 K/30.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=25.8 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=30.00 K, output_bytes=703.1 KB, output_batches=4, rows_pruned=0, rows_scanned=30.00 K]
 (15 rows)
 
 -- Block B: correctness. Run the same query with gallop disabled and
@@ -210,8 +210,8 @@ JOIN t2_b ON t1.fk_b = t2_b.fk
 WHERE t1.body @@@ 'doc'
 ORDER BY t1.id
 LIMIT 10;
-                                                                                                                                                                                                         QUERY PLAN                                                                                                                                                                                                          
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: t2_a INNER (t1 INNER t2_b)
@@ -222,12 +222,12 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 509], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[t2_a, t1, t2_b], metrics=[output_rows=601, output_bytes=78.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4], metrics=[output_rows=601, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=297.0 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_b@4, id@5], metrics=[output_rows=1.10 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4], metrics=[output_rows=601, output_bytes=256.0 KB, output_batches=1, build_mem_used=290.1 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_b@4, id@5], metrics=[output_rows=1.10 K, output_bytes=256.0 KB, output_batches=1, build_mem_used=51.2 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=4, input_rows=30.00 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=3.67% (1.10 K/30.00 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=34.4 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=30.00 K, output_bytes=937.5 KB, output_batches=4, rows_pruned=0, rows_scanned=30.00 K]
            :         CooperativeExec
            :           PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
 (18 rows)
@@ -290,8 +290,8 @@ JOIN t2_c ON t1.fk_c = t2_c.fk
 WHERE t1.body @@@ 'doc'
 ORDER BY t1.id
 LIMIT 10;
-                                                                                                                                                                                                              QUERY PLAN                                                                                                                                                                                                               
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                                QUERY PLAN                                                                                                                                                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: t2_a INNER ((t1 INNER t2_b) INNER t2_c)
@@ -302,13 +302,13 @@ LIMIT 10;
            : ProjectionExec: expr=[id@2 as col_1, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1, ctid_2@3 as ctid_2, ctid_3@4 as ctid_3], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 809], metrics=[output_rows=10, output_bytes=400.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[t2_a, t1, t2_b, t2_c], metrics=[output_rows=301, output_bytes=73.4 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_c@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4, ctid_3@5], metrics=[output_rows=301, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=601, input_batches=1, input_rows=301, build_mem_used=345.1 K, avg_fanout=100% (301/301), probe_hit_rate=100% (301/301)]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@3, fk@1)], projection=[ctid_0@0, ctid_1@1, fk_c@2, id@4, ctid_2@5], metrics=[output_rows=601, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, build_mem_used=362.6 K, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
-           :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_c@4, fk_b@5, id@6], metrics=[output_rows=1.10 K, output_bytes=320.0 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=1.10 K, build_mem_used=52.47 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=100% (1.10 K/1.10 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_c@2, fk@1)], projection=[ctid_0@0, ctid_1@1, id@3, ctid_2@4, ctid_3@5], metrics=[output_rows=301, output_bytes=320.0 KB, output_batches=1, build_mem_used=337.1 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=601, input_batches=1, input_rows=301, avg_fanout=100% (301/301), probe_hit_rate=100% (301/301)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk_b@3, fk@1)], projection=[ctid_0@0, ctid_1@1, fk_c@2, id@4, ctid_2@5], metrics=[output_rows=601, output_bytes=320.0 KB, output_batches=1, build_mem_used=354.1 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=1, input_rows=601, avg_fanout=100% (601/601), probe_hit_rate=100% (601/601)]
+           :           HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(fk@1, fk_a@1)], projection=[ctid_0@0, ctid_1@2, fk_c@4, fk_b@5, id@6], metrics=[output_rows=1.10 K, output_bytes=320.0 KB, output_batches=1, build_mem_used=51.2 KB, array_map_created_count=0, build_input_batches=1, build_input_rows=1.10 K, input_batches=4, input_rows=30.00 K, avg_fanout=100% (1.10 K/1.10 K), probe_hit_rate=3.67% (1.10 K/30.00 K)]
            :             CooperativeExec
            :               PgSearchScan: segments=1, query="all", metrics=[output_rows=1.10 K, output_bytes=17.2 KB, output_batches=1]
            :             CooperativeExec
-           :               PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1.10 K, output_bytes=43.0 KB, output_batches=1, rows_pruned=0, rows_scanned=1.10 K]
+           :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"body","query_string":"doc","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=30.00 K, output_bytes=1171.9 KB, output_batches=4, rows_pruned=0, rows_scanned=30.00 K]
            :           CooperativeExec
            :             PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=601, output_bytes=9.4 KB, output_batches=1, rows_pruned=0, rows_scanned=601]
            :         CooperativeExec

--- a/pg_search/tests/pg_regress/expected/join_key_types.out
+++ b/pg_search/tests/pg_regress/expected/join_key_types.out
@@ -64,7 +64,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT o.id, o.description, c.name AS customer_name
@@ -217,7 +217,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"details","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"details","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT i.id, i.name, t.type_name
@@ -377,7 +377,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"item OR laptop OR novel","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"item OR laptop OR novel","lenient":null,"conjunction_mode":null}}}}
 (19 rows)
 
 -- Should return only rows with non-NULL category_id that match the search

--- a/pg_search/tests/pg_regress/expected/join_multi_table.out
+++ b/pg_search/tests/pg_regress/expected/join_multi_table.out
@@ -209,7 +209,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -358,7 +358,7 @@ LIMIT 10;
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (22 rows)
@@ -532,7 +532,7 @@ LIMIT 5;
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (25 rows)
 
 SELECT l1.name, l2.name, l3.name, l4.name
@@ -587,7 +587,7 @@ LIMIT 5;
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L1-A","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L1-A","lenient":null,"conjunction_mode":null}}}}
 (25 rows)
 
 SELECT l1.name, l4.name
@@ -639,7 +639,7 @@ LIMIT 5;
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"L2-B","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (25 rows)
 
 SELECT l1.name, l4.name

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -55,7 +55,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
 (19 rows)
 
 SELECT t1.val, t2.val
@@ -112,7 +112,7 @@ OFFSET 5 LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
 
 SELECT t1.val, t2.val
@@ -181,7 +181,7 @@ LIMIT 10;
                  :         CooperativeExec
                  :           PgSearchScan: segments=1, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
 (19 rows)
 
 SELECT t1.val, t2.val
@@ -335,7 +335,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all"
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 -- Cap the scanner batch size so Top K can tighten its threshold between batches.
@@ -348,8 +348,8 @@ JOIN dyn_filter_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val'
 ORDER BY t1.val ASC
 LIMIT 10;
-                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                       
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                       QUERY PLAN                                                                                                                                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: t2 INNER t1
@@ -361,11 +361,11 @@ LIMIT 10;
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, metrics=[rows_input=8.25 K, rows_output=10, segments_seen=2]
            :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.25 K, output_bytes=235.4 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=362.5 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, build_mem_used=400.0 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=362.5 KB, output_batches=2, build_mem_used=390.6 KB, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.0 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
 (16 rows)
 
 -- Verify results
@@ -452,7 +452,7 @@ LIMIT 25;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all"
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (18 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
@@ -462,8 +462,8 @@ JOIN null_val_t2 t2 ON t1.id = t2.t1_id
 WHERE t1.val @@@ 'val' OR t1.val IS NULL
 ORDER BY t1.val DESC NULLS FIRST, t1.id
 LIMIT 25;
-                                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                                      
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                           
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=25.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=25.00 loops=1)
          Relation Tree: t2 INNER t1
@@ -475,11 +475,11 @@ LIMIT 25;
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, metrics=[rows_input=8.48 K, rows_output=25, segments_seen=1]
            :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.48 K, output_bytes=376.4 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.48 K, output_bytes=499.9 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.48 K, build_mem_used=400.0 K, avg_fanout=100% (8.48 K/8.48 K), probe_hit_rate=100% (8.48 K/8.48 K)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.48 K, output_bytes=499.9 KB, output_batches=2, build_mem_used=390.6 KB, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.48 K, avg_fanout=100% (8.48 K/8.48 K), probe_hit_rate=100% (8.48 K/8.48 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.48 K, output_bytes=241.4 KB, output_batches=4, rows_pruned=11.52 K, rows_scanned=20.00 K]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.48 K, output_bytes=241.4 KB, output_batches=4, rows_pruned=11.52 K, rows_scanned=20.00 K]
 (16 rows)
 
 SELECT t1.id, t1.val
@@ -549,7 +549,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all"
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (18 rows)
 
 SELECT t1.id, t1.val
@@ -651,7 +651,7 @@ LIMIT 15;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (17 rows)
 
 SELECT t1.id, t1.val

--- a/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by_alias_expression.out
@@ -67,7 +67,7 @@ LIMIT 10;
                  :           CooperativeExec
                  :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"technology_name","query_string":"java","lenient":null,"conjunction_mode":null}}}}
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT cccf.*

--- a/pg_search/tests/pg_regress/expected/join_outer_pathkey.out
+++ b/pg_search/tests/pg_regress/expected/join_outer_pathkey.out
@@ -90,11 +90,11 @@ WARNING:  For SEMI/ANTI/LeftMark join correctness, JoinScan needs to use a subop
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, company_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"Acme OR Globex OR Initech","lenient":null,"conjunction_mode":null}}}}
-           :         HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(product_id@0, id@2)]
+           :         HashJoinExec: mode=CollectLeft, join_type=LeftAnti, on=[(id@2, product_id@0)], null_aware
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query={"with_index":{"query":{"term":{"field":"tag","value":"niche"}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget OR gadget OR gizmo OR boring","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"term":{"field":"tag","value":"niche"}}}}
 (18 rows)
 
 SELECT p.id, p.description

--- a/pg_search/tests/pg_regress/expected/join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/join_predicates.out
@@ -79,7 +79,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -135,7 +135,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -212,7 +212,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -265,7 +265,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -308,7 +308,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"must":[{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"stand","lenient":null,"conjunction_mode":null}}]}}}}]}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}]}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"stand","lenient":null,"conjunction_mode":null}}]}}}}]}}
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -362,7 +362,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}]}}}}]}},{"boolean":{"should":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}]}}}}]}}]}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"boolean":{"must":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}]}}}}]}},{"boolean":{"should":[{"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"keyboard","lenient":null,"conjunction_mode":null}}}},{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"headphones","lenient":null,"conjunction_mode":null}}}}]}},{"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}]}}}}]}}]}}
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -406,7 +406,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -449,7 +449,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}]}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"boolean":{"must":["all"],"must_not":[{"parse_with_field":{"field":"description","query_string":"cable","lenient":null,"conjunction_mode":null}}]}}}}
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -619,7 +619,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"name"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}]}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"boolean":{"must":[{"const_score":{"query":{"exists":{"field":"name"}},"score":0.0}}],"must_not":[{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}]}}}}
 (17 rows)
 
 SELECT qgen_users.id, qgen_users.name 
@@ -664,7 +664,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT qgen_users.id, qgen_users.name 
@@ -858,7 +858,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.supplier_id, s.id AS supplier_pk
@@ -927,7 +927,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.id, p.supplier_id, s.id AS supplier_pk

--- a/pg_search/tests/pg_regress/expected/join_scoring.out
+++ b/pg_search/tests/pg_regress/expected/join_scoring.out
@@ -189,7 +189,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name, paradedb.score(s.id) AS supplier_score
@@ -245,7 +245,7 @@ LIMIT 10;
                  :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
                  :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id, id@3 as id]
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (21 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name,
@@ -302,7 +302,7 @@ LIMIT 10;
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"contact_info","query_string":"technology","lenient":null,"conjunction_mode":null}}}}
            :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, supplier_id@2 as supplier_id]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -79,7 +79,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1"}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- =====================================================================
@@ -267,7 +267,7 @@ LIMIT 10;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1"}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
 (17 rows)
 
 SELECT id, category
@@ -327,7 +327,7 @@ LIMIT 10;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"term":{"field":"group_id","value":"group_1"}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target_category\"","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT *

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive.out
@@ -955,7 +955,7 @@ LIMIT 5;
            :             PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
            :         ProjectionExec: expr=[ctid_0@0 as ctid_0, name@1 as name, id@2 as id, pdb_eval_expr_funcexpr_53eb87a5(CAST(name@1 AS Utf8)) as pdb_eval_expr_funcexpr_53eb87a5(i_0.name)]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
 (16 rows)
 
 SELECT i.id

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -74,7 +74,7 @@ LIMIT 3;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT f.id, f.title
@@ -121,7 +121,7 @@ LIMIT 3;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT f.id, f.title
@@ -149,8 +149,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 3;
-                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=3.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=3.00 loops=1)
          Relation Tree: d INNER f
@@ -162,11 +162,11 @@ LIMIT 3;
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=50, rows_output=3, segments_seen=1]
            :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=50, output_bytes=1450.0 B, output_batches=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=50, build_mem_used=344, avg_fanout=100% (50/50), probe_hit_rate=100% (50/50)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=50, output_bytes=128.6 KB, output_batches=1, build_mem_used=344.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=100, avg_fanout=100% (50/50), probe_hit_rate=50% (50/100)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=5, output_bytes=152.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=50, output_bytes=1882.0 B, output_batches=1, rows_pruned=0, rows_scanned=50]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=100, output_bytes=3.7 KB, output_batches=1, rows_pruned=0, rows_scanned=100]
 (16 rows)
 
 -- =============================================================================
@@ -278,7 +278,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (17 rows)
 
 -- =============================================================================
@@ -347,7 +347,7 @@ LIMIT 3;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 -- Verify results are the same with optimization disabled
@@ -431,7 +431,7 @@ LIMIT 5;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT f.id, f.title
@@ -498,7 +498,7 @@ LIMIT 5;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT f.id, f.title, f.content
@@ -656,8 +656,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 5;
-                                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                                          
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                                            
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=5.00 loops=1)
          Relation Tree: d INNER f
@@ -668,12 +668,12 @@ LIMIT 5;
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, metrics=[rows_input=14.42 K, rows_output=5, segments_seen=2]
-           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=14.42 K, output_bytes=802.8 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=14.42 K, output_bytes=833.6 KB, output_batches=2, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=14.42 K, build_mem_used=228, avg_fanout=100% (14.42 K/14.42 K), probe_hit_rate=55.81% (14.42 K/25.83 K)]
+           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=14.42 K, output_bytes=624.9 KB, output_batches=3]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=14.42 K, output_bytes=732.4 KB, output_batches=3, build_mem_used=228.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=24.03 K, avg_fanout=100% (14.42 K/14.42 K), probe_hit_rate=23.22% (14.42 K/62.09 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=14.42 K, output_bytes=521.0 KB, output_batches=4, rows_pruned=15.58 K, rows_scanned=30.00 K]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=24.03 K, output_bytes=868.3 KB, output_batches=4, rows_pruned=25.97 K, rows_scanned=50.00 K]
 (16 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/expected/term_set_dispatch.out
+++ b/pg_search/tests/pg_regress/expected/term_set_dispatch.out
@@ -86,8 +86,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=4.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -98,11 +98,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1, row_replacements=4]
            :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=4, output_bytes=128.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, build_mem_used=80.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=2, input_rows=10.00 K, avg_fanout=100% (4/4), probe_hit_rate=0.04% (4/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_unique.id
@@ -129,8 +129,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 5
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=5.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=5.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -141,11 +141,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=5, output_bytes=160.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=5, output_bytes=160.0 B, output_batches=1, row_replacements=5]
            :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=5, output_bytes=128.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=5, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=5, input_batches=1, input_rows=5, build_mem_used=100, avg_fanout=100% (5/5), probe_hit_rate=100% (5/5)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=5, output_bytes=256.0 KB, output_batches=1, build_mem_used=100.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=5, input_batches=2, input_rows=10.00 K, avg_fanout=100% (5/5), probe_hit_rate=0.05% (5/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":5}}}]}}, metrics=[output_rows=5, output_bytes=80.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5, output_bytes=120.0 B, output_batches=1, rows_pruned=0, rows_scanned=5]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_unique.id
@@ -172,8 +172,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 6
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                   QUERY PLAN                                                                                                                                                                                   
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                            
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=6.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=6.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -184,11 +184,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=6, output_bytes=192.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=6, output_bytes=192.0 B, output_batches=1, row_replacements=6]
            :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=6, output_bytes=128.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=6, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=6, input_batches=1, input_rows=6, build_mem_used=120, avg_fanout=100% (6/6), probe_hit_rate=100% (6/6)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=6, output_bytes=256.0 KB, output_batches=1, build_mem_used=120.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=6, input_batches=2, input_rows=10.00 K, avg_fanout=100% (6/6), probe_hit_rate=0.06% (6/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":6}}}]}}, metrics=[output_rows=6, output_bytes=96.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_unique.id
@@ -218,8 +218,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 50
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -229,12 +229,12 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
-           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=5.00 K, output_bytes=156.2 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=5.00 K, output_bytes=156.2 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=50, input_batches=1, input_rows=5.00 K, build_mem_used=1.00 K, avg_fanout=100% (5.00 K/5.00 K), probe_hit_rate=100% (5.00 K/5.00 K)]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.10 K, output_bytes=128.1 KB, output_batches=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.10 K, output_bytes=128.1 KB, output_batches=1, build_mem_used=1000.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=50, input_batches=2, input_rows=8.19 K, avg_fanout=100% (4.10 K/4.10 K), probe_hit_rate=50.05% (4.10 K/8.19 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":50}}}]}}, metrics=[output_rows=50, output_bytes=800.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=5.00 K, output_bytes=117.2 KB, output_batches=1, rows_pruned=0, rows_scanned=5.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=8.19 K, output_bytes=192.0 KB, output_batches=2, rows_pruned=1.81 K, rows_scanned=10.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_multi.id
@@ -266,8 +266,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 60
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                                      
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -277,12 +277,12 @@ LIMIT 10;
          DataFusion Physical Plan: 
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
-           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=6.00 K, output_bytes=187.5 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=1, input_rows=6.00 K, build_mem_used=1.20 K, avg_fanout=100% (6.00 K/6.00 K), probe_hit_rate=100% (6.00 K/6.00 K)]
+           :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.92 K, output_bytes=153.8 KB, output_batches=1]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.92 K, output_bytes=153.8 KB, output_batches=1, build_mem_used=1200.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=60, input_batches=2, input_rows=8.19 K, avg_fanout=100% (4.92 K/4.92 K), probe_hit_rate=60.06% (4.92 K/8.19 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":60}}}]}}, metrics=[output_rows=60, output_bytes=960.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6.00 K, output_bytes=140.6 KB, output_batches=1, rows_pruned=0, rows_scanned=6.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=8.19 K, output_bytes=192.0 KB, output_batches=2, rows_pruned=1.81 K, rows_scanned=10.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_multi.id
@@ -315,8 +315,8 @@ FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
 ORDER BY ts_sorted.id ASC
 LIMIT 10;
-                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                            
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                               QUERY PLAN                                                                                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_sorted INNER ts_outer
@@ -327,11 +327,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[ts_sorted, ts_outer], metrics=[output_rows=100, output_bytes=129.6 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=100, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=1, input_rows=100, build_mem_used=2.00 K, avg_fanout=100% (100/100), probe_hit_rate=100% (100/100)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=100, output_bytes=256.0 KB, output_batches=1, build_mem_used=2000.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=2, input_rows=10.00 K, avg_fanout=100% (100/100), probe_hit_rate=1% (100/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100}}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query="all", metrics=[output_rows=100, output_bytes=2.3 KB, output_batches=1, rows_pruned=0, rows_scanned=100]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 SELECT ts_outer.id, ts_sorted.id
@@ -364,8 +364,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=4.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -376,11 +376,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1, row_replacements=4]
            :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=4, output_bytes=128.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, build_mem_used=80.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=2, input_rows=10.00 K, avg_fanout=100% (4/4), probe_hit_rate=0.04% (4/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_unique;
@@ -395,8 +395,8 @@ FROM ts_outer JOIN ts_unique ON ts_outer.id = ts_unique.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 20
 ORDER BY ts_unique.id ASC
 LIMIT 10;
-                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                             QUERY PLAN                                                                                                                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_unique INNER ts_outer
@@ -407,11 +407,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[ts_unique, ts_outer], metrics=[output_rows=20, output_bytes=128.3 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=20, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=20, input_batches=1, input_rows=20, build_mem_used=400, avg_fanout=100% (20/20), probe_hit_rate=100% (20/20)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=20, output_bytes=256.0 KB, output_batches=1, build_mem_used=400.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=20, input_batches=2, input_rows=10.00 K, avg_fanout=100% (20/20), probe_hit_rate=0.2% (20/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":20}}}]}}, metrics=[output_rows=20, output_bytes=320.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=20, output_bytes=480.0 B, output_batches=1, rows_pruned=0, rows_scanned=20]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_unique;
@@ -427,8 +427,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 40
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                                   
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -439,11 +439,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=4.00 K, output_bytes=190.5 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=1, input_rows=4.00 K, build_mem_used=800, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=100% (4.00 K/4.00 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4.00 K, output_bytes=256.0 KB, output_batches=1, build_mem_used=800.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=40, input_batches=2, input_rows=10.00 K, avg_fanout=100% (4.00 K/4.00 K), probe_hit_rate=40% (4.00 K/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":40}}}]}}, metrics=[output_rows=40, output_bytes=640.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=4.00 K, output_bytes=93.8 KB, output_batches=1, rows_pruned=0, rows_scanned=4.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_multi;
@@ -459,8 +459,8 @@ FROM ts_outer JOIN ts_multi ON ts_outer.id = ts_multi.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 100
 ORDER BY ts_multi.id ASC
 LIMIT 10;
-                                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                                     
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                                     QUERY PLAN                                                                                                                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=10.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=10.00 loops=1)
          Relation Tree: ts_multi INNER ts_outer
@@ -471,11 +471,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@1 < 10], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1, row_replacements=10]
            :     VisibilityFilterExec: tables=[ts_multi, ts_outer], metrics=[output_rows=8.19 K, output_bytes=256.0 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=8.19 K, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=2, input_rows=8.19 K, build_mem_used=2.00 K, avg_fanout=100% (8.19 K/8.19 K), probe_hit_rate=100% (8.19 K/8.19 K)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=8.19 K, output_bytes=256.0 KB, output_batches=1, build_mem_used=2000.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=100, input_batches=2, input_rows=8.19 K, avg_fanout=100% (8.19 K/8.19 K), probe_hit_rate=100% (8.19 K/8.19 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":100}}}]}}, metrics=[output_rows=100, output_bytes=1600.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=8.19 K, output_bytes=192.0 KB, output_batches=2, rows_pruned=1.81 K, rows_scanned=10.00 K]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=8.19 K, output_bytes=192.0 KB, output_batches=2, rows_pruned=1.81 K, rows_scanned=10.00 K]
 (15 rows)
 
 RESET paradedb.term_set_bitset_max_density_multi;
@@ -492,8 +492,8 @@ FROM ts_outer JOIN ts_sorted ON ts_outer.id = ts_sorted.fk
 WHERE ts_outer.val @@@ 'doc' AND ts_outer.id <= 4
 ORDER BY ts_sorted.id ASC
 LIMIT 10;
-                                                                                                                                                                                  QUERY PLAN                                                                                                                                                                                   
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                           QUERY PLAN                                                                                                                                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=4.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=4.00 loops=1)
          Relation Tree: ts_sorted INNER ts_outer
@@ -504,11 +504,11 @@ LIMIT 10;
            : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1]
            :   SortExec: TopK(fetch=10), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[false], metrics=[output_rows=4, output_bytes=128.0 B, output_batches=1, row_replacements=4]
            :     VisibilityFilterExec: tables=[ts_sorted, ts_outer], metrics=[output_rows=4, output_bytes=128.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=1, input_rows=4, build_mem_used=80, avg_fanout=100% (4/4), probe_hit_rate=100% (4/4)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, fk@1)], projection=[ctid_0@2, id@4, ctid_1@0, id@1], metrics=[output_rows=4, output_bytes=256.0 KB, output_batches=1, build_mem_used=80.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=4, input_batches=2, input_rows=10.00 K, avg_fanout=100% (4/4), probe_hit_rate=0.04% (4/10.00 K)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"doc","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"id","lower_bound":null,"upper_bound":{"included":4}}}]}}, metrics=[output_rows=4, output_bytes=64.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=4, output_bytes=96.0 B, output_batches=1, rows_pruned=0, rows_scanned=4]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=10.00 K, output_bytes=234.4 KB, output_batches=2, rows_pruned=0, rows_scanned=10.00 K]
 (15 rows)
 
 RESET paradedb.term_set_gallop_enabled;

--- a/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
+++ b/pg_search/tests/pg_regress/expected/topk-indexed-expressions.out
@@ -345,7 +345,7 @@ ORDER BY s.name ASC
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (18 rows)
 
 SELECT p.name, s.name AS supplier_name

--- a/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
+++ b/pg_search/tests/pg_regress/expected/topk_dynamic_filter.out
@@ -77,7 +77,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -124,7 +124,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -151,8 +151,8 @@ JOIN suppliers s ON p.supplier_id = s.id
 WHERE s.region @@@ 'wireless'
 ORDER BY p.id
 LIMIT 3;
-                                                                                                                                                                                    QUERY PLAN                                                                                                                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                      QUERY PLAN                                                                                                                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=3.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=3.00 loops=1)
          Relation Tree: s INNER p
@@ -163,11 +163,11 @@ LIMIT 3;
            : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=3, output_bytes=72.0 B, output_batches=1]
            :   SortExec: TopK(fetch=3), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false], filter=[id@2 < 14], metrics=[output_rows=3, output_bytes=72.0 B, output_batches=1, row_replacements=3]
            :     VisibilityFilterExec: tables=[s, p], metrics=[output_rows=6, output_bytes=64.1 KB, output_batches=1]
-           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, id@4], metrics=[output_rows=6, output_bytes=192.0 KB, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=6, build_mem_used=20, avg_fanout=100% (6/6), probe_hit_rate=100% (6/6)]
+           :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, id@4], metrics=[output_rows=6, output_bytes=192.0 KB, output_batches=1, build_mem_used=20.0 B, array_map_created_count=1, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=30, avg_fanout=100% (6/6), probe_hit_rate=20% (6/30)]
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=16.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=144.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=30, output_bytes=720.0 B, output_batches=1, rows_pruned=0, rows_scanned=30]
 (15 rows)
 
 -- =============================================================================
@@ -198,7 +198,7 @@ LIMIT 2;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -241,7 +241,7 @@ LIMIT 2;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id, p.name, p.price, s.name AS supplier_name
@@ -285,7 +285,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"global","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"premium","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id, p.name, s.name AS supplier_name
@@ -339,7 +339,7 @@ LIMIT 3;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"region","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query="all"
+           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT p.id, p.name, p.price
@@ -471,8 +471,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 3;
-                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                             
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=3.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=3.00 loops=1)
          Relation Tree: d INNER f
@@ -484,11 +484,11 @@ LIMIT 3;
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=70, rows_output=3, segments_seen=1]
            :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=70, output_bytes=2030.0 B, output_batches=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=70, build_mem_used=424, avg_fanout=100% (70/70), probe_hit_rate=100% (70/70)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=70, output_bytes=128.9 KB, output_batches=1, build_mem_used=424.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=7, input_batches=1, input_rows=200, avg_fanout=100% (70/70), probe_hit_rate=35% (70/200)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=7, output_bytes=232.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=automaton, query="all", metrics=[output_rows=70, output_bytes=2.6 KB, output_batches=1, rows_pruned=0, rows_scanned=70]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=200, output_bytes=7.4 KB, output_batches=1, rows_pruned=0, rows_scanned=200]
 (16 rows)
 
 SELECT f.id, f.title
@@ -518,8 +518,8 @@ WHERE f.document_id IN (
 )
 ORDER BY f.title ASC
 LIMIT 3;
-                                                                                                                                                                                          QUERY PLAN                                                                                                                                                                                          
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                                                            QUERY PLAN                                                                                                                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit (actual rows=3.00 loops=1)
    ->  Custom Scan (ParadeDB Join Scan) (actual rows=3.00 loops=1)
          Relation Tree: d INNER f
@@ -531,11 +531,11 @@ LIMIT 3;
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=3, output_bytes=152.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=3, metrics=[rows_input=10, rows_output=3, segments_seen=1]
            :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=10, output_bytes=290.0 B, output_batches=1]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=10, build_mem_used=105, avg_fanout=100% (10/10), probe_hit_rate=100% (10/10)]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=10, output_bytes=128.1 KB, output_batches=1, build_mem_used=105.0 B, array_map_created_count=0, build_input_batches=1, build_input_rows=1, input_batches=1, input_rows=200, avg_fanout=100% (10/10), probe_hit_rate=5% (10/200)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"title","query_string":"intro","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=1, output_bytes=32.0 B, output_batches=1]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=10, output_bytes=378.0 B, output_batches=1, rows_pruned=0, rows_scanned=10]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=200, output_bytes=7.4 KB, output_batches=1, rows_pruned=0, rows_scanned=200]
 (16 rows)
 
 SELECT f.id, f.title

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -22,7 +22,7 @@ cmd_lib = "1.9.6"
 dotenvy = "0.15.7"
 futures = "0.3.32"
 lockfree-object-pool = "0.1.6"
-pgvector = { version = "0.4.1", features = ["sqlx"] }
+pgvector = { version = "=0.4.1", features = ["sqlx"] }
 pretty_assertions = "1.4.1"
 rand = "0.9.4"
 rstest = "0.25.0"


### PR DESCRIPTION
## What

Update to a `DataFusion` `0.55.x` pre-release ([63e25c15bc72e731c174ba03d1143b243cc1aaae](https://github.com/apache/datafusion/commits/63e25c15bc72e731c174ba03d1143b243cc1aaae) (Fri Jul 10)) which includes [support for Range-partitioned hash joins](https://github.com/apache/datafusion/pull/23184).

## Why

We will soon want to begin testing declaring Range partitioning from our table provider.