### PR TITLE
ci: bump stressgres Docker publish disk and alert Slack on failure

### DIFF
--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -24,6 +24,7 @@ jobs:
       - cpu=8
       - ram=32
       - image=ubuntu24-full-x64
+      - volume=80gb # default runner ships with 30GB — see https://runs-on.com/runners/linux/
 
     steps:
       - name: Checkout Git Repository
@@ -59,3 +60,10 @@ jobs:
           sbom: true
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Notify Slack on Failure
+        if: failure()
+        run: |
+          GITHUB_RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          MESSAGE="<!here> \`publish-stressgres-docker\` workflow failed in \`${{ github.repository }}\` on branch \`${{ github.ref_name }}\` -- investigate immediately! GitHub Action Logs: ${GITHUB_RUN_URL}"
+          curl -X POST -H 'Content-type: application/json' -d "{\"text\": \"${MESSAGE}\"}" ${{ secrets.SLACK_GITHUB_CHANNEL_WEBHOOK_URL }}


### PR DESCRIPTION
The `Publish Stressgres (Docker)` job [failed with `No space left on device`](https://github.com/paradedb/paradedb/actions/runs/28990888359/job/86030170482). The default runs-on runner ships with only 30GB, and the multi-platform (amd64+arm64) build with SBOM and `provenance: mode=max` exhausted it.

- Bump the runner to `volume=80gb`, matching the convention used across the other workflows.
- Add a `Notify Slack on Failure` step mirroring the other publish jobs so future failures alert the channel.

https://claude.ai/code/session_01HDXPaKmRg4j9kJ4RxR31Dm