### PR TITLE
chore: bump Rust toolchain to 1.97.0

### DIFF
--- a/benchmarks/src/sample.rs
+++ b/benchmarks/src/sample.rs
@@ -144,7 +144,7 @@ pub fn run_sample(args: SampleArgs) -> Result<()> {
 
     println!("Removing root table data from local disk...");
     std::fs::remove_dir_all(&local_root_data_path)
-        .with_context(|| format!("Failed to remove dir: '{}'", &local_root_data_path))?;
+        .with_context(|| format!("Failed to remove dir: '{}'", local_root_data_path))?;
 
     // re-enable multi-threading
     conn.execute("RESET threads;", [])

--- a/docker/Dockerfile.proptests
+++ b/docker/Dockerfile.proptests
@@ -7,7 +7,7 @@
 # the in-cluster ParadeDB primary by the driver script (see
 # tests/antithesis/singleton_driver_property-tests.sh).
 
-FROM rust:1.96-slim
+FROM rust:1.97-slim
 
 # Required for the piped RUN below (hadolint DL4006).
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/docker/Dockerfile.stressgres
+++ b/docker/Dockerfile.stressgres
@@ -11,7 +11,7 @@
 #       memory: "4Gi"
 #       cpu: "2000m"
 
-FROM rust:1.96-slim-trixie
+FROM rust:1.97-slim-trixie
 
 # Install build and runtime dependencies. Upgrade existing OS packages first so
 # we pick up the latest Debian security fixes regardless of the base layer's age.

--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -586,13 +586,10 @@ fn set_missing_on_terms(
 ) {
     use crate::schema::SearchFieldType;
 
-    for (
-        _name,
-        Aggregation {
-            agg,
-            sub_aggregation,
-        },
-    ) in aggs.iter_mut()
+    for Aggregation {
+        agg,
+        sub_aggregation,
+    } in aggs.values_mut()
     {
         if let AggregationVariants::Terms(terms) = agg {
             if terms.missing.is_none() {

--- a/pg_search/src/api/tokenizers/definitions.rs
+++ b/pg_search/src/api/tokenizers/definitions.rs
@@ -81,7 +81,7 @@ pub(crate) mod pdb {
     // Magic number: "err\0" - includes null bytes to ensure no valid text string can match
     // (PostgreSQL text values cannot contain embedded nulls). Prints as the string "err" if
     // interpreted as TEXT, making it a bit easier to catch.
-    const ALIAS_MAGIC: u32 = u32::from_ne_bytes([b'e', b'r', b'r', b'\0']);
+    const ALIAS_MAGIC: u32 = u32::from_ne_bytes(*b"err\0");
 
     impl DatumWithType {
         unsafe fn new(mut datum: pg_sys::Datum, typoid: pg_sys::Oid) -> *mut Self {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -1330,19 +1330,17 @@ unsafe fn build_search_filter(
     let mut expr_trees: Vec<JoinLevelExpr> = Vec::new();
 
     for &clause in clauses {
-        match transform_to_search_expr(
+        // If any clause can't be fully transformed, bail out.
+        // Returning None leaves the clause as "unhandled", which causes
+        // has_non_equi_join_quals to reject the DataFusion path.
+        let expr = transform_to_search_expr(
             root,
             clause,
             &sources,
             &mut temp_clause,
             &mut multi_table_clauses,
-        ) {
-            Some(expr) => expr_trees.push(expr),
-            // If any clause can't be fully transformed, bail out.
-            // Returning None leaves the clause as "unhandled", which causes
-            // has_non_equi_join_quals to reject the DataFusion path.
-            None => return None,
-        }
+        )?;
+        expr_trees.push(expr);
     }
 
     if expr_trees.is_empty() {

--- a/pg_search/src/postgres/customscan/basescan/projections/window_agg.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/window_agg.rs
@@ -331,15 +331,14 @@ unsafe fn convert_window_func_to_aggregate_type(
 
         // Extract the jsonb argument (first arg)
         let first_arg = args.get_ptr(0)?;
-        let json_value = if let Some(const_node) = nodecast!(Const, T_Const, first_arg) {
+        let const_node = nodecast!(Const, T_Const, first_arg)?;
+        let json_value = {
             if (*const_node).constisnull {
                 return None;
             }
             let jsonb_datum = (*const_node).constvalue;
             let jsonb = <pgrx::JsonB as pgrx::FromDatum>::from_datum(jsonb_datum, false)?;
             jsonb.0
-        } else {
-            return None;
         };
 
         // Extract solve_mvcc bool argument (second arg) if using the two-arg overload
@@ -423,10 +422,9 @@ unsafe fn extract_field_name_from_aggregate_arg(
     let (var, missing) =
         if let Some(coalesce_node) = nodecast!(CoalesceExpr, T_CoalesceExpr, arg_node) {
             parse_coalesce_expression(coalesce_node).ok()?
-        } else if let Some(var) = nodecast!(Var, T_Var, arg_node) {
-            (var, None)
         } else {
-            return None;
+            let var = nodecast!(Var, T_Var, arg_node)?;
+            (var, None)
         };
 
     // Get heaprelid from the rtable using VarContext

--- a/pg_search/src/postgres/customscan/joinscan/planning.rs
+++ b/pg_search/src/postgres/customscan/joinscan/planning.rs
@@ -236,7 +236,8 @@ pub(super) unsafe fn collect_join_sources_base_rel(
             let mut state = QualExtractState::default();
             // Extract search-capable predicates all at once. This is required
             // for score filters, which must wrap the rest of the search query.
-            if let Some(qual) = extract_quals(
+            // Fail the JoinScan if any search predicate cannot be extracted.
+            let qual = extract_quals(
                 &context,
                 rti,
                 classified.search_ri.as_ptr().cast(),
@@ -245,15 +246,11 @@ pub(super) unsafe fn collect_join_sources_base_rel(
                 false,
                 &mut state,
                 true,
-            ) {
-                let query = SearchQueryInput::from(&qual);
-                side_info = side_info.with_query(query);
-                if state.uses_our_operator {
-                    side_info = side_info.with_search_predicate();
-                }
-            } else {
-                // Fail the JoinScan if any search predicate cannot be extracted.
-                return None;
+            )?;
+            let query = SearchQueryInput::from(&qual);
+            side_info = side_info.with_query(query);
+            if state.uses_our_operator {
+                side_info = side_info.with_search_predicate();
             }
         }
     }

--- a/pg_search/src/postgres/customscan/joinscan/predicate.rs
+++ b/pg_search/src/postgres/customscan/joinscan/predicate.rs
@@ -243,17 +243,14 @@ pub unsafe fn transform_to_search_expr(
         let list = PgList::<pg_sys::Node>::from_pg(node as *mut pg_sys::List);
         let mut children = Vec::new();
         for item in list.iter_ptr() {
-            if let Some(child_expr) = transform_to_search_expr(
+            let child_expr = transform_to_search_expr(
                 root,
                 item,
                 sources,
                 join_clause,
                 multi_table_predicate_clauses,
-            ) {
-                children.push(child_expr);
-            } else {
-                return None;
-            }
+            )?;
+            children.push(child_expr);
         }
         return if children.is_empty() {
             None
@@ -274,17 +271,14 @@ pub unsafe fn transform_to_search_expr(
             pg_sys::BoolExprType::AND_EXPR | pg_sys::BoolExprType::OR_EXPR => {
                 let mut children = Vec::new();
                 for arg in args.iter_ptr() {
-                    if let Some(child_expr) = transform_to_search_expr(
+                    let child_expr = transform_to_search_expr(
                         root,
                         arg,
                         sources,
                         join_clause,
                         multi_table_predicate_clauses,
-                    ) {
-                        children.push(child_expr);
-                    } else {
-                        return None;
-                    }
+                    )?;
+                    children.push(child_expr);
                 }
                 if children.is_empty() {
                     None

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -426,12 +426,7 @@ impl SearchQueryInput {
         use crate::MORE_LIKE_THIS_SELECTIVITY;
 
         match self {
-            SearchQueryInput::Boolean {
-                must,
-                should,
-                must_not: _,
-                ..
-            } => {
+            SearchQueryInput::Boolean { must, should, .. } => {
                 // AND: product of children selectivities; OR: max of children selectivities.
                 let must_sel = must
                     .iter()

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.96.0"
+channel = "1.97.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]

--- a/stressgres/src/tui.rs
+++ b/stressgres/src/tui.rs
@@ -71,7 +71,7 @@ pub fn run(suite_runner: Arc<SuiteRunner>) -> anyhow::Result<()> {
         make_runner_view(&suite_runner, &mut job_views, &job);
     }
     mux.add_right_of(job_views, root_id)?;
-    mux.set_container_split_ratio(root_id, 0.5)?;
+    mux.set_container_split_ratio(root_id, 0.5_f32)?;
 
     cursive.add_fullscreen_layer(
         LinearLayout::vertical().child(mux).child(


### PR DESCRIPTION
Bumps the pinned toolchain from 1.96.0 to 1.97.0, along with the `rust:1.96` base images in the proptests and stressgres Dockerfiles.

1.97 promotes several lints under our `-D warnings` clippy gate. The sites it flags are fixed here:

- `float_literal_f32_fallback` — annotate the split-ratio literal as `f32`
- `useless_borrows_in_formatting` — drop a redundant `&` in a `format!` arg
- `unneeded_wildcard_pattern` — drop `must_not: _` covered by `..`
- `for_kv_map` — iterate `values_mut()` instead of discarding the key
- `byte_char_slices` — use a byte-string literal for the alias magic
- `question_mark` — collapse five `if let Some(_) … else return None` blocks

The `question_mark` rewrites keep the existing bail-with-`None` control flow.

Verified locally: `cargo clippy --workspace --all-targets -- -D warnings` passes with 0 errors, and `cargo fmt --check` is clean.

https://claude.ai/code/session_01NeoHTLLmSviDko1bNMaPPL