### PR TITLE
fix: return error instead of panicking for missing segment component path

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -190,9 +190,11 @@ impl MVCCDirectory {
 
         match meta_entry {
             LoadedSegmentMetaEntry::Persisted { entry, .. } => {
-                let file_entry = entry
-                    .file_entry(uuid_string, path)
-                    .expect("No such path for {entry:?}: {path:?}");
+                let Some(file_entry) = entry.file_entry(uuid_string, path) else {
+                    return Err(TantivyError::OpenDirectoryError(
+                        OpenDirectoryError::DoesNotExist(path.to_path_buf()),
+                    ));
+                };
                 Ok(Arc::new(unsafe {
                     SegmentComponentReader::new(&self.indexrel, file_entry)
                 }))


### PR DESCRIPTION
Closes #5534.

`MVCCDirectory::file_entry` called `.expect(...)` on the `Option` returned by `entry.file_entry(uuid_string, path)`, so a persisted segment that is missing a component path after a crash/restart panicked and surfaced to the client as `XX000: No such path ...`. The `.expect` string was also a plain literal, so the `{entry:?}` and `{path:?}` placeholders printed verbatim instead of interpolating.

This returns `TantivyError::OpenDirectoryError(OpenDirectoryError::DoesNotExist(path))` for the missing-component case, matching the error the same function already returns a few lines above when the segment itself is not in `all_entries`, so the query fails gracefully instead of panicking at the SQL boundary.

I was not able to run the pgrx test suite locally (it needs `cargo pgrx init` with a full Postgres 18 build), but the change mirrors the existing not-found path in the same function and uses types already imported and used there.