### PR TITLE
refactor(dst): Refactor Antithesis assertions so they're inside a single file

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -191,7 +191,7 @@ jobs:
           PG_CONFIG_PATH="/usr/lib/postgresql/${{ env.PG_VERSION }}/bin/pg_config"
           RUSTFLAGS="-Ccodegen-units=1 -Cpasses=sancov-module -Cllvm-args=-sanitizer-coverage-level=3 -Cllvm-args=-sanitizer-coverage-trace-pc-guard -Clink-args=-Wl,--build-id -lvoidstar" \
           CARGO_PROFILE_RELEASE_WITH_DEBUG_LTO=off \
-            cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH" --features antithesis
+            cargo pgrx package --profile=release-with-debug --pg-config "$PG_CONFIG_PATH" --features dst
 
       # Catch the broken-symbol case above before shipping to Antithesis.
       # Undefined Rust symbols (_ZN/_R) mean a broken .so; Postgres C symbols stay undefined and are fine.

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -20,9 +20,8 @@ pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = ["dep:proptest"]
 deferred_wal = []
 # Emit deterministic-simulation-testing (DST) assertions from bug-class code paths (e.g. a
-# background-merge crash), via the vendor SDK in `src/dst.rs`. Enabled only for the
-# instrumented build; a no-op everywhere else. Vendor-neutral name so the harness (today
-# Antithesis) can be swapped without touching call sites.
+# background-merge crash), via the Antithesis SDK in `src/dst.rs`. Enabled only for the
+# instrumented build; a no-op everywhere else.
 dst = ["dep:antithesis_sdk"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 block_tracker = [] # for debugging when blocks are acquired and released

--- a/pg_search/Cargo.toml
+++ b/pg_search/Cargo.toml
@@ -19,9 +19,11 @@ pg17 = ["pgrx/pg17", "pgrx-tests/pg17"]
 pg18 = ["pgrx/pg18", "pgrx-tests/pg18"]
 pg_test = ["dep:proptest"]
 deferred_wal = []
-# Emit Antithesis assertions from bug-class code paths (e.g. a background-merge crash).
-# Enabled only for the Antithesis-instrumented build; a no-op everywhere else.
-antithesis = ["dep:antithesis_sdk"]
+# Emit deterministic-simulation-testing (DST) assertions from bug-class code paths (e.g. a
+# background-merge crash), via the vendor SDK in `src/dst.rs`. Enabled only for the
+# instrumented build; a no-op everywhere else. Vendor-neutral name so the harness (today
+# Antithesis) can be swapped without touching call sites.
+dst = ["dep:antithesis_sdk"]
 unsafe-postgres = ["pgrx/unsafe-postgres"]
 block_tracker = [] # for debugging when blocks are acquired and released
 debug-logging = [

--- a/pg_search/src/dst.rs
+++ b/pg_search/src/dst.rs
@@ -22,19 +22,23 @@
 //!
 //! Built only under `--features dst` (the instrumented build); a no-op everywhere else,
 //! so production `pg_search` never links the SDK.
+//!
+//! [`report_merge_crash!`] is a forwarding macro, not a function, so the SDK captures the
+//! assertion's location at the call site (`background_merge`) rather than here. The
+//! bug-class classification stays in the [`merge_crash_details`] function.
 
+#[cfg(feature = "dst")]
 use pgrx::pg_sys::panic::CaughtError;
 
-/// Unreachable: surface a background-merge worker crash as an invariant violation so the
-/// run fails instead of silently passing on a crash that only ever reached the container's
-/// stdout.
+/// The DST details payload for a background-merge worker crash, or `None` when `caught` is
+/// not a bug.
 ///
 /// Fires only for bug-class errors — internal-error / corruption SQLSTATEs and Rust
 /// panics. An interrupt-driven cancellation is not a bug and never reaches here:
 /// `merge_index` downgrades it to a `warning!`, so the faults we deliberately inject do
 /// not trip the assertion.
 #[cfg(feature = "dst")]
-pub(crate) fn report_merge_crash(caught: &CaughtError) {
+pub(crate) fn merge_crash_details(caught: &CaughtError) -> Option<serde_json::Value> {
     use pgrx::PgSqlErrorCode::*;
 
     let report = match caught {
@@ -52,20 +56,35 @@ pub(crate) fn report_merge_crash(caught: &CaughtError) {
                     | ERRCODE_INDEX_CORRUPTED
                     | ERRCODE_ASSERT_FAILURE
             ) {
-                return;
+                return None;
             }
             report
         }
     };
 
-    antithesis_sdk::assert_unreachable!(
-        "pg_search background merge crashed",
-        &serde_json::json!({
-            "sqlstate": format!("{:?}", report.sql_error_code()),
-            "message": report.message(),
-        })
-    );
+    Some(serde_json::json!({
+        "sqlstate": format!("{:?}", report.sql_error_code()),
+        "message": report.message(),
+    }))
+}
+
+/// Unreachable: surface a background-merge worker crash as an invariant violation so the
+/// run fails instead of silently passing on a crash that only ever reached the container's
+/// stdout.
+#[cfg(feature = "dst")]
+macro_rules! report_merge_crash {
+    ($caught:expr) => {
+        if let Some(details) = $crate::dst::merge_crash_details($caught) {
+            ::antithesis_sdk::assert_unreachable!("pg_search background merge crashed", &details);
+        }
+    };
 }
 
 #[cfg(not(feature = "dst"))]
-pub(crate) fn report_merge_crash(_caught: &CaughtError) {}
+macro_rules! report_merge_crash {
+    ($caught:expr) => {{
+        let _ = $caught;
+    }};
+}
+
+pub(crate) use report_merge_crash;

--- a/pg_search/src/dst.rs
+++ b/pg_search/src/dst.rs
@@ -25,7 +25,7 @@
 //!
 //! [`report_merge_crash!`] is a forwarding macro, not a function, so the SDK captures the
 //! assertion's location at the call site (`background_merge`) rather than here. The
-//! bug-class classification stays in the [`merge_crash_details`] function.
+//! bug-class classification stays in the `merge_crash_details` function.
 
 #[cfg(feature = "dst")]
 use pgrx::pg_sys::panic::CaughtError;
@@ -33,8 +33,8 @@ use pgrx::pg_sys::panic::CaughtError;
 /// The DST details payload for a background-merge worker crash, or `None` when `caught` is
 /// not a bug.
 ///
-/// Fires only for bug-class errors — internal-error / corruption SQLSTATEs and Rust
-/// panics. An interrupt-driven cancellation is not a bug and never reaches here:
+/// Returns `Some` only for bug-class errors — internal-error / corruption SQLSTATEs and
+/// Rust panics. An interrupt-driven cancellation is not a bug and never reaches here:
 /// `merge_index` downgrades it to a `warning!`, so the faults we deliberately inject do
 /// not trip the assertion.
 #[cfg(feature = "dst")]

--- a/pg_search/src/dst.rs
+++ b/pg_search/src/dst.rs
@@ -1,0 +1,73 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Deterministic-simulation-testing (DST) hooks.
+//!
+//! The only module that talks to the DST vendor SDK — currently Antithesis, pulled in as
+//! the optional `antithesis_sdk` dependency. Everything else in `pg_search` calls this
+//! crate-local vocabulary, so moving to a different DST harness means rewriting this file
+//! and the one dependency line in `Cargo.toml`, not chasing vendor calls across the tree.
+//!
+//! Built only under `--features dst` (the instrumented build); a no-op everywhere else,
+//! so production `pg_search` never links the SDK.
+
+use pgrx::pg_sys::panic::CaughtError;
+
+/// Unreachable: surface a background-merge worker crash as an invariant violation so the
+/// run fails instead of silently passing on a crash that only ever reached the container's
+/// stdout.
+///
+/// Fires only for bug-class errors — internal-error / corruption SQLSTATEs and Rust
+/// panics. An interrupt-driven cancellation is not a bug and never reaches here:
+/// `merge_index` downgrades it to a `warning!`, so the faults we deliberately inject do
+/// not trip the assertion.
+#[cfg(feature = "dst")]
+pub(crate) fn report_merge_crash(caught: &CaughtError) {
+    use pgrx::PgSqlErrorCode::*;
+
+    let report = match caught {
+        // A Rust panic (a failed `expect`, or the `panic!("failed to merge…")` in
+        // `merge_index`) is always a bug.
+        CaughtError::RustPanic { ereport, .. } => ereport,
+        // A Postgres/ereport error is a bug only when it is an internal error or
+        // corruption; cancellations, shutdowns and connection faults are the chaos we
+        // are injecting, not defects.
+        CaughtError::PostgresError(report) | CaughtError::ErrorReport(report) => {
+            if !matches!(
+                report.sql_error_code(),
+                ERRCODE_INTERNAL_ERROR
+                    | ERRCODE_DATA_CORRUPTED
+                    | ERRCODE_INDEX_CORRUPTED
+                    | ERRCODE_ASSERT_FAILURE
+            ) {
+                return;
+            }
+            report
+        }
+    };
+
+    antithesis_sdk::assert_unreachable!(
+        "pg_search background merge crashed",
+        &serde_json::json!({
+            "sqlstate": format!("{:?}", report.sql_error_code()),
+            "message": report.message(),
+        })
+    );
+}
+
+#[cfg(not(feature = "dst"))]
+pub(crate) fn report_merge_crash(_caught: &CaughtError) {}

--- a/pg_search/src/dst.rs
+++ b/pg_search/src/dst.rs
@@ -17,10 +17,8 @@
 
 //! Deterministic-simulation-testing (DST) hooks.
 //!
-//! The only module that talks to the DST vendor SDK — currently Antithesis, pulled in as
-//! the optional `antithesis_sdk` dependency. Everything else in `pg_search` calls this
-//! crate-local vocabulary, so moving to a different DST harness means rewriting this file
-//! and the one dependency line in `Cargo.toml`, not chasing vendor calls across the tree.
+//! The only module that talks to the DST vendor SDK (Antithesis), pulled in as
+//! the optional `antithesis_sdk` dependency.
 //!
 //! Built only under `--features dst` (the instrumented build); a no-op everywhere else,
 //! so production `pg_search` never links the SDK.

--- a/pg_search/src/lib.rs
+++ b/pg_search/src/lib.rs
@@ -19,6 +19,7 @@
 mod aggregate;
 mod api;
 mod bootstrap;
+mod dst;
 mod index;
 mod postgres;
 mod query;

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -399,7 +399,7 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
         // fuzzer's run fails instead of silently passing. Rethrowing preserves the
         // existing behaviour (Postgres logs the error and the worker exits).
         .catch_others(|caught| {
-            crate::dst::report_merge_crash(&caught);
+            crate::dst::report_merge_crash!(&caught);
             caught.rethrow()
         })
         .execute();

--- a/pg_search/src/postgres/merge.rs
+++ b/pg_search/src/postgres/merge.rs
@@ -395,61 +395,16 @@ unsafe extern "C-unwind" fn background_merge(arg: pg_sys::Datum) {
         }))
         // A crash here dies in this background worker: it never reaches a client
         // connection, and Postgres logs only to the container's stdout, so nothing
-        // outside would fail on it. Report it to Antithesis before rethrowing so the
+        // outside would fail on it. Report it to the DST harness before rethrowing so the
         // fuzzer's run fails instead of silently passing. Rethrowing preserves the
         // existing behaviour (Postgres logs the error and the worker exits).
         .catch_others(|caught| {
-            report_background_merge_crash(&caught);
+            crate::dst::report_merge_crash(&caught);
             caught.rethrow()
         })
         .execute();
     })
 }
-
-/// Under Antithesis, surface a background-merge crash as an assertion failure.
-///
-/// We fire only for bug-class errors — internal-error / corruption SQLSTATEs (class
-/// `XX`) and Rust panics. An interrupt-driven cancellation is not a bug and never
-/// reaches here: [`merge_index`] downgrades it to a `warning!` (see the
-/// `check_for_interrupts!` before it re-raises a merge error), so the faults we
-/// deliberately inject do not trip the assertion.
-#[cfg(feature = "antithesis")]
-fn report_background_merge_crash(caught: &pg_sys::panic::CaughtError) {
-    use pg_sys::panic::CaughtError;
-    use pgrx::PgSqlErrorCode::*;
-
-    let report = match caught {
-        // A Rust panic (a failed `expect`, or the `panic!("failed to merge…")` in
-        // `merge_index`) is always a bug.
-        CaughtError::RustPanic { ereport, .. } => ereport,
-        // A Postgres/ereport error is a bug only when it is an internal error or
-        // corruption; cancellations, shutdowns and connection faults are the chaos we
-        // are injecting, not defects.
-        CaughtError::PostgresError(report) | CaughtError::ErrorReport(report) => {
-            if !matches!(
-                report.sql_error_code(),
-                ERRCODE_INTERNAL_ERROR
-                    | ERRCODE_DATA_CORRUPTED
-                    | ERRCODE_INDEX_CORRUPTED
-                    | ERRCODE_ASSERT_FAILURE
-            ) {
-                return;
-            }
-            report
-        }
-    };
-
-    antithesis_sdk::assert_unreachable!(
-        "pg_search background merge crashed",
-        &serde_json::json!({
-            "sqlstate": format!("{:?}", report.sql_error_code()),
-            "message": report.message(),
-        })
-    );
-}
-
-#[cfg(not(feature = "antithesis"))]
-fn report_background_merge_crash(_caught: &pg_sys::panic::CaughtError) {}
 
 #[inline]
 #[allow(clippy::too_many_arguments)]

--- a/stressgres/src/dst.rs
+++ b/stressgres/src/dst.rs
@@ -17,12 +17,10 @@
 
 //! Deterministic-simulation-testing (DST) hooks.
 //!
-//! The only module that talks to the DST vendor SDK — currently Antithesis, pulled in as
-//! `antithesis_sdk`. The rest of stressgres calls this crate-local vocabulary instead of
-//! the SDK directly, so moving to a different DST harness means rewriting this file and
-//! the one dependency line in `Cargo.toml`, not chasing vendor calls across the tree.
+//! The only module that talks to the DST vendor SDK (Antithesis), pulled in as
+//! `antithesis_sdk`.
 //!
-//! stressgres links the SDK unconditionally: it is test-only tooling, and the SDK is a
+//! Stressgres links the SDK unconditionally: it is test-only tooling, and the SDK is a
 //! runtime no-op outside the DST environment, so there is no feature gate here (unlike
 //! `pg_search`, which gates its equivalent module behind `--features dst`).
 

--- a/stressgres/src/dst.rs
+++ b/stressgres/src/dst.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Deterministic-simulation-testing (DST) hooks.
+//!
+//! The only module that talks to the DST vendor SDK — currently Antithesis, pulled in as
+//! `antithesis_sdk`. The rest of stressgres calls this crate-local vocabulary instead of
+//! the SDK directly, so moving to a different DST harness means rewriting this file and
+//! the one dependency line in `Cargo.toml`, not chasing vendor calls across the tree.
+//!
+//! stressgres links the SDK unconditionally: it is test-only tooling, and the SDK is a
+//! runtime no-op outside the DST environment, so there is no feature gate here (unlike
+//! `pg_search`, which gates its equivalent module behind `--features dst`).
+
+use antithesis_sdk::{assert_reachable, assert_sometimes};
+use serde_json::json;
+
+/// Register the assertion catalog so the harness knows which sites exist but were never
+/// hit, instead of a never-reached assertion passing vacuously. Call once at startup.
+pub fn init() {
+    antithesis_sdk::antithesis_init();
+}
+
+/// Signal that setup finished and the workload is about to start. The harness holds fault
+/// injection until this fires, so every suite gets a clean startup and actually runs its
+/// workload rather than being killed mid-initialisation.
+pub fn setup_complete(suite: &str) {
+    antithesis_sdk::lifecycle::setup_complete(&json!({ "suite": suite }));
+}
+
+/// Reachability: mark that the workload retried and rode out a transient database fault.
+/// A run where this is never hit exercised no fault and proves nothing about recovery.
+pub fn retried_transient_fault() {
+    assert_reachable!("stressgres retried a transient database fault");
+}
+
+/// Sometimes: `narrowed` is true when a recovery poke shrank the grace window during an
+/// active fault — the only situation in which the liveness check can actually fail, so it
+/// must hold true at least once across the fault search or the check proved nothing.
+pub fn poke_narrowed_window(narrowed: bool) {
+    assert_sometimes!(
+        narrowed,
+        "a recovery poke narrowed the grace window during an active database fault"
+    );
+}

--- a/stressgres/src/dst.rs
+++ b/stressgres/src/dst.rs
@@ -20,11 +20,14 @@
 //! The only module that talks to the DST vendor SDK (Antithesis), pulled in as
 //! `antithesis_sdk`.
 //!
+//! The assertion wrappers are forwarding macros, not functions, so the SDK captures each
+//! assertion's location at the real call site rather than here in `dst.rs`. The lifecycle
+//! calls carry no location, so they stay plain functions.
+//!
 //! Stressgres links the SDK unconditionally: it is test-only tooling, and the SDK is a
 //! runtime no-op outside the DST environment, so there is no feature gate here (unlike
 //! `pg_search`, which gates its equivalent module behind `--features dst`).
 
-use antithesis_sdk::{assert_reachable, assert_sometimes};
 use serde_json::json;
 
 /// Register the assertion catalog so the harness knows which sites exist but were never
@@ -42,16 +45,22 @@ pub fn setup_complete(suite: &str) {
 
 /// Reachability: mark that the workload retried and rode out a transient database fault.
 /// A run where this is never hit exercised no fault and proves nothing about recovery.
-pub fn retried_transient_fault() {
-    assert_reachable!("stressgres retried a transient database fault");
+macro_rules! retried_transient_fault {
+    () => {
+        ::antithesis_sdk::assert_reachable!("stressgres retried a transient database fault")
+    };
 }
+pub(crate) use retried_transient_fault;
 
-/// Sometimes: `narrowed` is true when a recovery poke shrank the grace window during an
+/// Sometimes: `$narrowed` is true when a recovery poke shrank the grace window during an
 /// active fault — the only situation in which the liveness check can actually fail, so it
 /// must hold true at least once across the fault search or the check proved nothing.
-pub fn poke_narrowed_window(narrowed: bool) {
-    assert_sometimes!(
-        narrowed,
-        "a recovery poke narrowed the grace window during an active database fault"
-    );
+macro_rules! poke_narrowed_window {
+    ($narrowed:expr) => {
+        ::antithesis_sdk::assert_sometimes!(
+            $narrowed,
+            "a recovery poke narrowed the grace window during an active database fault"
+        )
+    };
 }
+pub(crate) use poke_narrowed_window;

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -36,7 +36,6 @@
 //! When a non-zero grace is enabled, bug detection is expected to come from Antithesis
 //! properties / postgres-side checks, not from stressgres exit codes.
 
-use antithesis_sdk::{assert_reachable, assert_sometimes};
 use anyhow::Result;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -255,12 +254,9 @@ pub(crate) fn tolerate_transient<T>(
 
                 // A narrower window means the supervisor healed the faults and started
                 // the recovery clock while we were down, which is the only situation in
-                // which the liveness check can actually fail. If Antithesis never
+                // which the liveness check can actually fail. If the harness never
                 // reaches it, the check passed vacuously and proved nothing.
-                assert_sometimes!(
-                    last_grace.is_some_and(|last| grace < last),
-                    "a recovery poke narrowed the grace window during an active database fault"
-                );
+                crate::dst::poke_narrowed_window(last_grace.is_some_and(|last| grace < last));
                 // No symmetric "widened during a fault" assertion: the only widening is the
                 // supervisor restoring the baseline, which happens deep in the healed quiet
                 // period with no active fault to observe it. That path is pinned by the
@@ -280,7 +276,7 @@ pub(crate) fn tolerate_transient<T>(
                         down_since.elapsed()
                     )));
                 }
-                assert_reachable!("stressgres retried a transient database fault");
+                crate::dst::retried_transient_fault();
                 eprintln!("stressgres: transient database fault, retrying: {e:#}");
                 interruptible_sleep(alive, backoff);
                 backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);

--- a/stressgres/src/fault_tolerance.rs
+++ b/stressgres/src/fault_tolerance.rs
@@ -256,7 +256,7 @@ pub(crate) fn tolerate_transient<T>(
                 // the recovery clock while we were down, which is the only situation in
                 // which the liveness check can actually fail. If the harness never
                 // reaches it, the check passed vacuously and proved nothing.
-                crate::dst::poke_narrowed_window(last_grace.is_some_and(|last| grace < last));
+                crate::dst::poke_narrowed_window!(last_grace.is_some_and(|last| grace < last));
                 // No symmetric "widened during a fault" assertion: the only widening is the
                 // supervisor restoring the baseline, which happens deep in the healed quiet
                 // period with no active fault to observe it. That path is pinned by the
@@ -276,7 +276,7 @@ pub(crate) fn tolerate_transient<T>(
                         down_since.elapsed()
                     )));
                 }
-                crate::dst::retried_transient_fault();
+                crate::dst::retried_transient_fault!();
                 eprintln!("stressgres: transient database fault, retrying: {e:#}");
                 interruptible_sleep(alive, backoff);
                 backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);

--- a/stressgres/src/main.rs
+++ b/stressgres/src/main.rs
@@ -20,6 +20,7 @@
 mod auto;
 mod cli;
 mod csv;
+mod dst;
 mod fault_tolerance;
 mod graph;
 mod headless;
@@ -53,9 +54,9 @@ pub struct MetricsLine {
 
 /// Main entry point using subcommands.
 fn main() -> anyhow::Result<()> {
-    // Registers the assertion catalog so Antithesis knows which `assert_reachable!`
-    // sites exist but were never hit. A no-op outside the Antithesis environment.
-    antithesis_sdk::antithesis_init();
+    // Register the DST assertion catalog (see `dst`), so a never-hit reachability site is
+    // reported rather than passing vacuously. A no-op outside the DST environment.
+    dst::init();
 
     let cli = Cli::parse();
 
@@ -87,13 +88,10 @@ fn main() -> anyhow::Result<()> {
                 );
                 return Ok(());
             }
-            // Setup (schema build) is done and the workload is about to start. Antithesis
-            // holds fault injection until this signal, so every suite gets a clean startup
-            // and actually runs its workload rather than being killed mid-initialisation.
-            // A no-op outside the Antithesis environment.
-            antithesis_sdk::lifecycle::setup_complete(&serde_json::json!({
-                "suite": args.suite_path.display().to_string(),
-            }));
+            // Setup (schema build) is done and the workload is about to start; signal the
+            // DST harness, which holds fault injection until now so every suite gets a
+            // clean startup rather than being killed mid-initialisation.
+            dst::setup_complete(&args.suite_path.display().to_string());
             let mut log_file = args.log_file.clone();
             if let Some(path) = log_file.as_ref() {
                 if path.display().to_string() == "-" {


### PR DESCRIPTION
## What

Refactor Antithesis assertions so they're inside a single file, for simplicity.

## Why

Scope is deliberately a single swap-point module per crate, **not** a pluggable
`DstBackend` trait. A migration would also rewrite the manifests, driver scripts,
`ANTITHESIS_STOP_FAULTS`, and the fault-exclusion patterns, which are platform-shaped
regardless — so this buys clean product code and a one-file assertion swap, not a turnkey
migration.

## Notes

- **No behaviour change, and no loss of triage fidelity**: the assertion wrappers are
  forwarding macros, not functions, so they expand at the call site and the SDK still
  captures the real `file`/`line`/`function`. Verified via `ANTITHESIS_SDK_LOCAL_OUTPUT`
  that the two stressgres asserts resolve to `stressgres::fault_tolerance::tolerate_transient`
  at their real lines, and the pg_search merge-crash assert to `background_merge`.
- stressgres links the SDK unconditionally (test-only tooling, runtime no-op
  off-platform); pg_search keeps it optional behind the renamed `dst` feature, so
  production `pg_search` never links it.

## Tests

- `cargo test -p stressgres` (16 pass), `cargo clippy -p stressgres --all-targets -- -D warnings`.
- `cargo clippy -p pg_search --features dst -- -D warnings` and `cargo check -p pg_search` (no-op stub) both clean.

