### PR TITLE
ci(lint): gate rustdoc warnings in lint-rust

### DIFF
--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -81,13 +81,13 @@ jobs:
       - name: Run Rustfmt
         run: cargo fmt -- --check
 
-      - name: Run Clippy
-        run: cargo clippy --workspace --all-targets -- -D warnings --no-deps
-
       - name: Run Rustdoc
         env:
           RUSTDOCFLAGS: "-D warnings"
         run: cargo doc --workspace --no-deps --document-private-items
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings --no-deps
 
       - name: Install cargo-machete
         run: cargo install -j $(nproc) cargo-machete --locked --debug

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -84,9 +84,6 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings --no-deps
 
-      # Fail on broken intra-doc links, bare URLs, and malformed HTML in doc comments.
-      # --document-private-items so crate-internal docs are checked too; matches Clippy's
-      # default feature set (single pg version), so cfg-gated doc links aren't covered.
       - name: Run Rustdoc
         env:
           RUSTDOCFLAGS: "-D warnings"

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -84,6 +84,14 @@ jobs:
       - name: Run Clippy
         run: cargo clippy --workspace --all-targets -- -D warnings --no-deps
 
+      # Fail on broken intra-doc links, bare URLs, and malformed HTML in doc comments.
+      # --document-private-items so crate-internal docs are checked too; matches Clippy's
+      # default feature set (single pg version), so cfg-gated doc links aren't covered.
+      - name: Run Rustdoc
+        env:
+          RUSTDOCFLAGS: "-D warnings"
+        run: cargo doc --workspace --no-deps --document-private-items
+
       - name: Install cargo-machete
         run: cargo install -j $(nproc) cargo-machete --locked --debug
 

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -62,7 +62,7 @@ pub fn mean(data: &[f64]) -> f64 {
 /// Returns the half-width of the confidence interval for the provided confidence level
 ///
 /// The math for this comes from single-level version of what is shown in this paper:
-/// https://dl.acm.org/doi/10.1145/2555670.2464160.
+/// <https://dl.acm.org/doi/10.1145/2555670.2464160>.
 pub fn confidence_interval_half_width(data: &[f64], confidence_level: f64) -> f64 {
     assert!(!data.is_empty());
     assert!(confidence_level > 0.0);

--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -57,7 +57,7 @@ use tantivy::{Directory, IndexMeta, SegmentMeta, TantivyError};
 /// which creates less lock contention than allocating one block at a time.
 pub const BUFWRITER_CAPACITY: usize = bm25_max_free_space() * MAX_BUFFERS_TO_EXTEND_BY;
 
-/// Describes how a [`MvccDirectory`] should resolve segment visibility.  Note that
+/// Describes how a `MvccDirectory` should resolve segment visibility.  Note that
 /// this enum is purposely non-cloneable.  Wrap it with an [`Arc`] if you need that.  Because of
 /// the [`MvccSatisfies::ParallelWorker`] variant, cloning could be incredibly expensive when
 /// an index has many (thousands!) of segments.
@@ -389,7 +389,7 @@ impl Directory for MVCCDirectory {
     }
 
     /// Returns a list of all segment components to Tantivy,
-    /// identified by <uuid>.<ext> PathBufs
+    /// identified by `<uuid>.<ext>` PathBufs
     fn list_managed_files(&self) -> tantivy::Result<std::collections::HashSet<PathBuf>> {
         unsafe {
             Ok(MetaPage::open(&self.indexrel)

--- a/pg_search/src/postgres/catalog.rs
+++ b/pg_search/src/postgres/catalog.rs
@@ -235,7 +235,7 @@ pub fn lookup_database_collation_locale() -> Option<CollationLocale> {
 }
 
 /// Helper function to lookup the `collcollate` and `collprovider` fields for a collation object in `pg_collation`
-/// Note that while `collprovider` is always present in `pg_collation`, `collcollate` may be NULL: https://www.postgresql.org/docs/current/catalog-pg-collation.html
+/// Note that while `collprovider` is always present in `pg_collation`, `collcollate` may be NULL: <https://www.postgresql.org/docs/current/catalog-pg-collation.html>
 pub fn lookup_collation_locale(collation: pg_sys::Oid) -> Option<CollationLocale> {
     unsafe {
         let entry =

--- a/pg_search/src/postgres/composite.rs
+++ b/pg_search/src/postgres/composite.rs
@@ -227,7 +227,7 @@ pub unsafe fn get_composite_fields_for_index(
 /// ```sql
 /// CREATE INDEX idx ON t USING bm25 (id, ROW(a,b,c)::my_type);
 /// ```
-/// The composite at values[1] is unpacked once during construction.
+/// The composite at `values[1]` is unpacked once during construction.
 /// Fields "a", "b", "c" are then retrieved via simple lookups.
 ///
 /// # Lifetime

--- a/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/aggregate_type.rs
@@ -404,7 +404,7 @@ impl AggregateType {
     /// - Any referenced field is a NUMERIC type (not supported for aggregation)
     ///
     /// TODO: remove field existence check once Tantivy aggregation validation is fixed.
-    /// https://github.com/quickwit-oss/tantivy/issues/2767
+    /// <https://github.com/quickwit-oss/tantivy/issues/2767>
     pub fn validate_fields(&self, schema: &SearchIndexSchema) -> Result<(), String> {
         // Check NUMERIC field support for standard aggregates
         if let Some(field) = self.field_name() {

--- a/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/datafusion_build.rs
@@ -174,7 +174,7 @@ pub unsafe fn collect_join_agg_sources(
 ///    the planner has absorbed WHERE-clause quals into `RestrictInfo` lists on
 ///    the planned `JoinPath` nodes - so `(*from).quals` can be null even for
 ///    `SELECT ... FROM a, b WHERE a.id = b.id`. We recursively walk the path
-///    tree via [`extract_equi_keys_from_path`], inspecting each `JoinPath`'s
+///    tree via `extract_equi_keys_from_path`, inspecting each `JoinPath`'s
 ///    `joinrestrictinfo` for `OpExpr` nodes with merge-joinable (equality)
 ///    operators whose two sides reference different base relations.
 ///
@@ -1287,8 +1287,8 @@ unsafe fn all_vars_are_fast_fields_for_agg(
 }
 
 /// Transform collected cross-table clause pointers into a `JoinLevelExpr`
-/// tree by delegating to JoinScan's [`transform_to_search_expr`] via a
-/// temporary [`JoinCSClause`]. After plan_positions have been assigned,
+/// tree by delegating to JoinScan's `transform_to_search_expr` via a
+/// temporary `JoinCSClause`. After plan_positions have been assigned,
 /// `plan.sources()` returns `&[&JoinSource]` - the same type JoinScan uses -
 /// so the shared function works directly.
 ///

--- a/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/join_targetlist.rs
@@ -55,7 +55,7 @@ fn find_source_by_rti<'a>(
 }
 
 /// Simplified aggregate classification for the DataFusion backend.
-/// Unlike [`AggregateType`] (Tantivy-oriented), this enum is lightweight and maps
+/// Unlike `AggregateType` (Tantivy-oriented), this enum is lightweight and maps
 /// directly to DataFusion aggregate expressions.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum AggKind {

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -1916,7 +1916,7 @@ unsafe fn group_key_to_datum(
 }
 
 /// Detects ORDER BY + LIMIT for join aggregate queries and returns a
-/// [`DataFusionTopK`] describing the sort target, direction, and K.
+/// `DataFusionTopK` describing the sort target, direction, and K.
 ///
 /// Supports two patterns:
 /// - **ORDER BY aggregate LIMIT K** (e.g., `ORDER BY COUNT(*) DESC LIMIT 5`)

--- a/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/scan_state.rs
@@ -75,7 +75,7 @@ pub struct DataFusionAggState {
     pub current_batch: Option<RecordBatch>,
     /// Row index within current_batch.
     pub batch_row_idx: usize,
-    /// Mapping from group_columns[i] to its 0-based column index in DataFusion's
+    /// Mapping from `group_columns[i]` to its 0-based column index in DataFusion's
     /// output RecordBatch. Needed because DataFusion deduplicates grouping
     /// expressions (e.g. metadata.brand).
     pub group_df_indices: Vec<usize>,

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -1884,14 +1884,14 @@ fn validate_topk_expectation(
 /// If the query can return "fast fields", make that determination here, falling back to the
 /// [`NormalScanExecState`] if not.
 ///
-/// We support [`ColumnarExecState`] when there are a mix of string and numeric fast fields.
+/// We support `ColumnarExecState` when there are a mix of string and numeric fast fields.
 ///
 /// If we have failed to extract all relevant information at planning time, then the fast-field
 /// execution methods might still fall back to `Normal` at execution time: see the notes in
 /// `assign_exec_method` and `compute_exec_which_fast_fields`.
 ///
 /// `pdb.score()`, `ctid`, and `tableoid` are considered fast fields for the purposes of
-/// these specialized [`ExecMethod`]s.
+/// these specialized `ExecMethod`s.
 ///
 fn choose_exec_method(
     privdata: &PrivateData,

--- a/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
+++ b/pg_search/src/postgres/customscan/datafusion/expr_translators.rs
@@ -205,7 +205,7 @@ impl<'a> PredicateTranslator<'a> {
         }
     }
 
-    /// Translate a `CaseExpr` (CASE [operand] WHEN … THEN … ELSE … END).
+    /// Translate a `CaseExpr` (CASE `operand` WHEN … THEN … ELSE … END).
     pub(crate) unsafe fn translate_case_expr(&self, node: *mut pg_sys::Node) -> Option<Expr> {
         let case = node as *mut pg_sys::CaseExpr;
 

--- a/pg_search/src/postgres/customscan/datafusion/translator.rs
+++ b/pg_search/src/postgres/customscan/datafusion/translator.rs
@@ -412,7 +412,7 @@ pub fn make_col(relation: &str, name: &str) -> Expr {
 /// Lower a `JoinNode` over already-built left/right `DataFrame`s.
 ///
 /// Builds equi-join keys with [`build_equi_join_exprs`], maps the
-/// [`super::build::JoinType`] into DataFusion's `JoinType`, and dispatches
+/// `super::build::JoinType` into DataFusion's `JoinType`, and dispatches
 /// to `join_on` (when there are equi keys) or `join` (cross join). Caller
 /// is responsible for any post-join filter handling - `JoinNode::filter`
 /// is not consulted here.
@@ -476,7 +476,7 @@ fn build_null_aware_anti_join(
     Ok(DataFrame::new(session_state, plan))
 }
 
-/// Map a [`super::build::JoinType`] to DataFusion's `JoinType`. Returns
+/// Map a `super::build::JoinType` to DataFusion's `JoinType`. Returns
 /// `Err(NotImplemented)` for variants the translator does not lower -
 /// today only `UniqueOuter` / `UniqueInner`, which are Postgres-side
 /// optimizer artifacts that should never reach the DataFusion executor.

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -134,9 +134,9 @@
 //! - [`planning`]: Cost estimation, condition extraction, field collection, pathkey handling.
 //! - [`predicate`]: Transform PostgreSQL expressions to evaluable expression trees.
 //! - [`scan_state`]: Execution state and DataFusion plan building.
-//! - [`translator`]: Maps PostgreSQL expressions/columns to DataFusion expressions.
+//! - `translator`: Maps PostgreSQL expressions/columns to DataFusion expressions.
 //! - [`privdat`]: Private data serialization between planning and execution.
-//! - [`explain`]: EXPLAIN output formatting.
+//! - `explain`: EXPLAIN output formatting.
 
 pub mod build;
 pub mod planning;
@@ -516,7 +516,7 @@ impl JoinScan {
     ///
     /// Returns `Err` with a descriptive message if any activation check fails.
     /// The caller can then optionally perform join-level predicate extraction on
-    /// the returned clause before passing it to [`finalize_clause_into_path`].
+    /// the returned clause before passing it to `finalize_clause_into_path`.
     unsafe fn validate_and_build_clause(
         root: *mut pg_sys::PlannerInfo,
         plan: &RelNode,
@@ -1917,7 +1917,7 @@ fn bake_logical_plan(private_data: &mut PrivateData, custom_exprs: *mut pg_sys::
     );
 }
 
-/// Walk `node` and build an [`InputVarInfo`] for every base-relation Var
+/// Walk `node` and build an `InputVarInfo` for every base-relation Var
 /// referenced, capturing type metadata from the live Var pointer so execution
 /// doesn't need catalog lookups. Uses `pull_var_clause` (same as the DISTINCT
 /// extraction path in `planning.rs`) to recurse through all wrappers.
@@ -1971,7 +1971,7 @@ unsafe fn splice_path_private_into_list(
 }
 
 impl JoinScan {
-    /// Body of [`<Self as CustomScan>::create_custom_path`] in `?`-style.
+    /// Body of `<Self as CustomScan>::create_custom_path` in `?`-style.
     /// The Ok variant returns the assembled `CustomPath` plus the alias list
     /// (for the "successful" mark) and the trailing multi-table clauses to
     /// splice onto `custom_private`. The Err variants distinguish silent

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! https://www.postgresql.org/docs/current/custom-scan.html
+//! <https://www.postgresql.org/docs/current/custom-scan.html>
 
 #![allow(clippy::tabs_in_doc_comments)]
 

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -25,10 +25,10 @@
 //! per-scan state.
 //!
 //! This module isolates the shape-agnostic logic. Per-scan
-//! [`crate::postgres::customscan::mpp::host::MppWorkerHost`] impls (in
+//! `crate::postgres::customscan::mpp::host::MppWorkerHost` impls (in
 //! `aggregatescan::mpp` and `joinscan::mpp`) extract their inputs into [`MppWorkerInputs`],
 //! build their seed `SessionContext`, and are driven by
-//! [`crate::postgres::customscan::mpp::host::exec_mpp_worker`], which calls
+//! `crate::postgres::customscan::mpp::host::exec_mpp_worker`, which calls
 //! [`run_mpp_worker`].
 
 use std::sync::Arc;
@@ -64,7 +64,7 @@ use crate::scan::physical_codec::deserialize_physical_plan_with_runtime;
 use datafusion_distributed::shm::SetPlanFrame;
 
 /// Bundle of inputs the worker dispatcher needs. Per-scan
-/// [`crate::postgres::customscan::mpp::host::MppWorkerHost`] impls populate this from their
+/// `crate::postgres::customscan::mpp::host::MppWorkerHost` impls populate this from their
 /// typed state and hand it to [`run_mpp_worker`].
 pub(crate) struct MppWorkerInputs {
     /// The leader's `ParallelScanState`, used to claim the partitioning source's segment slice.

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -345,7 +345,7 @@ pub struct MppWorkerState {
     /// Worker's MppMesh. The single `inbound_receiver` pulls frames addressed to this
     /// proc from both the DSM MPSC inbox and the in-proc self-loop channel; demux by
     /// `(sender_proc, stage_id, partition)` happens inside the handle's channel-buffer
-    /// registry. Read by the multi-fragment dispatcher driven by [`mpp::host::exec_mpp_worker`].
+    /// registry. Read by the multi-fragment dispatcher driven by `mpp::host::exec_mpp_worker`.
     pub mesh: Arc<MppMesh>,
 }
 

--- a/pg_search/src/postgres/customscan/pg_expr_udf.rs
+++ b/pg_search/src/postgres/customscan/pg_expr_udf.rs
@@ -257,7 +257,7 @@ unsafe fn populate_slot(
 }
 
 /// Single-pass Datum→Arrow conversion: evaluate the PG expression for each row
-/// and append the result directly to an Arrow builder. No intermediate Vec<Datum>.
+/// and append the result directly to an Arrow builder. No intermediate `Vec<Datum>`.
 ///
 /// Follows the `fetch_ff_column!` pattern from `fast_fields_helper.rs`.
 ///

--- a/pg_search/src/postgres/customscan/pushdown.rs
+++ b/pg_search/src/postgres/customscan/pushdown.rs
@@ -160,7 +160,7 @@ pub struct PushdownField {
 }
 
 impl PushdownField {
-    /// Given a Postgres [`pg_sys::Var`] and a [`SearchIndexSchema`], try to create a [`PushdownField`].
+    /// Given a Postgres [`pg_sys::Var`] and a `SearchIndexSchema`, try to create a [`PushdownField`].
     /// The purpose of this is to guard against the case where we mistakenly push down a field that's not indexed.
     ///
     /// Returns `Some(PushdownField)` if the field is found in the schema, `None` otherwise.

--- a/pg_search/src/postgres/heap.rs
+++ b/pg_search/src/postgres/heap.rs
@@ -233,7 +233,7 @@ impl VisibilityChecker {
     /// Checks if a batch of rows are visible, and computes their updated ctid (by following a HOT
     /// chain) if so. Panics if any ctids are absent.
     ///
-    /// See [`check`](Self::check) for details on visibility checking logic.
+    /// See `check` for details on visibility checking logic.
     pub fn check_batch(&mut self, ctids: &[Option<u64>], results: &mut [Option<u64>]) {
         if ctids.is_empty() {
             return;

--- a/pg_search/src/postgres/rel.rs
+++ b/pg_search/src/postgres/rel.rs
@@ -304,7 +304,7 @@ impl PgSearchRelation {
     }
 
     /// Returns true if Postgres thinks this relation needs WAL *or* instead returns the WAL-ness
-    /// based on a prior call to [`set_need_wal`].
+    /// based on a prior call to `set_need_wal`.
     pub fn need_wal(&self) -> bool {
         self.0.as_ref().unwrap().7.get(self.as_ptr())
     }

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -165,7 +165,7 @@ impl From<PgItem> for MutableSegmentEntry {
     }
 }
 
-/// Prior to https://github.com/paradedb/paradedb/pull/2487, the field storing this tag contained
+/// Prior to <https://github.com/paradedb/paradedb/pull/2487>, the field storing this tag contained
 /// either A. FrozenTransactionId, or B. GetCurrentTransactionId(). After #2487 and before #3203,
 /// the field contained `InvalidTransactionId`. We treat all such tags as representing an
 /// `Immutable` segment in `impl From<u32> for Self`.

--- a/pg_search/src/postgres/storage/buffer.rs
+++ b/pg_search/src/postgres/storage/buffer.rs
@@ -828,8 +828,8 @@ impl BufferManager {
         }
     }
 
-    /// Like [`new_buffer`], but returns an iterator of buffers instead.
-    /// This is better than calling [`new_buffer`] multiple times because it avoids potentially
+    /// Like `new_buffer`, but returns an iterator of buffers instead.
+    /// This is better than calling `new_buffer` multiple times because it avoids potentially
     /// locking the relation for every new buffer.
     pub fn new_buffers(&mut self, npages: usize) -> Box<dyn Iterator<Item = BufferMut>> {
         if npages == 0 {

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -126,7 +126,7 @@ pub trait FreeSpaceManager {
 /// those from hot-standby servers.  Reusing a block before all nodes in the cluster and/or all
 /// concurrent backends are aware that it's been deleted can cause race conditions and data corruption.
 ///
-/// The on-disk structure is simply a linked list of blocks where each block, a [`v1::FSMBlock`],
+/// The on-disk structure is simply a linked list of blocks where each block, a `v1::FSMBlock`,
 /// is a fixed-sized array of ([`pg_sys::BlockNumber`], [`pg_sys::TransactionId`]) pairs.
 ///
 /// Each block starts with a small [`FSMBlockHeader`] indicating the type of block (we've had a few
@@ -533,8 +533,8 @@ pub mod v1 {
 
 /// The [`v2`] FreeSpaceManager is a fixed-size AVL tree laid out as an array on the FSM's first block.
 ///
-/// Each entry in the AVL tree is called a [`Slot`] and each slot has a key, value, and tag.  The key
-/// is a 64bit [`pg_sys::FullTransactionId`], the value is actually the Rust unit type ([`()`]), and
+/// Each entry in the AVL tree is called a `Slot` and each slot has a key, value, and tag.  The key
+/// is a 64bit [`pg_sys::FullTransactionId`], the value is actually the Rust unit type (`()`), and
 /// the tag is a [`pg_sys::BlockNumber`].
 ///
 /// Each slot gets its own statically assigned tag value when a relation's FSM is first initialized.

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -173,7 +173,7 @@ impl LinkedBytesListWriter {
         Ok(())
     }
 
-    /// Write the pending [`BlockList`] data to disk.  This must be called once, as soon as the caller
+    /// Write the pending `BlockList` data to disk.  This must be called once, as soon as the caller
     /// is positive this [`LinkedBytesListWriter`] is itself complete and fully written to disk.
     pub fn finalize_and_write(mut self) -> std::io::Result<LinkedBytesList> {
         // now that we're being finalized we can set the `last_blockno` of our metadata page
@@ -331,7 +331,7 @@ impl LinkedBytesList {
     /// no other concurrent Postgres backend would have open any block that will be returned from
     /// this function.
     ///
-    /// We take care of this, elsewhere, through our constructs like the [`PinCushion`], the [`MergeLock`],
+    /// We take care of this, elsewhere, through our constructs like the `PinCushion`, the `MergeLock`,
     /// and atomically managing the segment entries list through an atomic copy-on-write approach.
     pub fn freeable_blocks(mut self) -> impl Iterator<Item = pg_sys::BlockNumber> {
         // in addition to the list itself, we also have a secondary list of linked blocks (which

--- a/pg_search/src/postgres/storage/merge.rs
+++ b/pg_search/src/postgres/storage/merge.rs
@@ -31,7 +31,7 @@ use tantivy::index::SegmentId;
 #[repr(transparent)]
 pub struct VacuumSentinel(pub PinnedBuffer);
 
-/// The metadata stored on the [`Metadata`] page
+/// The metadata stored on the `Metadata` page
 #[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MergeLockData {

--- a/pg_search/src/postgres/storage/metadata.rs
+++ b/pg_search/src/postgres/storage/metadata.rs
@@ -30,7 +30,7 @@ use pgrx::{
     PgSqlErrorCode,
 };
 
-/// The metadata stored on the [`Metadata`] page
+/// The metadata stored on the `Metadata` page
 #[derive(Debug, Copy, Clone)]
 #[repr(C, packed)]
 pub struct MetaPageData {
@@ -280,7 +280,7 @@ impl MetaPage {
     }
 
     ///
-    /// A LinkedItemList<SegmentMetaEntry> containing segments which are no longer visible from the
+    /// A `LinkedItemList<SegmentMetaEntry>` containing segments which are no longer visible from the
     /// live `SEGMENT_METAS_START` list, and which will be recyclable when no transactions might still
     /// be reading them on physical replicas.
     ///

--- a/pg_search/src/postgres/storage/utils.rs
+++ b/pg_search/src/postgres/storage/utils.rs
@@ -83,7 +83,7 @@ impl RelationBufferAccess {
         &self.rel
     }
 
-    /// Return one [`pg_sys::BUFFER_LOCK_EXCLUSIVE`] locked [`pg_sys:Buffer`].  This buffer
+    /// Return one [`pg_sys::BUFFER_LOCK_EXCLUSIVE`] locked [`pg_sys::Buffer`].  This buffer
     /// is guaranteed to be "new" in that it was created by extending the relation
     ///
     /// The [`pg_sys::Page`] representation has not been initialized.  The caller must do this.
@@ -94,7 +94,7 @@ impl RelationBufferAccess {
         )
     }
 
-    /// Return an iterator of [`pg_sys::BUFFER_LOCK_EXCLUSIVE`] locked [`pg_sys:Buffer`]s.  The buffers
+    /// Return an iterator of [`pg_sys::BUFFER_LOCK_EXCLUSIVE`] locked [`pg_sys::Buffer`]s.  The buffers
     /// are pinned _a priori_ but are locked during iteration.
     ///
     /// These buffers are guaranteed to be "new" in that they were created by extending the relation.

--- a/pg_search/src/query/mod.rs
+++ b/pg_search/src/query/mod.rs
@@ -824,7 +824,7 @@ impl From<TermInputWire> for TermInput {
     }
 }
 
-/// Serialize a [`SearchQueryInput`] node to a Postgres [`pg_sys::Const`] node, palloc'd
+/// Serialize a `SearchQueryInput` node to a Postgres [`pg_sys::Const`] node, palloc'd
 /// in the current memory context.
 impl From<SearchQueryInput> for *mut pg_sys::Const {
     fn from(value: SearchQueryInput) -> Self {
@@ -1625,7 +1625,7 @@ fn value_to_json_term(
     Ok(term)
 }
 
-/// Converts a dot-separated path string (e.g. `"Top.Science.Biology"`) to a Tantivy [`Facet`].
+/// Converts a dot-separated path string (e.g. `"Top.Science.Biology"`) to a Tantivy `Facet`.
 pub(super) fn dot_path_to_facet(text: &str) -> tantivy::schema::Facet {
     tantivy::schema::Facet::from_path(text.split('.'))
 }

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -110,7 +110,7 @@ pub enum ScanRecipe {
 }
 
 /// State for a scan partition.
-/// Uses Arc<FFHelper> so the same FFHelper can be shared across multiple partitions.
+/// Uses `Arc<FFHelper>` so the same FFHelper can be shared across multiple partitions.
 pub struct ScanPartition {
     pub recipe: ScanRecipe,
     pub ffhelper: Arc<FFHelper>,

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -69,7 +69,7 @@
 //! the tiebreaker, so it keeps them all for the final Top K to resolve.
 //! This is safe (never drops correct rows) but slightly less aggressive
 //! than theoretically possible when there are many duplicates.
-//! TODO(https://github.com/paradedb/paradedb/issues/4255): rewrite the full
+//! TODO(<https://github.com/paradedb/paradedb/issues/4255>): rewrite the full
 //! Top K sort expression in terms of term ordinals to handle tiebreakers
 //! natively.
 

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -62,16 +62,14 @@
 //! where `S` is the number of segments. Pass-through rows (State 2 and NULL
 //! ordinals) are emitted immediately and are not bounded by K.
 //!
-//! **Compound sorts:** Only the primary sort column is used for ordinal
-//! pruning. When the Top K sort has tiebreaker columns (e.g.
-//! `ORDER BY val DESC, id ASC LIMIT 25`), all rows tied at the boundary
-//! ordinal are retained — the exec cannot distinguish between them without
-//! the tiebreaker, so it keeps them all for the final Top K to resolve.
-//! This is safe (never drops correct rows) but slightly less aggressive
-//! than theoretically possible when there are many duplicates.
-//! TODO(<https://github.com/paradedb/paradedb/issues/4255>): rewrite the full
-//! Top K sort expression in terms of term ordinals to handle tiebreakers
-//! natively.
+//! **Compound sorts:** every sort column is used, not just the primary. The
+//! per-segment buffer keys on the full compound `OwnedRow`, and the global
+//! threshold is published as a lexicographic filter over all sort exprs — each
+//! deferred column resolved via `ord_to_str`, non-deferred columns read
+//! directly — so `ORDER BY val DESC, id ASC LIMIT 25` breaks ties on `id`
+//! rather than retaining every row that shares the boundary `val`. Only rows
+//! tied across the *entire* sort key are conservatively retained, per the
+//! `survivors_s` bound above.
 
 use crate::api::HashMap;
 use crate::index::fast_fields_helper::{CanonicalColumn, FFHelper, FFType, NULL_TERM_ORDINAL};

--- a/pg_search/src/schema/mod.rs
+++ b/pg_search/src/schema/mod.rs
@@ -73,7 +73,7 @@ pub enum SearchFieldType {
     /// The i16 is the scale (number of decimal places).
     Numeric64(pg_sys::Oid, i16),
     /// NUMERIC with precision > 18 or unlimited: stored as lexicographically sortable bytes.
-    /// The Option<i16> is the scale (number of decimal places), or None for unlimited precision.
+    /// The `Option<i16>` is the scale (number of decimal places), or None for unlimited precision.
     NumericBytes(pg_sys::Oid, Option<i16>),
 }
 

--- a/stressgres/src/graph.rs
+++ b/stressgres/src/graph.rs
@@ -80,7 +80,7 @@ const PALETTE: &[RGBColor] = &[
     GREEN,
 ];
 
-/// Create one PNG with as many sub-charts are there are individual metrics gathered from the [`LogRecord`]s
+/// Create one PNG with as many sub-charts are there are individual metrics gathered from the `LogRecord`s
 fn generate_graph(metrics: &[String], records: &[MetricsLine], output_path: &str) -> Result<()> {
     // The final order of subcharts we want to show (left to right):
     eprintln!("metrics={metrics:?}");

--- a/tokenizers/src/manager.rs
+++ b/tokenizers/src/manager.rs
@@ -59,7 +59,7 @@ pub struct SearchTokenizerFilters {
 }
 
 impl SearchTokenizerFilters {
-    /// Returns a [`SearchTokenizerFilter`] instance that effectively does not filter, or otherwise
+    /// Returns a `SearchTokenizerFilter` instance that effectively does not filter, or otherwise
     /// mutate tokens.
     ///
     /// This should be used for declaring the "key field" in an index.  It can be used for other


### PR DESCRIPTION
## What

Add a Rustdoc step to `lint-rust` (`RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items`) so broken intra-doc links, bare URLs, and malformed HTML in doc comments fail CI, and clear the 53 pre-existing warnings that surface under `--document-private-items`.

Follow-up to the doc-link fix in #5547, which noted the linter would have caught it — this wires up that gate.

## The fixes

- **De-link** intra-doc references that don't resolve (out-of-scope, private, or local-variable targets), keeping the backticked inline code — e.g. `[`ExecMethod`]` → ``ExecMethod``.
- **Path typos**: `pg_sys:Buffer` → `pg_sys::Buffer`.
- **Bare URLs** wrapped in angle brackets.
- **Generic type expressions** (`Option<i16>`, `Vec<Datum>`, `<uuid>.<ext>`) backticked so rustdoc stops parsing them as unclosed HTML tags.

No runtime code changed — doc comments only, plus the workflow step.

## Notes

- `--document-private-items` is what catches most of these: crate-internal modules (`mod foo;`) are skipped by default `cargo doc`.
- Matches Clippy's default feature set (single pg version), so cfg-gated doc links aren't covered — a link that only breaks under a disabled `#[cfg]` won't be caught. Acceptable for now.
- The `proc-macro-error2` future-incompat notice is a dependency-level cargo report, not a rustdoc lint, so it doesn't trip `-D warnings`.

## Tests

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --document-private-items` — clean (exit 0).
- Same with the default (public-only) doc build — clean.
- `cargo fmt -- --check` — clean.

https://claude.ai/code/session_01369qmSBKYCAXRv1qJsKS8g