### PR TITLE
fix: sorting by a nullable NUMERIC field in the Join Scan crashed

### DIFF
--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -1737,11 +1737,17 @@ impl SegmentedTopKState {
         // 3. Materialize sort column values for each candidate and build a
         //    second RowConverter using materialized data types (Utf8View/BinaryView
         //    for deferred columns, original type for non-deferred).
-        let materialized_sort_fields: Vec<SortField> = self
+        struct SortCol<'a> {
+            expr: &'a datafusion::physical_expr::PhysicalSortExpr,
+            deferred: Option<&'a DeferredSortColumn>,
+            mat_type: arrow_schema::DataType,
+        }
+
+        let sort_cols: Vec<SortCol> = self
             .sort_exprs
             .iter()
             .map(|expr| {
-                let is_deferred = expr
+                let deferred = expr
                     .expr
                     .downcast_ref::<datafusion::physical_expr::expressions::Column>()
                     .and_then(|c| {
@@ -1749,9 +1755,8 @@ impl SegmentedTopKState {
                             .iter()
                             .find(|d| d.sort_col_idx == c.index())
                     });
-                let data_type = if let Some(deferred) = is_deferred {
-                    let col = self.ffhelper.column(0, deferred.canonical.ff_index);
-                    match col {
+                let mat_type = if let Some(deferred) = deferred {
+                    match self.ffhelper.column(0, deferred.canonical.ff_index) {
                         FFType::Bytes(_) => arrow_schema::DataType::BinaryView,
                         _ => arrow_schema::DataType::Utf8View,
                     }
@@ -1760,11 +1765,31 @@ impl SegmentedTopKState {
                         .data_type(&self.schema)
                         .unwrap_or(arrow_schema::DataType::Utf8View)
                 };
-                SortField::new_with_options(data_type, expr.options)
+                SortCol {
+                    expr,
+                    deferred,
+                    mat_type,
+                }
+            })
+            .collect();
+
+        let materialized_sort_fields: Vec<SortField> = sort_cols
+            .iter()
+            .map(|sort_col| {
+                SortField::new_with_options(sort_col.mat_type.clone(), sort_col.expr.options)
             })
             .collect();
 
         let mat_row_converter = RowConverter::new(materialized_sort_fields)?;
+
+        // A NULL must match the RowConverter's declared field type:
+        // convert_columns rejects mismatches ("expected BinaryView got
+        // Utf8View" for a NULL in a Bytes-backed NUMERIC sort key).
+        let typed_null = |sort_col: &SortCol| -> ScalarValue {
+            ScalarValue::try_from(&sort_col.mat_type)
+                .unwrap_or_else(|_| ScalarValue::Utf8View(None))
+        };
+
         // Batch-convert all ordinal survivors' rows in a single convert_rows call.
         // We collect `Row<'_>` directly to avoid cloning `OwnedRow`.
         let ord_rows: Vec<_> = candidates
@@ -1789,17 +1814,8 @@ impl SegmentedTopKState {
 
         let mut ord_pos = 0;
         for (batch_idx, row_idx, ord_info) in candidates.iter() {
-            for (i, sort_expr) in self.sort_exprs.iter().enumerate() {
-                let is_deferred = sort_expr
-                    .expr
-                    .downcast_ref::<datafusion::physical_expr::expressions::Column>()
-                    .and_then(|c| {
-                        self.deferred_columns
-                            .iter()
-                            .find(|d| d.sort_col_idx == c.index())
-                    });
-
-                let value = if let Some(deferred) = is_deferred {
+            for (i, sort_col) in sort_cols.iter().enumerate() {
+                let value = if let Some(deferred) = sort_col.deferred {
                     if let Some((seg_ord, _)) = ord_info {
                         // Ordinal survivor: use pre-batched arrays with our sequential counter.
                         let arrays = all_ord_arrays
@@ -1810,8 +1826,9 @@ impl SegmentedTopKState {
                             .downcast_ref::<UInt64Array>()
                             .map(|a| a.value(ord_pos));
                         if let Some(term_ord) = term_ord {
-                            let col = self.ffhelper.column(*seg_ord, deferred.canonical.ff_index);
-                            match col {
+                            let ff_col =
+                                self.ffhelper.column(*seg_ord, deferred.canonical.ff_index);
+                            match ff_col {
                                 FFType::Text(str_col) => {
                                     let mut s = String::new();
                                     if str_col.ord_to_str(term_ord, &mut s).is_ok() {
@@ -1828,22 +1845,22 @@ impl SegmentedTopKState {
                                         ScalarValue::BinaryView(None)
                                     }
                                 }
-                                _ => ScalarValue::Utf8View(None),
+                                _ => typed_null(sort_col),
                             }
                         } else {
-                            ScalarValue::Utf8View(None)
+                            typed_null(sort_col)
                         }
                     } else {
                         // NULL ordinal pass-through
-                        ScalarValue::Utf8View(None)
+                        typed_null(sort_col)
                     }
                 } else {
                     // Non-deferred column: evaluate directly from the batch.
                     let batch = &self.batches[*batch_idx];
-                    let val = sort_expr.expr.evaluate(batch)?;
+                    let val = sort_col.expr.expr.evaluate(batch)?;
                     let arr = val.into_array(batch.num_rows())?;
                     ScalarValue::try_from_array(&arr, *row_idx)
-                        .unwrap_or(ScalarValue::Utf8View(None))
+                        .unwrap_or_else(|_| typed_null(sort_col))
                 };
                 column_values[i].push(value);
             }

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -1785,9 +1785,10 @@ impl SegmentedTopKState {
         // A NULL must match the RowConverter's declared field type:
         // convert_columns rejects mismatches ("expected BinaryView got
         // Utf8View" for a NULL in a Bytes-backed NUMERIC sort key).
-        let typed_null = |sort_col: &SortCol| -> ScalarValue {
+        // If the type is unsupported, propagate the error rather than
+        // substituting a differently typed NULL that the converter will reject.
+        let typed_null = |sort_col: &SortCol| -> Result<ScalarValue> {
             ScalarValue::try_from(&sort_col.mat_type)
-                .unwrap_or_else(|_| ScalarValue::Utf8View(None))
         };
 
         // Batch-convert all ordinal survivors' rows in a single convert_rows call.
@@ -1834,7 +1835,7 @@ impl SegmentedTopKState {
                                     if str_col.ord_to_str(term_ord, &mut s).is_ok() {
                                         ScalarValue::Utf8View(Some(s))
                                     } else {
-                                        ScalarValue::Utf8View(None)
+                                        typed_null(sort_col)?
                                     }
                                 }
                                 FFType::Bytes(bytes_col) => {
@@ -1842,25 +1843,24 @@ impl SegmentedTopKState {
                                     if bytes_col.ord_to_bytes(term_ord, &mut b).is_ok() {
                                         ScalarValue::BinaryView(Some(b))
                                     } else {
-                                        ScalarValue::BinaryView(None)
+                                        typed_null(sort_col)?
                                     }
                                 }
-                                _ => typed_null(sort_col),
+                                _ => typed_null(sort_col)?,
                             }
                         } else {
-                            typed_null(sort_col)
+                            typed_null(sort_col)?
                         }
                     } else {
                         // NULL ordinal pass-through
-                        typed_null(sort_col)
+                        typed_null(sort_col)?
                     }
                 } else {
                     // Non-deferred column: evaluate directly from the batch.
                     let batch = &self.batches[*batch_idx];
                     let val = sort_col.expr.expr.evaluate(batch)?;
                     let arr = val.into_array(batch.num_rows())?;
-                    ScalarValue::try_from_array(&arr, *row_idx)
-                        .unwrap_or_else(|_| typed_null(sort_col))
+                    ScalarValue::try_from_array(&arr, *row_idx).or_else(|_| typed_null(sort_col))?
                 };
                 column_values[i].push(value);
             }

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -476,7 +476,8 @@ fn joinscan_nullable_numeric_composite_sort_matches_fallback(
     .execute(&mut conn);
 
     // NULLS LAST exercises the crash; NULLS FIRST forces NULL rows into the
-    // final top-k so their sort placement is verified too.
+    // final top-k so their sort placement is verified too. The p.id tiebreaker
+    // is evaluated directly; a deferred second key remains uncovered until #5567.
     for nulls in ["LAST", "FIRST"] {
         let query = format!(
             r#"

--- a/tests/tests/joins.rs
+++ b/tests/tests/joins.rs
@@ -433,3 +433,81 @@ fn joinscan_cross_table_duplicate_output_name_matches_fallback(
 
     Ok(())
 }
+
+#[rstest]
+fn joinscan_nullable_numeric_composite_sort_matches_fallback(
+    mut conn: PgConnection,
+) -> Result<(), sqlx::Error> {
+    // Regression test for https://github.com/paradedb/paradedb/issues/5560:
+    // ORDER BY a nullable NUMERIC composite field crashed SegmentedTopKExec with
+    // "RowConverter column schema mismatch, expected BinaryView got Utf8View".
+    // NULL sort keys were materialized as Utf8View nulls while the NUMERIC
+    // column (a Bytes fast field) was declared BinaryView to the RowConverter.
+    r#"
+    SET paradedb.enable_custom_scan = on;
+    SET paradedb.enable_join_custom_scan = on;
+    SET max_parallel_workers_per_gather = 0;
+    SET enable_hashjoin = off;
+    SET enable_mergejoin = off;
+    SET enable_nestloop = off;
+
+    DROP TABLE IF EXISTS nn_parent;
+    DROP TABLE IF EXISTS nn_child;
+    DROP TYPE IF EXISTS nn_ps;
+    CREATE TABLE nn_parent (id int PRIMARY KEY, kind text, score_num numeric);
+    CREATE TABLE nn_child  (id bigint PRIMARY KEY, parent_id bigint);
+
+    -- deterministic scores (not random()) so Join Scan and fallback results compare equal
+    INSERT INTO nn_parent
+    SELECT g,
+           CASE WHEN g % 3 = 0 THEN 'novel' ELSE 'manga' END,
+           CASE WHEN g % 4 = 0 THEN NULL ELSE ((g * 37) % 1000)::numeric / 1000 END
+    FROM generate_series(1, 2000) g;
+    INSERT INTO nn_child SELECT g, ((g * 7) % 2000) + 1 FROM generate_series(1, 400) g;
+
+    CREATE TYPE nn_ps AS (kind pdb.literal_normalized, score_num numeric);
+    CREATE INDEX nn_parent_bm25 ON nn_parent USING bm25 (id, (ROW(kind, score_num)::nn_ps))
+    WITH (key_field = 'id');
+    CREATE INDEX nn_child_bm25 ON nn_child USING bm25 (id, parent_id)
+    WITH (key_field = 'id');
+    ANALYZE nn_parent;
+    ANALYZE nn_child;
+    "#
+    .execute(&mut conn);
+
+    // NULLS LAST exercises the crash; NULLS FIRST forces NULL rows into the
+    // final top-k so their sort placement is verified too.
+    for nulls in ["LAST", "FIRST"] {
+        let query = format!(
+            r#"
+            SELECT p.id
+            FROM nn_parent p JOIN nn_child c ON c.parent_id = p.id
+            WHERE p.kind @@@ pdb.term('manga') AND c.id @@@ pdb.all()
+            ORDER BY p.score_num DESC NULLS {nulls}, p.id
+            LIMIT 5
+            "#
+        );
+
+        let explain_lines: Vec<String> =
+            format!("EXPLAIN (COSTS OFF, VERBOSE) {query}").fetch_scalar(&mut conn);
+        let explain = explain_lines.join("\n");
+        assert!(
+            explain.contains("Custom Scan (ParadeDB Join Scan)"),
+            "{explain}"
+        );
+        assert!(explain.contains("SegmentedTopKExec"), "{explain}");
+
+        "SET paradedb.enable_join_custom_scan = on; DISCARD PLANS;".execute(&mut conn);
+        let joinscan_rows = query.as_str().fetch_result::<(i32,)>(&mut conn)?;
+
+        "SET paradedb.enable_join_custom_scan = off; DISCARD PLANS;".execute(&mut conn);
+        let fallback_rows = query.as_str().fetch_result::<(i32,)>(&mut conn)?;
+
+        "SET paradedb.enable_join_custom_scan = on;".execute(&mut conn);
+
+        assert_eq!(joinscan_rows, fallback_rows, "NULLS {nulls}");
+        assert_eq!(joinscan_rows.len(), 5, "NULLS {nulls}");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5560

## What

Fix a Join Scan crash when `ORDER BY` uses a nullable NUMERIC fast field:

```
ERROR: DataFusion execution failed: Arrow error: Invalid argument error:
       RowConverter column schema mismatch, expected BinaryView got Utf8View
```

## Why

NUMERIC is stored as a Bytes fast field, so the top-k sorter declares that sort
column as `BinaryView`. Rows whose sort key is NULL skip the ordinal path, and
their placeholders were hard-coded `ScalarValue::Utf8View(None)` — a text-typed
null fed into a byte-typed converter. Text keys never crashed because the types
happened to match; fixed-width types don't use this path.

## How

Derive each sort column's deferred info and materialized type once (`SortCol` in
`emit_final_topk`) and build both the RowConverter fields and the NULL
placeholders from it, so a NULL always carries the declared column type and
sorts correctly under both `NULLS LAST` and `NULLS FIRST`.

Composite sorts with a nullable key remain affected by pre-existing #5567; that
fix follows in a separate PR.

## Tests

- New `joinscan_nullable_numeric_composite_sort_matches_fallback`: nullable
  NUMERIC sort over a join, Join Scan results compared against the standard
  Postgres plan, for `NULLS LAST` and `NULLS FIRST` (the latter puts NULL keys
  in the top-k, checking their ordering).
- Verified against the issue's reproduction on PostgreSQL 18; reverting only
  this change reproduces the exact reported error.
