### PR TITLE
fix: `GROUP BY` uses the correct cardinality estimate to route between Tantivy/Datafusion

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -87,7 +87,6 @@ use crate::postgres::customscan::exec::{
 use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::hook::query_has_paradedb_agg;
 use crate::postgres::customscan::joinscan::scan_state::{build_physical_plan, build_task_context};
-use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::orderby::is_collation_pushdown_safe;
 use crate::postgres::customscan::projections::{create_placeholder_targetlist, placeholder_procid};
 use crate::postgres::customscan::solve_expr::SolvePostgresExpressions;
@@ -203,17 +202,23 @@ impl CustomScan for AggregateScan {
         match input_rel.reloptkind {
             pg_sys::RelOptKind::RELOPT_BASEREL => {
                 let use_datafusion = unsafe {
-                    // If the estimated number of groups exceeds Tantivy's bucket limit,
-                    // fall back to DataFusion which has no such limit.
-                    let estimated_groups = builder.args().output_rel().rows;
+                    // If the estimated number of groups exceeds Tantivy's bucket
+                    // limit, fall back to DataFusion which has no such limit;
+                    // Tantivy would otherwise silently truncate the GROUP BY at the
+                    // cap. A single-column GROUP BY bounded by a LIMIT within the
+                    // cap is exempt — Tantivy answers it correctly and faster via
+                    // its bounded top-N pushdown.
                     let max_buckets = gucs::max_term_agg_buckets() as f64;
-                    if estimated_groups > max_buckets {
-                        true
-                    } else {
+                    let exceeds_cap = builder.args().estimate_group_count() > max_buckets;
+                    let bounded_on_tantivy = builder.args().is_single_grouping_column()
+                        && builder
+                            .args()
+                            .limit_plus_offset()
+                            .is_some_and(|fetch| fetch as f64 <= max_buckets);
+                    (exceeds_cap && !bounded_on_tantivy)
                         // ORDER BY aggregate + LIMIT: route to DataFusion which has
                         // no bucket cap and provides native TopK via SortExec(fetch=K).
-                        build::has_aggregate_orderby_with_limit(builder.args())
-                    }
+                        || build::has_aggregate_orderby_with_limit(builder.args())
                 };
                 if use_datafusion {
                     if !gucs::enable_aggregate_custom_scan() && !has_paradedb_agg {
@@ -1940,9 +1945,7 @@ unsafe fn detect_join_aggregate_topk(
     // Must have a LIMIT for TopK to matter. We require a STATIC value here
     // because DataFusion's TopK rule needs a concrete K at planning time.
     // Parameterized LIMIT is left as a regular sort+limit pipeline.
-    let limit_offset = LimitOffset::from_parse(parse)?;
-    let static_fetch = limit_offset.static_fetch()?;
-    let k = static_fetch;
+    let k = args.limit_plus_offset()?;
 
     // Only single sort clause for TopK
     let sort_clauses = PgList::<pg_sys::SortGroupClause>::from_pg((*parse).sortClause);

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -205,12 +205,16 @@ impl CustomScan for AggregateScan {
                     // If the estimated number of groups exceeds Tantivy's bucket
                     // limit, fall back to DataFusion which has no such limit;
                     // Tantivy would otherwise silently truncate the GROUP BY at the
-                    // cap. A single-column GROUP BY bounded by a LIMIT within the
-                    // cap is exempt — Tantivy answers it correctly and faster via
-                    // its bounded top-N pushdown.
+                    // cap. A single-column GROUP BY that is key-ordered and bounded
+                    // by a LIMIT within the cap is exempt — Tantivy answers it
+                    // correctly and faster via its bounded top-N pushdown. The
+                    // ORDER BY on the grouping key is required: only a key-ordered
+                    // prefix has exact counts past the cap; an unordered or
+                    // count-ordered LIMIT would silently return approximate counts.
                     let max_buckets = gucs::max_term_agg_buckets() as f64;
                     let exceeds_cap = builder.args().estimate_group_count() > max_buckets;
                     let bounded_on_tantivy = builder.args().is_single_grouping_column()
+                        && builder.args().orders_by_grouping_key()
                         && builder
                             .args()
                             .limit_plus_offset()

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -20,7 +20,7 @@
 #![allow(clippy::tabs_in_doc_comments)]
 
 use parking_lot::Mutex;
-use pgrx::{direct_function_call, pg_sys, IntoDatum, PgMemoryContexts};
+use pgrx::{direct_function_call, pg_sys, IntoDatum, PgList, PgMemoryContexts};
 
 use std::ffi::{CStr, CString};
 use std::ptr::NonNull;
@@ -365,6 +365,58 @@ impl CreateUpperPathsHookArgs {
                 .as_ref()
                 .expect("Args::output_rel should not be null")
         }
+    }
+
+    /// Estimate how many groups the GROUP BY will produce, so routing can send
+    /// high-cardinality aggregates to DataFusion (no bucket cap) and keep
+    /// low-cardinality ones on the faster Tantivy path.
+    ///
+    /// We cannot use `output_rel.rows`: at the `UPPERREL_GROUP_AGG` hook the
+    /// grouped relation's row estimate is not yet populated (it reads as ~0), so
+    /// an `output_rel.rows > max_buckets` check never fires. Instead we call
+    /// Postgres's own `estimate_num_groups` directly, seeded with the base
+    /// relation's post-restriction row count (`input_rel.rows`, which reflects
+    /// the `@@@` selectivity). That estimator draws `n_distinct` from
+    /// `pg_statistic`, which is the signal that actually predicts truncation.
+    ///
+    /// Returns `1.0` when there is no GROUP BY (a scalar aggregate cannot
+    /// truncate).
+    pub unsafe fn estimate_group_count(&self) -> f64 {
+        let parse = self.root().parse;
+        if parse.is_null() || (*parse).groupClause.is_null() {
+            return 1.0;
+        }
+
+        let group_exprs =
+            pg_sys::get_sortgrouplist_exprs((*parse).groupClause, (*parse).targetList);
+        if group_exprs.is_null() {
+            return 1.0;
+        }
+
+        pg_sys::estimate_num_groups(
+            self.root,
+            group_exprs,
+            self.input_rel().rows,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+
+    /// The statically-known `LIMIT + OFFSET` of the query, or `None` when there
+    /// is no LIMIT or its value is parameterized (not known at planning time).
+    pub unsafe fn limit_plus_offset(&self) -> Option<usize> {
+        limit_offset::LimitOffset::from_parse(self.root().parse).and_then(|lo| lo.static_fetch())
+    }
+
+    /// True when the query groups by exactly one column. Tantivy's bounded top-N
+    /// pushdown is only safe for a single grouping column: with several, a nested
+    /// terms level can drop whole outer groupings before they are combined, which
+    /// a LIMIT cannot recover.
+    pub unsafe fn is_single_grouping_column(&self) -> bool {
+        let parse = self.root().parse;
+        !parse.is_null()
+            && !(*parse).groupClause.is_null()
+            && PgList::<pg_sys::SortGroupClause>::from_pg((*parse).groupClause).len() == 1
     }
 }
 

--- a/pg_search/src/postgres/customscan/mod.rs
+++ b/pg_search/src/postgres/customscan/mod.rs
@@ -418,6 +418,33 @@ impl CreateUpperPathsHookArgs {
             && !(*parse).groupClause.is_null()
             && PgList::<pg_sys::SortGroupClause>::from_pg((*parse).groupClause).len() == 1
     }
+
+    /// True when the query's `ORDER BY` sorts by the single grouping key itself
+    /// (e.g. `GROUP BY cat ORDER BY cat`).
+    ///
+    /// Tantivy's bounded top-N pushdown only returns exact counts for a
+    /// key-ordered prefix. With `segment_size` capped at `max_buckets`, a group
+    /// among the first K keys is retained in every segment — at most K-1 keys
+    /// can precede it anywhere — so its count is complete. A count-ordered or
+    /// unordered `LIMIT` gives only an approximate prefix once distinct groups
+    /// exceed the cap: a high-total group thinly spread across segments can be
+    /// dropped from each segment's capped bucket list before the merge. Routing
+    /// therefore only keeps the key-ordered case on Tantivy.
+    pub unsafe fn orders_by_grouping_key(&self) -> bool {
+        let parse = self.root().parse;
+        if parse.is_null() || (*parse).sortClause.is_null() || (*parse).groupClause.is_null() {
+            return false;
+        }
+        let sort_clauses = PgList::<pg_sys::SortGroupClause>::from_pg((*parse).sortClause);
+        let group_clauses = PgList::<pg_sys::SortGroupClause>::from_pg((*parse).groupClause);
+        if sort_clauses.len() != 1 || group_clauses.len() != 1 {
+            return false;
+        }
+        match (sort_clauses.get_ptr(0), group_clauses.get_ptr(0)) {
+            (Some(sort), Some(group)) => (*sort).tleSortGroupRef == (*group).tleSortGroupRef,
+            _ => false,
+        }
+    }
 }
 
 /// Helper function for wrapping a raw [`pg_sys::CustomScanState`] pointer with something more

--- a/pg_search/tests/pg_regress/expected/aggregate_datafusion_routing.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_datafusion_routing.out
@@ -1,0 +1,134 @@
+-- =====================================================================
+-- Routing between the Tantivy and DataFusion aggregate backends
+-- =====================================================================
+-- A single-table GROUP BY routes to DataFusion (no bucket cap) when the
+-- estimated group count exceeds paradedb.max_term_agg_buckets, otherwise it
+-- stays on the faster Tantivy path. The estimate comes from
+-- estimate_num_groups seeded with the base relation's post-filter row count, so
+-- it reflects both the column's n_distinct and the @@@ selectivity.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+DROP TABLE IF EXISTS routing_test;
+CREATE TABLE routing_test (id bigint, cat text, sub text);
+-- 50 distinct cat values, 2 distinct sub values, over 100k rows
+INSERT INTO routing_test
+SELECT g,
+       'cat_' || lpad((g % 50)::text, 2, '0'),
+       'sub_' || (g % 2)::text
+FROM generate_series(1, 100000) g;
+CREATE INDEX routing_test_idx ON routing_test
+USING bm25 (id, (cat::pdb.literal), (sub::pdb.literal)) WITH (key_field='id');
+ANALYZE routing_test;
+SET paradedb.max_term_agg_buckets = 10;
+-- 50 groups > cap: unbounded GROUP BY routes to DataFusion.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all() GROUP BY cat;
+                                        QUERY PLAN                                         
+-------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Backend: DataFusion
+   Indexes: routing_test_idx (routing_test)
+   Group By: cat
+   Aggregates: COUNT(*)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Single, gby=[cat@0 as cat], aggr=[count(1) as agg_0]
+     :   CooperativeExec
+     :     PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
+
+-- ...and DataFusion returns every group (no truncation).
+SELECT COUNT(*) AS groups FROM (
+    SELECT cat FROM routing_test WHERE id @@@ pdb.all() GROUP BY cat
+) s;
+ groups 
+--------
+     50
+(1 row)
+
+-- Single column bounded by LIMIT+OFFSET within the cap: stays on Tantivy.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 5 OFFSET 3;
+                                                        QUERY PLAN                                                        
+--------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Aggregate Scan) on routing_test
+         Index: routing_test_idx
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+           Applies to Aggregates: COUNT(*)
+           Group By: cat
+           Limit: 5
+           Offset: 3
+           Aggregate Definition: {"grouped":{"terms":{"field":"cat","order":{"_key":"asc"},"segment_size":10,"size":10}}}
+(9 rows)
+
+-- LIMIT+OFFSET beyond the cap: bounded pushdown unsafe, so DataFusion.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 8 OFFSET 5;
+                                                         QUERY PLAN                                                         
+----------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: cat
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Backend: DataFusion
+               Indexes: routing_test_idx (routing_test)
+               Group By: cat
+               Aggregates: COUNT(*)
+               DataFusion Physical Plan: 
+                 : SortExec: TopK(fetch=13), expr=[cat@0 ASC NULLS LAST], preserve_partitioning=[false]
+                 :   AggregateExec: mode=Single, gby=[cat@0 as cat], aggr=[count(1) as agg_0]
+                 :     CooperativeExec
+                 :       PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(13 rows)
+
+-- Multiple grouping columns cannot use the bounded pushdown safely: DataFusion.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, sub, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat, sub ORDER BY cat, sub LIMIT 5;
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: cat, sub
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Backend: DataFusion
+               Indexes: routing_test_idx (routing_test)
+               Group By: cat, sub
+               Aggregates: COUNT(*)
+               DataFusion Physical Plan: 
+                 : AggregateExec: mode=Single, gby=[cat@0 as cat, sub@1 as sub], aggr=[count(1) as agg_0]
+                 :   CooperativeExec
+                 :     PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(12 rows)
+
+-- Selective filter: only a few rows match, so few groups are possible even
+-- though cat has 50 distinct values overall — stays on the fast Tantivy path.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ '7' GROUP BY cat;
+                                                               QUERY PLAN                                                                
+-----------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on routing_test
+   Index: routing_test_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"7","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Group By: cat
+     Aggregate Definition: {"grouped":{"terms":{"field":"cat","segment_size":10,"size":10}}}
+(6 rows)
+
+-- Low grouping cardinality (2 groups < cap): stays on Tantivy.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT sub, COUNT(*) FROM routing_test WHERE id @@@ pdb.all() GROUP BY sub;
+                                         QUERY PLAN                                          
+---------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on routing_test
+   Index: routing_test_idx
+   Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+     Applies to Aggregates: COUNT(*)
+     Group By: sub
+     Aggregate Definition: {"grouped":{"terms":{"field":"sub","segment_size":10,"size":10}}}
+(6 rows)
+
+RESET paradedb.max_term_agg_buckets;
+DROP TABLE routing_test;

--- a/pg_search/tests/pg_regress/expected/aggregate_datafusion_routing.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_datafusion_routing.out
@@ -45,7 +45,8 @@ SELECT COUNT(*) AS groups FROM (
      50
 (1 row)
 
--- Single column bounded by LIMIT+OFFSET within the cap: stays on Tantivy.
+-- Single column, key-ordered, bounded by LIMIT+OFFSET within the cap: stays on
+-- Tantivy via the bounded top-N pushdown.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
 GROUP BY cat ORDER BY cat LIMIT 5 OFFSET 3;
@@ -61,6 +62,50 @@ GROUP BY cat ORDER BY cat LIMIT 5 OFFSET 3;
            Offset: 3
            Aggregate Definition: {"grouped":{"terms":{"field":"cat","order":{"_key":"asc"},"segment_size":10,"size":10}}}
 (9 rows)
+
+-- ...and that Tantivy-bounded path returns exactly the requested key-ordered
+-- window with exact counts (each cat has 2000 rows), never a truncated result.
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 5 OFFSET 3;
+  cat   | count 
+--------+-------
+ cat_03 |  2000
+ cat_04 |  2000
+ cat_05 |  2000
+ cat_06 |  2000
+ cat_07 |  2000
+(5 rows)
+
+-- Single column bounded by LIMIT within the cap but WITHOUT ORDER BY on the key:
+-- the bounded prefix would be count-ordered and approximate once distinct groups
+-- exceed the cap, so this must route to DataFusion rather than stay on Tantivy.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all() GROUP BY cat LIMIT 5;
+                                           QUERY PLAN                                            
+-------------------------------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Backend: DataFusion
+         Indexes: routing_test_idx (routing_test)
+         Group By: cat
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : AggregateExec: mode=Single, gby=[cat@0 as cat], aggr=[count(1) as agg_0]
+           :   CooperativeExec
+           :     PgSearchScan: segments=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(10 rows)
+
+-- ...and every group it returns carries its exact count (2000), never an
+-- approximate or truncated one.
+SELECT COUNT(*) AS returned_groups, MIN(cnt) AS min_count, MAX(cnt) AS max_count
+FROM (
+    SELECT cat, COUNT(*) AS cnt FROM routing_test WHERE id @@@ pdb.all()
+    GROUP BY cat LIMIT 5
+) s;
+ returned_groups | min_count | max_count 
+-----------------+-----------+-----------
+               5 |      2000 |      2000
+(1 row)
 
 -- LIMIT+OFFSET beyond the cap: bounded pushdown unsafe, so DataFusion.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/expected/aggregate_single_table_datafusion.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_single_table_datafusion.out
@@ -90,27 +90,41 @@ SELECT category, COUNT(*)
 FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
 GROUP BY category;
-                                                                                                                    QUERY PLAN                                                                                                                    
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan) on public.df_fallback_products
-   Output: category, pdb.agg_fn('COUNT(*)'::text)
-   Index: df_fallback_products_idx
-   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp","lenient":null,"conjunction_mode":null}}}}
-     Applies to Aggregates: COUNT(*)
-     Group By: category
-     Aggregate Definition: {"grouped":{"terms":{"field":"category","segment_size":1,"size":1}}}
-(7 rows)
+                                                                                                                                QUERY PLAN                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: category, (count(*))
+   Backend: DataFusion
+   Indexes: df_fallback_products_idx (df_fallback_products)
+   Group By: category
+   Aggregates: COUNT(*)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
+     :   CooperativeExec
+     :     PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
--- Test 2.2: With bucket limit = 1, Tantivy returns only 1 group (truncated)
+-- Test 2.2: With bucket limit = 1, the estimate exceeds the cap so it routes to
+-- DataFusion and returns every group (no truncation).
 SELECT category, COUNT(*)
 FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
 GROUP BY category
 ORDER BY category;
- category | count 
-----------+-------
- Audio    |     1
-(1 row)
+  category   | count 
+-------------+-------
+ Audio       |     1
+ Books       |     1
+ Clothing    |     1
+ Electronics |     2
+ Fitness     |     1
+ Furniture   |     1
+ Kitchen     |     1
+ Lighting    |     1
+ Office      |     1
+ Sports      |     1
+ Toys        |     1
+(11 rows)
 
 -- Test 2.3: Multiple aggregates via DataFusion fallback
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
@@ -118,28 +132,42 @@ SELECT category, COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
 FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
 GROUP BY category;
-                                                                                                                                                      QUERY PLAN                                                                                                                                                      
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan) on public.df_fallback_products
-   Output: category, pdb.agg_fn('COUNT(*)'::text), pdb.agg_fn('SUM'::text), pdb.agg_fn('AVG'::text), pdb.agg_fn('MIN'::text), pdb.agg_fn('MAX'::text)
-   Index: df_fallback_products_idx
-   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp","lenient":null,"conjunction_mode":null}}}}
-     Applies to Aggregates: COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
-     Group By: category
-     Aggregate Definition: {"grouped":{"aggs":{"0":{"sum":{"field":"price","missing":null,"none_if_no_match":true}},"1":{"avg":{"field":"rating","missing":null}},"2":{"min":{"field":"price","missing":null}},"3":{"max":{"field":"price","missing":null}}},"terms":{"field":"category","segment_size":1,"size":1}}}
-(7 rows)
+                                                                                                                                QUERY PLAN                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: category, (count(*)), (sum(price)), (avg(rating)), (min(price)), (max(price))
+   Backend: DataFusion
+   Indexes: df_fallback_products_idx (df_fallback_products)
+   Group By: category
+   Aggregates: COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(df_fallback_products_0.price) as agg_1, avg(df_fallback_products_0.rating) as agg_2, min(df_fallback_products_0.price) as agg_3, max(df_fallback_products_0.price) as agg_4]
+     :   CooperativeExec
+     :     PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp","lenient":null,"conjunction_mode":null}}}}
+(10 rows)
 
 SELECT category, COUNT(*), SUM(price), AVG(rating), MIN(price), MAX(price)
 FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
 GROUP BY category
 ORDER BY category;
- category | count |  sum   | avg |  min   |  max   
-----------+-------+--------+-----+--------+--------
- Audio    |     1 | 199.99 |   4 | 199.99 | 199.99
-(1 row)
+  category   | count |   sum   | avg |  min   |   max   
+-------------+-------+---------+-----+--------+---------
+ Audio       |     1 |  199.99 |   4 | 199.99 |  199.99
+ Books       |     1 |   14.99 |   5 |  14.99 |   14.99
+ Clothing    |     1 |  129.99 |   3 | 129.99 |  129.99
+ Electronics |     2 | 2299.98 | 4.5 | 999.99 | 1299.99
+ Fitness     |     1 |   29.99 |   3 |  29.99 |   29.99
+ Furniture   |     1 |  399.99 |   4 | 399.99 |  399.99
+ Kitchen     |     1 |   79.99 |   5 |  79.99 |   79.99
+ Lighting    |     1 |   59.99 |   4 |  59.99 |   59.99
+ Office      |     1 |    2.99 |   3 |   2.99 |    2.99
+ Sports      |     1 |   89.99 |   4 |  89.99 |   89.99
+ Toys        |     1 |   49.99 |   2 |  49.99 |   49.99
+(11 rows)
 
--- Test 2.4: Scalar aggregate (no GROUP BY) via DataFusion fallback
+-- Test 2.4: Scalar aggregate (no GROUP BY) stays on Tantivy — it produces a
+-- single row and cannot truncate, so the bucket cap is irrelevant.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*), SUM(price)
 FROM df_fallback_products
@@ -172,10 +200,20 @@ FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
 GROUP BY category
 ORDER BY category;
- category | count |  sum   
-----------+-------+--------
- Audio    |     1 | 199.99
-(1 row)
+  category   | count |   sum   
+-------------+-------+---------
+ Audio       |     1 |  199.99
+ Books       |     1 |   14.99
+ Clothing    |     1 |  129.99
+ Electronics |     2 | 2299.98
+ Fitness     |     1 |   29.99
+ Furniture   |     1 |  399.99
+ Kitchen     |     1 |   79.99
+ Lighting    |     1 |   59.99
+ Office      |     1 |    2.99
+ Sports      |     1 |   89.99
+ Toys        |     1 |   49.99
+(11 rows)
 
 -- Postgres native
 SET paradedb.enable_aggregate_custom_scan TO off;

--- a/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
+++ b/pg_search/tests/pg_regress/expected/groupby_aggregate_highcard.out
@@ -21,15 +21,20 @@ SELECT rating, COUNT(*) FROM products
 WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY rating;
-                                                      QUERY PLAN                                                       
------------------------------------------------------------------------------------------------------------------------
- Custom Scan (ParadeDB Aggregate Scan) on products
-   Index: products_idx
-   Tantivy Query: {"with_index":{"query":"all"}}
-     Applies to Aggregates: COUNT(*)
-     Group By: rating
-     Aggregate Definition: {"grouped":{"terms":{"field":"rating","order":{"_key":"asc"},"segment_size":10,"size":10}}}
-(6 rows)
+                                         QUERY PLAN                                         
+--------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: rating
+   ->  Custom Scan (ParadeDB Aggregate Scan)
+         Backend: DataFusion
+         Indexes: products_idx (products)
+         Group By: rating
+         Aggregates: COUNT(*)
+         DataFusion Physical Plan: 
+           : AggregateExec: mode=Single, gby=[rating@0 as rating], aggr=[count(1) as agg_0]
+           :   CooperativeExec
+           :     PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(11 rows)
 
 -- Limit + offset exceeds max_term_agg_buckets
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -38,18 +43,22 @@ WHERE id @@@ paradedb.all()
 GROUP BY rating
 ORDER BY rating
 LIMIT 5 OFFSET 6;
-                                                         QUERY PLAN                                                          
------------------------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                 
+-----------------------------------------------------------------------------------------------------------
  Limit
-   ->  Custom Scan (ParadeDB Aggregate Scan) on products
-         Index: products_idx
-         Tantivy Query: {"with_index":{"query":"all"}}
-           Applies to Aggregates: COUNT(*)
-           Group By: rating
-           Limit: 5
-           Offset: 6
-           Aggregate Definition: {"grouped":{"terms":{"field":"rating","order":{"_key":"asc"},"segment_size":10,"size":10}}}
-(9 rows)
+   ->  Sort
+         Sort Key: rating
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Backend: DataFusion
+               Indexes: products_idx (products)
+               Group By: rating
+               Aggregates: COUNT(*)
+               DataFusion Physical Plan: 
+                 : SortExec: TopK(fetch=11), expr=[rating@0 ASC NULLS LAST], preserve_partitioning=[false]
+                 :   AggregateExec: mode=Single, gby=[rating@0 as rating], aggr=[count(1) as agg_0]
+                 :     CooperativeExec
+                 :       PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":"all"}}
+(13 rows)
 
 -- Ordering on a non grouping column
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
@@ -58,23 +67,21 @@ WHERE id @@@ paradedb.all()
 GROUP BY rating, id
 ORDER BY rating, id
 LIMIT 5 OFFSET 5;
-WARNING:  Aggregate Scan not used: Field 'rating' is not a grouping column. To disable this warning: SET paradedb.check_aggregate_scan = false (table: products)
-                            QUERY PLAN                             
--------------------------------------------------------------------
+                                                  QUERY PLAN                                                  
+--------------------------------------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: rating, id
-         ->  HashAggregate
-               Group Key: id
-               ->  Custom Scan (ParadeDB Base Scan) on products
-                     Table: products
-                     Index: products_idx
-                     Exec Method: ColumnarExecState
-                     Fast Fields: id, rating
-                     Scores: false
-                     Full Index Scan: true
-                     Tantivy Query: {"with_index":{"query":"all"}}
-(13 rows)
+         ->  Custom Scan (ParadeDB Aggregate Scan)
+               Backend: DataFusion
+               Indexes: products_idx (products)
+               Group By: id, rating
+               Aggregates: COUNT(*)
+               DataFusion Physical Plan: 
+                 : AggregateExec: mode=Single, gby=[rating@1 as rating, id@0 as id], aggr=[count(1) as agg_0]
+                 :   CooperativeExec
+                 :     PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+(12 rows)
 
 -- This should be pushed down
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)

--- a/pg_search/tests/pg_regress/sql/aggregate_datafusion_routing.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_datafusion_routing.sql
@@ -36,10 +36,30 @@ SELECT COUNT(*) AS groups FROM (
     SELECT cat FROM routing_test WHERE id @@@ pdb.all() GROUP BY cat
 ) s;
 
--- Single column bounded by LIMIT+OFFSET within the cap: stays on Tantivy.
+-- Single column, key-ordered, bounded by LIMIT+OFFSET within the cap: stays on
+-- Tantivy via the bounded top-N pushdown.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
 GROUP BY cat ORDER BY cat LIMIT 5 OFFSET 3;
+
+-- ...and that Tantivy-bounded path returns exactly the requested key-ordered
+-- window with exact counts (each cat has 2000 rows), never a truncated result.
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 5 OFFSET 3;
+
+-- Single column bounded by LIMIT within the cap but WITHOUT ORDER BY on the key:
+-- the bounded prefix would be count-ordered and approximate once distinct groups
+-- exceed the cap, so this must route to DataFusion rather than stay on Tantivy.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all() GROUP BY cat LIMIT 5;
+
+-- ...and every group it returns carries its exact count (2000), never an
+-- approximate or truncated one.
+SELECT COUNT(*) AS returned_groups, MIN(cnt) AS min_count, MAX(cnt) AS max_count
+FROM (
+    SELECT cat, COUNT(*) AS cnt FROM routing_test WHERE id @@@ pdb.all()
+    GROUP BY cat LIMIT 5
+) s;
 
 -- LIMIT+OFFSET beyond the cap: bounded pushdown unsafe, so DataFusion.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)

--- a/pg_search/tests/pg_regress/sql/aggregate_datafusion_routing.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_datafusion_routing.sql
@@ -1,0 +1,64 @@
+-- =====================================================================
+-- Routing between the Tantivy and DataFusion aggregate backends
+-- =====================================================================
+-- A single-table GROUP BY routes to DataFusion (no bucket cap) when the
+-- estimated group count exceeds paradedb.max_term_agg_buckets, otherwise it
+-- stays on the faster Tantivy path. The estimate comes from
+-- estimate_num_groups seeded with the base relation's post-filter row count, so
+-- it reflects both the column's n_distinct and the @@@ selectivity.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+DROP TABLE IF EXISTS routing_test;
+CREATE TABLE routing_test (id bigint, cat text, sub text);
+
+-- 50 distinct cat values, 2 distinct sub values, over 100k rows
+INSERT INTO routing_test
+SELECT g,
+       'cat_' || lpad((g % 50)::text, 2, '0'),
+       'sub_' || (g % 2)::text
+FROM generate_series(1, 100000) g;
+
+CREATE INDEX routing_test_idx ON routing_test
+USING bm25 (id, (cat::pdb.literal), (sub::pdb.literal)) WITH (key_field='id');
+
+ANALYZE routing_test;
+
+SET paradedb.max_term_agg_buckets = 10;
+
+-- 50 groups > cap: unbounded GROUP BY routes to DataFusion.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all() GROUP BY cat;
+
+-- ...and DataFusion returns every group (no truncation).
+SELECT COUNT(*) AS groups FROM (
+    SELECT cat FROM routing_test WHERE id @@@ pdb.all() GROUP BY cat
+) s;
+
+-- Single column bounded by LIMIT+OFFSET within the cap: stays on Tantivy.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 5 OFFSET 3;
+
+-- LIMIT+OFFSET beyond the cap: bounded pushdown unsafe, so DataFusion.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 8 OFFSET 5;
+
+-- Multiple grouping columns cannot use the bounded pushdown safely: DataFusion.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, sub, COUNT(*) FROM routing_test WHERE id @@@ pdb.all()
+GROUP BY cat, sub ORDER BY cat, sub LIMIT 5;
+
+-- Selective filter: only a few rows match, so few groups are possible even
+-- though cat has 50 distinct values overall — stays on the fast Tantivy path.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT cat, COUNT(*) FROM routing_test WHERE id @@@ '7' GROUP BY cat;
+
+-- Low grouping cardinality (2 groups < cap): stays on Tantivy.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT sub, COUNT(*) FROM routing_test WHERE id @@@ pdb.all() GROUP BY sub;
+
+RESET paradedb.max_term_agg_buckets;
+DROP TABLE routing_test;

--- a/pg_search/tests/pg_regress/sql/aggregate_single_table_datafusion.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_single_table_datafusion.sql
@@ -76,7 +76,8 @@ FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
 GROUP BY category;
 
--- Test 2.2: With bucket limit = 1, Tantivy returns only 1 group (truncated)
+-- Test 2.2: With bucket limit = 1, the estimate exceeds the cap so it routes to
+-- DataFusion and returns every group (no truncation).
 SELECT category, COUNT(*)
 FROM df_fallback_products
 WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphones OR yoga OR book OR pen OR desk OR lamp'
@@ -96,7 +97,8 @@ WHERE description @@@ 'laptop OR shoes OR jacket OR robot OR coffee OR headphone
 GROUP BY category
 ORDER BY category;
 
--- Test 2.4: Scalar aggregate (no GROUP BY) via DataFusion fallback
+-- Test 2.4: Scalar aggregate (no GROUP BY) stays on Tantivy — it produces a
+-- single row and cannot truncate, so the bucket cap is irrelevant.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
 SELECT COUNT(*), SUM(price)
 FROM df_fallback_products


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #
- Related: #5565 (remove the bucket-limit error once DataFusion aggregates are competitively fast)

## What

The previous cardinality estimate was incorrect, causing Tantivy to be used when it shouldn't be + silent truncation of results. The reason the old estimate was wrong was because it used `output_rel().rows` which was always `0` at the time it was read (it gets populated after our hook runs). Instead we need to use Postgres' `estimate_num_groups`.

While we're in limbo before #5565, an over-cap `GROUP BY` that still lands on Tantivy (e.g. from a stale estimate) must error rather than silently truncate. That guard is handled in the stacked PR #5571.

## Why

## How

## Tests

See the changed regression test output in existing tests.
