### PR TITLE
fix: Error if Tantivy truncates results

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -367,7 +367,7 @@ pub fn init() {
     GucRegistry::define_int_guc(
         c"paradedb.max_term_agg_buckets",
         c"Maximum number of buckets/groups that can be returned by a terms aggregation",
-        c"Mostly used for testing. If this number is exceeded, that means the result could be truncated and the query will be cancelled.",
+        c"If a GROUP BY / terms aggregation would produce more groups than this, the result would be silently truncated, so the query is cancelled with an error instead. Raise this to cover the group cardinality, or add a LIMIT to bound the result.",
         &MAX_TERM_AGG_BUCKETS,
         1,
         DEFAULT_BUCKET_LIMIT as i32,

--- a/pg_search/src/postgres/customscan/aggregatescan/build.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/build.rs
@@ -318,6 +318,12 @@ impl AggregateCSClause {
         !self.targetlist.grouping_columns().is_empty()
     }
 
+    /// The statically-known `LIMIT + OFFSET`, or `None` when there is no LIMIT or
+    /// its value is parameterized.
+    pub fn static_fetch(&self) -> Option<usize> {
+        self.limit_offset.as_ref().and_then(|lo| lo.static_fetch())
+    }
+
     pub fn index_created_by_version(&self) -> Option<Version> {
         self.index_created_by_version
     }

--- a/pg_search/src/postgres/customscan/aggregatescan/exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/exec.rs
@@ -102,7 +102,9 @@ pub fn aggregation_results_iter(
 
     // Tantivy caps a terms aggregation at `size` and folds the dropped groups into
     // `sum_other_doc_count` rather than erroring, which would silently return an
-    // incomplete GROUP BY. Fail loudly instead.
+    // incomplete GROUP BY. Fail loudly instead. This is an interim guard until we
+    // route on cost between Tantivy and DataFusion; see
+    // https://github.com/paradedb/paradedb/issues/5565.
     if !truncation_recoverable && result.any_terms_truncated(bucket_limit as u64) {
         let on_fields = if grouping_fields.is_empty() {
             String::new()

--- a/pg_search/src/postgres/customscan/aggregatescan/exec.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/exec.rs
@@ -71,6 +71,21 @@ pub fn aggregation_results_iter(
     // Use the GUC for term aggregation bucket limits (single source of truth).
     let bucket_limit: u32 = gucs::max_term_agg_buckets() as u32;
     let mvcc_enabled = aggregate_clause.mvcc_enabled();
+    let grouping_fields: Vec<String> = aggregate_clause
+        .grouping_columns()
+        .into_iter()
+        .map(|column| column.field_name)
+        .collect();
+    // Routing (see create_custom_path) sends high-cardinality GROUP BYs to
+    // DataFusion using an estimate, but a stale/wrong estimate can still land an
+    // over-cap query here. Truncation at the cap is only recoverable for a single
+    // grouping column bounded by a static LIMIT+OFFSET within the cap: the ordered
+    // prefix Tantivy returns covers the requested window. Otherwise a dropped
+    // group is silent data loss, so we error instead.
+    let truncation_recoverable = grouping_fields.len() == 1
+        && aggregate_clause
+            .static_fetch()
+            .is_some_and(|fetch| fetch as u64 <= bucket_limit as u64);
 
     let result: AggregationResults = execute_aggregate(
         state.custom_state().indexrel(),
@@ -84,6 +99,28 @@ pub fn aggregation_results_iter(
     )
     .unwrap_or_else(|e| pgrx::error!("Failed to execute filter aggregation: {}", e))
     .into();
+
+    // Tantivy caps a terms aggregation at `size` and folds the dropped groups into
+    // `sum_other_doc_count` rather than erroring, which would silently return an
+    // incomplete GROUP BY. Fail loudly instead.
+    if !truncation_recoverable && result.any_terms_truncated(bucket_limit as u64) {
+        let on_fields = if grouping_fields.is_empty() {
+            String::new()
+        } else {
+            let names = grouping_fields
+                .iter()
+                .map(|field| format!("\"{field}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!(" on {names}")
+        };
+        pgrx::error!(
+            "GROUP BY{on_fields} produced more than paradedb.max_term_agg_buckets ({bucket_limit}) \
+             groups; returning the result would silently drop groups. Raise \
+             paradedb.max_term_agg_buckets to cover the group cardinality, or add a LIMIT to bound \
+             the result."
+        );
+    }
 
     if result.is_empty() {
         if state.custom_state().aggregate_clause.has_groupby() {
@@ -270,6 +307,39 @@ pub fn aggregate_result_to_datum(
 }
 
 impl AggregationResults {
+    /// True when a terms (GROUP BY) aggregation was truncated at the
+    /// `max_term_agg_buckets` cap: a bucket list filled to the cap with a
+    /// non-zero `sum_other_doc_count` (dropped groups). A smaller user LIMIT
+    /// leaves `buckets.len() < max_buckets`, so it does not count. Tantivy folds
+    /// the dropped groups into `sum_other_doc_count` rather than erroring, so the
+    /// caller must reject the result to avoid silently returning an incomplete
+    /// GROUP BY.
+    fn any_terms_truncated(&self, max_buckets: u64) -> bool {
+        fn walk<'a>(
+            mut results: impl Iterator<Item = &'a TantivyAggregationResult>,
+            max_buckets: u64,
+        ) -> bool {
+            results.any(|result| match result {
+                TantivyAggregationResult::BucketResult(BucketResult::Terms {
+                    buckets,
+                    sum_other_doc_count,
+                    ..
+                }) => {
+                    (*sum_other_doc_count > 0 && buckets.len() as u64 >= max_buckets)
+                        || buckets
+                            .iter()
+                            .any(|bucket| walk(bucket.sub_aggregation.0.values(), max_buckets))
+                }
+                TantivyAggregationResult::BucketResult(BucketResult::Filter(filter)) => {
+                    walk(filter.sub_aggregations.0.values(), max_buckets)
+                }
+                _ => false,
+            })
+        }
+
+        max_buckets != 0 && walk(self.0.values(), max_buckets)
+    }
+
     pub fn is_empty(&self) -> bool {
         // we should return an empty result set if either the Aggregations JSON is empty,
         // or if the top-level `_doc_count` is `0.0` (i.e. zero documents were matched)

--- a/pg_search/tests/pg_regress/expected/aggregate_truncation_guard.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_truncation_guard.out
@@ -1,0 +1,56 @@
+-- =====================================================================
+-- Runtime guard against silently truncated GROUP BY results
+-- =====================================================================
+-- Routing normally sends high-cardinality GROUP BYs to DataFusion, but it relies
+-- on the planner's group-count estimate. When that estimate is stale/wrong the
+-- query can still land on Tantivy, which caps a terms aggregation at
+-- paradedb.max_term_agg_buckets and folds the dropped groups into
+-- sum_other_doc_count. This test forces that case (stale statistics) and checks
+-- that we error instead of returning an incomplete result.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+DROP TABLE IF EXISTS trunc_guard;
+-- Disable autovacuum so our deliberately-stale statistics are not refreshed.
+CREATE TABLE trunc_guard (id bigint, cat text) WITH (autovacuum_enabled = false);
+-- Seed with only 2 distinct cat values, then ANALYZE: the planner now believes
+-- cat has ~2 distinct values.
+INSERT INTO trunc_guard SELECT g, 'seed_' || (g % 2) FROM generate_series(1, 100) g;
+CREATE INDEX trunc_guard_idx ON trunc_guard
+USING bm25 (id, (cat::pdb.literal)) WITH (key_field='id');
+ANALYZE trunc_guard;
+-- Add 200 genuinely-distinct cat values WITHOUT re-analyzing. The stale estimate
+-- (~2) stays below the cap, so routing keeps these queries on Tantivy even
+-- though the true cardinality (202) exceeds it.
+INSERT INTO trunc_guard SELECT g, 'cat_' || g FROM generate_series(1000, 1199) g;
+SET paradedb.max_term_agg_buckets = 10;
+-- Unbounded GROUP BY: Tantivy truncates to the cap, so the guard errors instead
+-- of returning a partial result.
+SELECT cat, COUNT(*) FROM trunc_guard WHERE id @@@ pdb.all() GROUP BY cat ORDER BY cat;
+ERROR:  GROUP BY on "cat" produced more than paradedb.max_term_agg_buckets (10) groups; returning the result would silently drop groups. Raise paradedb.max_term_agg_buckets to cover the group cardinality, or add a LIMIT to bound the result.
+-- Recoverable: a single grouping column bounded by a LIMIT within the cap is
+-- answered correctly via Tantivy's ordered prefix, so no error. Returns the 5
+-- smallest keys.
+SELECT cat, COUNT(*) FROM trunc_guard WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 5;
+   cat    | count 
+----------+-------
+ cat_1000 |     1
+ cat_1001 |     1
+ cat_1002 |     1
+ cat_1003 |     1
+ cat_1004 |     1
+(5 rows)
+
+-- Once statistics are refreshed the estimate is accurate, so routing sends the
+-- unbounded query to DataFusion and every group is returned — no error.
+ANALYZE trunc_guard;
+SELECT COUNT(*) AS groups FROM (
+    SELECT cat FROM trunc_guard WHERE id @@@ pdb.all() GROUP BY cat
+) s;
+ groups 
+--------
+    202
+(1 row)
+
+RESET paradedb.max_term_agg_buckets;
+DROP TABLE trunc_guard;

--- a/pg_search/tests/pg_regress/sql/aggregate_truncation_guard.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_truncation_guard.sql
@@ -1,0 +1,50 @@
+-- =====================================================================
+-- Runtime guard against silently truncated GROUP BY results
+-- =====================================================================
+-- Routing normally sends high-cardinality GROUP BYs to DataFusion, but it relies
+-- on the planner's group-count estimate. When that estimate is stale/wrong the
+-- query can still land on Tantivy, which caps a terms aggregation at
+-- paradedb.max_term_agg_buckets and folds the dropped groups into
+-- sum_other_doc_count. This test forces that case (stale statistics) and checks
+-- that we error instead of returning an incomplete result.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+
+DROP TABLE IF EXISTS trunc_guard;
+-- Disable autovacuum so our deliberately-stale statistics are not refreshed.
+CREATE TABLE trunc_guard (id bigint, cat text) WITH (autovacuum_enabled = false);
+
+-- Seed with only 2 distinct cat values, then ANALYZE: the planner now believes
+-- cat has ~2 distinct values.
+INSERT INTO trunc_guard SELECT g, 'seed_' || (g % 2) FROM generate_series(1, 100) g;
+CREATE INDEX trunc_guard_idx ON trunc_guard
+USING bm25 (id, (cat::pdb.literal)) WITH (key_field='id');
+ANALYZE trunc_guard;
+
+-- Add 200 genuinely-distinct cat values WITHOUT re-analyzing. The stale estimate
+-- (~2) stays below the cap, so routing keeps these queries on Tantivy even
+-- though the true cardinality (202) exceeds it.
+INSERT INTO trunc_guard SELECT g, 'cat_' || g FROM generate_series(1000, 1199) g;
+
+SET paradedb.max_term_agg_buckets = 10;
+
+-- Unbounded GROUP BY: Tantivy truncates to the cap, so the guard errors instead
+-- of returning a partial result.
+SELECT cat, COUNT(*) FROM trunc_guard WHERE id @@@ pdb.all() GROUP BY cat ORDER BY cat;
+
+-- Recoverable: a single grouping column bounded by a LIMIT within the cap is
+-- answered correctly via Tantivy's ordered prefix, so no error. Returns the 5
+-- smallest keys.
+SELECT cat, COUNT(*) FROM trunc_guard WHERE id @@@ pdb.all()
+GROUP BY cat ORDER BY cat LIMIT 5;
+
+-- Once statistics are refreshed the estimate is accurate, so routing sends the
+-- unbounded query to DataFusion and every group is returned — no error.
+ANALYZE trunc_guard;
+SELECT COUNT(*) AS groups FROM (
+    SELECT cat FROM trunc_guard WHERE id @@@ pdb.all() GROUP BY cat
+) s;
+
+RESET paradedb.max_term_agg_buckets;
+DROP TABLE trunc_guard;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #

## What

We use cardinality estimates to route queries to Tantivy vs Datafusion, but those estimates can be stale. If a query incorrectly gets routed to Tantivy, we should error instead of silently truncating.

## Why

## How

## Tests
