### PR TITLE
chore: Remove unused deferred column state

### DIFF
--- a/pg_search/src/index/fast_fields_helper.rs
+++ b/pg_search/src/index/fast_fields_helper.rs
@@ -408,12 +408,8 @@ impl WhichFastField {
             WhichFastField::Score => DataType::Float32,
             WhichFastField::Named(_, field_type) => field_type.arrow_data_type(),
             WhichFastField::Junk(_) => DataType::Null,
-            WhichFastField::Deferred(_, field_type) => {
-                let is_bytes = matches!(
-                    field_type.arrow_data_type(),
-                    arrow_schema::DataType::BinaryView | arrow_schema::DataType::LargeBinary
-                );
-                crate::scan::deferred_encode::deferred_union_data_type(is_bytes)
+            WhichFastField::Deferred(_, _field_type) => {
+                crate::scan::deferred_encode::deferred_union_data_type()
             }
             WhichFastField::DeferredCtid(_) => DataType::UInt64,
         }

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -42,7 +42,7 @@ The planner hook builds a [`JoinCSClause`][joincsc] — a serializable IR captur
 
 ### 4. Deferred Columns
 
-String columns are emitted as a [3-way `UnionArray`](../../scan/deferred_encode.rs) (doc_address | term_ordinal | materialized) so intermediate nodes work with cheap integer ordinals instead of decoded strings. The [decision to defer](../../scan/table_provider.rs) is made in [`configure_deferred_outputs()`][defer-decision].
+String columns are emitted as a [2-way `UnionArray`](../../scan/deferred_encode.rs) (doc_address | term_ordinal) so intermediate nodes work with cheap integer ordinals instead of decoded strings. The [decision to defer](../../scan/table_provider.rs) is made in [`configure_deferred_outputs()`][defer-decision].
 
 ### 5. Pruning Path
 
@@ -79,7 +79,7 @@ Execution-layer files under [`pg_search/src/scan/`](../../scan/):
 | [`batch_scanner.rs`](../../scan/batch_scanner.rs)     | [`Scanner::next()`][scanner-next] — batch iteration, pre-filter, visibility                                                         |
 | [`execution_plan.rs`](../../scan/execution_plan.rs)   | [`PgSearchScanPlan`][scan-plan] — dynamic filter integration                                                                        |
 | [`pre_filter.rs`](../../scan/pre_filter.rs)           | [`try_rewrite_binary`][rewrite-binary], [`collect_filters`][collect-filters]                                                        |
-| [`deferred_encode.rs`](../../scan/deferred_encode.rs) | 3-way UnionArray construction and unpacking                                                                                         |
+| [`deferred_encode.rs`](../../scan/deferred_encode.rs) | 2-way UnionArray construction and unpacking                                                                                         |
 
 ## GUCs
 

--- a/pg_search/src/scan/batch_scanner.rs
+++ b/pg_search/src/scan/batch_scanner.rs
@@ -433,41 +433,24 @@ impl Scanner {
                         _ => Some(col_array),
                     }
                 }
-                // Determine which union state to emit for the deferred column:
-                // 1. Some(UInt64) -> The pre-filter already fetched ordinals. Emit State 1 (Term Ordinals).
-                // 2. Some(other)  -> The pre-filter fully materialized the column. Emit State 2 (Materialized).
-                // 3. None         -> The pre-filter didn't touch this column. Emit State 0 (DocAddress).
+                // When resolving the data block, we build a 2-state UnionArray:
+                // 0. None -> We just have doc ids. Emit State 0 (Doc Address).
+                // 1. Some(UInt64) -> The pre-filter already resolved term ordinals. Emit State 1.
                 WhichFastField::DeferredCtid(_) => Some(Arc::new(
                     crate::scan::deferred_encode::pack_doc_addresses(segment_ord, &ids),
                 ) as ArrayRef),
-                WhichFastField::Deferred(_, field_type) => {
-                    let is_bytes = matches!(
-                        field_type.arrow_data_type(),
-                        arrow_schema::DataType::BinaryView | arrow_schema::DataType::LargeBinary
-                    );
-                    use arrow_schema::DataType;
-
-                    match &memoized_columns[ff_index] {
-                        Some(col_array) if col_array.data_type() == &DataType::UInt64 => {
-                            Some(crate::scan::deferred_encode::build_state_term_ordinals(
-                                segment_ord,
-                                col_array.clone(),
-                                is_bytes,
-                            ))
-                        }
-                        Some(col_array) => {
-                            Some(crate::scan::deferred_encode::build_state_hydrated(
-                                col_array.clone(),
-                                is_bytes,
-                            ))
-                        }
-                        None => Some(crate::scan::deferred_encode::build_state_doc_address(
+                WhichFastField::Deferred(_, _field_type) => match &memoized_columns[ff_index] {
+                    Some(col_array) => {
+                        Some(crate::scan::deferred_encode::build_state_term_ordinals(
                             segment_ord,
-                            &ids,
-                            is_bytes,
-                        )),
+                            col_array.clone(),
+                        ))
                     }
-                }
+                    None => Some(crate::scan::deferred_encode::build_state_doc_address(
+                        segment_ord,
+                        &ids,
+                    )),
+                },
             })
             .collect();
 

--- a/pg_search/src/scan/deferred_encode.rs
+++ b/pg_search/src/scan/deferred_encode.rs
@@ -62,7 +62,7 @@ pub fn unpack_doc_address(packed: u64) -> (u32, u32) {
 }
 
 /// Helper to get just the UnionFields (required by UnionArray::try_new)
-pub fn deferred_union_fields(is_bytes: bool) -> UnionFields {
+pub fn deferred_union_fields() -> UnionFields {
     let fields = vec![
         Field::new("doc_address", doc_address_type(), true).with_metadata(
             [(
@@ -78,39 +78,25 @@ pub fn deferred_union_fields(is_bytes: bool) -> UnionFields {
             )]
             .into(),
         ),
-        Field::new(
-            "materialized",
-            if is_bytes {
-                DataType::BinaryView
-            } else {
-                DataType::Utf8View
-            },
-            true,
-        ),
     ];
-    UnionFields::try_new(vec![0, 1, 2], fields).expect("Failed to create UnionFields")
+    UnionFields::try_new(vec![0, 1], fields).expect("Failed to create UnionFields")
 }
 
-/// The schema definition for our 3-way UnionArray
-pub fn deferred_union_data_type(is_bytes: bool) -> DataType {
-    DataType::Union(deferred_union_fields(is_bytes), UnionMode::Dense)
+/// The schema definition for our 2-way UnionArray
+pub fn deferred_union_data_type() -> DataType {
+    DataType::Union(deferred_union_fields(), UnionMode::Dense)
 }
 
 // State 0
-pub fn build_state_doc_address(
-    segment_ord: SegmentOrdinal,
-    doc_ids: &[DocId],
-    is_bytes: bool,
-) -> ArrayRef {
+pub fn build_state_doc_address(segment_ord: SegmentOrdinal, doc_ids: &[DocId]) -> ArrayRef {
     let len = doc_ids.len();
-    let fields = deferred_union_fields(is_bytes);
+    let fields = deferred_union_fields();
     let type_ids = ScalarBuffer::from(vec![0_i8; len]);
     let offsets = ScalarBuffer::from((0..len).map(|i| i as i32).collect::<Vec<_>>());
 
     let children: Vec<ArrayRef> = vec![
         Arc::new(pack_doc_addresses(segment_ord, doc_ids)),
         new_empty_array(fields[1].1.data_type()),
-        new_empty_array(fields[2].1.data_type()),
     ];
 
     Arc::new(
@@ -120,13 +106,9 @@ pub fn build_state_doc_address(
 }
 
 // State 1
-pub fn build_state_term_ordinals(
-    segment_ord: SegmentOrdinal,
-    ordinals: ArrayRef,
-    is_bytes: bool,
-) -> ArrayRef {
+pub fn build_state_term_ordinals(segment_ord: SegmentOrdinal, ordinals: ArrayRef) -> ArrayRef {
     let len = ordinals.len();
-    let fields = deferred_union_fields(is_bytes);
+    let fields = deferred_union_fields();
     let type_ids = ScalarBuffer::from(vec![1_i8; len]);
     let offsets = ScalarBuffer::from((0..len).map(|i| i as i32).collect::<Vec<_>>());
 
@@ -144,11 +126,7 @@ pub fn build_state_term_ordinals(
         .unwrap(),
     ) as ArrayRef;
 
-    let children: Vec<ArrayRef> = vec![
-        new_empty_array(fields[0].1.data_type()),
-        term_ord_struct,
-        new_empty_array(fields[2].1.data_type()),
-    ];
+    let children: Vec<ArrayRef> = vec![new_empty_array(fields[0].1.data_type()), term_ord_struct];
 
     Arc::new(
         UnionArray::try_new(fields, type_ids, Some(offsets), children)
@@ -156,47 +134,10 @@ pub fn build_state_term_ordinals(
     )
 }
 
-// State 2
-pub fn build_state_hydrated(materialized: ArrayRef, is_bytes: bool) -> ArrayRef {
-    let len = materialized.len();
-    let fields = deferred_union_fields(is_bytes);
-    let type_ids = ScalarBuffer::from(vec![2_i8; len]);
-    let offsets = ScalarBuffer::from((0..len).map(|i| i as i32).collect::<Vec<_>>());
-
-    let children: Vec<ArrayRef> = vec![
-        new_empty_array(fields[0].1.data_type()),
-        new_empty_array(fields[1].1.data_type()),
-        materialized,
-    ];
-
-    Arc::new(
-        UnionArray::try_new(fields, type_ids, Some(offsets), children)
-            .expect("Failed to construct State 2 UnionArray"),
-    )
-}
-
-/// Extracts the underlying materialized string/bytes data type from a deferred Union schema field.
-/// The Union array uses a 3-state encoding:
-/// 0 = doc_address (UInt64)
-/// 1 = term_ordinal (Struct)
-/// 2 = materialized (Utf8View / BinaryView)
-pub fn extract_materialized_type_from_union(
-    union_fields: &arrow_schema::UnionFields,
-) -> arrow_schema::DataType {
-    // The materialized type is always safely located at index 2
-    union_fields
-        .iter()
-        .nth(2)
-        .expect("Deferred Union schema is missing the materialized field variant")
-        .1
-        .data_type()
-        .clone()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_array::{Array, StringViewArray};
+    use arrow_array::Array;
 
     #[test]
     fn pack_unpack_roundtrip() {
@@ -222,7 +163,7 @@ mod tests {
 
     #[test]
     fn build_state_doc_address_creates_state_0() {
-        let array = build_state_doc_address(1, &[5, 10], false);
+        let array = build_state_doc_address(1, &[5, 10]);
         let union_array = array.as_any().downcast_ref::<UnionArray>().unwrap();
         assert_eq!(union_array.len(), 2);
         assert!(union_array.type_ids().iter().all(|&id| id == 0));
@@ -235,7 +176,7 @@ mod tests {
     #[test]
     fn build_state_term_ordinals_creates_state_1() {
         let ordinals: ArrayRef = Arc::new(UInt64Array::from(vec![Some(100), Some(200)]));
-        let array = build_state_term_ordinals(2, ordinals, false);
+        let array = build_state_term_ordinals(2, ordinals);
         let union_array = array.as_any().downcast_ref::<UnionArray>().unwrap();
         assert_eq!(union_array.len(), 2);
         assert!(union_array.type_ids().iter().all(|&id| id == 1));
@@ -255,30 +196,5 @@ mod tests {
             .unwrap();
         assert_eq!(term_ords.value(0), 100);
         assert_eq!(term_ords.value(1), 200);
-    }
-
-    #[test]
-    fn build_state_hydrated_creates_state_2() {
-        let strings: ArrayRef = Arc::new(StringViewArray::from(vec!["hello", "world"]));
-        let array = build_state_hydrated(strings, false);
-        let union_array = array.as_any().downcast_ref::<UnionArray>().unwrap();
-        assert_eq!(union_array.len(), 2);
-        assert!(union_array.type_ids().iter().all(|&id| id == 2));
-        let child = union_array.child(2);
-        let string_array = child.as_any().downcast_ref::<StringViewArray>().unwrap();
-        assert_eq!(string_array.value(0), "hello");
-        assert_eq!(string_array.value(1), "world");
-    }
-
-    #[test]
-    fn deferred_union_fields_text_vs_bytes() {
-        let text_fields = deferred_union_fields(false);
-        let bytes_fields = deferred_union_fields(true);
-        // Fields 0 and 1 are identical
-        assert_eq!(text_fields[0].1.data_type(), bytes_fields[0].1.data_type());
-        assert_eq!(text_fields[1].1.data_type(), bytes_fields[1].1.data_type());
-        // Field 2 differs: Utf8View for text, BinaryView for bytes
-        assert_eq!(*text_fields[2].1.data_type(), DataType::Utf8View);
-        assert_eq!(*bytes_fields[2].1.data_type(), DataType::BinaryView);
     }
 }

--- a/pg_search/src/scan/late_materialization.rs
+++ b/pg_search/src/scan/late_materialization.rs
@@ -21,7 +21,6 @@ use std::sync::Arc;
 
 use crate::index::fast_fields_helper::CanonicalColumn;
 use crate::index::fast_fields_helper::FFHelper;
-use crate::scan::deferred_encode::extract_materialized_type_from_union;
 use crate::scan::execution_plan::PgSearchScanPlan;
 use crate::scan::table_provider::PgSearchTableProvider;
 use crate::scan::tantivy_lookup_exec::TantivyLookupExec;
@@ -237,16 +236,7 @@ fn get_union_info(
     let mut new_fields = Vec::new();
 
     for (qualifier, field) in schema.iter() {
-        if let arrow_schema::DataType::Union(union_fields, _) = field.data_type() {
-            let materialized_type = extract_materialized_type_from_union(union_fields);
-
-            let materialized_field = Arc::new(arrow_schema::Field::new(
-                field.name(),
-                materialized_type,
-                field.is_nullable(),
-            ));
-            new_fields.push((qualifier.cloned(), materialized_field));
-
+        if let arrow_schema::DataType::Union(_, _) = field.data_type() {
             // Find the matching deferred field by tracing the column lineage back to its
             // base TableScan name. Name-matching is safe here because we consume entries from
             // all_deferred one-by-one: for a self-join both sides produce an identical
@@ -254,12 +244,27 @@ fn get_union_info(
             // claims its own entry without duplication.
             let col =
                 datafusion::common::Column::from((qualifier.cloned().as_ref(), field.as_ref()));
+            let mut is_bytes = false;
             if let Some(base_col) = trace_column(plan, &col) {
                 if let Some(pos) = all_deferred.iter().position(|d| d.name == base_col.name) {
                     let d = all_deferred.remove(pos);
+                    is_bytes = d.is_bytes;
                     active_deferred.push(d);
                 }
             }
+
+            let materialized_type = if is_bytes {
+                arrow_schema::DataType::BinaryView
+            } else {
+                arrow_schema::DataType::Utf8View
+            };
+
+            let materialized_field = Arc::new(arrow_schema::Field::new(
+                field.name(),
+                materialized_type,
+                field.is_nullable(),
+            ));
+            new_fields.push((qualifier.cloned(), materialized_field));
         } else {
             new_fields.push((qualifier.cloned(), field.clone()));
         }
@@ -590,11 +595,29 @@ impl UserDefinedLogicalNodeCore for LateMaterializeNode {
         for (i, field) in child_schema.fields().iter().enumerate() {
             let (qualifier, _) = child_schema.qualified_field(i);
 
-            if let arrow_schema::DataType::Union(union_fields, _) = field.data_type() {
+            if let arrow_schema::DataType::Union(_, _) = field.data_type() {
+                // Find the corresponding deferred field by tracing column lineage.
+                // Name-matching is safe: for a self-join both sides produce identical
+                // DeferredField structs; we consume entries one-by-one so each Union
+                // column in the child schema claims its own distinct slot.
+                let target_col = datafusion::common::Column::from((qualifier, field.as_ref()));
+                let mut is_bytes = false;
+                if let Some(base_col) = trace_column(&input, &target_col) {
+                    if let Some(pos) = deferred_pool.iter().position(|d| d.name == base_col.name) {
+                        let d = deferred_pool.remove(pos);
+                        is_bytes = d.is_bytes;
+                        new_deferred_fields.push(d);
+                    }
+                }
+
                 // When DataFusion's `OptimizeProjections` rule rebuilds nodes, it trims the schema.
                 // We must manually map the incoming `Union` types back to their materialized `T` types
                 // to construct a truthful output schema, avoiding invariant panics.
-                let materialized_type = extract_materialized_type_from_union(union_fields);
+                let materialized_type = if is_bytes {
+                    arrow_schema::DataType::BinaryView
+                } else {
+                    arrow_schema::DataType::Utf8View
+                };
 
                 qualified_fields.push((
                     qualifier.cloned(),
@@ -604,17 +627,6 @@ impl UserDefinedLogicalNodeCore for LateMaterializeNode {
                         field.is_nullable(),
                     )),
                 ));
-
-                // Find the corresponding deferred field by tracing column lineage.
-                // Name-matching is safe: for a self-join both sides produce identical
-                // DeferredField structs; we consume entries one-by-one so each Union
-                // column in the child schema claims its own distinct slot.
-                let target_col = datafusion::common::Column::from((qualifier, field.as_ref()));
-                if let Some(base_col) = trace_column(&input, &target_col) {
-                    if let Some(pos) = deferred_pool.iter().position(|d| d.name == base_col.name) {
-                        new_deferred_fields.push(deferred_pool.remove(pos));
-                    }
-                }
             } else {
                 qualified_fields.push((
                     qualifier.cloned(),

--- a/pg_search/src/scan/segmented_topk_exec.rs
+++ b/pg_search/src/scan/segmented_topk_exec.rs
@@ -21,13 +21,12 @@
 //! how this node fits into the overall physical plan and pruning pipeline.
 //!
 //! `SegmentedTopKExec` sits between `TantivyLookupExec` and its child in the
-//! physical plan. It operates on the 3-way deferred `UnionArray` columns emitted
+//! physical plan. It operates on the 2-way deferred `UnionArray` columns emitted
 //! by late materialization:
 //!   - State 0 (doc_address): unpacks `(segment_ord, doc_id)` and bulk-fetches
 //!     term ordinals via `FFHelper`.
 //!   - State 1 (term_ordinals): uses ordinals directly (already resolved by
 //!     pre-filter memoization).
-//!   - State 2 (materialized): already-decoded strings/bytes — always kept.
 //!
 //! For States 0 and 1, a per-segment buffer (a `Vec` with capacity 2 * K) and
 //! QuickSelect retain only the top K rows per segment. All batches are
@@ -59,7 +58,7 @@
 //!
 //!   sum_s(survivors_s) <= K * S  (when no boundary ties)
 //!
-//! where `S` is the number of segments. Pass-through rows (State 2 and NULL
+//! where `S` is the number of segments. Pass-through rows (NULL
 //! ordinals) are emitted immediately and are not bounded by K.
 //!
 //! **Compound sorts:** every sort column is used, not just the primary. The
@@ -532,7 +531,7 @@ struct SegmentedTopKState {
     /// Keeps track of the buffered rows for compaction.
     /// (batch_idx, row_idx, seg_ord, row_data)
     row_ordinals: Vec<(usize, usize, SegmentOrdinal, OwnedRow)>,
-    /// Buffered pass-through rows (State 2 and NULL ordinals) that bypass
+    /// Buffered pass-through rows (NULL ordinals) that bypass
     /// ordinal comparison. These are included in the final sort + limit.
     pass_through_rows: Vec<(usize, usize)>,
 
@@ -552,7 +551,7 @@ struct SegmentedTopKState {
     rows_input: Count,
     rows_output: Count,
     /// Counts segments that had rows participating in ordinal comparison (States 0+1).
-    /// Segments with only State 2 (materialized) or only NULLs are not counted.
+    /// Segments with only NULLs are not counted.
     segments_seen: Count,
 }
 
@@ -569,7 +568,7 @@ impl SegmentedTopKState {
 
     /// Ingest a single batch: extract ordinals, update per-segment buffers,
     /// and publish thresholds. The batch is buffered for the final emission
-    /// phase. Pass-through rows (State 2 and NULL ordinals) are buffered
+    /// phase. Pass-through rows (NULL ordinals) are buffered
     /// in `pass_through_rows` for the final sort + limit.
     fn collect_batch(&mut self, batch: &RecordBatch, batch_idx: usize) -> Result<()> {
         let num_rows = batch.num_rows();
@@ -655,7 +654,7 @@ impl SegmentedTopKState {
 
         self.publish_global_threshold()?;
 
-        // Buffer pass-through rows (State 2 + NULL ordinals) for the final sort.
+        // Buffer pass-through rows (NULL ordinals) for the final sort.
         for (row_idx, &is_pt) in pass_through.iter().enumerate() {
             if is_pt {
                 self.pass_through_rows.push((batch_idx, row_idx));
@@ -666,7 +665,7 @@ impl SegmentedTopKState {
     }
 
     /// Helper to extract term ordinals from a deferred UnionArray.
-    /// Mutates `pass_through` for rows that contain State 2 or NULLs, and populates `row_to_seg` mapping.
+    /// Mutates `pass_through` for rows that contain NULLs, and populates `row_to_seg` mapping.
     fn extract_deferred_ordinals(
         &self,
         batch: &RecordBatch,
@@ -697,7 +696,6 @@ impl SegmentedTopKState {
             match type_ids[row_idx] {
                 0 => state0_rows.push(row_idx),
                 1 => state1_rows.push(row_idx),
-                2 => pass_through[row_idx] = true,
                 _ => unreachable!("Invalid Union state"),
             }
         }
@@ -1303,33 +1301,8 @@ impl SegmentedTopKState {
                             ScalarValue::Utf8View(None)
                         }
                     } else {
-                        // Pass-through row: extract materialized value from
-                        // UnionArray State 2 child.
-                        let batch = &self.batches[*batch_idx];
-                        let union_col = batch
-                            .column(deferred.sort_col_idx)
-                            .as_any()
-                            .downcast_ref::<UnionArray>();
-                        if let Some(union_arr) = union_col {
-                            let type_ids = union_arr.type_ids();
-                            let offsets = union_arr.offsets();
-                            if let Some(offsets) = offsets {
-                                if type_ids[*row_idx] == 2 {
-                                    // State 2: materialized child
-                                    let child = union_arr.child(2);
-                                    let ci = offsets[*row_idx] as usize;
-                                    ScalarValue::try_from_array(child, ci)
-                                        .unwrap_or(ScalarValue::Utf8View(None))
-                                } else {
-                                    // NULL ordinal pass-through
-                                    ScalarValue::Utf8View(None)
-                                }
-                            } else {
-                                ScalarValue::Utf8View(None)
-                            }
-                        } else {
-                            ScalarValue::Utf8View(None)
-                        }
+                        // NULL ordinal pass-through
+                        ScalarValue::Utf8View(None)
                     }
                 } else {
                     // Non-deferred column: evaluate directly from the batch.
@@ -1509,7 +1482,7 @@ mod tests {
         ));
 
         let schema = Arc::new(Schema::new(vec![
-            Field::new("sort_col", deferred_union_data_type(false), true),
+            Field::new("sort_col", deferred_union_data_type(), true),
             Field::new("id", arrow_schema::DataType::Int64, true),
         ]));
 
@@ -1551,7 +1524,7 @@ mod tests {
                     continue;
                 }
 
-                let name_array = build_state_doc_address(seg_ord as u32, &doc_ids, false);
+                let name_array = build_state_doc_address(seg_ord as u32, &doc_ids);
                 let mut id_builder = arrow_array::builder::Int64Builder::with_capacity(doc_ids.len());
 
                 for doc_id in &doc_ids {

--- a/pg_search/src/scan/tantivy_lookup_exec.rs
+++ b/pg_search/src/scan/tantivy_lookup_exec.rs
@@ -508,8 +508,7 @@ type OrdsBySegment = Vec<Vec<(usize, Option<TermOrdinal>)>>;
 
 /// Resolves State 0 (packed doc addresses) to term ordinals, grouped by segment.
 ///
-/// Union states: 0 = packed (segment_ord, doc_id), 1 = pre-resolved (segment_ord, term_ord),
-/// 2 = already-materialized string/bytes.
+/// Union states: 0 = packed (segment_ord, doc_id), 1 = pre-resolved (segment_ord, term_ord).
 ///
 /// Returns the same shape as State 1: a vector indexed by segment ordinal,
 /// of `(row_index, Option<TermOrdinal>)` pair vectors.
@@ -675,8 +674,8 @@ fn decode_term_ordinals(
 
 /// Materializes deferred union values into their original text or bytes representation.
 ///
-/// This function converts a 3-way `UnionArray` (containing either a packed `DocAddress`,
-/// `TermOrdinal`s, or already-materialized strings) into an Arrow `ArrayRef` matching the
+/// This function converts a 2-way `UnionArray` (containing either a packed `DocAddress`
+/// or `TermOrdinal`s) into an Arrow `ArrayRef` matching the
 /// requested String or Binary view array type. To maximize efficiency, it groups requests
 /// by segment, sorts them for sequential dictionary access, fetches materialized columns
 /// per segment, and then uses Arrow's `interleave` to reconstruct the data in the
@@ -696,12 +695,10 @@ fn materialize_deferred_column(
 
     let mut state_0_rows: Vec<usize> = Vec::new();
     let mut state_1_rows: Vec<usize> = Vec::new();
-    let mut state_2_rows: Vec<usize> = Vec::new();
     for row in 0..num_rows {
         match type_ids[row] {
             0 => state_0_rows.push(row),
             1 => state_1_rows.push(row),
-            2 => state_2_rows.push(row),
             _ => unreachable!("Invalid Union State"),
         }
     }
@@ -733,16 +730,6 @@ fn materialize_deferred_column(
         &mut indices,
     )?;
 
-    // Step 3. Map pre-materialized rows (State 2) directly from the compact child.
-    if !state_2_rows.is_empty() {
-        let materialized_child = union_array.child(2);
-        segment_arrays.push(materialized_child.clone());
-        let array_idx = segment_arrays.len() - 1;
-        for &row_idx in &state_2_rows {
-            indices[row_idx] = (array_idx, offsets[row_idx] as usize);
-        }
-    }
-
     if segment_arrays.is_empty() {
         // All rows were somehow unhandled — return a null array of the right type.
         return Ok(new_null_array(
@@ -755,7 +742,7 @@ fn materialize_deferred_column(
         ));
     }
 
-    // Step 4. Use Arrow's interleave to perform zero-copy (for views) reassembly of the
+    // Step 3. Use Arrow's interleave to perform zero-copy (for views) reassembly of the
     // segment arrays into the final array matching the original row order.
     let segment_arrays_refs: Vec<&dyn arrow_array::Array> =
         segment_arrays.iter().map(|a| a.as_ref()).collect();

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -360,8 +360,8 @@ LIMIT 10;
            : ProjectionExec: expr=[val@2 as col_1, NULL as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=10, output_bytes=320.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, metrics=[rows_input=8.25 K, rows_output=10, segments_seen=2]
-           :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.25 K, output_bytes=235.4 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=362.5 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, build_mem_used=400.0 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
+           :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.25 K, output_bytes=234.5 KB, output_batches=2]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=361.6 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, build_mem_used=400.0 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :           CooperativeExec
@@ -474,8 +474,8 @@ LIMIT 25;
            : ProjectionExec: expr=[id@2 as col_1, val@3 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[val], metrics=[output_rows=25, output_bytes=1008.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, metrics=[rows_input=8.48 K, rows_output=25, segments_seen=1]
-           :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.48 K, output_bytes=376.4 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.48 K, output_bytes=499.9 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.48 K, build_mem_used=400.0 K, avg_fanout=100% (8.48 K/8.48 K), probe_hit_rate=100% (8.48 K/8.48 K)]
+           :       VisibilityFilterExec: tables=[t2, t1], metrics=[output_rows=8.48 K, output_bytes=371.9 KB, output_batches=2]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.48 K, output_bytes=495.3 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.48 K, build_mem_used=400.0 K, avg_fanout=100% (8.48 K/8.48 K), probe_hit_rate=100% (8.48 K/8.48 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :           CooperativeExec

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -668,8 +668,8 @@ LIMIT 5;
            : ProjectionExec: expr=[NULL as col_1, title@2 as col_2, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :   TantivyLookupExec: decode=[title], metrics=[output_rows=5, output_bytes=288.0 B, output_batches=1]
            :     SegmentedTopKExec: expr=[title@2 ASC NULLS LAST], k=5, metrics=[rows_input=14.42 K, rows_output=5, segments_seen=2]
-           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=14.42 K, output_bytes=802.8 KB, output_batches=2]
-           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=14.42 K, output_bytes=833.6 KB, output_batches=2, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=14.42 K, build_mem_used=228, avg_fanout=100% (14.42 K/14.42 K), probe_hit_rate=55.81% (14.42 K/25.83 K)]
+           :       VisibilityFilterExec: tables=[d, f], metrics=[output_rows=14.42 K, output_bytes=577.5 KB, output_batches=2]
+           :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, document_id@1)], projection=[ctid_0@0, ctid_1@2, title@4], metrics=[output_rows=14.42 K, output_bytes=608.2 KB, output_batches=2, array_map_created_count=0, build_input_batches=1, build_input_rows=3, input_batches=4, input_rows=14.42 K, build_mem_used=228, avg_fanout=100% (14.42 K/14.42 K), probe_hit_rate=55.81% (14.42 K/25.83 K)]
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :           CooperativeExec


### PR DESCRIPTION
## What

Remove state `2` (fully materialized strings/bytes) from the UnionArray which is used to represent deferred columns.

## Why

It has not been used in a long time (possibly ever). Our scan will only ever produce states `0` (`DocAddress`) or `1` (`SegmentOrdinal` + `TermOrdinal`), because pre/dynamic filtering translates filters into a `TermOrdinal` in order to apply them: it will not fully decode strings before emitting them.

## Tests

Unchanged. Some minor statistics changes in plans due to a smaller union.