### PR TITLE
chore: Prepare the `0.24.3` release.

### DIFF
--- a/docs/changelog/0.24.3.mdx
+++ b/docs/changelog/0.24.3.mdx
@@ -3,16 +3,10 @@ title: 0.24.3
 noindex: true
 ---
 
-## New Features 🎉
-
-- Eagerly abort an index build when it will not fit on disk, failing fast instead of exhausting disk space.
-
-## Performance Improvements 🚀
-
-- Cap index build worker memory at 1GB to reduce peak memory usage during index creation.
-
 ## Stability Improvements 💪
 
+- Eagerly abort an index build when it will not fit on disk, failing fast instead of exhausting disk space.
+- Cap index build worker memory at 1GB to reduce peak memory usage during index creation.
 - Bound sequential scan memory usage by spilling to a `BufFile`.
 - Use the correct cardinality estimate when routing `GROUP BY` between Tantivy and DataFusion.
 - Return an error instead of silently returning incomplete results when Tantivy truncates results.

--- a/docs/changelog/0.24.3.mdx
+++ b/docs/changelog/0.24.3.mdx
@@ -1,0 +1,20 @@
+---
+title: 0.24.3
+noindex: true
+---
+
+## New Features 🎉
+
+- Eagerly abort an index build when it will not fit on disk, failing fast instead of exhausting disk space.
+
+## Performance Improvements 🚀
+
+- Cap index build worker memory at 1GB to reduce peak memory usage during index creation.
+
+## Stability Improvements 💪
+
+- Bound sequential scan memory usage by spilling to a `BufFile`.
+- Use the correct cardinality estimate when routing `GROUP BY` between Tantivy and DataFusion.
+- Return an error instead of silently returning incomplete results when Tantivy truncates results.
+
+The full changelog is available [on the GitHub Release](https://github.com/paradedb/paradedb/releases/tag/v0.24.3).

--- a/docs/deploy/cloud-platforms/digitalocean.mdx
+++ b/docs/deploy/cloud-platforms/digitalocean.mdx
@@ -38,7 +38,7 @@ curl -fsSL https://get.docker.com | sh
 The `tag` query parameter pins the ParadeDB version. See the [Docker Hub page](https://hub.docker.com/r/paradedb/paradedb/tags) for available tags.
 
 ```bash
-curl -fsSL "https://paradedb.com/install.sh?tag=0.24.2-pg18" | sh
+curl -fsSL "https://paradedb.com/install.sh?tag=0.24.3-pg18" | sh
 ```
 
 Once the install completes, note the password printed to the terminal — you will need it for the `psql` connection string below.

--- a/docs/deploy/self-hosted/extension.mdx
+++ b/docs/deploy/self-hosted/extension.mdx
@@ -37,7 +37,7 @@ If you are using a different version of Postgres or a different operating system
 The prebuilt releases can be found in [GitHub Releases](https://github.com/paradedb/paradedb/releases).
 
 <Note>
-  You can replace `0.24.2` with the `pg_search` version you wish to install and
+  You can replace `0.24.3` with the `pg_search` version you wish to install and
   `18` with the version of Postgres you are using.
 </Note>
 
@@ -45,49 +45,49 @@ The prebuilt releases can be found in [GitHub Releases](https://github.com/parad
 
 ```bash Ubuntu 24.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/postgresql-18-pg-search_0.24.2-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/postgresql-18-pg-search_0.24.3-1PARADEDB-noble_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Ubuntu 22.04
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/postgresql-18-pg-search_0.24.2-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/postgresql-18-pg-search_0.24.3-1PARADEDB-jammy_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 13
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/postgresql-18-pg-search_0.24.2-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/postgresql-18-pg-search_0.24.3-1PARADEDB-trixie_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash Debian 12
 # Available arch versions are amd64, arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/postgresql-18-pg-search_0.24.2-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/postgresql-18-pg-search_0.24.3-1PARADEDB-bookworm_amd64.deb" -o /tmp/pg_search.deb
 sudo apt-get install -y /tmp/*.deb
 ```
 
 ```bash RHEL 10
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/pg_search_18-0.24.2-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/pg_search_18-0.24.3-1PARADEDB.el10.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash RHEL 9
 # Available arch versions are x86_64, aarch64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/pg_search_18-0.24.2-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/pg_search_18-0.24.3-1PARADEDB.el9.x86_64.rpm" -o /tmp/pg_search.rpm
 sudo dnf install -y /tmp/*.rpm
 ```
 
 ```bash macOS 15 (Sequoia)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/pg_search@18--0.24.2.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/pg_search@18--0.24.3.arm64_sequoia.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 
 ```bash macOS 14 (Sonoma)
 # Available arch version is arm64
-curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.2/pg_search@18--0.24.2.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
+curl -L "https://github.com/paradedb/paradedb/releases/download/v0.24.3/pg_search@18--0.24.3.arm64_sonoma.pkg" -o ~/Downloads/pg_search.pkg
 sudo installer -pkg ~/Downloads/pg_search.pkg -target /
 ```
 

--- a/docs/deploy/upgrading.mdx
+++ b/docs/deploy/upgrading.mdx
@@ -37,7 +37,7 @@ If `pg_extension` is greater than `paradedb.version_info()`, it means that the e
 
 ## Getting the Latest Version
 
-The latest version of `pg_search` is `0.24.2`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
+The latest version of `pg_search` is `0.24.3`. Please refer to the [releases](https://github.com/paradedb/paradedb/releases) page for all available versions of `pg_search`.
 
 ## Updating ParadeDB
 
@@ -79,10 +79,10 @@ To upgrade the ParadeDB Docker image while preserving your data volume:
    to `latest` to pull the latest Docker image. You can find the full list of available tags on [Docker Hub](https://hub.docker.com/r/paradedb/paradedb/tags).
 
 ```bash
-docker pull paradedb/paradedb:0.24.2
+docker pull paradedb/paradedb:0.24.3
 ```
 
-The latest version of the Docker image should be `0.24.2`.
+The latest version of the Docker image should be `0.24.3`.
 
 3. Start the new ParadeDB Docker image via `docker run paradedb`.
 
@@ -99,7 +99,7 @@ To upgrade the extensions running in a self-managed Postgres:
 After ParadeDB has been upgraded, connect to it and run the following command in all databases that `pg_search` is installed in. This step is required regardless of the environment that ParadeDB is installed in (Helm, Docker, or self-managed Postgres).
 
 ```sql
-ALTER EXTENSION pg_search UPDATE TO '0.24.2';
+ALTER EXTENSION pg_search UPDATE TO '0.24.3';
 ```
 
 ## Verify the Upgrade

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -15,7 +15,7 @@
   "navigation": {
     "versions": [
       {
-        "version": "v0.24.2",
+        "version": "v0.24.3",
         "anchors": [
           {
             "anchor": "Documentation",
@@ -345,6 +345,7 @@
               {
                 "group": "Changelog",
                 "pages": [
+                  "changelog/0.24.3",
                   "changelog/0.24.2",
                   "changelog/0.24.1",
                   "changelog/0.24.0",


### PR DESCRIPTION
# Description

Prepares the `0.24.3` release: adds the changelog and bumps version references across the docs. Cuts from the commits landed on `0.24.x` since `0.24.2`:

- perf: cap index build worker memory at 1GB (#5537)
- fix: Bound seqscan memory by spilling to `BufFile` (#5554)
- feat: eagerly abort index build if it will not fit on disk (#5570)
- fix: `GROUP BY` uses the correct cardinality estimate to route between Tantivy/Datafusion (#5577)
- fix: Error if Tantivy truncates results (#5578)

## Changes

- Add `docs/changelog/0.24.3.mdx`.
- Bump `0.24.2` → `0.24.3` in the deploy/upgrade docs.
- Add the `0.24.3` changelog page and bump the docs version in `docs/docs.json`.

This targets `main`; it will be backported to `0.24.x` as part of the release.