### PR TITLE
fix: bound high-cardinality benchmark GROUP BY with LIMIT

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/cardinality.sql
@@ -14,10 +14,10 @@ SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(post_type_id) FROM
 SET paradedb.enable_aggregate_custom_scan TO off; SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- high-cardinality aggregate scan
-SET paradedb.enable_aggregate_custom_scan TO off; SET work_mem TO '4GB'; SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET paradedb.enable_aggregate_custom_scan TO off; SET work_mem TO '4GB'; SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags LIMIT 65000;
 
 -- high-cardinality aggregate scan using pdb.agg
-SET paradedb.enable_aggregate_custom_scan TO on; SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET paradedb.enable_aggregate_custom_scan TO on; SET work_mem = '4GB'; SELECT tags, COUNT(tags), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags LIMIT 65000;
 
 -- high-cardinality aggregate scan using pdb.agg (mvcc disabled)
-SET paradedb.enable_aggregate_custom_scan TO off; SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags;
+SET paradedb.enable_aggregate_custom_scan TO off; SET work_mem = '4GB'; SELECT tags, pdb.agg('{"value_count": {"field": "tags"}}', false) as count, pdb.agg('{"min": {"field": "score"}}', false) as min, pdb.agg('{"max": {"field": "score"}}', false) as max, pdb.agg('{"sum": {"field": "score"}}', false) as sum FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags LIMIT 65000;


### PR DESCRIPTION
## What

Adds `LIMIT 65000` to the three high-cardinality `GROUP BY tags` queries in the stackoverflow benchmark's [`cardinality.sql`](https://github.com/paradedb/paradedb/blob/main/benchmarks/datasets/stackoverflow/queries/cardinality.sql).

## Why

The `main` **Benchmark pg_search (Queries)** job [failed on the 20M stackoverflow dataset](https://github.com/paradedb/paradedb/actions/runs/29453874769/job/87482528390) with:

```
ERROR: GROUP BY on "tags" produced more than paradedb.max_term_agg_buckets (65000)
groups; returning the result would silently drop groups.
```

This is the intended behavior of the truncation guard added in #5571: the single-table Tantivy aggregate custom scan now errors rather than silently dropping groups when the term-aggregation cap is exceeded. On the 20M dataset, `GROUP BY tags` produces more than 65000 groups, so the benchmark query trips the guard and the job exits 1.

The guard treats truncation as recoverable for a single grouping column bounded by a static `LIMIT ≤ max_term_agg_buckets`. `LIMIT 65000` keeps the custom-scan variant on the Tantivy path within the cap. The two `custom_scan TO off` variants still aggregate everything internally (the `LIMIT` only bounds returned rows), so their benchmark timings are unchanged and all three stay comparable.

Other benchmark `GROUP BY` queries were audited and don't need changes: the `bucket-*` queries group by low-cardinality columns, `aggregate_topk_count.sql` already bounds with `LIMIT 10`, and the `join_aggregate_*` queries run through DataFusion (not the Tantivy terms-agg guard).