### PR TITLE
feat: recognize query-time vector operands

### DIFF
--- a/pg_search/src/api/mod.rs
+++ b/pg_search/src/api/mod.rs
@@ -388,6 +388,8 @@ pub enum OrderByFeature {
         /// `EState.es_param_list_info` and writes the floats into `query_vector`.
         #[serde(default)]
         query_vector_param_id: Option<i32>,
+        #[serde(default)]
+        query_vector_expr: Option<String>,
         /// Metric implied by the operator that drove this ORDER BY
         /// (`<->` → L2, `<=>` → Cosine, `<#>` → InnerProduct). Drives
         /// EXPLAIN output and whether the resolved query vector is
@@ -457,25 +459,53 @@ impl OrderByInfo {
         }
     }
 
-    /// If this `OrderByInfo` carries a parameterized vector ORDER BY
-    /// (`<-> $1` style, generic-plan prepared statement), look up the
-    /// bound `Param` value in the executor's `es_param_list_info`,
-    /// convert it to `Vec<f32>`, optionally L2-normalize for cosine,
-    /// and overwrite `query_vector` so downstream search code sees a
-    /// concrete vector.
+    /// Resolve a not-yet-concrete vector ORDER BY query vector into
+    /// `query_vector`, so downstream search code sees a concrete vector.
+    /// Two deferred forms are handled:
     ///
-    /// No-op for `OrderByFeature::VectorDistance` whose param ID is
-    /// already `None` (i.e. the vector was a literal `Const`), and
-    /// for every other `OrderByFeature` variant.
-    pub unsafe fn resolve_param(&mut self, estate: *mut pgrx::pg_sys::EState) {
+    ///   * `query_vector_param_id` — a bound `Param` (`<-> $1` style,
+    ///     generic-plan prepared statement), looked up in the executor's
+    ///     `es_param_list_info`; and
+    ///   * `query_vector_expr` — a serialized non-`Var`, non-volatile operand
+    ///     expression (e.g. `current_setting('cohere.qvec')::vector`),
+    ///     deserialized and evaluated once against `planstate`'s ExprContext.
+    ///
+    /// No-op for a `VectorDistance` whose vector was already a literal `Const`
+    /// (both fields `None`), and for every other `OrderByFeature` variant.
+    /// Idempotent: each deferred form is cleared once resolved.
+    pub unsafe fn resolve_query_vector(
+        &mut self,
+        estate: *mut pgrx::pg_sys::EState,
+        planstate: *mut pgrx::pg_sys::PlanState,
+    ) {
         let OrderByFeature::VectorDistance {
             query_vector,
             query_vector_param_id,
+            query_vector_expr,
             ..
         } = &mut self.feature
         else {
             return;
         };
+
+        if let Some(expr_str) = query_vector_expr.take() {
+            use crate::postgres::customscan::expr_eval::PreparedPgExpr;
+            let prepared = PreparedPgExpr::from_serialized(&expr_str, &[]);
+            let expr_state = pg_sys::ExecInitExpr(prepared.as_ptr(), planstate);
+            let econtext = (*planstate).ps_ExprContext;
+            assert!(
+                !econtext.is_null(),
+                "planstate has no ExprContext to evaluate vector ORDER BY operand"
+            );
+            let mut isnull = false;
+            let datum = pg_sys::ExecEvalExpr(expr_state, econtext, &mut isnull);
+            assert!(!isnull, "vector ORDER BY operand evaluated to NULL");
+            *query_vector = PgVector::from_datum(datum, false)
+                .expect("vector ORDER BY operand should not be NULL")
+                .0;
+            return;
+        }
+
         let Some(paramid) = *query_vector_param_id else {
             return;
         };

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -311,13 +311,16 @@ impl ExecMethod for TopKScanExecState {
             }
         }
 
-        // Resolve any parameterized vector ORDER BY query vectors (generic
-        // prepared-statement plans where `<-> $1` left a Param node behind
-        // at planning time). We mutate both copies — the canonical one in
-        // `state.exec_method_type` and our local clone — so subsequent
-        // reads see the bound floats.
+        // Resolve any not-yet-concrete vector ORDER BY query vectors: a bound
+        // `<-> $1` Param (generic prepared-statement plan) or a serialized
+        // non-Var, non-volatile operand expression (e.g.
+        // `<-> current_setting('cohere.qvec')::vector`) left behind at planning
+        // time. We mutate both copies — the canonical one in
+        // `state.exec_method_type` and our local clone — so subsequent reads
+        // see the resolved floats.
         unsafe {
             let estate = (*cstate).ss.ps.state;
+            let planstate = std::ptr::addr_of_mut!((*cstate).ss.ps);
             if !estate.is_null() {
                 if let ExecMethodType::TopK {
                     orderby_info: Some(infos),
@@ -325,12 +328,12 @@ impl ExecMethod for TopKScanExecState {
                 } = &mut state.exec_method_type
                 {
                     for info in infos.iter_mut() {
-                        info.resolve_param(estate);
+                        info.resolve_query_vector(estate, planstate);
                     }
                 }
                 if let Some(infos) = self.orderby_info.as_mut() {
                     for info in infos.iter_mut() {
-                        info.resolve_param(estate);
+                        info.resolve_query_vector(estate, planstate);
                     }
                 }
             }

--- a/pg_search/src/postgres/customscan/builders/custom_path.rs
+++ b/pg_search/src/postgres/customscan/builders/custom_path.rs
@@ -41,6 +41,8 @@ pub enum OrderByStyle {
         query_vector: Vec<f32>,
         /// See `OrderByFeature::VectorDistance::query_vector_param_id`.
         query_vector_param_id: Option<i32>,
+        /// See `OrderByFeature::VectorDistance::query_vector_expr`.
+        query_vector_expr: Option<String>,
         /// See `OrderByFeature::VectorDistance::metric`.
         metric: crate::vector::metric::VectorMetric,
     },
@@ -107,6 +109,7 @@ impl From<&OrderByStyle> for OrderByInfo {
                 rti,
                 query_vector,
                 query_vector_param_id,
+                query_vector_expr,
                 metric,
                 ..
             } => OrderByFeature::VectorDistance {
@@ -114,6 +117,7 @@ impl From<&OrderByStyle> for OrderByInfo {
                 rti: *rti,
                 query_vector: query_vector.clone(),
                 query_vector_param_id: *query_vector_param_id,
+                query_vector_expr: query_vector_expr.clone(),
                 metric: *metric,
             },
         };

--- a/pg_search/src/postgres/customscan/orderby.rs
+++ b/pg_search/src/postgres/customscan/orderby.rs
@@ -53,16 +53,19 @@ pub enum SortExpressionType {
     /// Sorting by an expression that matched an indexed expression in `pg_index.indexprs`.
     IndexedExpression,
     /// Sorting by vector distance: `ORDER BY col <-> '[...]'`.
-    /// Carries the resolved query vector (if a `Const`), or the
-    /// `Param` ID to resolve at execution time (if a parameterized
-    /// generic plan), plus the metric implied by the operator
-    /// (`<->` → L2, `<=>` → Cosine, `<#>` → InnerProduct).
+    /// Carries the resolved query vector (if a `Const`), the `Param` ID
+    /// to resolve at execution time (if a parameterized generic plan),
+    /// or a serialized non-`Var`, non-volatile operand expression
+    /// (`query_vector_expr`) to evaluate once at execution time (e.g.
+    /// `current_setting('...')::vector`), plus the metric implied by the
+    /// operator (`<->` → L2, `<=>` → Cosine, `<#>` → InnerProduct).
     /// Query vectors are passed through to tantivy raw — the storage
     /// layer owns unit-norm policy for the doc side, and the cosine
     /// scoring kernel handles non-unit queries via `inv_norm_q`.
     VectorDistance {
         query_vector: Vec<f32>,
         query_vector_param_id: Option<i32>,
+        query_vector_expr: Option<String>,
         metric: VectorMetric,
     },
     /// Sorting by a vector distance operator whose implied metric
@@ -382,6 +385,7 @@ unsafe fn extract_vector_distance(
             SortExpressionType::VectorDistance {
                 query_vector,
                 query_vector_param_id: None,
+                query_vector_expr: None,
                 metric: op_metric,
             },
         ));
@@ -400,12 +404,35 @@ unsafe fn extract_vector_distance(
             SortExpressionType::VectorDistance {
                 query_vector: Vec::new(),
                 query_vector_param_id: Some((*param).paramid),
+                query_vector_expr: None,
                 metric: op_metric,
             },
         ));
     }
 
-    None
+    if pg_sys::contain_volatile_functions(value_node) || pg_sys::contain_var_clause(value_node) {
+        return None;
+    }
+    let serialized = {
+        let c_str = pg_sys::nodeToString(value_node.cast());
+        if c_str.is_null() {
+            return None;
+        }
+        let owned = std::ffi::CStr::from_ptr(c_str)
+            .to_string_lossy()
+            .into_owned();
+        pg_sys::pfree(c_str.cast());
+        owned
+    };
+    Some((
+        var_node,
+        SortExpressionType::VectorDistance {
+            query_vector: Vec::new(),
+            query_vector_param_id: None,
+            query_vector_expr: Some(serialized),
+            metric: op_metric,
+        },
+    ))
 }
 
 /// Extract FuncExpr from PlaceHolderVar node
@@ -623,6 +650,7 @@ where
                     SortExpressionType::VectorDistance {
                         ref query_vector,
                         query_vector_param_id,
+                        ref query_vector_expr,
                         metric,
                     } => {
                         if let Some(field_name) = field_name_opt {
@@ -632,6 +660,7 @@ where
                                 rti,
                                 query_vector: query_vector.clone(),
                                 query_vector_param_id,
+                                query_vector_expr: query_vector_expr.clone(),
                                 metric,
                             });
                             found_valid_member = true;

--- a/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
+++ b/pg_search/tests/pg_regress/expected/vector_search_pushdown.out
@@ -31,10 +31,10 @@ CREATE INDEX vsp_idx ON vsp
     USING bm25 (id, label, vec vector_l2_ops)
     WITH (key_field = id);
 -- match: <-> pushes down
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-                      QUERY PLAN                       
--------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Base Scan) on vsp
          Table: vsp
@@ -43,11 +43,10 @@ SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 
          Scores: false
             TopK Order By: vec <-> vector asc
             TopK Limit: 2
-         Full Index Scan: true
-         Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
  id 
 ----
   1
@@ -55,11 +54,11 @@ SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 
 (2 rows)
 
 -- mismatch: <=> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
-                         QUERY PLAN                          
--------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: ((vec <=> '[1,0,0]'::vector))
@@ -68,11 +67,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
                Index: vsp_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Full Index Scan: true
-               Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
  id 
 ----
@@ -81,11 +79,11 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (2 rows)
 
 -- mismatch: <#> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
-                         QUERY PLAN                          
--------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: ((vec <#> '[1,0,0]'::vector))
@@ -94,11 +92,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
                Index: vsp_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Full Index Scan: true
-               Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_l2_ops opclass (L2). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <-> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
  id 
 ----
@@ -114,11 +111,11 @@ CREATE INDEX vsp_idx ON vsp
     USING bm25 (id, label, vec vector_cosine_ops)
     WITH (key_field = id);
 -- mismatch: <-> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
-                         QUERY PLAN                          
--------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: ((vec <-> '[1,0,0]'::vector))
@@ -127,11 +124,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
                Index: vsp_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Full Index Scan: true
-               Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
  id 
 ----
@@ -140,10 +136,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (2 rows)
 
 -- match: <=> pushes down
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-                      QUERY PLAN                       
--------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Base Scan) on vsp
          Table: vsp
@@ -152,11 +148,10 @@ SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 
          Scores: false
             TopK Order By: vec <=> vector asc
             TopK Limit: 2
-         Full Index Scan: true
-         Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
  id 
 ----
   1
@@ -164,11 +159,11 @@ SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 
 (2 rows)
 
 -- mismatch: <#> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
-                         QUERY PLAN                          
--------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: ((vec <#> '[1,0,0]'::vector))
@@ -177,11 +172,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
                Index: vsp_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Full Index Scan: true
-               Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <#> (InnerProduct) operator but the index attribute was built with the vector_cosine_ops opclass (Cosine). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <=> (matching the index opclass), or rebuild the index with the vector_ip_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
  id 
 ----
@@ -197,11 +191,11 @@ CREATE INDEX vsp_idx ON vsp
     USING bm25 (id, label, vec vector_ip_ops)
     WITH (key_field = id);
 -- mismatch: <-> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
-                         QUERY PLAN                          
--------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: ((vec <-> '[1,0,0]'::vector))
@@ -210,11 +204,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
                Index: vsp_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Full Index Scan: true
-               Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <-> (L2) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_l2_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
  id 
 ----
@@ -223,11 +216,11 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (2 rows)
 
 -- mismatch: <=> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
-                         QUERY PLAN                          
--------------------------------------------------------------
+                                  QUERY PLAN                                  
+------------------------------------------------------------------------------
  Limit
    ->  Sort
          Sort Key: ((vec <=> '[1,0,0]'::vector))
@@ -236,11 +229,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
                Index: vsp_idx
                Exec Method: NormalScanExecState
                Scores: false
-               Full Index Scan: true
-               Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+               Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). Reason: ORDER BY uses the <=> (Cosine) operator but the index attribute was built with the vector_ip_ops opclass (InnerProduct). This may cause poor performance on large datasets. Remedies: Either change the ORDER BY operator to <#> (matching the index opclass), or rebuild the index with the vector_cosine_ops opclass on the vector column.. To disable this warning: SET paradedb.check_topk_scan = false (table: vsp)
  id 
 ----
@@ -249,10 +241,10 @@ WARNING:  Query has LIMIT 2 but is not using Top K scan (using Normal instead). 
 (2 rows)
 
 -- match: <#> pushes down
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-                      QUERY PLAN                       
--------------------------------------------------------
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Base Scan) on vsp
          Table: vsp
@@ -261,14 +253,60 @@ SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 
          Scores: false
             TopK Order By: vec <#> vector asc
             TopK Limit: 2
-         Full Index Scan: true
-         Tantivy Query: {"with_index":{"query":"all"}}
-(10 rows)
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
 
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
  id 
 ----
   1
+  2
+(2 rows)
+
+DROP INDEX vsp_idx;
+-- ============================================================
+-- Runtime query-vector operand (not a Const, not a Param)
+-- ============================================================
+-- A stable, Var-free operand such as current_setting(...)::vector must push
+-- down through TopK (evaluated once at execution start), and must reflect the
+-- GUC's current value rather than a stale plan-time fold.
+CREATE INDEX vsp_idx ON vsp
+    USING bm25 (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+SET vsp.q = '[1,0,0]';
+-- pushes down (Custom Scan / TopKScanExecState), not a Sort fallback
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all()
+    ORDER BY vec <=> current_setting('vsp.q')::vector LIMIT 2;
+                               QUERY PLAN                               
+------------------------------------------------------------------------
+ Limit
+   ->  Custom Scan (ParadeDB Base Scan) on vsp
+         Table: vsp
+         Index: vsp_idx
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: vec <=> vector asc
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"all":{"field":"id"}}}}
+(9 rows)
+
+-- ... and returns the same ranking as the equivalent literal
+SELECT id FROM vsp WHERE id @@@ pdb.all()
+    ORDER BY vec <=> current_setting('vsp.q')::vector LIMIT 2;
+ id 
+----
+  1
+  2
+(2 rows)
+
+-- changing the GUC changes the ranking (proves no stale plan-time fold)
+SET vsp.q = '[0,0,1]';
+SELECT id FROM vsp WHERE id @@@ pdb.all()
+    ORDER BY vec <=> current_setting('vsp.q')::vector LIMIT 2;
+ id 
+----
+  4
   2
 (2 rows)
 

--- a/pg_search/tests/pg_regress/sql/vector_search_pushdown.sql
+++ b/pg_search/tests/pg_regress/sql/vector_search_pushdown.sql
@@ -37,19 +37,19 @@ CREATE INDEX vsp_idx ON vsp
     WITH (key_field = id);
 
 -- match: <-> pushes down
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 
 -- mismatch: <=> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 
 -- mismatch: <#> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
 
 DROP INDEX vsp_idx;
 
@@ -62,19 +62,19 @@ CREATE INDEX vsp_idx ON vsp
     WITH (key_field = id);
 
 -- mismatch: <-> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 
 -- match: <=> pushes down
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 
 -- mismatch: <#> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
 
 DROP INDEX vsp_idx;
 
@@ -87,19 +87,47 @@ CREATE INDEX vsp_idx ON vsp
     WITH (key_field = id);
 
 -- mismatch: <-> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <-> '[1,0,0]' LIMIT 2;
 
 -- mismatch: <=> falls back, planner warns
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <=> '[1,0,0]' LIMIT 2;
 
 -- match: <#> pushes down
-EXPLAIN (COSTS OFF)
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
-SELECT id FROM vsp WHERE id @@@ paradedb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+SELECT id FROM vsp WHERE id @@@ pdb.all() ORDER BY vec <#> '[1,0,0]' LIMIT 2;
+
+DROP INDEX vsp_idx;
+
+
+-- ============================================================
+-- Runtime query-vector operand (not a Const, not a Param)
+-- ============================================================
+-- A stable, Var-free operand such as current_setting(...)::vector must push
+-- down through TopK (evaluated once at execution start), and must reflect the
+-- GUC's current value rather than a stale plan-time fold.
+CREATE INDEX vsp_idx ON vsp
+    USING bm25 (id, label, vec vector_cosine_ops)
+    WITH (key_field = id);
+
+SET vsp.q = '[1,0,0]';
+
+-- pushes down (Custom Scan / TopKScanExecState), not a Sort fallback
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id FROM vsp WHERE id @@@ pdb.all()
+    ORDER BY vec <=> current_setting('vsp.q')::vector LIMIT 2;
+-- ... and returns the same ranking as the equivalent literal
+SELECT id FROM vsp WHERE id @@@ pdb.all()
+    ORDER BY vec <=> current_setting('vsp.q')::vector LIMIT 2;
+
+-- changing the GUC changes the ranking (proves no stale plan-time fold)
+SET vsp.q = '[0,0,1]';
+SELECT id FROM vsp WHERE id @@@ pdb.all()
+    ORDER BY vec <=> current_setting('vsp.q')::vector LIMIT 2;
 
 DROP INDEX vsp_idx;
 


### PR DESCRIPTION
## What

The vector `ORDER BY` TopK pushdown only recognized a literal `Const` or a bound `PARAM_EXTERN` as the query vector. A stable, `Var`-free operand such as `current_setting('my.qvec')::vector` fell back to an exact `Sort` + full scan, so the bm25 vector index was never exercised.

This matters beyond the obvious GUC case: it's what lets a kNN benchmark (and any query that parameterizes the query vector via a session setting) actually drive the index. Verified before the fix: such a query planned as `Sort -> Custom Scan (NormalScanExecState)`.

## How

Recognize such an operand at planning time (`extract_vector_distance`): if it is non-volatile and free of `Var`s referencing the scan, serialize it with `nodeToString` and carry it on `OrderByInfo::VectorDistance.query_vector_expr`. At execution start the basescan deserializes it (`PreparedPgExpr`), `ExecInitExpr` + `ExecEvalExpr` it once against the scan's `ExprContext`, and writes the floats into `query_vector` — the same one-shot resolution already used for the `PARAM_EXTERN` path.

Evaluating at execution (rather than folding at plan time) keeps a cached generic plan correct: it re-reads the setting's current value instead of a stale plan-time constant. Metric-mismatch, volatile, and `Var` operands still fall back to a regular sort.

## Tests

New `vector_search_pushdown` case: `current_setting(...)::vector` pushes down to `TopKScanExecState`, returns the same ranking as the literal form, and tracks a mid-session GUC change (proving no stale fold).