### PR TITLE
ci: run lint and test workflows on target-patch-* branches

### DIFF
--- a/.github/workflows/check-typo.yml
+++ b/.github/workflows/check-typo.yml
@@ -6,6 +6,9 @@
 name: Check Typo
 
 on:
+  push:
+    branches:
+      - target-patch-*
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/lint-bash.yml
+++ b/.github/workflows/lint-bash.yml
@@ -6,6 +6,12 @@
 name: Lint Bash
 
 on:
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - "**/*.sh"
+      - ".github/workflows/lint-bash.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/lint-docker.yml
+++ b/.github/workflows/lint-docker.yml
@@ -6,6 +6,12 @@
 name: Lint Docker
 
 on:
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - ".github/workflows/lint-docker.yml"
+      - "docker/**"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/lint-format.yml
+++ b/.github/workflows/lint-format.yml
@@ -6,6 +6,9 @@
 name: Lint Format
 
 on:
+  push:
+    branches:
+      - target-patch-*
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -6,6 +6,13 @@
 name: Lint Markdown
 
 on:
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - "**/*.md"
+      - "**/*.mdx"
+      - ".github/workflows/lint-markdown.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/lint-rust.yml
+++ b/.github/workflows/lint-rust.yml
@@ -6,6 +6,13 @@
 name: Lint Rust
 
 on:
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - "**/*.rs"
+      - "**/*.toml"
+      - ".github/workflows/lint-rust.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/lint-yaml.yml
+++ b/.github/workflows/lint-yaml.yml
@@ -6,6 +6,13 @@
 name: Lint YAML
 
 on:
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - "**/*.yml"
+      - "**/*.yaml"
+      - ".github/workflows/lint-yaml.yml"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/test-pg_search-schema.yml
+++ b/.github/workflows/test-pg_search-schema.yml
@@ -6,6 +6,13 @@
 name: Test pg_search (Schema)
 
 on:
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - ".github/workflows/test-pg_search-schema.yml"
+      - "pg_search/**"
+      - "!pg_search/README.md"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/test-pg_search-upgrade.yml
+++ b/.github/workflows/test-pg_search-upgrade.yml
@@ -6,6 +6,14 @@
 name: Test pg_search (Upgrade)
 
 on:
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - ".github/workflows/test-pg_search-upgrade.yml"
+      - "pg_search/**"
+      - "tests/**"
+      - "tokenizers/**"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -9,6 +9,15 @@ on:
   # We run nightly to update the code coverage baseline without excessive post-PR runs
   schedule:
     - cron: "0 7 * * *" # daily 07:00 UTC (~2am ET)
+  push:
+    branches:
+      - target-patch-*
+    paths:
+      - ".github/workflows/test-pg_search.yml"
+      - "pg_search/**"
+      - "!pg_search/README.md"
+      - "tests/**"
+      - "tokenizers/**"
   pull_request:
     types: [opened, synchronize, reopened]
     paths:


### PR DESCRIPTION
## What

Adds a `push:` trigger for the `target-patch-*` branch glob to ten lint/test workflows, and fixes one stale path filter.

## Why

`paradedb/paradedb-enterprise` carries its enterprise patches on top of this repo and replays new community commits onto them. That sync pushes the result to a `target-patch-*` branch to run CI before promoting it to `main`, so the enterprise copies of these ten workflows each add a `push:` trigger for that glob.

That trigger is currently the **only** difference between the two copies of these files. Ten workflows drift for a purely mechanical reason, which makes every community edit to a trigger block a potential replay conflict. Carrying the trigger here makes the files byte-identical and removes that conflict surface — these are exactly the files community edits most often, so it is a recurring cost for no benefit.

This follows existing precedent: `test-pg_search-antithesis.yml` already branches on `github.repository == 'paradedb/paradedb-enterprise'` in this repo.

## This is inert here

- `push.branches` is only evaluated when a ref matching the glob is pushed, and no `target-patch-*` branch exists in `paradedb/paradedb`. No extra runs, no CI minutes, no new required-check entries.
- The existing concurrency groups key on `${{ github.head_ref || github.ref }}`, which already falls back to `github.ref` on `push` events, so no group collides.
- Diff is **63 insertions, 0 deletions**, across 10 files.

## Drive-by fix

The enterprise copy of `test-pg_search-schema.yml` filtered its push block on `.github/workflows/check-pg_search-schema-upgrade.yml` — a file that exists in **neither** repo, left over from an earlier rename. The `pull_request` block ten lines below it already uses the correct `test-pg_search-schema.yml`. Corrected here rather than enshrining a dead filter; `paradedb-enterprise` needs the same one-line fix for that file to go fully byte-identical.

## Verification

- All ten files parse, and each resolves to `push.branches == ["target-patch-*"]`.
- Nine of ten are now byte-identical to their `paradedb-enterprise` counterparts; the tenth differs only by the corrected path above.
- No `.yml` path filter in any touched push block points at a nonexistent file.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
