### PR TITLE
ci: guard community-only publish workflows by repository

### DIFF
--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -17,7 +17,11 @@ jobs:
   publish-pg_search-pgxn:
     name: Publish pg_search to PGXN
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.ref, '-rc.') }}
+    # PGXN distributes the AGPL community extension, so this only runs on
+    # paradedb/paradedb. The repository guard lets paradedb/paradedb-enterprise
+    # carry this file unchanged (the job is skipped there) instead of deleting it,
+    # which keeps the two repos from drifting. See also test-pg_search-antithesis.yml.
+    if: ${{ !contains(github.ref, '-rc.') && github.repository == 'paradedb/paradedb' }}
     container: pgxn/pgxn-tools
 
     steps:

--- a/.github/workflows/publish-pg_search-pgxn.yml
+++ b/.github/workflows/publish-pg_search-pgxn.yml
@@ -17,10 +17,7 @@ jobs:
   publish-pg_search-pgxn:
     name: Publish pg_search to PGXN
     runs-on: ubuntu-latest
-    # PGXN distributes the AGPL community extension, so this only runs on
-    # paradedb/paradedb. The repository guard lets paradedb/paradedb-enterprise
-    # carry this file unchanged (the job is skipped there) instead of deleting it,
-    # which keeps the two repos from drifting. See also test-pg_search-antithesis.yml.
+    # Only ParadeDB Community is shipped to PGXN
     if: ${{ !contains(github.ref, '-rc.') && github.repository == 'paradedb/paradedb' }}
     container: pgxn/pgxn-tools
 

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -34,7 +34,11 @@ jobs:
   publish-pg_search-postgresapp:
     name: Publish pg_search for Postgres.app (PostgreSQL ${{ matrix.pg_version }}, arm64)
     runs-on: macos-15
-    if: ${{ !contains(github.ref, '-rc.') }}
+    # Postgres.app distributes the AGPL community extension, so this only runs on
+    # paradedb/paradedb. The repository guard lets paradedb/paradedb-enterprise
+    # carry this file unchanged (the job is skipped there) instead of deleting it,
+    # which keeps the two repos from drifting. See also test-pg_search-antithesis.yml.
+    if: ${{ !contains(github.ref, '-rc.') && github.repository == 'paradedb/paradedb' }}
     strategy:
       matrix:
         # Postgres.app only supports loadable extensions installed in Application Support

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -34,10 +34,7 @@ jobs:
   publish-pg_search-postgresapp:
     name: Publish pg_search for Postgres.app (PostgreSQL ${{ matrix.pg_version }}, arm64)
     runs-on: macos-15
-    # Postgres.app distributes the AGPL community extension, so this only runs on
-    # paradedb/paradedb. The repository guard lets paradedb/paradedb-enterprise
-    # carry this file unchanged (the job is skipped there) instead of deleting it,
-    # which keeps the two repos from drifting. See also test-pg_search-antithesis.yml.
+    # Only ParadeDB Community is shipped to Postgres.app
     if: ${{ !contains(github.ref, '-rc.') && github.repository == 'paradedb/paradedb' }}
     strategy:
       matrix:


### PR DESCRIPTION
## What

Adds a `github.repository == 'paradedb/paradedb'` clause to the job guard on the two community-only publish workflows:

```diff
-    if: ${{ !contains(github.ref, '-rc.') }}
+    if: ${{ !contains(github.ref, '-rc.') && github.repository == 'paradedb/paradedb' }}
```

## Why

`paradedb/paradedb-enterprise` replays new community commits on top of its enterprise patches. Publishing the AGPL community extension to PGXN and Postgres.app is genuinely community-only, so enterprise currently **deletes both files outright** — `publish-pg_search-pgxn.yml` (41 lines) and `publish-pg_search-postgresapp.yml` (399 lines), **440 lines of permanent diff**.

But the *file* doesn't have to be community-only — only the *job* does. With a repository guard, enterprise can carry both files byte-identical and the job simply never runs there. That removes 440 lines of drift, and with it the recurring cost of re-resolving those deletions whenever community edits either workflow.

This follows existing precedent in this repo — `test-pg_search-antithesis.yml` already branches on `github.repository == 'paradedb/paradedb-enterprise'`.

## Behavior in this repo is unchanged

`github.repository` is literally `paradedb/paradedb` here, so the added clause is always true and the guard reduces to the existing `-rc.` check. Simulated across both repos and both tag shapes:

| repo | ref | result |
|---|---|---|
| `paradedb/paradedb` | `refs/tags/v0.24.3` | **runs** (unchanged) |
| `paradedb/paradedb` | `refs/tags/v0.24.3-rc.1` | skipped (unchanged) |
| `paradedb/paradedb-enterprise` | `refs/tags/v0.24.3` | skipped (new) |
| `paradedb/paradedb-enterprise` | `refs/tags/v0.24.3-rc.1` | skipped |

Each workflow has exactly one job, so one clause per file covers it. Skipped jobs never evaluate their `secrets` context, so the `PGXN_*` and Apple notarization secrets are not required to exist in enterprise.

## Note

This PR is the enabler, not the payoff: it does not shrink the diff on its own. A follow-up in `paradedb-enterprise` restores the two deleted files once this lands.

Companion to #5592, which removes the `target-patch-*` trigger drift from ten lint/test workflows.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
