### PR TITLE
ci(antithesis): share the suite setup helper with paradedb-enterprise

### DIFF
--- a/stressgres/suites/antithesis/helper_suite_setup.sh
+++ b/stressgres/suites/antithesis/helper_suite_setup.sh
@@ -18,12 +18,27 @@ rewrite_single() {
   sed -i 's|\[server\.style\.Automatic\]|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' "$1"
 }
 
-# Point a logical-replication suite's publisher at the vanilla Postgres pod (an upstream
-# primary we do not control) and its subscriber at paradedb-rw (the CNPG primary, has
-# pg_search).
-rewrite_pub_sub() {
+# Point a suite's publisher at the vanilla Postgres pod (an upstream primary we do not
+# control).
+rewrite_publisher() {
   sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Publisher"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@logical-replication-publisher:5432/postgres?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' "$1"
+}
+
+# Point a suite's subscriber at paradedb-rw (the CNPG primary, has pg_search).
+rewrite_subscriber() {
   sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "Subscriber"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-rw:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' "$1"
+}
+
+# Point a suite's WAL receiver at paradedb-ro, the CNPG read-only service. Enterprise runs a
+# 3-instance cluster, so paradedb-ro routes to a standby streaming from paradedb-rw.
+rewrite_wal_receiver() {
+  sed -i -z 's|\[server\.style\.Automatic\]\npostgresql_conf = "WalReceiver"|[server.style.With]\nconnection_string = "postgresql://postgres:antithesis-super-secret-password@paradedb-ro:5432/paradedb?connect_timeout=5\&keepalives=1\&keepalives_idle=5\&keepalives_interval=2\&keepalives_count=3\&tcp_user_timeout=15"|' "$1"
+}
+
+# Point a logical-replication suite at its publisher and subscriber.
+rewrite_pub_sub() {
+  rewrite_publisher  "$1"
+  rewrite_subscriber "$1"
 }
 
 # vanilla-postgres.toml hardcodes a localhost connection string rather than
@@ -40,10 +55,14 @@ setup() {
 
   echo ""
   echo "Pointing ${toml} at its cluster(s)..."
+  # A _phys topology adds a physical replica streaming from paradedb-rw: sub_phys is that
+  # WAL sender/receiver pair on its own, pub_sub_phys hangs it off a logical subscriber.
   case "${topology}" in
-    single)  rewrite_single  "${path}" ;;
-    pub_sub) rewrite_pub_sub "${path}" ;;
-    vanilla) rewrite_vanilla "${path}" ;;
+    single)       rewrite_single     "${path}" ;;
+    pub_sub)      rewrite_pub_sub    "${path}" ;;
+    vanilla)      rewrite_vanilla    "${path}" ;;
+    sub_phys)     rewrite_subscriber "${path}"; rewrite_wal_receiver "${path}" ;;
+    pub_sub_phys) rewrite_pub_sub    "${path}"; rewrite_wal_receiver "${path}" ;;
     *) echo "unknown topology: ${topology}" >&2; exit 1 ;;
   esac
 


### PR DESCRIPTION
## What

Adopts `paradedb-enterprise`'s version of `stressgres/suites/antithesis/helper_suite_setup.sh` verbatim, so the file stops drifting between the two repos. Two parts:

1. **A behavior-neutral refactor.** `rewrite_pub_sub` is split into `rewrite_publisher` + `rewrite_subscriber`, with `rewrite_pub_sub` composing the two.
2. **Two topologies this repo doesn't use yet.** `rewrite_wal_receiver`, plus the `sub_phys` / `pub_sub_phys` cases in `setup`.

## Why

`paradedb/paradedb-enterprise` replays new community commits on top of its enterprise patches. This helper is a *shared* file that this repo actively edits — #5563 refactored it three commits ago — and enterprise has to extend it for the physical-replication suites it runs on Antithesis. So every community change to it risks a replay conflict. Making the file identical removes that permanently.

## Part 1 is provably a no-op here

This repo's `first_` commands only ever pass `single`, `pub_sub`, and `vanilla`. I ran the current helper and this one over all seven of this repo's suites at their real topologies and diffed the rewritten TOMLs:

```
IDENTICAL  background-merge.toml            IDENTICAL  single-server.toml
IDENTICAL  bulk-updates.toml                IDENTICAL  vanilla-postgres.toml
IDENTICAL  logical-replication-merge.toml   IDENTICAL  wide-table.toml
IDENTICAL  logical-replication.toml
```

Same `sed` expressions, same order — `rewrite_pub_sub` just calls the two halves.

## Part 2 is dead code here, and that's the honest trade

`rewrite_wal_receiver` targets `paradedb-ro`, the CNPG read-only service, which only exists on a multi-instance cluster; this repo's Antithesis manifest runs `instances: 1`. Nothing here calls it — no `first_` command passes `sub_phys` or `pub_sub_phys` — so it never executes.

**The suites that use it can't come with it.** Physical replication is enterprise-gated: `custom_rmgr.rs`'s `rm_redo` aborts recovery on a standby with *"replicas are not supported on community and require paradedb enterprise"*. So `physical-replication.toml` and `physical-logical-replication.toml` and their `first_` scripts have to stay enterprise-only — they'd fail immediately here. Those are enterprise-only *new* files, which cost nothing at sync time; it's this *shared* file that generates the recurring conflicts.

So the cost is ~15 lines of currently-unused shell here, in exchange for a file that never conflicts again. Worth it, but flagging it plainly rather than burying it — if you'd rather not carry dead code, the alternative is upstreaming only Part 1, which cuts the drift roughly in half and is a pure win.

`shellcheck -S style` is clean.

Companion to #5592 and #5593.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
