### PR TITLE
ci: guard the ORM release notification by repository

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -396,7 +396,11 @@ jobs:
     name: Notify ORM Repos of New Release
     runs-on: ubuntu-latest
     needs: publish-paradedb-docker-image
-    if: ${{ !contains(github.event.inputs.version || github.ref, '-rc.') }}
+    # The ORM wrappers track community releases, so this only runs on
+    # paradedb/paradedb. The repository guard lets paradedb/paradedb-enterprise
+    # carry this job unchanged (it is skipped there) instead of deleting it,
+    # which keeps the two repos from drifting. See also test-pg_search-antithesis.yml.
+    if: ${{ !contains(github.event.inputs.version || github.ref, '-rc.') && github.repository == 'paradedb/paradedb' }}
     env:
       # ORM repos to notify on new releases
       ORM_REPOS: |


### PR DESCRIPTION
## What

Adds a `github.repository == 'paradedb/paradedb'` clause to the `notify-orm-repos` job guard in `publish-paradedb-docker.yml`.

```diff
-    if: ${{ !contains(github.event.inputs.version || github.ref, '-rc.') }}
+    if: ${{ !contains(github.event.inputs.version || github.ref, '-rc.') && github.repository == 'paradedb/paradedb' }}
```

## Why

`paradedb/paradedb-enterprise` replays new community commits on top of its enterprise patches. The ORM wrappers (`drizzle-paradedb`, `django-paradedb`, `sqlalchemy-paradedb`, `rails-paradedb`, `efcore-paradedb`) track community releases, so enterprise currently **deletes this entire job** — ~75 lines of standing diff in a file that is already the single most drifted workflow between the two repos.

The job doesn't need to be deleted, only skipped. With a repository guard, enterprise can carry it unchanged.

Follows existing precedent in this repo — `test-pg_search-antithesis.yml` already branches on `github.repository == 'paradedb/paradedb-enterprise'`.

## Behavior here is unchanged

`github.repository` is literally `paradedb/paradedb` in this repo, so the added clause is always true and the guard reduces to the existing `-rc.` check.

The only job depending on `notify-orm-repos` is `notify-slack-on-failure`, which is guarded by `always()` and tests `needs.notify-orm-repos.result == 'failure'`. A skipped job reports `'skipped'`, not `'failure'`, so nothing downstream changes here and enterprise gets no spurious Slack alert.

## Note

This is an enabler: it does not shrink the diff on its own. A follow-up in `paradedb-enterprise` restores the job once this lands. `publish-paradedb-docker.yml` will still drift on the Dockerfile-architecture split (`open-dockerfile-prs`, checksum resolution, image names), which is genuinely enterprise-only — this just removes the ~75 lines that aren't.

Companion to #5592, #5593, and #5594.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
