### PR TITLE
ci: derive the release repository from the github context

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -360,7 +360,7 @@ jobs:
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
-            /repos/paradedb/paradedb/releases/tags/v${{ steps.version.outputs.tag_version }})
+            /repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }})
           echo "REST API Response: $RESPONSE"
 
           UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url' | sed 's/{.*}//')

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -269,7 +269,7 @@ jobs:
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
-            /repos/paradedb/paradedb/releases/tags/v${{ steps.version.outputs.tag_version }})
+            /repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }})
           echo "REST API Response: $RESPONSE"
 
           UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url' | sed 's/{.*}//')

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -314,7 +314,7 @@ jobs:
           Release:        1%{?dist}
           Summary:        Full-text search for PostgreSQL using BM25
           License:        GNU Affero General Public License v3.0
-          URL:            https://github.com/paradedb/paradedb
+          URL:            ${{ github.server_url }}/${{ github.repository }}
 
           BuildRequires:  postgresql${{ matrix.pg_version }}-devel
           Requires:       postgresql${{ matrix.pg_version }}-server
@@ -367,7 +367,7 @@ jobs:
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
-            /repos/paradedb/paradedb/releases/tags/v${{ steps.version.outputs.tag_version }})
+            /repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }})
           echo "REST API Response: $RESPONSE"
 
           UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url' | sed 's/{.*}//')

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -347,7 +347,7 @@ jobs:
         run: |
           RESPONSE=$(gh api \
             -H "Authorization: token $GH_TOKEN" \
-            /repos/paradedb/paradedb/releases/tags/v${{ steps.version.outputs.tag_version }})
+            /repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }})
           echo "REST API Response: $RESPONSE"
 
           UPLOAD_URL=$(echo "$RESPONSE" | jq -r '.upload_url' | sed 's/{.*}//')


### PR DESCRIPTION
## What

Derives the release repository from the `github` context instead of hardcoding `paradedb/paradedb`, in the four `publish-pg_search-*` workflows.

```diff
-            /repos/paradedb/paradedb/releases/tags/v${{ steps.version.outputs.tag_version }})
+            /repos/${{ github.repository }}/releases/tags/v${{ steps.version.outputs.tag_version }})
```

and in the RHEL specfile:

```diff
-          URL:            https://github.com/paradedb/paradedb
+          URL:            ${{ github.server_url }}/${{ github.repository }}
```

5 lines across 4 files.

## Why

Two reasons.

**It's a latent bug here.** Hardcoding the repo slug means these workflows query *this* repo's releases even when run from a fork, rather than the repo they're running in.

**It removes drift.** `paradedb/paradedb-enterprise` replays new community commits on top of its enterprise patches, and has to patch each of these five lines to point at its own repo. Deriving them from context makes the lines identical in both repos.

## Provably a no-op in both repos

`github.repository` is literally `paradedb/paradedb` here and `github.server_url` is `https://github.com`, so every touched line renders to exactly its current value:

```
/repos/paradedb/paradedb/releases/tags/v${{ steps.version.outputs.tag_version }})
URL:            https://github.com/paradedb/paradedb
```

And in enterprise the same lines render to exactly what that repo hardcodes today (`/repos/paradedb/paradedb-enterprise/...`, `https://github.com/paradedb/paradedb-enterprise`) — so it's a no-op there too, just without the patch.

The RHEL `URL:` sits inside a `cat <<EOF > $spec_file` heredoc in a `run:` block; adjacent lines already interpolate `${{ matrix.pg_version }}` and `${{ steps.version.outputs.tag_version }}`, so expressions are evaluated there.

## Deliberately not touched

`publish-pg_search-debian.yml` and `publish-pg_search-ubuntu.yml` also hardcode `Source: https://github.com/paradedb/paradedb` in their control files — but those lines **do not drift** (enterprise leaves them pointing here), so templating them would silently change enterprise's package metadata. Out of scope; flagging in case that asymmetry with RHEL's `URL:` is unintentional.

These four files will still drift on the `-enterprise` package asset names, which is a genuine product distinction and should stay.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
