### PR TITLE
ci(antithesis): derive the workload image name from the repository

### DIFF
--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -285,10 +285,7 @@ jobs:
         with:
           ref: ${{ env.COMMIT_SHA }}
 
-      # The workload image and the run's `antithesis.source` are named after the repository,
-      # so a fork or downstream repo builds, pushes and triggers against its own image
-      # rather than this one. $GITHUB_REPOSITORY is `owner/name` and is set for every
-      # trigger, including `schedule`, whose event payload is empty.
+      # The workload image and the run's `antithesis.source` are named after the repository
       - name: Resolve Registry Image Name From Repository
         run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
 

--- a/.github/workflows/test-pg_search-antithesis.yml
+++ b/.github/workflows/test-pg_search-antithesis.yml
@@ -285,6 +285,13 @@ jobs:
         with:
           ref: ${{ env.COMMIT_SHA }}
 
+      # The workload image and the run's `antithesis.source` are named after the repository,
+      # so a fork or downstream repo builds, pushes and triggers against its own image
+      # rather than this one. $GITHUB_REPOSITORY is `owner/name` and is set for every
+      # trigger, including `schedule`, whose event payload is empty.
+      - name: Resolve Registry Image Name From Repository
+        run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -309,7 +316,7 @@ jobs:
         id: extract-workload-metadata
         uses: docker/metadata-action@v6
         with:
-          images: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/paradedb
+          images: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/${{ env.REPO_NAME }}
           tags: |
             type=raw,value=${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}
             type=raw,value=antithesis-latest
@@ -331,7 +338,7 @@ jobs:
       - name: Patch ParadeDB K8s Manifest With Workload Image Tagged With Git SHA
         working-directory: docker/manifests/
         run: |
-          sed -i "s|imageName: .*|imageName: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/paradedb:${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}|" antithesis-paradedb.yaml
+          sed -i "s|imageName: .*|imageName: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/${{ env.REPO_NAME }}:${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}|" antithesis-paradedb.yaml
           cat antithesis-paradedb.yaml
 
       - name: Patch Driver K8s Manifest With Driver Image Tagged With Git SHA
@@ -397,13 +404,13 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GITHUB_TOKEN }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/paradedb-config-${{ matrix.workload }}:${{ env.COMMIT_SHA }}
-          images: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/paradedb:${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}
+          images: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/${{ env.REPO_NAME }}:${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}
           description: "[${{ github.repository }}] ${{ matrix.workload }} CI for ${{ github.ref_name }} (commit ${{ env.COMMIT_SHA }})"
           email_recipients: ${{ github.event.inputs.emails || 'developers@paradedb.com' }}
           additional_parameters: |-
             antithesis.duration=${{ github.event.inputs.duration || (github.event_name == 'pull_request' && '60') || '360' }}
             antithesis.is_ephemeral=${{ github.event_name == 'pull_request' }}
-            antithesis.source=paradedb
+            antithesis.source=${{ env.REPO_NAME }}
             custom.network_fault_exclusion_patterns=coredns,${{ matrix.workload }},logical-replication-publisher
             custom.container_faults_stop_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher
             custom.container_faults_kill_exclusion_patterns=coredns,${{ matrix.workload }}${{ matrix.workload == 'proptests' && ',paradedb' || '' }},cloudnative-pg,logical-replication-publisher


### PR DESCRIPTION
## What

Derives the Antithesis workload image name and `antithesis.source` from the repository, instead of hardcoding `paradedb` in four places.

```yaml
- name: Resolve Registry Image Name From Repository
  run: echo "REPO_NAME=${GITHUB_REPOSITORY#*/}" >> "$GITHUB_ENV"
```

```diff
-          images: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/paradedb
+          images: us-central1-docker.pkg.dev/molten-verve-216720/paradedb-repository/${{ env.REPO_NAME }}
```

## Why

The workload image and the run's `antithesis.source` are named after the repository, so a fork or downstream repo has to patch these four lines to build, push and trigger against its own image rather than this one. Deriving the name means nobody has to.

## Provably a no-op here

`$GITHUB_REPOSITORY` is `paradedb/paradedb` in this repo, so `${GITHUB_REPOSITORY#*/}` is `paradedb` and all four touched lines render to exactly their current values:

```
images: .../paradedb-repository/paradedb
sed -i "s|imageName: .*|imageName: .../paradedb-repository/paradedb:${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}|" antithesis-paradedb.yaml
images: .../paradedb-repository/paradedb:${{ env.PG_VERSION }}-${{ env.COMMIT_SHA }}
antithesis.source=paradedb
```

## Why a shell step rather than an expression

`github.repository` is `owner/name`, and the image path needs just `name` — but Actions expressions have no `split()`/`replace()`, so the owner can't be stripped inline.

`${{ github.event.repository.name }}` would give the bare name, but `github.event` is the event payload and the docs list the `schedule` event's payload as [*"Not applicable"*](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#schedule). This workflow has a `schedule` trigger, and an empty render there would silently push to `paradedb-repository/:18-<sha>`. `$GITHUB_REPOSITORY` is a [default environment variable](https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables) set for every trigger, so the shell expansion can't be caught out that way — and it keeps the derivation generic, with no repository names hardcoded anywhere.

All four usages are in the `antithesis-trigger-test-run` job, so one step covers them; it is ordered before the first use. `shellcheck` clean.

## Scope

Only the four lines that actually vary by repo. The `paradedb-config-${{ matrix.workload }}` references (lines 347, 399) are **not** touched — that image name is the same everywhere.

Companion to #5592, #5593, #5594, #5595 and #5596.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
