### PR TITLE
docs: Add Heroku deployment page explaining ephemeral-dyno limitation

### DIFF
--- a/docs/deploy/cloud-platforms/heroku.mdx
+++ b/docs/deploy/cloud-platforms/heroku.mdx
@@ -1,0 +1,51 @@
+---
+title: Heroku
+description: Notes on running ParadeDB on Heroku, and why a persistent-volume PaaS is a better fit
+canonical: https://docs.paradedb.com/deploy/cloud-platforms/heroku
+---
+
+<Warning>
+  Heroku is **not recommended** for self-hosted ParadeDB. Heroku dynos have an
+  [ephemeral filesystem](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem):
+  any data written locally is discarded when the dyno restarts, which Heroku
+  does at least once every 24 hours. That is fundamentally incompatible with
+  ParadeDB's on-disk storage under `/var/lib/postgresql`.
+
+  If you need Postgres-compatible search on Heroku, you have two realistic
+  options:
+
+  1. Use a persistent-volume PaaS instead (see the alternatives below).
+  2. Run ParadeDB somewhere with real block storage and connect to it from
+     your Heroku app as an external database.
+</Warning>
+
+## Why Heroku's Model Doesn't Fit
+
+Heroku dynos are single-slug Docker containers with a **read-only application slug** and a **writable but ephemeral** `/tmp` and working directory. There is no persistent block-storage attachment for standard dynos.
+
+ParadeDB, in contrast, is a stateful Postgres image whose entire correctness relies on the data directory at `/var/lib/postgresql` surviving container restarts. Every time Heroku recycles the dyno (at minimum daily), that directory would be wiped and the database re-initialized from scratch.
+
+This is not a configuration issue you can work around inside the Heroku container model — it is a mismatch between "stateless request handler" and "long-lived database process".
+
+## Recommended Alternatives
+
+Persistent-volume PaaS platforms that run the `paradedb/paradedb` Docker image without this problem:
+
+- **[Fly.io](/deploy/cloud-platforms/fly-io)** — Fly volumes mount into machines; Heroku-like git-and-deploy UX
+- **[Render](/deploy/cloud-platforms/render)** — persistent disks attached to private services; one-click blueprint available
+- **[Railway](/deploy/cloud-platforms/railway)** — persistent volumes and TCP proxies; one-click template available
+- **[DigitalOcean Droplet](/deploy/cloud-platforms/digitalocean)** — full VM control with the `install.sh` bootstrapper
+
+Any of these preserves ParadeDB's data across restarts and redeploys.
+
+## If You Must Use Heroku
+
+The only supported pattern is to run ParadeDB **outside** Heroku on a persistent-volume host (any of the platforms above), then connect to it from your Heroku app the same way you'd connect to any external Postgres:
+
+```bash
+heroku config:set DATABASE_URL="postgres://postgres:<YOUR_STRONG_PASSWORD>@<PARADEDB_HOST>:5432/paradedb" -a <YOUR_HEROKU_APP>
+```
+
+Your application code uses `DATABASE_URL` as it would with any Postgres backend; ParadeDB's BM25 and columnar features are available through the standard Postgres wire protocol.
+
+For fully managed production use with high availability, replicas, and BYOC, see [ParadeDB Enterprise](/deploy/enterprise).

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -313,7 +313,8 @@
                     "pages": [
                       "deploy/cloud-platforms/railway",
                       "deploy/cloud-platforms/render",
-                      "deploy/cloud-platforms/digitalocean"
+                      "deploy/cloud-platforms/digitalocean",
+                      "deploy/cloud-platforms/heroku"
                     ]
                   },
                   {


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #4618

## What

Adds `docs/deploy/cloud-platforms/heroku.mdx` — a Heroku page that honestly explains why Heroku is not a good fit for self-hosted ParadeDB (ephemeral dynos + daily restarts wipe `/var/lib/postgresql`), then points users at the persistent-volume PaaS alternatives and documents the only supported pattern (run ParadeDB elsewhere, connect from the Heroku app via `DATABASE_URL`).

## Why

#4618 asks for Heroku docs. Rather than skip it or ship an incorrect "how to deploy ParadeDB on Heroku dynos" page that would silently lose users' data on the first dyno restart, this page closes the issue by answering the underlying question ("can I use Heroku?") accurately.

## How

The page uses a `<Warning>` block up front so users immediately see the recommendation, then explains the fundamental incompatibility (dyno ephemeral filesystem vs. Postgres data directory), links to the four persistent-volume PaaS pages that DO work (Fly.io, Render, Railway, DigitalOcean), and documents the "external ParadeDB + Heroku app connects via DATABASE_URL" pattern for users who need to keep their app on Heroku.

Also registers the page in `docs/docs.json` under the "Cloud Platforms" group so it renders in the Mintlify sidebar alongside the other cloud-platform pages.

Docs-only change; no code impact.

## Tests

N/A — content-only Mintlify `.mdx` + single-line JSON navigation update. `docs/docs.json` remains valid JSON. The Heroku ephemeral-filesystem behavior cited is documented in [Heroku's own dyno docs](https://devcenter.heroku.com/articles/dynos#ephemeral-filesystem). The internal cross-links (`/deploy/cloud-platforms/fly-io`, `/render`, `/railway`, `/digitalocean`) resolve against the existing sidebar structure.

<sub>Note: this is the same batch as #5599 (Fly.io) and #5600 (Dokku), all editing the same `Cloud Platforms` group in `docs/docs.json`. Whichever merges first, the others will need a trivial rebase. Happy to rebase whenever.</sub>
