### PR TITLE
ci: fix the stale sync branch name in a comment

### DIFF
--- a/.github/workflows/test-pg_search-docker.yml
+++ b/.github/workflows/test-pg_search-docker.yml
@@ -79,7 +79,7 @@ jobs:
       # paradedb/paradedb this is always already published (the release workflow only commits
       # the regenerated Dockerfiles *after* the .deb is uploaded — see PR #4967), so this gate
       # is a no-op here. In the enterprise rebase, however, the regenerated Dockerfiles for a
-      # new version land on the enterprise-patch-* branch *before* that version's enterprise
+      # new version land on the target-patch-* branch *before* that version's enterprise
       # release and its .deb exist, so the image cannot build yet. Detect that pre-release
       # window and skip the smoke test; it runs normally once the referenced release is out.
       - name: Check whether the referenced pg_search release is published


### PR DESCRIPTION
## What

One word: the sync branch this comment names was renamed, and this copy was missed.

```diff
-      # new version land on the enterprise-patch-* branch *before* that version's enterprise
+      # new version land on the target-patch-* branch *before* that version's enterprise
```

## Why

`enterprise-patch-*` no longer exists. The branch is created by `sync-core.sh` in `paradedb/actions`, which only ever names it `target-patch-*`:

```bash
PATCH_BRANCH_NAME="target-patch-$(date -u +%Y-%m-%d-%H%M%S)"
...
if ! [[ "$BRANCH_NAME" =~ ^target-patch-[0-9]{4}-[0-9]{2}-[0-9]{2}-[0-9]{6}$ ]]; then
```

This comment is the only remaining reference to the old name in this repo — `git grep enterprise-patch` returns nothing after this change.

`paradedb/paradedb-enterprise` corrected its copy when the rename happened, so this line is also 2 lines of permanent, pointless drift between the two repos: the comment is identical on either side of it.

Doc-only; no behavior change.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
