### PR TITLE
ci: derive the published Docker image names from the repository

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -5,7 +5,7 @@
 # the pg_search .deb has been published to GitHub Releases. Stable releases publish Docker images for
 # all of our supported PostgreSQL versions, while beta releases only publish the default PostgreSQL
 # version we run as default (currently 18). This workflow also publishes the non-runnable
-# paradedb/paradedb-extension image for Postgres 18+ deployments that mount Postgres extension images.
+# extension image for Postgres 18+ deployments that mount Postgres extension images.
 # Once the runnable Docker images are published, notify ORM wrapper repositories via repository_dispatch
 # so they can run compatibility checks against the new version. This is done in
 # `publish-paradedb-docker.yml` since ORM integration tests are run against our Docker image.
@@ -201,7 +201,10 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: paradedb/paradedb
+          # Named after the repository, so a downstream repo publishes its own image rather
+          # than this one. `workflow_dispatch` is this workflow's only trigger, so the event
+          # payload is always populated.
+          images: paradedb/${{ github.event.repository.name }}
           tags: |
             type=raw,value=${{ matrix.pg_version }}-${{ needs.generate-dockerfiles.outputs.tag }}
             type=raw,value=${{ needs.generate-dockerfiles.outputs.tag }}-pg${{ matrix.pg_version }}
@@ -252,7 +255,11 @@ jobs:
         # see a mounted /share/extension directory.
         pg_version: [18]
     env:
-      image_name: paradedb/paradedb-extension
+      # Named after the repository, so a downstream repo publishes its own image rather than
+      # this one. Job-level `env:` cannot read the `env` context, so this derives from
+      # `github.event.repository.name`; `workflow_dispatch` is this workflow's only trigger,
+      # so the event payload is always populated.
+      image_name: paradedb/${{ github.event.repository.name }}-extension
       image_os: trixie
 
     steps:

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -201,9 +201,6 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          # Named after the repository, so a downstream repo publishes its own image rather
-          # than this one. `workflow_dispatch` is this workflow's only trigger, so the event
-          # payload is always populated.
           images: paradedb/${{ github.event.repository.name }}
           tags: |
             type=raw,value=${{ matrix.pg_version }}-${{ needs.generate-dockerfiles.outputs.tag }}
@@ -255,10 +252,6 @@ jobs:
         # see a mounted /share/extension directory.
         pg_version: [18]
     env:
-      # Named after the repository, so a downstream repo publishes its own image rather than
-      # this one. Job-level `env:` cannot read the `env` context, so this derives from
-      # `github.event.repository.name`; `workflow_dispatch` is this workflow's only trigger,
-      # so the event payload is always populated.
       image_name: paradedb/${{ github.event.repository.name }}-extension
       image_os: trixie
 


### PR DESCRIPTION
## What

Derives the two published Docker image names from the repository instead of hardcoding `paradedb`, and drops a repo-specific image name from the header comment.

```diff
-          images: paradedb/paradedb
+          images: paradedb/${{ github.event.repository.name }}

-      image_name: paradedb/paradedb-extension
+      image_name: paradedb/${{ github.event.repository.name }}-extension
```

## Why

Both names already follow the `paradedb/<repo-name>` pattern, so this is the same idea as #5596 (release repo) and #5597 (Antithesis workload image): a downstream repo publishes its own image rather than patching these lines every sync. `paradedb/paradedb-enterprise` currently carries all three as standing drift.

## Provably a no-op here

`github.event.repository.name` is literally `paradedb` in this repo, so both lines render to exactly their current values:

```
images: paradedb/paradedb
image_name: paradedb/paradedb-extension
```

And in `paradedb-enterprise` they render to exactly what that repo hardcodes today (`paradedb/paradedb-enterprise`, `paradedb/paradedb-enterprise-extension`) — so it's a no-op there too, just without the patch.

## Why `github.event.repository.name` here

#5597 deliberately avoided this expression and used `${GITHUB_REPOSITORY#*/}` in a step, because that workflow has a `schedule` trigger whose payload the docs list as *"Not applicable"* — an empty render would have silently produced a broken image name.

That doesn't apply here: **`workflow_dispatch` is this workflow's only trigger**, so the event payload is always populated. And the step trick isn't available anyway — `image_name` sits in a job-level `env:`, which cannot read the `env` context, so it must come from `github`.

## Scope

Only the lines that vary by repo. The header comment loses `paradedb/paradedb-extension` in favour of "the non-runnable extension image", since naming one repo's image in shared documentation is what made it drift.

`file: docker/Dockerfile.paradedb-${{ matrix.pg_version }}` and `docker/Dockerfile.extension` are **not** touched: community renders a Dockerfile per Postgres version (Docker Official Images does not support build args), while downstreams may ship a single build-arg Dockerfile. That is an architecture difference, not a naming one.

https://claude.ai/code/session_01SSAhtREnw1jbvSek8puC8T
