### PR TITLE
ci: cover the composite actions in dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,6 @@
 version: 2
 
 updates:
-  # "/" only reaches .github/workflows; the composite actions under .github/actions/*/action.yml
-  # need their own entry. Single-level glob, not **, to avoid duplicate PRs
-  # (dependabot/dependabot-core#10884).
   - package-ecosystem: "github-actions"
     directories:
       - "/.github/actions/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,13 @@
 version: 2
 
 updates:
+  # "/" only reaches .github/workflows; the composite actions under .github/actions/*/action.yml
+  # need their own entry. Single-level glob, not **, to avoid duplicate PRs
+  # (dependabot/dependabot-core#10884).
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "monthly"
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "github-actions"
     directories:
       - "/.github/actions/*"
-      - "/.github/workflows/*"
+      - "/.github/workflows"
     schedule:
       interval: "monthly"
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,8 @@ updates:
   # (dependabot/dependabot-core#10884).
   - package-ecosystem: "github-actions"
     directories:
-      - "/"
       - "/.github/actions/*"
+      - "/.github/workflows/*"
     schedule:
       interval: "monthly"
     ignore:


### PR DESCRIPTION
## What

`github-actions` goes from `directory: "/"` to `directories: ["/", "/.github/actions/*"]`. From the same org-wide audit as paradedb/cloud#305.

## Why

`directory: "/"` only reaches `.github/workflows` (and a root `action.yml`) — it does not recurse into `.github/actions`. So the third-party actions pinned inside our five composite actions (`benchmark-queries`, `benchmark-stressgres`, `benchmarks-from-main`, `setup-benchmark-cluster`, `test-pg_search-upgrade`) have never been offered an update, while the ones in `.github/workflows` have been getting bumped monthly.

`/.github/actions/*` is a single-level glob rather than `**` to avoid the github-actions globstar duplicate-PR issue ([dependabot-core#10884](https://github.com/dependabot/dependabot-core/issues/10884)), matching cloud#305.

## Note — not changing, but worth knowing

The `cargo` and `docker` entries in this file are commented out. I left them alone since that reads as deliberate, but if they're ever re-enabled the shape has drifted:

- The commented cargo entries point at `/pg_search` and `/tokenizers`. **`tokenizers` no longer exists**, and the repo is now a workspace rooted at `/` with six members, so a single `cargo: "/"` entry would cover all of them.
- The commented docker entry points at `/docker`, which still matches the 15 Dockerfiles there.

Happy to open a separate PR re-enabling either if you want them back — that's a noise/benefit call I didn't want to make inside a coverage fix.

## Tests

Prettier-clean, parses under `yq`, and `/.github/actions/*` expands to exactly the five composite-action directories present. Dependabot behavior can't be exercised locally; the real proof is the next monthly run.

https://claude.ai/code/session_01Mzkzx3hJsXN26mZZ8RXdEX