### PR TITLE
chore: Show regress diff on CI failure

### DIFF
--- a/.github/workflows/test-pg_search.yml
+++ b/.github/workflows/test-pg_search.yml
@@ -292,10 +292,13 @@ jobs:
         if: matrix.pg_impl == 'pgrx'
         run: |
           set -e
-          cargo pgrx regress --package pg_search pg${{ matrix.pg_version }} --auto
-          # `--auto` promotes any output diff into the working tree, so a zero exit code
-          # doesn't mean the baselines matched. Fail if anything was promoted.
-          git diff --exit-code
+          # `--auto` promotes test diffs into the working tree, but the command still exits
+          # with a non-zero status code on failure. We catch this failure to print the diffs
+          # so they show up in CI, and then manually exit with an error.
+          cargo pgrx regress --package pg_search pg${{ matrix.pg_version }} --auto || {
+            git diff
+            exit 1
+          }
 
       - name: Stop PostgreSQL to flush coverage data (pgrx)
         if: matrix.pg_impl == 'pgrx' && always()


### PR DESCRIPTION
Currently, regress failures do not render their diffs, because `--auto` will fail with a non-zero exit code, causing `set -e` to exit the script before diff rendering: see https://github.com/paradedb/paradedb/actions/runs/29598321405/job/87944061118?pr=5542

Instead, catch the failure of `--auto` and render the diff.