### PR TITLE
fix: Render metrics in aggregatescan `EXPLAIN ANALYZE`.

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -42,7 +42,11 @@ use std::sync::Arc;
 
 use crate::postgres::catalog::is_ltree_oid;
 
+use crate::postgres::customscan::datafusion::explain::{
+    explain_physical_plan, get_plan_with_merged_metrics,
+};
 use datafusion::execution::TaskContext;
+use datafusion::physical_plan::ExecutionPlan;
 
 use datafusion_distributed::{DistributedExt, DistributedTaskContext};
 
@@ -629,11 +633,7 @@ impl CustomScan for AggregateScan {
 
     fn shutdown_custom_scan(state: &mut CustomScanStateWrapper<Self>) {
         // Drop the gather stream first (fires the leader-inbox detach on an early-terminated LIMIT
-        // query so blocked producers stop), then wait for the workers to finish and flush their
-        // `TaskMetrics`: `recv` blocks until every worker detaches its completion queue, which it
-        // does only after sending metrics. The builder-launched workers need this explicit join so
-        // the metrics land before the EXPLAIN render (which runs before end_custom_scan, where the
-        // context is finally destroyed). Harmless when the gather already reached EOF.
+        // query so blocked producers stop).
         if let Some(df_state) = state.custom_state_mut().datafusion_state.as_mut() {
             df_state.stream = None;
             // Release the DSM-backed control senders before `recv`. A producer's `work_mem`
@@ -658,6 +658,9 @@ impl CustomScan for AggregateScan {
                     );
                 }
             }
+            // Join the producer workers so their metrics land before the EXPLAIN render (which runs
+            // before end_custom_scan, where the context is finally destroyed). A worker error is
+            // re-raised from inside `recv`.
             if let Some(leader) = df_state.mpp.leader_mut() {
                 if let Some(finish) = leader.finish.as_mut() {
                     let _ = finish.recv();
@@ -949,80 +952,77 @@ impl AggregateScan {
         )
     }
 
-    /// Rebuild and render the DataFusion physical plan into the explainer.
-    /// Used only by plain EXPLAIN (no ANALYZE); EXPLAIN ANALYZE would cache
-    /// the executing plan separately.
+    /// Rebuild or retrieve the DataFusion physical plan for EXPLAIN rendering.
     ///
-    /// When `mpp_is_active()` we rebuild with the same distributed planner
-    /// the leader will run with, attached to a drain-less stub mesh — the
-    /// planner only consults the mesh's worker count, not the actual
-    /// `shm_mq` queues, so the stub is enough to produce a `DistributedExec`
-    /// root. That lets us render via `datafusion_distributed::display_plan_ascii`
-    /// Rebuild and render the DataFusion physical plan for EXPLAIN.
-    /// In EXPLAIN ANALYZE, the plan is already built and contains execution metrics.
-    /// In plain EXPLAIN, we must rebuild the plan.
+    /// In EXPLAIN ANALYZE, the plan is already built (cached on the execution state)
+    /// and contains execution metrics. We merge in MPP worker metrics if applicable.
+    ///
+    /// In plain EXPLAIN, execution hasn't happened, so we must rebuild the physical plan.
+    /// When `mpp_is_active()` we rebuild with the same distributed planner the leader
+    /// will run with, attached to a drain-less stub mesh. The planner only consults
+    /// the mesh's worker count, not the actual `shm_mq` queues, so the stub is enough
+    /// to produce a `DistributedExec` root. That lets us render the stage boxes via
+    /// `datafusion_distributed::display_plan_ascii`.
     fn render_df_physical_plan(
         df_state: &scan_state::DataFusionAggState,
         explainer: &mut Explainer,
     ) {
-        let plan: std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan> =
-            if explainer.is_analyze() {
-                let Some(plan) = df_state.physical_plan.clone() else {
-                    return;
-                };
-                let merged = match (df_state.mpp.leader(), df_state.runtime.as_ref()) {
-                    (Some(_), Some(_runtime)) => {
-                        crate::postgres::customscan::mpp::glue::merge_worker_metrics(&plan)
-                    }
-                    _ => None,
-                };
-                merged.unwrap_or(plan)
-            } else {
-                let custom_exprs = df_state.custom_exprs;
-                let custom_scan_tlist = df_state.custom_scan_tlist;
-                let ctx = if mpp_is_active() {
-                    // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
-                    // The shared session-context builder takes `mesh = None` and derives `n_workers`
-                    // from `producer_worker_count()`, so the planner still emits a `DistributedExec`
-                    // root with the right stage sizing for display.
-                    Self::build_mpp_session_context(None)
-                } else {
-                    create_aggregate_session_context()
-                };
-                let Ok(runtime) = tokio::runtime::Builder::new_current_thread().build() else {
-                    explainer.add_text("DataFusion Plan", "(tokio runtime unavailable)");
-                    return;
-                };
-                let plan_result = runtime.block_on(async {
-                    let (logical, _) = build_join_aggregate_plan(
-                        &df_state.plan,
-                        &df_state.targetlist,
-                        df_state.topk.as_ref(),
-                        &df_state.join_level_predicates,
-                        custom_exprs,
-                        custom_scan_tlist,
-                        df_state.having_filter.as_ref(),
-                        &ctx,
-                        None,
-                        None,
-                        None,
-                    )
-                    .await?;
-                    build_physical_plan(&ctx, logical).await
-                });
-                match plan_result {
-                    Ok(p) => p,
-                    Err(e) => {
-                        explainer.add_text(
-                            "DataFusion Plan",
-                            format!("(rebuild failed during EXPLAIN: {e})"),
-                        );
-                        return;
-                    }
-                }
+        let plan: Arc<dyn ExecutionPlan> = if explainer.is_analyze() {
+            let Some(plan) = df_state.physical_plan.clone() else {
+                return;
             };
+            get_plan_with_merged_metrics(
+                &plan,
+                df_state.mpp.leader().is_some(),
+                df_state.runtime.is_some(),
+                explainer,
+            )
+        } else {
+            let custom_exprs = df_state.custom_exprs;
+            let custom_scan_tlist = df_state.custom_scan_tlist;
+            let ctx = if mpp_is_active() {
+                // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
+                // The shared session-context builder takes `mesh = None` and derives `n_workers`
+                // from `producer_worker_count()`, so the planner still emits a `DistributedExec`
+                // root with the right stage sizing for display.
+                Self::build_mpp_session_context(None)
+            } else {
+                create_aggregate_session_context()
+            };
+            let Ok(runtime) = tokio::runtime::Builder::new_current_thread().build() else {
+                explainer.add_text("DataFusion Plan", "(tokio runtime unavailable)");
+                return;
+            };
+            let plan_result = runtime.block_on(async {
+                let (logical, _) = build_join_aggregate_plan(
+                    &df_state.plan,
+                    &df_state.targetlist,
+                    df_state.topk.as_ref(),
+                    &df_state.join_level_predicates,
+                    custom_exprs,
+                    custom_scan_tlist,
+                    df_state.having_filter.as_ref(),
+                    &ctx,
+                    None,
+                    None,
+                    None,
+                )
+                .await?;
+                build_physical_plan(&ctx, logical).await
+            });
+            match plan_result {
+                Ok(p) => p,
+                Err(e) => {
+                    explainer.add_text(
+                        "DataFusion Plan",
+                        format!("(rebuild failed during EXPLAIN: {e})"),
+                    );
+                    return;
+                }
+            }
+        };
 
-        crate::postgres::customscan::datafusion::explain::explain_physical_plan(plan, explainer);
+        explain_physical_plan(&plan, explainer);
     }
 
     /// Existing single-table Tantivy aggregate path.

--- a/pg_search/src/postgres/customscan/aggregatescan/mod.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/mod.rs
@@ -43,10 +43,8 @@ use std::sync::Arc;
 use crate::postgres::catalog::is_ltree_oid;
 
 use datafusion::execution::TaskContext;
-use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::{
-    display_plan_ascii, DistributedExec, DistributedExt, DistributedTaskContext,
-};
+
+use datafusion_distributed::{DistributedExt, DistributedTaskContext};
 
 use datafusion_distributed::shm::MppMesh;
 
@@ -430,11 +428,6 @@ impl CustomScan for AggregateScan {
     ) {
         if state.custom_state().is_datafusion_backend() {
             explainer.add_text("Backend", "DataFusion");
-            if explainer.is_analyze() {
-                if let Some(ref df_state) = state.custom_state().datafusion_state {
-                    Self::render_executed_plan_with_metrics(df_state, explainer);
-                }
-            }
             if let Some(ref df_state) = state.custom_state().datafusion_state {
                 // Show indexes from the join tree sources
                 let indexes: Vec<String> = df_state
@@ -965,108 +958,71 @@ impl AggregateScan {
     /// planner only consults the mesh's worker count, not the actual
     /// `shm_mq` queues, so the stub is enough to produce a `DistributedExec`
     /// root. That lets us render via `datafusion_distributed::display_plan_ascii`
-    /// and surface the boxed `Stage N — Tasks: t0:[p0..pN]` topology the
-    /// executor will actually run. When MPP is off we fall back to the
-    /// serial context and the standard `displayable().indent(false)` tree.
-    ///
-    /// Failures here go to a single explainer line rather than crashing
-    /// EXPLAIN; the failure mode is non-load-bearing diagnostics.
+    /// Rebuild and render the DataFusion physical plan for EXPLAIN.
+    /// In EXPLAIN ANALYZE, the plan is already built and contains execution metrics.
+    /// In plain EXPLAIN, we must rebuild the plan.
     fn render_df_physical_plan(
         df_state: &scan_state::DataFusionAggState,
         explainer: &mut Explainer,
     ) {
-        let custom_exprs = df_state.custom_exprs;
-        let custom_scan_tlist = df_state.custom_scan_tlist;
-        let ctx = if mpp_is_active() {
-            // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
-            // The shared session-context builder takes `mesh = None` and derives `n_workers`
-            // from `producer_worker_count()`, so the planner still emits a `DistributedExec`
-            // root with the right stage sizing for display.
-            Self::build_mpp_session_context(None)
-        } else {
-            create_aggregate_session_context()
-        };
-        let Ok(runtime) = tokio::runtime::Builder::new_current_thread().build() else {
-            explainer.add_text("DataFusion Plan", "(tokio runtime unavailable)");
-            return;
-        };
-        let plan_result = runtime.block_on(async {
-            let (logical, _) = build_join_aggregate_plan(
-                &df_state.plan,
-                &df_state.targetlist,
-                df_state.topk.as_ref(),
-                &df_state.join_level_predicates,
-                custom_exprs,
-                custom_scan_tlist,
-                df_state.having_filter.as_ref(),
-                &ctx,
-                None,
-                None,
-                None,
-            )
-            .await?;
-            build_physical_plan(&ctx, logical).await
-        });
-        match plan_result {
-            Ok(plan) => {
-                explainer.add_text("DataFusion Physical Plan", "");
-                for line in Self::render_plan_for_explain(plan.as_ref()).lines() {
-                    explainer.add_text("  ", line);
-                }
-            }
-            Err(e) => {
-                explainer.add_text(
-                    "DataFusion Plan",
-                    format!("(rebuild failed during EXPLAIN: {e})"),
-                );
-            }
-        }
-    }
-
-    /// EXPLAIN ANALYZE: merge the worker metrics that arrived over the mesh into the executed
-    /// plan and render it. The leader's own nodes already carry their metrics; the worker
-    /// fragments reported theirs as `TaskMetrics` frames when they finished.
-    fn render_executed_plan_with_metrics(
-        df_state: &scan_state::DataFusionAggState,
-        explainer: &mut Explainer,
-    ) {
-        let Some(plan) = df_state.physical_plan.clone() else {
-            return;
-        };
-        let rendered = match (df_state.mpp.leader(), df_state.runtime.as_ref()) {
-            (Some(_), Some(_runtime)) => {
-                match crate::postgres::customscan::mpp::glue::merge_worker_metrics(&plan) {
-                    Some(merged) => display_plan_ascii(merged.as_ref(), true),
-                    None => {
+        let plan: std::sync::Arc<dyn datafusion::physical_plan::ExecutionPlan> =
+            if explainer.is_analyze() {
+                let Some(plan) = df_state.physical_plan.clone() else {
+                    return;
+                };
+                let merged = match (df_state.mpp.leader(), df_state.runtime.as_ref()) {
+                    (Some(_), Some(_runtime)) => {
+                        crate::postgres::customscan::mpp::glue::merge_worker_metrics(&plan)
+                    }
+                    _ => None,
+                };
+                merged.unwrap_or(plan)
+            } else {
+                let custom_exprs = df_state.custom_exprs;
+                let custom_scan_tlist = df_state.custom_scan_tlist;
+                let ctx = if mpp_is_active() {
+                    // EXPLAIN-time: skip the shm_mq transport install (no execution, no `open()` call).
+                    // The shared session-context builder takes `mesh = None` and derives `n_workers`
+                    // from `producer_worker_count()`, so the planner still emits a `DistributedExec`
+                    // root with the right stage sizing for display.
+                    Self::build_mpp_session_context(None)
+                } else {
+                    create_aggregate_session_context()
+                };
+                let Ok(runtime) = tokio::runtime::Builder::new_current_thread().build() else {
+                    explainer.add_text("DataFusion Plan", "(tokio runtime unavailable)");
+                    return;
+                };
+                let plan_result = runtime.block_on(async {
+                    let (logical, _) = build_join_aggregate_plan(
+                        &df_state.plan,
+                        &df_state.targetlist,
+                        df_state.topk.as_ref(),
+                        &df_state.join_level_predicates,
+                        custom_exprs,
+                        custom_scan_tlist,
+                        df_state.having_filter.as_ref(),
+                        &ctx,
+                        None,
+                        None,
+                        None,
+                    )
+                    .await?;
+                    build_physical_plan(&ctx, logical).await
+                });
+                match plan_result {
+                    Ok(p) => p,
+                    Err(e) => {
                         explainer.add_text(
-                            "DataFusion Physical Plan",
-                            "(worker metrics incomplete; a worker may not have reported)",
+                            "DataFusion Plan",
+                            format!("(rebuild failed during EXPLAIN: {e})"),
                         );
                         return;
                     }
                 }
-            }
-            // Serial fallback: no workers, the plain metrics display tells the whole story.
-            _ => Self::render_plan_for_explain(plan.as_ref()),
-        };
-        explainer.add_text("DataFusion Physical Plan", "");
-        for line in rendered.lines() {
-            explainer.add_text("  ", line);
-        }
-    }
+            };
 
-    /// Render a physical plan for EXPLAIN. `DistributedExec` roots go through
-    /// `display_plan_ascii` for the boxed-stage rendering; serial plans keep
-    /// the standard `displayable().indent(false)` tree so non-MPP expected
-    /// outputs are stable.
-    fn render_plan_for_explain(plan: &dyn ExecutionPlan) -> String {
-        if plan.is::<DistributedExec>() {
-            display_plan_ascii(plan, false)
-        } else {
-            datafusion::physical_plan::displayable(plan)
-                .indent(false)
-                .to_string()
-        }
+        crate::postgres::customscan::datafusion::explain::explain_physical_plan(plan, explainer);
     }
 
     /// Existing single-table Tantivy aggregate path.

--- a/pg_search/src/postgres/customscan/datafusion/explain.rs
+++ b/pg_search/src/postgres/customscan/datafusion/explain.rs
@@ -148,7 +148,9 @@ pub fn format_join_level_expr(expr: &JoinLevelExpr, join_clause: &JoinCSClause) 
 /// (`elapsed_compute`, named `Time` values) are stripped so that regression
 /// test output remains stable.  Pass `true` (e.g. for EXPLAIN ANALYZE VERBOSE)
 /// to include everything.
-pub fn render_plan_with_metrics(
+// TODO(#4152): PG parallel workers each run their own `exec_custom_scan` with their
+// own plan instance, so these metrics only cover the leader's share.
+fn render_plan_with_metrics(
     plan: &dyn ExecutionPlan,
     indent: usize,
     include_timing: bool,
@@ -196,24 +198,49 @@ pub fn render_plan_with_metrics(
 /// Renders a physical plan for EXPLAIN.
 /// For EXPLAIN ANALYZE, renders with metrics. For plain EXPLAIN, renders with
 /// ASCII boxes for DistributedExec or a tree format for non-distributed plans.
-pub fn explain_physical_plan(plan: Arc<dyn ExecutionPlan>, explainer: &mut Explainer) {
+pub fn explain_physical_plan(plan: &Arc<dyn ExecutionPlan>, explainer: &mut Explainer) {
     explainer.add_text("DataFusion Physical Plan", "");
-    if explainer.is_analyze() {
+    if plan.is::<DistributedExec>() {
+        // TODO: `display_plan_ascii` does not currently support stripping `elapsed_compute`
+        // or other timing data, so MPP EXPLAIN ANALYZE will include timing metrics even when
+        // `TIMING OFF` is requested. This makes regression tests flake. We should upstream
+        // a feature to `datafusion-distributed` to optionally strip these metrics.
+        let rendered = display_plan_ascii(plan.as_ref(), explainer.is_analyze());
+        for line in rendered.lines() {
+            explainer.add_text("  ", line);
+        }
+    } else if explainer.is_analyze() {
         let mut lines = Vec::new();
         render_plan_with_metrics(plan.as_ref(), 0, explainer.is_verbose(), &mut lines);
         for line in lines {
             explainer.add_text("  ", line);
         }
     } else {
-        let rendered = if plan.is::<DistributedExec>() {
-            display_plan_ascii(plan.as_ref(), false)
-        } else {
-            datafusion::physical_plan::displayable(plan.as_ref())
-                .indent(false)
-                .to_string()
-        };
+        let rendered = datafusion::physical_plan::displayable(plan.as_ref())
+            .indent(false)
+            .to_string();
         for line in rendered.lines() {
             explainer.add_text("  ", line);
         }
     }
+}
+
+/// Merges MPP worker metrics if we are the leader. If the merge times out or fails,
+/// it appends a warning to the explainer and returns the original plan.
+pub fn get_plan_with_merged_metrics(
+    plan: &Arc<dyn ExecutionPlan>,
+    is_leader: bool,
+    has_runtime: bool,
+    explainer: &mut Explainer,
+) -> Arc<dyn ExecutionPlan> {
+    if is_leader && has_runtime {
+        if let Some(merged) = crate::postgres::customscan::mpp::glue::merge_worker_metrics(plan) {
+            return merged;
+        }
+        explainer.add_text(
+            "  (worker metrics incomplete; a worker may not have reported)",
+            "",
+        );
+    }
+    Arc::clone(plan)
 }

--- a/pg_search/src/postgres/customscan/datafusion/explain.rs
+++ b/pg_search/src/postgres/customscan/datafusion/explain.rs
@@ -25,9 +25,14 @@
 //! predicate-tree EXPLAIN can both reach them.
 
 use crate::postgres::customscan::explain::ExplainFormat;
+use crate::postgres::customscan::explainer::Explainer;
 use crate::postgres::customscan::joinscan::build::{JoinCSClause, JoinLevelExpr, RelationAlias};
 use crate::postgres::deparse::node_to_string_fallback;
+use datafusion::physical_plan::metrics::MetricValue;
+use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
+use datafusion_distributed::{display_plan_ascii, DistributedExec};
 use pgrx::pg_sys;
+use std::sync::Arc;
 
 /// Format a PostgreSQL expression node for EXPLAIN output.
 /// Returns a human-readable description of the expression.
@@ -135,5 +140,80 @@ pub fn format_join_level_expr(expr: &JoinLevelExpr, join_clause: &JoinCSClause) 
             }
             format_expr_for_explain(node.cast())
         },
+    }
+}
+
+/// Recursively formats a DataFusion physical plan as a string, appending
+/// collected metrics.  When `include_timing` is false, timing metrics
+/// (`elapsed_compute`, named `Time` values) are stripped so that regression
+/// test output remains stable.  Pass `true` (e.g. for EXPLAIN ANALYZE VERBOSE)
+/// to include everything.
+pub fn render_plan_with_metrics(
+    plan: &dyn ExecutionPlan,
+    indent: usize,
+    include_timing: bool,
+    lines: &mut Vec<String>,
+) {
+    use std::fmt::Write;
+
+    let mut line = format!("{:indent$}", "", indent = indent * 2);
+
+    struct Fmt<'a>(&'a dyn ExecutionPlan);
+    impl std::fmt::Display for Fmt<'_> {
+        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            self.0.fmt_as(DisplayFormatType::Default, f)
+        }
+    }
+    write!(line, "{}", Fmt(plan)).unwrap();
+
+    if let Some(metrics) = plan.metrics() {
+        let aggregated = metrics
+            .aggregate_by_name()
+            .sorted_for_display()
+            .timestamps_removed();
+        let parts: Vec<String> = aggregated
+            .iter()
+            .filter(|m| {
+                include_timing
+                    || !matches!(
+                        m.value(),
+                        MetricValue::ElapsedCompute(_) | MetricValue::Time { .. }
+                    )
+            })
+            .map(|m| m.to_string())
+            .collect();
+        if !parts.is_empty() {
+            write!(line, ", metrics=[{}]", parts.join(", ")).unwrap();
+        }
+    }
+
+    lines.push(line);
+    for child in plan.children() {
+        render_plan_with_metrics(child.as_ref(), indent + 1, include_timing, lines);
+    }
+}
+
+/// Renders a physical plan for EXPLAIN.
+/// For EXPLAIN ANALYZE, renders with metrics. For plain EXPLAIN, renders with
+/// ASCII boxes for DistributedExec or a tree format for non-distributed plans.
+pub fn explain_physical_plan(plan: Arc<dyn ExecutionPlan>, explainer: &mut Explainer) {
+    explainer.add_text("DataFusion Physical Plan", "");
+    if explainer.is_analyze() {
+        let mut lines = Vec::new();
+        render_plan_with_metrics(plan.as_ref(), 0, explainer.is_verbose(), &mut lines);
+        for line in lines {
+            explainer.add_text("  ", line);
+        }
+    } else {
+        let rendered = if plan.is::<DistributedExec>() {
+            display_plan_ascii(plan.as_ref(), false)
+        } else {
+            datafusion::physical_plan::displayable(plan.as_ref())
+                .indent(false)
+                .to_string()
+        };
+        for line in rendered.lines() {
+            explainer.add_text("  ", line);
+        }
     }
 }

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -155,7 +155,9 @@ use self::planning::{
 };
 use self::predicate::{all_vars_are_fast_fields_recursive, extract_join_level_conditions};
 use self::privdat::PrivateData;
-use crate::postgres::customscan::datafusion::explain::{format_join_level_expr, get_attname_safe};
+use crate::postgres::customscan::datafusion::explain::{
+    explain_physical_plan, format_join_level_expr, get_attname_safe, get_plan_with_merged_metrics,
+};
 use crate::postgres::customscan::datafusion::translator::PredicateTranslator;
 use crate::postgres::customscan::pullup::resolve_fast_field;
 use crate::postgres::utils::expr_contains_any_operator;
@@ -1331,19 +1333,13 @@ impl CustomScan for JoinScan {
                 // Under MPP the worker fragments reported their metrics as mesh frames when
                 // they exited; fold them in so the stage boxes show more than the leader's
                 // own nodes.
-                let merged = match (
-                    state.custom_state().mpp.leader(),
-                    state.custom_state().runtime.as_ref(),
-                ) {
-                    (Some(_), Some(_runtime)) => {
-                        crate::postgres::customscan::mpp::glue::merge_worker_metrics(physical_plan)
-                    }
-                    _ => None,
-                };
-                let plan = merged.as_ref().unwrap_or(physical_plan).clone();
-                crate::postgres::customscan::datafusion::explain::explain_physical_plan(
-                    plan, explainer,
+                let plan = get_plan_with_merged_metrics(
+                    physical_plan,
+                    state.custom_state().mpp.leader().is_some(),
+                    state.custom_state().runtime.is_some(),
+                    explainer,
                 );
+                explain_physical_plan(&plan, explainer);
             }
         } else if let Some(ref logical_plan) = state.custom_state().logical_plan {
             // Plain EXPLAIN reconstructs the physical plan by deserializing the logical
@@ -1385,10 +1381,7 @@ impl CustomScan for JoinScan {
             let physical_plan = runtime
                 .block_on(build_physical_plan(&ctx, logical_plan))
                 .expect("Failed to create execution plan");
-            crate::postgres::customscan::datafusion::explain::explain_physical_plan(
-                physical_plan,
-                explainer,
-            );
+            explain_physical_plan(&physical_plan, explainer);
         }
     }
 

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -191,10 +191,9 @@ use crate::postgres::ParallelScanArgs;
 use crate::postgres::ParallelScanState;
 use crate::scan::codec::{deserialize_logical_plan_with_runtime, serialize_logical_plan};
 use crate::DEFAULT_PARAMETERIZED_LIMIT_ESTIMATE;
-use datafusion::physical_plan::displayable;
-use datafusion::physical_plan::metrics::MetricValue;
-use datafusion::physical_plan::{DisplayFormatType, ExecutionPlan};
-use datafusion_distributed::{display_plan_ascii, DistributedExec, DistributedExt};
+
+use datafusion::physical_plan::ExecutionPlan;
+use datafusion_distributed::DistributedExt;
 use pgrx::{pg_guard, pg_sys, PgList};
 use std::ffi::{c_void, CStr};
 use std::sync::Arc;
@@ -1341,13 +1340,10 @@ impl CustomScan for JoinScan {
                     }
                     _ => None,
                 };
-                let plan = merged.as_ref().unwrap_or(physical_plan);
-                explainer.add_text("DataFusion Physical Plan", "");
-                let mut lines = Vec::new();
-                render_plan_with_metrics(plan.as_ref(), 0, explainer.is_verbose(), &mut lines);
-                for line in &lines {
-                    explainer.add_text("  ", line);
-                }
+                let plan = merged.as_ref().unwrap_or(physical_plan).clone();
+                crate::postgres::customscan::datafusion::explain::explain_physical_plan(
+                    plan, explainer,
+                );
             }
         } else if let Some(ref logical_plan) = state.custom_state().logical_plan {
             // Plain EXPLAIN reconstructs the physical plan by deserializing the logical
@@ -1389,17 +1385,10 @@ impl CustomScan for JoinScan {
             let physical_plan = runtime
                 .block_on(build_physical_plan(&ctx, logical_plan))
                 .expect("Failed to create execution plan");
-            explainer.add_text("DataFusion Physical Plan", "");
-            let rendered = if physical_plan.is::<DistributedExec>() {
-                display_plan_ascii(physical_plan.as_ref(), false)
-            } else {
-                displayable(physical_plan.as_ref())
-                    .indent(false)
-                    .to_string()
-            };
-            for line in rendered.lines() {
-                explainer.add_text("  ", line);
-            }
+            crate::postgres::customscan::datafusion::explain::explain_physical_plan(
+                physical_plan,
+                explainer,
+            );
         }
     }
 
@@ -2381,62 +2370,5 @@ impl JoinScan {
         // Use ExecStoreVirtualTuple to properly mark the slot as containing a virtual tuple
         pg_sys::ExecStoreVirtualTuple(result_slot);
         Some(result_slot)
-    }
-}
-
-/// Render a DataFusion physical plan tree with metrics.
-///
-/// Each node is rendered via its `DisplayAs` implementation, followed by
-/// collected metrics.  When `include_timing` is false, timing metrics
-/// (`elapsed_compute`, named `Time` values) are stripped so that regression
-/// test output remains stable.  Pass `true` (e.g. for EXPLAIN ANALYZE VERBOSE)
-/// to include everything.
-///
-/// TODO: In parallel mode each worker runs its own `exec_custom_scan` with its
-/// own plan instances, so the metrics stored on the leader's plan only reflect
-/// the leader's share of the work.  Once JoinScan parallelism is refactored
-/// (#4152), aggregate these across workers.
-fn render_plan_with_metrics(
-    plan: &dyn ExecutionPlan,
-    indent: usize,
-    include_timing: bool,
-    lines: &mut Vec<String>,
-) {
-    use std::fmt::Write;
-
-    let mut line = format!("{:indent$}", "", indent = indent * 2);
-
-    struct Fmt<'a>(&'a dyn ExecutionPlan);
-    impl std::fmt::Display for Fmt<'_> {
-        fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-            self.0.fmt_as(DisplayFormatType::Default, f)
-        }
-    }
-    write!(line, "{}", Fmt(plan)).unwrap();
-
-    if let Some(metrics) = plan.metrics() {
-        let aggregated = metrics
-            .aggregate_by_name()
-            .sorted_for_display()
-            .timestamps_removed();
-        let parts: Vec<String> = aggregated
-            .iter()
-            .filter(|m| {
-                include_timing
-                    || !matches!(
-                        m.value(),
-                        MetricValue::ElapsedCompute(_) | MetricValue::Time { .. }
-                    )
-            })
-            .map(|m| m.to_string())
-            .collect();
-        if !parts.is_empty() {
-            write!(line, ", metrics=[{}]", parts.join(", ")).unwrap();
-        }
-    }
-
-    lines.push(line);
-    for child in plan.children() {
-        render_plan_with_metrics(child.as_ref(), indent + 1, include_timing, lines);
     }
 }

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -1915,6 +1915,29 @@ WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enabl
 
 SET paradedb.enable_aggregate_custom_scan TO on;
 -- =====================================================================
+-- SECTION 28: EXPLAIN ANALYZE Metrics Output
+-- =====================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT COUNT(*)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop';
+                                                                                                                                                                 QUERY PLAN                                                                                                                                                                 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) (actual rows=1.00 loops=1)
+   Backend: DataFusion
+   Indexes: agg_join_products_idx (p), agg_join_tags_idx (t)
+   Aggregates: COUNT(*)
+   DataFusion Physical Plan: 
+     : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0], metrics=[output_rows=1, output_bytes=8.0 B, output_batches=1]
+     :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[], metrics=[output_rows=6, output_bytes=0.0 B, output_batches=1, array_map_created_count=1, build_input_batches=1, build_input_rows=3, input_batches=1, input_rows=6, build_mem_used=44, avg_fanout=100% (6/6), probe_hit_rate=100% (6/6)]
+     :     CooperativeExec
+     :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=24.0 B, output_batches=1]
+     :     CooperativeExec
+     :       PgSearchScan: segments=1, dynamic_filters=1, dynamic_filter_pushdown=linear, query="all", metrics=[output_rows=6, output_bytes=48.0 B, output_batches=1, rows_pruned=0, rows_scanned=6]
+(11 rows)
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;

--- a/pg_search/tests/pg_regress/sql/aggregate_join.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_join.sql
@@ -1176,6 +1176,15 @@ ORDER BY p.category;
 SET paradedb.enable_aggregate_custom_scan TO on;
 
 -- =====================================================================
+-- SECTION 28: EXPLAIN ANALYZE Metrics Output
+-- =====================================================================
+EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
+SELECT COUNT(*)
+FROM agg_join_products p
+JOIN agg_join_tags t ON p.id = t.product_id
+WHERE p.description @@@ 'laptop';
+
+-- =====================================================================
 -- Clean up
 -- =====================================================================
 DROP TABLE agg_join_tags;


### PR DESCRIPTION
## What

Add DataFusion metrics for the `aggregatescan`, and fix redundant rendering of the plan under `EXPLAIN ANALYZE`. Unify `DataFusion` plan rendering across the `aggregatescan` and `joinscan`.

## Why

To remove redundancy, and expose more metrics (including runtimes) under `EXPLAIN ANALYZE`. 

## Tests

New regress test shows `EXPLAIN ANALYZE` metrics for the `aggregatescan`.