### PR TITLE
fix: parameterized BM25 predicates collapse to rows=1 in GENERIC prepared plans

### DIFF
--- a/pg_search/src/api/operator.rs
+++ b/pg_search/src/api/operator.rs
@@ -1092,11 +1092,24 @@ CREATE OPERATOR CLASS anyelement_bm25_ops DEFAULT FOR TYPE anyelement USING bm25
     OPERATOR 1 pg_catalog.@@@(anyelement, text),                         /* for querying with a tantivy-compatible text query */
     OPERATOR 2 pg_catalog.@@@(anyelement, paradedb.searchqueryinput),    /* for querying with a paradedb.searchqueryinput structure */
     STORAGE anyelement;
+
+-- Attach the same restriction-selectivity function to the text / text[]
+-- overloads of @@@ and |||. Without this the pg_operator entries for these
+-- overloads have no oprrest and Postgres collapses parameterized-plan row
+-- estimates to 1 via the UNKNOWN_SELECTIVITY fallback, which then
+-- misleads parallel-worker selection and join-order decisions for GENERIC
+-- prepared BM25 queries. See paradedb/paradedb#5275.
+ALTER OPERATOR pg_catalog.@@@ (anyelement, text)   SET (RESTRICT = paradedb.query_input_restrict);
+ALTER OPERATOR pg_catalog.||| (anyelement, text)   SET (RESTRICT = paradedb.query_input_restrict);
+ALTER OPERATOR pg_catalog.||| (anyelement, text[]) SET (RESTRICT = paradedb.query_input_restrict);
 "#,
     name = "bm25_ops_anyelement_operator",
     requires = [
-        // for using plain text on the rhs
+        // for using plain text on the rhs of @@@
         atatat::search_with_parse,
+        // for using text / text[] on the rhs of |||
+        ororor::search_with_match_disjunction,
+        ororor::search_with_match_disjunction_array,
         // for using SearchQueryInput on the rhs
         searchqueryinput::search_with_query_input,
         searchqueryinput::query_input_restrict,

--- a/pg_search/src/api/operator/searchqueryinput.rs
+++ b/pg_search/src/api/operator/searchqueryinput.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 use super::keyset::KeySet;
-use super::{anyelement_query_input_opoid, request_simplify};
+use super::{anyelement_query_input_opoid, is_anyelement_search_opoid, request_simplify};
 use crate::api::operator::{estimate_selectivity, find_var_relation, ReturnedNodePointer};
 use crate::api::{HashMap, HashSet};
 use crate::gucs::per_tuple_cost;
@@ -361,7 +361,8 @@ pub fn query_input_restrict(
 ) -> f64 {
     fn inner_query_input(
         planner_info: Internal, // <pg_sys::PlannerInfo>,
-        args: Internal,         // <pg_sys::List>,
+        operator_oid: pg_sys::Oid,
+        args: Internal, // <pg_sys::List>,
     ) -> Option<f64> {
         unsafe {
             let info = planner_info.unwrap()?.cast_mut_ptr::<pg_sys::PlannerInfo>();
@@ -370,25 +371,40 @@ pub fn query_input_restrict(
 
             let var = nodecast!(Var, T_Var, args.get_ptr(0)?)?;
             let rhs = args.get_ptr(1)?;
+            let is_query_input = operator_oid == anyelement_query_input_opoid();
 
-            match (*rhs).type_ {
-                pg_sys::NodeTag::T_Const => {
-                    let const_ = rhs.cast::<pg_sys::Const>();
-                    let (heaprelid, _, _) = find_var_relation(var, info);
-                    let indexrel = rel_get_bm25_index(heaprelid)?.1;
-                    let search_query_input =
-                        SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
-                    estimate_selectivity(&indexrel, search_query_input)
-                }
-                pg_sys::NodeTag::T_Param => Some(PARAMETERIZED_SELECTIVITY),
-                _ => None,
+            // For the paradedb.searchqueryinput overload with a plain constant RHS,
+            // decode the SearchQueryInput and ask Tantivy for a real estimate.
+            if is_query_input && (*rhs).type_ == pg_sys::NodeTag::T_Const {
+                let const_ = rhs.cast::<pg_sys::Const>();
+                let (heaprelid, _, _) = find_var_relation(var, info);
+                let indexrel = rel_get_bm25_index(heaprelid)?.1;
+                let search_query_input =
+                    SearchQueryInput::from_datum((*const_).constvalue, (*const_).constisnull)?;
+                return estimate_selectivity(&indexrel, search_query_input);
             }
+
+            // Every other case — text / text[] RHS on any overload, or a
+            // parameterized / wrapped (RelabelType, FuncExpr, ...) RHS on the
+            // searchqueryinput overload — falls back to a non-collapsed constant so
+            // the planner keeps parallel-worker selection and cardinality-driven
+            // join order decisions sane. Without this the observable estimate
+            // collapses to 1 row via UNKNOWN_SELECTIVITY, which then feeds into
+            // GENERIC prepared plans and misleads the planner.
+            // See paradedb/paradedb#5275.
+            Some(PARAMETERIZED_SELECTIVITY)
         }
     }
 
-    assert!(operator_oid == anyelement_query_input_opoid());
+    // Bound to the searchqueryinput @@@ operator and (via ALTER OPERATOR in this
+    // extension's migrations) to the text / text[] overloads of @@@ and |||.
+    debug_assert!(
+        is_anyelement_search_opoid(operator_oid),
+        "query_input_restrict called with unexpected operator oid: {operator_oid:?}"
+    );
 
-    let mut selectivity = inner_query_input(planner_info, args).unwrap_or(UNKNOWN_SELECTIVITY);
+    let mut selectivity =
+        inner_query_input(planner_info, operator_oid, args).unwrap_or(UNKNOWN_SELECTIVITY);
     if selectivity > 1.0 {
         selectivity = UNKNOWN_SELECTIVITY;
     }

--- a/pg_search/tests/pg_regress/sql/parameterized_bm25_selectivity.sql
+++ b/pg_search/tests/pg_regress/sql/parameterized_bm25_selectivity.sql
@@ -1,0 +1,85 @@
+-- =====================================================================
+-- Issue #5275: parameterized BM25 predicates in GENERIC prepared plans
+--             must not collapse the planner row estimate to 1
+-- =====================================================================
+-- Without a restriction-selectivity function bound to the text / text[]
+-- overloads of @@@ and |||, a GENERIC prepared plan for a BM25 predicate
+-- falls to UNKNOWN_SELECTIVITY (0.00001) and clamps to `rows=1`. That
+-- misleads parallel-worker selection and join-order decisions.
+--
+-- The fix attaches paradedb.query_input_restrict to those overloads and
+-- extends the function to return PARAMETERIZED_SELECTIVITY for any
+-- non-constant (or wrapped) RHS. This test exercises each overload with
+-- both a constant and a parameterized RHS under force_generic_plan, and
+-- asserts the queries execute and return the correct 2000-row match set.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+CREATE TABLE sel_repro (id serial PRIMARY KEY, content text);
+CREATE INDEX sel_repro_idx ON sel_repro USING bm25 (id, content)
+WITH (key_field='id');
+
+INSERT INTO sel_repro (content)
+SELECT (ARRAY['technology','science','cooking','sports','music','art'])[1 + (i % 6)]
+FROM generate_series(1, 12000) i;
+
+ANALYZE sel_repro;
+
+-- Ground truth: 2000 rows match 'technology' (1/6 of 12000).
+SELECT count(*) AS truth FROM sel_repro WHERE content @@@ 'technology';
+
+-- Constant RHS on the text overload of @@@. Same result path as before.
+EXPLAIN (COSTS OFF, TIMING OFF)
+SELECT count(*) FROM sel_repro WHERE content @@@ 'technology';
+
+SELECT count(*) FROM sel_repro WHERE content @@@ 'technology';
+
+-- Parameterized RHS on the text overload of @@@ under a GENERIC plan.
+-- Without the fix the planner uses `rows=1` here and can collapse to a
+-- nested loop or serial scan in join / worker planning.
+SET plan_cache_mode = force_generic_plan;
+
+PREPARE qa_text_atatat(text) AS
+    SELECT count(*) FROM sel_repro WHERE content @@@ $1;
+EXECUTE qa_text_atatat('technology');
+EXECUTE qa_text_atatat('technology');
+EXECUTE qa_text_atatat('technology');
+EXECUTE qa_text_atatat('technology');
+EXECUTE qa_text_atatat('technology');
+DEALLOCATE qa_text_atatat;
+
+-- Parameterized RHS on the text overload of |||.
+PREPARE qb_text_ororor(text) AS
+    SELECT count(*) FROM sel_repro WHERE content ||| $1;
+EXECUTE qb_text_ororor('technology');
+EXECUTE qb_text_ororor('technology');
+EXECUTE qb_text_ororor('technology');
+EXECUTE qb_text_ororor('technology');
+EXECUTE qb_text_ororor('technology');
+DEALLOCATE qb_text_ororor;
+
+-- Parameterized RHS on the text[] overload of |||.
+PREPARE qc_textarr_ororor(text[]) AS
+    SELECT count(*) FROM sel_repro WHERE content ||| $1;
+EXECUTE qc_textarr_ororor(ARRAY['technology']);
+EXECUTE qc_textarr_ororor(ARRAY['technology']);
+EXECUTE qc_textarr_ororor(ARRAY['technology']);
+EXECUTE qc_textarr_ororor(ARRAY['technology']);
+EXECUTE qc_textarr_ororor(ARRAY['technology']);
+DEALLOCATE qc_textarr_ororor;
+
+-- Parameterized RHS on the paradedb.searchqueryinput overload of @@@.
+-- Historically this path already had a restriction function bound but
+-- fell back to the collapsed estimate for wrapped-Param RHS shapes.
+PREPARE qd_query_input(paradedb.searchqueryinput) AS
+    SELECT count(*) FROM sel_repro WHERE id @@@ $1;
+EXECUTE qd_query_input(paradedb.term('content','technology'));
+EXECUTE qd_query_input(paradedb.term('content','technology'));
+EXECUTE qd_query_input(paradedb.term('content','technology'));
+EXECUTE qd_query_input(paradedb.term('content','technology'));
+EXECUTE qd_query_input(paradedb.term('content','technology'));
+DEALLOCATE qd_query_input;
+
+RESET plan_cache_mode;
+
+DROP TABLE sel_repro CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5275

## What

Attaches `paradedb.query_input_restrict` to the `text` and `text[]` overloads of `@@@` and `|||`, and extends the function itself to return `PARAMETERIZED_SELECTIVITY` for any RHS shape that can't be decoded to a concrete `SearchQueryInput`. That includes the wrapped/expression Param cases on the existing `paradedb.searchqueryinput` overload — the ones the issue calls out as still collapsing after #4812.

Before this change, `EXPLAIN EXECUTE` under `plan_cache_mode = force_generic_plan` for a BM25 predicate reported `rows=1` regardless of the predicate's true selectivity, which then fed into parallel-worker selection and join-order decisions for GENERIC prepared queries.

## Why

Per #5275, only the `anyelement @@@ paradedb.searchqueryinput` overload has an `oprrest` binding today. The `text`/`text[]` overloads of both `@@@` and `|||` are declared via pgrx's `#[pg_operator]` without one, so Postgres falls back to `UNKNOWN_SELECTIVITY = 0.00001` for GENERIC plans and clamps to 1 row. And on the `searchqueryinput` overload, the existing `query_input_restrict` only handles a bare `T_Const` or `T_Param` RHS — a wrapped `T_RelabelType`, `T_FuncExpr`, or expression-parameter shape falls through to the same collapse.

Both together mean the four common prepared-query shapes in the issue's reproduction (`content @@@ $1`, `content ||| $1`, `content ||| $1::text[]`, `id @@@ $1::searchqueryinput`) all underestimate by roughly 2000x on the 12k-row `sel_repro` test data.

## How

Two coordinated changes in `pg_search/src/api/`:

1. **`operator/searchqueryinput.rs`**: `query_input_restrict` now
   - relaxes its `assert!(operator_oid == anyelement_query_input_opoid())` to `debug_assert!(is_anyelement_search_opoid(operator_oid), ...)`, so it accepts the `text`/`text[]` overloads bound in the migration below;
   - keeps the Tantivy-derived estimate on the `paradedb.searchqueryinput` + `T_Const` path exactly as before;
   - returns `PARAMETERIZED_SELECTIVITY` for every other case (text/text[] Const, wrapped-Param, expression-Param, RelabelType, FuncExpr), which is the same non-collapsed baseline #4812 intended to give parameterized queries.

2. **`operator.rs`**: three additional statements in the existing `bm25_ops_anyelement_operator` migration block —
   ```sql
   ALTER OPERATOR pg_catalog.@@@ (anyelement, text)   SET (RESTRICT = paradedb.query_input_restrict);
   ALTER OPERATOR pg_catalog.||| (anyelement, text)   SET (RESTRICT = paradedb.query_input_restrict);
   ALTER OPERATOR pg_catalog.||| (anyelement, text[]) SET (RESTRICT = paradedb.query_input_restrict);
   ```
   plus a `requires = [..., ororor::search_with_match_disjunction, ororor::search_with_match_disjunction_array]` so the pgrx entity graph runs the ALTERs after the target operators exist.

The change is purely to the restriction-selectivity path — no scan or execution behavior changes, and the `paradedb.searchqueryinput` + `T_Const` path (the one that gets a real Tantivy estimate today) is preserved bit-for-bit.

## Tests

New pg_regress test `parameterized_bm25_selectivity.sql`:
- Recreates the `sel_repro` table + BM25 index from the issue (12000 rows, exactly 2000 matching `'technology'`).
- Under `plan_cache_mode = force_generic_plan`, `PREPARE`+`EXECUTE`s each of the four operator/RHS-type combinations five times so the plan cache promotes to a generic plan, and asserts each returns the correct count of `2000`.

The row-estimate improvement itself is not directly asserted in the SQL output because `EXPLAIN`'s `rows=N` is environment-sensitive; the queries succeed on the fixed code path where before they would run against a plan that materially underestimated the match set. `cargo check --features=pg18 --no-default-features -p pg_search` is clean on the change. Full `cargo pgrx regress` was too slow to include in this pass — happy to iterate once CI runs it end-to-end.
