### PR TITLE
ci: scan, sign, and attest the published image (Trivy + keyless cosign)

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -230,6 +230,33 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
 
+      # Scan the image customers run for known OS/library CVEs before we sign or
+      # publish it as trusted. `ignore-unfixed` skips advisories with no upstream
+      # fix (nothing actionable); the build fails on any fixable CRITICAL/HIGH.
+      # To loosen the gate, narrow `severity` (e.g. CRITICAL) or set exit-code 0.
+      - name: Scan Image for Vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.10.1
+
+      # Keyless signature over the image digest (Sigstore OIDC via the Actions
+      # id-token, logged in Rekor). Unlike GitHub build attestations this needs no
+      # GitHub Enterprise, so it also works on the synced enterprise repo. The
+      # cloud verifies it with `cosign verify` against the same digest.
+      - name: Sign Image with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign --recursive \
+            "index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}"
+
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v4
         with:
@@ -323,6 +350,31 @@ jobs:
           sbom: true
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
+
+      # Scan the extension image for known OS/library CVEs before we sign or publish
+      # it. `ignore-unfixed` skips advisories with no upstream fix; the build fails
+      # on any fixable CRITICAL/HIGH. Narrow `severity` or set exit-code 0 to loosen.
+      - name: Scan Image for Vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
+          format: table
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "1"
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.10.1
+
+      # Keyless signature over the image digest (Sigstore OIDC via the Actions
+      # id-token, logged in Rekor). Needs no GitHub Enterprise, so it also works on
+      # the synced enterprise repo. The cloud verifies it against the same digest.
+      - name: Sign Image with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: |
+          cosign sign --recursive \
+            "index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}"
 
       - name: Sign and Attest Build Provenance
         uses: actions/attest-build-provenance@v4

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -31,11 +31,10 @@ concurrency:
   group: publish-paradedb-docker-${{ github.event.inputs.version || github.ref }}
   cancel-in-progress: true
 
-# Used by actions/attest-build-provenance to sign the builds
+# id-token: write lets cosign sign and attest the images keylessly via Sigstore.
 permissions:
   contents: write
   id-token: write
-  attestations: write
   pull-requests: write
 
 jobs:
@@ -252,12 +251,35 @@ jobs:
           cosign sign --recursive \
             "index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}"
 
-      - name: Sign and Attest Build Provenance
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: index.docker.io/paradedb/paradedb
-          subject-digest: ${{ steps.build-push.outputs.digest }}
-          push-to-registry: true
+      # Signed SLSA provenance over the image digest via Sigstore. Works without GitHub Enterprise.
+      - name: Attest Build Provenance with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          IMAGE_REF: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
+          BUILDER_ID: ${{ github.server_url }}/${{ github.workflow_ref }}
+          SOURCE_URI: git+${{ github.server_url }}/${{ github.repository }}@${{ github.ref }}
+          SOURCE_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg builder "$BUILDER_ID" \
+            --arg uri "$SOURCE_URI" \
+            --arg sha "$SOURCE_SHA" \
+            --arg runid "$RUN_ID" \
+            '{
+              builder: { id: $builder },
+              buildType: "https://github.com/actions/runner",
+              invocation: {
+                configSource: {
+                  uri: $uri,
+                  digest: { sha1: $sha },
+                  entryPoint: ".github/workflows/publish-paradedb-docker.yml"
+                }
+              },
+              metadata: { buildInvocationId: $runid },
+              materials: [{ uri: $uri, digest: { sha1: $sha } }]
+            }' > provenance.json
+          cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
   # Beta (`-rc.`) releases publish only the runnable PG 18 image, not the mountable extension image.
   publish-extension-image:
@@ -368,12 +390,35 @@ jobs:
           cosign sign --recursive \
             "index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}"
 
-      - name: Sign and Attest Build Provenance
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-name: index.docker.io/${{ env.image_name }}
-          subject-digest: ${{ steps.build-push.outputs.digest }}
-          push-to-registry: true
+      # Signed SLSA provenance over the image digest via Sigstore. Works without GitHub Enterprise.
+      - name: Attest Build Provenance with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          IMAGE_REF: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
+          BUILDER_ID: ${{ github.server_url }}/${{ github.workflow_ref }}
+          SOURCE_URI: git+${{ github.server_url }}/${{ github.repository }}@${{ github.ref }}
+          SOURCE_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg builder "$BUILDER_ID" \
+            --arg uri "$SOURCE_URI" \
+            --arg sha "$SOURCE_SHA" \
+            --arg runid "$RUN_ID" \
+            '{
+              builder: { id: $builder },
+              buildType: "https://github.com/actions/runner",
+              invocation: {
+                configSource: {
+                  uri: $uri,
+                  digest: { sha1: $sha },
+                  entryPoint: ".github/workflows/publish-paradedb-docker.yml"
+                }
+              },
+              metadata: { buildInvocationId: $runid },
+              materials: [{ uri: $uri, digest: { sha1: $sha } }]
+            }' > provenance.json
+          cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
   # Skip for beta (`-rc.`) releases, since we don't want to open Dockerfile-update PRs for prereleases
   open-dockerfile-prs:

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -247,9 +247,7 @@ jobs:
       - name: Sign Image with Cosign (keyless)
         env:
           COSIGN_YES: "true"
-        run: |
-          cosign sign --recursive \
-            "index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}"
+        run: cosign sign --recursive "index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}"
 
       # Signed SLSA provenance over the image digest via Sigstore. Works without GitHub Enterprise.
       - name: Attest Build Provenance with Cosign (keyless)
@@ -386,9 +384,7 @@ jobs:
       - name: Sign Image with Cosign (keyless)
         env:
           COSIGN_YES: "true"
-        run: |
-          cosign sign --recursive \
-            "index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}"
+        run: cosign sign --recursive "index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}"
 
       # Signed SLSA provenance over the image digest via Sigstore. Works without GitHub Enterprise.
       - name: Attest Build Provenance with Cosign (keyless)

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -244,9 +244,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4
 
-      # Keyless Sigstore signature over the image digest. Works without GitHub
-      # Enterprise, so it also covers the synced enterprise image; the cloud
-      # verifies it at deploy.
+      # Keyless Sigstore signature over the image digest. Works without GitHub Enterprise
       - name: Sign Image with Cosign (keyless)
         env:
           COSIGN_YES: "true"
@@ -362,9 +360,7 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4
 
-      # Keyless Sigstore signature over the image digest. Works without GitHub
-      # Enterprise, so it also covers the synced enterprise image; the cloud
-      # verifies it at deploy.
+      # Keyless Sigstore signature over the image digest. Works without GitHub Enterprise
       - name: Sign Image with Cosign (keyless)
         env:
           COSIGN_YES: "true"

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -230,10 +230,8 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Scan the image customers run for known OS/library CVEs before we sign or
-      # publish it as trusted. `ignore-unfixed` skips advisories with no upstream
-      # fix (nothing actionable); the build fails on any fixable CRITICAL/HIGH.
-      # To loosen the gate, narrow `severity` (e.g. CRITICAL) or set exit-code 0.
+      # Fail the release on fixable CRITICAL/HIGH CVEs in the image before we sign
+      # or publish it. ignore-unfixed drops advisories with no upstream fix.
       - name: Scan Image for Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -244,12 +242,11 @@ jobs:
           exit-code: "1"
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.10.1
+        uses: sigstore/cosign-installer@v4
 
-      # Keyless signature over the image digest (Sigstore OIDC via the Actions
-      # id-token, logged in Rekor). Unlike GitHub build attestations this needs no
-      # GitHub Enterprise, so it also works on the synced enterprise repo. The
-      # cloud verifies it with `cosign verify` against the same digest.
+      # Keyless Sigstore signature over the image digest. Works without GitHub
+      # Enterprise, so it also covers the synced enterprise image; the cloud
+      # verifies it at deploy.
       - name: Sign Image with Cosign (keyless)
         env:
           COSIGN_YES: "true"
@@ -351,9 +348,8 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Scan the extension image for known OS/library CVEs before we sign or publish
-      # it. `ignore-unfixed` skips advisories with no upstream fix; the build fails
-      # on any fixable CRITICAL/HIGH. Narrow `severity` or set exit-code 0 to loosen.
+      # Fail the release on fixable CRITICAL/HIGH CVEs in the image before we sign
+      # or publish it. ignore-unfixed drops advisories with no upstream fix.
       - name: Scan Image for Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -364,11 +360,11 @@ jobs:
           exit-code: "1"
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.10.1
+        uses: sigstore/cosign-installer@v4
 
-      # Keyless signature over the image digest (Sigstore OIDC via the Actions
-      # id-token, logged in Rekor). Needs no GitHub Enterprise, so it also works on
-      # the synced enterprise repo. The cloud verifies it against the same digest.
+      # Keyless Sigstore signature over the image digest. Works without GitHub
+      # Enterprise, so it also covers the synced enterprise image; the cloud
+      # verifies it at deploy.
       - name: Sign Image with Cosign (keyless)
         env:
           COSIGN_YES: "true"

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -241,7 +241,7 @@ jobs:
           exit-code: "1"
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Keyless Sigstore signature over the image digest. Works without GitHub Enterprise
       - name: Sign Image with Cosign (keyless)
@@ -378,7 +378,7 @@ jobs:
           exit-code: "1"
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Keyless Sigstore signature over the image digest. Works without GitHub Enterprise
       - name: Sign Image with Cosign (keyless)


### PR DESCRIPTION
## What

Add container-image CVE scanning and Sigstore signing/attestation to the release image build (`publish-paradedb-docker.yml`), for both the runnable image and the mountable extension image. After each `Build and Push` step:

1. **Trivy scan** by digest, failing the release on fixable `CRITICAL`/`HIGH` CVEs (`ignore-unfixed: true` skips advisories with no upstream fix).
2. **Keyless cosign sign** over the same digest.
3. **Keyless cosign attest** of a signed SLSA provenance predicate over the same digest.

The `actions/attest-build-provenance` step is **replaced** by cosign attest (see below), and the now-unused `attestations: write` permission is dropped.

## Why

The runnable ParadeDB image ships to customers via the cloud, but nothing scanned it (or the extension image) for OS/library CVEs. Signing was a GitHub **build-provenance attestation**, which requires **GitHub Enterprise for private repos** and is therefore unavailable on the synced `paradedb-enterprise` repo (we're on GitHub Teams).

Cosign has no such requirement: it uses Sigstore's public infrastructure and the ambient Actions OIDC token, storing the signature and provenance attestation **in the registry**, so it works identically on this public repo and the private enterprise repo after sync. Replacing `attest-build-provenance` with `cosign attest` gives one uniform, plan-independent mechanism for signing + provenance across both repos, at roughly SLSA L2.

This is the upstream half of paradedb/cloud#345. The cloud side already resolves and pins the image by `@sha256:` digest at deploy (paradedb/cloud#353, merged); a follow-up there adds `cosign verify` / `cosign verify-attestation` against that same digest.

## How

- Both build jobs reference the image via the **repository-name expression** (`paradedb/${{ github.event.repository.name }}` / `${{ env.image_name }}`), so the scan/sign/attest targets resolve correctly after the sync rewrites the repo to `paradedb-enterprise`.
- The SLSA provenance predicate is built with `jq` (guaranteed-valid JSON) from GitHub Actions context: builder id (`github.workflow_ref`), source repo + commit, and run id.
- `id-token: write` was already granted; scanning runs before signing/attesting, so a vulnerable image is never signed.
- `provenance: mode=max` and `sbom: true` on `build-push` are unchanged, so BuildKit still attaches registry-native SLSA provenance and an SBOM.

## Tests

- This workflow runs only on `workflow_dispatch` at release time, so it isn't exercised by PR CI. Validated statically: the file parses as YAML, passes `prettier --check` (the repo's `lint-yaml` gate), the `jq` provenance predicate produces valid JSON, and the committed blob is byte-identical to the locally validated copy.
- **Reviewer note — action pins:** `aquasecurity/trivy-action@v0.36.0` and `sigstore/cosign-installer@v4` were resolved from the GitHub tags API (this environment couldn't reach GitHub directly for commit SHAs). Please confirm these tags or SHA-pin them before merge, and sanity-check the Trivy gate policy (currently: fail on fixable CRITICAL/HIGH; narrow `severity` or set `exit-code: 0` to loosen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqjgD6dn6Gzye9hkdjnFpr