### PR TITLE
ci: sign build artifacts with keyless cosign instead of GitHub attestations

### DIFF
--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Install Dependencies
         if: steps.guard.outputs.build == 'true'
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base
 
       - name: Checkout Git Repository
         if: steps.guard.outputs.build == 'true'

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -22,11 +22,10 @@ concurrency:
   group: publish-pg_search-debian-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# Used by actions/attest-build-provenance to sign the builds
+# id-token: write lets cosign sign the builds keylessly via Sigstore.
 permissions:
   contents: write
   id-token: write
-  attestations: write
 
 jobs:
   # Stable releases build the full matrix. Beta releases (`-rc.` tags) build only what the PG 18
@@ -342,12 +341,19 @@ jobs:
           sudo chmod -R 755 ${package_dir}
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
-      - name: Sign and Attest Build Provenance
+      - name: Install Cosign
         if: steps.guard.outputs.build == 'true'
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: |
-            ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+        uses: sigstore/cosign-installer@v4
+
+      # Keyless Sigstore signature over the .deb. Works without GitHub Enterprise;
+      # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.
+      - name: Sign .deb with Cosign (keyless)
+        if: steps.guard.outputs.build == 'true'
+        shell: bash
+        env:
+          COSIGN_YES: "true"
+          DEB: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+        run: cosign sign-blob --yes --bundle "${DEB}.cosign.bundle" "$DEB"
 
       # Note: We need to specify bash as the shell to ensure that it doesn't default to /bin/sh on Debian, which
       # is not capable of parsing certain control characters
@@ -375,6 +381,16 @@ jobs:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
+          overwrite: true
+
+      - name: Upload pg_search .deb Cosign Bundle to GitHub Release
+        if: steps.guard.outputs.build == 'true'
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb.cosign.bundle
+          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb.cosign.bundle
           overwrite: true
 
       - name: Notify Slack on Failure

--- a/.github/workflows/publish-pg_search-debian.yml
+++ b/.github/workflows/publish-pg_search-debian.yml
@@ -343,7 +343,7 @@ jobs:
 
       - name: Install Cosign
         if: steps.guard.outputs.build == 'true'
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Keyless Sigstore signature over the .deb. Works without GitHub Enterprise;
       # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -65,9 +65,13 @@ jobs:
             pg_version: 18
 
     steps:
-      # We force reinstall git to make sure it is in PATH
+      # Force reinstall git to make sure it is in PATH. gettext provides envsubst,
+      # which sigstore/cosign-installer needs and which isn't on PATH by default.
       - name: Install Dependencies
-        run: brew reinstall git
+        run: |
+          brew reinstall git
+          brew install gettext
+          echo "$(brew --prefix gettext)/bin" >> "$GITHUB_PATH"
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -257,7 +257,7 @@ jobs:
           rm -f "$RUNNER_TEMP/AuthKey.p8"
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Keyless Sigstore signature over the .pkg. Works without GitHub Enterprise;
       # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -22,11 +22,10 @@ concurrency:
   group: publish-pg_search-macos-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# Used by actions/attest-build-provenance to sign the builds
+# id-token: write lets cosign sign the builds keylessly via Sigstore.
 permissions:
   contents: write
   id-token: write
-  attestations: write
 
 jobs:
   publish-pg_search-macos:
@@ -257,10 +256,16 @@ jobs:
           xcrun stapler staple "$PKG"
           rm -f "$RUNNER_TEMP/AuthKey.p8"
 
-      - name: Sign and Attest Build Provenance
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: ./pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4
+
+      # Keyless Sigstore signature over the .pkg. Works without GitHub Enterprise;
+      # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.
+      - name: Sign .pkg with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          PKG: ./pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+        run: cosign sign-blob --yes --bundle "${PKG}.cosign.bundle" "$PKG"
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -283,6 +288,15 @@ jobs:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
           asset_name: pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg
+          overwrite: true
+
+      - name: Upload pg_search .pkg Cosign Bundle to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg.cosign.bundle
+          asset_name: pg_search@${{ matrix.pg_version }}--${{ steps.version.outputs.tag_version }}.arm64_${{ steps.version.outputs.os_version }}.pkg.cosign.bundle
           overwrite: true
 
       - name: Notify Slack on Failure

--- a/.github/workflows/publish-pg_search-macos.yml
+++ b/.github/workflows/publish-pg_search-macos.yml
@@ -69,6 +69,10 @@ jobs:
       # which sigstore/cosign-installer needs and which isn't on PATH by default.
       - name: Install Dependencies
         run: |
+          # The GitHub macOS runner images ship with aws/tap pre-tapped but untrusted,
+          # which makes Homebrew print a "taps are not trusted" warning on every brew
+          # invocation. We don't use it, so untap it to keep the logs clean.
+          brew untap aws/tap || true
           brew reinstall git
           brew install gettext
           echo "$(brew --prefix gettext)/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -183,7 +183,7 @@ jobs:
           echo "Detected RHEL Version: $RHEL_VERSION for image: ${{ matrix.image }}"
 
           # Install dependencies
-          dnf install -y sudo wget git ca-certificates gcc llvm llvm-libs llvm-devel pkgconf-pkg-config openssl-devel jq rpm-build clang clang-devel
+          dnf install -y sudo wget git ca-certificates gcc llvm llvm-libs llvm-devel pkgconf-pkg-config openssl-devel jq rpm-build clang clang-devel gettext
 
           # Add Oracle Linux ${RHEL_VERSION} repositories to enable epel-release
           sudo tee /etc/yum.repos.d/oracle-linux-ol${RHEL_VERSION}.repo > /dev/null <<EOF

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -22,11 +22,10 @@ concurrency:
   group: publish-pg_search-rhel-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# Used by actions/attest-build-provenance to sign the builds
+# id-token: write lets cosign sign the builds keylessly via Sigstore.
 permissions:
   contents: write
   id-token: write
-  attestations: write
 
 jobs:
   publish-pg_search-rhel:
@@ -354,11 +353,16 @@ jobs:
           echo "Building RPM package..."
           rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_search.spec
 
-      - name: Sign and Attest Build Provenance
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: |
-            ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4
+
+      # Keyless Sigstore signature over the .rpm. Works without GitHub Enterprise;
+      # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.
+      - name: Sign .rpm with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          RPM: rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
+        run: cosign sign-blob --yes --bundle "$HOME/${RPM}.cosign.bundle" "$HOME/$RPM"
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -381,6 +385,15 @@ jobs:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
           asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm
+          overwrite: true
+
+      - name: Upload pg_search .rpm Cosign Bundle to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ~/rpmbuild/RPMS/${{ matrix.arch }}/pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm.cosign.bundle
+          asset_name: pg_search_${{ matrix.pg_version }}-${{ steps.version.outputs.tag_version }}-1PARADEDB.${{ steps.version.outputs.os_version }}.${{ matrix.arch }}.rpm.cosign.bundle
           overwrite: true
 
       - name: Notify Slack on Failure

--- a/.github/workflows/publish-pg_search-rhel.yml
+++ b/.github/workflows/publish-pg_search-rhel.yml
@@ -354,7 +354,7 @@ jobs:
           rpmbuild --without debuginfo -ba ~/rpmbuild/SPECS/pg_search.spec
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Keyless Sigstore signature over the .rpm. Works without GitHub Enterprise;
       # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -22,11 +22,10 @@ concurrency:
   group: publish-pg_search-ubuntu-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# Used by actions/attest-build-provenance to sign the builds
+# id-token: write lets cosign sign the builds keylessly via Sigstore.
 permissions:
   contents: write
   id-token: write
-  attestations: write
 
 jobs:
   publish-pg_search-ubuntu:
@@ -334,11 +333,16 @@ jobs:
           sudo chmod -R 755 ${package_dir}
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
-      - name: Sign and Attest Build Provenance
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: |
-            ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4
+
+      # Keyless Sigstore signature over the .deb. Works without GitHub Enterprise;
+      # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.
+      - name: Sign .deb with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          DEB: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
+        run: cosign sign-blob --yes --bundle "${DEB}.cosign.bundle" "$DEB"
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -361,6 +365,15 @@ jobs:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb
           asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb
+          overwrite: true
+
+      - name: Upload pg_search .deb Cosign Bundle to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./pg_search-${{ steps.version.outputs.tag_version }}-${{ steps.version.outputs.os_version }}-${{ matrix.arch }}-pg${{ matrix.pg_version }}.deb.cosign.bundle
+          asset_name: postgresql-${{ matrix.pg_version }}-pg-search_${{ steps.version.outputs.tag_version }}-1PARADEDB-${{ steps.version.outputs.os_version }}_${{ matrix.arch }}.deb.cosign.bundle
           overwrite: true
 
       - name: Notify Slack on Failure

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -193,7 +193,7 @@ jobs:
 
     steps:
       - name: Install Dependencies
-        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq
+        run: DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y sudo wget git ca-certificates curl gnupg gpg lsb-release pkg-config libssl-dev jq gettext-base
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/publish-pg_search-ubuntu.yml
+++ b/.github/workflows/publish-pg_search-ubuntu.yml
@@ -334,7 +334,7 @@ jobs:
           sudo dpkg-deb -Zxz --build --root-owner-group ${package_dir}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4
+        uses: sigstore/cosign-installer@v4.1.2
 
       # Keyless Sigstore signature over the .deb. Works without GitHub Enterprise;
       # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.

--- a/.github/workflows/publish-stressgres-docker.yml
+++ b/.github/workflows/publish-stressgres-docker.yml
@@ -13,8 +13,10 @@ concurrency:
   group: publish-stressgres-docker-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+# id-token: write lets cosign sign and attest the image keylessly via Sigstore.
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   publish-stressgres-docker:
@@ -54,6 +56,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_ACCESS_TOKEN }}
 
       - name: Build and Push Docker Image to Docker Hub
+        id: build-push
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -63,6 +66,45 @@ jobs:
           sbom: true
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # Keyless Sigstore signature over the image digest. Works without GitHub Enterprise.
+      - name: Sign Image with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: cosign sign --recursive "index.docker.io/paradedb/stressgres@${{ steps.build-push.outputs.digest }}"
+
+      # Signed SLSA provenance over the image digest via Sigstore. Works without GitHub Enterprise.
+      - name: Attest Build Provenance with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          IMAGE_REF: index.docker.io/paradedb/stressgres@${{ steps.build-push.outputs.digest }}
+          BUILDER_ID: ${{ github.server_url }}/${{ github.workflow_ref }}
+          SOURCE_URI: git+${{ github.server_url }}/${{ github.repository }}@${{ github.ref }}
+          SOURCE_SHA: ${{ github.sha }}
+          RUN_ID: ${{ github.run_id }}
+        run: |
+          jq -n \
+            --arg builder "$BUILDER_ID" \
+            --arg uri "$SOURCE_URI" \
+            --arg sha "$SOURCE_SHA" \
+            --arg runid "$RUN_ID" \
+            '{
+              builder: { id: $builder },
+              buildType: "https://github.com/actions/runner",
+              invocation: {
+                configSource: {
+                  uri: $uri,
+                  digest: { sha1: $sha },
+                  entryPoint: ".github/workflows/publish-stressgres-docker.yml"
+                }
+              },
+              metadata: { buildInvocationId: $runid },
+              materials: [{ uri: $uri, digest: { sha1: $sha } }]
+            }' > provenance.json
+          cosign attest --yes --type slsaprovenance --predicate provenance.json "$IMAGE_REF"
 
       - name: Notify Slack on Failure
         if: failure()

--- a/pg_search/src/postgres/customscan/parallel.rs
+++ b/pg_search/src/postgres/customscan/parallel.rs
@@ -153,6 +153,9 @@ pub fn max_useful_workers(
         return 0;
     }
 
+    // Only the pg15+ `debug_parallel_query` block below mutates this; on pg15
+    // that block is compiled out, leaving the binding immutable.
+    #[cfg_attr(feature = "pg15", allow(unused_mut))]
     let mut nworkers = clamp_to_gather_limits(segment_count.saturating_sub(1));
 
     #[cfg(not(feature = "pg15"))]

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -782,6 +782,10 @@ impl ParallelScanState {
 
         #[cfg(not(feature = "pg15"))]
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
+        // `defer_leader_for_debug` only drives the pg15+ `debug_parallel_query`
+        // deadline retry below; on pg15 that block is compiled out, leaving it unused.
+        #[cfg(feature = "pg15")]
+        let _ = defer_leader_for_debug;
 
         loop {
             let _mutex = self.acquire_mutex();


### PR DESCRIPTION
## What

Replace `actions/attest-build-provenance` with keyless Sigstore cosign across the artifact-publish workflows, so provenance/signing works on the private enterprise repo (which can't use GitHub attestations without GitHub Enterprise).

- **`publish-pg_search-{debian,ubuntu,rhel,macos}.yml`** — `cosign sign-blob` over each built `.deb`/`.rpm`/`.pkg`, with the `.cosign.bundle` uploaded next to the package on the GitHub Release (verify with `cosign verify-blob --bundle`). Drops `attest-build-provenance` and the now-unused `attestations: write`.
- **`publish-stressgres-docker.yml`** — the `paradedb/stressgres` image (previously unsigned) now gets `cosign sign` + `cosign attest` (signed SLSA provenance) over its digest, mirroring the main image in #5621. Adds `id-token: write`.

`publish-pg_search-postgresapp.yml` is intentionally **left on `attest-build-provenance`**: it's community-only (not run on the enterprise repo), and the `.pkg` is already Apple Developer-ID signed + notarized.

## Why

GitHub build attestations require GitHub Enterprise on private repos, so the `attest-build-provenance` steps can't run on the synced `paradedb-enterprise` repo. Keyless cosign uses Sigstore's public infrastructure and the ambient Actions OIDC token, storing signatures in the registry (images) or as release-asset bundles (packages), so it works identically on the public and private repos. Counterpart to the image change in #5621.

## How

- Package signing: `cosign sign-blob --yes --bundle <artifact>.cosign.bundle <artifact>`, then upload the bundle via the existing `shogo82148/actions-upload-release-asset` step (asset name = package + `.cosign.bundle`). rhel resolves its `~/rpmbuild` path via `$HOME` (a tilde in a quoted variable wouldn't expand).
- Image signing (stressgres): `cosign sign --recursive` + `cosign attest --type slsaprovenance` with a `jq`-built SLSA v0.2 predicate over the pushed digest.
- `id-token: write` is the only permission cosign needs; `attestations: write` is removed where it was only used by the old attestation.

## Tests

- These run on tag push / `workflow_dispatch` at release time, so they aren't exercised by PR CI. Validated statically: all files parse as YAML, pass `prettier --check`, and the SLSA predicate produces valid JSON. The `cosign-installer@v4.1.2` pin and cosign sign/attest flow were proven green in the #5621 dispatch test.
- **Reviewer note — action pin:** `sigstore/cosign-installer@v4.1.2` is a full tag (no floating `v4` exists — a `@v4` ref fails to resolve). Confirm or SHA-pin before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqjgD6dn6Gzye9hkdjnFpr