### PR TITLE
chore: Do not ALTER SYSTEM in regress tests.

### DIFF
--- a/pg_search/tests/pg_regress/expected/setup.out
+++ b/pg_search/tests/pg_regress/expected/setup.out
@@ -2,13 +2,13 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 -- Pin parallelism so regress plans don't depend on the local cluster's worker config. The value
 -- drives how much a query parallelizes, MPP or not, so a stock cluster and a tuned one would
 -- otherwise produce different plans. Tests that want more workers raise it themselves.
-ALTER SYSTEM SET max_parallel_workers_per_gather = 2;
-SELECT pg_reload_conf();
- pg_reload_conf 
-----------------
- t
-(1 row)
-
+DO $$
+BEGIN
+    EXECUTE format('ALTER DATABASE %I SET max_parallel_workers_per_gather = 2', current_database());
+END
+$$;
+-- Also set it for the current session, in case any subsequent setup steps rely on it
+SET max_parallel_workers_per_gather = 2;
 DROP TABLE IF EXISTS mock_items_issue_2528;
 CALL paradedb.create_bm25_test_table(
   schema_name => 'public',

--- a/pg_search/tests/pg_regress/sql/setup.sql
+++ b/pg_search/tests/pg_regress/sql/setup.sql
@@ -3,8 +3,13 @@ CREATE EXTENSION IF NOT EXISTS pg_search;
 -- Pin parallelism so regress plans don't depend on the local cluster's worker config. The value
 -- drives how much a query parallelizes, MPP or not, so a stock cluster and a tuned one would
 -- otherwise produce different plans. Tests that want more workers raise it themselves.
-ALTER SYSTEM SET max_parallel_workers_per_gather = 2;
-SELECT pg_reload_conf();
+DO $$
+BEGIN
+    EXECUTE format('ALTER DATABASE %I SET max_parallel_workers_per_gather = 2', current_database());
+END
+$$;
+-- Also set it for the current session, in case any subsequent setup steps rely on it
+SET max_parallel_workers_per_gather = 2;
 
 DROP TABLE IF EXISTS mock_items_issue_2528;
 CALL paradedb.create_bm25_test_table(


### PR DESCRIPTION
`ALTER SYSTEM` has side-effects outside of the regress tests: it will write out a `postgresql.auto.conf` file which adjusts settings system-wide.

Switch to altering only the active database for the regress run.