### PR TITLE
ci: sign postgresapp .pkg and pg_search schema with keyless cosign

### DIFF
--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -24,11 +24,10 @@ concurrency:
   group: publish-pg_search-postgresapp-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
-# Used by actions/attest-build-provenance to sign the builds
+# id-token: write lets cosign sign the builds keylessly via Sigstore.
 permissions:
   contents: write
   id-token: write
-  attestations: write
 
 jobs:
   publish-pg_search-postgresapp:
@@ -258,10 +257,16 @@ jobs:
           xcrun stapler staple "${{ steps.pkg.outputs.pkg_path }}"
           rm -f "$RUNNER_TEMP/AuthKey.p8"
 
-      - name: Sign and Attest Build Provenance
-        uses: actions/attest-build-provenance@v4
-        with:
-          subject-path: ./${{ steps.pkg.outputs.pkg_path }}
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # Keyless Sigstore signature over the .pkg. Works without GitHub Enterprise;
+      # the .cosign.bundle is uploaded next to the package for `cosign verify-blob`.
+      - name: Sign .pkg with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+          PKG: ./${{ steps.pkg.outputs.pkg_path }}
+        run: cosign sign-blob --yes --bundle "${PKG}.cosign.bundle" "$PKG"
 
       - name: Retrieve GitHub Release Upload URL
         id: upload_url
@@ -282,6 +287,15 @@ jobs:
           upload_url: ${{ steps.upload_url.outputs.upload_url }}
           asset_path: ./${{ steps.pkg.outputs.pkg_path }}
           asset_name: ${{ steps.pkg.outputs.pkg_name }}
+          overwrite: true
+
+      - name: Upload pg_search .pkg Cosign Bundle to GitHub Release
+        uses: shogo82148/actions-upload-release-asset@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          upload_url: ${{ steps.upload_url.outputs.upload_url }}
+          asset_path: ./${{ steps.pkg.outputs.pkg_path }}.cosign.bundle
+          asset_name: ${{ steps.pkg.outputs.pkg_name }}.cosign.bundle
           overwrite: true
 
       # Open a PR to PostgresApp/PostgresApp updating the pg_search download URL on

--- a/.github/workflows/publish-pg_search-postgresapp.yml
+++ b/.github/workflows/publish-pg_search-postgresapp.yml
@@ -42,9 +42,13 @@ jobs:
         pg_version: [18]
 
     steps:
-      # We force reinstall git to make sure it is in PATH
+      # Force reinstall git to make sure it is in PATH. gettext provides envsubst,
+      # which sigstore/cosign-installer needs and which isn't on PATH by default.
       - name: Install Dependencies
-        run: brew reinstall git
+        run: |
+          brew reinstall git
+          brew install gettext
+          echo "$(brew --prefix gettext)/bin" >> "$GITHUB_PATH"
 
       - name: Checkout Git Repository
         uses: actions/checkout@v7

--- a/.github/workflows/publish-pg_search-schema.yml
+++ b/.github/workflows/publish-pg_search-schema.yml
@@ -21,8 +21,10 @@ concurrency:
   group: publish-pg_search-schema-${{ github.ref }}
   cancel-in-progress: true
 
+# id-token: write lets cosign sign the schema keylessly via Sigstore.
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   publish-pg_search-schema:
@@ -91,10 +93,20 @@ jobs:
             echo "version=$(echo ${{ github.ref_name }} | sed 's/^v//')" >> $GITHUB_OUTPUT
           fi
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.1.2
+
+      # Keyless Sigstore signature over the schema. Works without GitHub Enterprise;
+      # the .cosign.bundle is uploaded next to it for `cosign verify-blob`.
+      - name: Sign Schema with Cosign (keyless)
+        env:
+          COSIGN_YES: "true"
+        run: cosign sign-blob --yes --bundle pg_search.schema.sql.cosign.bundle pg_search.schema.sql
+
       - name: Upload Schema to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload v${{ steps.version.outputs.version }} pg_search.schema.sql --clobber
+        run: gh release upload v${{ steps.version.outputs.version }} pg_search.schema.sql pg_search.schema.sql.cosign.bundle --clobber
 
       - name: Notify Slack on Failure
         if: failure()


### PR DESCRIPTION
## What

Extend the keyless cosign signing from #5622 to the two remaining release artifacts:

- **`publish-pg_search-postgresapp.yml`** — replace `actions/attest-build-provenance` with `cosign sign-blob` over the notarized `.pkg`, uploading the `.cosign.bundle` next to it on the GitHub Release. Drop the now-unused `attestations: write`.
- **`publish-pg_search-schema.yml`** — previously **unsigned**; now `cosign sign-blob` over `pg_search.schema.sql` with the `.cosign.bundle` uploaded alongside it. Adds `id-token: write`.

## Why

Follow-up to #5622, completing keyless-cosign coverage across the release artifacts. postgresapp was community-only (so its GitHub attestation wasn't broken on enterprise) but is switched for a uniform signing story; its Apple Developer-ID signature + notarization are untouched — the cosign bundle is an additional supply-chain signature, not a replacement for the macOS trust chain. The schema file had no provenance at all, so this adds it.

## How

- `cosign sign-blob --yes --bundle <artifact>.cosign.bundle <artifact>` (keyless, Sigstore OIDC via the Actions `id-token`), then publish the bundle to the Release — via the existing `shogo82148/actions-upload-release-asset` step for postgresapp, and by extending the `gh release upload` command for schema. Consumers verify with `cosign verify-blob --bundle <bundle> <artifact>`.
- `id-token: write` is the only permission cosign needs.

## Tests

- Both run on tag push / `workflow_dispatch` at release time, so they aren't exercised by PR CI. Validated statically: both parse as YAML and pass `prettier --check`. The `cosign-installer@v4.1.2` pin and cosign sign flow were proven green in the #5621 dispatch test.
- **Reviewer note — action pin:** `sigstore/cosign-installer@v4.1.2` is a full tag (no floating `v4` exists). Confirm or SHA-pin before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqjgD6dn6Gzye9hkdjnFpr

---
_Generated by [Claude Code](https://claude.ai/code/session_01CqjgD6dn6Gzye9hkdjnFpr)_