### PR TITLE
ci: gate image release on CRITICAL CVEs only, report HIGH non-blocking

### DIFF
--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -229,7 +229,6 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Report fixable CRITICAL/HIGH CVEs in the image (always shown in the logs).
       - name: Scan Image for Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -239,12 +238,6 @@ jobs:
           ignore-unfixed: true
           exit-code: "0"
 
-      # Gate the release on fixable CRITICAL CVEs only. HIGH (e.g. Go-stdlib DoS
-      # advisories inherited from the base image) is reported above but non-blocking.
-      # skip-files excludes /usr/local/bin/gosu: a non-networked setuid step-down
-      # helper from the postgres base image whose only findings are its bundled Go
-      # stdlib, flagged by version and not reachable. Scoped to the file (not its
-      # ever-growing CVE list) as a stopgap; remove once gosu is fixed (see #5626).
       - name: Gate Release on Critical Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -380,7 +373,6 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Report fixable CRITICAL/HIGH CVEs in the image (always shown in the logs).
       - name: Scan Image for Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
@@ -390,8 +382,6 @@ jobs:
           ignore-unfixed: true
           exit-code: "0"
 
-      # Gate the release on fixable CRITICAL CVEs only. HIGH (e.g. Go-stdlib DoS
-      # advisories inherited from the base image) is reported above but non-blocking.
       - name: Gate Release on Critical Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -229,14 +229,23 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Fail the release on fixable CRITICAL/HIGH CVEs in the image before we sign
-      # or publish it. ignore-unfixed drops advisories with no upstream fix.
+      # Report fixable CRITICAL/HIGH CVEs in the image (always shown in the logs).
       - name: Scan Image for Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
           format: table
           severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"
+
+      # Gate the release on fixable CRITICAL CVEs only. HIGH (e.g. Go-stdlib DoS
+      # advisories inherited from the base image) is reported above but non-blocking.
+      - name: Gate Release on Critical Vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
+          severity: CRITICAL
           ignore-unfixed: true
           exit-code: "1"
 
@@ -366,14 +375,23 @@ jobs:
           provenance: mode=max
           tags: ${{ steps.meta.outputs.tags }}
 
-      # Fail the release on fixable CRITICAL/HIGH CVEs in the image before we sign
-      # or publish it. ignore-unfixed drops advisories with no upstream fix.
+      # Report fixable CRITICAL/HIGH CVEs in the image (always shown in the logs).
       - name: Scan Image for Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
           format: table
           severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: "0"
+
+      # Gate the release on fixable CRITICAL CVEs only. HIGH (e.g. Go-stdlib DoS
+      # advisories inherited from the base image) is reported above but non-blocking.
+      - name: Gate Release on Critical Vulnerabilities (Trivy)
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: index.docker.io/${{ env.image_name }}@${{ steps.build-push.outputs.digest }}
+          severity: CRITICAL
           ignore-unfixed: true
           exit-code: "1"
 

--- a/.github/workflows/publish-paradedb-docker.yml
+++ b/.github/workflows/publish-paradedb-docker.yml
@@ -241,12 +241,17 @@ jobs:
 
       # Gate the release on fixable CRITICAL CVEs only. HIGH (e.g. Go-stdlib DoS
       # advisories inherited from the base image) is reported above but non-blocking.
+      # skip-files excludes /usr/local/bin/gosu: a non-networked setuid step-down
+      # helper from the postgres base image whose only findings are its bundled Go
+      # stdlib, flagged by version and not reachable. Scoped to the file (not its
+      # ever-growing CVE list) as a stopgap; remove once gosu is fixed (see #5626).
       - name: Gate Release on Critical Vulnerabilities (Trivy)
         uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: index.docker.io/paradedb/${{ github.event.repository.name }}@${{ steps.build-push.outputs.digest }}
           severity: CRITICAL
           ignore-unfixed: true
+          skip-files: usr/local/bin/gosu
           exit-code: "1"
 
       - name: Install Cosign


### PR DESCRIPTION
## What

Two changes to the Trivy gate added in #5621, on both image jobs:

1. **Split into report + gate.** A non-blocking report of fixable `CRITICAL`/`HIGH` CVEs (always shown in the logs), and a hard gate that fails only on fixable **`CRITICAL`**.
2. **Skip `/usr/local/bin/gosu` in the gate** (runnable image). Every finding on that image is in `gosu` — a non-networked setuid step-down helper from the `postgres` base image, built with an old Go toolchain — including one `crypto/tls` CRITICAL. They're Go stdlib flagged by version, not reachable in how `gosu` is used, and a base bump doesn't clear them (the Dockerfile already tracks the rolling `postgres:18-trixie` tag). Scoped to the binary path rather than its ever-growing CVE list.

## Why

A release-dispatch test of the runnable image ([run](https://github.com/paradedb/paradedb/actions/runs/29760792886/job/88415281001)) failed the gate. Investigation: **15 findings (14 HIGH, 1 CRITICAL), all in `gosu`**; the Debian OS packages and Python deps are clean. Blocking releases on a non-reachable, base-image-owned Go binary isn't useful. The report step keeps the findings visible; the durable fix (rebuild/replace `gosu`) is tracked in #5626.

## How

- Report step: `severity: CRITICAL,HIGH`, `exit-code: 0`.
- Gate step: `severity: CRITICAL`, `exit-code: 1`, `ignore-unfixed: true`, plus `skip-files: usr/local/bin/gosu` on the runnable image. To re-tighten later, add `HIGH` to the gate severity and/or drop the skip once #5626 lands.

## Tests

- Runs only on release `workflow_dispatch`, so not exercised by PR CI. Validated statically: parses as YAML, passes `prettier --check`. The two-step Trivy pattern reuses the action/inputs already proven green in the #5621 dispatch test; the `skip-files` path matches Trivy's reported target (`usr/local/bin/gosu`) and wants a dispatch to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CqjgD6dn6Gzye9hkdjnFpr