### PR TITLE
fix: Retarget docs introduction title and description

### DIFF
--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 title: Search without a second system
-description: One Postgres for your application data, full-text search, vector retrieval, and aggregations. Home of the pg_search extension.
+description: Developer documentation for ParadeDB and the pg_search extension — installation, indexing, query syntax, and deployment guides.
 canonical: https://docs.paradedb.com/welcome/introduction
 ---
 

--- a/docs/welcome/introduction.mdx
+++ b/docs/welcome/introduction.mdx
@@ -1,5 +1,6 @@
 ---
-title: Search without a second system
+title: Introduction to ParadeDB and pg_search
+sidebarTitle: Introduction
 description: Developer documentation for ParadeDB and the pg_search extension — installation, indexing, query syntax, and deployment guides.
 canonical: https://docs.paradedb.com/welcome/introduction
 ---


### PR DESCRIPTION
# Ticket(s) Closed

None

## What

Gives `docs/welcome/introduction.mdx` a title and meta description distinct from the `www.paradedb.com` homepage.

## Why

The description half of this change was part of #5627 but did not make it into the merged commit — `6f6be30a8` contains only `docs/docs.json`. The title half of that PR worked: docs pages now serve per-page titles, and the Semrush audit dropped from 107 errors to 3.

**Description.** One of the 3 remaining errors is real — `/welcome/introduction` and the homepage serve byte-identical descriptions. Per-page descriptions work correctly elsewhere (`/documentation/getting-started/install` serves `How to run the ParadeDB Docker image`), so this is a duplicated string in frontmatter, not a config override.

**Title.** Not flagged by Semrush, but the two pages were competing for the same query:

| | `<title>` | chars |
| --- | --- | --- |
| docs intro (before) | `Search without a second system - ParadeDB` | 41 |
| www.paradedb.com | `ParadeDB — Search without a second system` | 41 |

Same five words, reordered. The homepage should own that phrase; the docs intro should target documentation intent (`paradedb docs`, `pg_search documentation`) instead. New title renders as `Introduction to ParadeDB and pg_search - ParadeDB` (48 chars, under the ~60 char truncation limit).

The other 2 duplicate-description errors are `www.paradedb.com` and `www.paradedb.com/` — the same page enumerated twice. Both emit an identical, correct canonical, and no internal link or sitemap entry uses the trailing-slash form. Nothing to fix; expect those 2 to persist.

## How

**`docs/welcome/introduction.mdx`**

- `title` → `Introduction to ParadeDB and pg_search`
- Added `sidebarTitle: Introduction` to keep the nav entry short
- `description` → `Developer documentation for ParadeDB and the pg_search extension — installation, indexing, query syntax, and deployment guides.`

## Tests

- Verified against production that the title fix from #5627 deployed and that per-page descriptions render correctly on other docs pages
- Expect errors to go 3 → 2 on the next crawl

**Two things to confirm on the preview deploy:**

- The visible H1 on the page changes from `Search without a second system` — the positioning line introduced in #5549 — to `Introduction to ParadeDB and pg_search`. This is a side effect of `title` driving both `<title>` and the H1 in Mintlify. If the positioning line should stay as the H1, this commit should be dropped and only the description kept.
- `sidebarTitle` is not used anywhere else in this repo, so its behavior here is unverified. If it does not take effect, the sidebar entry becomes the full 38-character title.

https://claude.ai/code/session_017mie7S69bSCa3SreQs9erR