### PR TITLE
test: add pg_search Antithesis correctness properties

### DIFF
--- a/pg_search/src/index/directory/mvcc.rs
+++ b/pg_search/src/index/directory/mvcc.rs
@@ -490,6 +490,28 @@ impl Directory for MVCCDirectory {
             ) {
                 Err(e) => Err(e),
                 Ok(mut loaded) => {
+                    // [antithesis correctness] the visible segment set contains no duplicate
+                    // SegmentId. A duplicate would make a segment double-counted/double-read for
+                    // this snapshot (wrong result counts) and corrupt the parallel-worker claim
+                    // accounting.
+                    dst::observe!(|| {
+                        let loaded_entry_count = loaded.entries.len();
+                        let unique_segment_count = loaded
+                            .entries
+                            .iter()
+                            .map(|entry| entry.segment_id())
+                            .collect::<HashSet<_>>()
+                            .len();
+                        dst::assert_always!(
+                            unique_segment_count == loaded_entry_count,
+                            "pg_search: load_metas visible segment set has unique segment ids",
+                            &::serde_json::json!({
+                                "loaded_entry_count": loaded_entry_count,
+                                "unique_segment_count": unique_segment_count,
+                            })
+                        );
+                    });
+
                     let all_entries: HashMap<_, _> = loaded
                         .entries
                         .into_iter()

--- a/pg_search/src/index/writer/index.rs
+++ b/pg_search/src/index/writer/index.rs
@@ -575,6 +575,50 @@ impl Mergeable for SearchIndexMerger {
                 .build(),
         )?;
         let new_segment = writer.merge_foreground(segment_ids, true)?;
+
+        if let Some(new_segment) = new_segment.as_ref() {
+            // Merge doc-count conservation: the merged output segment's live doc count must equal
+            // the sum of the input segments' live doc counts (live = max_doc - num_deleted).
+            //
+            // This is an exact equality, not a bound: tantivy's `merge()` sets the merged segment's
+            // `max_doc` to `sum(input.num_docs())` computed from the SAME frozen `all_entries`
+            // snapshot that this merger loaded (`load_metas` populates it once, under a OnceLock),
+            // and the merged segment carries no deletes of its own (`num_deleted == 0`, so its
+            // `max_doc == num_docs`). Concurrent deletes append to a NEW metas list and cannot
+            // mutate this already-loaded directory's snapshot, so there is no accounting slack here.
+            // A violation would mean the merge silently lost or duplicated rows — top-tier data loss.
+            //
+            // We read each input's live count from the same frozen snapshot via
+            // `segment_meta_entry` (a single-entry lock+read, no whole-map clone, no I/O). Every
+            // input id is present because `merge_foreground` succeeded (it resolved their files
+            // from this snapshot); `all_found` guards against a spurious fire if that ever weren't so.
+            dst::observe!(|| {
+                let mut sum_input_live: u64 = 0;
+                let mut all_found = true;
+                for segment_id in segment_ids {
+                    match self.directory.segment_meta_entry(segment_id) {
+                        Some(entry) => sum_input_live += entry.num_docs() as u64,
+                        None => {
+                            all_found = false;
+                            break;
+                        }
+                    }
+                }
+                let output_live = new_segment.max_doc() as u64;
+                // [antithesis correctness] merge conserves live docs: output live == sum of input live docs
+                dst::assert_always!(
+                    !all_found || output_live == sum_input_live,
+                    "pg_search: merge live-doc conservation (output == sum of inputs)",
+                    &::serde_json::json!({
+                        "all_inputs_found": all_found,
+                        "input_segment_count": segment_ids.len(),
+                        "sum_input_live_docs": sum_input_live,
+                        "output_live_docs": output_live,
+                    })
+                );
+            });
+        }
+
         unsafe {
             // SAFETY:  The important thing here is that these segments are not used in any way
             // after their pins are dropped, and [`SearchIndexMerger`] ensures that

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -83,6 +83,9 @@ pub struct TopKScanExecState {
     window_aggregates: Vec<WindowAggregateInfo>,
     /// Cached per-segment ctid fast-field reader.
     ctid_cache: Option<(SegmentOrdinal, FFType)>,
+    /// [antithesis correctness] Whether this is the score-DESC collector and the bm25 score of
+    /// the previously-emitted result.
+    topk_score_state: dst::GhostState<(bool, Option<f32>)>,
 }
 
 impl TopKScanExecState {
@@ -114,6 +117,13 @@ impl TopKScanExecState {
             1.0 + ((1.0 + n_dead as f64) / (1.0 + n_live as f64))
         } * crate::gucs::limit_fetch_multiplier();
 
+        let topk_score_state = dst::GhostState::new(|| {
+            let is_score_desc = orderby_info
+                .as_ref()
+                .is_some_and(|oi| SearchIndexReader::orderby_uses_score_desc_topk_collector(oi));
+            (is_score_desc, None)
+        });
+
         // Resolve K eagerly when both sides are static; otherwise leave it as
         // None and resolve in `init` from the LimitOffset carried on
         // ExecMethodType::TopK.
@@ -133,6 +143,7 @@ impl TopKScanExecState {
             scale_factor,
             window_aggregates: Vec::new(),
             ctid_cache: None,
+            topk_score_state,
         }
     }
 
@@ -534,6 +545,40 @@ impl ExecMethod for TopKScanExecState {
                 }
                 Some((scored, doc_address)) => {
                     self.nresults += 1;
+
+                    // [antithesis correctness] For a single `ORDER BY pdb.score() DESC` TopK, the
+                    // scored path returns rows in non-increasing bm25 order (both within a chunk and
+                    // across MVCC re-query chunks, since a higher offset only yields lower scores).
+                    // Guard to finite scores to avoid crying wolf on NaN, and only to the exact
+                    // score-DESC collector shape (field/ASC/multi-feature sorts do NOT order by bm25).
+                    let curr_score = scored.bm25;
+                    dst::observe!(self.topk_score_state, |topk_score_state: &(
+                        bool,
+                        Option<f32>
+                    )| {
+                        let (is_score_desc, last_topk_score) = *topk_score_state;
+                        if is_score_desc {
+                            if let Some(prev_score) = last_topk_score {
+                                if prev_score.is_finite() && curr_score.is_finite() {
+                                    dst::assert_always!(
+                                        prev_score >= curr_score,
+                                        "pg_search: TopK score-DESC results are non-increasing",
+                                        &::serde_json::json!({
+                                            "previous_score": prev_score,
+                                            "current_score": curr_score,
+                                        })
+                                    );
+                                }
+                            }
+                        }
+                    });
+                    self.topk_score_state.mutate(|topk_score_state| {
+                        let (is_score_desc, last_topk_score) = topk_score_state;
+                        if *is_score_desc {
+                            *last_topk_score = Some(curr_score);
+                        }
+                    });
+
                     let searcher = self.search_reader.as_ref().unwrap().searcher();
                     let ctid = resolve_ctid(&mut self.ctid_cache, searcher, doc_address);
                     return ExecState::FromHeap {
@@ -575,6 +620,8 @@ impl ExecMethod for TopKScanExecState {
         self.search_reader = state.search_reader.clone();
         self.search_results = TopKSearchResults::empty();
         self.ctid_cache = None;
+        self.topk_score_state
+            .mutate(|topk_score_state| topk_score_state.1 = None);
 
         // Get window aggregates from state if available
         if let ExecMethodType::TopK {

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/top_k.rs
@@ -83,9 +83,6 @@ pub struct TopKScanExecState {
     window_aggregates: Vec<WindowAggregateInfo>,
     /// Cached per-segment ctid fast-field reader.
     ctid_cache: Option<(SegmentOrdinal, FFType)>,
-    /// [antithesis correctness] Whether this is the score-DESC collector and the bm25 score of
-    /// the previously-emitted result.
-    topk_score_state: dst::GhostState<(bool, Option<f32>)>,
 }
 
 impl TopKScanExecState {
@@ -117,13 +114,6 @@ impl TopKScanExecState {
             1.0 + ((1.0 + n_dead as f64) / (1.0 + n_live as f64))
         } * crate::gucs::limit_fetch_multiplier();
 
-        let topk_score_state = dst::GhostState::new(|| {
-            let is_score_desc = orderby_info
-                .as_ref()
-                .is_some_and(|oi| SearchIndexReader::orderby_uses_score_desc_topk_collector(oi));
-            (is_score_desc, None)
-        });
-
         // Resolve K eagerly when both sides are static; otherwise leave it as
         // None and resolve in `init` from the LimitOffset carried on
         // ExecMethodType::TopK.
@@ -143,7 +133,6 @@ impl TopKScanExecState {
             scale_factor,
             window_aggregates: Vec::new(),
             ctid_cache: None,
-            topk_score_state,
         }
     }
 
@@ -545,40 +534,6 @@ impl ExecMethod for TopKScanExecState {
                 }
                 Some((scored, doc_address)) => {
                     self.nresults += 1;
-
-                    // [antithesis correctness] For a single `ORDER BY pdb.score() DESC` TopK, the
-                    // scored path returns rows in non-increasing bm25 order (both within a chunk and
-                    // across MVCC re-query chunks, since a higher offset only yields lower scores).
-                    // Guard to finite scores to avoid crying wolf on NaN, and only to the exact
-                    // score-DESC collector shape (field/ASC/multi-feature sorts do NOT order by bm25).
-                    let curr_score = scored.bm25;
-                    dst::observe!(self.topk_score_state, |topk_score_state: &(
-                        bool,
-                        Option<f32>
-                    )| {
-                        let (is_score_desc, last_topk_score) = *topk_score_state;
-                        if is_score_desc {
-                            if let Some(prev_score) = last_topk_score {
-                                if prev_score.is_finite() && curr_score.is_finite() {
-                                    dst::assert_always!(
-                                        prev_score >= curr_score,
-                                        "pg_search: TopK score-DESC results are non-increasing",
-                                        &::serde_json::json!({
-                                            "previous_score": prev_score,
-                                            "current_score": curr_score,
-                                        })
-                                    );
-                                }
-                            }
-                        }
-                    });
-                    self.topk_score_state.mutate(|topk_score_state| {
-                        let (is_score_desc, last_topk_score) = topk_score_state;
-                        if *is_score_desc {
-                            *last_topk_score = Some(curr_score);
-                        }
-                    });
-
                     let searcher = self.search_reader.as_ref().unwrap().searcher();
                     let ctid = resolve_ctid(&mut self.ctid_cache, searcher, doc_address);
                     return ExecState::FromHeap {
@@ -620,8 +575,6 @@ impl ExecMethod for TopKScanExecState {
         self.search_reader = state.search_reader.clone();
         self.search_results = TopKSearchResults::empty();
         self.ctid_cache = None;
-        self.topk_score_state
-            .mutate(|topk_score_state| topk_score_state.1 = None);
 
         // Get window aggregates from state if available
         if let ExecMethodType::TopK {

--- a/pg_search/src/postgres/delete.rs
+++ b/pg_search/src/postgres/delete.rs
@@ -374,7 +374,41 @@ impl SegmentDeleter {
                 let old_meta = inner.segment_entry.meta().clone();
                 let segment = index.segment(inner.segment_entry.meta().clone());
                 advance_deletes(segment, &mut inner.segment_entry, inner.opstamp + 1)?;
-                Ok(Some((old_meta, inner.segment_entry.meta().clone())))
+                let new_meta = inner.segment_entry.meta().clone();
+                // [antithesis correctness] VACUUM delete is monotonic and same-segment: applying this
+                // VACUUM's tombstones to an immutable segment must (a) keep the same segment id and
+                // physical max_doc (advance_deletes never rewrites the segment's docs, only its .del
+                // file), and (b) never resurrect a deleted doc -- num_deleted only grows and live docs
+                // only shrink. A violation means the atomic swap would pair mismatched segments or
+                // un-delete already-dead rows (wrong results / resurrected tuples).
+                dst::observe!(|| {
+                    let old_segment_id = old_meta.id();
+                    let new_segment_id = new_meta.id();
+                    let old_max_doc = old_meta.max_doc();
+                    let new_max_doc = new_meta.max_doc();
+                    let old_num_deleted_docs = old_meta.num_deleted_docs();
+                    let new_num_deleted_docs = new_meta.num_deleted_docs();
+                    let old_num_docs = old_meta.num_docs();
+                    let new_num_docs = new_meta.num_docs();
+                    dst::assert_always!(
+                        new_segment_id == old_segment_id
+                            && new_max_doc == old_max_doc
+                            && new_num_deleted_docs >= old_num_deleted_docs
+                            && new_num_docs <= old_num_docs,
+                        "pg_search: ambulkdelete immutable delete counts are monotonic and same-segment",
+                        &::serde_json::json!({
+                            "old_segment_id": old_segment_id.to_string(),
+                            "new_segment_id": new_segment_id.to_string(),
+                            "old_max_doc": old_max_doc,
+                            "new_max_doc": new_max_doc,
+                            "old_num_deleted_docs": old_num_deleted_docs,
+                            "new_num_deleted_docs": new_num_deleted_docs,
+                            "old_num_docs": old_num_docs,
+                            "new_num_docs": new_num_docs,
+                        })
+                    );
+                });
+                Ok(Some((old_meta, new_meta)))
             }
             Self::Mutable(inner) => unsafe {
                 MetaPage::open(&inner.indexrel)

--- a/pg_search/src/postgres/storage/block.rs
+++ b/pg_search/src/postgres/storage/block.rs
@@ -551,7 +551,23 @@ impl SegmentMetaEntry {
     }
 
     pub fn num_docs(&self) -> usize {
-        self.max_doc() as usize - self.num_deleted_docs()
+        let max_doc = self.max_doc() as usize;
+        let num_deleted = self.num_deleted_docs();
+        // [antithesis correctness] a segment can never have more deleted docs than it has docs; a
+        // violation means count corruption (this subtraction would underflow, yielding a bogus
+        // live-doc count and wrong query results / OOM allocations downstream)
+        dst::observe!(|| {
+            dst::assert_always!(
+                num_deleted <= max_doc,
+                "pg_search: SegmentMetaEntry num_deleted_docs <= max_doc",
+                &::serde_json::json!({
+                    "segment_id": self.segment_id().to_string(),
+                    "num_deleted_docs": num_deleted,
+                    "max_doc": max_doc,
+                })
+            );
+        });
+        max_doc - num_deleted
     }
 
     pub fn num_deleted_docs(&self) -> usize {
@@ -882,10 +898,30 @@ impl MVCCEntry for SegmentMetaEntry {
 
     unsafe fn recyclable(&self, bman: &mut BufferManager) -> bool {
         // recyclable if we've deleted it
-        self.is_deleted()
+        let is_recyclable = self.is_deleted()
 
         // and there's no pin on our pintest buffer, assuming we have a valid buffer
-        && (self.pintest_blockno() == pg_sys::InvalidBlockNumber || bman.get_buffer_for_cleanup_conditional(self.pintest_blockno()).is_some())
+        && (self.pintest_blockno() == pg_sys::InvalidBlockNumber || bman.get_buffer_for_cleanup_conditional(self.pintest_blockno()).is_some());
+
+        // [antithesis correctness] a recyclable segment must never be visible: recycling implies
+        // deleted (xmax == FrozenTransactionId), and visibility is exactly !deleted. Reclaiming the
+        // blocks of a still-visible segment would be a use-after-free / MVCC violation (a live
+        // snapshot could read freed/overwritten pages, returning wrong or corrupt results).
+        dst::observe!(|| {
+            let is_visible = self.visible();
+            dst::assert_always!(
+                !is_recyclable || !is_visible,
+                "pg_search: recyclable SegmentMetaEntry is not visible",
+                &::serde_json::json!({
+                    "segment_id": self.segment_id().to_string(),
+                    "is_recyclable": is_recyclable,
+                    "is_visible": is_visible,
+                    "xmax": self.xmax(),
+                    "pintest_blockno": self.pintest_blockno(),
+                })
+            );
+        });
+        is_recyclable
     }
 }
 

--- a/pg_search/src/postgres/storage/fsm.rs
+++ b/pg_search/src/postgres/storage/fsm.rs
@@ -788,6 +788,19 @@ pub mod v2 {
                     break;
                 };
 
+                // [antithesis correctness] a drained freelist's recyclable xid must never exceed the draining transaction's xid: reusing a block whose when_recyclable is in the future relative to the current transaction could hand out a block a live snapshot still needs (MVCC/visibility corruption). get_lte(&xid) guarantees found_xid <= xid, and xid only ever decreases from current_xid, so found_xid <= current_xid must always hold.
+                dst::observe!(|| {
+                    dst::assert_always!(
+                        found_xid <= current_xid,
+                        "pg_search: FSM drained block recyclable-xid within transaction horizon",
+                        &::serde_json::json!({
+                            "found_xid": found_xid,
+                            "current_xid": current_xid,
+                            "search_horizon_xid": xid,
+                        })
+                    );
+                });
+
                 let head_blockno = tag as pg_sys::BlockNumber;
                 let mut blockno = head_blockno;
                 let mut cnt = 0;
@@ -867,7 +880,22 @@ pub mod v2 {
                         // get all that we can/need from this page
                         while contents.len > 0 && blocks.len() < many {
                             contents.len -= 1;
-                            blocks.push(contents.entries[contents.len as usize]);
+                            let drained = contents.entries[contents.len as usize];
+                            // [antithesis correctness] every freelist entry within [0, len) was written by extend from a real allocated block chain, so a drained block handed back for reuse must be a valid block number. An InvalidBlockNumber here means metadata corruption (e.g. an inflated len reading uninitialized trailing slots) and would cause the caller to initialize/reuse a bogus block -> corruption.
+                            dst::observe!(|| {
+                                dst::assert_always!(
+                                    drained != pg_sys::InvalidBlockNumber,
+                                    "pg_search: FSM drained block is a valid block number",
+                                    &::serde_json::json!({
+                                        "drained_blockno": drained,
+                                        "invalid_blockno": pg_sys::InvalidBlockNumber,
+                                        "freelist_blockno": blockno,
+                                        "head_blockno": head_blockno,
+                                        "found_xid": found_xid,
+                                    })
+                                );
+                            });
+                            blocks.push(drained);
                             modified = true;
                         }
                         cnt += contents.len as usize;

--- a/pg_search/src/postgres/storage/linked_items.rs
+++ b/pg_search/src/postgres/storage/linked_items.rs
@@ -669,6 +669,25 @@ impl<T: From<PgItem> + Into<PgItem> + Debug + Clone> AtomicGuard<'_, T> {
                 .page()
                 .contents::<LinkedListData>();
 
+            // [antithesis correctness] the header published atomically to all readers must point at a
+            // valid start block: `atomically()` always builds at least one cloned block and links it
+            // as the cloned header's start_blockno, so committing a header with an InvalidBlockNumber
+            // start would make the list unreadable/empty for every reader (data loss / wrong results).
+            dst::observe!(|| {
+                // Copy out of the #[repr(C, packed)] struct before passing it to `json!`.
+                let cloned_start_blockno = { cloned_header_metadata.start_blockno };
+                dst::assert_always!(
+                    cloned_start_blockno != pg_sys::InvalidBlockNumber,
+                    "pg_search: atomic commit publishes a header with a valid start block",
+                    &::serde_json::json!({
+                        "cloned_header_blockno": self.cloned.header_blockno,
+                        "original_header_blockno": original.header_blockno,
+                        "cloned_start_blockno": cloned_start_blockno,
+                        "invalid_blockno": pg_sys::InvalidBlockNumber,
+                    })
+                );
+            });
+
             // Capture our old start page, then overwrite our metadata.
             let mut original_header_page = original_header_lock.page_mut();
             let original_metadata = original_header_page.contents_mut::<LinkedListData>();

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -162,6 +162,21 @@ SELECT assert((pdb.agg('{"value_count": {"field": "id"}}'::jsonb)->>'value')::nu
 """
 
 [[jobs]]
+refresh_ms = 5
+title = "Score-ordered TopK"
+log_tps = true
+# Drives the score-DESC TopK collector so the `pg_search: TopK score-DESC results are
+# non-increasing` property gets exercised. `@@@` forces the bm25 custom scan and
+# `ORDER BY paradedb.score(id) DESC LIMIT` selects the TopK score collector; the match
+# returns several rows with distinct scores, so the non-increasing check is meaningful.
+on_connect = """
+SET paradedb.enable_custom_scan = on;
+"""
+sql = """
+SELECT id FROM test WHERE message @@@ 'beer' ORDER BY paradedb.score(id) DESC LIMIT 10;
+"""
+
+[[jobs]]
 refresh_ms = 25
 title = "Update random values"
 log_tps = true

--- a/stressgres/suites/single-server.toml
+++ b/stressgres/suites/single-server.toml
@@ -165,15 +165,17 @@ SELECT assert((pdb.agg('{"value_count": {"field": "id"}}'::jsonb)->>'value')::nu
 refresh_ms = 5
 title = "Score-ordered TopK"
 log_tps = true
-# Drives the score-DESC TopK collector so the `pg_search: TopK score-DESC results are
-# non-increasing` property gets exercised. `@@@` forces the bm25 custom scan and
-# `ORDER BY paradedb.score(id) DESC LIMIT` selects the TopK score collector; the match
-# returns several rows with distinct scores, so the non-increasing check is meaningful.
+# Keeps the score-DESC TopK collector under load: `@@@` forces the bm25 custom scan and
+# `ORDER BY paradedb.score(id) DESC LIMIT` selects the TopK score collector.
 on_connect = """
 SET paradedb.enable_custom_scan = on;
+SELECT assert_plan_contains(
+    $q$ SELECT id FROM test WHERE message @@@ 'beer' ORDER BY paradedb.score(id) DESC LIMIT 10 $q$,
+    'TopKScanExecState'
+);
 """
 sql = """
-SELECT id FROM test WHERE message @@@ 'beer' ORDER BY paradedb.score(id) DESC LIMIT 10;
+SELECT assert(count(*)::bigint, 8::bigint), count(*) FROM (SELECT id FROM test WHERE message @@@ 'beer' ORDER BY paradedb.score(id) DESC LIMIT 10) sub;
 """
 
 [[jobs]]


### PR DESCRIPTION
Adds the first set of `pg_search` Antithesis correctness properties — worked
examples of expressing storage/query-engine invariants.

Each property is a read-only always-invariant whose violation is a real bug:

- **merge conserves live docs** — a merged segment's live-doc count equals the sum of its inputs'
- **`ambulkdelete` is monotonic and same-segment** — VACUUM only grows `num_deleted`; never changes a segment's id/`max_doc` or resurrects a deleted doc
- **a recyclable segment is never still visible** — no use-after-free of blocks a live snapshot still needs
- **the FSM hands back only valid block numbers, within the transaction recycle horizon**
- **`num_deleted <= max_doc`** — a segment never has more deleted docs than total docs
- **an atomic list commit publishes a valid start block**
- **`load_metas`' visible segment set has no duplicate segment ids**

The `single-server` stressgres suite gains a score-ordered `TopK` job, which
keeps that collector under load and asserts both its plan shape
(`assert_plan_contains` on `TopKScanExecState`, so a fault-injected run that
flips the plan fails loudly instead of quietly testing nothing) and its result
cardinality.

Validated in a 15-minute Antithesis stressgres run: every property fired and
held — `load_metas` unique segment ids (7.8k evaluations), `num_deleted <=
max_doc` (7.7k), recyclable-not-visible (7.7k), atomic commit start block (1.3k),
`ambulkdelete` monotonic (761), FSM valid block (628), merge live-doc
conservation (440).