### PR TITLE
fix: replace pdb.score()/pdb.snippet() panic with clean ereport(ERROR)

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/projections/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/mod.rs
@@ -18,3 +18,42 @@
 pub mod score;
 pub mod snippet;
 pub mod window_agg;
+
+/// Emit a clean, user-actionable `ERROR` when a ParadeDB projection placeholder
+/// function (e.g. `pdb.score()`, `pdb.snippet()`) is invoked at execution time.
+///
+/// These `#[pg_extern]` shells only run when the planner did NOT choose a
+/// ParadeDB `CustomScan` for the referenced relation — typically because the
+/// query has no ParadeDB search predicate (`@@@`, `|||`, ...) on that relation.
+/// Historically the shells `panic!()`d with a generic "Unsupported query
+/// shape. Please report at github" message, which reads like an internal bug
+/// and gives the user nothing actionable. This helper emits a proper Postgres
+/// `ERROR` with `ERRCODE_FEATURE_NOT_SUPPORTED`, a detail explaining why the
+/// shell was reached, and a hint pointing at the required search predicate.
+///
+/// See paradedb/paradedb#5052.
+pub fn unsupported_projection_error(func_name: &'static str) -> ! {
+    use pgrx::pg_sys::panic::ErrorReport;
+    use pgrx::{PgLogLevel, PgSqlErrorCode};
+
+    ErrorReport::new(
+        PgSqlErrorCode::ERRCODE_FEATURE_NOT_SUPPORTED,
+        format!("`{func_name}` requires a ParadeDB search predicate on its referenced relation"),
+        func_name,
+    )
+    .set_detail(
+        "This function is a placeholder that is only evaluated inside a ParadeDB \
+         `CustomScan`. It was reached at execution time because the planner did \
+         not choose a `CustomScan` for the referenced relation.",
+    )
+    .set_hint(
+        "Add a ParadeDB search predicate (e.g. `@@@` or `|||`) on the relation \
+         referenced by this function, or remove the function from the query.",
+    )
+    .report(PgLogLevel::ERROR);
+
+    // ereport(ERROR, ...) longjmps and never returns, but pgrx types `.report()`
+    // as `()`. `unreachable!()` closes the `!` return type without adding a
+    // panic path.
+    unreachable!("ereport(ERROR) does not return")
+}

--- a/pg_search/src/postgres/customscan/basescan/projections/score.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/score.rs
@@ -28,7 +28,7 @@ mod pdb {
     #[allow(unused_variables)]
     #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
     fn score_from_relation(relation_reference: AnyElement) -> f32 {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::super::unsupported_projection_error("pdb.score")
     }
 
     extension_sql!(
@@ -46,7 +46,7 @@ mod pdb {
 #[allow(unused_variables)]
 #[pg_extern(name = "score", stable, parallel_safe, cost = 1)]
 fn paradedb_score_from_relation(relation_reference: AnyElement) -> Option<f32> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    super::unsupported_projection_error("paradedb.score")
 }
 
 extension_sql!(

--- a/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
+++ b/pg_search/src/postgres/customscan/basescan/projections/snippet.rs
@@ -348,7 +348,7 @@ pub mod pdb {
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> String {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::super::unsupported_projection_error("pdb.snippet")
     }
 
     #[allow(unused_variables)]
@@ -362,7 +362,7 @@ pub mod pdb {
         offset: default!(Option<i32>, "NULL"),
         sort_by: default!(String, "'score'"),
     ) -> Vec<String> {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::super::unsupported_projection_error("pdb.snippets")
     }
 
     #[allow(unused_variables)]
@@ -386,7 +386,7 @@ AS 'MODULE_PATHNAME', 'snippet_positions_from_relation_wrapper';
         limit: default!(Option<i32>, "NULL"),
         offset: default!(Option<i32>, "NULL"),
     ) -> IntArray2D {
-        panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+        super::super::unsupported_projection_error("pdb.snippet_positions")
     }
 }
 
@@ -403,7 +403,7 @@ fn paradedb_snippet_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> Option<String> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    super::unsupported_projection_error("paradedb.snippet")
 }
 
 #[warn(deprecated)]
@@ -418,7 +418,7 @@ fn paradedb_snippets_from_relation(
     offset: default!(Option<i32>, "NULL"),
     sort_by: default!(String, "'score'"),
 ) -> Option<Vec<String>> {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    super::unsupported_projection_error("paradedb.snippets")
 }
 
 #[warn(deprecated)]
@@ -443,7 +443,7 @@ fn paradedb_snippet_positions_from_relation(
     limit: default!(Option<i32>, "NULL"),
     offset: default!(Option<i32>, "NULL"),
 ) -> pdb::IntArray2D {
-    panic!("Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose");
+    super::unsupported_projection_error("paradedb.snippet_positions")
 }
 
 extension_sql!(


### PR DESCRIPTION
# Ticket(s) Closed

- Partially closes #5052 (error-message portion — see \"Scope\" below)

## What

Routes the eight `pdb.score`/`pdb.snippet*` and `paradedb.score`/`paradedb.snippet*` `#[pg_extern]` shells through a new shared helper that emits a proper `ereport(ERROR)` with a message, `DETAIL`, and `HINT`, in place of the current `panic!(\"Unsupported query shape. Please report at github.com/paradedb/paradedb/...\")`.

Before:
```
ERROR:  XX000: Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
```

After:
```
ERROR:  0A000: `pdb.score` requires a ParadeDB search predicate on its referenced relation
DETAIL:  This function is a placeholder that is only evaluated inside a ParadeDB `CustomScan`. It was reached at execution time because the planner did not choose a `CustomScan` for the referenced relation.
HINT:  Add a ParadeDB search predicate (e.g. `@@@` or `|||`) on the relation referenced by this function, or remove the function from the query.
```

## Why

#5052 reports two related pieces of misleading UX around `pdb.score()` used without a search predicate:

1. `EXPLAIN` shows a plain PostgreSQL `Seq Scan + Sort` plan even though the query cannot execute.
2. The `SELECT` itself later fails with `Unsupported query shape. Please report at github.com/paradedb/paradedb/...`.

That second message is a placeholder pgrx panic — SQLSTATE `XX000` with the exact wording ParadeDB uses for genuine internal bugs. But this failure is entirely user-driven: `pdb.score(rel)` requires a ParadeDB search predicate (`@@@`, `|||`, etc.) on `rel`, and without one the planner does not build the CustomScan that would normally intercept and evaluate the placeholder. Telling the user to file an internal bug ticket for this case is actively wrong — nothing about their query is unrepresentable, they just need to add a search predicate or drop the projection.

## How

Adds `unsupported_projection_error(func_name)` to `pg_search/src/postgres/customscan/basescan/projections/mod.rs`. It composes an `ErrorReport` with:

- **Code**: `ERRCODE_FEATURE_NOT_SUPPORTED` (`0A000`) instead of the `XX000` that pgrx maps a raw Rust `panic!` to.
- **Message**: names the placeholder function (`pdb.score`, `paradedb.snippets`, etc.) so the user can find the offending call in a multi-projection query.
- **Detail**: explains the invariant — the shell is only reachable when the planner did not choose a CustomScan for the referenced relation.
- **Hint**: tells the user exactly what to do: add a `@@@` / `|||` predicate on the referenced relation, or remove the placeholder from the projection.

Then rewrites all eight placeholder shells — the four `pdb.*` overloads inside `mod pdb` (`score`, `snippet`, `snippets`, `snippet_positions`) and the four `paradedb.*` legacy backwards-compat shims — to call the helper. The helper returns `!` (via `unreachable!()` after `.report(PgLogLevel::ERROR)`) so it fits every existing signature (`f32`, `Option<f32>`, `String`, `Option<String>`, `Vec<String>`, `Option<Vec<String>>`, `IntArray2D`, `pdb::IntArray2D`) without touching return types or the SQL layer.

## Scope — what this does and does not fix

**Does fix (execution-time behavior — the second half of #5052):**
- The user-facing SELECT no longer emits a message that asks them to file an internal bug ticket. They now get a proper feature-not-supported error with a hint that points at the fix.
- SQLSTATE moves from `XX000` (`internal_error`) to `0A000` (`feature_not_supported`), which is what monitoring tools like pg_stat_statements / Datadog use to distinguish user errors from server bugs.

**Does not fix (EXPLAIN-time detection — the first half of #5052):**
- `EXPLAIN` without `ANALYZE` still shows a plain PostgreSQL plan when there's no search predicate, because `EXPLAIN` doesn't invoke the projection functions. Rejecting the query at EXPLAIN time requires a planner-hook walk over the parse tree to look for placeholder funcoids and confirm each referenced RTE has a matching search operator in `baserestrictinfo` / `joinquals`. That's a larger, riskier change — a false positive breaks legitimate queries where the search predicate is on a joined relation or a pulled-up subquery — so I've kept it out of this PR. Happy to follow up in a separate PR if you'd like.

## Tests

- `cargo check --features=pg18 --no-default-features -p pg_search` is clean.
- No SQL regression test is added: the fix is a mechanical route-through-helper replacement of eight `panic!()` sites and the behavior is obvious by inspection. A regress test asserting the new SQLSTATE + message would be useful but wants an authoritative expected `.out` from CI; happy to add one in a follow-up if you'd like it here instead.

## Notes

Zero functional regression risk: the helper is only reached when the previous code path was already `panic!()`ing, so any query that runs today continues to run, and any query that used to panic now gets a strictly cleaner error instead. All existing regression tests that exercise `pdb.score()` / `pdb.snippet()` through the CustomScan path never touch these shells.

Related issues in the same area: #5108 (fixed) also concerned these placeholders reaching the panic through `PlaceHolderVar` handling; that fix routes valid uses back through the CustomScan. #5052 is about the leftover error UX when the CustomScan is not chosen at all.