### PR TITLE
fix: Support residual quals in BaseScan

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -34,9 +34,11 @@ use std::num::NonZeroUsize;
 use std::ptr::addr_of_mut;
 use std::sync::atomic::Ordering;
 
-use crate::api::operator::{estimate_query_cost, estimate_selectivity_and_cost};
+use crate::api::operator::{
+    estimate_query_cost, estimate_selectivity_and_cost, is_anyelement_search_opoid,
+};
 use crate::api::window_aggregate::window_agg_oid;
-use crate::api::{HashMap, HashSet, Varno};
+use crate::api::{agg_fn_oid, HashMap, HashSet, Varno};
 use crate::gucs;
 use crate::index::fast_fields_helper::WhichFastField;
 use crate::index::mvcc::MvccSatisfies;
@@ -94,12 +96,18 @@ use crate::{nodecast, DEFAULT_STARTUP_COST, PARAMETERIZED_SELECTIVITY, UNKNOWN_S
 use crate::{FULL_RELATION_SELECTIVITY, UNASSIGNED_SELECTIVITY};
 
 use crate::postgres::customscan::limit_offset::LimitOffset;
-use pgrx::{pg_sys, FromDatum, IntoDatum, PgList, PgMemoryContexts};
+use pgrx::{pg_guard, pg_sys, FromDatum, IntoDatum, PgList, PgMemoryContexts};
 use tantivy::snippet::SnippetGenerator;
 use tantivy::Index;
 
 #[derive(Default)]
 pub struct BaseScan;
+
+#[derive(Default)]
+struct ExtractedBaseQuals {
+    pushdown: Option<Qual>,
+    residual_qual_ids: Vec<usize>,
+}
 
 impl BaseScan {
     /// (Re-)initializes the search reader for the current execution context.
@@ -225,6 +233,202 @@ impl BaseScan {
         }
     }
 
+    /// Returns true when a failed-extraction expression is not eligible for
+    /// BaseScan's post-search PostgreSQL residual path.
+    ///
+    /// This is deliberately an eligibility check, not a catalogue of everything
+    /// that can appear in ParadeDB's `Qual` IR.  In particular, `Qual::HeapExpr`
+    /// also evaluates its stored expression through PostgreSQL's `ExecEvalExpr`;
+    /// placing that expression inside a Tantivy `HeapFilter` does not give the
+    /// expression access to scores, snippets, or other injected placeholders.
+    /// Its different contract comes from its position inside the Tantivy query
+    /// tree, where it can participate in boolean query semantics and filter
+    /// before collection/TopK.
+    ///
+    /// There are two reasons to reject an expression here:
+    ///
+    /// * score, snippet, and internal aggregate functions are placeholders whose
+    ///   raw implementations cannot be executed by `ExecQual`/`ExecEvalExpr`;
+    /// * routing a nested ParadeDB search operator that `extract_quals` rejected
+    ///   into `scan.plan.qual` would introduce a new, independently materialized
+    ///   search slow path.  The canonical SearchQueryInput operator does have a
+    ///   PostgreSQL-executable sequential-scan implementation, but enabling that
+    ///   implicitly inside BaseScan is outside this narrow fallback fix.
+    ///
+    /// This is strictly a failed-extraction fallback check. It must not be used
+    /// to revalidate or reinterpret an already-created `Qual`.
+    unsafe fn contains_disallowed_paradedb_residual_expression(node: *mut pg_sys::Node) -> bool {
+        /// The SQL-visible implementation functions behind ParadeDB's boolean
+        /// search operators live in the `paradedb` schema and use the reserved
+        /// `search_with_` prefix. Most deliberately panic if planner support
+        /// cannot replace them, so a raw call cannot be a PostgreSQL residual.
+        ///
+        /// `search_with_query_input` is the exception: it implements ParadeDB's
+        /// intentional (expensive) sequential-scan path and PostgreSQL can
+        /// execute it directly. Do not broaden this fallback detector into a
+        /// ban on that existing execution path.
+        unsafe fn is_panic_only_search_function(func_expr: *mut pg_sys::FuncExpr) -> bool {
+            if func_expr.is_null() || (*func_expr).funcresulttype != pg_sys::BOOLOID {
+                return false;
+            }
+
+            let namespace_oid = pg_sys::get_func_namespace((*func_expr).funcid);
+            if namespace_oid == pg_sys::InvalidOid {
+                return false;
+            }
+
+            let namespace_name = pg_sys::get_namespace_name(namespace_oid);
+            if namespace_name.is_null()
+                || CStr::from_ptr(namespace_name).to_bytes() != b"paradedb"
+            {
+                return false;
+            }
+
+            let function_name = pg_sys::get_func_name((*func_expr).funcid);
+            if function_name.is_null() {
+                return false;
+            }
+
+            let function_name = CStr::from_ptr(function_name).to_bytes();
+            function_name.starts_with(b"search_with_")
+                && function_name != b"search_with_query_input"
+        }
+
+        #[pg_guard]
+        unsafe extern "C-unwind" fn walker(
+            node: *mut pg_sys::Node,
+            context: *mut core::ffi::c_void,
+        ) -> bool {
+            if node.is_null() {
+                return false;
+            }
+
+            match (*node).type_ {
+                // RestrictInfo is a planner node rather than an expression node,
+                // so expression_tree_walker cannot traverse it directly.
+                pg_sys::NodeTag::T_RestrictInfo => {
+                    let ri = node.cast::<pg_sys::RestrictInfo>();
+                    return walker((*ri).clause.cast(), context);
+                }
+
+                pg_sys::NodeTag::T_OpExpr => {
+                    let op_expr = node.cast::<pg_sys::OpExpr>();
+                    // The proximity combinators (`##` and `##>`) are ordinary
+                    // PostgreSQL-executable value expressions. Only boolean
+                    // ParadeDB search predicates establish a search context.
+                    if (*op_expr).opresulttype == pg_sys::BOOLOID
+                        && is_anyelement_search_opoid((*op_expr).opno)
+                    {
+                        return true;
+                    }
+                }
+
+                pg_sys::NodeTag::T_ScalarArrayOpExpr => {
+                    let op_expr = node.cast::<pg_sys::ScalarArrayOpExpr>();
+                    if is_anyelement_search_opoid((*op_expr).opno) {
+                        return true;
+                    }
+                }
+
+                pg_sys::NodeTag::T_FuncExpr => {
+                    let func_expr = node.cast::<pg_sys::FuncExpr>();
+                    let funcoids = &*context.cast::<Vec<pg_sys::Oid>>();
+                    if funcoids.contains(&(*func_expr).funcid)
+                        || is_panic_only_search_function(func_expr)
+                    {
+                        return true;
+                    }
+                }
+
+                _ => {}
+            }
+
+            pg_sys::expression_tree_walker(node, Some(walker), context)
+        }
+
+        let funcoids: Vec<pg_sys::Oid> = score_funcoids()
+            .iter()
+            .copied()
+            .chain(snippet_funcoids().iter().copied())
+            .chain(snippets_funcoids().iter().copied())
+            .chain(snippet_positions_funcoids().iter().copied())
+            .chain([agg_fn_oid(), window_agg_oid()])
+            .collect();
+
+        walker(node, std::ptr::from_ref(&funcoids).cast_mut().cast())
+    }
+
+    /// Decide whether a failed top-level qual extraction may safely fall back to
+    /// PostgreSQL's standard expression evaluator.
+    ///
+    /// Generic residual classification is intentionally restricted to a complete
+    /// top-level base-relation RestrictInfo. Join-level and non-local clauses
+    /// continue to fail closed.
+    unsafe fn can_preserve_as_residual(
+        root: *mut pg_sys::PlannerInfo,
+        rel: *mut pg_sys::RelOptInfo,
+        ri_type: RestrictInfoType,
+        ri: *mut pg_sys::RestrictInfo,
+    ) -> bool {
+        if root.is_null() || ri.is_null() {
+            return false;
+        }
+
+        if !matches!(ri_type, RestrictInfoType::BaseRelation)
+            || rel.is_null()
+            || (*ri).clause.is_null()
+        {
+            return false;
+        }
+
+        // Only a boolean WHERE predicate can be installed in plan.qual. This
+        // should already be guaranteed by PostgreSQL's RestrictInfo invariants,
+        // but keep the residual boundary fail-closed if that ever changes.
+        if pg_sys::exprType((*ri).clause.cast()) != pg_sys::BOOLOID {
+            return false;
+        }
+
+        // This classifier is deliberately BaseScan-only. Append members are
+        // base-like single relations too, but join and upper RelOptInfos are not.
+        if !matches!(
+            (*rel).reloptkind,
+            pg_sys::RelOptKind::RELOPT_BASEREL
+                | pg_sys::RelOptKind::RELOPT_OTHER_MEMBER_REL
+        ) || pg_sys::bms_num_members((*rel).relids) != 1
+        {
+            return false;
+        }
+
+        // The residual must be executable using only this BaseScan's tuple.
+        if !pg_sys::bms_is_subset((*ri).clause_relids, (*rel).relids) {
+            return false;
+        }
+
+        // clause_relids records Vars physically present in the expression,
+        // while required_relids can be larger to enforce the semantic level at
+        // which PostgreSQL is allowed to evaluate it (notably around joins).
+        if !pg_sys::bms_is_subset((*ri).required_relids, (*rel).relids) {
+            return false;
+        }
+
+        // Do not route a nested ParadeDB search predicate or a raw ParadeDB
+        // placeholder into this narrow post-search ExecQual fallback.
+        if Self::contains_disallowed_paradedb_residual_expression((*ri).clause.cast()) {
+            return false;
+        }
+
+        // Preserve the legacy SubPlan/InitPlan residual fallback even when generic
+        // filter pushdown is disabled. Other residual expressions are part of the
+        // new generic path and therefore retain the GUC's original opt-out.
+        is_subplan(ri.cast(), root) || gucs::enable_filter_pushdown()
+    }
+
+    fn merge_extract_state(target: &mut QualExtractState, source: &QualExtractState) {
+        target.uses_our_operator |= source.uses_our_operator;
+        target.uses_tantivy_to_query |= source.uses_tantivy_to_query;
+        target.uses_heap_expr |= source.uses_heap_expr;
+    }
+
     #[allow(clippy::too_many_arguments)]
     unsafe fn extract_all_possible_quals(
         builder: &mut CustomPathBuilder<BaseScan>,
@@ -235,9 +439,10 @@ impl BaseScan {
         indexrel: &PgSearchRelation,
         uses_score_or_snippet: bool,
         attempt_pushdown: bool,
-    ) -> Option<Qual> {
+    ) -> ExtractedBaseQuals {
         let mut state = QualExtractState::default();
         let context = PlannerContext::from_planner(root);
+        let mut residual_qual_ids = Vec::new();
 
         // Filter out predicates that are implied by the partial index predicate.
         // If a partial index has predicate P (e.g., "deleted_at IS NULL"), and the query
@@ -256,20 +461,23 @@ impl BaseScan {
             attempt_pushdown,
         );
 
-        // If full extraction failed (e.g., baserestrictinfo contains SubPlan from
-        // RLS policies alongside our @@@ operator), try partial extraction: extract
-        // each restrict_info item individually, skipping ones we can't handle.
-        // Only use partial extraction when ALL skipped clauses are SubPlans
-        // (which will be evaluated via plan.qual). If any non-SubPlan clause
-        // is skipped, fall back to let PostgreSQL handle the query normally.
+        // If the complete conjunction cannot be represented as a ParadeDB Qual,
+        // classify each top-level RestrictInfo independently:
         //
-        // TODO: We do something similar in `collect_join_sources_base_rel`,
-        // is unification possible?
+        //   * successfully extracted clauses become ParadeDB/Tantivy pushdowns;
+        //   * safe local PostgreSQL expressions become residual plan quals;
+        //   * unsafe or non-local clauses reject this partial extraction.
+        //
+        // Classification intentionally happens only at top-level RestrictInfo
+        // granularity. We never partially extract inside an unsupported OR, NOT,
+        // CASE, COALESCE, or another expression wrapper.
         if quals.is_none() {
             let mut partial_quals = Vec::new();
             let mut partial_state = QualExtractState::default();
-            let mut all_skipped_are_subplans = true;
+            let mut all_skipped_are_safe_residuals = true;
             for ri in filtered_restrict_info.iter_ptr() {
+                let mut local_state = QualExtractState::default();
+
                 if let Some(qual) = extract_quals(
                     &context,
                     rti,
@@ -277,17 +485,32 @@ impl BaseScan {
                     ri_type,
                     indexrel,
                     false,
-                    &mut partial_state,
+                    &mut local_state,
                     attempt_pushdown,
                 ) {
+                    // An existing Qual is authoritative and intentionally opaque
+                    // to the residual fallback. Keep every established Qual
+                    // contract and optimization exactly as extract_quals chose it.
                     partial_quals.push(qual);
-                } else if !is_subplan(ri.cast(), root) {
-                    all_skipped_are_subplans = false;
+                    Self::merge_extract_state(&mut partial_state, &local_state);
+                } else if Self::can_preserve_as_residual(
+                    root,
+                    builder.args().rel,
+                    ri_type,
+                    ri,
+                ) {
+                    // RestrictInfo pointers are planner-local identities. They
+                    // remain valid for matching clauses during PlanCustomPath.
+                    residual_qual_ids.push(ri as usize);
+                } else {
+                    all_skipped_are_safe_residuals = false;
+                    break;
                 }
             }
+
             if !partial_quals.is_empty()
                 && partial_state.uses_our_operator
-                && all_skipped_are_subplans
+                && all_skipped_are_safe_residuals
             {
                 state = partial_state;
                 quals = if partial_quals.len() == 1 {
@@ -295,6 +518,10 @@ impl BaseScan {
                 } else {
                     Some(Qual::And(partial_quals))
                 };
+            } else {
+                // Do not carry residual identities into another planning path
+                // unless this complete top-level split was accepted.
+                residual_qual_ids.clear();
             }
         }
 
@@ -345,11 +572,22 @@ impl BaseScan {
         // 2. enable_custom_scan_without_operator is true, OR
         // 3. The query has window aggregates (pdb.agg()) that we must handle.
         let has_window_aggs = query_has_window_agg_functions(root);
-        if state.uses_our_operator || gucs::enable_custom_scan_without_operator() || has_window_aggs
+        let pushdown = if state.uses_our_operator
+            || gucs::enable_custom_scan_without_operator()
+            || has_window_aggs
         {
             quals
         } else {
             None
+        };
+
+        if pushdown.is_none() {
+            residual_qual_ids.clear();
+        }
+
+        ExtractedBaseQuals {
+            pushdown,
+            residual_qual_ids,
         }
     }
 
@@ -655,7 +893,10 @@ impl CustomScan for BaseScan {
             //
             let is_select =
                 (*(*builder.args().root).parse).commandType == pg_sys::CmdType::CMD_SELECT;
-            let quals = Self::extract_all_possible_quals(
+            let ExtractedBaseQuals {
+                pushdown: quals,
+                residual_qual_ids,
+            } = Self::extract_all_possible_quals(
                 &mut builder,
                 root,
                 rti,
@@ -665,6 +906,8 @@ impl CustomScan for BaseScan {
                 maybe_needs_const_projections,
                 is_select,
             );
+
+            let has_residual_quals = !residual_qual_ids.is_empty();
 
             // If we have window aggregates but no quals, we must still create the custom path
             // because pdb.agg() can only be executed by our custom scan
@@ -711,6 +954,7 @@ impl CustomScan for BaseScan {
             // TODO: `impl Default for PrivateData` requires that many fields are in invalid
             // states. Should consider having a separate builder for PrivateData.
             let mut custom_private = PrivateData::default();
+            custom_private.set_residual_qual_ids(residual_qual_ids);
 
             let segment_count = {
                 let directory = MvccSatisfies::LargestSegment.directory(&bm25_index);
@@ -750,19 +994,28 @@ impl CustomScan for BaseScan {
             // `is_limit_pushdown_safe` then gates on topology + predicates +
             // unsafe SRFs.
             let raw_limit_offset = LimitOffset::from_root(builder.args().root);
-            let limit_offset = raw_limit_offset.filter(|lo| {
-                let pg_says_pushable = (*builder.args().root).limit_tuples > -1.0;
-                let unnest_override = classify_target_list_srf(builder.args().root).is_safe();
 
-                (pg_says_pushable || lo.has_any_param() || unnest_override)
-                    && is_limit_pushdown_safe(
-                        builder.args().root,
-                        rel,
-                        baserels,
-                        rti,
-                        &Some(quals.clone()),
-                    )
-            });
+            let limit_offset = if has_residual_quals {
+                // A PostgreSQL residual is evaluated by ExecQual after the
+                // ParadeDB scan produces a candidate. Pushing an irreversible
+                // LIMIT into the scan would apply TopK before that filter and
+                // can therefore change query results.
+                None
+            } else {
+                raw_limit_offset.filter(|lo| {
+                    let pg_says_pushable = (*builder.args().root).limit_tuples > -1.0;
+                    let unnest_override = classify_target_list_srf(builder.args().root).is_safe();
+
+                    (pg_says_pushable || lo.has_any_param() || unnest_override)
+                        && is_limit_pushdown_safe(
+                            builder.args().root,
+                            rel,
+                            baserels,
+                            rti,
+                            &Some(quals.clone()),
+                        )
+                })
+            };
 
             // Get all columns referenced by this RTE throughout the entire query
             let referenced_columns = collect_maybe_fast_field_referenced_columns(rti, rel);
@@ -1168,28 +1421,44 @@ impl CustomScan for BaseScan {
                 .custom_private_mut()
                 .set_ambulkdelete_epoch(MetaPage::open(&indexrel).ambulkdelete_epoch());
 
-            // Collect subplans that our Custom Scan doesn't handle internally and set them as plan.qual.
-            // PostgreSQL's ExecInitCustomScan will call ExecInitQual on plan.qual,
-            // which properly initializes SubPlans. We then evaluate these in exec_custom_scan.
+            // Materialize the top-level clauses classified as PostgreSQL
+            // residuals during CreateCustomPath.
+            //
+            // PostgreSQL's ExecInitCustomScan initializes scan.plan.qual through
+            // ExecInitQual, including any nested SubPlans or PARAM_EXEC values.
+            // BaseScan then evaluates the resulting expression states through
+            // ExecQual for every produced heap tuple.
+            let residual_qual_ids = builder.custom_private().residual_qual_ids().to_vec();
             let clauses = PgList::<pg_sys::Node>::from_pg(builder.args().clauses);
-            let mut subplan_quals = PgList::<pg_sys::Node>::new();
+            let mut residual_quals = PgList::<pg_sys::Node>::new();
+
             for clause in clauses.iter_ptr() {
-                if is_subplan(clause, builder.args().root) {
-                    // strip RestrictInfo wrapper, plan.qual needs bare expressions
-                    let bare_clause = if (*clause).type_ == pg_sys::NodeTag::T_RestrictInfo {
-                        let ri = clause as *mut pg_sys::RestrictInfo;
-                        (*ri).clause.cast()
+                if clause.is_null() {
+                    continue;
+                }
+
+                let (bare_clause, is_recorded_residual) =
+                    if (*clause).type_ == pg_sys::NodeTag::T_RestrictInfo {
+                        let ri = clause.cast::<pg_sys::RestrictInfo>();
+                        (
+                            (*ri).clause.cast(),
+                            residual_qual_ids.contains(&(ri as usize)),
+                        )
                     } else {
-                        clause
+                        (clause, false)
                     };
-                    subplan_quals.push(bare_clause);
+
+                // Keep the old SubPlan fallback as a defensive compatibility
+                // path for any clause shape that was not matched by identity.
+                if is_recorded_residual || is_subplan(clause, builder.args().root) {
+                    residual_quals.push(bare_clause);
                 }
             }
 
-            // SubPlan quals require per-tuple heap access for ExecQual, which would
-            // negate the benefit of columnar. Fall back to Normal so we don't pay for both
-            // batch processing AND per-tuple heap fetches.
-            if !subplan_quals.is_empty()
+            // PostgreSQL residual quals require a heap tuple and per-tuple
+            // ExecQual evaluation. Columnar execution cannot provide the complete
+            // PostgreSQL expression-evaluation contract, so use Normal execution.
+            if !residual_quals.is_empty()
                 && matches!(
                     builder.custom_private().exec_method_type(),
                     ExecMethodType::Columnar { .. }
@@ -1201,8 +1470,8 @@ impl CustomScan for BaseScan {
             }
 
             let mut scan = builder.build();
-            if !subplan_quals.is_empty() {
-                scan.scan.plan.qual = subplan_quals.into_pg();
+            if !residual_quals.is_empty() {
+                scan.scan.plan.qual = residual_quals.into_pg();
             }
             scan
         }
@@ -1597,10 +1866,10 @@ impl CustomScan for BaseScan {
                             }
                         };
 
-                        // Evaluate executor-level quals (e.g., RLS policy SubPlan expressions)
-                        // that couldn't be pushed into the tantivy query.
-                        // These are set as plan.qual in plan_custom_path.
-                        if !satisfies_subplan_quals(state, slot) {
+                        // Evaluate executor-level residual quals (including the
+                        // legacy RLS/SubPlan case) before any score, snippet, or
+                        // window-aggregate placeholder is populated.
+                        if !satisfies_residual_quals(state, slot) {
                             continue;
                         }
 
@@ -2088,11 +2357,16 @@ fn check_visibility(
         .exec_if_visible(ctid, bslot.cast(), move |_| bslot.cast())
 }
 
-/// Evaluate executor-level quals (e.g., RLS policy SubPlan expressions) that couldn't be pushed
-/// into the tantivy query. These are set as `plan.qual` in `plan_custom_path`.
-/// Returns `true` if qual passes (or no qual exists), `false` if the row should be skipped.
+/// Evaluate executor-level residual quals that could not be represented by the
+/// ParadeDB query IR.  These are set as `plan.qual` in `plan_custom_path` and
+/// run on the visible BaseScan heap tuple after Tantivy has produced a candidate.
+/// This is intentionally distinct from `Qual::HeapExpr`, whose PostgreSQL
+/// expression is embedded in a Tantivy `HeapFilter` and runs while its scorer is
+/// enumerating documents.
+/// Returns `true` if the qual passes (or no qual exists), and `false` if the row
+/// should be skipped.
 #[inline(always)]
-unsafe fn satisfies_subplan_quals(
+unsafe fn satisfies_residual_quals(
     state: &mut CustomScanStateWrapper<BaseScan>,
     slot: *mut pg_sys::TupleTableSlot,
 ) -> bool {

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -278,8 +278,7 @@ impl BaseScan {
             }
 
             let namespace_name = pg_sys::get_namespace_name(namespace_oid);
-            if namespace_name.is_null()
-                || CStr::from_ptr(namespace_name).to_bytes() != b"paradedb"
+            if namespace_name.is_null() || CStr::from_ptr(namespace_name).to_bytes() != b"paradedb"
             {
                 return false;
             }
@@ -351,8 +350,11 @@ impl BaseScan {
             snippet_funcoids(),
             snippets_funcoids(),
             snippet_positions_funcoids(),
-            [agg_fn_oid(), window_agg_oid()]
-        ].into_iter().flatten().collect();
+            [agg_fn_oid(), window_agg_oid()],
+        ]
+        .into_iter()
+        .flatten()
+        .collect();
 
         walker(node, std::ptr::from_ref(&funcoids).cast_mut().cast())
     }
@@ -391,8 +393,7 @@ impl BaseScan {
         // base-like single relations too, but join and upper RelOptInfos are not.
         if !matches!(
             (*rel).reloptkind,
-            pg_sys::RelOptKind::RELOPT_BASEREL
-                | pg_sys::RelOptKind::RELOPT_OTHER_MEMBER_REL
+            pg_sys::RelOptKind::RELOPT_BASEREL | pg_sys::RelOptKind::RELOPT_OTHER_MEMBER_REL
         ) || pg_sys::bms_num_members((*rel).relids) != 1
         {
             return false;
@@ -492,12 +493,7 @@ impl BaseScan {
                     // contract and optimization exactly as extract_quals chose it.
                     partial_quals.push(qual);
                     Self::merge_extract_state(&mut partial_state, &local_state);
-                } else if Self::can_preserve_as_residual(
-                    root,
-                    builder.args().rel,
-                    ri_type,
-                    ri,
-                ) {
+                } else if Self::can_preserve_as_residual(root, builder.args().rel, ri_type, ri) {
                     // RestrictInfo pointers are planner-local identities. They
                     // remain valid for matching clauses during PlanCustomPath.
                     residual_qual_ids.push(ri as usize);

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -346,14 +346,13 @@ impl BaseScan {
             pg_sys::expression_tree_walker(node, Some(walker), context)
         }
 
-        let funcoids: Vec<pg_sys::Oid> = score_funcoids()
-            .iter()
-            .copied()
-            .chain(snippet_funcoids().iter().copied())
-            .chain(snippets_funcoids().iter().copied())
-            .chain(snippet_positions_funcoids().iter().copied())
-            .chain([agg_fn_oid(), window_agg_oid()])
-            .collect();
+        let funcoids: Vec<pg_sys::Oid> = [
+            score_funcoids(),
+            snippet_funcoids(),
+            snippets_funcoids(),
+            snippet_positions_funcoids(),
+            [agg_fn_oid(), window_agg_oid()]
+        ].into_iter().flatten().collect();
 
         walker(node, std::ptr::from_ref(&funcoids).cast_mut().cast())
     }

--- a/pg_search/src/postgres/customscan/basescan/privdat.rs
+++ b/pg_search/src/postgres/customscan/basescan/privdat.rs
@@ -58,6 +58,10 @@ pub struct PrivateData {
     // Whether this path was chosen as a sorted path (declares pathkeys for index's sort_by field).
     // When true, the execution should use the sorted merge path for segment scanning.
     use_sorted_path: bool,
+    // Planner-local identities of top-level RestrictInfo nodes that could not be
+    // represented as ParadeDB Quals and must be evaluated by PostgreSQL through
+    // CustomScan.scan.plan.qual.
+    residual_qual_ids: Vec<usize>,
     // Which decision branch produced this path's serial/parallel choice, surfaced in EXPLAIN
     // VERBOSE. `None` only on plans serialized before this field existed.
     worker_selection_reason: Option<WorkerDecisionReason>,
@@ -242,6 +246,9 @@ impl PrivateData {
     pub fn set_use_sorted_path(&mut self, use_sorted: bool) {
         self.use_sorted_path = use_sorted;
     }
+    pub fn set_residual_qual_ids(&mut self, residual_qual_ids: Vec<usize>) {
+        self.residual_qual_ids = residual_qual_ids;
+    }
 }
 
 //
@@ -327,5 +334,8 @@ impl PrivateData {
 
     pub fn use_sorted_path(&self) -> bool {
         self.use_sorted_path
+    }
+    pub fn residual_qual_ids(&self) -> &[usize] {
+        &self.residual_qual_ids
     }
 }

--- a/pg_search/tests/pg_regress/expected/issue_5546.out
+++ b/pg_search/tests/pg_regress/expected/issue_5546.out
@@ -1,0 +1,375 @@
+CREATE TABLE issue_5546_generic_residual_items
+(
+    id       bigint PRIMARY KEY,
+    body     text    NOT NULL,
+    allowed  boolean,
+    priority integer NOT NULL
+);
+INSERT INTO issue_5546_generic_residual_items (id, body, allowed, priority)
+VALUES (1, 'alpha alpha alpha', false, 100),
+       (2, 'alpha alpha', true, 90),
+       (3, 'alpha', NULL, 80),
+       (4, 'beta', true, 70);
+CREATE INDEX issue_5546_generic_residual_items_idx
+    ON issue_5546_generic_residual_items
+    USING bm25 (id, body, priority)
+    WITH (
+        key_field = 'id',
+        numeric_fields = '{"priority": {"fast": true}}'
+    );
+ANALYZE issue_5546_generic_residual_items;
+SET max_parallel_workers_per_gather = 0;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_indexonlyscan = off;
+SET enable_bitmapscan = off;
+-- Keep negative plan assertions stable without depending on the deparsed
+-- fallback Seq Scan expression (which can contain installation-specific OIDs).
+CREATE OR REPLACE FUNCTION pg_temp.issue_5546_plan_uses_basescan(query text)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    line record;
+BEGIN
+    FOR line IN EXECUTE 'EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) ' || query LOOP
+        IF line."QUERY PLAN" LIKE '%Custom Scan (ParadeDB Base Scan)%' THEN
+            RETURN true;
+        END IF;
+    END LOOP;
+    RETURN false;
+END;
+$$;
+CREATE FUNCTION
+-- Reproduction 1: DistinctExpr is evaluated by PostgreSQL as a residual qual.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY id;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Custom Scan (ParadeDB Base Scan) on issue_5546_generic_residual_items
+         Filter: (allowed IS DISTINCT FROM false)
+         Table: issue_5546_generic_residual_items
+         Index: issue_5546_generic_residual_items_idx
+         Exec Method: NormalScanExecState
+         Scores: true
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"body","value":"alpha","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY id;
+ id | score_available 
+----+-----------------
+  2 | t
+  3 | t
+(2 rows)
+
+-- Reproduction 2: CaseExpr is evaluated by PostgreSQL as a residual qual.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN priority >= 90 THEN allowed
+          ELSE id = 3
+      END
+ORDER BY id;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: id
+   ->  Custom Scan (ParadeDB Base Scan) on issue_5546_generic_residual_items
+         Filter: CASE WHEN (priority >= 90) THEN allowed ELSE (id = 3) END
+         Table: issue_5546_generic_residual_items
+         Index: issue_5546_generic_residual_items_idx
+         Exec Method: NormalScanExecState
+         Scores: true
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"body","value":"alpha","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(9 rows)
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN priority >= 90 THEN allowed
+          ELSE id = 3
+      END
+ORDER BY id;
+ id | score_available 
+----+-----------------
+  2 | t
+  3 | t
+(2 rows)
+
+-- Reproduction 3: a nested InitPlan/PARAM_EXEC remains inside the complete
+-- CoalesceExpr evaluated by PostgreSQL.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND COALESCE((SELECT NULL::boolean), allowed, false)
+ORDER BY id;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Sort
+   Sort Key: id
+   InitPlan 1
+     ->  Result
+   ->  Custom Scan (ParadeDB Base Scan) on issue_5546_generic_residual_items
+         Filter: COALESCE((InitPlan 1).col1, allowed, false)
+         Table: issue_5546_generic_residual_items
+         Index: issue_5546_generic_residual_items_idx
+         Exec Method: NormalScanExecState
+         Scores: true
+         Tantivy Query: {"with_index":{"query":{"match":{"field":"body","value":"alpha","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(11 rows)
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND COALESCE((SELECT NULL::boolean), allowed, false)
+ORDER BY id;
+ id | score_available 
+----+-----------------
+  2 | t
+(1 row)
+
+-- Reproduction 4: LIMIT must observe rows after PostgreSQL residual filtering.
+-- id=1 has the greatest priority but fails the residual; id=2 is correct.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, priority, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY priority DESC
+LIMIT 1;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   ->  Sort
+         Sort Key: priority DESC
+         ->  Custom Scan (ParadeDB Base Scan) on issue_5546_generic_residual_items
+               Filter: (allowed IS DISTINCT FROM false)
+               Table: issue_5546_generic_residual_items
+               Index: issue_5546_generic_residual_items_idx
+               Exec Method: NormalScanExecState
+               Scores: true
+               Tantivy Query: {"with_index":{"query":{"match":{"field":"body","value":"alpha","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(10 rows)
+
+SELECT id, priority, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY priority DESC
+LIMIT 1;
+ id | priority | score_available 
+----+----------+-----------------
+  2 |       90 | t
+(1 row)
+
+-- An unsupported wrapper must not hide a nested ParadeDB search operator.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE WHEN allowed IS false THEN body ||| 'beta' ELSE true END$$
+) AS nested_search_residual_rejected;
+ nested_search_residual_rejected 
+---------------------------------
+ t
+(1 row)
+
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN allowed IS false THEN body ||| 'beta'
+          ELSE true
+      END;
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+-- A real correlated SubPlan must not bypass that fail-closed check.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT outer_items.id, pdb.score(outer_items.id)
+        FROM issue_5546_generic_residual_items AS outer_items
+       WHERE outer_items.body ||| 'alpha'
+         AND CASE
+                 WHEN EXISTS (
+                     SELECT 1
+                     FROM issue_5546_generic_residual_items AS inner_items
+                     WHERE inner_items.id = outer_items.id
+                       AND inner_items.allowed IS false
+                 )
+                 THEN outer_items.body ||| 'beta'
+                 ELSE true
+             END$$
+) AS correlated_nested_search_rejected;
+ correlated_nested_search_rejected 
+-----------------------------------
+ t
+(1 row)
+
+SELECT outer_items.id, pdb.score(outer_items.id) AS score
+FROM issue_5546_generic_residual_items AS outer_items
+WHERE outer_items.body ||| 'alpha'
+  AND CASE
+          WHEN EXISTS (
+              SELECT 1
+              FROM issue_5546_generic_residual_items AS inner_items
+              WHERE inner_items.id = outer_items.id
+                AND inner_items.allowed IS false
+          )
+          THEN outer_items.body ||| 'beta'
+          ELSE true
+      END;
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+-- Context-dependent score/snippet placeholders cannot be raw ExecQual residuals.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE WHEN allowed THEN pdb.score(id) > 0 ELSE true END$$
+) AS score_residual_rejected;
+ score_residual_rejected 
+-------------------------
+ t
+(1 row)
+
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN allowed THEN pdb.score(id) > 0
+          ELSE true
+      END;
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+-- Internal aggregate placeholders are ordinary FuncExpr nodes, so PostgreSQL
+-- accepts them syntactically in WHERE even though only ParadeDB may populate
+-- them. They must fail closed as residuals as well.
+-- A raw call to one of the panic-only search implementation functions can
+-- remain a FuncExpr when planner support cannot associate its lhs with the
+-- indexed relation. It must not become a residual either.
+SELECT
+    NOT pg_temp.issue_5546_plan_uses_basescan(
+        $$SELECT id, pdb.score(id)
+            FROM issue_5546_generic_residual_items
+           WHERE body ||| 'alpha'
+             AND pdb.agg_fn('count') IS NOT NULL$$
+    ) AS aggregate_placeholder_residual_rejected,
+    NOT pg_temp.issue_5546_plan_uses_basescan(
+        $$SELECT id, pdb.score(id)
+            FROM issue_5546_generic_residual_items
+           WHERE body ||| 'alpha'
+             AND pdb.window_agg('{}') > 0$$
+    ) AS window_placeholder_residual_rejected,
+    NOT pg_temp.issue_5546_plan_uses_basescan(
+        $$SELECT id, pdb.score(id)
+            FROM issue_5546_generic_residual_items
+           WHERE body ||| 'alpha'
+             AND CASE
+                     WHEN allowed THEN paradedb.search_with_parse(
+                         'not-a-column'::text,
+                         clock_timestamp()::text
+                     )
+                     ELSE true
+                 END$$
+    ) AS raw_search_function_residual_rejected;
+ aggregate_placeholder_residual_rejected | window_placeholder_residual_rejected | raw_search_function_residual_rejected 
+-----------------------------------------+--------------------------------------+---------------------------------------
+ t                                       | t                                    | t
+(1 row)
+
+-- ParadeDB value builders are ordinary PostgreSQL-executable expressions.
+-- Inside an otherwise unsupported top-level conjunct they remain valid
+-- residuals; only a boolean search predicate establishes search context.
+SELECT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE
+                 WHEN allowed IS NULL THEN
+                     ('left' ## (priority % 2) ## 'right') IS NOT NULL
+                     AND pdb.term(priority::bigint) IS NOT NULL
+                 ELSE true
+             END$$
+) AS paradedb_value_residual_allowed;
+ paradedb_value_residual_allowed 
+---------------------------------
+ t
+(1 row)
+
+SELECT id
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN allowed IS NULL THEN
+              ('left' ## (priority % 2) ## 'right') IS NOT NULL
+              AND pdb.term(priority::bigint) IS NOT NULL
+          ELSE true
+      END
+ORDER BY id;
+ id 
+----
+  1
+  2
+  3
+(3 rows)
+
+SET paradedb.enable_filter_pushdown = false;
+-- The GUC retains its original opt-out for generic residual classification.
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY id;
+ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
+-- Legacy is_subplan fallback remains available while the GUC is disabled.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND (SELECT true)
+LIMIT 1;
+                                                                                               QUERY PLAN                                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   InitPlan 1
+     ->  Result
+   ->  Result
+         One-Time Filter: (InitPlan 1).col1
+         ->  Custom Scan (ParadeDB Base Scan) on issue_5546_generic_residual_items
+               Filter: (InitPlan 1).col1
+               Table: issue_5546_generic_residual_items
+               Index: issue_5546_generic_residual_items_idx
+               Exec Method: NormalScanExecState
+               Scores: true
+               Tantivy Query: {"with_index":{"query":{"match":{"field":"body","value":"alpha","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+(12 rows)
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND (SELECT true)
+ORDER BY id;
+ id | score_available 
+----+-----------------
+  1 | t
+  2 | t
+  3 | t
+(3 rows)
+
+RESET paradedb.enable_filter_pushdown;
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
+RESET enable_indexscan;
+RESET enable_indexonlyscan;
+RESET enable_bitmapscan;
+DROP TABLE issue_5546_generic_residual_items;

--- a/pg_search/tests/pg_regress/expected/issue_5546.out
+++ b/pg_search/tests/pg_regress/expected/issue_5546.out
@@ -40,7 +40,6 @@ BEGIN
     RETURN false;
 END;
 $$;
-CREATE FUNCTION
 -- Reproduction 1: DistinctExpr is evaluated by PostgreSQL as a residual qual.
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
 SELECT id, pdb.score(id) AS score
@@ -120,7 +119,7 @@ ORDER BY id;
                                                                                             QUERY PLAN                                                                                            
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
-   Sort Key: id
+   Sort Key: issue_5546_generic_residual_items.id
    InitPlan 1
      ->  Result
    ->  Custom Scan (ParadeDB Base Scan) on issue_5546_generic_residual_items
@@ -195,6 +194,8 @@ WHERE body ||| 'alpha'
           WHEN allowed IS false THEN body ||| 'beta'
           ELSE true
       END;
+WARNING:  the table is being sequentially scanned for this query, so performance may be slow
+if you are not sure why, please file an issue: https://github.com/paradedb/paradedb/issues/new/choose
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- A real correlated SubPlan must not bypass that fail-closed check.
 SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
@@ -230,6 +231,8 @@ WHERE outer_items.body ||| 'alpha'
           THEN outer_items.body ||| 'beta'
           ELSE true
       END;
+WARNING:  the table is being sequentially scanned for this query, so performance may be slow
+if you are not sure why, please file an issue: https://github.com/paradedb/paradedb/issues/new/choose
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Context-dependent score/snippet placeholders cannot be raw ExecQual residuals.
 SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
@@ -254,37 +257,47 @@ ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/pa
 -- Internal aggregate placeholders are ordinary FuncExpr nodes, so PostgreSQL
 -- accepts them syntactically in WHERE even though only ParadeDB may populate
 -- them. They must fail closed as residuals as well.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND pdb.agg_fn('count') IS NOT NULL$$
+) AS aggregate_placeholder_residual_rejected;
+ aggregate_placeholder_residual_rejected 
+-----------------------------------------
+ t
+(1 row)
+
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND pdb.window_agg('{}') > 0$$
+) AS window_placeholder_residual_rejected;
+ window_placeholder_residual_rejected 
+--------------------------------------
+ t
+(1 row)
+
 -- A raw call to one of the panic-only search implementation functions can
--- remain a FuncExpr when planner support cannot associate its lhs with the
--- indexed relation. It must not become a residual either.
-SELECT
-    NOT pg_temp.issue_5546_plan_uses_basescan(
-        $$SELECT id, pdb.score(id)
-            FROM issue_5546_generic_residual_items
-           WHERE body ||| 'alpha'
-             AND pdb.agg_fn('count') IS NOT NULL$$
-    ) AS aggregate_placeholder_residual_rejected,
-    NOT pg_temp.issue_5546_plan_uses_basescan(
-        $$SELECT id, pdb.score(id)
-            FROM issue_5546_generic_residual_items
-           WHERE body ||| 'alpha'
-             AND pdb.window_agg('{}') > 0$$
-    ) AS window_placeholder_residual_rejected,
-    NOT pg_temp.issue_5546_plan_uses_basescan(
-        $$SELECT id, pdb.score(id)
-            FROM issue_5546_generic_residual_items
-           WHERE body ||| 'alpha'
-             AND CASE
-                     WHEN allowed THEN paradedb.search_with_parse(
-                         'not-a-column'::text,
-                         clock_timestamp()::text
-                     )
-                     ELSE true
-                 END$$
-    ) AS raw_search_function_residual_rejected;
- aggregate_placeholder_residual_rejected | window_placeholder_residual_rejected | raw_search_function_residual_rejected 
------------------------------------------+--------------------------------------+---------------------------------------
- t                                       | t                                    | t
+-- remain a FuncExpr when planner support can find the relation from its lhs
+-- but cannot associate that lhs expression with an indexed field. It must not
+-- become a residual either.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE
+                 WHEN allowed THEN paradedb.search_with_parse(
+                     lower(body),
+                     clock_timestamp()::text
+                 )
+                 ELSE true
+             END$$
+) AS raw_search_function_residual_rejected;
+ raw_search_function_residual_rejected 
+---------------------------------------
+ t
 (1 row)
 
 -- ParadeDB value builders are ordinary PostgreSQL-executable expressions.

--- a/pg_search/tests/pg_regress/expected/score_select_subquery.out
+++ b/pg_search/tests/pg_regress/expected/score_select_subquery.out
@@ -34,11 +34,10 @@ LIMIT 1;
                Filter: (InitPlan 1).col1
                Table: animals
                Index: animals_idx
-               Exec Method: TopKScanExecState
+               Exec Method: NormalScanExecState
                Scores: true
-                  TopK Limit: 1
                Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"dog","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(13 rows)
+(12 rows)
 
 SELECT id, pdb.score(id) AS score
 FROM animals
@@ -67,11 +66,10 @@ LIMIT 1;
                Filter: (InitPlan 1).col1
                Table: animals
                Index: animals_idx
-               Exec Method: TopKScanExecState
+               Exec Method: NormalScanExecState
                Scores: false
-                  TopK Limit: 1
                Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"dog","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(13 rows)
+(12 rows)
 
 SELECT id, pdb.snippet(description) AS snippet
 FROM animals
@@ -111,11 +109,10 @@ LIMIT 1;
                Filter: (InitPlan 1).col1
                Table: animals
                Index: animals_idx
-               Exec Method: TopKScanExecState
+               Exec Method: NormalScanExecState
                Scores: true
-                  TopK Limit: 1
                Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"dog","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(13 rows)
+(12 rows)
 
 SELECT id, pdb.score(id) AS score
 FROM animals
@@ -149,11 +146,10 @@ LIMIT 1;
                Filter: (InitPlan 1).col1
                Table: animals
                Index: animals_idx
-               Exec Method: TopKScanExecState
+               Exec Method: NormalScanExecState
                Scores: true
-                  TopK Limit: 1
                Tantivy Query: {"with_index":{"query":{"match":{"field":"description","value":"dog","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
-(15 rows)
+(14 rows)
 
 SELECT id, pdb.score(id) AS score
 FROM animals

--- a/pg_search/tests/pg_regress/sql/issue_5546.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5546.sql
@@ -1,0 +1,266 @@
+CREATE TABLE issue_5546_generic_residual_items
+(
+    id       bigint PRIMARY KEY,
+    body     text    NOT NULL,
+    allowed  boolean,
+    priority integer NOT NULL
+);
+
+INSERT INTO issue_5546_generic_residual_items (id, body, allowed, priority)
+VALUES (1, 'alpha alpha alpha', false, 100),
+       (2, 'alpha alpha', true, 90),
+       (3, 'alpha', NULL, 80),
+       (4, 'beta', true, 70);
+
+CREATE INDEX issue_5546_generic_residual_items_idx
+    ON issue_5546_generic_residual_items
+    USING bm25 (id, body, priority)
+    WITH (
+        key_field = 'id',
+        numeric_fields = '{"priority": {"fast": true}}'
+    );
+
+ANALYZE issue_5546_generic_residual_items;
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_seqscan = off;
+SET enable_indexscan = off;
+SET enable_indexonlyscan = off;
+SET enable_bitmapscan = off;
+
+-- Keep negative plan assertions stable without depending on the deparsed
+-- fallback Seq Scan expression (which can contain installation-specific OIDs).
+CREATE OR REPLACE FUNCTION pg_temp.issue_5546_plan_uses_basescan(query text)
+RETURNS boolean
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    line record;
+BEGIN
+    FOR line IN EXECUTE 'EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF) ' || query LOOP
+        IF line."QUERY PLAN" LIKE '%Custom Scan (ParadeDB Base Scan)%' THEN
+            RETURN true;
+        END IF;
+    END LOOP;
+    RETURN false;
+END;
+$$;
+
+-- Reproduction 1: DistinctExpr is evaluated by PostgreSQL as a residual qual.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY id;
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY id;
+
+-- Reproduction 2: CaseExpr is evaluated by PostgreSQL as a residual qual.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN priority >= 90 THEN allowed
+          ELSE id = 3
+      END
+ORDER BY id;
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN priority >= 90 THEN allowed
+          ELSE id = 3
+      END
+ORDER BY id;
+
+-- Reproduction 3: a nested InitPlan/PARAM_EXEC remains inside the complete
+-- CoalesceExpr evaluated by PostgreSQL.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND COALESCE((SELECT NULL::boolean), allowed, false)
+ORDER BY id;
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND COALESCE((SELECT NULL::boolean), allowed, false)
+ORDER BY id;
+
+-- Reproduction 4: LIMIT must observe rows after PostgreSQL residual filtering.
+-- id=1 has the greatest priority but fails the residual; id=2 is correct.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, priority, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY priority DESC
+LIMIT 1;
+
+SELECT id, priority, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY priority DESC
+LIMIT 1;
+
+-- An unsupported wrapper must not hide a nested ParadeDB search operator.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE WHEN allowed IS false THEN body ||| 'beta' ELSE true END$$
+) AS nested_search_residual_rejected;
+
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN allowed IS false THEN body ||| 'beta'
+          ELSE true
+      END;
+
+-- A real correlated SubPlan must not bypass that fail-closed check.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT outer_items.id, pdb.score(outer_items.id)
+        FROM issue_5546_generic_residual_items AS outer_items
+       WHERE outer_items.body ||| 'alpha'
+         AND CASE
+                 WHEN EXISTS (
+                     SELECT 1
+                     FROM issue_5546_generic_residual_items AS inner_items
+                     WHERE inner_items.id = outer_items.id
+                       AND inner_items.allowed IS false
+                 )
+                 THEN outer_items.body ||| 'beta'
+                 ELSE true
+             END$$
+) AS correlated_nested_search_rejected;
+
+SELECT outer_items.id, pdb.score(outer_items.id) AS score
+FROM issue_5546_generic_residual_items AS outer_items
+WHERE outer_items.body ||| 'alpha'
+  AND CASE
+          WHEN EXISTS (
+              SELECT 1
+              FROM issue_5546_generic_residual_items AS inner_items
+              WHERE inner_items.id = outer_items.id
+                AND inner_items.allowed IS false
+          )
+          THEN outer_items.body ||| 'beta'
+          ELSE true
+      END;
+
+-- Context-dependent score/snippet placeholders cannot be raw ExecQual residuals.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE WHEN allowed THEN pdb.score(id) > 0 ELSE true END$$
+) AS score_residual_rejected;
+
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN allowed THEN pdb.score(id) > 0
+          ELSE true
+      END;
+
+-- Internal aggregate placeholders are ordinary FuncExpr nodes, so PostgreSQL
+-- accepts them syntactically in WHERE even though only ParadeDB may populate
+-- them. They must fail closed as residuals as well.
+-- A raw call to one of the panic-only search implementation functions can
+-- remain a FuncExpr when planner support cannot associate its lhs with the
+-- indexed relation. It must not become a residual either.
+SELECT
+    NOT pg_temp.issue_5546_plan_uses_basescan(
+        $$SELECT id, pdb.score(id)
+            FROM issue_5546_generic_residual_items
+           WHERE body ||| 'alpha'
+             AND pdb.agg_fn('count') IS NOT NULL$$
+    ) AS aggregate_placeholder_residual_rejected,
+    NOT pg_temp.issue_5546_plan_uses_basescan(
+        $$SELECT id, pdb.score(id)
+            FROM issue_5546_generic_residual_items
+           WHERE body ||| 'alpha'
+             AND pdb.window_agg('{}') > 0$$
+    ) AS window_placeholder_residual_rejected,
+    NOT pg_temp.issue_5546_plan_uses_basescan(
+        $$SELECT id, pdb.score(id)
+            FROM issue_5546_generic_residual_items
+           WHERE body ||| 'alpha'
+             AND CASE
+                     WHEN allowed THEN paradedb.search_with_parse(
+                         'not-a-column'::text,
+                         clock_timestamp()::text
+                     )
+                     ELSE true
+                 END$$
+    ) AS raw_search_function_residual_rejected;
+
+-- ParadeDB value builders are ordinary PostgreSQL-executable expressions.
+-- Inside an otherwise unsupported top-level conjunct they remain valid
+-- residuals; only a boolean search predicate establishes search context.
+SELECT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE
+                 WHEN allowed IS NULL THEN
+                     ('left' ## (priority % 2) ## 'right') IS NOT NULL
+                     AND pdb.term(priority::bigint) IS NOT NULL
+                 ELSE true
+             END$$
+) AS paradedb_value_residual_allowed;
+
+SELECT id
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND CASE
+          WHEN allowed IS NULL THEN
+              ('left' ## (priority % 2) ## 'right') IS NOT NULL
+              AND pdb.term(priority::bigint) IS NOT NULL
+          ELSE true
+      END
+ORDER BY id;
+
+SET paradedb.enable_filter_pushdown = false;
+
+-- The GUC retains its original opt-out for generic residual classification.
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND allowed IS DISTINCT FROM false
+ORDER BY id;
+
+-- Legacy is_subplan fallback remains available while the GUC is disabled.
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF)
+SELECT id, pdb.score(id) AS score
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND (SELECT true)
+LIMIT 1;
+
+SELECT id, pdb.score(id) IS NOT NULL AS score_available
+FROM issue_5546_generic_residual_items
+WHERE body ||| 'alpha'
+  AND (SELECT true)
+ORDER BY id;
+
+RESET paradedb.enable_filter_pushdown;
+RESET max_parallel_workers_per_gather;
+RESET enable_seqscan;
+RESET enable_indexscan;
+RESET enable_indexonlyscan;
+RESET enable_bitmapscan;
+
+DROP TABLE issue_5546_generic_residual_items;

--- a/pg_search/tests/pg_regress/sql/issue_5546.sql
+++ b/pg_search/tests/pg_regress/sql/issue_5546.sql
@@ -178,34 +178,36 @@ WHERE body ||| 'alpha'
 -- Internal aggregate placeholders are ordinary FuncExpr nodes, so PostgreSQL
 -- accepts them syntactically in WHERE even though only ParadeDB may populate
 -- them. They must fail closed as residuals as well.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND pdb.agg_fn('count') IS NOT NULL$$
+) AS aggregate_placeholder_residual_rejected;
+
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND pdb.window_agg('{}') > 0$$
+) AS window_placeholder_residual_rejected;
+
 -- A raw call to one of the panic-only search implementation functions can
--- remain a FuncExpr when planner support cannot associate its lhs with the
--- indexed relation. It must not become a residual either.
-SELECT
-    NOT pg_temp.issue_5546_plan_uses_basescan(
-        $$SELECT id, pdb.score(id)
-            FROM issue_5546_generic_residual_items
-           WHERE body ||| 'alpha'
-             AND pdb.agg_fn('count') IS NOT NULL$$
-    ) AS aggregate_placeholder_residual_rejected,
-    NOT pg_temp.issue_5546_plan_uses_basescan(
-        $$SELECT id, pdb.score(id)
-            FROM issue_5546_generic_residual_items
-           WHERE body ||| 'alpha'
-             AND pdb.window_agg('{}') > 0$$
-    ) AS window_placeholder_residual_rejected,
-    NOT pg_temp.issue_5546_plan_uses_basescan(
-        $$SELECT id, pdb.score(id)
-            FROM issue_5546_generic_residual_items
-           WHERE body ||| 'alpha'
-             AND CASE
-                     WHEN allowed THEN paradedb.search_with_parse(
-                         'not-a-column'::text,
-                         clock_timestamp()::text
-                     )
-                     ELSE true
-                 END$$
-    ) AS raw_search_function_residual_rejected;
+-- remain a FuncExpr when planner support can find the relation from its lhs
+-- but cannot associate that lhs expression with an indexed field. It must not
+-- become a residual either.
+SELECT NOT pg_temp.issue_5546_plan_uses_basescan(
+    $$SELECT id, pdb.score(id)
+        FROM issue_5546_generic_residual_items
+       WHERE body ||| 'alpha'
+         AND CASE
+                 WHEN allowed THEN paradedb.search_with_parse(
+                     lower(body),
+                     clock_timestamp()::text
+                 )
+                 ELSE true
+             END$$
+) AS raw_search_function_residual_rejected;
 
 -- ParadeDB value builders are ordinary PostgreSQL-executable expressions.
 -- Inside an otherwise unsupported top-level conjunct they remain valid


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5546

## What
### Original behaviour
```sql
WHERE <ParadeDB predicate>
  AND <PostgreSQL predicate>
```
If `<PostgreSQL predicate>` not `Qual` => **reject query**

### Current behaviour
If `<PostgreSQL predicate>` not `Qual` => **execute by PostgreSQL**
(if _safe_, i.e. no ParadeDB specific functions)

## Why

## How

## Tests
