### PR TITLE
ci: wait for app token to propagate before publishing benchmarks

### DIFF
--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -68,7 +68,7 @@ runs:
     - name: Sleep before publish
       if: github.ref == 'refs/heads/main'
       shell: bash
-      run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
+      run: sleep $(( 1 + RANDOM % 61 ))
 
     - name: Publish Benchmark Metrics
       uses: benchmark-action/github-action-benchmark@v1

--- a/.github/actions/benchmark-queries/action.yml
+++ b/.github/actions/benchmark-queries/action.yml
@@ -63,13 +63,6 @@ runs:
       shell: bash
       run: rm -rf ./benchmark-data-repository
 
-    # we sleep for a random number of seconds to hopefully avoid conflicting with other concurrent
-    # benchmark-action publish actions running in other jobs
-    - name: Sleep before publish
-      if: github.ref == 'refs/heads/main'
-      shell: bash
-      run: sleep $(( 1 + RANDOM % 61 ))
-
     - name: Publish Benchmark Metrics
       uses: benchmark-action/github-action-benchmark@v1
       with:

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -107,6 +107,29 @@ runs:
         client-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}
 
+    # Freshly minted GitHub App installation tokens are eventually consistent: git
+    # operations can fail with "repository not found" (a 404, since this repo is private)
+    # for a second or two after the token is created. github-action-benchmark clones the
+    # repo as its first act, so it hits that window and takes the whole job down with it.
+    # Block here until the token actually works.
+    - name: Wait for App Token to Become Usable
+      shell: bash
+      env:
+        APP_TOKEN: ${{ steps.app-token.outputs.token }}
+      run: |
+        auth="Authorization: Basic $(printf 'x-access-token:%s' "$APP_TOKEN" | base64 -w0)"
+        for attempt in $(seq 1 10); do
+          if git -c http.extraheader="$auth" ls-remote \
+              "https://github.com/${{ github.repository }}.git" HEAD >/dev/null 2>&1; then
+            echo "App token usable after ${attempt} attempt(s)"
+            exit 0
+          fi
+          echo "App token not usable yet (attempt ${attempt}/10); retrying in 5s"
+          sleep 5
+        done
+        echo "App token never became usable after 10 attempts" >&2
+        exit 1
+
     # Necessary to avoid "destination path is not empty" error
     - name: Cleanup Previous Benchmark Publish Working Directory
       shell: bash
@@ -116,7 +139,7 @@ runs:
     # benchmark-action publish actions running in other jobs
     - name: Sleep before publish
       shell: bash
-      run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
+      run: sleep $(( 1 + RANDOM % 61 ))
 
     - name: Publish TPS Metrics
       uses: benchmark-action/github-action-benchmark@v1
@@ -144,7 +167,7 @@ runs:
     # benchmark-action publish actions running in other jobs
     - name: Sleep before publish
       shell: bash
-      run: echo $(( 1 + RANDOM % ( 61 - 1 + 1 ) ))
+      run: sleep $(( 1 + RANDOM % 61 ))
 
     - name: Publish Other Metrics
       uses: benchmark-action/github-action-benchmark@v1

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -107,11 +107,6 @@ runs:
         client-id: ${{ inputs.github_app_id }}
         private-key: ${{ inputs.github_app_private_key }}
 
-    # Freshly minted GitHub App installation tokens are eventually consistent: git
-    # operations can fail with "repository not found" (a 404, since this repo is private)
-    # for a second or two after the token is created. github-action-benchmark clones the
-    # repo as its first act, so it hits that window and takes the whole job down with it.
-    # Block here until the token actually works.
     - name: Wait for App Token to Become Usable
       shell: bash
       env:

--- a/.github/actions/benchmark-stressgres/action.yml
+++ b/.github/actions/benchmark-stressgres/action.yml
@@ -130,12 +130,6 @@ runs:
       shell: bash
       run: rm -rf ./benchmark-data-repository
 
-    # we sleep for a random number of seconds to hopefully avoid conflicting with other concurrent
-    # benchmark-action publish actions running in other jobs
-    - name: Sleep before publish
-      shell: bash
-      run: sleep $(( 1 + RANDOM % 61 ))
-
     - name: Publish TPS Metrics
       uses: benchmark-action/github-action-benchmark@v1
       with:
@@ -157,12 +151,6 @@ runs:
     - name: Cleanup Previous Benchmark Publish Working Directory
       shell: bash
       run: rm -rf ./benchmark-data-repository
-
-    # we sleep for a random number of seconds to hopefully avoid conflicting with other concurrent
-    # benchmark-action publish actions running in other jobs
-    - name: Sleep before publish
-      shell: bash
-      run: sleep $(( 1 + RANDOM % 61 ))
 
     - name: Publish Other Metrics
       uses: benchmark-action/github-action-benchmark@v1


### PR DESCRIPTION
## Problem

Stressgres benchmark jobs intermittently die at the publish step with:

```
fatal: repository 'https://github.com/paradedb/<repo>.git/' not found
Error: The process '/usr/bin/git' failed with exit code 128
```

The repo is private, so GitHub answers unauthorized requests with **404 rather than 403** — this is an auth failure, not a missing repo.

Timestamps from a failing run show the cause:

```
20:08:27.120  actions/create-github-app-token@v3   <- token minted
20:08:27.570  git clone ...                        <- 450ms after minting
20:08:27.657  fatal: repository not found
```

Freshly minted GitHub App installation tokens are eventually consistent and can 404 on git operations for a second or two. `github-action-benchmark` clones the repo as its first act, so it lands inside that window. The benchmark itself had already passed — and because the publish step failed, the 6 remaining suites were skipped, costing a ~20min job and most of its coverage.

Note this action clones the repo on *every* publish: 2 publishes × 7 suites = **14 full clones per job**, so there are 14 chances per job to hit this.

## Changes

**1. Gate the publish steps on the token actually working.** Poll `git ls-remote` after minting, with backoff, so we never hand a not-yet-live token to `github-action-benchmark`. Uses `http.extraheader` rather than a token-in-URL so it can't leak into error output.

**2. Drop the three "Sleep before publish" steps** (two in `benchmark-stressgres`, one in `benchmark-queries`). They were added on a guess — *"we (likely) need to sleep before publishing benchmarks"* (#2836) — and were written as `echo` rather than `sleep`, so they printed a random number and exited in ~11ms. They have never once actually slept.

They're also unnecessary. The concurrent-publish collision they hedged against is already handled upstream: `github-action-benchmark`'s `writeBenchmarkToGitHubPagesWithRetry` catches remote-rejected pushes, resets the generated commit, re-pulls and retries, initialized with `retry: 10`. That *resolves* collisions rather than just lowering their odds. Making the sleeps real would have added ~7min of average idle per job on a metal instance to duplicate a retry the action already does better.

## Deliberately not doing

**Hoisting the token mint to job level.** A full stressgres job runs ~1h49m, past the 1h installation token lifetime, so later suites would start failing on expiry instead of propagation.

**A blind retry around the publish steps.** `github-action-benchmark` pushes the data point *before* it handles alerts/comments, so retrying a step that failed after the push would append the same benchmark twice and corrupt the history. The readiness gate addresses the observed failure mode without that risk.
