### PR TITLE
chore: Adjust aggregate join benchmarks to better align with known use-cases

### DIFF
--- a/benchmarks/datasets/stackoverflow/queries/aggregate_topk_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/aggregate_topk_count.sql
@@ -8,7 +8,7 @@
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (aggregate custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT
     p.title,
     COUNT(*)
 FROM stackoverflow_posts p

--- a/benchmarks/datasets/stackoverflow/queries/cardinality.sql
+++ b/benchmarks/datasets/stackoverflow/queries/cardinality.sql
@@ -1,17 +1,17 @@
 -- numeric ff
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(DISTINCT post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(DISTINCT post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- better numeric ff
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id ORDER BY post_type_id);
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id ORDER BY post_type_id);
 
 -- aggregate custom scan
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id);
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(*) FROM (SELECT post_type_id FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY post_type_id);
 
 -- pdb.agg (under the hood) without GROUP BY
-SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT COUNT(post_type_id) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- pdb.agg without GROUP BY (mvcc disabled)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT pdb.agg('{"value_count": {"field": "post_type_id"}}', false) FROM stackoverflow_posts WHERE body ||| 'javascript';
 
 -- high-cardinality aggregate scan
 SET paradedb.enable_aggregate_custom_scan TO off; SET work_mem TO '4GB'; SELECT tags, COUNT(*), MIN(score), MAX(score), SUM(score) FROM stackoverflow_posts WHERE body ||| 'javascript' GROUP BY tags LIMIT 65000;

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_count.sql
@@ -8,7 +8,7 @@
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*)
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_date_histogram.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_date_histogram.sql
@@ -1,0 +1,34 @@
+-- Shape: Date Histogram on JOIN
+-- Join: stackoverflow_posts -> comments
+-- Description: Group by a time bucket (month) using date_trunc. This models the
+-- extremely common Elasticsearch date_histogram aggregation used for time-series
+-- analytics. Sorted chronologically.
+
+-- Query Info (statistics from 100k dataset; larger datasets may have different values):
+-- - 'code' selectivity on stackoverflow_posts.body: ~75%
+
+-- Postgres default plan (custom scan off)
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT
+    date_trunc('month', p.creation_date) AS month,
+    COUNT(*)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'
+GROUP BY
+    month
+ORDER BY
+    month ASC;
+
+-- TODO(https://github.com/paradedb/paradedb/issues/4082): Aggregate scan currently falls back to Postgres for date_trunc.
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT
+    date_trunc('month', p.creation_date) AS month,
+    COUNT(*)
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'
+GROUP BY
+    month
+ORDER BY
+    month ASC;

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_date_histogram.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_date_histogram.sql
@@ -8,7 +8,7 @@
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT
     date_trunc('month', p.creation_date) AS month,
     COUNT(*)
 FROM stackoverflow_posts p

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
@@ -1,24 +1,24 @@
 -- Shape: GROUP BY aggregate on JOIN
 -- Join: stackoverflow_posts → comments
--- Description: Grouped aggregate (COUNT, SUM) with GROUP BY on the parent
--- table's title column. Exercises the DataFusion backend's grouped
--- aggregate pipeline including custom_scan_tlist for scanrelid=0.
+-- Description: Grouped aggregate (COUNT, SUM) with GROUP BY on a low-cardinality
+-- dimension (post_type_id). Sorted by sub-aggregation metric (SUM). Exercises the
+-- DataFusion backend's grouped aggregate pipeline including custom_scan_tlist for scanrelid=0.
 
 -- Query Info (statistics from 100k dataset; larger datasets may have different values):
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT p.title, COUNT(*), SUM(c.score)
+SET paradedb.enable_aggregate_custom_scan TO off; SELECT p.post_type_id, COUNT(*), SUM(c.score)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code'
-GROUP BY p.title
-ORDER BY p.title;
+GROUP BY p.post_type_id
+ORDER BY SUM(c.score) DESC;
 
 -- DataFusion aggregate scan (temporarily increased from 4GB to 8GB)
-SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT p.title, COUNT(*), SUM(c.score)
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT p.post_type_id, COUNT(*), SUM(c.score)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code'
-GROUP BY p.title
-ORDER BY p.title;
+GROUP BY p.post_type_id
+ORDER BY SUM(c.score) DESC;

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
@@ -8,7 +8,7 @@
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT p.post_type_id, COUNT(*), SUM(c.score)
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT p.post_type_id, COUNT(*), SUM(c.score)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code'

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_groupby.sql
@@ -15,7 +15,7 @@ WHERE p.body ||| 'code'
 GROUP BY p.post_type_id
 ORDER BY SUM(c.score) DESC;
 
--- DataFusion aggregate scan (temporarily increased from 4GB to 8GB)
+-- DataFusion aggregate scan
 SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT p.post_type_id, COUNT(*), SUM(c.score)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_multi.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_multi.sql
@@ -8,7 +8,7 @@
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*), MIN(c.score), MAX(c.score)
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT COUNT(*), MIN(c.score), MAX(c.score)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE p.body ||| 'code';

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
@@ -10,7 +10,7 @@
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (aggregate custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT
     p.owner_display_name,
     COUNT(*)
 FROM stackoverflow_posts p

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
@@ -1,36 +1,38 @@
 -- Shape: TopK Aggregate on JOIN (DataFusion)
 -- Join: stackoverflow_posts -> comments
--- Description: GROUP BY a field on the search-side table with COUNT(*)
--- ordered DESC and LIMIT 10 on a join query. Tests the DataFusion
--- TopKAggregateExec optimization versus full aggregation + post-hoc sort.
+-- Description: GROUP BY a medium-cardinality dimension (owner_display_name)
+-- on the search-side table with COUNT(*) ordered DESC and LIMIT 10 on a
+-- join query. This realistically models an Elasticsearch Terms Aggregation
+-- and tests the DataFusion TopKAggregateExec optimization versus full
+-- aggregation + post-hoc sort.
 
 -- Query Info (statistics from 100k dataset; larger datasets may have different values):
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (aggregate custom scan off)
 SET paradedb.enable_aggregate_custom_scan TO off; SELECT
-    p.title,
+    p.owner_display_name,
     COUNT(*)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE
     p.body ||| 'code'
 GROUP BY
-    p.title
+    p.owner_display_name
 ORDER BY
     COUNT(*) DESC
 LIMIT 10;
 
 -- DataFusion TopK aggregate scan
 SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO on; SELECT
-    p.title,
+    p.owner_display_name,
     COUNT(*)
 FROM stackoverflow_posts p
 JOIN comments c ON p.id = c.post_id
 WHERE
     p.body ||| 'code'
 GROUP BY
-    p.title
+    p.owner_display_name
 ORDER BY
     COUNT(*) DESC
 LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_topk_count.sql
@@ -6,8 +6,9 @@
 -- and tests the DataFusion TopKAggregateExec optimization versus full
 -- aggregation + post-hoc sort.
 
--- Query Info (statistics from 100k dataset; larger datasets may have different values):
+-- Query Info (statistics from 20m dataset):
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
+-- - owner_display_name distinct count: ~70k, null count: ~19.5m (highly sparse)
 
 -- Postgres default plan (aggregate custom scan off)
 SET work_mem TO '4GB'; SET paradedb.enable_aggregate_custom_scan TO off; SELECT

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_window_facet.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_window_facet.sql
@@ -1,0 +1,39 @@
+-- Shape: Multi-Facet Window Aggregates on JOIN
+-- Join: stackoverflow_posts -> comments
+-- Description: Uses window functions (OVER PARTITION BY) to retrieve Top K hits 
+-- alongside global facet counts across multiple dimensions. This perfectly mimics 
+-- Elasticsearch's faceting behavior, but currently prevents TopK optimization.
+
+-- Query Info (statistics from 100k dataset; larger datasets may have different values):
+-- - 'code' selectivity on stackoverflow_posts.body: ~75%
+
+-- Postgres default plan (custom scan off)
+SET paradedb.enable_aggregate_custom_scan TO off; SET paradedb.enable_join_custom_scan TO off; SELECT
+    c.id,
+    p.post_type_id,
+    p.owner_user_id,
+    COUNT(*) OVER (PARTITION BY p.post_type_id) as post_type_facet,
+    COUNT(*) OVER (PARTITION BY p.owner_user_id) as user_facet
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'
+ORDER BY
+    c.score DESC
+LIMIT 10;
+
+-- TODO(https://github.com/paradedb/paradedb/issues/5637): Implement support for executing window functions with the DataFusion backend for aggregate scans on joins.
+-- Custom scan enabled
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO on; SET paradedb.enable_join_custom_scan TO on; SELECT
+    c.id,
+    p.post_type_id,
+    p.owner_user_id,
+    COUNT(*) OVER (PARTITION BY p.post_type_id) as post_type_facet,
+    COUNT(*) OVER (PARTITION BY p.owner_user_id) as user_facet
+FROM stackoverflow_posts p
+JOIN comments c ON p.id = c.post_id
+WHERE
+    p.body ||| 'code'
+ORDER BY
+    c.score DESC
+LIMIT 10;

--- a/benchmarks/datasets/stackoverflow/queries/join_aggregate_window_facet.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_aggregate_window_facet.sql
@@ -8,7 +8,7 @@
 -- - 'code' selectivity on stackoverflow_posts.body: ~75%
 
 -- Postgres default plan (custom scan off)
-SET paradedb.enable_aggregate_custom_scan TO off; SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '8GB'; SET paradedb.enable_aggregate_custom_scan TO off; SET paradedb.enable_join_custom_scan TO off; SELECT
     c.id,
     p.post_type_id,
     p.owner_user_id,

--- a/benchmarks/datasets/stackoverflow/queries/join_distinct_parent_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_distinct_parent_sort.sql
@@ -6,7 +6,7 @@
 -- - reputation > 100 selectivity on users.reputation: ~82% (active users are overrepresented at smaller sizes; likely lower for larger datasets)
 -- - score > 0 selectivity on comments.score: ~17%
 
-SET paradedb.enable_join_custom_scan TO off; SELECT DISTINCT
+SET work_mem TO '8GB'; SET paradedb.enable_join_custom_scan TO off; SELECT DISTINCT
     u.id,
     u.display_name,
     u.about_me

--- a/benchmarks/datasets/stackoverflow/queries/join_foreign_filter_local_sort.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_foreign_filter_local_sort.sql
@@ -6,7 +6,7 @@
 -- - reputation > 100 selectivity on users.reputation: ~82% (active users are overrepresented at smaller sizes; likely lower for larger datasets)
 -- - 'error' selectivity on stackoverflow_posts.title: ~1%
 
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
     p.id,
     p.title,
     p.creation_date,

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-large.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-large.sql
@@ -5,7 +5,7 @@
 -- - 'error' selectivity on stackoverflow_posts.title: ~1%
 -- - 'question' selectivity on comments.text: ~7%
 
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
   *
 FROM
   users JOIN stackoverflow_posts ON users.id = stackoverflow_posts.owner_user_id JOIN comments ON comments.post_id = stackoverflow_posts.id

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-small.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-no-scores-small.sql
@@ -5,7 +5,7 @@
 -- - 'error' selectivity on stackoverflow_posts.title: ~1%
 -- - 'question' selectivity on comments.text: ~7%
 
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
   users.id,
   stackoverflow_posts.id,
   comments.id

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-large.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-large.sql
@@ -6,7 +6,7 @@
 -- - 'question' selectivity on comments.text: ~7%
 
 -- Directly, without a CTE.
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
   *,
   pdb.score(users.id) + pdb.score(stackoverflow_posts.id) + pdb.score(comments.id) AS pdb_score
 FROM
@@ -17,7 +17,7 @@ ORDER BY pdb_score DESC
 LIMIT 1000;
 
 -- CTE to execute a smaller join before Top K and then fetch the rest of the content after Top K.
-SET paradedb.enable_join_custom_scan TO off; WITH topk AS (
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; WITH topk AS (
   SELECT
     users.id AS user_id,
     stackoverflow_posts.id AS post_id,

--- a/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-small.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_hierarchical_content-scores-small.sql
@@ -5,7 +5,7 @@
 -- - 'error' selectivity on stackoverflow_posts.title: ~1%
 -- - 'question' selectivity on comments.text: ~7%
 
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
   users.id,
   stackoverflow_posts.id,
   comments.id,

--- a/benchmarks/datasets/stackoverflow/queries/join_permissioned_search.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_permissioned_search.sql
@@ -6,7 +6,7 @@
 -- - 'how using get create' selectivity on stackoverflow_posts.title: ~10%
 -- - reputation > 100 selectivity on users.reputation: ~82% (active users are overrepresented at smaller sizes; likely lower for larger datasets)
 
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
     p.id,
     p.title,
     pdb.score(p.id) as relevance

--- a/benchmarks/datasets/stackoverflow/queries/join_semi_filter.sql
+++ b/benchmarks/datasets/stackoverflow/queries/join_semi_filter.sql
@@ -11,7 +11,7 @@
 -- twins, since the sort toggle that separated them is gone. Drop them on the next pass that can
 -- reset the benchmark baseline (removing alternatives renumbers the stored history).
 
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
     p.id,
     p.title,
     p.creation_date
@@ -45,7 +45,7 @@ ORDER BY
 LIMIT 25;
 
 -- Sortedness enabled, no join scan.
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
     p.id,
     p.title,
     p.creation_date
@@ -62,7 +62,7 @@ ORDER BY
 LIMIT 25;
 
 -- term_set workaround, no join
-SET paradedb.enable_join_custom_scan TO off; SELECT
+SET work_mem TO '4GB'; SET paradedb.enable_join_custom_scan TO off; SELECT
     p.id,
     p.title,
     p.creation_date


### PR DESCRIPTION
## What

* Use a lower cardinality field for `join_aggregate_topk_count`
* Adjust `join_aggregate_groupby` (with no `LIMIT`) to execute on a very low cardinality property.
* Add a date-histogram-over-join query.
* Add an example of using our window function syntax above a join.
* Align memory limits across all variants of a query.

## Why

Our goal with aggregates-on-joins is to execute queries with roughly the same shape as our other aggregates, except atop joins.

But currently, a few of the queries aggregate on unrealistic properties (i.e. they don't reduce cardinality), and we don't currently have benchmarks which capture our [faceting syntax](https://docs.paradedb.com/documentation/aggregates/facets), or aggregate on dates (which is very common in Elastic).

Finally, we align the memory usage across all variants of a query to ensure that we don't give an unfair advantage to DataFusion before we've implemented spilling.