### PR TITLE
perf: replace LRU with FIFO cache in LinkedBytesList

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -42,11 +42,6 @@ static ENABLE_JOIN_CUSTOM_SCAN: GucSetting<bool> = GucSetting::<bool>::new(true)
 /// default is `false`.
 static ENABLE_CUSTOM_SCAN_WITHOUT_OPERATOR: GucSetting<bool> = GucSetting::<bool>::new(false);
 
-/// When `true`, a vector (IVF) ORDER BY scan emits one `probe_stats …` NOTICE
-/// per query with the aggregated probe-loop counters. Off by default and
-/// zero-cost when off (no `ProbeStats` is collected).
-static LOG_PROBE_STATS: GucSetting<bool> = GucSetting::<bool>::new(false);
-
 /// Allows the user to toggle the use of custom scan for queries that include non-indexed fields.
 /// When enabled, queries with non-indexed predicates will use HeapExpr for heap filtering.
 static ENABLE_FILTER_PUSHDOWN: GucSetting<bool> = GucSetting::<bool>::new(true);
@@ -274,17 +269,6 @@ pub fn init() {
         c"Enable ParadeDB's experimental join custom scan",
         c"Enable ParadeDB's experimental join custom scan. Default is false.",
         &ENABLE_JOIN_CUSTOM_SCAN,
-        GucContext::Userset,
-        GucFlags::default(),
-    );
-
-    GucRegistry::define_bool_guc(
-        c"paradedb.log_probe_stats",
-        c"Emit a NOTICE with IVF probe-loop counters per vector query",
-        c"When on, a vector (IVF) ORDER BY scan emits one `probe_stats ...` NOTICE per query \
-          with the aggregated probe counters (visited/pruned/scored/clusters/termination). \
-          Off by default and zero-cost when off.",
-        &LOG_PROBE_STATS,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -659,10 +643,6 @@ pub fn enable_custom_scan() -> bool {
 
 pub fn enable_aggregate_custom_scan() -> bool {
     ENABLE_AGGREGATE_CUSTOM_SCAN.get()
-}
-
-pub fn log_probe_stats() -> bool {
-    LOG_PROBE_STATS.get()
 }
 
 pub fn check_aggregate_scan() -> bool {

--- a/pg_search/src/index/reader/index.rs
+++ b/pg_search/src/index/reader/index.rs
@@ -19,7 +19,7 @@ use std::cmp::Ordering;
 use std::fmt::{Debug, Display};
 use std::path::PathBuf;
 use std::ptr::NonNull;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use crate::aggregate::mvcc_collector::MVCCFilterCollector;
 use crate::api::operator::keyset::KeySet;
@@ -51,7 +51,6 @@ use tantivy::index::{Index, Order, SegmentId};
 use tantivy::query::{EnableScoring, QueryClone, QueryParser, Weight};
 use tantivy::snippet::SnippetGenerator;
 use tantivy::vector::ivf::AdaptiveProbeParams;
-use tantivy::vector::{ProbeStats, ProbeTermination};
 use tantivy::{
     query::Query, schema::OwnedValue, DateTime, DocAddress, DocId, DocSet, Executor, IndexReader,
     ReloadPolicy, Score, Searcher, SegmentOrdinal, SegmentReader, TantivyDocument,
@@ -60,75 +59,6 @@ use tantivy::{
 /// The maximum number of sort-features/`OrderByInfo`s supported for
 /// `SearchIndexReader::search_top_k_in_segments`.
 pub const MAX_TOPK_FEATURES: usize = 5;
-
-/// Aggregate the per-segment IVF [`ProbeStats`] of one vector query into a
-/// single parseable `probe_stats …` line. Scalars sum across segments;
-/// `termination` is tallied per variant (so a `Ceiling` on any segment stays
-/// visible). The summed line preserves the per-segment invariant
-/// `visited == pruned_filter + pruned_dead + pruned_seen + scored`.
-///
-/// Line-grammar note: tantivy's `ProbeStats::routing.visited_count` is
-/// surfaced as `router_scored=`. It counts centroids the router actually
-/// scored — the beam's visit set when routing went through the persisted
-/// RNG, or all of them on the linear fallback.
-///
-/// The two trailing compound tokens reuse `termination=`'s `key:N` comma
-/// style and sit at the end of the line so prefix parsers are unaffected.
-/// They always print, zeros included — the grammar is constant-shape.
-/// `postings=` buckets probed IVF clusters by posting-fetch outcome (one
-/// stride-sized read per surviving row / skipped outright when the gate
-/// pre-pass leaves zero survivors); the two buckets partition the probed
-/// clusters, so `row + skipped == clusters_probed` — asserted in the unit
-/// tests. `exact_rows=` counts flat-path stride-sized row reads (one per
-/// survivor scored). At 0% selectivity the empty-filter short-circuit
-/// returns before the probe loop, so every posting counter is zero by
-/// design and the partition invariant holds trivially (0 == 0 clusters
-/// probed).
-fn format_probe_stats(per_segment: &[ProbeStats]) -> String {
-    let mut visited = 0usize;
-    let mut pruned_filter = 0usize;
-    let mut pruned_dead = 0usize;
-    let mut pruned_seen = 0usize;
-    let mut scored = 0usize;
-    let mut clusters_probed = 0usize;
-    let mut router_scored = 0usize;
-    let mut min_candidates = 0usize;
-    let (mut ceiling, mut gate, mut exhausted) = (0usize, 0usize, 0usize);
-    let (mut postings_row, mut postings_skipped) = (0usize, 0usize);
-    let mut exact_rows = 0usize;
-    for s in per_segment {
-        visited += s.vectors_visited;
-        pruned_filter += s.pruned_filter;
-        pruned_dead += s.pruned_dead;
-        pruned_seen += s.pruned_seen;
-        scored += s.candidates_scored;
-        clusters_probed += s.probed_clusters.len();
-        router_scored += s.routing.visited_count;
-        min_candidates += s.min_candidates;
-        match s.termination {
-            ProbeTermination::Ceiling => ceiling += 1,
-            ProbeTermination::Gate => gate += 1,
-            ProbeTermination::Exhausted => exhausted += 1,
-        }
-        postings_row += s.postings_row;
-        postings_skipped += s.postings_skipped;
-        exact_rows += s.exact_rows_read;
-    }
-    format!(
-        "probe_stats visited={visited} pruned_filter={pruned_filter} \
-         pruned_dead={pruned_dead} pruned_seen={pruned_seen} scored={scored} \
-         clusters_probed={clusters_probed} router_scored={router_scored} \
-         min_candidates={min_candidates} termination=ceiling:{ceiling},gate:{gate},exhausted:{exhausted} \
-         postings=row:{postings_row},skipped:{postings_skipped} \
-         exact_rows={exact_rows}"
-    )
-}
-
-/// Emit the aggregated probe stats as one NOTICE. Only called when
-/// `paradedb.log_probe_stats` is on (off by default, zero-cost when off).
-fn emit_probe_stats_notice(per_segment: &[ProbeStats]) {
-    pgrx::notice!("{}", format_probe_stats(per_segment));
-}
 
 #[derive(Debug, Clone, Copy)]
 pub struct DocsEstimate {
@@ -1037,22 +967,8 @@ impl SearchIndexReader {
                         max_probe_fraction: crate::gucs::vector_cluster_max_probe(),
                         ..Default::default()
                     });
-                // Probe-stats NOTICE (GUC `paradedb.log_probe_stats`, off by
-                // default, zero-cost when off). The collector pushes one
-                // ProbeStats per segment into the sink; we aggregate the scalars
-                // and tally `termination`, then emit a single line. This vector
-                // search runs once per scan, so the NOTICE is once per query.
-                let probe_stats_sink =
-                    crate::gucs::log_probe_stats().then(|| Arc::new(Mutex::new(Vec::new())));
-                let collector = match &probe_stats_sink {
-                    Some(sink) => collector.with_probe_stats_sink(Arc::clone(sink)),
-                    None => collector,
-                };
                 let (top_docs, aggregation_results) =
                     self.collect_maybe_auxiliary(segment_ids, collector, aux_collector);
-                if let Some(sink) = probe_stats_sink {
-                    emit_probe_stats_notice(&sink.lock().unwrap());
-                }
                 TopKSearchResults::new_for_score(top_docs, aggregation_results)
             }
         }
@@ -1689,95 +1605,5 @@ impl ErasedFeatures {
             OwnedValue::Null => None,
             _ => panic!("expected a f64 for the score"),
         })
-    }
-}
-
-#[cfg(test)]
-mod probe_stats_tests {
-    use super::*;
-    use tantivy::vector::IvfSearchMetrics;
-
-    fn seg(termination: ProbeTermination) -> ProbeStats {
-        // visited (25) == pruned_filter(5) + pruned_dead(2) + pruned_seen(8) + scored(10);
-        // postings row(2) + skipped(1) == probed_clusters.len() (3).
-        ProbeStats {
-            probed_clusters: vec![0, 1, 2],
-            candidates_scored: 10,
-            vectors_visited: 25,
-            pruned_filter: 5,
-            pruned_dead: 2,
-            pruned_seen: 8,
-            postings_row: 2,
-            postings_skipped: 1,
-            exact_rows_read: 0,
-            routing: IvfSearchMetrics {
-                visited_count: 9,
-                graph: None,
-            },
-            min_candidates: 16,
-            termination,
-        }
-    }
-
-    /// Pull `key=N` off the formatted line.
-    fn scalar(line: &str, key: &str) -> usize {
-        let tail = line.split(&format!("{key}=")).nth(1).unwrap();
-        tail.split(' ').next().unwrap().parse().unwrap()
-    }
-
-    /// Pull `sub:N` out of a `key=a:N,b:N,…` compound token.
-    fn compound(line: &str, key: &str, sub: &str) -> usize {
-        let tail = line.split(&format!("{key}=")).nth(1).unwrap();
-        let token = tail.split(' ').next().unwrap();
-        let entry = token
-            .split(',')
-            .find(|e| e.starts_with(&format!("{sub}:")))
-            .unwrap();
-        entry.split(':').nth(1).unwrap().parse().unwrap()
-    }
-
-    #[test]
-    fn format_probe_stats_sums_scalars_and_tallies_termination() {
-        let line =
-            format_probe_stats(&[seg(ProbeTermination::Gate), seg(ProbeTermination::Ceiling)]);
-        // Scalars summed; termination tallied per variant; summed invariant
-        // holds (visited 50 == 10+4+16+20).
-        assert_eq!(
-            line,
-            "probe_stats visited=50 pruned_filter=10 pruned_dead=4 pruned_seen=16 scored=20 clusters_probed=6 router_scored=18 min_candidates=32 termination=ceiling:1,gate:1,exhausted:0 postings=row:4,skipped:2 exact_rows=0"
-        );
-    }
-
-    #[test]
-    fn format_probe_stats_empty() {
-        assert_eq!(
-            format_probe_stats(&[]),
-            "probe_stats visited=0 pruned_filter=0 pruned_dead=0 pruned_seen=0 scored=0 clusters_probed=0 router_scored=0 min_candidates=0 termination=ceiling:0,gate:0,exhausted:0 postings=row:0,skipped:0 exact_rows=0"
-        );
-    }
-
-    /// The two trailing tokens: `postings=` sums the per-segment fetch-mode
-    /// buckets, `exact_rows=` the flat-path row reads, and the emitted line
-    /// upholds the partition invariant `row + skipped == clusters_probed`
-    /// (an IVF segment's buckets partition its probed clusters; a flat
-    /// segment contributes zero to all three sides).
-    #[test]
-    fn format_probe_stats_posting_and_exact_tokens() {
-        // One IVF-shaped segment plus one flat-shaped segment, which fills
-        // only the `exact_rows_read` counter (everything else default).
-        let flat = ProbeStats {
-            exact_rows_read: 11,
-            ..Default::default()
-        };
-        let line = format_probe_stats(&[seg(ProbeTermination::Exhausted), flat]);
-        assert_eq!(
-            line,
-            "probe_stats visited=25 pruned_filter=5 pruned_dead=2 pruned_seen=8 scored=10 clusters_probed=3 router_scored=9 min_candidates=16 termination=ceiling:0,gate:0,exhausted:2 postings=row:2,skipped:1 exact_rows=11"
-        );
-        // Partition invariant, parsed back off the emitted line.
-        assert_eq!(
-            compound(&line, "postings", "row") + compound(&line, "postings", "skipped"),
-            scalar(&line, "clusters_probed"),
-        );
     }
 }

--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -367,6 +367,7 @@ impl ColumnarExecState {
             None,
             index_rel.oid().to_u32(),
             None,
+            1,
         );
 
         let task_ctx = Arc::new(TaskContext::default());

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -477,7 +477,18 @@ pub(super) unsafe fn query_has_window_agg_functions(root: *mut pg_sys::PlannerIn
 /// Classification of any set-returning function found in the target list,
 /// used to decide whether pushing LIMIT through this scan is safe. PG sets
 /// `limit_tuples == -1.0` whenever any SRF is present, so we walk once and
-/// distinguish between "no SRF / safe (unnest only) / unsafe".
+/// distinguish between "no SRF / safe (unnest of a ParadeDB SRF placeholder) /
+/// unsafe (any other SRF, or `unnest` of a user expression)".
+///
+/// The `Safe` case must stay narrow: `unnest` is only row-preserving when its
+/// argument is guaranteed non-empty, and for a user expression that is a
+/// data-dependent property unknowable at plan time — an empty or NULL array
+/// silently drops rows below the LIMIT with nothing to refill (see #5573).
+/// The paradedb snippet SRFs (`pdb.snippets`, `pdb.snippet_positions`, and
+/// their legacy `paradedb.*` shims) are placeholders that only fire for rows
+/// the CustomScan actually matched; their output vectors are non-empty by
+/// construction on matching rows, so `unnest(pdb.snippets(...))` may safely
+/// take the LIMIT-pushdown fast path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TargetListSrf {
     None,
@@ -494,9 +505,10 @@ impl TargetListSrf {
     }
 }
 
-/// Walk the target list once and classify any SRFs. Only `unnest` is
-/// row-preserving (and therefore limit-safe); everything else is treated as
-/// unsafe so LIMIT pushdown stops above the scan.
+/// Walk the target list once and classify any SRFs. Only `unnest` whose
+/// argument is a ParadeDB snippet placeholder function is treated as safe;
+/// everything else — arbitrary `unnest` of a user expression, or any other
+/// SRF — is unsafe so LIMIT pushdown stops above the scan.
 unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetListSrf {
     if root.is_null() || (*root).parse.is_null() || (*(*root).parse).targetList.is_null() {
         return TargetListSrf::None;
@@ -508,7 +520,11 @@ unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetList
             continue;
         }
         match nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
-            Some(func_expr) if is_unnest_func((*func_expr).funcid) => found_safe = true,
+            Some(func_expr)
+                if is_unnest_func((*func_expr).funcid) && unnest_arg_is_paradedb_srf(func_expr) =>
+            {
+                found_safe = true
+            }
             _ => return TargetListSrf::Unsafe,
         }
     }
@@ -517,6 +533,28 @@ unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetList
     } else {
         TargetListSrf::None
     }
+}
+
+/// True when the sole argument to an `unnest` FuncExpr is a call to one of
+/// the ParadeDB snippet/placeholder SRFs whose output vector is non-empty by
+/// construction on matching rows (`pdb.snippets`, `pdb.snippet_positions`,
+/// and their legacy `paradedb.*` shims). Any other argument shape — a Var,
+/// a CASE, a user function — cannot be proved non-empty at plan time.
+unsafe fn unnest_arg_is_paradedb_srf(unnest_expr: *mut pg_sys::FuncExpr) -> bool {
+    use crate::postgres::customscan::basescan::projections::snippet::{
+        snippet_positions_funcoids, snippets_funcoids,
+    };
+
+    let args = PgList::<pg_sys::Node>::from_pg((*unnest_expr).args);
+    if args.len() != 1 {
+        return false;
+    }
+    let arg = args.get_ptr(0).unwrap_or(std::ptr::null_mut());
+    let Some(inner) = nodecast!(FuncExpr, T_FuncExpr, arg) else {
+        return false;
+    };
+    let inner_oid = (*inner).funcid;
+    snippets_funcoids().contains(&inner_oid) || snippet_positions_funcoids().contains(&inner_oid)
 }
 
 /// Returns `true` if any predicate in `baserestrictinfo` cannot be fully
@@ -745,8 +783,11 @@ impl CustomScan for BaseScan {
             //   - PG already proved it safe (`limit_tuples > -1.0`)
             //   - The value is a Param (PG can't evaluate at plan time but
             //     we can at exec time)
-            //   - A row-preserving `unnest` SRF zeroed PG's `limit_tuples`,
-            //     but `limit + offset` rows here is still enough
+            //   - A row-preserving `unnest` of a ParadeDB snippet SRF zeroed
+            //     PG's `limit_tuples`, but `limit + offset` rows here is
+            //     still enough (the paradedb SRF is non-empty by
+            //     construction on matching rows). `unnest` of a user
+            //     expression is NOT covered by this override — see #5573.
             // `is_limit_pushdown_safe` then gates on topology + predicates +
             // unsafe SRFs.
             let raw_limit_offset = LimitOffset::from_root(builder.args().root);

--- a/pg_search/src/postgres/customscan/joinscan/README.md
+++ b/pg_search/src/postgres/customscan/joinscan/README.md
@@ -15,6 +15,8 @@ ProjectionExec
         PgSearchScan (files)          ← lazy scan, deferred columns, receives dynamic filters
 ```
 
+When parallel execution is enabled in PostgreSQL, JoinScan exclusively relies on Massively Parallel Processing (MPP) via `datafusion-distributed` to parallelize queries. DataFusion's in-process multithreading is completely bypassed because PostgreSQL has already launched independent parallel worker processes. Instead, the above physical plan is intercepted by the `DistributedPlanner` and sliced into network stages (`DistributedExec`), mapping distributed tasks 1:1 with PostgreSQL workers.
+
 [`SegmentedTopKExec`][topk-exec] publishes dynamic filter thresholds that are pushed down through the join to the probe-side scan, pruning rows at the scanner level. It also performs the final materialized sort and LIMIT, so `TantivyLookupExec` only decodes K rows (not K×segments).
 
 ## How It Works
@@ -40,6 +42,8 @@ The planner hook builds a [`JoinCSClause`][joincsc] — a serializable IR captur
 2. **[`SegmentedTopKRule`][topk-rule]** — injects [`SegmentedTopKExec`][topk-exec] for Top K on deferred columns, removes the now-redundant `SortExec(TopK)`, [wraps blocking nodes][wrap-blocking] with [`FilterPassthroughExec`][filter-passthrough]
 3. **FilterPushdown (Post)** — pushes `SegmentedTopKExec`'s `DynamicFilterPhysicalExpr` down to the scan
 
+If `max_parallel_workers_per_gather > 0` and PostgreSQL has planned parallel execution, `DistributedPlanner` converts the finalized physical plan into an MPP execution tree (`DistributedExec`), slicing it into isolated tasks.
+
 ### 4. Deferred Columns
 
 String columns are emitted as a [2-way `UnionArray`](../../scan/deferred_encode.rs) (doc_address | term_ordinal) so intermediate nodes work with cheap integer ordinals instead of decoded strings. The [decision to defer](../../scan/table_provider.rs) is made in [`configure_deferred_outputs()`][defer-decision].
@@ -55,6 +59,16 @@ There are two primary pruning mechanisms for dynamic filters that are pushed dow
 ### 6. Execution Result
 
 After all input is consumed, `SegmentedTopKExec` materializes sort column values, performs the final sort, and emits exactly K rows. `TantivyLookupExec` decodes deferred strings for those K rows only. JoinScanState extracts CTIDs and fetches heap tuples — the only point where the PostgreSQL heap is accessed.
+
+### 7. MPP Execution and Parallelism
+
+JoinScan does not use DataFusion's standard in-process multithreading. Since PostgreSQL already coordinates execution across independent backend processes via the `Gather` node, relying on thread-level parallelism inside a Postgres worker would result in `Workers * Threads` explosions, and Postgres does not support interacting with its APIs anywhere but on the `main` thread.
+
+Instead, MPP via `datafusion-distributed` is our only mechanism for parallelizing joins. We map PostgreSQL parallel workers to distributed tasks based on segment count:
+
+1. **Partition Output Definition**: Because index segments are checked out atomically from shared memory, [`PgSearchScanPlan`][scan-plan] natively partitions its output by the number of segments. In [`table_provider.rs`](../../scan/table_provider.rs), we formally expose the scan's output partition count as `min(segment_count, target_partitions)`.
+2. **Task Estimation**: During MPP planning, [`PgSearchScanTaskEstimator`](../mpp/task_estimator.rs) intercepts the leaf nodes and requests exactly this `partition_count` number of tasks.
+3. **Execution Routing**: This routes large multi-segment tables to scale out across all available PostgreSQL parallel workers, where each parallel worker uses `ParallelScanState` to lazily claim segments. Conversely, tables with a single segment evaluate to exactly 1 task; `datafusion-distributed` detects the absence of parallel work, avoids MPP planning overhead entirely, and falls back to running the query via local serial execution on a single worker.
 
 ## Key Files
 

--- a/pg_search/src/postgres/customscan/mpp/exec_worker.rs
+++ b/pg_search/src/postgres/customscan/mpp/exec_worker.rs
@@ -54,7 +54,7 @@ use datafusion_distributed::PartitionSink;
 use crate::postgres::customscan::mpp::dispatch::fragments_for_worker;
 use crate::postgres::customscan::mpp::glue::producer_worker_count;
 use crate::postgres::customscan::mpp::interrupt::{check_for_interrupts, HeldInterrupts};
-use crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator;
+use crate::postgres::customscan::mpp::task_estimator::PgSearchScanTaskEstimator;
 use crate::postgres::customscan::mpp::worker_fragments::FragmentRouting;
 use crate::postgres::utils::ExprContextGuard;
 use crate::postgres::ParallelScanState;
@@ -155,10 +155,7 @@ pub(crate) fn build_mpp_session_context(
             state_builder.with_distributed_channel_resolver(ShmChannelResolver::new(mesh));
     }
     let state_builder = state_builder
-        // Broadcast-subtree cap. Chain order matters: this has to come before the leaf
-        // estimator, otherwise the leaf's `Desired(n_workers)` wins, every producer task
-        // re-emits the full build side, and the consumer's `select_all` over-counts.
-        .with_distributed_task_estimator(BroadcastBuildSideOneTaskEstimator)
+        .with_distributed_task_estimator(PgSearchScanTaskEstimator)
         .with_distributed_task_estimator(n_workers)
         .with_distributed_broadcast_joins(true)
         .expect("with_distributed_broadcast_joins")
@@ -233,7 +230,9 @@ pub(crate) fn run_mpp_worker(
         Err(e) => pgrx::error!("mpp worker: build fragment assignments failed: {e}"),
     };
     if fragments.is_empty() {
-        pgrx::warning!(
+        // TODO(#5667): Wait to request parallel workers from Postgres until after the plan
+        // is generated so we only launch as many workers as we have fragments for.
+        pgrx::debug1!(
             "mpp worker (proc={this_proc}): no fragments assigned; skipping (worker emits zero rows)"
         );
         return;
@@ -297,8 +296,7 @@ pub(crate) fn run_mpp_worker(
     let hash_mem_multiplier = unsafe { pg_sys::hash_mem_multiplier };
     let session_arc = Arc::new(session);
 
-    // Two `Future` shapes share this vector: real producer-fragment futures and broadcast
-    // short-circuit EOF-only stubs. The alias keeps the `Vec<_>` declaration legible and silences
+    // All fragment futures share this vector. The alias keeps the `Vec<_>` declaration legible and silences
     // clippy::type_complexity.
     type FragmentFuture = std::pin::Pin<
         Box<
@@ -376,44 +374,6 @@ pub(crate) fn run_mpp_worker(
                         Arc::clone(&worker_mesh) as Arc<dyn CooperativeDrainSet>
                     ),
                 )));
-            }
-
-            // Broadcast invariant: fail-loud cap check.
-            //
-            // The natural-shape plan canonical-replicates the build subtree via the `mpp build
-            // all-gather` step. Every producer task would scan the full canonical data, and the
-            // consumer's `select_all` would over-count by `input_task_count`. The planner-level
-            // `BroadcastBuildSideOneTaskEstimator` caps the build subtree at task_count=1, so a
-            // correct plan produces exactly one Broadcast fragment with task_idx == 0.
-            //
-            // A non-zero `task_idx` here means the cap silently failed: maybe the estimator
-            // wasn't installed, the chain order is wrong, or a future planner pass re-expanded
-            // the build subtree. We surface this as a hard error rather than silently
-            // EOF-only-ing the fragment.
-            if matches!(
-                fragment.routing,
-                FragmentRouting::Hashed {
-                    broadcast: true,
-                    ..
-                }
-            ) {
-                debug_assert!(
-                    fragment.task_idx == 0,
-                    "mpp dispatcher: Broadcast fragment with task_idx={} but \
-                     BroadcastBuildSideOneTaskEstimator should have capped \
-                     input_task_count at 1; plan-walk drift?",
-                    fragment.task_idx,
-                );
-                if fragment.task_idx != 0 {
-                    return Err(datafusion::common::DataFusionError::Internal(format!(
-                        "mpp worker dispatch (proc={this_proc}): Broadcast fragment \
-                         (stage_id={}, task_idx={}) with task_idx > 0. The planner-level \
-                         BroadcastBuildSideOneTaskEstimator should cap input_task_count at 1. \
-                         A non-zero task_idx here indicates plan-walk drift or a missing \
-                         estimator chain on this session.",
-                        fragment.stage_id, fragment.task_idx,
-                    )));
-                }
             }
 
             // Build a TaskContext seeded with the right `DistributedTaskContext` so the boundary

--- a/pg_search/src/postgres/customscan/mpp/glue.rs
+++ b/pg_search/src/postgres/customscan/mpp/glue.rs
@@ -72,6 +72,7 @@ pub fn mpp_is_active() -> bool {
 /// true. Callers must gate on [`mpp_is_active`] first. Debug builds assert; release builds
 /// return the raw GUC, which can leave [`producer_worker_count`] below 2 and break the
 /// planner's `target_partitions` / mesh-width invariant.
+// TODO(#5667): Evaluate bounding or replacing mpp_worker_count dynamically based on df-d planner output.
 pub fn mpp_worker_count() -> u32 {
     debug_assert!(
         mpp_is_active(),

--- a/pg_search/src/postgres/customscan/mpp/task_estimator.rs
+++ b/pg_search/src/postgres/customscan/mpp/task_estimator.rs
@@ -15,103 +15,55 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-//! Delta from upstream: caps `BroadcastExec` subtrees at `task_count = 1`.
-//!
-//! Upstream DF-D's default estimator returns `Desired(n_workers)` for memory leaves, so a
-//! `NetworkBroadcastExec` built over the canonical-replica all-gather step would get
-//! `input_task_count = n_workers`. Every producer task would re-emit the full build side and the
-//! consumer's `select_all` would over-count by `n_workers`. This estimator caps the build subtree
-//! at one task, so the wire-layer `FragmentRouting::Broadcast` only ever sees `task_idx == 0`.
-//!
-//! Registered first in the DF-D `CombinedTaskEstimator` chain, which returns the first `Some(_)`.
-//! Returns `None` for everything that isn't a `BroadcastExec`, so the default leaf estimator
-//! handles the fallthrough.
-
 use std::sync::Arc;
 
 use datafusion::config::ConfigOptions;
 use datafusion::physical_plan::ExecutionPlan;
-use datafusion_distributed::{BroadcastExec, TaskEstimation, TaskEstimator};
+use datafusion_distributed::{TaskEstimation, TaskEstimator};
 
-/// Caps every [`BroadcastExec`] subtree at `task_count = 1`.
+use crate::scan::execution_plan::PgSearchScanPlan;
+
+/// `PgSearchScanTaskEstimator` intercepts `PgSearchScanPlan` during distributed planning
+/// and requests a number of tasks equal to `partition_count = min(segment_count, target_partitions)`.
 ///
-/// Targeting `BroadcastExec` directly (instead of marking the leaf) survives DataFusion's
-/// HashJoin build/probe reordering: the `BroadcastExec` always sits above whichever side ends up
-/// as the build, so the cap lands at the right point regardless.
+/// This correctly maps PostgreSQL parallel workers to tasks, ensuring that tables with 1 segment
+/// do not force MPP planning and fall back to local serial execution, whereas large tables
+/// scale out efficiently across all available Postgres parallel workers.
 #[derive(Debug)]
-pub struct BroadcastBuildSideOneTaskEstimator;
+pub(crate) struct PgSearchScanTaskEstimator;
 
-impl TaskEstimator for BroadcastBuildSideOneTaskEstimator {
+impl TaskEstimator for PgSearchScanTaskEstimator {
     fn task_estimation(
         &self,
         plan: &Arc<dyn ExecutionPlan>,
-        _: &ConfigOptions,
+        _cfg: &ConfigOptions,
     ) -> Option<TaskEstimation> {
-        if plan.is::<BroadcastExec>() {
-            Some(TaskEstimation::maximum(1))
-        } else {
-            None
-        }
+        let _ = plan.downcast_ref::<PgSearchScanPlan>()?;
+
+        let partition_count = plan.properties().output_partitioning().partition_count();
+
+        Some(TaskEstimation::desired(partition_count))
     }
 
     fn scale_up_leaf_node(
         &self,
-        _: &Arc<dyn ExecutionPlan>,
-        _: usize,
-        _: &ConfigOptions,
+        plan: &Arc<dyn ExecutionPlan>,
+        task_count: usize,
+        _cfg: &ConfigOptions,
     ) -> datafusion::error::Result<Option<Arc<dyn ExecutionPlan>>> {
-        Ok(None)
-    }
-}
+        if plan.downcast_ref::<PgSearchScanPlan>().is_none() {
+            return Ok(None);
+        }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use datafusion::arrow::datatypes::{DataType, Field, Schema};
-    use datafusion::physical_plan::empty::EmptyExec;
+        // Each worker decodes its own copy, and `execute()` dynamically claims segments from the
+        // parallel state. Variants in the same process share state: see `ExecutionState` for why
+        // this is safe.
+        let variants = (0..task_count)
+            .map(|_| Arc::clone(plan))
+            .collect::<Vec<_>>();
 
-    fn cfg() -> ConfigOptions {
-        ConfigOptions::default()
-    }
-
-    fn empty_leaf() -> Arc<dyn ExecutionPlan> {
-        let schema = Arc::new(Schema::new(vec![Field::new("x", DataType::Int32, false)]));
-        Arc::new(EmptyExec::new(schema))
-    }
-
-    #[test]
-    fn broadcast_exec_is_capped_at_one() {
-        let inner = empty_leaf();
-        let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(inner, 1));
-        let est = BroadcastBuildSideOneTaskEstimator;
-        let out = est.task_estimation(&broadcast, &cfg()).expect("estimation");
-        // `TaskEstimation::maximum(1)` is what propagates up to
-        // `NetworkBroadcastExec::input_task_count = 1`.
-        assert_eq!(out.task_count.as_usize(), 1);
-        // `task_count` is `Maximum`, not `Desired`. Confirm the variant so an accidental
-        // refactor that promotes it to `Desired` (and therefore loses the "hard cap" behaviour)
-        // breaks the test.
-        assert!(matches!(
-            out.task_count,
-            datafusion_distributed::TaskCountAnnotation::Maximum(1)
-        ));
-    }
-
-    #[test]
-    fn non_broadcast_node_falls_through() {
-        let plan = empty_leaf();
-        let est = BroadcastBuildSideOneTaskEstimator;
-        assert!(est.task_estimation(&plan, &cfg()).is_none());
-    }
-
-    #[test]
-    fn scale_up_is_a_no_op() {
-        let inner = empty_leaf();
-        let broadcast: Arc<dyn ExecutionPlan> = Arc::new(BroadcastExec::new(inner, 1));
-        let est = BroadcastBuildSideOneTaskEstimator;
-        assert!(est
-            .scale_up_leaf_node(&broadcast, 7, &cfg())
-            .unwrap()
-            .is_none());
+        Ok(Some(Arc::new(
+            datafusion_distributed::DistributedLeafExec::try_new(Arc::clone(plan), variants)?,
+        )))
     }
 }

--- a/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
+++ b/pg_search/src/postgres/customscan/mpp/worker_fragments.rs
@@ -94,12 +94,6 @@ pub enum FragmentRouting {
     Hashed {
         /// `route_partition(q).consumer_task` for each producer output partition `q`.
         consumer_task: Vec<u32>,
-        /// `true` for broadcast. The build subtree is capped at `task_count = 1` via
-        /// [`BroadcastBuildSideOneTaskEstimator`], so the dispatcher only ever sees
-        /// `task_idx == 0` broadcast fragments; the cap is asserted at dispatch.
-        ///
-        /// [`BroadcastBuildSideOneTaskEstimator`]: crate::postgres::customscan::mpp::task_estimator::BroadcastBuildSideOneTaskEstimator
-        broadcast: bool,
     },
 }
 
@@ -154,7 +148,7 @@ fn collect_stages(
         // destination proc for every output partition from `(type, top_level)`. The fork's gRPC
         // path keys dispatch on resolver URLs and never has to decide this; our shm_mq peers are
         // push-driven without URLs, so the dispatcher has to. Shuffle and Broadcast share the
-        // receive-side math but Broadcast caps to task 0; Coalesce collapses to one consumer task;
+        // receive-side math; Coalesce collapses to one consumer task;
         // top-level (`nested == false`) routes to the leader.
         let routing = if plan.is::<NetworkCoalesceExec>() {
             if nested {
@@ -168,46 +162,22 @@ fn collect_stages(
                 // Top-level NetworkCoalesceExec (gather to leader): consumer is leader proc 0.
                 FragmentRouting::Coalesce { dest_proc: 0 }
             }
-        } else if plan.is::<NetworkShuffleExec>() {
+        } else if plan.is::<NetworkShuffleExec>() || plan.is::<NetworkBroadcastExec>() {
             if nested {
-                // Nested NetworkShuffleExec: hash-partitioned mesh. Each output partition q maps
-                // to the consumer task `route_partition(q)` selects.
+                // Nested NetworkShuffleExec or NetworkBroadcastExec: hash-partitioned mesh.
+                // Each output partition q maps to the consumer task `route_partition(q)` selects.
                 FragmentRouting::Hashed {
                     consumer_task: route_consumer_tasks()?,
-                    broadcast: false,
                 }
             } else {
-                // Top-level NetworkShuffleExec isn't a shape our customscan plans produce.
-                // Shuffles emit hash-partitioned output into a parent consumer stage, not directly
-                // into the leader. Coalescing the partitions to proc 0 would technically work (each
-                // batch reaches `select_all` exactly once) but it would mask a planner anomaly by
-                // silently treating hash-partitioned output as one logical stream.
+                // Top-level NetworkShuffleExec / NetworkBroadcastExec isn't a shape our customscan plans produce.
+                // They emit partitioned or broadcast output into a parent consumer stage, not directly
+                // into the leader.
                 crate::postgres::customscan::mpp::fail_loud(format!(
-                    "mpp worker_fragments: top-level NetworkShuffleExec is unsupported \
-                     (stage_id={stage_id}). Shuffles emit hash-partitioned output into a \
-                     parent consumer stage; a top-level shuffle is a planner anomaly."
-                ))
-            }
-        } else if plan.is::<NetworkBroadcastExec>() {
-            if nested {
-                // Nested NetworkBroadcastExec: same receive-side routing as Shuffle (via
-                // `route_partition`), but the dispatcher only runs the producer plan on task 0 to
-                // avoid the canonical-replica duplication described on `FragmentRouting::Hashed`.
-                FragmentRouting::Hashed {
-                    consumer_task: route_consumer_tasks()?,
-                    broadcast: true,
-                }
-            } else {
-                // Top-level NetworkBroadcastExec isn't a shape the natural-shape AggregateScan
-                // plan produces; broadcast always sits nested inside the HashJoin build subtree.
-                // Falling through to `Coalesce { dest_proc: 0 }` would send every input task's full
-                // canonical replica to the leader and `select_all` would over-count by
-                // `input_task_count`. Fail loudly so a future planner change that hits this shape
-                // can't silently produce wrong answers.
-                crate::postgres::customscan::mpp::fail_loud(format!(
-                    "mpp worker_fragments: top-level NetworkBroadcastExec is unsupported \
-                     (stage_id={stage_id}). The natural-shape AggregateScan plan does not \
-                     produce this shape; route via a NetworkCoalesceExec gather instead."
+                    "mpp worker_fragments: top-level {} is unsupported \
+                     (stage_id={stage_id}). They emit output into a \
+                     parent consumer stage; a top-level boundary of this type is a planner anomaly.",
+                    plan.name()
                 ))
             }
         } else {
@@ -279,15 +249,10 @@ mod tests {
     fn routing_hashed_carries_consumer_tasks() {
         let r = FragmentRouting::Hashed {
             consumer_task: vec![0, 0, 1],
-            broadcast: false,
         };
         match r {
-            FragmentRouting::Hashed {
-                consumer_task,
-                broadcast,
-            } => {
+            FragmentRouting::Hashed { consumer_task } => {
                 assert_eq!(consumer_task, vec![0, 0, 1]);
-                assert!(!broadcast);
             }
             _ => panic!("expected Hashed"),
         }

--- a/pg_search/src/postgres/storage/linked_bytes.rs
+++ b/pg_search/src/postgres/storage/linked_bytes.rs
@@ -39,6 +39,10 @@ const BLOCK_CACHE_SIZE: usize = 16;
 /// Unified cache entry: stores OwnedBytes which wraps an Arc'd ImmutablePage.
 /// get_byte indexes directly into the pre-resolved &[u8] slice (no vtable dispatch).
 /// get_bytes_range_block clones the Arc on cache hit.
+///
+/// The cache is a plain FIFO (admit at back, evict at front, no promotion on
+/// hit): every reuse pattern it serves is immediate-recency, so promotion
+/// would only add work on the hot path.
 struct CacheEntry {
     block_ord: usize,
     block_bytes: OwnedBytes,
@@ -386,7 +390,6 @@ impl LinkedBytesList {
             }
         }
         if let Some(pos) = cache.iter().rposition(|e| e.block_ord == block_ord) {
-            // No LRU promotion — not needed for fieldnorm reads.
             return cache[pos].block_bytes[local_offset];
         }
 
@@ -426,28 +429,21 @@ impl LinkedBytesList {
             return block_bytes.slice(slice_start..slice_end);
         }
 
-        // Multi-page read, fallback to copying
-        let mut blockno = self
-            .block_for_ord(start_block_ord)
-            .expect("block not found");
-
+        // Multi-page read: must copy, but each page is served through the block
+        // cache so blocks shared with adjacent reads (torn items on a page
+        // boundary, consecutive spans) skip the buffer manager round trip.
         let mut data = Vec::with_capacity(range.len());
         let mut remaining = range.len();
 
-        while data.len() != range.len() && blockno != pg_sys::InvalidBlockNumber {
-            let buffer = self.bman.get_buffer(blockno);
-            let page = buffer.page();
-            let special = page.special::<BM25PageSpecialData>();
-            let slice_start = if data.is_empty() {
+        for block_ord in start_block_ord..=end_block_ord {
+            let block_bytes = self.get_bytes_range_block(block_ord);
+            let slice_start = if block_ord == start_block_ord {
                 range.start % ITEM_SIZE
             } else {
                 0
             };
             let slice_len = (ITEM_SIZE - slice_start).min(remaining);
-            let slice = page.as_slice_range(slice_start, slice_len);
-
-            data.extend_from_slice(slice);
-            blockno = special.next_blockno;
+            data.extend_from_slice(&block_bytes[slice_start..slice_start + slice_len]);
             remaining -= slice_len;
         }
 
@@ -458,11 +454,10 @@ impl LinkedBytesList {
         // SAFETY: Postgres backends are single-threaded.
         let cache = self.cache.get();
         if let Some(pos) = cache.iter().rposition(|e| e.block_ord == start_block_ord) {
-            // Cache hit: move to back, Arc clone.
-            let entry = cache.remove(pos).unwrap();
-            let block_bytes = entry.block_bytes.clone();
-            cache.push_back(entry);
-            return block_bytes;
+            // Cache hit: Arc clone. The cache is a plain FIFO -- no promotion on
+            // hit, because all reuse through it is immediate-recency (adjacent
+            // reads touching the same or a boundary block).
+            return cache[pos].block_bytes.clone();
         }
 
         // Cache miss: read the block.

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -87,7 +87,12 @@ pub struct ScannerConfig {
 }
 
 /// State for a scan partition.
+///
 /// Uses `Arc<FFHelper>` so the same FFHelper can be shared across multiple partitions.
+///
+/// Lazily claims segments from `ParallelScanState`. `source_idx = Some(i)` claims from source
+/// `i`'s pool for MPP sources; `None` uses the single-counter `checkout_segment_for_source(0)`
+/// for basescan and non-MPP parallel joins.
 pub struct ScanState {
     pub parallel_state: Option<*mut ParallelScanState>,
     pub source_idx: Option<usize>,
@@ -98,12 +103,39 @@ pub struct ScanState {
     pub reader: SearchIndexReader,
 }
 
+/// Execution state for a single `PgSearchScanPlan`.
+///
+/// In multi-partition distributed execution, operators like `NestedLoopJoinExec` or `datafusion-distributed`'s
+/// worker fragment runner execute all partitions of a plan concurrently across tasks.
+/// For plans initialized with a `ScanState`, the first `execute()` takes the reader. If the plan has multiple
+/// partitions (`partition_count > 1`), subsequent calls up to `partition_count` yield an empty stream (`Empty`).
+/// Once all budget calls are spent, the state transitions to `Consumed`.
+///
+/// Because all tasks/variants in a single process share the exact same `ExecutionState` instance (cloned via `Arc`),
+/// this state machine is essential for correctness when a process hosts multiple tasks for the same scan stage.
+/// The first task to poll `execute()` takes the `Ready` state and returns a stream that dynamically claims segments
+/// from the `ParallelScanState`. The subsequent tasks encounter the `Empty` state and return empty streams, safely
+/// allowing the first stream to do all the work for that process's portion of segments.
+#[derive(Default)]
+pub enum ExecutionState {
+    /// Initialized with state, ready to execute.
+    Ready(Box<UnsafeSendSync<ScanState>>),
+    /// Reader has been taken, but remaining partitions may still be executed (yielding empty streams).
+    Empty { remaining_partitions: usize },
+    /// Initialized without state (used in tests or empty placeholders).
+    #[default]
+    Uninitialized,
+    /// All expected partition executions have completed; subsequent execute() calls return an error.
+    Consumed,
+}
+
 /// A DataFusion `ExecutionPlan` for scanning `pg_search` index segments.
 ///
-/// The plan exposes exactly one partition containing a lazily-evaluated
-/// `MultiSegmentSearchResults` stream. Segments are claimed dynamically from
-/// `ParallelScanState` when running in parallel (load-balancing across workers as they
-/// process data) or chained sequentially when serial.
+/// Under multi-partition distributed execution, this plan's `output_partitioning` declares
+/// a *capacity* (`min(segments, target_partitions)`). The partitions do not statically map
+/// to data; instead, tasks dynamically claim segments from the shared `ParallelScanState` as
+/// they process the stream returned by `execute()`. See `ExecutionState` for details on how
+/// multiple tasks safely share state within a single process.
 pub struct PgSearchScanPlan {
     /// State for this single-partition scan.
     ///
@@ -112,7 +144,7 @@ pub struct PgSearchScanPlan {
     /// requirements. This is safe because we are running in a single-threaded
     /// environment (Postgres), which also means that the duration for which we
     /// hold this Mutex does not impact performance.
-    state: Mutex<Option<UnsafeSendSync<ScanState>>>,
+    state: Mutex<ExecutionState>,
     /// Estimated row count, computed once at construction.
     /// Stored separately so `partition_statistics` is deterministic, even after
     /// the state has been consumed.
@@ -174,6 +206,8 @@ impl PgSearchScanPlan {
     /// * `resolved_query` - The filter-combined, param-solved query the readers were opened
     ///   with. Used for EXPLAIN and shipped on dispatch.
     /// * `sort_order` - Optional sort order declaration for equivalence properties
+    /// * `partition_count` - Number of distributed tasks/partitions this scan natively supports
+    ///   (usually `min(segments, target_partitions)`).
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         state: Option<ScanState>,
@@ -184,19 +218,19 @@ impl PgSearchScanPlan {
         ffhelper: Option<Arc<FFHelper>>,
         indexrelid: u32,
         deferred_ctid_plan_position: Option<usize>,
+        partition_count: usize,
     ) -> Self {
         let needs_ffhelper = !deferred_fields.is_empty() || deferred_ctid_plan_position.is_some();
         if needs_ffhelper && ffhelper.is_none() {
             panic!("deferred lookup/visibility requires an FFHelper, but ffhelper is None");
         }
-        // Ensure we always return exactly one partition to satisfy DataFusion distribution
-        // requirements (e.g. HashJoinExec mode=CollectLeft requires SinglePartition).
+        // Output partitioning tells datafusion-distributed how many tasks this leaf can naturally split into.
         // If state is None, execute() will return an EmptyStream for this single partition.
         let eq_properties = build_equivalence_properties(schema, sort_order);
 
         let properties = Arc::new(PlanProperties::new(
             eq_properties,
-            Partitioning::UnknownPartitioning(1),
+            Partitioning::UnknownPartitioning(partition_count),
             EmissionType::Incremental,
             Boundedness::Bounded,
         ));
@@ -213,8 +247,20 @@ impl PgSearchScanPlan {
             })
             .unwrap_or(0);
 
+        assert!(
+            partition_count <= segment_count.max(1),
+            "partition_count {} exceeds segment_count {}",
+            partition_count,
+            segment_count
+        );
+
+        let exec_state = match state {
+            Some(s) => ExecutionState::Ready(Box::new(UnsafeSendSync(s))),
+            None => ExecutionState::Uninitialized,
+        };
+
         Self {
-            state: Mutex::new(state.map(UnsafeSendSync)),
+            state: Mutex::new(exec_state),
             planner_estimated_rows,
             segment_count,
             properties,
@@ -254,9 +300,14 @@ impl PgSearchScanPlan {
             .state
             .lock()
             .map_err(|e| DataFusionError::Internal(format!("lock PgSearchScanPlan state: {e}")))?;
-        let state = state_guard.as_ref().ok_or_else(|| {
-            DataFusionError::Internal("PgSearchScan dispatch: partition already consumed".into())
-        })?;
+        let state = match &*state_guard {
+            ExecutionState::Ready(state) => state,
+            _ => {
+                return Err(DataFusionError::Internal(
+                    "PgSearchScan dispatch: partition already consumed or uninitialized".into(),
+                ));
+            }
+        };
         let (source_idx, planner_estimated_rows, scanner_config) = (
             state.0.source_idx,
             state.0.planner_estimated_rows,
@@ -282,6 +333,7 @@ impl PgSearchScanPlan {
             batch_size_hint: scanner_config.batch_size_hint,
             source_idx,
             planner_estimated_rows,
+            partition_count: self.properties.output_partitioning().partition_count(),
         };
         serde_json::to_vec(&descriptor).map_err(|e| {
             DataFusionError::Internal(format!("PgSearchScan dispatch: serialize: {e}"))
@@ -382,6 +434,7 @@ impl PgSearchScanPlan {
             ffhelper_arg,
             descriptor.indexrelid,
             deferred_ctid_plan_position,
+            descriptor.partition_count,
         )))
     }
 }
@@ -406,6 +459,7 @@ struct ScanDispatchDescriptor {
     /// single-counter checkout (basescan and non-MPP parallel joins). All-sources position.
     source_idx: Option<usize>,
     planner_estimated_rows: u64,
+    partition_count: usize,
 }
 
 /// Build `EquivalenceProperties` with the specified sort ordering.
@@ -460,7 +514,7 @@ fn strategy_name(strategy: tantivy::query::StrategyTag) -> &'static str {
 
 impl DisplayAs for PgSearchScanPlan {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "PgSearchScan: segments={}", self.segment_count,)?;
+        write!(f, "PgSearchScan: segments={}", self.segment_count)?;
         if !self.dynamic_filters.is_empty() {
             write!(f, ", dynamic_filters={}", self.dynamic_filters.len())?;
         }
@@ -496,9 +550,20 @@ impl ExecutionPlan for PgSearchScanPlan {
     }
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
+        let partition_count = self.properties.output_partitioning().partition_count();
         let num_rows = match partition {
-            Some(0) | None => Precision::Inexact(self.planner_estimated_rows as usize),
-            Some(_) => Precision::Absent,
+            None => Precision::Inexact(self.planner_estimated_rows as usize),
+            Some(p) if p < partition_count => {
+                let rows_per_partition =
+                    self.planner_estimated_rows as usize / partition_count.max(1);
+                Precision::Inexact(rows_per_partition)
+            }
+            Some(p) => {
+                return Err(DataFusionError::Internal(format!(
+                    "Partition {} out of range (have {} partitions)",
+                    p, partition_count
+                )))
+            }
         };
 
         let column_statistics = self
@@ -545,16 +610,49 @@ impl ExecutionPlan for PgSearchScanPlan {
             )));
         }
 
-        // Handle the case where no state was provided (test cases) or already consumed.
-        let state_opt = state_guard.take();
-        if state_opt.is_none() {
-            let schema = self.properties.eq_properties.schema().clone();
-            return Ok(Box::pin(unsafe {
-                UnsafeSendStream::new(futures::stream::empty(), schema)
-            }));
-        }
+        // Handle state transitions for execution.
+        let partition_count = self.properties.output_partitioning().partition_count();
+        let exec_state = std::mem::take(&mut *state_guard);
+        let scan_state = match exec_state {
+            ExecutionState::Ready(state) => {
+                if partition_count > 1 {
+                    *state_guard = ExecutionState::Empty {
+                        remaining_partitions: partition_count - 1,
+                    };
+                } else {
+                    *state_guard = ExecutionState::Consumed;
+                }
+                state.0
+            }
+            ExecutionState::Empty {
+                remaining_partitions,
+            } => {
+                if remaining_partitions > 1 {
+                    *state_guard = ExecutionState::Empty {
+                        remaining_partitions: remaining_partitions - 1,
+                    };
+                } else {
+                    *state_guard = ExecutionState::Consumed;
+                }
+                let schema = self.properties.eq_properties.schema().clone();
+                return Ok(Box::pin(unsafe {
+                    UnsafeSendStream::new(futures::stream::empty(), schema)
+                }));
+            }
+            ExecutionState::Uninitialized => {
+                let schema = self.properties.eq_properties.schema().clone();
+                return Ok(Box::pin(unsafe {
+                    UnsafeSendStream::new(futures::stream::empty(), schema)
+                }));
+            }
+            ExecutionState::Consumed => {
+                return Err(DataFusionError::Internal(
+                    "PgSearchScanPlan partition executed more than once".into(),
+                ));
+            }
+        };
 
-        let UnsafeSendSync(ScanState {
+        let ScanState {
             parallel_state,
             source_idx,
             planner_estimated_rows,
@@ -562,7 +660,12 @@ impl ExecutionPlan for PgSearchScanPlan {
             ffhelper,
             mut visibility,
             mut reader,
-        }) = state_opt.unwrap();
+        } = scan_state;
+
+        assert!(
+            partition_count <= 1 || parallel_state.is_some(),
+            "PgSearchScanPlan executed with partition_count > 1 but without a ParallelScanState"
+        );
 
         let has_dynamic_filters = !self.dynamic_filters.is_empty();
         let rows_scanned = has_dynamic_filters
@@ -693,21 +796,16 @@ impl ExecutionPlan for PgSearchScanPlan {
 
         if !dynamic_filters.is_empty() {
             // Transfer state from the old plan to the new one.
-            let state = self
-                .state
-                .lock()
-                .map_err(|e| {
-                    DataFusionError::Internal(format!(
-                        "Failed to lock PgSearchScanPlan state during filter pushdown: {e}"
-                    ))
-                })?
-                .take()
-                .map(|s| s.0);
+            let state = std::mem::take(&mut *self.state.lock().map_err(|e| {
+                DataFusionError::Internal(format!(
+                    "Failed to lock PgSearchScanPlan state during filter pushdown: {e}"
+                ))
+            })?);
 
             let resolved_query = self.resolved_query.clone();
 
             let new_plan = Arc::new(PgSearchScanPlan {
-                state: Mutex::new(state.map(UnsafeSendSync)),
+                state: Mutex::new(state),
                 planner_estimated_rows: self.planner_estimated_rows,
                 segment_count: self.segment_count,
                 properties: self.properties.clone(),
@@ -842,6 +940,7 @@ mod tests {
             None,
             0,
             Some(1),
+            1,
         );
     }
 
@@ -856,6 +955,7 @@ mod tests {
             None,
             0,
             None,
+            1,
         );
     }
 }

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -406,6 +406,7 @@ impl PgSearchTableProvider {
         schema: SchemaRef,
         resolved_query: SearchQueryInput,
         ffhelper: Arc<FFHelper>,
+        partition_count: usize,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let deferred = self.deferred_fields();
         let deferred_ctid_plan_position = self.deferred_ctid_plan_position();
@@ -428,6 +429,7 @@ impl PgSearchTableProvider {
             ffhelper_arg,
             self.scan_info.indexrelid.to_u32(),
             deferred_ctid_plan_position,
+            partition_count,
         )))
     }
 
@@ -456,6 +458,7 @@ impl PgSearchTableProvider {
         resolved_query: SearchQueryInput,
         planner_estimated_rows: u64,
         source_idx: Option<usize>,
+        partition_count: usize,
     ) -> Result<Arc<dyn ExecutionPlan>> {
         let ffhelper = Arc::new(ffhelper);
         let scanner_config = crate::scan::execution_plan::ScannerConfig {
@@ -474,7 +477,13 @@ impl PgSearchTableProvider {
             reader: reader.clone(),
         };
 
-        self.create_scan(Some(state), schema, resolved_query, ffhelper)
+        self.create_scan(
+            Some(state),
+            schema,
+            resolved_query,
+            ffhelper,
+            partition_count,
+        )
     }
 }
 
@@ -540,7 +549,7 @@ impl TableProvider for PgSearchTableProvider {
 impl PgSearchTableProvider {
     async fn scan_inner(
         &self,
-        _state: &dyn Session,
+        state: &dyn Session,
         projection: Option<&Vec<usize>>,
         filters: &[Expr],
         _limit: Option<usize>,
@@ -617,6 +626,14 @@ impl PgSearchTableProvider {
 
         let total_estimated_rows = self.scan_info.estimate.as_planner_estimate();
 
+        let segment_count = reader.segment_readers().len();
+        let target_partitions = state.config().target_partitions();
+        // The output partitions of the scan equal min(segments, target_partitions).
+        // This instructs datafusion-distributed to split the query into exactly this many
+        // tasks for this leaf, routing multi-segment tables to parallel workers while keeping
+        // small 1-segment tables serial.
+        let partition_count = std::cmp::min(segment_count, target_partitions).max(1);
+
         self.create_lazy_scan(
             parallel_state,
             &reader,
@@ -628,6 +645,7 @@ impl PgSearchTableProvider {
             query,
             total_estimated_rows,
             self.source_idx,
+            partition_count,
         )
     }
 }

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -113,6 +113,7 @@ mod tests {
             None,
             0,
             None,
+            1,
         );
 
         let task_ctx = Arc::new(TaskContext::default());

--- a/pg_search/src/scan/visibility_ctid_resolver_rule.rs
+++ b/pg_search/src/scan/visibility_ctid_resolver_rule.rs
@@ -153,6 +153,7 @@ mod tests {
             Some(ffhelper.clone()),
             0,
             Some(7),
+            1,
         );
 
         let (_, found) = find_ffhelper_for_plan_position(&scan, 7)
@@ -199,6 +200,7 @@ mod tests {
             Some(ffhelper.clone()),
             0,
             None,
+            1,
         );
         let stk = SegmentedTopKExec::new(
             Arc::new(scan),
@@ -233,6 +235,7 @@ mod tests {
             Some(ffhelper_scan.clone()),
             0,
             Some(plan_pos),
+            1,
         );
 
         let vis_data = Arc::new(AbsorbedVisibilityData::new(

--- a/pg_search/tests/pg_regress/expected/basescan_limit_unnest.out
+++ b/pg_search/tests/pg_regress/expected/basescan_limit_unnest.out
@@ -1,0 +1,94 @@
+-- =====================================================================
+-- Issue #5573: LIMIT must not be pushed into BaseScan when a
+--              row-reducing set-returning function sits above it.
+-- =====================================================================
+-- Before the fix, `classify_target_list_srf` marked `unnest` as
+-- "row-preserving" and let BaseScan cap its TopK to `LIMIT` rows.
+-- `unnest(ARRAY[]::T[])` and `unnest(NULL)` emit ZERO rows, so the
+-- ProjectSet above the scan then discarded rows from an already-capped
+-- output and returned fewer than LIMIT results.
+--
+-- This test exercises the buggy case (mixed empty/NULL/non-empty
+-- arrays under `unnest` with a `@@@` predicate + LIMIT) and asserts
+-- the query returns exactly LIMIT rows.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP SCHEMA IF EXISTS pdb_unnest_limit CASCADE;
+CREATE SCHEMA pdb_unnest_limit;
+SET search_path = pdb_unnest_limit, public;
+CREATE TABLE items (id int PRIMARY KEY, kind text);
+INSERT INTO items
+SELECT g, CASE WHEN g % 3 = 0 THEN 'novel' ELSE 'manga' END
+FROM generate_series(1, 2000) g;
+CREATE INDEX items_bm25 ON items USING bm25 (id, kind) WITH (key_field = 'id');
+ANALYZE items;
+SET paradedb.enable_custom_scan = on;
+-- Row-reducing unnest: even ids emit one row, odd ids emit zero rows.
+-- Correct answer is 5 rows because there are >>5 matching even ids.
+-- Before the fix, this returned only 2 rows: TopK capped input to 5
+-- (ids 1, 2, 4, 5, 7), then ProjectSet dropped ids 1, 5, 7.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+ id | u 
+----+---
+  2 | 1
+  4 | 1
+  8 | 1
+ 10 | 1
+ 14 | 1
+(5 rows)
+
+-- Same shape with NULL arrays instead of empty arrays.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE NULL::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+ id | u 
+----+---
+  2 | 1
+  4 | 1
+  8 | 1
+ 10 | 1
+ 14 | 1
+(5 rows)
+
+-- Sanity: the non-reducing case (every input row multiplies into >=1 output
+-- rows) still returns exactly LIMIT rows and still routes through the scan.
+SELECT id, unnest(ARRAY[1, 2]) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id, u
+LIMIT 6;
+ id | u 
+----+---
+  1 | 1
+  1 | 2
+  2 | 1
+  2 | 2
+  4 | 1
+  4 | 2
+(6 rows)
+
+-- Sanity: with `paradedb.enable_custom_scan = off` the query falls back to
+-- a plain PostgreSQL plan (no BaseScan involved) and should return 5 rows.
+-- This is the reference the fix restores parity with.
+SET paradedb.enable_custom_scan = off;
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind = 'manga'
+ORDER BY id
+LIMIT 5;
+ id | u 
+----+---
+  2 | 1
+  4 | 1
+  8 | 1
+ 10 | 1
+ 14 | 1
+(5 rows)
+
+RESET paradedb.enable_custom_scan;
+DROP SCHEMA pdb_unnest_limit CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_4779.out
+++ b/pg_search/tests/pg_regress/expected/issue_4779.out
@@ -169,8 +169,8 @@ WHERE EXISTS (SELECT 1 FROM t_a_4779 a WHERE a.main_id = m.id AND a.id @@@ pdb.a
   AND EXISTS (SELECT 1 FROM t_b_4779 b WHERE b.main_id = m.id AND b.id @@@ pdb.all())
   AND m.id @@@ pdb.all()
 ORDER BY m.id DESC LIMIT 10;
-                                                          QUERY PLAN                                                          
-------------------------------------------------------------------------------------------------------------------------------
+                                                           QUERY PLAN                                                           
+--------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: (m SEMI b) SEMI a
@@ -178,23 +178,18 @@ ORDER BY m.id DESC LIMIT 10;
          Limit: 10
          Order By: m.id desc
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec
-           : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
-           : │   SortPreservingMergeExec: [id@1 DESC], fetch=10
-           : │     SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
-           : │       VisibilityFilterExec: tables=[m]
-           : │         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           : │           CoalescePartitionsExec
-           : │             [Stage 1] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
-           : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           : │             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           : └──────────────────────────────────────────────────
-           :   ┌───── Stage 1 ── tasks=3, partitions=9
-           :   │ HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
-           :   │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :   │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │     PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
-           :   └──────────────────────────────────────────────────
-(24 rows)
+           : ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           :   SortPreservingMergeExec: [id@1 DESC], fetch=10
+           :     SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
+           :       VisibilityFilterExec: tables=[m]
+           :         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :           CoalescePartitionsExec
+           :             HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, main_id@0)]
+           :               PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :               RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :                 PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+           :           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"all":{"field":"id"}}}}
+(19 rows)
 
 DROP TABLE t_main_4779, t_a_4779, t_b_4779 CASCADE;

--- a/pg_search/tests/pg_regress/expected/issue_4910.out
+++ b/pg_search/tests/pg_regress/expected/issue_4910.out
@@ -79,8 +79,8 @@ WHERE
     AND contact_id @@@ paradedb.range(field => 'contact_id', range => '(0,)'::int8range)
 ORDER BY revenue_rank DESC NULLS LAST, contact_id ASC
 LIMIT 25;
-                                                                                        QUERY PLAN                                                                                         
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                          QUERY PLAN                                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    ->  Custom Scan (ParadeDB Join Scan)
          Relation Tree: (cccf ANTI cne) SEMI ce
@@ -88,32 +88,17 @@ LIMIT 25;
          Limit: 25
          Order By: cccf.revenue_rank desc nulls last, cccf.contact_id asc
          DataFusion Physical Plan: 
-           : ┌───── DistributedExec
-           : │ ProjectionExec: expr=[contact_id@3 as col_1, company_id@1 as col_2, revenue_rank@2 as col_3, ctid_0@0 as ctid_0]
-           : │   SortPreservingMergeExec: [revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], fetch=25
-           : │     [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
-           : └──────────────────────────────────────────────────
-           :   ┌───── Stage 3 ── tasks=3, partitions=9
-           :   │ SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[true]
-           :   │   VisibilityFilterExec: tables=[cccf]
-           :   │     HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
-           :   │       CoalescePartitionsExec
-           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │       HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
-           :   │         CoalescePartitionsExec
-           :   │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
-           :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=3
-           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, query="all"
-           :     └──────────────────────────────────────────────────
-           :     ┌───── Stage 2 ── tasks=1, partitions=3
-           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
-           :     └──────────────────────────────────────────────────
-(32 rows)
+           : ProjectionExec: expr=[contact_id@3 as col_1, company_id@1 as col_2, revenue_rank@2 as col_3, ctid_0@0 as ctid_0]
+           :   SortPreservingMergeExec: [revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], fetch=25
+           :     SortExec: TopK(fetch=25), expr=[revenue_rank@2 DESC NULLS LAST, contact_id@3 ASC NULLS LAST], preserve_partitioning=[true]
+           :       VisibilityFilterExec: tables=[cccf]
+           :         HashJoinExec: mode=CollectLeft, join_type=RightSemi, on=[(company_id@0, company_id@1)]
+           :           PgSearchScan: segments=1, query="all"
+           :           HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, company_id@1)]
+           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse":{"query_string":"speciality:salesforce","lenient":null,"conjunction_mode":null}}}}
+           :             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :               PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"range":{"field":"contact_id","lower_bound":{"included":1},"upper_bound":null}}}}
+(17 rows)
 
 -- Result rows in parallel mode (verifies correctness, not just plan shape).
 SELECT contact_id, company_id, revenue_rank

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
@@ -111,8 +111,8 @@ WHERE NOT EXISTS (
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id DESC
 LIMIT 5000;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: i.id
    ->  Custom Scan (ParadeDB Join Scan)
@@ -131,15 +131,19 @@ LIMIT 5000;
            :   │   VisibilityFilterExec: tables=[i]
            :   │     NestedLoopJoinExec: join_type=RightAnti, filter=pattern@2 = name@0 OR pattern@2 = alt_name@1, projection=[ctid_0@0, id@3]
            :   │       CoalescePartitionsExec
-           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │         PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=6, input_tasks=2
+           :   │       DistributedLeafExec:
+           :   │         t0: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         t1: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         t2: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=3
-           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
+           :     ┌───── Stage 1 ── tasks=2, partitions=12
+           :     │ BroadcastExec: input_partitions=2, consumer_tasks=3, output_partitions=6
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
+           :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
            :     └──────────────────────────────────────────────────
-(26 rows)
+(30 rows)
 
 CREATE TEMP TABLE jsd_par_r1_on AS
 SELECT i.id
@@ -231,8 +235,8 @@ WHERE EXISTS (
 AND i.id @@@ 'category:"target"'
 ORDER BY i.id ASC
 LIMIT 5000;
-                                                                                            QUERY PLAN                                                                                            
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: i.id
    ->  Custom Scan (ParadeDB Join Scan)
@@ -251,15 +255,19 @@ LIMIT 5000;
            :   │   VisibilityFilterExec: tables=[i]
            :   │     NestedLoopJoinExec: join_type=RightSemi, filter=pattern@3 = name@0 OR pattern@3 = alt_name@1 OR pattern@3 = category@2, projection=[ctid_0@0, id@4]
            :   │       CoalescePartitionsExec
-           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │         PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=6, input_tasks=2
+           :   │       DistributedLeafExec:
+           :   │         t0: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         t1: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         t2: PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=3
-           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
+           :     ┌───── Stage 1 ── tasks=2, partitions=12
+           :     │ BroadcastExec: input_partitions=2, consumer_tasks=3, output_partitions=6
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
+           :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
            :     └──────────────────────────────────────────────────
-(26 rows)
+(30 rows)
 
 CREATE TEMP TABLE jsd_par_r2_on AS
 SELECT i.id

--- a/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
+++ b/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
@@ -97,8 +97,8 @@ WHERE i.overview @@@ 'software'
   )
 ORDER BY i.id DESC
 LIMIT 10;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: i.id
    ->  Custom Scan (ParadeDB Join Scan)
@@ -116,21 +116,25 @@ LIMIT 10;
            : │         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
            : │           CoalescePartitionsExec
            : │             [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
-           : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           : │             PgSearchScan: segments=30, dynamic_filters=1, query="all"
+           : │           DistributedLeafExec:
+           : │             t0: PgSearchScan: segments=30, dynamic_filters=1, query="all"
            : └──────────────────────────────────────────────────
            :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, id@1)]
            :   │   CoalescePartitionsExec
-           :   │     [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │     PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :   │     [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=6, input_tasks=2
+           :   │   DistributedLeafExec:
+           :   │     t0: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :   │     t1: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :   │     t2: PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=3
-           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
+           :     ┌───── Stage 1 ── tasks=2, partitions=12
+           :     │ BroadcastExec: input_partitions=2, consumer_tasks=3, output_partitions=6
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
+           :     │     t1: PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
            :     └──────────────────────────────────────────────────
-(31 rows)
+(35 rows)
 
 SELECT i.id
 FROM js_rti_items i

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -159,8 +159,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -170,21 +170,25 @@ WHERE f.content @@@ 'Section';
      : ┌───── DistributedExec
      : │ AggregateExec: mode=Final, gby=[], aggr=[count(1) as agg_0]
      : │   CoalescePartitionsExec
-     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 2 ── tasks=3, partitions=9
+     :   ┌───── Stage 2 ── tasks=2, partitions=6
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :   │       PgSearchScan: segments=2, dynamic_filters=1, query="all"
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+     :   │       DistributedLeafExec:
+     :   │         t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+     :   │         t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── tasks=1, partitions=3
-     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-     :     │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     ┌───── Stage 1 ── tasks=2, partitions=8
+     :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+     :     │   DistributedLeafExec:
+     :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
-(23 rows)
+(27 rows)
 
 SELECT COUNT(*)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id
@@ -201,8 +205,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.title
 ORDER BY f.title
 LIMIT 5;
-                                                                                                    QUERY PLAN                                                                                                    
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                       QUERY PLAN                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -217,27 +221,31 @@ LIMIT 5;
                DataFusion Physical Plan: 
                  : ┌───── DistributedExec
                  : │ SortPreservingMergeExec: [title@0 ASC NULLS LAST], fetch=5
-                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
                  : └──────────────────────────────────────────────────
-                 :   ┌───── Stage 3 ── tasks=3, partitions=3
+                 :   ┌───── Stage 3 ── tasks=2, partitions=3
                  :   │ SortExec: TopK(fetch=5), expr=[title@0 ASC NULLS LAST], preserve_partitioning=[true]
                  :   │   AggregateExec: mode=FinalPartitioned, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-                 :   │     [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                 :   │     [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
                  :   └──────────────────────────────────────────────────
-                 :     ┌───── Stage 2 ── tasks=3, partitions=9
-                 :     │ RepartitionExec: partitioning=Hash([title@0], 9), input_partitions=3
+                 :     ┌───── Stage 2 ── tasks=2, partitions=6
+                 :     │ RepartitionExec: partitioning=Hash([title@0], 6), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+                 :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── tasks=1, partitions=3
-                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-                 :       │   PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       ┌───── Stage 1 ── tasks=2, partitions=8
+                 :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :       │   DistributedLeafExec:
+                 :       │     t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
-(34 rows)
+(38 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
 FROM mpp_files f JOIN mpp_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -118,26 +118,30 @@ ORDER BY f.category;
          DataFusion Physical Plan: 
            : ┌───── DistributedExec
            : │ CoalescePartitionsExec
-           : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │   [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 3 ── tasks=3, partitions=3
+           :   ┌───── Stage 3 ── tasks=2, partitions=3
            :   │ AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1, min(p_1.size_bytes) as agg_2, max(p_1.size_bytes) as agg_3]
-           :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+           :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 2 ── tasks=3, partitions=9
-           :     │ RepartitionExec: partitioning=Hash([category@0], 9), input_partitions=3
+           :     ┌───── Stage 2 ── tasks=2, partitions=6
+           :     │ RepartitionExec: partitioning=Hash([category@0], 6), input_partitions=3
            :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1, min(p_1.size_bytes) as agg_2, max(p_1.size_bytes) as agg_3]
            :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
            :     │       CoalescePartitionsExec
-           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+           :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :     │         DistributedLeafExec:
+           :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-           :       ┌───── Stage 1 ── tasks=1, partitions=3
-           :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :       │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       ┌───── Stage 1 ── tasks=2, partitions=8
+           :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :       │   DistributedLeafExec:
+           :       │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
-(31 rows)
+(35 rows)
 
 SELECT f.category,
        COUNT(*) AS row_count,
@@ -189,8 +193,8 @@ WHERE f.content @@@ 'Section'
 GROUP BY f.category, f.title
 ORDER BY f.category, f.title
 LIMIT 10;
-                                                                                          QUERY PLAN                                                                                           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, f.title, (count(*))
    ->  Sort
@@ -205,26 +209,30 @@ LIMIT 10;
                DataFusion Physical Plan: 
                  : ┌───── DistributedExec
                  : │ CoalescePartitionsExec
-                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
                  : └──────────────────────────────────────────────────
-                 :   ┌───── Stage 3 ── tasks=3, partitions=3
+                 :   ┌───── Stage 3 ── tasks=2, partitions=3
                  :   │ AggregateExec: mode=FinalPartitioned, gby=[category@0 as category, title@1 as title], aggr=[count(1) as agg_0]
-                 :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                 :   │   [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
                  :   └──────────────────────────────────────────────────
-                 :     ┌───── Stage 2 ── tasks=3, partitions=9
-                 :     │ RepartitionExec: partitioning=Hash([category@0, title@1], 9), input_partitions=3
+                 :     ┌───── Stage 2 ── tasks=2, partitions=6
+                 :     │ RepartitionExec: partitioning=Hash([category@0, title@1], 6), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[category@1 as category, title@0 as title], aggr=[count(1) as agg_0]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, category@2]
                  :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+                 :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── tasks=1, partitions=3
-                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-                 :       │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       ┌───── Stage 1 ── tasks=2, partitions=8
+                 :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :       │   DistributedLeafExec:
+                 :       │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
-(33 rows)
+(37 rows)
 
 SELECT f.category, f.title, COUNT(*) AS pages_per_file
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -273,8 +281,8 @@ GROUP BY f.category
 HAVING COUNT(*) > 100
 ORDER BY s DESC
 LIMIT 3;
-                                                                                          QUERY PLAN                                                                                           
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                             QUERY PLAN                                                                                              
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.category, (count(*)), (sum(p.size_bytes))
    ->  Sort
@@ -289,28 +297,32 @@ LIMIT 3;
                DataFusion Physical Plan: 
                  : ┌───── DistributedExec
                  : │ SortPreservingMergeExec: [agg_1@2 DESC], fetch=3
-                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+                 : │   [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
                  : └──────────────────────────────────────────────────
-                 :   ┌───── Stage 3 ── tasks=3, partitions=3
+                 :   ┌───── Stage 3 ── tasks=2, partitions=3
                  :   │ SortExec: TopK(fetch=3), expr=[agg_1@2 DESC], preserve_partitioning=[true]
                  :   │   FilterExec: agg_0@1 > 100
                  :   │     AggregateExec: mode=FinalPartitioned, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-                 :   │       [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+                 :   │       [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
                  :   └──────────────────────────────────────────────────
-                 :     ┌───── Stage 2 ── tasks=3, partitions=9
-                 :     │ RepartitionExec: partitioning=Hash([category@0], 9), input_partitions=3
+                 :     ┌───── Stage 2 ── tasks=2, partitions=6
+                 :     │ RepartitionExec: partitioning=Hash([category@0], 6), input_partitions=3
                  :     │   AggregateExec: mode=Partial, gby=[category@0 as category], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
                  :     │       CoalescePartitionsExec
-                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
+                 :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+                 :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+                 :     │         DistributedLeafExec:
+                 :     │           t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+                 :     │           t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
-                 :       ┌───── Stage 1 ── tasks=1, partitions=3
-                 :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-                 :       │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       ┌───── Stage 1 ── tasks=2, partitions=8
+                 :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+                 :       │   DistributedLeafExec:
+                 :       │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
-(35 rows)
+(39 rows)
 
 SELECT f.category, COUNT(*) AS c, SUM(p.size_bytes) AS s
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -346,8 +358,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section';
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                      QUERY PLAN                                                                                       
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT(*)'::text)
    Backend: DataFusion
@@ -357,21 +369,25 @@ WHERE f.content @@@ 'Section';
      : ┌───── DistributedExec
      : │ AggregateExec: mode=Final, gby=[], aggr=[count(1) as agg_0]
      : │   CoalescePartitionsExec
-     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 2 ── tasks=3, partitions=9
+     :   ┌───── Stage 2 ── tasks=2, partitions=6
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(1) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :   │       PgSearchScan: segments=2, dynamic_filters=1, query="all"
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+     :   │       DistributedLeafExec:
+     :   │         t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+     :   │         t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── tasks=1, partitions=3
-     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-     :     │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     ┌───── Stage 1 ── tasks=2, partitions=8
+     :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+     :     │   DistributedLeafExec:
+     :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
-(23 rows)
+(27 rows)
 
 SELECT COUNT(*)
 FROM mpp_postagg_files f JOIN mpp_postagg_pages p ON f.id = p.file_id
@@ -436,8 +452,8 @@ JOIN mpp_postagg_categories c ON f.category = c.name
 WHERE f.content @@@ 'Section'
 GROUP BY c.name
 ORDER BY c.name;
-                                                                                                 QUERY PLAN                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
    Output: c.name, (count(*)), (sum(p.size_bytes))
    Sort Key: c.name
@@ -450,33 +466,39 @@ ORDER BY c.name;
          DataFusion Physical Plan: 
            : ┌───── DistributedExec
            : │ CoalescePartitionsExec
-           : │   [Stage 4] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │   [Stage 4] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 4 ── tasks=3, partitions=3
+           :   ┌───── Stage 4 ── tasks=2, partitions=3
            :   │ AggregateExec: mode=FinalPartitioned, gby=[name@0 as name], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
-           :   │   [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=3
+           :   │   [Stage 3] => NetworkShuffleExec: output_partitions=3, input_tasks=2
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 3 ── tasks=3, partitions=9
-           :     │ RepartitionExec: partitioning=Hash([name@0], 9), input_partitions=3
+           :     ┌───── Stage 3 ── tasks=2, partitions=6
+           :     │ RepartitionExec: partitioning=Hash([name@0], 6), input_partitions=3
            :     │   AggregateExec: mode=Partial, gby=[name@1 as name], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
            :     │     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(name@0, category@0)], projection=[size_bytes@2, name@0]
            :     │       CoalescePartitionsExec
-           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
            :     │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[category@1, size_bytes@3]
            :     │         CoalescePartitionsExec
-           :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :     │           PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+           :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :     │           DistributedLeafExec:
+           :     │             t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :     │             t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
-           :       ┌───── Stage 1 ── tasks=1, partitions=3
-           :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :       │   PgSearchScan: segments=2, query="all"
+           :       ┌───── Stage 1 ── tasks=2, partitions=8
+           :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :       │   DistributedLeafExec:
+           :       │     t0: PgSearchScan: segments=2, query="all"
+           :       │     t1: PgSearchScan: segments=2, query="all"
            :       └──────────────────────────────────────────────────
-           :       ┌───── Stage 2 ── tasks=1, partitions=3
-           :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :       │   PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       ┌───── Stage 2 ── tasks=2, partitions=8
+           :       │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :       │   DistributedLeafExec:
+           :       │     t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │     t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
-(38 rows)
+(44 rows)
 
 SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
 FROM mpp_postagg_files f

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -131,8 +131,8 @@ FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
 WHERE f.content @@@ 'Section'
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                      QUERY PLAN                                                                                       
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                         QUERY PLAN                                                                                          
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -145,23 +145,27 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=3, partitions=9
+           :   ┌───── Stage 2 ── tasks=2, partitions=6
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         CoalescePartitionsExec
-           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │           PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :   │           DistributedLeafExec:
+           :   │             t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :   │             t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=3
-           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     ┌───── Stage 1 ── tasks=2, partitions=8
+           :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │     t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
-(28 rows)
+(32 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id
@@ -225,8 +229,8 @@ WHERE f.content @@@ 'Section'
   AND length(f.title) > 6
 ORDER BY f.title, p.size_bytes
 LIMIT 10;
-                                                                                                                                                  QUERY PLAN                                                                                                                                                  
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                                                                     QUERY PLAN                                                                                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: f.title, p.size_bytes
    ->  Custom Scan (ParadeDB Join Scan)
@@ -239,23 +243,27 @@ LIMIT 10;
            : ┌───── DistributedExec
            : │ ProjectionExec: expr=[title@3 as col_1, size_bytes@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
            : │   SortPreservingMergeExec: [title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], fetch=10
-           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
            : └──────────────────────────────────────────────────
-           :   ┌───── Stage 2 ── tasks=3, partitions=9
+           :   ┌───── Stage 2 ── tasks=2, partitions=6
            :   │ LocalLimitExec: fetch=10
            :   │   TantivyLookupExec: decode=[title]
            :   │     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :   │       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :   │         CoalescePartitionsExec
-           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │           PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+           :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :   │           DistributedLeafExec:
+           :   │             t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :   │             t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
-           :     ┌───── Stage 1 ── tasks=1, partitions=3
-           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     ┌───── Stage 1 ── tasks=2, partitions=8
+           :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │     t1: PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :     └──────────────────────────────────────────────────
-(28 rows)
+(32 rows)
 
 SELECT f.title, p.size_bytes
 FROM mpp_join_files f JOIN mpp_join_pages p ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/sql/basescan_limit_unnest.sql
+++ b/pg_search/tests/pg_regress/sql/basescan_limit_unnest.sql
@@ -1,0 +1,66 @@
+-- =====================================================================
+-- Issue #5573: LIMIT must not be pushed into BaseScan when a
+--              row-reducing set-returning function sits above it.
+-- =====================================================================
+-- Before the fix, `classify_target_list_srf` marked `unnest` as
+-- "row-preserving" and let BaseScan cap its TopK to `LIMIT` rows.
+-- `unnest(ARRAY[]::T[])` and `unnest(NULL)` emit ZERO rows, so the
+-- ProjectSet above the scan then discarded rows from an already-capped
+-- output and returned fewer than LIMIT results.
+--
+-- This test exercises the buggy case (mixed empty/NULL/non-empty
+-- arrays under `unnest` with a `@@@` predicate + LIMIT) and asserts
+-- the query returns exactly LIMIT rows.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP SCHEMA IF EXISTS pdb_unnest_limit CASCADE;
+CREATE SCHEMA pdb_unnest_limit;
+SET search_path = pdb_unnest_limit, public;
+
+CREATE TABLE items (id int PRIMARY KEY, kind text);
+INSERT INTO items
+SELECT g, CASE WHEN g % 3 = 0 THEN 'novel' ELSE 'manga' END
+FROM generate_series(1, 2000) g;
+CREATE INDEX items_bm25 ON items USING bm25 (id, kind) WITH (key_field = 'id');
+ANALYZE items;
+
+SET paradedb.enable_custom_scan = on;
+
+-- Row-reducing unnest: even ids emit one row, odd ids emit zero rows.
+-- Correct answer is 5 rows because there are >>5 matching even ids.
+-- Before the fix, this returned only 2 rows: TopK capped input to 5
+-- (ids 1, 2, 4, 5, 7), then ProjectSet dropped ids 1, 5, 7.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+
+-- Same shape with NULL arrays instead of empty arrays.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE NULL::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+
+-- Sanity: the non-reducing case (every input row multiplies into >=1 output
+-- rows) still returns exactly LIMIT rows and still routes through the scan.
+SELECT id, unnest(ARRAY[1, 2]) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id, u
+LIMIT 6;
+
+-- Sanity: with `paradedb.enable_custom_scan = off` the query falls back to
+-- a plain PostgreSQL plan (no BaseScan involved) and should return 5 rows.
+-- This is the reference the fix restores parity with.
+SET paradedb.enable_custom_scan = off;
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind = 'manga'
+ORDER BY id
+LIMIT 5;
+
+RESET paradedb.enable_custom_scan;
+DROP SCHEMA pdb_unnest_limit CASCADE;

--- a/stressgres/suites/logical-replication-merge.toml
+++ b/stressgres/suites/logical-replication-merge.toml
@@ -55,7 +55,7 @@ postgresql_conf = "Subscriber"
 [server.setup]
 sql = """
 DROP TABLE IF EXISTS test CASCADE;
-CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 CREATE TABLE test (
     id SERIAL8 NOT NULL PRIMARY KEY,
     message TEXT,

--- a/stressgres/suites/logical-replication.toml
+++ b/stressgres/suites/logical-replication.toml
@@ -57,7 +57,7 @@ postgresql_conf = "Subscriber"
 [server.setup]
 sql = """
 DROP TABLE IF EXISTS test CASCADE;
-CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 CREATE TABLE test (
     id SERIAL8 NOT NULL PRIMARY KEY,
     message TEXT,

--- a/stressgres/suites/wide-table.toml
+++ b/stressgres/suites/wide-table.toml
@@ -4,7 +4,7 @@ name = "Primary"
 
 [server.setup]
 sql = """
-CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 SET maintenance_work_mem = '8GB';
 
 CREATE OR REPLACE FUNCTION uuid_generate()

--- a/tests/tests/qgen.rs
+++ b/tests/tests/qgen.rs
@@ -195,9 +195,6 @@ impl GeneratedSubquery {
 /// Tests all JoinTypes against small tables (which are particularly important for joins which
 /// result in e.g. the cartesian product).
 ///
-/// TODO: Temporarily ignored post #5614.
-///
-#[ignore]
 #[rstest]
 #[tokio::test]
 async fn generated_joins_small(database: Db) {


### PR DESCRIPTION
In all callers use cases a simple FIFO based cache would be sufficient to avoid redundant pg get_buffer calls. In addition moving to a FIFO queue allows us to use the cache in multi-buffer reads. This was possible in LRU as well but would result in multi-page reads evicting cached buffers. This is not inherently wrong either but by swapping to a FIFO algorithm its more explicit that sequential scan based workloads have the best performance.

# Ticket(s) Closed

- Closes #

## What

## Why

## How

## Tests
