### PR TITLE
test: re-enable the `Virtual Tuples` assertion in `dont_do_parallel_index_scan`

### DIFF
--- a/pg_search/src/postgres/customscan/aggregatescan/filterquery.rs
+++ b/pg_search/src/postgres/customscan/aggregatescan/filterquery.rs
@@ -23,7 +23,7 @@
 //! pulls Postgres backend symbols (`BufferBlocks`, `CurrentMemoryContext`, ...)
 //! into the unit-test binary that `cargo test` builds. Those symbols only exist
 //! inside a running `postgres` process, so dyld rejects the binary at startup.
-//! Tracked in paradedb/paradedb#3715 (ours) and pgcentralfoundation/pgrx#2229 (upstream).
+//! Tracked in paradedb/paradedb#3715 (ours) and pgcentralfoundation/pgrx#2281 (upstream).
 
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
@@ -45,7 +45,7 @@ use tantivy::TantivyError;
 /// Type alias for the filter query builder function.
 /// Set at runtime to keep PostgreSQL symbols out of the typetag registration path
 /// — see module docs.
-// TODO(paradedb/paradedb#3715, pgcentralfoundation/pgrx#2229): remove the function-pointer
+// TODO(paradedb/paradedb#3715, pgcentralfoundation/pgrx#2281): remove the function-pointer
 // indirection once typetag registration stops pulling PG symbols into the test binary.
 type BuildFilterQueryFn = fn(serde_json::Value, u32) -> anyhow::Result<Box<dyn Query>>;
 

--- a/tests/tests/parallel_index_scan.rs
+++ b/tests/tests/parallel_index_scan.rs
@@ -63,12 +63,10 @@ fn dont_do_parallel_index_scan(mut conn: PgConnection) {
         plan.get("Node Type"),
         Some(&Value::String(String::from("Custom Scan")))
     );
-    // TODO: Make this not sporadically return 0 in CI:
-    //   see https://github.com/paradedb/paradedb/issues/2588
-    // pretty_assertions::assert_eq!(
-    //     plan.get("Virtual Tuples"),
-    //     Some(&Value::Number(serde_json::Number::from(3)))
-    // );
+    pretty_assertions::assert_eq!(
+        plan.get("Virtual Tuples"),
+        Some(&Value::Number(serde_json::Number::from(3)))
+    );
 
     let count = r#"
         select count(*) from paradedb.bm25_search where description @@@ 'shoes';


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #2588 (if CI stays green)

# What

Uncomments the `Virtual Tuples` assertion in `dont_do_parallel_index_scan`, which has been disabled since #2588.

Also repoints the two `filterquery.rs` TODOs from `pgcentralfoundation/pgrx#2229` to `pgcentralfoundation/pgrx#2281` — upstream closed 2229 as completed on 2026-04-24 and moved tracking to 2281, which describes the leak we actually hit (`typetag::serde` impls leaking Postgres symbols into `cargo test` binaries on pgrx 0.18+). No behaviour change; the `OnceLock<BuildFilterQueryFn>` workaround stays until 2281 lands.

# Why

The assertion was commented out because it sporadically returned 0 in CI. That flake was overwhelmingly on PG14, retired in #3964, and nothing has been reported since. Rather than leave a dead assertion in the tree indefinitely, turn it back on and let CI answer the question.

This is deliberately an experiment: if it flakes, we revert and #2588 keeps its evidence. If it holds across a few runs, we close #2588.

# How Has This Been Tested?

CI. Worth re-running the job a few times before merging, since a single green run doesn't disprove a sporadic failure.

https://claude.ai/code/session_01SM91sPv1F1rEj4YURygbdg