### PR TITLE
fix: Fix panic in index expressions on JSON

### DIFF
--- a/docs/documentation/sorting/topk.mdx
+++ b/docs/documentation/sorting/topk.mdx
@@ -281,13 +281,32 @@ await dbContext
 
 ## Sorting by JSON
 
-Ordering by JSON subfield is on the roadmap but not yet supported. For example, this query will not receive an optimized
-Top K scan:
+Ordering by a JSON subfield directly is not yet supported. For example, this query will not receive an optimized Top K scan:
 
 ```sql
 SELECT id, description, metadata
 FROM mock_items
 WHERE description ||| 'sleek running shoes'
 ORDER BY metadata->'weight'
+LIMIT 5;
+```
+
+However, you can achieve an optimized Top K scan by projecting the JSON field, casting it to the desired type, and indexing it with `pdb.alias`.
+
+For example, to order by a numeric `weight` field within a JSON column:
+
+```sql
+CREATE INDEX json_topk_idx ON mock_items
+USING bm25 (id, description, (((metadata->>'weight')::int)::pdb.alias('weight')))
+WITH (key_field='id', sort_by='weight');
+```
+
+You can then query and order by the exact underlying expression, which will now use the Top K optimization:
+
+```sql
+SELECT id, description, (metadata->>'weight')::int AS weight
+FROM mock_items
+WHERE description ||| 'sleek running shoes'
+ORDER BY (metadata->>'weight')::int
 LIMIT 5;
 ```

--- a/pg_search/src/postgres/utils.rs
+++ b/pg_search/src/postgres/utils.rs
@@ -373,6 +373,9 @@ pub struct ExtractedFieldAttribute {
 }
 
 /// Recursively strips tokenizer casts (e.g. `pdb.literal`, `pdb.alias`) from an expression.
+///
+/// This is used both for schema building (determining the inner type of an indexed expression)
+/// and for Top-K query planning (canonicalizing an indexed expression to match against an ORDER BY clause).
 pub unsafe fn strip_tokenizer_cast(node: *mut pg_sys::Node) -> *mut pg_sys::Node {
     if node.is_null() {
         return node;
@@ -386,11 +389,17 @@ pub unsafe fn strip_tokenizer_cast(node: *mut pg_sys::Node) -> *mut pg_sys::Node
             }
         }
     } else if let Some(relabel) = nodecast!(RelabelType, T_RelabelType, node) {
+        // RelabelType doesn't change physical datum representation, so it is safe to strip.
         return strip_tokenizer_cast((*relabel).arg.cast());
     } else if let Some(coerce) = nodecast!(CoerceToDomain, T_CoerceToDomain, node) {
+        // CoerceToDomain doesn't change physical datum representation, so it is safe to strip.
         return strip_tokenizer_cast((*coerce).arg.cast());
     } else if let Some(coerce) = nodecast!(CoerceViaIO, T_CoerceViaIO, node) {
-        return strip_tokenizer_cast((*coerce).arg.cast());
+        // CoerceViaIO (e.g. `text::int`) CAN change the underlying physical representation.
+        // We must only strip it if it explicitly targets a tokenizer type.
+        if type_is_tokenizer((*coerce).resulttype) {
+            return strip_tokenizer_cast((*coerce).arg.cast());
+        }
     }
 
     node

--- a/pg_search/tests/pg_regress/expected/index_json_expression.out
+++ b/pg_search/tests/pg_regress/expected/index_json_expression.out
@@ -39,4 +39,46 @@ SELECT COUNT(*) FROM mock_items WHERE metadata->>'color' @@@ 'white';
 (1 row)
 
 DROP TABLE mock_items;
+-- Test Top-K optimization with an index expression projecting a field from JSON
+CREATE TABLE json_topk_test (id SERIAL PRIMARY KEY, metadata JSONB, name TEXT);
+INSERT INTO json_topk_test (metadata, name) VALUES ('{"rating": 10}', 'foo'), ('{"rating": 20}', 'foo'), ('{"rating": 30}', 'bar');
+CREATE INDEX json_topk_idx ON json_topk_test
+USING bm25 (id, name, (((metadata->>'rating')::int)::pdb.alias('rating')))
+WITH (key_field='id', sort_by='rating DESC NULLS LAST');
+-- EXPLAIN to check if TopKScanExecState is used
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT id, (metadata->>'rating')::int AS rating
+FROM json_topk_test
+WHERE name @@@ 'foo'
+ORDER BY (metadata->>'rating')::int DESC NULLS LAST
+LIMIT 2;
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: id, (((metadata ->> 'rating'::text))::integer)
+   ->  Custom Scan (ParadeDB Base Scan) on public.json_topk_test
+         Output: id, ((metadata ->> 'rating'::text))::integer
+         Table: json_topk_test
+         Index: json_topk_idx
+         Worker Selection: Cost model
+         Exec Method: TopKScanExecState
+         Scores: false
+            TopK Order By: rating desc nulls last
+            TopK Limit: 2
+         Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"foo","lenient":null,"conjunction_mode":null}}}}
+(12 rows)
+
+-- Verify results
+SELECT id, (metadata->>'rating')::int AS rating
+FROM json_topk_test
+WHERE name @@@ 'foo'
+ORDER BY (metadata->>'rating')::int DESC NULLS LAST
+LIMIT 2;
+ id | rating 
+----+--------
+  2 |     20
+  1 |     10
+(2 rows)
+
+DROP TABLE json_topk_test;
 RESET paradedb.enable_aggregate_custom_scan;

--- a/pg_search/tests/pg_regress/sql/index_json_expression.sql
+++ b/pg_search/tests/pg_regress/sql/index_json_expression.sql
@@ -18,4 +18,29 @@ SELECT COUNT(*) FROM mock_items WHERE metadata->>'color' @@@ 'white';
 SELECT COUNT(*) FROM mock_items WHERE metadata->>'color' @@@ 'white';
 
 DROP TABLE mock_items;
+
+-- Test Top-K optimization with an index expression projecting a field from JSON
+CREATE TABLE json_topk_test (id SERIAL PRIMARY KEY, metadata JSONB, name TEXT);
+INSERT INTO json_topk_test (metadata, name) VALUES ('{"rating": 10}', 'foo'), ('{"rating": 20}', 'foo'), ('{"rating": 30}', 'bar');
+
+CREATE INDEX json_topk_idx ON json_topk_test
+USING bm25 (id, name, (((metadata->>'rating')::int)::pdb.alias('rating')))
+WITH (key_field='id', sort_by='rating DESC NULLS LAST');
+
+-- EXPLAIN to check if TopKScanExecState is used
+EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
+SELECT id, (metadata->>'rating')::int AS rating
+FROM json_topk_test
+WHERE name @@@ 'foo'
+ORDER BY (metadata->>'rating')::int DESC NULLS LAST
+LIMIT 2;
+
+-- Verify results
+SELECT id, (metadata->>'rating')::int AS rating
+FROM json_topk_test
+WHERE name @@@ 'foo'
+ORDER BY (metadata->>'rating')::int DESC NULLS LAST
+LIMIT 2;
+
+DROP TABLE json_topk_test;
 RESET paradedb.enable_aggregate_custom_scan;


### PR DESCRIPTION
## What

Indexing expressions on JSON projections were panicking at `CREATE INDEX` time due to overly aggressive stripping of casts.

## Why

In order to support `ORDER BY` on JSON fields.

Because of the dynamic typing involved in #1917 (to determine the type of the JSON column at runtime), it will always be a tiny bit slower and quite a bit more error prone than an index expression.

## Tests

Add a new regress test covering an `ORDER BY` on an JSON indexing expression.