### PR TITLE
fix: pin aggregate MVCC snapshot across freeze and heap recheck (#5548)

### DIFF
--- a/pg_search/src/aggregate/mod.rs
+++ b/pg_search/src/aggregate/mod.rs
@@ -22,6 +22,7 @@ use crate::aggregate::interrupt_collector::InterruptableCollector;
 use crate::aggregate::mvcc_collector::MVCCFilterCollector;
 use crate::api::version::VersionInfo;
 use crate::api::HashSet;
+use crate::gucs;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexReader;
 use crate::launch_parallel_process;
@@ -42,7 +43,7 @@ use crate::postgres::utils::ExprContextGuard;
 use crate::query::SearchQueryInput;
 use crate::schema::SearchIndexSchema;
 
-use pgrx::{check_for_interrupts, pg_sys};
+use pgrx::{check_for_interrupts, direct_function_call, pg_sys, IntoDatum};
 use tantivy::aggregation::agg_req::Aggregations;
 use tantivy::aggregation::agg_req::{Aggregation, AggregationVariants};
 use tantivy::aggregation::agg_result::AggregationResults;
@@ -113,6 +114,139 @@ struct ParallelAggregation {
     segment_ids: Vec<(SegmentId, NumDeletedDocs)>,
     ambulkdelete_epoch: u32,
 }
+
+/// Resolve the executor's official MVCC snapshot for aggregate execution.
+///
+/// Prefer `EState.es_snapshot` (JoinScan's pattern) so segment freeze and heap
+/// visibility share one query cut. See #5548.
+unsafe fn aggregate_query_snapshot(planstate: Option<*mut pg_sys::PlanState>) -> pg_sys::Snapshot {
+    if let Some(ps) = planstate {
+        if !ps.is_null() {
+            if let Some(estate) = (*ps).state.as_ref() {
+                if !estate.es_snapshot.is_null() {
+                    return estate.es_snapshot;
+                }
+            }
+        }
+    }
+    pg_sys::GetActiveSnapshot()
+}
+
+/// RAII pin that keeps a single MVCC snapshot active for the whole aggregate
+/// (segment discovery → parallel DSM serialization → worker collect).
+///
+/// Without this, `SearchIndexReader::open_with_context` can freeze segments under
+/// one cut while a later `GetActiveSnapshot()` for `VisibilityChecker` observes a
+/// newer READ COMMITTED cut, undercounting rows mid-UPDATE (#5548).
+struct AggregateMvccSnapshotPin {
+    pushed: bool,
+}
+
+impl AggregateMvccSnapshotPin {
+    /// Establish `snapshot` as the active cut for the duration of aggregate
+    /// execution. Returns the active snapshot pointer that callers must pass to
+    /// `VisibilityChecker` (Postgres may copy on push).
+    ///
+    /// # Safety
+    /// `snapshot` must remain valid for the pin's lifetime (estate snapshot or
+    /// already-active parallel-worker snapshot).
+    unsafe fn bind(snapshot: pg_sys::Snapshot) -> (Self, pg_sys::Snapshot) {
+        if snapshot.is_null() {
+            pgrx::error!("pg_search aggregate requires an active MVCC snapshot");
+        }
+
+        // Push only when the active stack is empty or points at a different cut.
+        // PushActiveSnapshot copies, so after a push GetActiveSnapshot() is the
+        // copy — that copy is what materialization and visibility must both use.
+        let need_push =
+            !pg_sys::ActiveSnapshotSet() || !std::ptr::eq(pg_sys::GetActiveSnapshot(), snapshot);
+        if need_push {
+            pg_sys::PushActiveSnapshot(snapshot);
+        }
+
+        (Self { pushed: need_push }, pg_sys::GetActiveSnapshot())
+    }
+}
+
+crate::impl_safe_drop!(AggregateMvccSnapshotPin, |self| {
+    if self.pushed {
+        unsafe {
+            pg_sys::PopActiveSnapshot();
+        }
+    }
+});
+
+/// Advisory-lock key used as the #5548 race gate (see `aggregate_concurrent` test).
+///
+/// Protocol: the test holds `pg_advisory_lock(5548)` before `COUNT(*)`. After
+/// segment materialization this guard unlocks (immediately visible to other
+/// backends — unlike an in-transaction SPI UPDATE of a gate table), sleeps, then
+/// pushes a fresh READ COMMITTED snapshot so a *late* `GetActiveSnapshot()` would
+/// observe concurrent UPDATEs. The production fix ignores that fresh cut.
+const AGGREGATE_MVCC_RACE_GATE_KEY: i64 = 5548;
+
+/// Test-only RAII guard that widens the #5548 race window.
+///
+/// When `paradedb.aggregate_mvcc_race_delay_ms > 0`:
+/// 1. Unlocks `AGGREGATE_MVCC_RACE_GATE_KEY` so the concurrent writer may UPDATE
+/// 2. Sleeps so those UPDATEs can commit and index a new ctid
+/// 3. Pushes a fresh READ COMMITTED snapshot (`GetTransactionSnapshot`)
+///
+/// The production fix captures the visibility snapshot *before* this runs and
+/// passes that pointer to `VisibilityChecker`, so the fresh cut is ignored.
+/// Default delay is 0 → this is a no-op in production.
+struct AggregateMvccRaceWindow {
+    pushed: bool,
+}
+
+impl AggregateMvccRaceWindow {
+    unsafe fn maybe_open() -> Self {
+        let delay_ms = gucs::aggregate_mvcc_race_delay_ms();
+        if delay_ms <= 0 {
+            return Self { pushed: false };
+        }
+
+        // Only the leader / serial backend should sleep; parallel workers would
+        // multiply the delay. ParallelWorkerNumber == -1 is the leader.
+        if pg_sys::ParallelWorkerNumber >= 0 {
+            return Self { pushed: false };
+        }
+
+        pgrx::warning!(
+            "paradedb.aggregate_mvcc_race_delay_ms={delay_ms}: widening #5548 freeze→recheck window"
+        );
+
+        // Release the session advisory lock held by the regression test. This is
+        // immediately visible to a blocked writer (SPI UPDATE of a gate row is
+        // not — it stays uncommitted until COUNT finishes).
+        let unlocked = direct_function_call::<bool>(
+            pg_sys::pg_advisory_unlock_int8,
+            &[AGGREGATE_MVCC_RACE_GATE_KEY.into_datum()],
+        )
+        .unwrap_or(false);
+        if !unlocked {
+            pgrx::warning!(
+                "paradedb.aggregate_mvcc_race_delay_ms: advisory unlock({AGGREGATE_MVCC_RACE_GATE_KEY}) returned false \
+                 (test must hold pg_advisory_lock({AGGREGATE_MVCC_RACE_GATE_KEY}) before COUNT)"
+            );
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(delay_ms as u64));
+        // Fresh RC cut: concurrent commits that landed during the sleep are now
+        // visible to GetActiveSnapshot(), matching the torn-read failure mode.
+        pg_sys::PushActiveSnapshot(pg_sys::GetTransactionSnapshot());
+        pgrx::warning!("paradedb.aggregate_mvcc_race_delay_ms: pushed fresh snapshot after delay");
+        Self { pushed: true }
+    }
+}
+
+crate::impl_safe_drop!(AggregateMvccRaceWindow, |self| {
+    if self.pushed {
+        unsafe {
+            pg_sys::PopActiveSnapshot();
+        }
+    }
+});
 
 impl ParallelStateType for State {}
 impl ParallelStateType for Config {}
@@ -257,6 +391,26 @@ impl<'a> ParallelAggregationWorker<'a> {
             standalone_context.as_ptr()
         };
 
+        // Reuse the already-bound active cut (leader pin or parallel-worker
+        // restore). Only bind if somehow nothing is active — never nest a second
+        // PushActiveSnapshot of es_snapshot on top of the leader's copy (#5548).
+        let _snapshot_pin;
+        let snapshot = unsafe {
+            if pg_sys::ActiveSnapshotSet() {
+                _snapshot_pin = None;
+                let snap = pg_sys::GetActiveSnapshot();
+                if snap.is_null() {
+                    pgrx::error!("pg_search aggregate requires an active MVCC snapshot");
+                }
+                snap
+            } else {
+                let (pin, snap) =
+                    AggregateMvccSnapshotPin::bind(aggregate_query_snapshot(planstate));
+                _snapshot_pin = Some(pin);
+                snap
+            }
+        };
+
         let reader = SearchIndexReader::open_with_context(
             &indexrel,
             self.query.clone(),
@@ -298,11 +452,21 @@ impl<'a> ParallelAggregationWorker<'a> {
             let heaprel = indexrel
                 .heap_relation()
                 .expect("index should belong to a heap relation");
+            // Force mutable-segment materialization under the pre-race active
+            // snapshot before we optionally widen the window. Otherwise collect()
+            // would materialize after a fresh PushActiveSnapshot and hide #5548.
+            let _ = reader.searcher().num_docs();
+            for seg in reader.segment_readers() {
+                let _ = crate::index::fast_fields_helper::FFType::new_ctid(seg.fast_fields());
+            }
+
+            // Widen the freeze→recheck window when the test GUC is set. The
+            // `snapshot` binding above must stay the one used for visibility —
+            // not GetActiveSnapshot() after this guard opens (#5548).
+            let _race_window = unsafe { AggregateMvccRaceWindow::maybe_open() };
             let mvcc_collector = MVCCFilterCollector::new(
                 base_collector,
-                VisibilityChecker::with_rel_and_snap(&heaprel, unsafe {
-                    pg_sys::GetActiveSnapshot()
-                }),
+                VisibilityChecker::with_rel_and_snap(&heaprel, snapshot),
             );
             reader.collect(InterruptableCollector::new(mvcc_collector))
         } else {
@@ -418,6 +582,11 @@ pub fn execute_aggregate(
             AggregateRequest::Sql(clause) => clause.use_min_sentinel_fields(),
             _ => HashSet::default(),
         };
+        // Pin the query snapshot BEFORE freezing segments and BEFORE
+        // InitializeParallelDSM serializes the active snapshot to workers, so
+        // every participant rechecks heap visibility against the same cut (#5548).
+        let (_snapshot_pin, _bound_snapshot) =
+            AggregateMvccSnapshotPin::bind(aggregate_query_snapshot(Some(planstate)));
         let reader = SearchIndexReader::open_with_context(
             index,
             query.clone(),

--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -70,6 +70,11 @@ static MAX_WINDOW_AGGREGATE_RESPONSE_BYTES: GucSetting<i32> = GucSetting::<i32>:
 /// For testing, ensures the same handling of null aggregates as Postgres
 static ADD_DOC_COUNT_TO_AGGS: GucSetting<bool> = GucSetting::<bool>::new(false);
 
+/// Test-only: milliseconds to sleep between aggregate segment freeze and heap
+/// MVCC recheck, then push a fresh READ COMMITTED snapshot. Widens the #5548
+/// race window (Antithesis does this via fault injection). Default 0 = no-op.
+static AGGREGATE_MVCC_RACE_DELAY_MS: GucSetting<i32> = GucSetting::<i32>::new(0);
+
 /// The number of fast-field columns below-which the ColumnarExecState will be used, rather
 /// than the NormalExecState. The Columnar execution mode fetches data as column-oriented, whereas
 /// the Normal mode fetches data as row-oriented.
@@ -418,6 +423,19 @@ pub fn init() {
         c"for testing, ensures the same handling of null aggregates as Postgres",
         c"Meant for internal testing usage",
         &ADD_DOC_COUNT_TO_AGGS,
+        GucContext::Userset,
+        GucFlags::default(),
+    );
+
+    GucRegistry::define_int_guc(
+        c"paradedb.aggregate_mvcc_race_delay_ms",
+        c"test-only delay between aggregate segment freeze and heap MVCC recheck",
+        c"Meant for internal testing of issue #5548. When > 0, sleeps then pushes a \
+          fresh READ COMMITTED snapshot so a late GetActiveSnapshot() can observe \
+          concurrent UPDATEs. Default 0 (no-op). Do not enable in production.",
+        &AGGREGATE_MVCC_RACE_DELAY_MS,
+        0,
+        60_000,
         GucContext::Userset,
         GucFlags::default(),
     );
@@ -771,6 +789,10 @@ pub fn min_rows_per_worker() -> i32 {
 
 pub fn add_doc_count_to_aggs() -> bool {
     ADD_DOC_COUNT_TO_AGGS.get()
+}
+
+pub fn aggregate_mvcc_race_delay_ms() -> i32 {
+    AGGREGATE_MVCC_RACE_DELAY_MS.get()
 }
 
 pub fn dynamic_filter_batch_size() -> i32 {

--- a/tests/tests/aggregate_concurrent.rs
+++ b/tests/tests/aggregate_concurrent.rs
@@ -1,0 +1,167 @@
+// Copyright (c) 2023-2026 ParadeDB, Inc.
+//
+// This file is part of ParadeDB - Postgres for Search and Analytics
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+//! Concurrent update reproducer for AggregateScan COUNT(*) / issue #5548.
+//!
+//! Protocol (UPDATEs only in the freeze→recheck gap):
+//! 1. Reader holds `pg_advisory_lock(5548)` before COUNT
+//! 2. Writer (OS thread) blocks on the same lock
+//! 3. COUNT with `paradedb.aggregate_mvcc_race_delay_ms > 0` materializes segments,
+//!    unlocks 5548, sleeps, pushes a fresh READ COMMITTED snapshot
+//! 4. Writer's autocommit UPDATEs of drink rows land during the sleep
+//! 5. A late GetActiveSnapshot() would undercount; the pinned-snapshot fix must not
+//!
+//! The writer uses `std::thread` (not `tokio::spawn`) because a blocking
+//! `pg_advisory_lock` on the current-thread tokio runtime would deadlock: COUNT
+//! never runs, so the unlock never happens.
+
+use anyhow::Result;
+use rstest::*;
+use serde_json::Value;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use tests::fixtures::*;
+use tokio::time::{sleep, Duration};
+
+/// Must match `AGGREGATE_MVCC_RACE_GATE_KEY` in `pg_search/src/aggregate/mod.rs`.
+const RACE_GATE_KEY: i64 = 5548;
+
+fn assert_uses_aggregate_scan(conn: &mut sqlx::PgConnection, query: &str) {
+    let explain_query = format!("EXPLAIN (FORMAT JSON) {}", query);
+    let (plan,): (Value,) = explain_query.fetch_one(conn);
+    let plan_str = format!("{:?}", plan);
+    assert!(
+        plan_str.contains("ParadeDB Aggregate Scan"),
+        "Query should use ParadeDB Aggregate Scan but got plan: {}",
+        plan_str
+    );
+}
+
+#[rstest]
+#[tokio::test]
+async fn aggregate_count_stable_under_concurrent_updates(database: Db) -> Result<()> {
+    let mut setup_conn = database.connection().await;
+
+    const N_ROWS: i64 = 3_000;
+    let expected_drink: i64 = (N_ROWS + 2) / 3; // ids ≡ 0 (mod 3) → 1000
+    const RACE_DELAY_MS: i64 = 500;
+    // Drink rows that sit in the hot update band (id < 10, id % 3 == 0).
+    const HOT_IDS: &str = "3, 6, 9";
+
+    format!(
+        r#"
+    CREATE EXTENSION IF NOT EXISTS pg_search;
+    SET paradedb.enable_aggregate_custom_scan = on;
+    SET max_parallel_workers_per_gather = 0;
+
+    DROP TABLE IF EXISTS agg_conc_test CASCADE;
+    CREATE TABLE agg_conc_test (
+        id BIGINT PRIMARY KEY,
+        message TEXT
+    );
+
+    INSERT INTO agg_conc_test (id, message)
+    SELECT
+        id,
+        CASE id % 3
+            WHEN 0 THEN 'drink some beer'
+            WHEN 1 THEN 'sip some wine'
+            ELSE 'eat some cheese'
+        END
+    FROM generate_series(1, {N_ROWS}) AS id;
+
+    CREATE INDEX agg_conc_idx ON agg_conc_test
+        USING bm25 (id, message)
+        WITH (key_field = 'id', mutable_segment_rows = 100);
+    "#
+    )
+    .execute(&mut setup_conn);
+
+    let count_query = "SELECT COUNT(*) FROM agg_conc_test WHERE message @@@ 'drink'";
+    assert_uses_aggregate_scan(&mut setup_conn, count_query);
+
+    let (baseline,): (i64,) = count_query.fetch_one(&mut setup_conn);
+    assert_eq!(baseline, expected_drink);
+
+    let stop_flag = Arc::new(AtomicBool::new(false));
+    let update_count = Arc::new(AtomicUsize::new(0));
+
+    // Reader must hold the gate lock *before* the writer waits on it.
+    let mut reader = database.connection().await;
+    format!(
+        r#"
+    SET paradedb.enable_aggregate_custom_scan = on;
+    SET max_parallel_workers_per_gather = 0;
+    SET client_min_messages TO warning;
+    SET paradedb.aggregate_mvcc_race_delay_ms = {RACE_DELAY_MS};
+    SELECT pg_advisory_lock({RACE_GATE_KEY});
+    "#
+    )
+    .execute(&mut reader);
+
+    let mut writer_conn = database.connection().await;
+    let stop = stop_flag.clone();
+    let updates = update_count.clone();
+    let writer = std::thread::spawn(move || {
+        // Block until the aggregate unlocks after materialization.
+        format!("SELECT pg_advisory_lock({RACE_GATE_KEY})").execute(&mut writer_conn);
+        format!("SELECT pg_advisory_unlock({RACE_GATE_KEY})").execute(&mut writer_conn);
+
+        if stop.load(Ordering::Relaxed) {
+            return;
+        }
+
+        // Autocommit UPDATEs inside the freeze→recheck window. Changing the
+        // trailing character keeps the row matching 'drink' but allocates a new
+        // ctid — the classic #5548 undercount shape.
+        r#"
+        UPDATE agg_conc_test
+        SET message = substring(message FROM 1 FOR length(message)-1)
+                      || chr((trunc(random() * 26) + 65)::int)
+        WHERE id IN (3, 6, 9)
+        "#
+        .execute(&mut writer_conn);
+        updates.fetch_add(3, Ordering::Relaxed);
+    });
+
+    // Give the writer thread time to block on the advisory lock.
+    sleep(Duration::from_millis(100)).await;
+
+    let (count,): (i64,) = count_query.fetch_one(&mut reader);
+
+    stop_flag.store(true, Ordering::Relaxed);
+    // COUNT may have unlocked already; ensure we never leave a stranded lock.
+    "SELECT pg_advisory_unlock_all()".execute(&mut reader);
+
+    writer
+        .join()
+        .expect("writer thread panicked waiting for race gate");
+
+    let updates = update_count.load(Ordering::Relaxed);
+    assert!(
+        updates > 0,
+        "writer must have committed UPDATEs during the race window (updates={updates})"
+    );
+    assert_eq!(
+        count, expected_drink,
+        "COUNT(*) undercounted under concurrent UPDATEs of ids [{HOT_IDS}] with \
+         paradedb.aggregate_mvcc_race_delay_ms enabled (got {count}, expected \
+         {expected_drink}, writer updates={updates}). This is issue #5548."
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Pin a single query MVCC snapshot for AggregateScan from segment freeze through heap visibility recheck, so `COUNT(*) … WHERE … @@@` no longer undercounts rows mid-`UPDATE` (#5548).
- Prefer `EState.es_snapshot` (same pattern as JoinScan) and pass that pinned cut into `VisibilityChecker` instead of a late `GetActiveSnapshot()`.
- Add `paradedb.aggregate_mvcc_race_delay_ms` (default 0) plus `tests/tests/aggregate_concurrent.rs` to widen the freeze→recheck window locally; with a late snapshot this undercounts by exactly the hot-updated drink rows (997 vs 1000), and passes with the pin.

## Test plan
- [x] `cargo test -p tests --test aggregate_concurrent` passes with the fix
- [x] Same test fails with late `GetActiveSnapshot()` after the race window (`997` vs `1000`)
- [ ] CI / Antithesis: please apply the `antithesis` label if useful — this is the AggregateScan race from #5547/#5548

Closes #5548