### PR TITLE
chore: Fix pg15 compile error.

### DIFF
--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -782,10 +782,6 @@ impl ParallelScanState {
 
         #[cfg(not(feature = "pg15"))]
         let deadline = std::time::Instant::now() + std::time::Duration::from_millis(50);
-        // `defer_leader_for_debug` only drives the pg15+ `debug_parallel_query`
-        // deadline retry below; on pg15 that block is compiled out, leaving it unused.
-        #[cfg(feature = "pg15")]
-        let _ = defer_leader_for_debug;
 
         loop {
             let _mutex = self.acquire_mutex();


### PR DESCRIPTION
Fix compile error introduced by bb7e700d2c1a5addcf98110673e18e207b80ca1b ... likely a merge conflict.