### PR TITLE
fix: reuse assign clusterer across merge batches

### DIFF
--- a/pg_search/src/vector/clusterer.rs
+++ b/pg_search/src/vector/clusterer.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use superkmeans::{HierarchicalSuperKMeans, HierarchicalSuperKMeansConfig};
 use tantivy::vector::{
@@ -27,7 +27,18 @@ use crate::postgres::options::BM25IndexOptions;
 
 const DEFAULT_ASSIGN_BATCH_SIZE: usize = 40_960;
 
-#[derive(Clone, Debug)]
+/// A `HierarchicalSuperKMeans` built for assignment, tagged with the
+/// `(dim, angular)` it was constructed for. `assign` never reads the clusterer's
+/// centroids, pruner, or cluster count — it derives everything from the vectors
+/// and centroids handed to it per call — so one instance is valid for every
+/// batch (and every merge) sharing the same `(dim, angular)`.
+struct AssignClusterer {
+    dim: usize,
+    angular: bool,
+    clusterer: Arc<HierarchicalSuperKMeans>,
+}
+
+#[derive(Clone)]
 pub struct SuperKMeansIvfClusterer {
     config: HierarchicalSuperKMeansConfig,
     centroid_ratio: f32,
@@ -38,6 +49,23 @@ pub struct SuperKMeansIvfClusterer {
     /// next-nearest cells at merge time, selected by tantivy's centroid
     /// selector (exact scan or `RelativeNeighborhoodGraph`).
     replicas: usize,
+    /// Lazily-built clusterer reused across `assign` batches.
+    assign_cache: Arc<Mutex<Option<AssignClusterer>>>,
+}
+
+impl std::fmt::Debug for SuperKMeansIvfClusterer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SuperKMeansIvfClusterer")
+            .field("config", &self.config)
+            .field("centroid_ratio", &self.centroid_ratio)
+            .field(
+                "training_samples_per_centroid",
+                &self.training_samples_per_centroid,
+            )
+            .field("assign_batch_size", &self.assign_batch_size)
+            .field("replicas", &self.replicas)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Default for SuperKMeansIvfClusterer {
@@ -52,6 +80,7 @@ impl Default for SuperKMeansIvfClusterer {
             training_samples_per_centroid: 32,
             assign_batch_size: DEFAULT_ASSIGN_BATCH_SIZE,
             replicas: 1,
+            assign_cache: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -226,11 +255,35 @@ impl IvfClusterer for SuperKMeansIvfClusterer {
             return Ok(Vec::new());
         }
 
-        let mut config = self.config.clone();
-        if matches!(options.metric(), Metric::Cosine | Metric::Dot) {
-            config.base.angular = true;
-        }
-        let clusterer = HierarchicalSuperKMeans::with_config(centroid_matrix.rows, dim, config);
+        let angular = matches!(options.metric(), Metric::Cosine | Metric::Dot);
+
+        // Build the clusterer once per `(dim, angular)` and reuse it across every batch.
+        let clusterer = {
+            let mut cache = self
+                .assign_cache
+                .lock()
+                .expect("assign clusterer cache mutex poisoned");
+            match cache.as_ref() {
+                Some(entry) if entry.dim == dim && entry.angular == angular => {
+                    entry.clusterer.clone()
+                }
+                _ => {
+                    let mut config = self.config.clone();
+                    config.base.angular = angular;
+                    let clusterer = Arc::new(HierarchicalSuperKMeans::with_config(
+                        centroid_matrix.rows,
+                        dim,
+                        config,
+                    ));
+                    *cache = Some(AssignClusterer {
+                        dim,
+                        angular,
+                        clusterer: clusterer.clone(),
+                    });
+                    clusterer
+                }
+            }
+        };
         // Primary (nearest-centroid) assignment via superkmeans, angular-aware
         // for cosine/dot. One cluster per vector — no replication. `n_centroids`
         // is derived from the centroid slice length.


### PR DESCRIPTION
## Problem

A `CREATE INDEX ... USING bm25 (... emb vector_cosine_ops)` on a large table appeared to hang. Sampling the leader and all three parallel workers showed them pinned at ~95% CPU in the **same** leaf, during the IVF vector segment merge:

```
VectorPlugin::merge → merge_ivfs → SuperKMeansIvfClusterer::assign
  → HierarchicalSuperKMeans::with_config → ADSamplingPruner::new
    → random_orthonormal_matrix   ← 100% of samples
```

Not a deadlock — a CPU hot loop. `merge_ivfs` calls `IvfClusterer::assign` once per batch (`assign_batch_size = 40_960`), and our `assign` impl rebuilt the entire `HierarchicalSuperKMeans` on every call. That constructor runs an O(d³) Householder QR to build the ADSampling rotation matrix (in fact **twice** — once in `SuperKMeans::with_config`, then overwritten in `HierarchicalSuperKMeans::with_config`). For a merge of *N* vectors that's `⌈N/40960⌉ × 2` full QR builds per worker.

Crucially, the assign path (`SuperKMeans::assign`) **never reads the pruner or the cluster count** — it derives `n_centroids` from the centroid slice and does brute-force nearest-centroid. So every one of those rotation-matrix rebuilds was dead work.

## Fix

Build the clusterer once per `(dim, angular)` and cache it behind an `Arc`, reused across all batches (and all merges). The cached entry is independent of the centroids handed to any single `assign` call, so reuse is correct. The `Arc` is cloned out and the lock dropped before the assignment compute, so concurrent batches never serialize on the cache.

Result: the O(d³) QR goes from hundreds of builds per merge down to **one** per `(dim, angular)`, per worker.

## Notes

- Self-contained; no `superkmeans-rs` rev bump required.
- A complementary optimization could live in superkmeans-rs (skip the double pruner build in `with_config`; flatten `random_orthonormal_matrix`'s cache-hostile `Vec<Vec<f32>>`), but that's not needed to fix this pathology.