### PR TITLE
fix: default probe epsilon 7.0 -> 0.5

### DIFF
--- a/pg_search/src/gucs.rs
+++ b/pg_search/src/gucs.rs
@@ -242,8 +242,8 @@ pub fn vector_cluster_max_probe_fraction() -> f32 {
 /// Query-time pruning factor for tantivy's `AdaptiveProbeParams`: how far
 /// past the best centroid the IVF probe loop keeps probing clusters. Lower
 /// epsilon probes fewer clusters, decreasing latency at the expense of
-/// recall. Default `7.0`, SPANN's recall@10-tuned value.
-static VECTOR_CLUSTER_PROBE_EPSILON: GucSetting<f64> = GucSetting::<f64>::new(7.0);
+/// recall. Default `0.5`.
+static VECTOR_CLUSTER_PROBE_EPSILON: GucSetting<f64> = GucSetting::<f64>::new(0.5);
 
 pub fn vector_cluster_probe_epsilon() -> f32 {
     VECTOR_CLUSTER_PROBE_EPSILON.get() as f32


### PR DESCRIPTION
Lowers the `paradedb.vector_cluster_probe_epsilon` default from `7.0` to `0.5`.

Epsilon is the distance-ratio gate on how far past the best centroid the IVF probe loop keeps probing; a lower value prunes sooner, so fewer clusters are probed by default — lower latency, at some cost to recall. Users who want the wider SPANN recall@10-tuned radius can still set it back up per-session.

One-line change to the GUC's default; still overridable at `SET` time.