### PR TITLE
fix: Fix segment count rendering in join/aggregate plans

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
+++ b/pg_search/src/postgres/customscan/basescan/exec_methods/fast_fields/columnar.rs
@@ -347,20 +347,18 @@ impl ColumnarExecState {
 
         // Create PgSearchScanPlan and execute via DataFusion
         let state_partition = ScanState {
-            recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
-                parallel_state: state.parallel_state,
-                source_idx: None,
-                // Basescan is never an MPP source.
-                planner_estimated_rows: 0,
-                scanner_config,
-            },
+            parallel_state: state.parallel_state,
+            source_idx: None,
+            // Basescan is never an MPP source.
+            planner_estimated_rows: 0,
+            scanner_config,
             ffhelper: Arc::clone(ffhelper),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader: search_reader.clone(),
         };
 
         let plan = PgSearchScanPlan::new(
-            vec![state_partition],
+            Some(state_partition),
             build_arrow_schema(&self.scanner_fast_fields),
             // TODO: Switch to an Arc in the scan state.
             state.search_query_input().clone(),

--- a/pg_search/src/postgres/mod.rs
+++ b/pg_search/src/postgres/mod.rs
@@ -951,6 +951,13 @@ impl ParallelScanState {
             .map(|b| SegmentId::from_bytes(*b))
             .collect()
     }
+
+    /// Return the total number of segments for a given source, waiting for initialization
+    /// if called before the leader has populated the shared state.
+    pub fn source_segment_count(&mut self, source_idx: usize) -> usize {
+        self.wait_for_initialization();
+        self.payload.source_ids(source_idx).len()
+    }
 }
 
 extern "C" {

--- a/pg_search/src/scan/execution_plan.rs
+++ b/pg_search/src/scan/execution_plan.rs
@@ -86,29 +86,17 @@ pub struct ScannerConfig {
     pub score_needed: bool,
 }
 
-/// Recipe for a scan partition.
-pub enum ScanRecipe {
-    /// Lazy claim from `ParallelScanState`. `source_idx = Some(i)` claims from source
-    /// `i`'s pool for MPP sources; `None` uses the single-counter `checkout_segment_for_source(0)`
-    /// for basescan and non-MPP parallel joins.
-    Lazy {
-        parallel_state: Option<*mut ParallelScanState>,
-        source_idx: Option<usize>,
-        planner_estimated_rows: u64,
-        scanner_config: ScannerConfig,
-    },
-}
-
 /// State for a scan partition.
 /// Uses `Arc<FFHelper>` so the same FFHelper can be shared across multiple partitions.
-pub struct ScanPartition {
-    pub recipe: ScanRecipe,
+pub struct ScanState {
+    pub parallel_state: Option<*mut ParallelScanState>,
+    pub source_idx: Option<usize>,
+    pub planner_estimated_rows: u64,
+    pub scanner_config: ScannerConfig,
     pub ffhelper: Arc<FFHelper>,
     pub visibility: Box<VisibilityChecker>,
     pub reader: SearchIndexReader,
 }
-
-pub type ScanState = ScanPartition;
 
 /// A DataFusion `ExecutionPlan` for scanning `pg_search` index segments.
 ///
@@ -117,18 +105,22 @@ pub type ScanState = ScanPartition;
 /// `ParallelScanState` when running in parallel (load-balancing across workers as they
 /// process data) or chained sequentially when serial.
 pub struct PgSearchScanPlan {
-    /// Segments to scan, indexed by partition.
+    /// State for this single-partition scan.
     ///
-    /// We use a Mutex to allow taking ownership of the scanners during `execute()`.
+    /// We use a Mutex to allow taking ownership of the scanner during `execute()`.
     /// We wrap the state in `UnsafeSendSync` to satisfy `ExecutionPlan`'s `Send` + `Sync`
     /// requirements. This is safe because we are running in a single-threaded
     /// environment (Postgres), which also means that the duration for which we
     /// hold this Mutex does not impact performance.
-    states: Mutex<Vec<Option<UnsafeSendSync<ScanState>>>>,
-    /// Estimated row counts for each partition, computed once at construction.
+    state: Mutex<Option<UnsafeSendSync<ScanState>>>,
+    /// Estimated row count, computed once at construction.
     /// Stored separately so `partition_statistics` is deterministic, even after
-    /// the states have been consumed.
-    partition_row_counts: Vec<u64>,
+    /// the state has been consumed.
+    planner_estimated_rows: u64,
+    /// Number of segments this plan will process, derived at construction time
+    /// from ParallelScanState or the reader, and kept around for EXPLAIN after
+    /// the state is consumed.
+    segment_count: usize,
     properties: Arc<PlanProperties>,
     resolved_query: SearchQueryInput,
     /// Dynamic filters pushed down from parent operators (e.g. Top K threshold
@@ -177,14 +169,14 @@ impl PgSearchScanPlan {
     ///
     /// # Arguments
     ///
-    /// * `states` - The list of pre-opened segments (one per partition)
+    /// * `state` - The pre-opened scan state (or None for tests)
     /// * `schema` - Arrow schema for the output
     /// * `resolved_query` - The filter-combined, param-solved query the readers were opened
     ///   with. Used for EXPLAIN and shipped on dispatch.
     /// * `sort_order` - Optional sort order declaration for equivalence properties
     #[allow(clippy::too_many_arguments)]
     pub fn new(
-        states: Vec<ScanState>,
+        state: Option<ScanState>,
         schema: SchemaRef,
         resolved_query: SearchQueryInput,
         sort_order: Option<&SortByField>,
@@ -197,42 +189,34 @@ impl PgSearchScanPlan {
         if needs_ffhelper && ffhelper.is_none() {
             panic!("deferred lookup/visibility requires an FFHelper, but ffhelper is None");
         }
-        // Ensure we always return at least one partition to satisfy DataFusion distribution
+        // Ensure we always return exactly one partition to satisfy DataFusion distribution
         // requirements (e.g. HashJoinExec mode=CollectLeft requires SinglePartition).
-        // If states is empty, execute() will return an EmptyStream for this single partition.
-        let partition_count = states.len().max(1);
+        // If state is None, execute() will return an EmptyStream for this single partition.
         let eq_properties = build_equivalence_properties(schema, sort_order);
 
         let properties = Arc::new(PlanProperties::new(
             eq_properties,
-            Partitioning::UnknownPartitioning(partition_count),
+            Partitioning::UnknownPartitioning(1),
             EmissionType::Incremental,
             Boundedness::Bounded,
         ));
 
-        let partition_row_counts: Vec<u64> = if states.is_empty() {
-            vec![0]
-        } else {
-            states
-                .iter()
-                .map(|s| {
-                    let ScanRecipe::Lazy {
-                        planner_estimated_rows,
-                        ..
-                    } = &s.recipe;
-                    *planner_estimated_rows
-                })
-                .collect()
-        };
-
-        let wrapped_states: Vec<Option<UnsafeSendSync<ScanState>>> = states
-            .into_iter()
-            .map(|s| Some(UnsafeSendSync(s)))
-            .collect();
+        let planner_estimated_rows = state
+            .as_ref()
+            .map(|s| s.planner_estimated_rows)
+            .unwrap_or(0);
+        let segment_count = state
+            .as_ref()
+            .map(|s| match s.parallel_state {
+                Some(ps) => unsafe { (*ps).source_segment_count(s.source_idx.unwrap_or(0)) },
+                None => s.reader.segment_ids().len(),
+            })
+            .unwrap_or(0);
 
         Self {
-            states: Mutex::new(wrapped_states),
-            partition_row_counts,
+            state: Mutex::new(state.map(UnsafeSendSync)),
+            planner_estimated_rows,
+            segment_count,
             properties,
             resolved_query,
             dynamic_filters: Vec::new(),
@@ -266,29 +250,18 @@ impl PgSearchScanPlan {
     /// from its own `ParallelScanState`. `resolved_query` is the filter-combined,
     /// param-solved query the reader was opened with, so the receiver needs no `ExprContext`.
     pub(crate) fn encode_for_dispatch(&self) -> Result<Vec<u8>> {
-        let states = self
-            .states
+        let state_guard = self
+            .state
             .lock()
-            .map_err(|e| DataFusionError::Internal(format!("lock PgSearchScanPlan states: {e}")))?;
-        // The dispatch path only ships the single-partition lazy scan (the MPP natural-shape
-        // leaf). Sorted/eager multi-partition scans aren't dispatched yet.
-        if states.len() != 1 {
-            return Err(DataFusionError::NotImplemented(format!(
-                "PgSearchScan dispatch: expected 1 partition, found {}",
-                states.len()
-            )));
-        }
-        let state = states[0].as_ref().ok_or_else(|| {
+            .map_err(|e| DataFusionError::Internal(format!("lock PgSearchScanPlan state: {e}")))?;
+        let state = state_guard.as_ref().ok_or_else(|| {
             DataFusionError::Internal("PgSearchScan dispatch: partition already consumed".into())
         })?;
-        let ScanRecipe::Lazy {
-            source_idx,
-            planner_estimated_rows,
-            scanner_config,
-            ..
-        } = &state.0.recipe;
-        let (source_idx, planner_estimated_rows, scanner_config) =
-            (*source_idx, *planner_estimated_rows, scanner_config.clone());
+        let (source_idx, planner_estimated_rows, scanner_config) = (
+            state.0.source_idx,
+            state.0.planner_estimated_rows,
+            state.0.scanner_config.clone(),
+        );
 
         let schema = self.properties.eq_properties.schema().clone();
         let schema_proto: datafusion_proto::protobuf::Schema =
@@ -383,12 +356,10 @@ impl PgSearchScanPlan {
             score_needed: descriptor.score_needed,
         };
         let state = ScanState {
-            recipe: ScanRecipe::Lazy {
-                parallel_state,
-                source_idx: descriptor.source_idx,
-                planner_estimated_rows: descriptor.planner_estimated_rows,
-                scanner_config,
-            },
+            parallel_state,
+            source_idx: descriptor.source_idx,
+            planner_estimated_rows: descriptor.planner_estimated_rows,
+            scanner_config,
             ffhelper: Arc::clone(&ffhelper),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader,
@@ -403,7 +374,7 @@ impl PgSearchScanPlan {
         };
 
         Ok(Arc::new(PgSearchScanPlan::new(
-            vec![state],
+            Some(state),
             schema,
             query,
             descriptor.sort_order.as_ref(),
@@ -492,11 +463,7 @@ fn strategy_name(strategy: tantivy::query::StrategyTag) -> &'static str {
 
 impl DisplayAs for PgSearchScanPlan {
     fn fmt_as(&self, _t: DisplayFormatType, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(
-            f,
-            "PgSearchScan: segments={}",
-            self.states.lock().unwrap().len(),
-        )?;
+        write!(f, "PgSearchScan: segments={}", self.segment_count,)?;
         if !self.dynamic_filters.is_empty() {
             write!(f, ", dynamic_filters={}", self.dynamic_filters.len())?;
         }
@@ -533,17 +500,8 @@ impl ExecutionPlan for PgSearchScanPlan {
 
     fn partition_statistics(&self, partition: Option<usize>) -> Result<Arc<Statistics>> {
         let num_rows = match partition {
-            Some(i) => {
-                if i >= self.partition_row_counts.len() {
-                    Precision::Absent
-                } else {
-                    Precision::Inexact(self.partition_row_counts[i] as usize)
-                }
-            }
-            None => {
-                let sum: u64 = self.partition_row_counts.iter().sum();
-                Precision::Inexact(sum as usize)
-            }
+            Some(0) | None => Precision::Inexact(self.planner_estimated_rows as usize),
+            Some(_) => Precision::Absent,
         };
 
         let column_statistics = self
@@ -578,7 +536,7 @@ impl ExecutionPlan for PgSearchScanPlan {
         partition: usize,
         _context: Arc<TaskContext>,
     ) -> Result<SendableRecordBatchStream> {
-        let mut states = self.states.lock().map_err(|e| {
+        let mut state_guard = self.state.lock().map_err(|e| {
             DataFusionError::Internal(format!("Failed to lock PgSearchScanPlan state: {e}"))
         })?;
 
@@ -590,8 +548,9 @@ impl ExecutionPlan for PgSearchScanPlan {
             )));
         }
 
-        // Handle the case where no segments were claimed (EmptyStream).
-        if states.is_empty() {
+        // Handle the case where no state was provided (test cases) or already consumed.
+        let state_opt = state_guard.take();
+        if state_opt.is_none() {
             let schema = self.properties.eq_properties.schema().clone();
             return Ok(Box::pin(unsafe {
                 UnsafeSendStream::new(futures::stream::empty(), schema)
@@ -599,13 +558,14 @@ impl ExecutionPlan for PgSearchScanPlan {
         }
 
         let UnsafeSendSync(ScanState {
-            recipe,
+            parallel_state,
+            source_idx,
+            planner_estimated_rows,
+            scanner_config,
             ffhelper,
             mut visibility,
             mut reader,
-        }) = states[partition].take().ok_or_else(|| {
-            DataFusionError::Internal(format!("Partition {} has already been executed", partition))
-        })?;
+        }) = state_opt.unwrap();
 
         let has_dynamic_filters = !self.dynamic_filters.is_empty();
         let rows_scanned = has_dynamic_filters
@@ -640,12 +600,7 @@ impl ExecutionPlan for PgSearchScanPlan {
                 dynamic_filter_pushdown.store(true, Ordering::Relaxed);
             }
 
-            let ScanRecipe::Lazy {
-                parallel_state,
-                source_idx,
-                planner_estimated_rows,
-                scanner_config,
-            } = recipe;
+
             let search_results = match parallel_state {
                 Some(ps) => reader.search_lazy(ps, source_idx, planner_estimated_rows),
                 None => reader.search(),
@@ -741,22 +696,23 @@ impl ExecutionPlan for PgSearchScanPlan {
 
         if !dynamic_filters.is_empty() {
             // Transfer state from the old plan to the new one.
-            let states: Vec<_> = self
-                .states
+            let state = self
+                .state
                 .lock()
                 .map_err(|e| {
                     DataFusionError::Internal(format!(
                         "Failed to lock PgSearchScanPlan state during filter pushdown: {e}"
                     ))
                 })?
-                .drain(..)
-                .collect();
+                .take()
+                .map(|s| s.0);
 
             let resolved_query = self.resolved_query.clone();
 
             let new_plan = Arc::new(PgSearchScanPlan {
-                states: Mutex::new(states),
-                partition_row_counts: self.partition_row_counts.clone(),
+                state: Mutex::new(state.map(UnsafeSendSync)),
+                planner_estimated_rows: self.planner_estimated_rows,
+                segment_count: self.segment_count,
                 properties: self.properties.clone(),
                 resolved_query,
                 dynamic_filters,
@@ -881,7 +837,7 @@ mod tests {
     #[should_panic(expected = "deferred lookup/visibility requires an FFHelper")]
     fn deferred_visibility_requires_ffhelper() {
         let _ = PgSearchScanPlan::new(
-            vec![],
+            None,
             empty_schema(),
             SearchQueryInput::All,
             None,
@@ -895,7 +851,7 @@ mod tests {
     #[pg_test]
     fn can_construct_plan() {
         let _ = PgSearchScanPlan::new(
-            vec![],
+            None,
             empty_schema(),
             SearchQueryInput::All,
             None,

--- a/pg_search/src/scan/table_provider.rs
+++ b/pg_search/src/scan/table_provider.rs
@@ -402,7 +402,7 @@ impl PgSearchTableProvider {
     #[allow(clippy::too_many_arguments)]
     fn create_scan(
         &self,
-        segments: Vec<ScanState>,
+        state: Option<ScanState>,
         schema: SchemaRef,
         resolved_query: SearchQueryInput,
         ffhelper: Arc<FFHelper>,
@@ -420,7 +420,7 @@ impl PgSearchTableProvider {
         };
 
         Ok(Arc::new(PgSearchScanPlan::new(
-            segments,
+            state,
             schema,
             resolved_query,
             None,
@@ -464,20 +464,17 @@ impl PgSearchTableProvider {
             batch_size_hint: None,
             score_needed: self.scan_info.score_needed,
         };
-        let recipe = crate::scan::execution_plan::ScanRecipe::Lazy {
+        let state = ScanState {
             parallel_state,
             source_idx,
             planner_estimated_rows,
             scanner_config,
-        };
-        let state = ScanState {
-            recipe,
             ffhelper: ffhelper.clone(),
             visibility: Box::new(visibility) as Box<VisibilityChecker>,
             reader: reader.clone(),
         };
 
-        self.create_scan(vec![state], schema, resolved_query, ffhelper)
+        self.create_scan(Some(state), schema, resolved_query, ffhelper)
     }
 }
 

--- a/pg_search/src/scan/tests.rs
+++ b/pg_search/src/scan/tests.rs
@@ -90,16 +90,14 @@ mod tests {
         let visibility = HeapVisibilityChecker::with_rel_and_snap(&heap_rel, snapshot);
 
         let partition = crate::scan::execution_plan::ScanState {
-            recipe: crate::scan::execution_plan::ScanRecipe::Lazy {
-                parallel_state: None,
-                source_idx: None,
-                planner_estimated_rows: 0,
-                scanner_config: crate::scan::execution_plan::ScannerConfig {
-                    which_fast_fields: fields.clone(),
-                    heap_relid: heap_oid.into(),
-                    batch_size_hint: None,
-                    score_needed: false,
-                },
+            parallel_state: None,
+            source_idx: None,
+            planner_estimated_rows: 0,
+            scanner_config: crate::scan::execution_plan::ScannerConfig {
+                which_fast_fields: fields.clone(),
+                heap_relid: heap_oid.into(),
+                batch_size_hint: None,
+                score_needed: false,
             },
             ffhelper: ffhelper.into(),
             visibility: Box::new(visibility),
@@ -107,7 +105,7 @@ mod tests {
         };
 
         let plan = PgSearchScanPlan::new(
-            vec![partition],
+            Some(partition),
             build_arrow_schema(&fields),
             SearchQueryInput::All,
             None,

--- a/pg_search/src/scan/visibility_ctid_resolver_rule.rs
+++ b/pg_search/src/scan/visibility_ctid_resolver_rule.rs
@@ -145,7 +145,7 @@ mod tests {
     fn matches_scan_by_deferred_ctid_plan_position() {
         let ffhelper = Arc::new(FFHelper::empty());
         let scan = PgSearchScanPlan::new(
-            vec![],
+            None,
             empty_schema(),
             SearchQueryInput::All,
             None,
@@ -191,7 +191,7 @@ mod tests {
         let schema = sort_schema();
         let ffhelper = Arc::new(FFHelper::empty());
         let scan = PgSearchScanPlan::new(
-            vec![],
+            None,
             schema.clone(),
             SearchQueryInput::All,
             None,
@@ -225,7 +225,7 @@ mod tests {
         let schema = sort_schema();
         let ffhelper_scan = Arc::new(FFHelper::empty());
         let scan = PgSearchScanPlan::new(
-            vec![],
+            None,
             schema.clone(),
             SearchQueryInput::All,
             None,

--- a/pg_search/tests/pg_regress/expected/aggregate_edgecases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_edgecases.out
@@ -20,7 +20,8 @@ WITH (
     text_fields = '{"data": {"fast": true}}'
 );
 -- Insert enough data to make the terms aggregation result > 1MB
-INSERT INTO large_agg_test (data) SELECT md5(g::text) FROM generate_series(1, 50000) g;
+INSERT INTO large_agg_test (data) SELECT md5(g::text) FROM generate_series(1, 25000) g;
+INSERT INTO large_agg_test (data) SELECT md5(g::text) FROM generate_series(25001, 50000) g;
 ANALYZE large_agg_test;
 -- The `max_window_aggregate_response_bytes` size guard tested below is parallel-only
 -- by design (it bounds the DSM transport buffer during a parallel scan); a serial
@@ -79,7 +80,8 @@ WITH (
     key_field = 'id',
     text_fields = '{"name": {}}'
 );
-INSERT INTO delete_agg_test VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+INSERT INTO delete_agg_test VALUES (1, 'a'), (2, 'b');
+INSERT INTO delete_agg_test VALUES (3, 'c'), (4, 'd'), (5, 'e');
 ANALYZE delete_agg_test;
 -- Delete all but one row
 DELETE FROM delete_agg_test WHERE id > 1;
@@ -159,7 +161,7 @@ LIMIT 1;
          Output: pdb.window_agg('{"entries":[{"Aggregate":{"CountAny":{"filter":null,"indexrelid":0}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), pdb.window_agg('{"entries":[{"Aggregate":{"Custom":{"agg_json":{"value_count":{"field":"id"}},"filter":null,"indexrelid":0,"mvcc_visibility":"Enabled"}}}],"groupby":{"grouping_columns":[]},"uses_our_operator":false}'::text), id
          Table: delete_agg_test
          Index: delete_agg_test_idx
-         Worker Selection: Cost model
+         Worker Selection: Cost model (LIMIT)
          Exec Method: TopKScanExecState
          Scores: false
             TopK Order By: id asc
@@ -194,7 +196,8 @@ WITH (
     key_field = 'id',
     text_fields = '{"category": {"fast": true}}'
 );
-INSERT INTO mvcc_agg_test (category) VALUES ('A'), ('B'), ('A');
+INSERT INTO mvcc_agg_test (category) VALUES ('A'), ('B');
+INSERT INTO mvcc_agg_test (category) VALUES ('A');
 ANALYZE mvcc_agg_test;
 -- Test solve_mvcc=false in standard aggregate
 EXPLAIN (FORMAT TEXT, COSTS OFF, TIMING OFF, VERBOSE)
@@ -259,7 +262,8 @@ USING bm25 (id, description, category)
 WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
 INSERT INTO triple_pipe_agg_test (description, category) VALUES
     ('running shoes for men', 'footwear'),
-    ('running shoes for women', 'footwear'),
+    ('running shoes for women', 'footwear');
+INSERT INTO triple_pipe_agg_test (description, category) VALUES
     ('casual walking shoes', 'footwear'),
     ('running shorts', 'apparel'),
     ('running jacket', 'apparel');

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -374,7 +374,7 @@ ORDER BY p.category;
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(DISTINCT t_1.tag_name) as agg_0]
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
            :     CooperativeExec
-           :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
            :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (14 rows)
@@ -430,7 +430,7 @@ ORDER BY t.tag_name;
            : AggregateExec: mode=Single, gby=[tag_name@1 as tag_name], aggr=[count(DISTINCT p_0.category) as agg_0]
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
            :     CooperativeExec
-           :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
            :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (14 rows)
@@ -493,7 +493,7 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
      : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(t_1.tag_name) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, product_id@0)], projection=[category@1, tag_name@3]
      :     CooperativeExec
-     :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
      :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (12 rows)
@@ -565,9 +565,9 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
            : AggregateExec: mode=Single, gby=[tag_name@0 as tag_name], aggr=[count(p_1.category) as agg_0]
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(product_id@0, id@0)], projection=[tag_name@1, category@3]
            :     CooperativeExec
-           :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"tag_name","query_string":"tech OR orphan_tag","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"tag_name","query_string":"tech OR orphan_tag","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
-           :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (14 rows)
 
 SELECT t.tag_name, COUNT(p.category)
@@ -1111,7 +1111,7 @@ GROUP BY p.category;
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 -- AVG(DISTINCT) should show AggregateScan (DataFusion supports DISTINCT)
@@ -1134,7 +1134,7 @@ GROUP BY p.category;
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 -- COUNT(DISTINCT) should still show AggregateScan (this still works)
@@ -1157,7 +1157,7 @@ GROUP BY p.category;
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 -- =====================================================================
@@ -1234,7 +1234,7 @@ WHERE p.description @@@ 'laptop' AND p.price > 500;
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}},{"range":{"field":"price","lower_bound":{"excluded":500.0},"upper_bound":null}}]}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 SELECT COUNT(*), SUM(p.price)
@@ -1365,7 +1365,7 @@ GROUP BY p.category;
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR toy","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (13 rows)
 
 SELECT p.category, BOOL_AND(p.in_stock)
@@ -1416,7 +1416,7 @@ GROUP BY p.category;
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (13 rows)
 
 SELECT p.category, STRING_AGG(t.tag_name, ', ')
@@ -1526,7 +1526,7 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
@@ -1610,7 +1610,7 @@ GROUP BY p.category;
      :       CooperativeExec
      :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (14 rows)
 
 SELECT p.category, STRING_AGG(t.tag_name, ', ' ORDER BY t.tag_name)
@@ -1679,7 +1679,7 @@ GROUP BY p.category;
      :       CooperativeExec
      :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes","lenient":null,"conjunction_mode":null}}}}
      :       CooperativeExec
-     :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :         PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (14 rows)
 
 SELECT p.category, ARRAY_AGG(t.tag_name ORDER BY t.tag_name)
@@ -1837,7 +1837,7 @@ GROUP BY p.category;
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (13 rows)
 
 -- Test 17.2: COUNT with FILTER — results
@@ -1934,7 +1934,7 @@ WHERE p.description @@@ 'laptop';
      :     CooperativeExec
      :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=24.0 B, output_batches=1]
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all", metrics=[output_rows=9, output_bytes=72.0 B, output_batches=2, rows_pruned=3, rows_scanned=12]
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all", metrics=[output_rows=9, output_bytes=72.0 B, output_batches=2, rows_pruned=3, rows_scanned=12]
 (11 rows)
 
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -204,7 +204,7 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
            : AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0, count(r_1.rating) as agg_1]
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :     CooperativeExec
-           :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
            :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (16 rows)
@@ -269,7 +269,7 @@ ORDER BY p.category;
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[category@0, rating@1]
            :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :       CooperativeExec
-           :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
            :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :     CooperativeExec
@@ -334,7 +334,7 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@1, supplier_name@3]
            :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@0, category@0)], projection=[category@0, rating@2]
            :       CooperativeExec
-           :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
            :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :     CooperativeExec
@@ -437,7 +437,7 @@ WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p,
            : AggregateExec: mode=Single, gby=[metadata.brand@0 as metadata.brand], aggr=[]
            :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(category@0, category@0)], projection=[metadata.brand@1]
            :     CooperativeExec
-           :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
+           :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR monitor OR racket OR novel","lenient":null,"conjunction_mode":null}}}}
            :     CooperativeExec
            :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (15 rows)
@@ -505,7 +505,7 @@ WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently suppo
            :   HashJoinExec: mode=CollectLeft, join_type=Left, on=[(category@1, category@0)], projection=[metadata.brand@0]
            :     HashJoinExec: mode=CollectLeft, join_type=Left, on=[(id@0, id@0)], projection=[metadata.brand@1, category@3]
            :       CooperativeExec
-           :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
+           :         PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop","lenient":null,"conjunction_mode":null}}}}
            :       CooperativeExec
            :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
            :     CooperativeExec

--- a/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_topk.out
@@ -473,7 +473,7 @@ LIMIT 3;
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[count(1) as agg_0]
                  :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1]
                  :       CooperativeExec
-                 :         PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :         PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
                  :       CooperativeExec
                  :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (16 rows)
@@ -575,7 +575,7 @@ LIMIT 3;
                  :   AggregateExec: mode=Single, gby=[category@0 as category], aggr=[min(p_0.price) as agg_0, max(p_0.price) as agg_1]
                  :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, product_id@0)], projection=[category@1, price@2]
                  :       CooperativeExec
-                 :         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
+                 :         PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"laptop OR shoes OR jacket OR dress OR toy OR puzzle OR cookbook","lenient":null,"conjunction_mode":null}}}}
                  :       CooperativeExec
                  :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
 (16 rows)

--- a/pg_search/tests/pg_regress/expected/issue_4531.out
+++ b/pg_search/tests/pg_regress/expected/issue_4531.out
@@ -181,9 +181,9 @@ ORDER BY p.id DESC LIMIT 10;
            :       HashJoinExec: mode=CollectLeft, join_type=LeftMark, on=[(supplier_id@1, id@0)]
            :         VisibilityFilterExec: tables=[p]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"widget","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (19 rows)
 
 SELECT p.id

--- a/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
+++ b/pg_search/tests/pg_regress/expected/issue_join_pre_filter.out
@@ -50,10 +50,10 @@ LIMIT 10;
            :     VisibilityFilterExec: tables=[u, p]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, owner_user_id@2)], projection=[ctid_0@0, score@2, ctid_1@3]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"range":{"field":"reputation","lower_bound":{"excluded":100},"upper_bound":null}}]}}
+           :           PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"range":{"field":"reputation","lower_bound":{"excluded":100},"upper_bound":null}}]}}
            :         ProjectionExec: expr=[pdb.score()@0 as score, ctid_1@1 as ctid_1, owner_user_id@2 as owner_user_id]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"match":{"field":"title","value":"how using get create","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
+           :             PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"match":{"field":"title","value":"how using get create","tokenizer":null,"distance":null,"transposition_cost_one":null,"prefix":null,"conjunction_mode":false}}}}
 (16 rows)
 
 -- Reproduce the bug

--- a/pg_search/tests/pg_regress/expected/join_deferred_visibility.out
+++ b/pg_search/tests/pg_regress/expected/join_deferred_visibility.out
@@ -280,7 +280,7 @@ LIMIT 5;
            :           CooperativeExec
            :             PgSearchScan: segments=1, query={"range":{"field":"rating","lower_bound":null,"upper_bound":{"excluded":4}}}
            :           CooperativeExec
-           :             PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless OR mouse","lenient":null,"conjunction_mode":null}}}}
+           :             PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless OR mouse","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
 
 SELECT i.id, i.name

--- a/pg_search/tests/pg_regress/expected/join_order_by.out
+++ b/pg_search/tests/pg_regress/expected/join_order_by.out
@@ -179,9 +179,9 @@ LIMIT 10;
                  :     VisibilityFilterExec: tables=[t2, t1]
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3]
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, query="all"
+                 :           PgSearchScan: segments=2, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
 (19 rows)
 
 SELECT t1.val, t2.val
@@ -332,9 +332,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, visibility_checks=[t2, t1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all"
+           :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 -- Cap the scanner batch size so Top K can tighten its threshold between batches.
@@ -361,9 +361,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[val@2 ASC NULLS LAST], k=10, visibility_checks=[t2, t1], metrics=[rows_filtered_invisible=0, rows_input=8.25 K, rows_output=10, segments_seen=2]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, val@4], metrics=[output_rows=8.25 K, output_bytes=361.6 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.25 K, build_mem_used=400.0 K, avg_fanout=100% (8.25 K/8.25 K), probe_hit_rate=100% (8.25 K/8.25 K)]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
+           :           PgSearchScan: segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
+           :           PgSearchScan: segments=2, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=8.25 K, output_bytes=234.1 KB, output_batches=4, rows_pruned=11.75 K, rows_scanned=20.00 K]
 (15 rows)
 
 -- Verify results
@@ -447,9 +447,9 @@ LIMIT 25;
            :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, visibility_checks=[t2, t1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all"
+           :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (17 rows)
 
 EXPLAIN (ANALYZE, COSTS OFF, TIMING OFF, BUFFERS OFF, SUMMARY OFF)
@@ -473,9 +473,9 @@ LIMIT 25;
            :     SegmentedTopKExec: expr=[val@3 DESC, id@2 ASC NULLS LAST], k=25, visibility_checks=[t2, t1], metrics=[rows_filtered_invisible=0, rows_input=8.43 K, rows_output=25, segments_seen=1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4], metrics=[output_rows=8.43 K, output_bytes=493.9 KB, output_batches=2, array_map_created_count=1, build_input_batches=4, build_input_rows=20.00 K, input_batches=4, input_rows=8.43 K, build_mem_used=400.0 K, avg_fanout=100% (8.43 K/8.43 K), probe_hit_rate=100% (8.43 K/8.43 K)]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
+           :           PgSearchScan: segments=2, query="all", metrics=[output_rows=20.00 K, output_bytes=312.5 KB, output_batches=4]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, rows_pruned=11.57 K, rows_scanned=20.00 K]
+           :           PgSearchScan: segments=2, dynamic_filters=2, dynamic_filter_pushdown=gallop, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}, metrics=[output_rows=8.43 K, output_bytes=239.9 KB, output_batches=4, rows_pruned=11.57 K, rows_scanned=20.00 K]
 (15 rows)
 
 SELECT t1.id, t1.val
@@ -542,9 +542,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[val@3 ASC NULLS LAST], k=10, visibility_checks=[t2, t1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3, val@4]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all"
+           :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (17 rows)
 
 SELECT t1.id, t1.val
@@ -644,9 +644,9 @@ LIMIT 15;
            :     VisibilityFilterExec: tables=[t2, t1]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(t1_id@1, id@1)], projection=[ctid_0@0, ctid_1@2, id@3]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all"
+           :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
+           :           PgSearchScan: segments=2, dynamic_filters=2, query={"boolean":{"should":[{"with_index":{"query":{"parse_with_field":{"field":"val","query_string":"val","lenient":null,"conjunction_mode":null}}}},{"boolean":{"must":["all"],"must_not":[{"exists":{"field":"val"}}]}}]}}
 (17 rows)
 
 SELECT t1.id, t1.val

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
@@ -100,6 +100,47 @@ ANALYZE jsd_par_exclusions;
 -- on top-level queries; pick a bound that comfortably exceeds the
 -- ~1802-row result set so no rows are dropped. The matching LIMIT on
 -- the JoinScan-off side keeps the comparison apples-to-apples.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT i.id
+FROM jsd_par_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5000;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: i.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: i.id
+         Relation Tree: i ANTI e
+         Limit: 5000
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           : │   SortPreservingMergeExec: [id@1 DESC], fetch=5000
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── tasks=3, partitions=9
+           :   │ SortExec: TopK(fetch=5000), expr=[id@1 DESC], preserve_partitioning=[true]
+           :   │   VisibilityFilterExec: tables=[i]
+           :   │     NestedLoopJoinExec: join_type=RightAnti, filter=pattern@2 = name@0 OR pattern@2 = alt_name@1, projection=[ctid_0@0, id@3]
+           :   │       CoalescePartitionsExec
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── tasks=1, partitions=3
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     └──────────────────────────────────────────────────
+(26 rows)
+
 CREATE TEMP TABLE jsd_par_r1_on AS
 SELECT i.id
 FROM jsd_par_items i
@@ -175,6 +216,51 @@ DROP TABLE jsd_par_r1_off;
 -- =====================================================================
 -- LIMIT well above the ~198-row result set so both sides capture the
 -- full set for the EXCEPT comparison.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT i.id
+FROM jsd_par_items i
+WHERE EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5000;
+                                                                                            QUERY PLAN                                                                                            
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: i.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: i.id
+         Relation Tree: i SEMI e
+         Limit: 5000
+         Order By: i.id asc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           : │   SortPreservingMergeExec: [id@1 ASC NULLS LAST], fetch=5000
+           : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── tasks=3, partitions=9
+           :   │ SortExec: TopK(fetch=5000), expr=[id@1 ASC NULLS LAST], preserve_partitioning=[true]
+           :   │   VisibilityFilterExec: tables=[i]
+           :   │     NestedLoopJoinExec: join_type=RightSemi, filter=pattern@3 = name@0 OR pattern@3 = alt_name@1 OR pattern@3 = category@2, projection=[ctid_0@0, id@4]
+           :   │       CoalescePartitionsExec
+           :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── tasks=1, partitions=3
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     └──────────────────────────────────────────────────
+(26 rows)
+
 CREATE TEMP TABLE jsd_par_r2_on AS
 SELECT i.id
 FROM jsd_par_items i

--- a/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti_disjunctive_parallel.out
@@ -133,11 +133,11 @@ LIMIT 5000;
            :   │       CoalescePartitionsExec
            :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     │   PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
            :     └──────────────────────────────────────────────────
 (26 rows)
 
@@ -253,11 +253,11 @@ LIMIT 5000;
            :   │       CoalescePartitionsExec
            :   │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :   │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │         PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
+           :   │         PgSearchScan: segments=4, query={"with_index":{"query":{"parse_with_field":{"field":"id","query_string":"category:\"target\"","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, query={"with_index":{"query":"all"}}
+           :     │   PgSearchScan: segments=2, query={"with_index":{"query":"all"}}
            :     └──────────────────────────────────────────────────
 (26 rows)
 

--- a/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
+++ b/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
@@ -117,18 +117,18 @@ LIMIT 10;
            : │           CoalescePartitionsExec
            : │             [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
            : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           : │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           : │             PgSearchScan: segments=30, dynamic_filters=1, query="all"
            : └──────────────────────────────────────────────────
            :   ┌───── Stage 2 ── tasks=3, partitions=9
            :   │ HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, id@1)]
            :   │   CoalescePartitionsExec
            :   │     [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :   │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │     PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :   │     PgSearchScan: segments=10, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
+           :     │   PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
            :     └──────────────────────────────────────────────────
 (31 rows)
 

--- a/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
+++ b/pg_search/tests/pg_regress/expected/joinscan-subquery-parallel-rti.out
@@ -69,7 +69,8 @@ INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(600001, 70
 INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(700001, 800000) i;
 INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(800001, 900000) i;
 INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(900001, 1000000) i;
-INSERT INTO js_rti_excluded (id, company_id, technology_name) SELECT x, x*3, 'Marketo' FROM generate_series(1, 5000) x;
+INSERT INTO js_rti_excluded (id, company_id, technology_name) SELECT x, x*3, 'Marketo' FROM generate_series(1, 2500) x;
+INSERT INTO js_rti_excluded (id, company_id, technology_name) SELECT x, x*3, 'Marketo' FROM generate_series(2501, 5000) x;
 RESET paradedb.global_mutable_segment_rows;
 ANALYZE;
 -- The query uses EXISTS and NOT IN subqueries (no explicit JOIN).
@@ -79,6 +80,58 @@ ANALYZE;
 --
 -- Before the fix, parallel workers panic with:
 -- "load_metas: MvccSatisfies::ParallelWorker didn't load the correct segments"
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT i.id
+FROM js_rti_items i
+WHERE i.overview @@@ 'software'
+  AND i.id NOT IN (
+      SELECT DISTINCT e.company_id
+      FROM js_rti_excluded e
+      WHERE e.id @@@ pdb.all()
+        AND e.technology_name === ARRAY['Marketo']
+  )
+  AND EXISTS (
+      SELECT p.id
+      FROM js_rti_people p
+      WHERE p.company_id = i.id
+  )
+ORDER BY i.id DESC
+LIMIT 10;
+                                                                                                    QUERY PLAN                                                                                                    
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: i.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: i.id
+         Relation Tree: (i ANTI e) SEMI p
+         Join Cond: i.id = p.company_id, i.id = e.company_id
+         Limit: 10
+         Order By: i.id desc
+         DataFusion Physical Plan: 
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[id@1 as col_1, ctid_0@0 as ctid_0]
+           : │   SortPreservingMergeExec: [id@1 DESC], fetch=10
+           : │     SortExec: TopK(fetch=10), expr=[id@1 DESC], preserve_partitioning=[true]
+           : │       VisibilityFilterExec: tables=[i]
+           : │         HashJoinExec: mode=CollectLeft, join_type=LeftSemi, on=[(id@1, company_id@0)]
+           : │           CoalescePartitionsExec
+           : │             [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+           : │           RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           : │             PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 2 ── tasks=3, partitions=9
+           :   │ HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(company_id@0, id@1)]
+           :   │   CoalescePartitionsExec
+           :   │     [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+           :   │   RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :   │     PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"overview","query_string":"software","lenient":null,"conjunction_mode":null}}}}
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── tasks=1, partitions=3
+           :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+           :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"all":{"field":"id"}}}},{"with_index":{"query":{"term_set":{"field":"technology_name","terms":["Marketo"]}}}}]}}
+           :     └──────────────────────────────────────────────────
+(31 rows)
+
 SELECT i.id
 FROM js_rti_items i
 WHERE i.overview @@@ 'software'

--- a/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
@@ -72,24 +72,44 @@ WITH (
     numeric_fields = '{ "age": { "fast": true } }',
     target_segment_count = 2
 );
+SET paradedb.global_mutable_segment_rows = 0;
 INSERT INTO js_parallel_distinct_users (uuid, name, age)
 SELECT
     '550e8400-e29b-41d4-a716-446655440000'::uuid,
     CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
     i
-FROM generate_series(1, 100) AS g(i);
+FROM generate_series(1, 50) AS g(i);
+INSERT INTO js_parallel_distinct_users (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(51, 100) AS g(i);
 INSERT INTO js_parallel_distinct_products (uuid, name, age)
 SELECT
     '550e8400-e29b-41d4-a716-446655440000'::uuid,
     CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
     i
-FROM generate_series(1, 100) AS g(i);
+FROM generate_series(1, 50) AS g(i);
+INSERT INTO js_parallel_distinct_products (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(51, 100) AS g(i);
 INSERT INTO js_parallel_distinct_orders (uuid, name, age)
 SELECT
     '550e8400-e29b-41d4-a716-446655440000'::uuid,
     CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
     i
-FROM generate_series(1, 100) AS g(i);
+FROM generate_series(1, 50) AS g(i);
+INSERT INTO js_parallel_distinct_orders (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(51, 100) AS g(i);
+RESET paradedb.global_mutable_segment_rows;
 ANALYZE js_parallel_distinct_users;
 ANALYZE js_parallel_distinct_products;
 ANALYZE js_parallel_distinct_orders;

--- a/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
+++ b/pg_search/tests/pg_regress/expected/joinscan_parallel_distinct.out
@@ -150,11 +150,11 @@ LIMIT 48;
                  :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(age@5, age@1)], projection=[ctid_0@0, id@1, name@2, ctid_1@3, id@4, ctid_2@6, id@8]
                  :         HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, id@1)]
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
+                 :             PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"name","query_string":"bob","lenient":null,"conjunction_mode":null}}}}
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (20 rows)
 
 -- And it must return the correct rows (DISTINCT + LIMIT).

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -86,9 +86,9 @@ WHERE f.content @@@ 'Section';
      : AggregateExec: mode=Single, gby=[], aggr=[count(1) as agg_0]
      :   HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[]
      :     CooperativeExec
-     :       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :       PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     CooperativeExec
-     :       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :       PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (12 rows)
 
 SELECT COUNT(*)
@@ -125,9 +125,9 @@ LIMIT 5;
                  :   AggregateExec: mode=Single, gby=[title@0 as title], aggr=[count(1) as agg_0, sum(p_1.size_bytes) as agg_1]
                  :     HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@0, file_id@0)], projection=[title@1, size_bytes@3]
                  :       CooperativeExec
-                 :         PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :         PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       CooperativeExec
-                 :         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :         PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (19 rows)
 
 SELECT f.title, COUNT(*), SUM(p.size_bytes)
@@ -178,11 +178,11 @@ WHERE f.content @@@ 'Section';
      :   │     CoalescePartitionsExec
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :   │       PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=1, partitions=3
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-     :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
 (23 rows)
 
@@ -231,11 +231,11 @@ LIMIT 5;
                  :     │       CoalescePartitionsExec
                  :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
                  :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=1, partitions=3
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-                 :       │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │   PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
 (34 rows)
 

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate.out
@@ -29,14 +29,6 @@ CREATE TABLE mpp_pages (
     page_text TEXT,
     size_bytes INTEGER
 );
-INSERT INTO mpp_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-INSERT INTO mpp_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
 CREATE INDEX mpp_files_idx ON mpp_files
 USING bm25 (id, title, content)
 WITH (
@@ -50,6 +42,24 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+INSERT INTO mpp_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+INSERT INTO mpp_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+INSERT INTO mpp_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
+RESET paradedb.global_mutable_segment_rows;
 ANALYZE mpp_files;
 ANALYZE mpp_pages;
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -34,16 +34,6 @@ CREATE TABLE mpp_postagg_pages (
     page_text TEXT,
     size_bytes INTEGER
 );
-INSERT INTO mpp_postagg_files (title, category, content)
-SELECT 'file-' || g,
-       'cat-' || (g % 5),
-       'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
 CREATE INDEX mpp_postagg_files_idx ON mpp_postagg_files
 USING bm25 (id, title, category, content)
 WITH (
@@ -57,8 +47,30 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
 ANALYZE mpp_postagg_files;
 ANALYZE mpp_postagg_pages;
+RESET paradedb.global_mutable_segment_rows;
 -- =====================================================================
 -- Scenario 1: GROUP BY one key with multiple aggregates.
 -- =====================================================================
@@ -383,16 +395,21 @@ CREATE TABLE mpp_postagg_categories (
     name TEXT,
     description TEXT
 );
-INSERT INTO mpp_postagg_categories (name, description)
-SELECT 'cat-' || g, 'Category ' || g || ' Section description'
-FROM generate_series(0, 4) AS g;
 CREATE INDEX mpp_postagg_categories_idx ON mpp_postagg_categories
 USING bm25 (id, name, description)
 WITH (
     key_field='id',
     text_fields='{"name": {"fast": true}, "description": {}}'
 );
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(0, 2) AS g;
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(3, 4) AS g;
 ANALYZE mpp_postagg_categories;
+RESET paradedb.global_mutable_segment_rows;
 SET max_parallel_workers_per_gather TO 0;
 SELECT c.name, COUNT(*) AS row_count, SUM(p.size_bytes) AS total_bytes
 FROM mpp_postagg_files f

--- a/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
+++ b/pg_search/tests/pg_regress/expected/mpp_aggregate_postagg.out
@@ -131,11 +131,11 @@ ORDER BY f.category;
            :     │       CoalescePartitionsExec
            :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
            :       ┌───── Stage 1 ── tasks=1, partitions=3
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
 (31 rows)
 
@@ -218,11 +218,11 @@ LIMIT 10;
                  :     │       CoalescePartitionsExec
                  :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
                  :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=1, partitions=3
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-                 :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
 (33 rows)
 
@@ -304,11 +304,11 @@ LIMIT 3;
                  :     │       CoalescePartitionsExec
                  :     │         [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
                  :     │       RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-                 :     │         PgSearchScan: segments=1, dynamic_filters=1, query="all"
+                 :     │         PgSearchScan: segments=2, dynamic_filters=1, query="all"
                  :     └──────────────────────────────────────────────────
                  :       ┌───── Stage 1 ── tasks=1, partitions=3
                  :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-                 :       │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+                 :       │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
                  :       └──────────────────────────────────────────────────
 (35 rows)
 
@@ -365,11 +365,11 @@ WHERE f.content @@@ 'Section';
      :   │     CoalescePartitionsExec
      :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
      :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :   │       PgSearchScan: segments=1, dynamic_filters=1, query="all"
+     :   │       PgSearchScan: segments=2, dynamic_filters=1, query="all"
      :   └──────────────────────────────────────────────────
      :     ┌───── Stage 1 ── tasks=1, partitions=3
      :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-     :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+     :     │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
      :     └──────────────────────────────────────────────────
 (23 rows)
 
@@ -466,15 +466,15 @@ ORDER BY c.name;
            :     │         CoalescePartitionsExec
            :     │           [Stage 2] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :     │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :     │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :     │           PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :     └──────────────────────────────────────────────────
            :       ┌───── Stage 1 ── tasks=1, partitions=3
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :       │   PgSearchScan: segments=1, query="all"
+           :       │   PgSearchScan: segments=2, query="all"
            :       └──────────────────────────────────────────────────
            :       ┌───── Stage 2 ── tasks=1, partitions=3
            :       │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :       │   PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :       │   PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :       └──────────────────────────────────────────────────
 (38 rows)
 

--- a/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
+++ b/pg_search/tests/pg_regress/expected/mpp_join_topk_ffhelper.out
@@ -56,10 +56,16 @@ USING bm25 (
 ) WITH (key_field = 'id', target_segment_count = 8, background_layer_sizes = '0');
 INSERT INTO mpp_topk_users (id, about_me, display_name)
 SELECT i, 'about java code', 'David John Alex'
-FROM generate_series(1, 5000) i;
+FROM generate_series(1, 2500) i;
+INSERT INTO mpp_topk_users (id, about_me, display_name)
+SELECT i, 'about java code', 'David John Alex'
+FROM generate_series(2501, 5000) i;
 INSERT INTO mpp_topk_posts (id, owner_user_id, title, body, tags)
 SELECT i, (i % 5000) + 1, 'title ' || lpad(i::text, 6, '0') || ' code', 'body code text', 'tag'
-FROM generate_series(1, 50000) i;
+FROM generate_series(1, 25000) i;
+INSERT INTO mpp_topk_posts (id, owner_user_id, title, body, tags)
+SELECT i, (i % 5000) + 1, 'title ' || lpad(i::text, 6, '0') || ' code', 'body code text', 'tag'
+FROM generate_series(25001, 50000) i;
 RESET paradedb.global_mutable_segment_rows;
 ANALYZE;
 -- No `EXPLAIN`: the dispatched plan prints per-task partition and segment counts that vary by

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -32,14 +32,6 @@ CREATE TABLE mpp_join_pages (
     page_text TEXT,
     size_bytes INTEGER
 );
-INSERT INTO mpp_join_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
 CREATE INDEX mpp_join_files_idx ON mpp_join_files
 USING bm25 (id, title, content)
 WITH (
@@ -53,6 +45,24 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_join_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+INSERT INTO mpp_join_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
+RESET paradedb.global_mutable_segment_rows;
 ANALYZE mpp_join_files;
 ANALYZE mpp_join_pages;
 -- =====================================================================

--- a/pg_search/tests/pg_regress/expected/mpp_joinscan.out
+++ b/pg_search/tests/pg_regress/expected/mpp_joinscan.out
@@ -94,9 +94,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes
@@ -155,11 +155,11 @@ LIMIT 10;
            :   │         CoalescePartitionsExec
            :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :   │           PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :     │   PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
            :     └──────────────────────────────────────────────────
 (28 rows)
 
@@ -249,11 +249,11 @@ LIMIT 10;
            :   │         CoalescePartitionsExec
            :   │           [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
            :   │         RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :   │           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :   │           PgSearchScan: segments=2, dynamic_filters=1, query="all"
            :   └──────────────────────────────────────────────────
            :     ┌───── Stage 1 ── tasks=1, partitions=3
            :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-           :     │   PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :     │   PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :     └──────────────────────────────────────────────────
 (28 rows)
 
@@ -306,9 +306,9 @@ LIMIT 10;
            :     SegmentedTopKExec: expr=[title@3 ASC NULLS LAST, size_bytes@1 ASC NULLS LAST], k=10, visibility_checks=[p, f]
            :       HashJoinExec: mode=CollectLeft, join_type=Inner, on=[(id@1, file_id@1)], projection=[ctid_0@3, size_bytes@5, ctid_1@0, title@2]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
+           :           PgSearchScan: segments=2, query={"boolean":{"must":[{"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}},{"heap_filter":{"indexed_query":"all","field_filters":[{"heap_filter":"(length(title) > 6)"}]}}]}}
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query="all"
+           :           PgSearchScan: segments=2, dynamic_filters=1, query="all"
 (17 rows)
 
 SELECT f.title, p.size_bytes

--- a/pg_search/tests/pg_regress/expected/mpp_workmem.out
+++ b/pg_search/tests/pg_regress/expected/mpp_workmem.out
@@ -33,14 +33,6 @@ CREATE TABLE mpp_wm_pages (
     page_text TEXT,
     size_bytes INTEGER
 );
-INSERT INTO mpp_wm_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 200000) AS g;
 CREATE INDEX mpp_wm_files_idx ON mpp_wm_files
 USING bm25 (id, title, content)
 WITH (
@@ -54,6 +46,24 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO mpp_wm_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+INSERT INTO mpp_wm_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 100000) AS g;
+INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(100001, 200000) AS g;
+RESET paradedb.global_mutable_segment_rows;
 ANALYZE mpp_wm_files;
 ANALYZE mpp_wm_pages;
 -- A TopN sort over the full match set can't fit in the minimum pool. The

--- a/pg_search/tests/pg_regress/expected/segmented_topk.out
+++ b/pg_search/tests/pg_regress/expected/segmented_topk.out
@@ -667,7 +667,7 @@ LIMIT 5;
            :         CooperativeExec
            :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"category","query_string":"PROJECT_ALPHA","lenient":null,"conjunction_mode":null}}}}, metrics=[output_rows=3, output_bytes=104.0 B, output_batches=1]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, rows_pruned=4.19 K, rows_scanned=30.00 K]
+           :           PgSearchScan: segments=4, dynamic_filters=2, dynamic_filter_pushdown=bitset_from_postings, query="all", metrics=[output_rows=25.81 K, output_bytes=932.8 KB, output_batches=4, rows_pruned=4.19 K, rows_scanned=30.00 K]
 (15 rows)
 
 SELECT f.id, f.title

--- a/pg_search/tests/pg_regress/sql/aggregate_edgecases.sql
+++ b/pg_search/tests/pg_regress/sql/aggregate_edgecases.sql
@@ -26,7 +26,8 @@ WITH (
 );
 
 -- Insert enough data to make the terms aggregation result > 1MB
-INSERT INTO large_agg_test (data) SELECT md5(g::text) FROM generate_series(1, 50000) g;
+INSERT INTO large_agg_test (data) SELECT md5(g::text) FROM generate_series(1, 25000) g;
+INSERT INTO large_agg_test (data) SELECT md5(g::text) FROM generate_series(25001, 50000) g;
 
 ANALYZE large_agg_test;
 
@@ -75,7 +76,8 @@ WITH (
     text_fields = '{"name": {}}'
 );
 
-INSERT INTO delete_agg_test VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');
+INSERT INTO delete_agg_test VALUES (1, 'a'), (2, 'b');
+INSERT INTO delete_agg_test VALUES (3, 'c'), (4, 'd'), (5, 'e');
 
 ANALYZE delete_agg_test;
 
@@ -136,7 +138,8 @@ WITH (
     text_fields = '{"category": {"fast": true}}'
 );
 
-INSERT INTO mvcc_agg_test (category) VALUES ('A'), ('B'), ('A');
+INSERT INTO mvcc_agg_test (category) VALUES ('A'), ('B');
+INSERT INTO mvcc_agg_test (category) VALUES ('A');
 
 ANALYZE mvcc_agg_test;
 
@@ -177,7 +180,8 @@ WITH (key_field = 'id', text_fields = '{"category": {"fast": true}}');
 
 INSERT INTO triple_pipe_agg_test (description, category) VALUES
     ('running shoes for men', 'footwear'),
-    ('running shoes for women', 'footwear'),
+    ('running shoes for women', 'footwear');
+INSERT INTO triple_pipe_agg_test (description, category) VALUES
     ('casual walking shoes', 'footwear'),
     ('running shorts', 'apparel'),
     ('running jacket', 'apparel');

--- a/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive_parallel.sql
+++ b/pg_search/tests/pg_regress/sql/join_semi_anti_disjunctive_parallel.sql
@@ -112,6 +112,18 @@ ANALYZE jsd_par_exclusions;
 -- on top-level queries; pick a bound that comfortably exceeds the
 -- ~1802-row result set so no rows are dropped. The matching LIMIT on
 -- the JoinScan-off side keeps the comparison apples-to-apples.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT i.id
+FROM jsd_par_items i
+WHERE NOT EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (e.pattern = i.name OR e.pattern = i.alt_name)
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id DESC
+LIMIT 5000;
+
 CREATE TEMP TABLE jsd_par_r1_on AS
 SELECT i.id
 FROM jsd_par_items i
@@ -166,6 +178,22 @@ DROP TABLE jsd_par_r1_off;
 -- =====================================================================
 -- LIMIT well above the ~198-row result set so both sides capture the
 -- full set for the EXCEPT comparison.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT i.id
+FROM jsd_par_items i
+WHERE EXISTS (
+    SELECT 1 FROM jsd_par_exclusions e
+    WHERE e.id @@@ paradedb.all()
+      AND (
+          e.pattern = i.name
+          OR e.pattern = i.alt_name
+          OR e.pattern = i.category
+      )
+)
+AND i.id @@@ 'category:"target"'
+ORDER BY i.id ASC
+LIMIT 5000;
+
 CREATE TEMP TABLE jsd_par_r2_on AS
 SELECT i.id
 FROM jsd_par_items i

--- a/pg_search/tests/pg_regress/sql/joinscan-subquery-parallel-rti.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan-subquery-parallel-rti.sql
@@ -80,7 +80,8 @@ INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(600001, 70
 INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(700001, 800000) i;
 INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(800001, 900000) i;
 INSERT INTO js_rti_people SELECT i, (i%100000)+1 FROM generate_series(900001, 1000000) i;
-INSERT INTO js_rti_excluded (id, company_id, technology_name) SELECT x, x*3, 'Marketo' FROM generate_series(1, 5000) x;
+INSERT INTO js_rti_excluded (id, company_id, technology_name) SELECT x, x*3, 'Marketo' FROM generate_series(1, 2500) x;
+INSERT INTO js_rti_excluded (id, company_id, technology_name) SELECT x, x*3, 'Marketo' FROM generate_series(2501, 5000) x;
 
 RESET paradedb.global_mutable_segment_rows;
 ANALYZE;
@@ -92,6 +93,24 @@ ANALYZE;
 --
 -- Before the fix, parallel workers panic with:
 -- "load_metas: MvccSatisfies::ParallelWorker didn't load the correct segments"
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT i.id
+FROM js_rti_items i
+WHERE i.overview @@@ 'software'
+  AND i.id NOT IN (
+      SELECT DISTINCT e.company_id
+      FROM js_rti_excluded e
+      WHERE e.id @@@ pdb.all()
+        AND e.technology_name === ARRAY['Marketo']
+  )
+  AND EXISTS (
+      SELECT p.id
+      FROM js_rti_people p
+      WHERE p.company_id = i.id
+  )
+ORDER BY i.id DESC
+LIMIT 10;
+
 SELECT i.id
 FROM js_rti_items i
 WHERE i.overview @@@ 'software'

--- a/pg_search/tests/pg_regress/sql/joinscan_parallel_distinct.sql
+++ b/pg_search/tests/pg_regress/sql/joinscan_parallel_distinct.sql
@@ -82,26 +82,51 @@ WITH (
     target_segment_count = 2
 );
 
+SET paradedb.global_mutable_segment_rows = 0;
+
 INSERT INTO js_parallel_distinct_users (uuid, name, age)
 SELECT
     '550e8400-e29b-41d4-a716-446655440000'::uuid,
     CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
     i
-FROM generate_series(1, 100) AS g(i);
+FROM generate_series(1, 50) AS g(i);
+
+INSERT INTO js_parallel_distinct_users (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(51, 100) AS g(i);
 
 INSERT INTO js_parallel_distinct_products (uuid, name, age)
 SELECT
     '550e8400-e29b-41d4-a716-446655440000'::uuid,
     CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
     i
-FROM generate_series(1, 100) AS g(i);
+FROM generate_series(1, 50) AS g(i);
+
+INSERT INTO js_parallel_distinct_products (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(51, 100) AS g(i);
 
 INSERT INTO js_parallel_distinct_orders (uuid, name, age)
 SELECT
     '550e8400-e29b-41d4-a716-446655440000'::uuid,
     CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
     i
-FROM generate_series(1, 100) AS g(i);
+FROM generate_series(1, 50) AS g(i);
+
+INSERT INTO js_parallel_distinct_orders (uuid, name, age)
+SELECT
+    '550e8400-e29b-41d4-a716-446655440000'::uuid,
+    CASE WHEN i % 2 = 0 THEN 'bob' ELSE 'alice' END,
+    i
+FROM generate_series(51, 100) AS g(i);
+
+RESET paradedb.global_mutable_segment_rows;
 
 ANALYZE js_parallel_distinct_users;
 ANALYZE js_parallel_distinct_products;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate.sql
@@ -35,16 +35,6 @@ CREATE TABLE mpp_pages (
     size_bytes INTEGER
 );
 
-INSERT INTO mpp_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-
-INSERT INTO mpp_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
-
 CREATE INDEX mpp_files_idx ON mpp_files
 USING bm25 (id, title, content)
 WITH (
@@ -59,6 +49,30 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
+
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO mpp_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+
+INSERT INTO mpp_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+
+INSERT INTO mpp_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+
+INSERT INTO mpp_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
+
+RESET paradedb.global_mutable_segment_rows;
 
 ANALYZE mpp_files;
 ANALYZE mpp_pages;

--- a/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_aggregate_postagg.sql
@@ -38,18 +38,6 @@ CREATE TABLE mpp_postagg_pages (
     size_bytes INTEGER
 );
 
-INSERT INTO mpp_postagg_files (title, category, content)
-SELECT 'file-' || g,
-       'cat-' || (g % 5),
-       'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-
-INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
-
 CREATE INDEX mpp_postagg_files_idx ON mpp_postagg_files
 USING bm25 (id, title, category, content)
 WITH (
@@ -65,8 +53,35 @@ WITH (
     text_fields='{"page_text": {}}'
 );
 
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+
+INSERT INTO mpp_postagg_files (title, category, content)
+SELECT 'file-' || g,
+       'cat-' || (g % 5),
+       'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+
+INSERT INTO mpp_postagg_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
+
 ANALYZE mpp_postagg_files;
 ANALYZE mpp_postagg_pages;
+RESET paradedb.global_mutable_segment_rows;
 
 -- =====================================================================
 -- Scenario 1: GROUP BY one key with multiple aggregates.
@@ -210,10 +225,6 @@ CREATE TABLE mpp_postagg_categories (
     description TEXT
 );
 
-INSERT INTO mpp_postagg_categories (name, description)
-SELECT 'cat-' || g, 'Category ' || g || ' Section description'
-FROM generate_series(0, 4) AS g;
-
 CREATE INDEX mpp_postagg_categories_idx ON mpp_postagg_categories
 USING bm25 (id, name, description)
 WITH (
@@ -221,7 +232,18 @@ WITH (
     text_fields='{"name": {"fast": true}, "description": {}}'
 );
 
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(0, 2) AS g;
+
+INSERT INTO mpp_postagg_categories (name, description)
+SELECT 'cat-' || g, 'Category ' || g || ' Section description'
+FROM generate_series(3, 4) AS g;
+
 ANALYZE mpp_postagg_categories;
+RESET paradedb.global_mutable_segment_rows;
 
 SET max_parallel_workers_per_gather TO 0;
 

--- a/pg_search/tests/pg_regress/sql/mpp_join_topk_ffhelper.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_join_topk_ffhelper.sql
@@ -65,11 +65,19 @@ USING bm25 (
 
 INSERT INTO mpp_topk_users (id, about_me, display_name)
 SELECT i, 'about java code', 'David John Alex'
-FROM generate_series(1, 5000) i;
+FROM generate_series(1, 2500) i;
+
+INSERT INTO mpp_topk_users (id, about_me, display_name)
+SELECT i, 'about java code', 'David John Alex'
+FROM generate_series(2501, 5000) i;
 
 INSERT INTO mpp_topk_posts (id, owner_user_id, title, body, tags)
 SELECT i, (i % 5000) + 1, 'title ' || lpad(i::text, 6, '0') || ' code', 'body code text', 'tag'
-FROM generate_series(1, 50000) i;
+FROM generate_series(1, 25000) i;
+
+INSERT INTO mpp_topk_posts (id, owner_user_id, title, body, tags)
+SELECT i, (i % 5000) + 1, 'title ' || lpad(i::text, 6, '0') || ' code', 'body code text', 'tag'
+FROM generate_series(25001, 50000) i;
 
 RESET paradedb.global_mutable_segment_rows;
 ANALYZE;

--- a/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_joinscan.sql
@@ -38,16 +38,6 @@ CREATE TABLE mpp_join_pages (
     size_bytes INTEGER
 );
 
-INSERT INTO mpp_join_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-
-INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
-
 CREATE INDEX mpp_join_files_idx ON mpp_join_files
 USING bm25 (id, title, content)
 WITH (
@@ -62,6 +52,30 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
+
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO mpp_join_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+
+INSERT INTO mpp_join_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+
+INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+
+INSERT INTO mpp_join_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
+
+RESET paradedb.global_mutable_segment_rows;
 
 ANALYZE mpp_join_files;
 ANALYZE mpp_join_pages;

--- a/pg_search/tests/pg_regress/sql/mpp_workmem.sql
+++ b/pg_search/tests/pg_regress/sql/mpp_workmem.sql
@@ -37,16 +37,6 @@ CREATE TABLE mpp_wm_pages (
     size_bytes INTEGER
 );
 
-INSERT INTO mpp_wm_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-
-INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
-SELECT (g % 200) + 1,
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 200000) AS g;
-
 CREATE INDEX mpp_wm_files_idx ON mpp_wm_files
 USING bm25 (id, title, content)
 WITH (
@@ -61,6 +51,30 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {}}'
 );
+
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO mpp_wm_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+
+INSERT INTO mpp_wm_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+
+INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 100000) AS g;
+
+INSERT INTO mpp_wm_pages (file_id, page_text, size_bytes)
+SELECT (g % 200) + 1,
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(100001, 200000) AS g;
+
+RESET paradedb.global_mutable_segment_rows;
 
 ANALYZE mpp_wm_files;
 ANALYZE mpp_wm_pages;

--- a/tests/tests/mpp_cancel.rs
+++ b/tests/tests/mpp_cancel.rs
@@ -39,18 +39,6 @@ CREATE TABLE mpp_users    (id bigserial primary key, uuid uuid, name text, age i
 CREATE TABLE mpp_products (id bigserial primary key, uuid uuid, name text, age int);
 CREATE TABLE mpp_orders   (id bigserial primary key, uuid uuid, name text, age int);
 
-INSERT INTO mpp_users (uuid, name, age, category)
-SELECT gen_random_uuid(), (ARRAY['bob','alice','carol','dave'])[1 + (g % 4)], g % 50, 'c' || (g % 5)
-FROM generate_series(1, 20000) AS g;
-
-INSERT INTO mpp_products (uuid, name, age)
-SELECT gen_random_uuid(), (ARRAY['bob','alice'])[1 + (g % 2)], g % 50
-FROM generate_series(1, 20000) AS g;
-
-INSERT INTO mpp_orders (uuid, name, age)
-SELECT gen_random_uuid(), 'x', g % 50
-FROM generate_series(1, 20000) AS g;
-
 CREATE INDEX mpp_users_idx ON mpp_users USING bm25 (id, uuid, name, age, category)
 WITH (key_field='id', text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true},"category":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
 
@@ -59,6 +47,34 @@ WITH (key_field='id', text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast
 
 CREATE INDEX mpp_orders_idx ON mpp_orders USING bm25 (id, uuid, name, age)
 WITH (key_field='id', text_fields='{"uuid":{"tokenizer":{"type":"keyword"},"fast":true},"name":{"tokenizer":{"type":"keyword"},"fast":true}}', numeric_fields='{"age":{"fast":true}}');
+
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO mpp_users (uuid, name, age, category)
+SELECT gen_random_uuid(), (ARRAY['bob','alice','carol','dave'])[1 + (g % 4)], g % 50, 'c' || (g % 5)
+FROM generate_series(1, 10000) AS g;
+
+INSERT INTO mpp_users (uuid, name, age, category)
+SELECT gen_random_uuid(), (ARRAY['bob','alice','carol','dave'])[1 + (g % 4)], g % 50, 'c' || (g % 5)
+FROM generate_series(10001, 20000) AS g;
+
+INSERT INTO mpp_products (uuid, name, age)
+SELECT gen_random_uuid(), (ARRAY['bob','alice'])[1 + (g % 2)], g % 50
+FROM generate_series(1, 10000) AS g;
+
+INSERT INTO mpp_products (uuid, name, age)
+SELECT gen_random_uuid(), (ARRAY['bob','alice'])[1 + (g % 2)], g % 50
+FROM generate_series(10001, 20000) AS g;
+
+INSERT INTO mpp_orders (uuid, name, age)
+SELECT gen_random_uuid(), 'x', g % 50
+FROM generate_series(1, 10000) AS g;
+
+INSERT INTO mpp_orders (uuid, name, age)
+SELECT gen_random_uuid(), 'x', g % 50
+FROM generate_series(10001, 20000) AS g;
+
+RESET paradedb.global_mutable_segment_rows;
 
 ANALYZE mpp_users;
 ANALYZE mpp_products;


### PR DESCRIPTION
## What

Further collapses some dead code after #5614, and moves from rendering segment counts based on the number of `ScanState`s, to the number of segments reported out of the `ParallelScanState`.

Additionally, expands the number of segments produced in MPP-relevant regress tests.

## Why

To fix `EXPLAIN` output, and to prepare for #5657, which will make the use of MPP much more dependent on the number of segments which are used.

## Tests

No behavior changes: only `EXPLAIN` changes.