### PR TITLE
feat: enabled LEFT, RIGHT, and FULL joins in JoinScan.

### DIFF
--- a/pg_search/src/postgres/customscan/joinscan/build.rs
+++ b/pg_search/src/postgres/customscan/joinscan/build.rs
@@ -160,9 +160,6 @@ impl From<*mut pg_sys::PlannerInfo> for PlannerRootId {
 
 /// Represents the join type for serialization.
 ///
-/// Note: Currently only Inner join is supported, but other variants are
-/// defined for future extensibility and to match PostgreSQL's JoinType enum.
-///
 /// The serde JSON shape of this enum (in particular, struct variant `Anti`)
 /// is **intra-process only** - it flows leader -> worker via `custom_private`
 /// within a single backend, never crosses a process or version boundary.
@@ -893,6 +890,9 @@ impl RelNode {
                 if !matches!(
                     j.join_type,
                     JoinType::Inner
+                        | JoinType::Left
+                        | JoinType::Right
+                        | JoinType::Full
                         | JoinType::Semi
                         | JoinType::Anti { .. }
                         | JoinType::LeftMark

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -168,6 +168,7 @@ use self::scan_state::{
 };
 use crate::api::HashSet;
 use crate::api::OrderByFeature;
+use arrow_array::Array;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags};
@@ -403,11 +404,11 @@ unsafe fn is_limit_pushdown_safe(
         .map(|s| s.scan_info.heap_rti)
         .collect();
 
-    // 2. Did JoinScan absorb ALL base relations?
-    #[cfg(feature = "pg15")]
+    // 2. Did JoinScan absorb ALL base relations? `all_baserels`, not
+    // `all_query_rels`: the latter also carries outer-join relids (PG16+),
+    // which are join identities rather than relations and can never appear
+    // in `absorbed_rtis`.
     let all_rels = (*root).all_baserels;
-    #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
-    let all_rels = (*root).all_query_rels;
 
     let mut absorbed_bms: *mut pg_sys::Bitmapset = std::ptr::null_mut();
     for rti in &absorbed_rtis {
@@ -1958,6 +1959,28 @@ impl JoinScan {
 
         join_keys.extend(join_conditions.equi_keys.clone());
 
+        // For outer joins, a non-equi ON condition (is_pushed_down == false)
+        // decides which rows match, and an unmatched preserved row must still
+        // be null-extended. The join-level predicate pipeline applies such
+        // clauses as scan-level or post-join filters, either of which changes
+        // the set of null-extended rows, so decline. WHERE clauses
+        // (is_pushed_down == true) are post-join filters by definition and
+        // stay safe.
+        let is_outer = matches!(
+            jointype,
+            pg_sys::JoinType::JOIN_LEFT | pg_sys::JoinType::JOIN_RIGHT | pg_sys::JoinType::JOIN_FULL
+        );
+        if is_outer
+            && join_conditions
+                .other_conditions
+                .iter()
+                .any(|&ri| !(*ri).is_pushed_down)
+        {
+            return Err(warn(JoinDeclineReason::new(
+                "JoinScan not used: outer joins support only equi-join conditions in the ON clause",
+            )));
+        }
+
         // For Semi/Anti with additional conditions that cannot ride the
         // MultiTablePredicate pipeline (setrefs would fail to resolve inner-side
         // Vars once the inner relation is pruned), try to absorb each condition
@@ -2058,7 +2081,7 @@ impl JoinScan {
         if !unsupported.is_empty() {
             return Err(warn(
                 JoinDeclineReason::new(
-                    "JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported",
+                    "JoinScan not used: unsupported join type",
                 )
                 .with_details(
                     unsupported
@@ -2148,6 +2171,10 @@ impl JoinScan {
         let result_slot = state.custom_state().result_slot?;
         let output_columns = state.custom_state().output_columns.clone();
         let mut fetched_sources = crate::api::HashSet::default();
+        // Sources whose ctid is NULL in this row: the row is null-extended by
+        // an outer join on that side, so there is no heap tuple to fetch and
+        // every column from that source must come out NULL.
+        let mut null_extended_sources = crate::api::HashSet::default();
 
         // Fetch tuples for all RTIs referenced in the output columns
         for col_info in &output_columns {
@@ -2156,16 +2183,22 @@ impl JoinScan {
                 privdat::OutputColumnInfo::Score { plan_position, .. } => *plan_position,
                 privdat::OutputColumnInfo::Pruned => continue,
             };
-            if !fetched_sources.contains(&plan_position) {
+            if !fetched_sources.contains(&plan_position)
+                && !null_extended_sources.contains(&plan_position)
+            {
                 let ctid = {
                     let batch = state.custom_state().current_batch.as_ref()?;
                     let rel_state = state.custom_state().relations.get(&plan_position)?;
                     let ctid_col = batch.column(rel_state.ctid_col_idx?);
-                    ctid_col
+                    let ctid_array = ctid_col
                         .as_any()
                         .downcast_ref::<arrow_array::UInt64Array>()
-                        .expect("ctid should be u64")
-                        .value(row_idx)
+                        .expect("ctid should be u64");
+                    if ctid_array.is_null(row_idx) {
+                        null_extended_sources.insert(plan_position);
+                        continue;
+                    }
+                    ctid_array.value(row_idx)
                 };
                 let rel_state = state.custom_state_mut().relations.get_mut(&plan_position)?;
                 if !rel_state
@@ -2194,12 +2227,20 @@ impl JoinScan {
                 break;
             }
             match col_info {
-                privdat::OutputColumnInfo::Score { .. } => {
+                privdat::OutputColumnInfo::Score { plan_position, .. } => {
+                    if null_extended_sources.contains(plan_position) {
+                        *nulls.add(i) = true;
+                        continue;
+                    }
                     let score_col = batch.column(i);
                     let score = if let Some(score_array) = score_col
                         .as_any()
                         .downcast_ref::<arrow_array::Float32Array>(
                     ) {
+                        if score_array.is_null(row_idx) {
+                            *nulls.add(i) = true;
+                            continue;
+                        }
                         score_array.value(row_idx)
                     } else {
                         0.0
@@ -2220,6 +2261,10 @@ impl JoinScan {
                     original_attno,
                     ..
                 } => {
+                    if null_extended_sources.contains(plan_position) {
+                        *nulls.add(i) = true;
+                        continue;
+                    }
                     let rel_state = state.custom_state().relations.get(plan_position)?;
                     let source_slot = rel_state.fetch_slot;
                     if *original_attno <= 0

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1899,6 +1899,24 @@ impl JoinScan {
         let innerrel = args.innerrel;
         let extra = args.extra;
 
+        // Mirrored / unique-ified variants the planner generates as alternatives
+        // for a joinrel it also offers as plain SEMI / ANTI. The canonical
+        // invocation carries the real decision (and any warning); a warning here
+        // would imply a capability gap that doesn't exist.
+        let is_planner_alternative = matches!(
+            jointype,
+            pg_sys::JoinType::JOIN_UNIQUE_OUTER | pg_sys::JoinType::JOIN_UNIQUE_INNER
+        );
+        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
+        let is_planner_alternative =
+            is_planner_alternative || jointype == pg_sys::JoinType::JOIN_RIGHT_ANTI;
+        #[cfg(feature = "pg18")]
+        let is_planner_alternative =
+            is_planner_alternative || jointype == pg_sys::JoinType::JOIN_RIGHT_SEMI;
+        if is_planner_alternative {
+            return Err(JoinPathDecline::Quiet);
+        }
+
         // Silent gates: collect outer/inner sources or bail without a warning.
         let (outer_node, mut join_keys) =
             collect_join_sources(root, outerrel).ok_or(JoinPathDecline::Quiet)?;

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -168,7 +168,6 @@ use self::scan_state::{
 };
 use crate::api::HashSet;
 use crate::api::OrderByFeature;
-use arrow_array::Array;
 use crate::index::mvcc::MvccSatisfies;
 use crate::index::reader::index::SearchIndexManifest;
 use crate::postgres::customscan::builders::custom_path::{CustomPathBuilder, Flags};
@@ -182,6 +181,7 @@ use crate::postgres::customscan::limit_offset::LimitOffset;
 use crate::postgres::customscan::mpp::glue::mpp_is_active;
 use crate::postgres::customscan::mpp::interrupt::block_on_next;
 use crate::postgres::customscan::mpp::launch::MppLifecycle;
+use arrow_array::Array;
 use datafusion_distributed::shm::MppMesh;
 
 use crate::postgres::customscan::parameterized_value::ParameterizedValue;
@@ -1968,7 +1968,9 @@ impl JoinScan {
         // stay safe.
         let is_outer = matches!(
             jointype,
-            pg_sys::JoinType::JOIN_LEFT | pg_sys::JoinType::JOIN_RIGHT | pg_sys::JoinType::JOIN_FULL
+            pg_sys::JoinType::JOIN_LEFT
+                | pg_sys::JoinType::JOIN_RIGHT
+                | pg_sys::JoinType::JOIN_FULL
         );
         if is_outer
             && join_conditions
@@ -2080,10 +2082,7 @@ impl JoinScan {
         let unsupported = plan.unsupported_join_types();
         if !unsupported.is_empty() {
             return Err(warn(
-                JoinDeclineReason::new(
-                    "JoinScan not used: unsupported join type",
-                )
-                .with_details(
+                JoinDeclineReason::new("JoinScan not used: unsupported join type").with_details(
                     unsupported
                         .iter()
                         .map(|t| t.to_string().to_uppercase())

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -2173,6 +2173,12 @@ impl JoinScan {
         // Sources whose ctid is NULL in this row: the row is null-extended by
         // an outer join on that side, so there is no heap tuple to fetch and
         // every column from that source must come out NULL.
+        //
+        // This can't resolve inside the DataFusion plan. Under late
+        // materialization only ctid columns cross the plan boundary, so the
+        // ctid's null bit is the one carrier of the null-extension; any
+        // plan-side rewrite would still hand this loop a per-row marker to
+        // check. The check is a null-bitmap read, not a heap access.
         let mut null_extended_sources = crate::api::HashSet::default();
 
         // Fetch tuples for all RTIs referenced in the output columns

--- a/pg_search/src/postgres/customscan/joinscan/mod.rs
+++ b/pg_search/src/postgres/customscan/joinscan/mod.rs
@@ -1899,24 +1899,6 @@ impl JoinScan {
         let innerrel = args.innerrel;
         let extra = args.extra;
 
-        // Mirrored / unique-ified variants the planner generates as alternatives
-        // for a joinrel it also offers as plain SEMI / ANTI. The canonical
-        // invocation carries the real decision (and any warning); a warning here
-        // would imply a capability gap that doesn't exist.
-        let is_planner_alternative = matches!(
-            jointype,
-            pg_sys::JoinType::JOIN_UNIQUE_OUTER | pg_sys::JoinType::JOIN_UNIQUE_INNER
-        );
-        #[cfg(any(feature = "pg16", feature = "pg17", feature = "pg18"))]
-        let is_planner_alternative =
-            is_planner_alternative || jointype == pg_sys::JoinType::JOIN_RIGHT_ANTI;
-        #[cfg(feature = "pg18")]
-        let is_planner_alternative =
-            is_planner_alternative || jointype == pg_sys::JoinType::JOIN_RIGHT_SEMI;
-        if is_planner_alternative {
-            return Err(JoinPathDecline::Quiet);
-        }
-
         // Silent gates: collect outer/inner sources or bail without a warning.
         let (outer_node, mut join_keys) =
             collect_join_sources(root, outerrel).ok_or(JoinPathDecline::Quiet)?;

--- a/pg_search/tests/pg_regress/expected/aggregate_join.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join.out
@@ -481,7 +481,6 @@ FROM agg_join_products p
 LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -503,7 +502,6 @@ FROM agg_join_products p
 LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count 
 -------------+-------
  Electronics |     4
@@ -519,7 +517,7 @@ LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -534,7 +532,6 @@ LEFT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -551,7 +548,6 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
                                                                                            QUERY PLAN                                                                                            
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -576,7 +572,6 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   tag_name  | count 
 ------------+-------
  orphan_tag |     0
@@ -591,7 +586,7 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   tag_name  | count 
 ------------+-------
  orphan_tag |     0
@@ -605,7 +600,6 @@ RIGHT JOIN agg_join_tags t ON p.id = t.product_id
 WHERE t.tag_name @@@ 'tech OR orphan_tag'
 GROUP BY t.tag_name
 ORDER BY t.tag_name;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   tag_name  | count 
 ------------+-------
  orphan_tag |     0
@@ -995,7 +989,6 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC NULLS LAST
 LIMIT 2;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortB | 19804
@@ -1011,7 +1004,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC NULLS LAST
 LIMIT 2;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortB | 19804
@@ -1027,7 +1020,6 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) ASC NULLS FIRST
 LIMIT 2;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1043,7 +1035,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) ASC NULLS FIRST
 LIMIT 2;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1060,7 +1052,6 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC
 LIMIT 2;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1076,7 +1067,7 @@ WHERE p.description @@@ 'nullsort'
 GROUP BY p.category
 ORDER BY SUM(t.product_id) DESC
 LIMIT 2;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
  category  |  sum  
 -----------+-------
  NullSortA |      
@@ -1512,7 +1503,6 @@ SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
 FROM agg_join_products p
 FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -1533,7 +1523,6 @@ SELECT COUNT(*), COUNT(p.category), COUNT(t.tag_name)
 FROM agg_join_products p
 FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes';
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
  count | count | count 
 -------+-------+-------
      8 |     8 |     8
@@ -1546,7 +1535,6 @@ FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1562,7 +1550,7 @@ FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96
@@ -1577,7 +1565,6 @@ FULL OUTER JOIN agg_join_tags t ON p.id = t.product_id
 WHERE p.description @@@ 'laptop OR shoes'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, t)
   category   | count |   sum   
 -------------+-------+---------
  Electronics |     4 | 4599.96

--- a/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_edge_cases.out
@@ -188,7 +188,6 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
                                                                                                                QUERY PLAN                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -215,7 +214,6 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -232,7 +230,7 @@ LEFT JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -319,7 +317,6 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
                                                                                                                 QUERY PLAN                                                                                                                 
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -348,7 +345,6 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
   category   | count | count | count 
 -------------+-------+-------+-------
  Books       |     1 |     0 |     0
@@ -366,7 +362,7 @@ LEFT JOIN ec_suppliers s ON p.category = s.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r, s)
   category   | count | count | count 
 -------------+-------+-------+-------
  Books       |     1 |     0 |     0
@@ -385,7 +381,6 @@ FULL JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -402,7 +397,7 @@ FULL JOIN ec_reviews r ON p.category = r.category
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR monitor OR racket OR novel'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: p, r)
   category   | count | count 
 -------------+-------+-------
  Books       |     1 |     0
@@ -489,7 +484,7 @@ LEFT JOIN ec_suppliers s ON r.category = s.category
 WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r, s)
                                                                                         QUERY PLAN                                                                                        
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -519,7 +514,7 @@ LEFT JOIN ec_suppliers s ON r.category = s.category
 WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r, s)
  brand_text | brand_json 
 ------------+------------
  TechCorp   | "TechCorp"
@@ -534,7 +529,7 @@ LEFT JOIN ec_suppliers s ON r.category = s.category
 WHERE p.description @@@ 'laptop'
 GROUP BY p.metadata->>'brand', p.metadata->'brand'
 ORDER BY brand_text;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, s)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: p, r, s)
  brand_text | brand_json 
 ------------+------------
  TechCorp   | "TechCorp"

--- a/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_fallback.out
@@ -200,7 +200,6 @@ LEFT JOIN fb_tags t ON p.id = t.product_id
 LEFT JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, t)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
@@ -227,7 +226,6 @@ LEFT JOIN fb_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, t)
   category   | count | count 
 -------------+-------+-------
  Clothing    |     1 |     1

--- a/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_multitable.out
@@ -225,7 +225,6 @@ LEFT JOIN mt_reviews r ON p.id = r.product_id
 WHERE p.description @@@ 'laptop OR shoes OR jacket OR kids'
 GROUP BY p.category
 ORDER BY p.category;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, r, t)
   category   | count | count 
 -------------+-------+-------
  Clothing    |     1 |     1

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -70,7 +70,7 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -95,7 +95,7 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |        10
@@ -114,7 +114,7 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -143,7 +143,7 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -167,7 +167,7 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -196,7 +196,7 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -215,7 +215,7 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
@@ -395,7 +395,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -424,7 +424,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
 (0 rows)
@@ -439,7 +439,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
 WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
@@ -459,7 +459,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
        label       | doc_count 
 -------------------+-----------
  Senior Programmer |         4

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -70,7 +70,6 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -95,7 +94,6 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |        10
@@ -114,7 +112,6 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -143,7 +140,6 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -167,7 +163,6 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -196,7 +191,6 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -215,7 +209,6 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
@@ -395,7 +388,6 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -424,7 +416,6 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
 (0 rows)
@@ -439,7 +430,6 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
 WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
@@ -459,7 +449,6 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
        label       | doc_count 
 -------------------+-----------
  Senior Programmer |         4

--- a/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/aggregate_join_semi_anti.out
@@ -70,6 +70,7 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                               QUERY PLAN                                                                                               
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -94,6 +95,7 @@ WHERE contact_id IN (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ 'list
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |        10
@@ -112,6 +114,7 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -140,6 +143,7 @@ WHERE EXISTS     (SELECT 1 FROM asa_contact_list cl WHERE cl.ldf_id = c.contact_
   AND c.job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTANTI, RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, cl)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -163,6 +167,7 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
                                                                                                QUERY PLAN                                                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -191,6 +196,7 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
  Senior Programmer |         7
@@ -209,6 +215,7 @@ WHERE contact_id IN     (SELECT ldf_id FROM asa_contact_list WHERE list_id @@@ '
   AND job_title @@@ 'Senior'
 GROUP BY job_title
 ORDER BY doc_count DESC, job_title;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_cccf, asa_contact_list)
 WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_cccf, asa_contact_list)
      job_title     | doc_count 
 -------------------+-----------
@@ -388,6 +395,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
                                                                                      QUERY PLAN                                                                                     
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -416,6 +424,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
 (0 rows)
@@ -430,6 +439,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
 WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
  label | doc_count 
 -------+-----------
@@ -449,6 +459,7 @@ WHERE id IN     (SELECT id FROM asa_excl_include)
   AND label @@@ 'Senior'
 GROUP BY label
 ORDER BY doc_count DESC, label;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: asa_excl_include, asa_excl_inner, asa_excl_outer)
        label       | doc_count 
 -------------------+-----------
  Senior Programmer |         4

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
@@ -661,7 +661,6 @@ JOIN (
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -707,7 +706,6 @@ JOIN (
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
            title            |    author     | rating |    score    |       related_title        
 ----------------------------+---------------+--------+-------------+----------------------------
  Post 1                     | Author 2      |      2 | 0.019852143 | Post 11

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
@@ -661,7 +661,7 @@ JOIN (
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -707,7 +707,7 @@ JOIN (
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
            title            |    author     | rating |    score    |       related_title        
 ----------------------------+---------------+--------+-------------+----------------------------
  Post 1                     | Author 2      |      2 | 0.019852143 | Post 11

--- a/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
+++ b/pg_search/tests/pg_regress/expected/columnar_advanced_06_score_function.out
@@ -661,6 +661,7 @@ JOIN (
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
                                                                                         QUERY PLAN                                                                                         
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Sort
@@ -706,6 +707,7 @@ JOIN (
 ) b ON a.author = b.author AND a.title <> b.title
 ORDER BY a.title, a.author, a.rating, a.score, b.title;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (table: score_test)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (table: score_test)
            title            |    author     | rating |    score    |       related_title        
 ----------------------------+---------------+--------+-------------+----------------------------
  Post 1                     | Author 2      |      2 | 0.019852143 | Post 11

--- a/pg_search/tests/pg_regress/expected/deprecated_score.out
+++ b/pg_search/tests/pg_regress/expected/deprecated_score.out
@@ -235,7 +235,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
@@ -303,7 +303,7 @@ FROM books b
 LEFT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY b.id, a.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0
@@ -316,7 +316,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY a.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0

--- a/pg_search/tests/pg_regress/expected/issue_2533.out
+++ b/pg_search/tests/pg_regress/expected/issue_2533.out
@@ -302,7 +302,7 @@ SELECT (SELECT COUNT(*)
            OR ((NOT (users.color @@@ 'blue')) OR (users.name @@@ 'bob')) AND
               NOT NOT ((NOT (orders.color @@@ 'blue')) OR (NOT (orders.color @@@ 'blue'))) AND NOT (users.age @@@ '20')
            OR ((NOT (users.color @@@ 'blue')) AND (users.color @@@ 'blue')));
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: orders, users)
+WARNING:  JoinScan not used: aggregates are not supported. Enable paradedb.enable_aggregate_custom_scan to optimize this query. (tables: orders, users)
  count | count 
 -------+-------
     13 |    13

--- a/pg_search/tests/pg_regress/expected/join_basic.out
+++ b/pg_search/tests/pg_regress/expected/join_basic.out
@@ -218,7 +218,7 @@ LIMIT 5;
 -- =============================================================================
 -- TEST 4: JoinScan should NOT be proposed for non-INNER joins (for now)
 -- =============================================================================
--- LEFT JOIN with LIMIT - should NOT use JoinScan (M1 only handles INNER JOIN)
+-- LEFT JOIN with LIMIT - uses JoinScan
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p
@@ -226,30 +226,27 @@ LEFT JOIN suppliers s ON p.supplier_id = s.id
 WHERE p.description @@@ 'wireless'
 ORDER BY p.id
 LIMIT 10;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: p, s)
-                                                                                   QUERY PLAN                                                                                    
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                   QUERY PLAN                                                                                                    
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.name, s.name
-   ->  Sort
+   ->  Custom Scan (ParadeDB Join Scan)
          Output: p.id, p.name, s.name
-         Sort Key: p.id
-         ->  Hash Right Join
-               Output: p.id, p.name, s.name
-               Hash Cond: (s.id = p.supplier_id)
-               ->  Seq Scan on public.suppliers s
-                     Output: s.id, s.name, s.contact_info, s.country
-               ->  Hash
-                     Output: p.id, p.name, p.supplier_id
-                     ->  Custom Scan (ParadeDB Base Scan) on public.products p
-                           Output: p.id, p.name, p.supplier_id
-                           Table: products
-                           Index: products_bm25_idx
-                           Worker Selection: Cost model
-                           Exec Method: NormalScanExecState
-                           Scores: false
-                           Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
-(20 rows)
+         Relation Tree: s RIGHT p
+         Join Cond: p.supplier_id = s.id
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, NULL as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[p]
+           :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, supplier_id@1)], projection=[ctid_0@0, ctid_1@2, id@4]
+           :         VisibilityFilterExec: tables=[s]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"description","query_string":"wireless","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
 
 -- =============================================================================
 -- TEST 5: JoinScan can be disabled via GUC

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -647,7 +647,6 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 1 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -691,7 +690,6 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY 0 - c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -735,7 +733,6 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -832,7 +829,6 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0::bigint DESC
 LIMIT 10;
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -647,7 +647,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 1 DESC
 LIMIT 10;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -691,7 +691,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY 0 - c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -735,7 +735,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + c.id DESC
 LIMIT 10;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -832,7 +832,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0::bigint DESC
 LIMIT 10;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/pg_search/tests/pg_regress/expected/join_orderby_expression.out
+++ b/pg_search/tests/pg_regress/expected/join_orderby_expression.out
@@ -647,6 +647,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 1 DESC
 LIMIT 10;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -690,6 +691,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY 0 - c.id DESC
 LIMIT 10;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -733,6 +735,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + c.id DESC
 LIMIT 10;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -829,6 +832,7 @@ WHERE c.id IN (
 AND c.description @@@ 'technology'
 ORDER BY c.id + 0::bigint DESC
 LIMIT 10;
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: c, fr)
 WARNING:  JoinScan not used: ORDER BY columns must be fast fields and have a byte-ordered (C-like) collation (tables: c, fr)
                                                                                  QUERY PLAN                                                                                  
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/pg_search/tests/pg_regress/expected/join_outer.out
+++ b/pg_search/tests/pg_regress/expected/join_outer.out
@@ -30,15 +30,6 @@ CREATE TABLE outer_pages (
     page_text TEXT,
     size_bytes INTEGER
 );
-INSERT INTO outer_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
--- file_id 51..250: files 1..50 stay unmatched, ids 201..250 dangle.
-INSERT INTO outer_pages (file_id, page_text, size_bytes)
-SELECT 51 + (g % 200),
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
 CREATE INDEX outer_files_idx ON outer_files
 USING bm25 (id, title, content)
 WITH (
@@ -52,6 +43,26 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {"fast": true}}'
 );
+-- Two inserts per table, each flushed to its own segment, so the scans
+-- report more than one partition and the distributed planner engages.
+SET paradedb.global_mutable_segment_rows = 0;
+INSERT INTO outer_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+INSERT INTO outer_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+-- file_id 51..250: files 1..50 stay unmatched, ids 201..250 dangle.
+INSERT INTO outer_pages (file_id, page_text, size_bytes)
+SELECT 51 + (g % 200),
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+INSERT INTO outer_pages (file_id, page_text, size_bytes)
+SELECT 51 + (g % 200),
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
 ANALYZE outer_files;
 ANALYZE outer_pages;
 -- =====================================================================
@@ -82,9 +93,9 @@ LIMIT 10;
            :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, file_id@1)], projection=[ctid_0@0, ctid_1@2, file_id@3, id@4]
            :         VisibilityFilterExec: tables=[f]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all"
+           :             PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT p.id, p.file_id, f.title
@@ -150,9 +161,9 @@ LIMIT 10;
            :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(file_id@1, id@1)], projection=[ctid_0@0, id@2, ctid_1@3, id@4]
            :         VisibilityFilterExec: tables=[p]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all"
+           :             PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT f.id, f.title, p.id AS page_id
@@ -198,9 +209,9 @@ LIMIT 10;
            :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, file_id@1)], projection=[ctid_0@0, ctid_1@2, file_id@3, id@4]
            :         VisibilityFilterExec: tables=[f]
            :           CooperativeExec
-           :             PgSearchScan: segments=1, query="all"
+           :             PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
 (18 rows)
 
 SELECT p.id, p.file_id, f.title
@@ -275,9 +286,9 @@ LIMIT 10;
                  :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, file_id@1)]
                  :         VisibilityFilterExec: tables=[f]
                  :           CooperativeExec
-                 :             PgSearchScan: segments=1, query="all"
+                 :             PgSearchScan: segments=2, query="all"
                  :         CooperativeExec
-                 :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+                 :           PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
 (20 rows)
 
 SELECT f.id, p.id AS page_id, p.file_id
@@ -322,9 +333,9 @@ LIMIT 10;
            :     VisibilityFilterExec: tables=[p]
            :       HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(id@0, file_id@1)]
            :         CooperativeExec
-           :           PgSearchScan: segments=1, query="all"
+           :           PgSearchScan: segments=2, query="all"
            :         CooperativeExec
-           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+           :           PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
 (17 rows)
 
 SELECT p.id, p.file_id
@@ -414,8 +425,8 @@ FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
 WHERE p.page_text @@@ 'Page'
 ORDER BY p.id
 LIMIT 10;
-                                                                                                QUERY PLAN                                                                                                 
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                 QUERY PLAN                                                                                                  
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.file_id, f.title
    ->  Custom Scan (ParadeDB Join Scan)
@@ -430,11 +441,12 @@ LIMIT 10;
            :     SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
            :       VisibilityFilterExec: tables=[p]
            :         HashJoinExec: mode=CollectLeft, join_type=Left, on=[(file_id@1, id@1)], projection=[ctid_0@3, ctid_1@0, file_id@1, id@2]
-           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+           :           CoalescePartitionsExec
+           :             PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
            :           VisibilityFilterExec: tables=[f]
-           :             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-           :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
-(18 rows)
+           :             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :               PgSearchScan: segments=2, dynamic_filters=1, query="all"
+(19 rows)
 
 SELECT p.id, p.file_id, f.title
 FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
@@ -580,8 +592,8 @@ EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT COUNT(f.id)
 FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
 WHERE p.page_text @@@ 'Page';
-                                                                                    QUERY PLAN                                                                                    
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                       QUERY PLAN                                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Custom Scan (ParadeDB Aggregate Scan)
    Output: pdb.agg_fn('COUNT'::text)
    Backend: DataFusion
@@ -591,21 +603,25 @@ WHERE p.page_text @@@ 'Page';
      : ┌───── DistributedExec
      : │ AggregateExec: mode=Final, gby=[], aggr=[count(f_1.id) as agg_0]
      : │   CoalescePartitionsExec
-     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
      : └──────────────────────────────────────────────────
-     :   ┌───── Stage 2 ── tasks=3, partitions=9
+     :   ┌───── Stage 2 ── tasks=2, partitions=6
      :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(f_1.id) as agg_0]
      :   │   HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@0, file_id@0)], projection=[id@0]
      :   │     CoalescePartitionsExec
-     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
-     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
-     :   │       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=2, stage_partitions=4, input_tasks=2
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+     :   │       DistributedLeafExec:
+     :   │         t0: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+     :   │         t1: PgSearchScan: segments=2, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
      :   └──────────────────────────────────────────────────
-     :     ┌───── Stage 1 ── tasks=1, partitions=3
-     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
-     :     │   PgSearchScan: segments=1, query="all"
+     :     ┌───── Stage 1 ── tasks=2, partitions=8
+     :     │ BroadcastExec: input_partitions=2, consumer_tasks=2, output_partitions=4
+     :     │   DistributedLeafExec:
+     :     │     t0: PgSearchScan: segments=2, query="all"
+     :     │     t1: PgSearchScan: segments=2, query="all"
      :     └──────────────────────────────────────────────────
-(23 rows)
+(27 rows)
 
 SELECT COUNT(f.id)
 FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/join_outer.out
+++ b/pg_search/tests/pg_regress/expected/join_outer.out
@@ -1,0 +1,619 @@
+-- =====================================================================
+-- Outer joins (LEFT / RIGHT / FULL) through JoinScan, serial and MPP.
+--
+-- Data is shaped so both sides have unmatched rows: files 1..50 have
+-- no pages, and pages with file_id 201..250 have no file. Each query
+-- runs in a serial pass and an MPP pass; results must match.
+-- =====================================================================
+CREATE EXTENSION IF NOT EXISTS pg_search;
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+-- Force parallel even on this tiny dataset; otherwise the cost-based
+-- planner picks the serial JoinScan and MPP never activates.
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+-- =====================================================================
+-- Test data
+-- =====================================================================
+CREATE TABLE outer_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE outer_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+INSERT INTO outer_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+-- file_id 51..250: files 1..50 stay unmatched, ids 201..250 dangle.
+INSERT INTO outer_pages (file_id, page_text, size_bytes)
+SELECT 51 + (g % 200),
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+CREATE INDEX outer_files_idx ON outer_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+CREATE INDEX outer_pages_idx ON outer_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {"fast": true}}'
+);
+ANALYZE outer_files;
+ANALYZE outer_pages;
+-- =====================================================================
+-- Pass 1: serial JoinScan (max_parallel_workers_per_gather = 0)
+-- =====================================================================
+SET max_parallel_workers_per_gather TO 0;
+-- LEFT: pages preserved, unmatched pages null-extend the files side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.file_id, f.title
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.file_id, f.title
+         Relation Tree: f RIGHT p
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, file_id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[p]
+           :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, file_id@1)], projection=[ctid_0@0, ctid_1@2, file_id@3, id@4]
+           :         VisibilityFilterExec: tables=[f]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+ id | file_id |  title  
+----+---------+---------
+  1 |      52 | file-52
+  2 |      53 | file-53
+  3 |      54 | file-54
+  4 |      55 | file-55
+  5 |      56 | file-56
+  6 |      57 | file-57
+  7 |      58 | file-58
+  8 |      59 | file-59
+  9 |      60 | file-60
+ 10 |      61 | file-61
+(10 rows)
+
+-- LEFT with the null-extended region on top (dangling file_ids).
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.file_id DESC, p.id
+LIMIT 10;
+ id  | file_id | title 
+-----+---------+-------
+ 199 |     250 | 
+ 399 |     250 | 
+ 599 |     250 | 
+ 799 |     250 | 
+ 999 |     250 | 
+ 198 |     249 | 
+ 398 |     249 | 
+ 598 |     249 | 
+ 798 |     249 | 
+ 998 |     249 | 
+(10 rows)
+
+-- LEFT: small side preserved, unmatched files null-extend the pages side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, f.title, p.id AS page_id
+FROM outer_files f LEFT JOIN outer_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.id, p.id
+LIMIT 10;
+                                                                                       QUERY PLAN                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.id, f.title, p.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: f.id, f.title, p.id
+         Relation Tree: p RIGHT f
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: f.id asc, p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, NULL as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST, id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[f]
+           :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(file_id@1, id@1)], projection=[ctid_0@0, id@2, ctid_1@3, id@4]
+           :         VisibilityFilterExec: tables=[p]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"content","query_string":"Section","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT f.id, f.title, p.id AS page_id
+FROM outer_files f LEFT JOIN outer_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.id, p.id
+LIMIT 10;
+ id |  title  | page_id 
+----+---------+---------
+  1 | file-1  |        
+  2 | file-2  |        
+  3 | file-3  |        
+  4 | file-4  |        
+  5 | file-5  |        
+  6 | file-6  |        
+  7 | file-7  |        
+  8 | file-8  |        
+  9 | file-9  |        
+ 10 | file-10 |        
+(10 rows)
+
+-- RIGHT: mirror of the first LEFT.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_files f RIGHT JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.file_id, f.title
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.file_id, f.title
+         Relation Tree: f RIGHT p
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, file_id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[p]
+           :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, file_id@1)], projection=[ctid_0@0, ctid_1@2, file_id@3, id@4]
+           :         VisibilityFilterExec: tables=[f]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT p.id, p.file_id, f.title
+FROM outer_files f RIGHT JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+ id | file_id |  title  
+----+---------+---------
+  1 |      52 | file-52
+  2 |      53 | file-53
+  3 |      54 | file-54
+  4 |      55 | file-55
+  5 |      56 | file-56
+  6 |      57 | file-57
+  7 |      58 | file-58
+  8 |      59 | file-59
+  9 |      60 | file-60
+ 10 |      61 | file-61
+(10 rows)
+
+-- FULL: both directions null-extend. The @@@ predicate sits in the ON
+-- clause; in WHERE it would reject null-extended file rows and reduce
+-- the join. Search predicates in outer ON clauses decline JoinScan, so
+-- this exercises the fallback, not the custom scan. No EXPLAIN: the
+-- fallback plan serializes the index OID into the join filter, which
+-- changes on every run.
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id AND f.content @@@ 'Section'
+ORDER BY f.id NULLS LAST, p.id NULLS LAST
+LIMIT 10;
+WARNING:  JoinScan not used: outer joins support only equi-join conditions in the ON clause (tables: f, p)
+ id | page_id | file_id 
+----+---------+---------
+  1 |         |        
+  2 |         |        
+  3 |         |        
+  4 |         |        
+  5 |         |        
+  6 |         |        
+  7 |         |        
+  8 |         |        
+  9 |         |        
+ 10 |         |        
+(10 rows)
+
+-- FULL with the search predicate in WHERE on the pages side: null-
+-- extended page rows can't satisfy it, so PG reduces to LEFT
+-- (pages preserved) before the join hook runs.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+                                                                                          QUERY PLAN                                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: f.id, p.id, p.file_id
+   ->  Result
+         Output: f.id, p.id, p.file_id
+         ->  Custom Scan (ParadeDB Join Scan)
+               Output: p.id, p.file_id, f.id
+               Relation Tree: f RIGHT p
+               Join Cond: f.id = p.file_id
+               Limit: 10
+               Order By: p.id asc
+               DataFusion Physical Plan: 
+                 : ProjectionExec: expr=[id@4 as col_1, file_id@3 as col_2, id@1 as col_3, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+                 :   SortExec: TopK(fetch=10), expr=[id@4 ASC NULLS LAST], preserve_partitioning=[false]
+                 :     VisibilityFilterExec: tables=[p]
+                 :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, file_id@1)]
+                 :         VisibilityFilterExec: tables=[f]
+                 :           CooperativeExec
+                 :             PgSearchScan: segments=1, query="all"
+                 :         CooperativeExec
+                 :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+(20 rows)
+
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+ id | page_id | file_id 
+----+---------+---------
+ 52 |       1 |      52
+ 53 |       2 |      53
+ 54 |       3 |      54
+ 55 |       4 |      55
+ 56 |       5 |      56
+ 57 |       6 |      57
+ 58 |       7 |      58
+ 59 |       8 |      59
+ 60 |       9 |      60
+ 61 |      10 |      61
+(10 rows)
+
+-- Anti-join spelled as LEFT ... IS NULL: only the null-extended rows.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page' AND f.id IS NULL
+ORDER BY p.id
+LIMIT 10;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.file_id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.file_id
+         Relation Tree: p ANTI f
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@2 as col_1, file_id@1 as col_2, ctid_0@0 as ctid_0]
+           :   SortExec: TopK(fetch=10), expr=[id@2 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[p]
+           :       HashJoinExec: mode=CollectLeft, join_type=RightAnti, on=[(id@0, file_id@1)]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+(17 rows)
+
+SELECT p.id, p.file_id
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page' AND f.id IS NULL
+ORDER BY p.id
+LIMIT 10;
+ id  | file_id 
+-----+---------
+ 150 |     201
+ 151 |     202
+ 152 |     203
+ 153 |     204
+ 154 |     205
+ 155 |     206
+ 156 |     207
+ 157 |     208
+ 158 |     209
+ 159 |     210
+(10 rows)
+
+-- Non-equi ON condition on an outer join: declines JoinScan (the
+-- pipeline would misapply it and change null-extension).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f
+    ON f.id = p.file_id AND p.size_bytes > 2048
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+WARNING:  JoinScan not used: outer joins support only equi-join conditions in the ON clause (tables: f, p)
+                                                                             QUERY PLAN                                                                              
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.file_id, f.title
+   ->  Sort
+         Output: p.id, p.file_id, f.title
+         Sort Key: p.id
+         ->  Hash Left Join
+               Output: p.id, p.file_id, f.title
+               Inner Unique: true
+               Hash Cond: (p.file_id = f.id)
+               Join Filter: (p.size_bytes > 2048)
+               ->  Custom Scan (ParadeDB Base Scan) on public.outer_pages p
+                     Output: p.id, p.file_id, p.size_bytes
+                     Table: outer_pages
+                     Index: outer_pages_idx
+                     Worker Selection: Cost model
+                     Exec Method: NormalScanExecState
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+               ->  Hash
+                     Output: f.title, f.id
+                     ->  Seq Scan on public.outer_files f
+                           Output: f.title, f.id
+(22 rows)
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f
+    ON f.id = p.file_id AND p.size_bytes > 2048
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+WARNING:  JoinScan not used: outer joins support only equi-join conditions in the ON clause (tables: f, p)
+ id | file_id | title 
+----+---------+-------
+  1 |      52 | 
+  2 |      53 | 
+  3 |      54 | 
+  4 |      55 | 
+  5 |      56 | 
+  6 |      57 | 
+  7 |      58 | 
+  8 |      59 | 
+  9 |      60 | 
+ 10 |      61 | 
+(10 rows)
+
+-- =====================================================================
+-- Pass 2: MPP (max_parallel_workers_per_gather = 4). Same queries,
+-- same results.
+-- =====================================================================
+SET max_parallel_workers_per_gather TO 4;
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+                                                                                                QUERY PLAN                                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: p.id, p.file_id, f.title
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: p.id, p.file_id, f.title
+         Relation Tree: f RIGHT p
+         Join Cond: f.id = p.file_id
+         Limit: 10
+         Order By: p.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, file_id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           :   SortPreservingMergeExec: [id@3 ASC NULLS LAST], fetch=10
+           :     SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
+           :       VisibilityFilterExec: tables=[p]
+           :         HashJoinExec: mode=CollectLeft, join_type=Left, on=[(file_id@1, id@1)], projection=[ctid_0@3, ctid_1@0, file_id@1, id@2]
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+           :           VisibilityFilterExec: tables=[f]
+           :             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+           :               PgSearchScan: segments=1, dynamic_filters=1, query="all"
+(18 rows)
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+ id | file_id |  title  
+----+---------+---------
+  1 |      52 | file-52
+  2 |      53 | file-53
+  3 |      54 | file-54
+  4 |      55 | file-55
+  5 |      56 | file-56
+  6 |      57 | file-57
+  7 |      58 | file-58
+  8 |      59 | file-59
+  9 |      60 | file-60
+ 10 |      61 | file-61
+(10 rows)
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.file_id DESC, p.id
+LIMIT 10;
+ id  | file_id | title 
+-----+---------+-------
+ 199 |     250 | 
+ 399 |     250 | 
+ 599 |     250 | 
+ 799 |     250 | 
+ 999 |     250 | 
+ 198 |     249 | 
+ 398 |     249 | 
+ 598 |     249 | 
+ 798 |     249 | 
+ 998 |     249 | 
+(10 rows)
+
+SELECT f.id, f.title, p.id AS page_id
+FROM outer_files f LEFT JOIN outer_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.id, p.id
+LIMIT 10;
+ id |  title  | page_id 
+----+---------+---------
+  1 | file-1  |        
+  2 | file-2  |        
+  3 | file-3  |        
+  4 | file-4  |        
+  5 | file-5  |        
+  6 | file-6  |        
+  7 | file-7  |        
+  8 | file-8  |        
+  9 | file-9  |        
+ 10 | file-10 |        
+(10 rows)
+
+SELECT p.id, p.file_id, f.title
+FROM outer_files f RIGHT JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+ id | file_id |  title  
+----+---------+---------
+  1 |      52 | file-52
+  2 |      53 | file-53
+  3 |      54 | file-54
+  4 |      55 | file-55
+  5 |      56 | file-56
+  6 |      57 | file-57
+  7 |      58 | file-58
+  8 |      59 | file-59
+  9 |      60 | file-60
+ 10 |      61 | file-61
+(10 rows)
+
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+ id | page_id | file_id 
+----+---------+---------
+ 52 |       1 |      52
+ 53 |       2 |      53
+ 54 |       3 |      54
+ 55 |       4 |      55
+ 56 |       5 |      56
+ 57 |       6 |      57
+ 58 |       7 |      58
+ 59 |       8 |      59
+ 60 |       9 |      60
+ 61 |      10 |      61
+(10 rows)
+
+SELECT p.id, p.file_id
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page' AND f.id IS NULL
+ORDER BY p.id
+LIMIT 10;
+ id  | file_id 
+-----+---------
+ 150 |     201
+ 151 |     202
+ 152 |     203
+ 153 |     204
+ 154 |     205
+ 155 |     206
+ 156 |     207
+ 157 |     208
+ 158 |     209
+ 159 |     210
+(10 rows)
+
+-- MPP aggregate over an outer join (the shape from the issue).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+                                                                    QUERY PLAN                                                                     
+---------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan) on public.outer_pages p
+   Output: pdb.agg_fn('COUNT(*)'::text)
+   Index: outer_pages_idx
+   Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+     Applies to Aggregates: COUNT(*)
+     Aggregate Definition: {"0":{"value_count":{"field":"ctid","missing":null}}}
+(6 rows)
+
+SELECT COUNT(*)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+ count 
+-------
+  1000
+(1 row)
+
+-- COUNT(f.id) references the nullable side, so the join survives PG's
+-- join removal and the aggregate runs on the DataFusion backend. The
+-- distributed plan broadcasts the files side and partitions the pages.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(f.id)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+                                                                                    QUERY PLAN                                                                                    
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Custom Scan (ParadeDB Aggregate Scan)
+   Output: pdb.agg_fn('COUNT'::text)
+   Backend: DataFusion
+   Indexes: outer_pages_idx (p), outer_files_idx (f)
+   Aggregates: COUNT(id)
+   DataFusion Physical Plan: 
+     : ┌───── DistributedExec
+     : │ AggregateExec: mode=Final, gby=[], aggr=[count(f_1.id) as agg_0]
+     : │   CoalescePartitionsExec
+     : │     [Stage 2] => NetworkCoalesceExec: output_partitions=9, input_tasks=3
+     : └──────────────────────────────────────────────────
+     :   ┌───── Stage 2 ── tasks=3, partitions=9
+     :   │ AggregateExec: mode=Partial, gby=[], aggr=[count(f_1.id) as agg_0]
+     :   │   HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@0, file_id@0)], projection=[id@0]
+     :   │     CoalescePartitionsExec
+     :   │       [Stage 1] => NetworkBroadcastExec: partitions_per_consumer=1, stage_partitions=3, input_tasks=1
+     :   │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=1
+     :   │       PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+     :   └──────────────────────────────────────────────────
+     :     ┌───── Stage 1 ── tasks=1, partitions=3
+     :     │ BroadcastExec: input_partitions=1, consumer_tasks=3, output_partitions=3
+     :     │   PgSearchScan: segments=1, query="all"
+     :     └──────────────────────────────────────────────────
+(23 rows)
+
+SELECT COUNT(f.id)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+ count 
+-------
+   750
+(1 row)
+
+DROP TABLE outer_pages;
+DROP TABLE outer_files;

--- a/pg_search/tests/pg_regress/expected/join_outer.out
+++ b/pg_search/tests/pg_regress/expected/join_outer.out
@@ -425,8 +425,8 @@ FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
 WHERE p.page_text @@@ 'Page'
 ORDER BY p.id
 LIMIT 10;
-                                                                                                 QUERY PLAN                                                                                                  
--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+                                                                                                  QUERY PLAN                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
    Output: p.id, p.file_id, f.title
    ->  Custom Scan (ParadeDB Join Scan)
@@ -436,17 +436,33 @@ LIMIT 10;
          Limit: 10
          Order By: p.id asc
          DataFusion Physical Plan: 
-           : ProjectionExec: expr=[id@3 as col_1, file_id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
-           :   SortPreservingMergeExec: [id@3 ASC NULLS LAST], fetch=10
-           :     SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
-           :       VisibilityFilterExec: tables=[p]
-           :         HashJoinExec: mode=CollectLeft, join_type=Left, on=[(file_id@1, id@1)], projection=[ctid_0@3, ctid_1@0, file_id@1, id@2]
-           :           CoalescePartitionsExec
-           :             PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
-           :           VisibilityFilterExec: tables=[f]
-           :             RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
-           :               PgSearchScan: segments=2, dynamic_filters=1, query="all"
-(19 rows)
+           : ┌───── DistributedExec
+           : │ ProjectionExec: expr=[id@3 as col_1, file_id@2 as col_2, NULL as col_3, ctid_0@0 as ctid_0, ctid_1@1 as ctid_1]
+           : │   SortPreservingMergeExec: [id@3 ASC NULLS LAST], fetch=10
+           : │     [Stage 3] => NetworkCoalesceExec: output_partitions=6, input_tasks=2
+           : └──────────────────────────────────────────────────
+           :   ┌───── Stage 3 ── tasks=2, partitions=3
+           :   │ SortExec: TopK(fetch=10), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[true]
+           :   │   VisibilityFilterExec: tables=[p]
+           :   │     HashJoinExec: mode=Partitioned, join_type=Left, on=[(file_id@1, id@1)], projection=[ctid_0@3, ctid_1@0, file_id@1, id@2]
+           :   │       [Stage 1] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+           :   │       [Stage 2] => NetworkShuffleExec: output_partitions=3, input_tasks=2
+           :   └──────────────────────────────────────────────────
+           :     ┌───── Stage 1 ── tasks=2, partitions=6
+           :     │ RepartitionExec: partitioning=Hash([file_id@1], 6), input_partitions=2
+           :     │   DistributedLeafExec:
+           :     │     t0: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+           :     │     t1: PgSearchScan: segments=2, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"page_text","query_string":"Page","lenient":null,"conjunction_mode":null}}}}
+           :     └──────────────────────────────────────────────────
+           :     ┌───── Stage 2 ── tasks=2, partitions=6
+           :     │ RepartitionExec: partitioning=Hash([id@1], 6), input_partitions=3
+           :     │   VisibilityFilterExec: tables=[f]
+           :     │     RepartitionExec: partitioning=RoundRobinBatch(3), input_partitions=2
+           :     │       DistributedLeafExec:
+           :     │         t0: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :     │         t1: PgSearchScan: segments=2, dynamic_filters=1, query="all"
+           :     └──────────────────────────────────────────────────
+(35 rows)
 
 SELECT p.id, p.file_id, f.title
 FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id

--- a/pg_search/tests/pg_regress/expected/join_outer_edge.out
+++ b/pg_search/tests/pg_regress/expected/join_outer_edge.out
@@ -1,0 +1,376 @@
+-- Outer-join edge cases through JoinScan: ORDER BY on the nullable side,
+-- score on the nullable side, cross-table OR predicates, ON-clause routing,
+-- and a FULL join that activates the custom scan. join_outer.sql covers the
+-- basic LEFT / RIGHT shapes.
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP TABLE IF EXISTS oj_fact CASCADE;
+DROP TABLE IF EXISTS oj_dim CASCADE;
+CREATE TABLE oj_fact (id INT PRIMARY KEY, dim_id INT, txt TEXT);
+CREATE TABLE oj_dim (id INT PRIMARY KEY, txt TEXT, price INT);
+-- Every third oj_fact row has a NULL dim_id (never matches);
+-- oj_dim rows 41..60 have no oj_fact partner.
+INSERT INTO oj_fact
+SELECT g, CASE WHEN g % 3 = 0 THEN NULL ELSE (g % 40) + 1 END, 'alpha item ' || g
+FROM generate_series(1, 100) g;
+INSERT INTO oj_dim
+SELECT g, 'beta item ' || g, g * 10
+FROM generate_series(1, 60) g;
+CREATE INDEX oj_fact_idx ON oj_fact
+USING bm25 (id, dim_id, txt)
+WITH (key_field='id', numeric_fields='{"dim_id":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
+CREATE INDEX oj_dim_idx ON oj_dim
+USING bm25 (id, txt, price)
+WITH (key_field='id', numeric_fields='{"price":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
+ANALYZE oj_fact;
+ANALYZE oj_dim;
+SET paradedb.enable_join_custom_scan = on;
+-- =============================================================================
+-- ORDER BY on the nullable side: null-extended rows sort as a NULL key
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY b.id NULLS FIRST, a.id LIMIT 8;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: a.id, b.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: a.id, b.id
+         Relation Tree: b RIGHT a
+         Join Cond: a.dim_id = b.id
+         Limit: 8
+         Order By: b.id asc nulls first, a.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=8), expr=[id@1 ASC, id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[a]
+           :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, dim_id@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4]
+           :         VisibilityFilterExec: tables=[b]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY b.id NULLS FIRST, a.id LIMIT 8;
+ id | id 
+----+----
+  3 |   
+  6 |   
+  9 |   
+ 12 |   
+ 15 |   
+ 18 |   
+ 21 |   
+ 24 |   
+(8 rows)
+
+-- =============================================================================
+-- Score on the nullable side: NULL for null-extended rows
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, paradedb.score(b.id) FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+                                                                                              QUERY PLAN                                                                                              
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: a.id, (paradedb.score(b.id))
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: a.id, (paradedb.score(b.id))
+         Relation Tree: b RIGHT a
+         Join Cond: a.dim_id = b.id
+         Limit: 8
+         Order By: a.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, score@0 as col_2, ctid_0@1 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=8), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[a]
+           :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@2, dim_id@1)], projection=[score@0, ctid_0@1, ctid_1@3, id@5]
+           :         VisibilityFilterExec: tables=[b]
+           :           ProjectionExec: expr=[pdb.score()@0 as score, ctid_0@1 as ctid_0, id@2 as id]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query="all"
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, dynamic_filters=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+(19 rows)
+
+SELECT a.id, paradedb.score(b.id) FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+ id | score 
+----+-------
+  1 |     0
+  2 |     0
+  3 |      
+  4 |     0
+  5 |     0
+  6 |      
+  7 |     0
+  8 |     0
+(8 rows)
+
+-- =============================================================================
+-- Cross-table OR search predicate as a WHERE (post-join) filter
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' OR b.txt @@@ 'beta' ORDER BY a.id LIMIT 8;
+                                                                                                                                       QUERY PLAN                                                                                                                                        
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: a.id, b.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: a.id, b.id
+         Relation Tree: b RIGHT a
+         Join Cond: a.dim_id = b.id
+         Join Predicate: (a:{"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}} OR b:{"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"beta","lenient":null,"conjunction_mode":null}}}})
+         Limit: 8
+         Order By: a.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=8), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[a]
+           :       FilterExec: pdb_search_predicate(ctid_1@2) OR pdb_search_predicate(ctid_0@0)
+           :         HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, dim_id@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4]
+           :           VisibilityFilterExec: tables=[b]
+           :             CooperativeExec
+           :               PgSearchScan: segments=1, query="all"
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query="all"
+(20 rows)
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' OR b.txt @@@ 'beta' ORDER BY a.id LIMIT 8;
+ id | id 
+----+----
+  1 |  2
+  2 |  3
+  3 |   
+  4 |  5
+  5 |  6
+  6 |   
+  7 |  8
+  8 |  9
+(8 rows)
+
+-- =============================================================================
+-- ON-clause qual on the nullable side only: PG pushes it into that scan,
+-- so JoinScan sees a plain equi-join and stays active
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: a.id, b.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: a.id, b.id
+         Relation Tree: b RIGHT a
+         Join Cond: a.dim_id = b.id
+         Limit: 8
+         Order By: a.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=8), expr=[id@3 ASC NULLS LAST], preserve_partitioning=[false]
+           :     VisibilityFilterExec: tables=[a]
+           :       HashJoinExec: mode=CollectLeft, join_type=Right, on=[(id@1, dim_id@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4]
+           :         VisibilityFilterExec: tables=[b]
+           :           CooperativeExec
+           :             PgSearchScan: segments=1, query={"range":{"field":"price","lower_bound":{"excluded":100},"upper_bound":null}}
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+ id | id 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  7 |   
+  8 |   
+(8 rows)
+
+-- =============================================================================
+-- Two-sided non-equi ON condition: declines with a warning
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+WARNING:  JoinScan not used: outer joins support only equi-join conditions in the ON clause (tables: a, b)
+                                                                           QUERY PLAN                                                                           
+----------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: a.id, b.id
+   ->  Sort
+         Output: a.id, b.id
+         Sort Key: a.id
+         ->  Hash Left Join
+               Output: a.id, b.id
+               Inner Unique: true
+               Hash Cond: (a.dim_id = b.id)
+               Join Filter: (a.id < b.price)
+               ->  Custom Scan (ParadeDB Base Scan) on public.oj_fact a
+                     Output: a.id, a.dim_id
+                     Table: oj_fact
+                     Index: oj_fact_idx
+                     Worker Selection: Cost model
+                     Exec Method: ColumnarExecState
+                     Fast Fields: dim_id, id
+                     Scores: false
+                     Tantivy Query: {"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+               ->  Hash
+                     Output: b.id, b.price
+                     ->  Seq Scan on public.oj_dim b
+                           Output: b.id, b.price
+(23 rows)
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+WARNING:  JoinScan not used: outer joins support only equi-join conditions in the ON clause (tables: a, b)
+ id | id 
+----+----
+  1 |  2
+  2 |  3
+  3 |   
+  4 |  5
+  5 |  6
+  6 |   
+  7 |  8
+  8 |  9
+(8 rows)
+
+-- =============================================================================
+-- FULL join: the search predicate lives inside a pulled-up subquery, below
+-- the join, so PG can neither reduce the FULL join nor reject it, and
+-- JoinScan runs it
+-- =============================================================================
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, b.id FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id ORDER BY f.id NULLS FIRST, b.id LIMIT 12;
+                                                                                    QUERY PLAN                                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Limit
+   Output: oj_fact.id, b.id
+   ->  Custom Scan (ParadeDB Join Scan)
+         Output: oj_fact.id, b.id
+         Relation Tree: b FULL oj_fact
+         Join Cond: oj_fact.dim_id = b.id
+         Limit: 12
+         Order By: oj_fact.id asc nulls first, b.id asc
+         DataFusion Physical Plan: 
+           : ProjectionExec: expr=[id@3 as col_1, id@1 as col_2, ctid_0@0 as ctid_0, ctid_1@2 as ctid_1]
+           :   SortExec: TopK(fetch=12), expr=[id@3 ASC, id@1 ASC NULLS LAST], preserve_partitioning=[false]
+           :     HashJoinExec: mode=CollectLeft, join_type=Full, on=[(id@1, dim_id@1)], projection=[ctid_0@0, id@1, ctid_1@2, id@4]
+           :       VisibilityFilterExec: tables=[b]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query="all"
+           :       VisibilityFilterExec: tables=[oj_fact]
+           :         CooperativeExec
+           :           PgSearchScan: segments=1, query={"with_index":{"query":{"parse_with_field":{"field":"txt","query_string":"alpha","lenient":null,"conjunction_mode":null}}}}
+(18 rows)
+
+SELECT f.id, b.id FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id ORDER BY f.id NULLS FIRST, b.id LIMIT 12;
+ id | id 
+----+----
+    | 41
+    | 42
+    | 43
+    | 44
+    | 45
+    | 46
+    | 47
+    | 48
+    | 49
+    | 50
+    | 51
+    | 52
+(12 rows)
+
+SELECT COUNT(*) FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id;
+ count 
+-------
+   120
+(1 row)
+
+-- =============================================================================
+-- Baselines with JoinScan off: results must match the sections above.
+-- paradedb.score() on the nullable side has no non-JoinScan fallback, so it
+-- has no baseline here.
+-- =============================================================================
+SET paradedb.enable_join_custom_scan = off;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY b.id NULLS FIRST, a.id LIMIT 8;
+ id | id 
+----+----
+  3 |   
+  6 |   
+  9 |   
+ 12 |   
+ 15 |   
+ 18 |   
+ 21 |   
+ 24 |   
+(8 rows)
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' OR b.txt @@@ 'beta' ORDER BY a.id LIMIT 8;
+WARNING:  the table is being sequentially scanned for this query, so performance may be slow
+if you are not sure why, please file an issue: https://github.com/paradedb/paradedb/issues/new/choose
+ id | id 
+----+----
+  1 |  2
+  2 |  3
+  3 |   
+  4 |  5
+  5 |  6
+  6 |   
+  7 |  8
+  8 |  9
+(8 rows)
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+ id | id 
+----+----
+  1 |   
+  2 |   
+  3 |   
+  4 |   
+  5 |   
+  6 |   
+  7 |   
+  8 |   
+(8 rows)
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+ id | id 
+----+----
+  1 |  2
+  2 |  3
+  3 |   
+  4 |  5
+  5 |  6
+  6 |   
+  7 |  8
+  8 |  9
+(8 rows)
+
+SELECT f.id, b.id FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id ORDER BY f.id NULLS FIRST, b.id LIMIT 12;
+ id | id 
+----+----
+    | 41
+    | 42
+    | 43
+    | 44
+    | 45
+    | 46
+    | 47
+    | 48
+    | 49
+    | 50
+    | 51
+    | 52
+(12 rows)
+
+SELECT COUNT(*) FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id;
+ count 
+-------
+   120
+(1 row)
+
+DROP TABLE oj_fact;
+DROP TABLE oj_dim;

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -169,7 +169,7 @@ AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
 WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
                                                                                       QUERY PLAN                                                                                      
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -220,7 +220,7 @@ AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
 WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
  id  |    category     
 -----+-----------------
   10 | target_category

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -169,7 +169,6 @@ AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
 WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
                                                                                       QUERY PLAN                                                                                      
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -220,7 +219,6 @@ AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
 WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
  id  |    category     
 -----+-----------------
   10 | target_category

--- a/pg_search/tests/pg_regress/expected/join_semi_anti.out
+++ b/pg_search/tests/pg_regress/expected/join_semi_anti.out
@@ -169,6 +169,7 @@ AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
 WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
                                                                                       QUERY PLAN                                                                                      
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -219,6 +220,7 @@ AND id @@@ 'category:"target_category"'
 ORDER BY id ASC
 LIMIT 10;
 WARNING:  JoinScan not used: join keys must be fast fields (tables: table_a, table_b)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: table_a, table_b)
  id  |    category     
 -----+-----------------
   10 | target_category

--- a/pg_search/tests/pg_regress/expected/join_tests.out
+++ b/pg_search/tests/pg_regress/expected/join_tests.out
@@ -150,7 +150,7 @@ FROM authors a
 LEFT JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'mystery' OR b.content @@@ 'romance')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
    author_name   |     book_title      | author_score | book_score 
 -----------------+---------------------+--------------+------------
  Agatha Christie | Murder Mystery Case |    1.5552412 |          0
@@ -166,7 +166,7 @@ FROM authors a
 RIGHT JOIN books b ON a.id = b.author_id
 WHERE (a.bio @@@ 'fiction' OR b.content @@@ 'magic')
 ORDER BY a.id, b.id, author_score DESC, book_score DESC;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  author_name  |      book_title      | author_score | book_score 
 --------------+----------------------+--------------+------------
  J.K. Rowling | Harry Potter Magic   |            0 |  1.3025584
@@ -489,7 +489,7 @@ FROM authors a
 LEFT JOIN books b ON a.id = b.author_id
 WHERE a.bio @@@ 'author' OR b.content @@@ 'story'
 ORDER BY a.id, b.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
    author_name   |      book_title      | author_score | book_score 
 -----------------+----------------------+--------------+------------
  J.K. Rowling    | Harry Potter Magic   |   0.66167223 | 0.27030534

--- a/pg_search/tests/pg_regress/expected/lateral-join.out
+++ b/pg_search/tests/pg_regress/expected/lateral-join.out
@@ -303,7 +303,7 @@ LEFT JOIN authors au ON a.author_id = au.id
 WHERE a.content @@@ 'technology'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, au)
+WARNING:  JoinScan not used: join keys must be fast fields (tables: a, au)
                                                                                QUERY PLAN                                                                                
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  Limit
@@ -331,7 +331,7 @@ LEFT JOIN authors au ON a.author_id = au.id
 WHERE a.content @@@ 'technology'
 ORDER BY paradedb.score(a.id) DESC
 LIMIT 5;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, au)
+WARNING:  JoinScan not used: join keys must be fast fields (tables: a, au)
  id |            title             |   score   | author_name 
 ----+------------------------------+-----------+-------------
  11 | Computer Vision Applications | 2.2999182 | Jane Smith

--- a/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
+++ b/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
@@ -85,7 +85,7 @@ AND EXISTS(
 )
 ORDER BY u.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: t, u)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: t, u)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: t, u)
  id | name  
 ----+-------
   1 | Alice
@@ -112,7 +112,7 @@ AND EXISTS(
 )
 ORDER BY u.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, id, t, ti, u)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: d, id, t, ti, u)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: d, id, t, ti, u)
  id | name 
 ----+------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
+++ b/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
@@ -85,7 +85,6 @@ AND EXISTS(
 )
 ORDER BY u.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: t, u)
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: t, u)
  id | name  
 ----+-------
   1 | Alice
@@ -112,7 +111,6 @@ AND EXISTS(
 )
 ORDER BY u.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, id, t, ti, u)
-WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: d, id, t, ti, u)
  id | name 
 ----+------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
+++ b/pg_search/tests/pg_regress/expected/or_exists_join_bug.out
@@ -85,6 +85,7 @@ AND EXISTS(
 )
 ORDER BY u.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: t, u)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: t, u)
  id | name  
 ----+-------
   1 | Alice
@@ -111,6 +112,7 @@ AND EXISTS(
 )
 ORDER BY u.id;
 WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: d, id, t, ti, u)
+WARNING:  JoinScan not used: unsupported join type (types: RIGHTSEMI, UNIQUEINNER, UNIQUEOUTER) (tables: d, id, t, ti, u)
  id | name 
 ----+------
 (0 rows)

--- a/pg_search/tests/pg_regress/expected/score_join_predicates.out
+++ b/pg_search/tests/pg_regress/expected/score_join_predicates.out
@@ -249,7 +249,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'Christie' OR b.content @@@ 'test') AND a.age > 60
 ORDER BY a.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 -- Test multiple score functions in same query
 -- This tests if score calculation is consistent across multiple score calls
@@ -317,7 +317,7 @@ FROM books b
 LEFT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY b.id, a.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0
@@ -330,7 +330,7 @@ FROM books b
 RIGHT JOIN authors a ON b.author_id = a.id
 WHERE (a.name @@@ 'King' OR b.content @@@ 'scoring')
 ORDER BY a.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
  id |     name     | author_score | book_score 
 ----+--------------+--------------+------------
   1 | Stephen King |    1.5404451 |          0

--- a/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_json_02_advanced.out
@@ -104,7 +104,7 @@ WHERE b.id @@@ paradedb.parse('metadata.content:test')
     OR r.id @@@ paradedb.parse('metadata.review:test')
     OR r.id @@@ paradedb.parse('metadata.review:snippet')
 ORDER BY b.id, r.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b, r)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
  book_id |   author_name   |                                                                       book_snippet                                                                       |         book_positions          |                            author_snippet                            | author_positions |                                               review_snippet                                                |         review_positions         | book_score | author_score | review_score 
 ---------+-----------------+----------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------+----------------------------------------------------------------------+------------------+-------------------------------------------------------------------------------------------------------------+----------------------------------+------------+--------------+--------------
        1 | Stephen King    | This is a <b>test</b> <b>test</b> of the snippet function with multiple <b>test</b> words                                                                | {{10,14},{15,19},{58,62}}       |                                                                      |                  | This is a <b>test</b> review of the <b>snippet</b> function with multiple <b>test</b> words                 | {{10,14},{29,36},{60,64}}        | 0.21010332 |            0 |   0.83736646
@@ -168,8 +168,7 @@ LEFT JOIN reviews r ON r.book_id = b.id
 WHERE (a.id @@@ paradedb.parse('metadata.age:55'))
     AND (a.id @@@ paradedb.parse('metadata.text:author') OR b.id @@@ paradedb.parse('metadata.content:test'))
 ORDER BY a.id, b.id, r.id;
-WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b)
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b, r)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
 ERROR:  Unsupported query shape. Please report at https://github.com/paradedb/paradedb/issues/new/choose
 \i common/snippet_json_advanced_cleanup.sql
 DROP TABLE IF EXISTS authors;

--- a/pg_search/tests/pg_regress/expected/snippet_position_01_advanced.out
+++ b/pg_search/tests/pg_regress/expected/snippet_position_01_advanced.out
@@ -256,7 +256,7 @@ WHERE b.content @@@ 'test'
     OR r.review @@@ 'test'
     OR r.review @@@ 'snippet'
 ORDER BY b.id, r.id;
-WARNING:  JoinScan not used: only INNER, ANTI, and SEMI JOIN are currently supported (types: LEFT, RIGHT) (tables: a, b, r)
+WARNING:  JoinScan not used: LIMIT is required for top-level queries (tables: a, b, r)
  book_id |                                                                       book_snippet                                                                       |         book_positions          |   author_snippet    | author_positions |                                               review_snippet                                                |         review_positions         | book_score | author_score | review_score 
 ---------+----------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------+---------------------+------------------+-------------------------------------------------------------------------------------------------------------+----------------------------------+------------+--------------+--------------
        1 |                                                                                                                                                          |                                 | J.K. <b>Rowling</b> | {{5,12}}         | This is a <b>test</b> review of the <b>snippet</b> function with multiple <b>test</b> words                 | {{10,14},{29,36},{60,64}}        |          0 |    1.5404451 |     0.494645

--- a/pg_search/tests/pg_regress/sql/join_basic.sql
+++ b/pg_search/tests/pg_regress/sql/join_basic.sql
@@ -135,7 +135,7 @@ LIMIT 5;
 -- TEST 4: JoinScan should NOT be proposed for non-INNER joins (for now)
 -- =============================================================================
 
--- LEFT JOIN with LIMIT - should NOT use JoinScan (M1 only handles INNER JOIN)
+-- LEFT JOIN with LIMIT - uses JoinScan
 EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
 SELECT p.id, p.name, s.name AS supplier_name
 FROM products p

--- a/pg_search/tests/pg_regress/sql/join_outer.sql
+++ b/pg_search/tests/pg_regress/sql/join_outer.sql
@@ -1,0 +1,254 @@
+-- =====================================================================
+-- Outer joins (LEFT / RIGHT / FULL) through JoinScan, serial and MPP.
+--
+-- Data is shaped so both sides have unmatched rows: files 1..50 have
+-- no pages, and pages with file_id 201..250 have no file. Each query
+-- runs in a serial pass and an MPP pass; results must match.
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+SET paradedb.enable_aggregate_custom_scan TO on;
+SET paradedb.enable_join_custom_scan TO on;
+
+SET paradedb.mpp_worker_count TO 4;
+SET max_parallel_workers_per_gather TO 4;
+SET max_parallel_workers TO 8;
+-- Force parallel even on this tiny dataset; otherwise the cost-based
+-- planner picks the serial JoinScan and MPP never activates.
+SET min_parallel_table_scan_size TO 0;
+SET parallel_setup_cost TO 0;
+SET parallel_tuple_cost TO 0;
+
+-- =====================================================================
+-- Test data
+-- =====================================================================
+
+CREATE TABLE outer_files (
+    id SERIAL PRIMARY KEY,
+    title TEXT,
+    content TEXT
+);
+CREATE TABLE outer_pages (
+    id SERIAL PRIMARY KEY,
+    file_id INTEGER,
+    page_text TEXT,
+    size_bytes INTEGER
+);
+
+INSERT INTO outer_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 200) AS g;
+
+-- file_id 51..250: files 1..50 stay unmatched, ids 201..250 dangle.
+INSERT INTO outer_pages (file_id, page_text, size_bytes)
+SELECT 51 + (g % 200),
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 1000) AS g;
+
+CREATE INDEX outer_files_idx ON outer_files
+USING bm25 (id, title, content)
+WITH (
+    key_field='id',
+    text_fields='{"title": {"fast": true}, "content": {}}'
+);
+
+CREATE INDEX outer_pages_idx ON outer_pages
+USING bm25 (id, file_id, page_text, size_bytes)
+WITH (
+    key_field='id',
+    numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
+    text_fields='{"page_text": {"fast": true}}'
+);
+
+ANALYZE outer_files;
+ANALYZE outer_pages;
+
+-- =====================================================================
+-- Pass 1: serial JoinScan (max_parallel_workers_per_gather = 0)
+-- =====================================================================
+
+SET max_parallel_workers_per_gather TO 0;
+
+-- LEFT: pages preserved, unmatched pages null-extend the files side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+-- LEFT with the null-extended region on top (dangling file_ids).
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.file_id DESC, p.id
+LIMIT 10;
+
+-- LEFT: small side preserved, unmatched files null-extend the pages side.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, f.title, p.id AS page_id
+FROM outer_files f LEFT JOIN outer_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.id, p.id
+LIMIT 10;
+
+SELECT f.id, f.title, p.id AS page_id
+FROM outer_files f LEFT JOIN outer_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.id, p.id
+LIMIT 10;
+
+-- RIGHT: mirror of the first LEFT.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_files f RIGHT JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id, f.title
+FROM outer_files f RIGHT JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+-- FULL: both directions null-extend. The @@@ predicate sits in the ON
+-- clause; in WHERE it would reject null-extended file rows and reduce
+-- the join. Search predicates in outer ON clauses decline JoinScan, so
+-- this exercises the fallback, not the custom scan. No EXPLAIN: the
+-- fallback plan serializes the index OID into the join filter, which
+-- changes on every run.
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id AND f.content @@@ 'Section'
+ORDER BY f.id NULLS LAST, p.id NULLS LAST
+LIMIT 10;
+
+-- FULL with the search predicate in WHERE on the pages side: null-
+-- extended page rows can't satisfy it, so PG reduces to LEFT
+-- (pages preserved) before the join hook runs.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+-- Anti-join spelled as LEFT ... IS NULL: only the null-extended rows.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page' AND f.id IS NULL
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page' AND f.id IS NULL
+ORDER BY p.id
+LIMIT 10;
+
+-- Non-equi ON condition on an outer join: declines JoinScan (the
+-- pipeline would misapply it and change null-extension).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f
+    ON f.id = p.file_id AND p.size_bytes > 2048
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f
+    ON f.id = p.file_id AND p.size_bytes > 2048
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+-- =====================================================================
+-- Pass 2: MPP (max_parallel_workers_per_gather = 4). Same queries,
+-- same results.
+-- =====================================================================
+
+SET max_parallel_workers_per_gather TO 4;
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id, f.title
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.file_id DESC, p.id
+LIMIT 10;
+
+SELECT f.id, f.title, p.id AS page_id
+FROM outer_files f LEFT JOIN outer_pages p ON f.id = p.file_id
+WHERE f.content @@@ 'Section'
+ORDER BY f.id, p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id, f.title
+FROM outer_files f RIGHT JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT f.id, p.id AS page_id, p.file_id
+FROM outer_files f FULL JOIN outer_pages p ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page'
+ORDER BY p.id
+LIMIT 10;
+
+SELECT p.id, p.file_id
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page' AND f.id IS NULL
+ORDER BY p.id
+LIMIT 10;
+
+-- MPP aggregate over an outer join (the shape from the issue).
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(*)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+
+SELECT COUNT(*)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+
+-- COUNT(f.id) references the nullable side, so the join survives PG's
+-- join removal and the aggregate runs on the DataFusion backend. The
+-- distributed plan broadcasts the files side and partitions the pages.
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT COUNT(f.id)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+
+SELECT COUNT(f.id)
+FROM outer_pages p LEFT JOIN outer_files f ON f.id = p.file_id
+WHERE p.page_text @@@ 'Page';
+
+DROP TABLE outer_pages;
+DROP TABLE outer_files;

--- a/pg_search/tests/pg_regress/sql/join_outer.sql
+++ b/pg_search/tests/pg_regress/sql/join_outer.sql
@@ -36,17 +36,6 @@ CREATE TABLE outer_pages (
     size_bytes INTEGER
 );
 
-INSERT INTO outer_files (title, content)
-SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
-FROM generate_series(1, 200) AS g;
-
--- file_id 51..250: files 1..50 stay unmatched, ids 201..250 dangle.
-INSERT INTO outer_pages (file_id, page_text, size_bytes)
-SELECT 51 + (g % 200),
-       'Page text for page ' || g,
-       (g * 17) % 4096
-FROM generate_series(1, 1000) AS g;
-
 CREATE INDEX outer_files_idx ON outer_files
 USING bm25 (id, title, content)
 WITH (
@@ -61,6 +50,31 @@ WITH (
     numeric_fields='{"file_id": {"fast": true}, "size_bytes": {"fast": true}}',
     text_fields='{"page_text": {"fast": true}}'
 );
+
+-- Two inserts per table, each flushed to its own segment, so the scans
+-- report more than one partition and the distributed planner engages.
+SET paradedb.global_mutable_segment_rows = 0;
+
+INSERT INTO outer_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(1, 100) AS g;
+
+INSERT INTO outer_files (title, content)
+SELECT 'file-' || g, 'Section ' || g || ' has content for testing'
+FROM generate_series(101, 200) AS g;
+
+-- file_id 51..250: files 1..50 stay unmatched, ids 201..250 dangle.
+INSERT INTO outer_pages (file_id, page_text, size_bytes)
+SELECT 51 + (g % 200),
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(1, 500) AS g;
+
+INSERT INTO outer_pages (file_id, page_text, size_bytes)
+SELECT 51 + (g % 200),
+       'Page text for page ' || g,
+       (g * 17) % 4096
+FROM generate_series(501, 1000) AS g;
 
 ANALYZE outer_files;
 ANALYZE outer_pages;

--- a/pg_search/tests/pg_regress/sql/join_outer_edge.sql
+++ b/pg_search/tests/pg_regress/sql/join_outer_edge.sql
@@ -1,0 +1,106 @@
+-- Outer-join edge cases through JoinScan: ORDER BY on the nullable side,
+-- score on the nullable side, cross-table OR predicates, ON-clause routing,
+-- and a FULL join that activates the custom scan. join_outer.sql covers the
+-- basic LEFT / RIGHT shapes.
+
+SET max_parallel_workers_per_gather = 0;
+SET enable_indexscan to OFF;
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP TABLE IF EXISTS oj_fact CASCADE;
+DROP TABLE IF EXISTS oj_dim CASCADE;
+
+CREATE TABLE oj_fact (id INT PRIMARY KEY, dim_id INT, txt TEXT);
+CREATE TABLE oj_dim (id INT PRIMARY KEY, txt TEXT, price INT);
+
+-- Every third oj_fact row has a NULL dim_id (never matches);
+-- oj_dim rows 41..60 have no oj_fact partner.
+INSERT INTO oj_fact
+SELECT g, CASE WHEN g % 3 = 0 THEN NULL ELSE (g % 40) + 1 END, 'alpha item ' || g
+FROM generate_series(1, 100) g;
+INSERT INTO oj_dim
+SELECT g, 'beta item ' || g, g * 10
+FROM generate_series(1, 60) g;
+
+CREATE INDEX oj_fact_idx ON oj_fact
+USING bm25 (id, dim_id, txt)
+WITH (key_field='id', numeric_fields='{"dim_id":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
+CREATE INDEX oj_dim_idx ON oj_dim
+USING bm25 (id, txt, price)
+WITH (key_field='id', numeric_fields='{"price":{"fast":true}}', text_fields='{"txt":{"fast":true}}');
+
+ANALYZE oj_fact;
+ANALYZE oj_dim;
+
+SET paradedb.enable_join_custom_scan = on;
+
+-- =============================================================================
+-- ORDER BY on the nullable side: null-extended rows sort as a NULL key
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY b.id NULLS FIRST, a.id LIMIT 8;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY b.id NULLS FIRST, a.id LIMIT 8;
+
+-- =============================================================================
+-- Score on the nullable side: NULL for null-extended rows
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, paradedb.score(b.id) FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+SELECT a.id, paradedb.score(b.id) FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+
+-- =============================================================================
+-- Cross-table OR search predicate as a WHERE (post-join) filter
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' OR b.txt @@@ 'beta' ORDER BY a.id LIMIT 8;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' OR b.txt @@@ 'beta' ORDER BY a.id LIMIT 8;
+
+-- =============================================================================
+-- ON-clause qual on the nullable side only: PG pushes it into that scan,
+-- so JoinScan sees a plain equi-join and stays active
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+
+-- =============================================================================
+-- Two-sided non-equi ON condition: declines with a warning
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+
+-- =============================================================================
+-- FULL join: the search predicate lives inside a pulled-up subquery, below
+-- the join, so PG can neither reduce the FULL join nor reject it, and
+-- JoinScan runs it
+-- =============================================================================
+
+EXPLAIN (COSTS OFF, VERBOSE, TIMING OFF)
+SELECT f.id, b.id FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id ORDER BY f.id NULLS FIRST, b.id LIMIT 12;
+SELECT f.id, b.id FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id ORDER BY f.id NULLS FIRST, b.id LIMIT 12;
+SELECT COUNT(*) FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id;
+
+-- =============================================================================
+-- Baselines with JoinScan off: results must match the sections above.
+-- paradedb.score() on the nullable side has no non-JoinScan fallback, so it
+-- has no baseline here.
+-- =============================================================================
+
+SET paradedb.enable_join_custom_scan = off;
+
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' ORDER BY b.id NULLS FIRST, a.id LIMIT 8;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id WHERE a.txt @@@ 'alpha' OR b.txt @@@ 'beta' ORDER BY a.id LIMIT 8;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND b.price > 100 WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+SELECT a.id, b.id FROM oj_fact a LEFT JOIN oj_dim b ON a.dim_id = b.id AND a.id < b.price WHERE a.txt @@@ 'alpha' ORDER BY a.id LIMIT 8;
+SELECT f.id, b.id FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id ORDER BY f.id NULLS FIRST, b.id LIMIT 12;
+SELECT COUNT(*) FROM (SELECT * FROM oj_fact WHERE txt @@@ 'alpha') f FULL JOIN oj_dim b ON f.dim_id = b.id;
+
+DROP TABLE oj_fact;
+DROP TABLE oj_dim;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5335

## What

Enabled `LEFT`, `RIGHT`, and `FULL` joins in JoinScan, and fixed the bugs that were hiding behind the old inner-only gate.

## Why

The gate predates outer-join support in the rest of the stack: the DataFusion translator and the visibility barriers already handle these join types, only the allow-list was left. The aggregate-on-join path already runs outer joins through MPP.

## How

- `collect_unsupported_join_types` accepts `Left` / `Right` / `Full`. Outer joins with non-equi ON conditions still decline, because the join-level predicate pipeline applies those as scan-level or post-join filters, which changes which rows null-extend. ON quals on the nullable side alone keep working; PG pushes them into that scan.
- The LIMIT-pushdown check compares absorbed relations against `all_baserels` instead of `all_query_rels`. On PG16+ the latter also carries outer-join relids, which are join identities and can never be absorbed, so every outer join failed the subset check.
- Tuple materialization checks the Arrow null bitmap on ctid columns. A null-extended row has a NULL ctid; reading it as a value fetched an unrelated heap tuple. Columns from that side (including `paradedb.score()`) now come out NULL.
- No MPP-side gating is needed: the pinned `datafusion-distributed` rewrites broadcast-unsafe collect-build joins to partitioned mode (datafusion-contrib/datafusion-distributed#563), so both outer-join orientations distribute.

BTW, to reproduce the original report: `COUNT(*)` with an unreferenced unique `dim.id` gets join-removed by PG and never exercises a join. `COUNT(d.id)` keeps the join alive; its plan shows `DistributedExec` with `dim` broadcast and `fact` partitioned.

## Tests

- `join_outer.sql`: LEFT / RIGHT / FULL through JoinScan and MPP, both orientations, the anti-join `IS NULL` pattern, and the decline paths. Serial and MPP passes must return the same rows.
- `join_outer_edge.sql`: ORDER BY on the nullable side, score on the nullable side, cross-table OR predicates, ON-clause routing, and a FULL join that activates JoinScan. Results are checked against `enable_join_custom_scan = off` baselines.
- Unit tests for the new task estimator.
- Expected outputs of existing tests updated where outer joins now reach later decline gates or switch to JoinScan.

