### PR TITLE
fix: don't push LIMIT below a row-reducing `unnest` in BaseScan

### DIFF
--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -521,8 +521,7 @@ unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetList
         }
         match nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
             Some(func_expr)
-                if is_unnest_func((*func_expr).funcid)
-                    && unnest_arg_is_paradedb_srf(func_expr) =>
+                if is_unnest_func((*func_expr).funcid) && unnest_arg_is_paradedb_srf(func_expr) =>
             {
                 found_safe = true
             }

--- a/pg_search/src/postgres/customscan/basescan/mod.rs
+++ b/pg_search/src/postgres/customscan/basescan/mod.rs
@@ -477,7 +477,18 @@ pub(super) unsafe fn query_has_window_agg_functions(root: *mut pg_sys::PlannerIn
 /// Classification of any set-returning function found in the target list,
 /// used to decide whether pushing LIMIT through this scan is safe. PG sets
 /// `limit_tuples == -1.0` whenever any SRF is present, so we walk once and
-/// distinguish between "no SRF / safe (unnest only) / unsafe".
+/// distinguish between "no SRF / safe (unnest of a ParadeDB SRF placeholder) /
+/// unsafe (any other SRF, or `unnest` of a user expression)".
+///
+/// The `Safe` case must stay narrow: `unnest` is only row-preserving when its
+/// argument is guaranteed non-empty, and for a user expression that is a
+/// data-dependent property unknowable at plan time — an empty or NULL array
+/// silently drops rows below the LIMIT with nothing to refill (see #5573).
+/// The paradedb snippet SRFs (`pdb.snippets`, `pdb.snippet_positions`, and
+/// their legacy `paradedb.*` shims) are placeholders that only fire for rows
+/// the CustomScan actually matched; their output vectors are non-empty by
+/// construction on matching rows, so `unnest(pdb.snippets(...))` may safely
+/// take the LIMIT-pushdown fast path.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TargetListSrf {
     None,
@@ -494,9 +505,10 @@ impl TargetListSrf {
     }
 }
 
-/// Walk the target list once and classify any SRFs. Only `unnest` is
-/// row-preserving (and therefore limit-safe); everything else is treated as
-/// unsafe so LIMIT pushdown stops above the scan.
+/// Walk the target list once and classify any SRFs. Only `unnest` whose
+/// argument is a ParadeDB snippet placeholder function is treated as safe;
+/// everything else — arbitrary `unnest` of a user expression, or any other
+/// SRF — is unsafe so LIMIT pushdown stops above the scan.
 unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetListSrf {
     if root.is_null() || (*root).parse.is_null() || (*(*root).parse).targetList.is_null() {
         return TargetListSrf::None;
@@ -508,7 +520,12 @@ unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetList
             continue;
         }
         match nodecast!(FuncExpr, T_FuncExpr, (*te).expr) {
-            Some(func_expr) if is_unnest_func((*func_expr).funcid) => found_safe = true,
+            Some(func_expr)
+                if is_unnest_func((*func_expr).funcid)
+                    && unnest_arg_is_paradedb_srf(func_expr) =>
+            {
+                found_safe = true
+            }
             _ => return TargetListSrf::Unsafe,
         }
     }
@@ -517,6 +534,28 @@ unsafe fn classify_target_list_srf(root: *mut pg_sys::PlannerInfo) -> TargetList
     } else {
         TargetListSrf::None
     }
+}
+
+/// True when the sole argument to an `unnest` FuncExpr is a call to one of
+/// the ParadeDB snippet/placeholder SRFs whose output vector is non-empty by
+/// construction on matching rows (`pdb.snippets`, `pdb.snippet_positions`,
+/// and their legacy `paradedb.*` shims). Any other argument shape — a Var,
+/// a CASE, a user function — cannot be proved non-empty at plan time.
+unsafe fn unnest_arg_is_paradedb_srf(unnest_expr: *mut pg_sys::FuncExpr) -> bool {
+    use crate::postgres::customscan::basescan::projections::snippet::{
+        snippet_positions_funcoids, snippets_funcoids,
+    };
+
+    let args = PgList::<pg_sys::Node>::from_pg((*unnest_expr).args);
+    if args.len() != 1 {
+        return false;
+    }
+    let arg = args.get_ptr(0).unwrap_or(std::ptr::null_mut());
+    let Some(inner) = nodecast!(FuncExpr, T_FuncExpr, arg) else {
+        return false;
+    };
+    let inner_oid = (*inner).funcid;
+    snippets_funcoids().contains(&inner_oid) || snippet_positions_funcoids().contains(&inner_oid)
 }
 
 /// Returns `true` if any predicate in `baserestrictinfo` cannot be fully
@@ -745,8 +784,11 @@ impl CustomScan for BaseScan {
             //   - PG already proved it safe (`limit_tuples > -1.0`)
             //   - The value is a Param (PG can't evaluate at plan time but
             //     we can at exec time)
-            //   - A row-preserving `unnest` SRF zeroed PG's `limit_tuples`,
-            //     but `limit + offset` rows here is still enough
+            //   - A row-preserving `unnest` of a ParadeDB snippet SRF zeroed
+            //     PG's `limit_tuples`, but `limit + offset` rows here is
+            //     still enough (the paradedb SRF is non-empty by
+            //     construction on matching rows). `unnest` of a user
+            //     expression is NOT covered by this override — see #5573.
             // `is_limit_pushdown_safe` then gates on topology + predicates +
             // unsafe SRFs.
             let raw_limit_offset = LimitOffset::from_root(builder.args().root);

--- a/pg_search/tests/pg_regress/expected/basescan_limit_unnest.out
+++ b/pg_search/tests/pg_regress/expected/basescan_limit_unnest.out
@@ -1,0 +1,94 @@
+-- =====================================================================
+-- Issue #5573: LIMIT must not be pushed into BaseScan when a
+--              row-reducing set-returning function sits above it.
+-- =====================================================================
+-- Before the fix, `classify_target_list_srf` marked `unnest` as
+-- "row-preserving" and let BaseScan cap its TopK to `LIMIT` rows.
+-- `unnest(ARRAY[]::T[])` and `unnest(NULL)` emit ZERO rows, so the
+-- ProjectSet above the scan then discarded rows from an already-capped
+-- output and returned fewer than LIMIT results.
+--
+-- This test exercises the buggy case (mixed empty/NULL/non-empty
+-- arrays under `unnest` with a `@@@` predicate + LIMIT) and asserts
+-- the query returns exactly LIMIT rows.
+CREATE EXTENSION IF NOT EXISTS pg_search;
+DROP SCHEMA IF EXISTS pdb_unnest_limit CASCADE;
+CREATE SCHEMA pdb_unnest_limit;
+SET search_path = pdb_unnest_limit, public;
+CREATE TABLE items (id int PRIMARY KEY, kind text);
+INSERT INTO items
+SELECT g, CASE WHEN g % 3 = 0 THEN 'novel' ELSE 'manga' END
+FROM generate_series(1, 2000) g;
+CREATE INDEX items_bm25 ON items USING bm25 (id, kind) WITH (key_field = 'id');
+ANALYZE items;
+SET paradedb.enable_custom_scan = on;
+-- Row-reducing unnest: even ids emit one row, odd ids emit zero rows.
+-- Correct answer is 5 rows because there are >>5 matching even ids.
+-- Before the fix, this returned only 2 rows: TopK capped input to 5
+-- (ids 1, 2, 4, 5, 7), then ProjectSet dropped ids 1, 5, 7.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+ id | u 
+----+---
+  2 | 1
+  4 | 1
+  8 | 1
+ 10 | 1
+ 14 | 1
+(5 rows)
+
+-- Same shape with NULL arrays instead of empty arrays.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE NULL::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+ id | u 
+----+---
+  2 | 1
+  4 | 1
+  8 | 1
+ 10 | 1
+ 14 | 1
+(5 rows)
+
+-- Sanity: the non-reducing case (every input row multiplies into >=1 output
+-- rows) still returns exactly LIMIT rows and still routes through the scan.
+SELECT id, unnest(ARRAY[1, 2]) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id, u
+LIMIT 6;
+ id | u 
+----+---
+  1 | 1
+  1 | 2
+  2 | 1
+  2 | 2
+  4 | 1
+  4 | 2
+(6 rows)
+
+-- Sanity: with `paradedb.enable_custom_scan = off` the query falls back to
+-- a plain PostgreSQL plan (no BaseScan involved) and should return 5 rows.
+-- This is the reference the fix restores parity with.
+SET paradedb.enable_custom_scan = off;
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind = 'manga'
+ORDER BY id
+LIMIT 5;
+ id | u 
+----+---
+  2 | 1
+  4 | 1
+  8 | 1
+ 10 | 1
+ 14 | 1
+(5 rows)
+
+RESET paradedb.enable_custom_scan;
+DROP SCHEMA pdb_unnest_limit CASCADE;

--- a/pg_search/tests/pg_regress/sql/basescan_limit_unnest.sql
+++ b/pg_search/tests/pg_regress/sql/basescan_limit_unnest.sql
@@ -1,0 +1,66 @@
+-- =====================================================================
+-- Issue #5573: LIMIT must not be pushed into BaseScan when a
+--              row-reducing set-returning function sits above it.
+-- =====================================================================
+-- Before the fix, `classify_target_list_srf` marked `unnest` as
+-- "row-preserving" and let BaseScan cap its TopK to `LIMIT` rows.
+-- `unnest(ARRAY[]::T[])` and `unnest(NULL)` emit ZERO rows, so the
+-- ProjectSet above the scan then discarded rows from an already-capped
+-- output and returned fewer than LIMIT results.
+--
+-- This test exercises the buggy case (mixed empty/NULL/non-empty
+-- arrays under `unnest` with a `@@@` predicate + LIMIT) and asserts
+-- the query returns exactly LIMIT rows.
+
+CREATE EXTENSION IF NOT EXISTS pg_search;
+
+DROP SCHEMA IF EXISTS pdb_unnest_limit CASCADE;
+CREATE SCHEMA pdb_unnest_limit;
+SET search_path = pdb_unnest_limit, public;
+
+CREATE TABLE items (id int PRIMARY KEY, kind text);
+INSERT INTO items
+SELECT g, CASE WHEN g % 3 = 0 THEN 'novel' ELSE 'manga' END
+FROM generate_series(1, 2000) g;
+CREATE INDEX items_bm25 ON items USING bm25 (id, kind) WITH (key_field = 'id');
+ANALYZE items;
+
+SET paradedb.enable_custom_scan = on;
+
+-- Row-reducing unnest: even ids emit one row, odd ids emit zero rows.
+-- Correct answer is 5 rows because there are >>5 matching even ids.
+-- Before the fix, this returned only 2 rows: TopK capped input to 5
+-- (ids 1, 2, 4, 5, 7), then ProjectSet dropped ids 1, 5, 7.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+
+-- Same shape with NULL arrays instead of empty arrays.
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE NULL::int[] END) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id
+LIMIT 5;
+
+-- Sanity: the non-reducing case (every input row multiplies into >=1 output
+-- rows) still returns exactly LIMIT rows and still routes through the scan.
+SELECT id, unnest(ARRAY[1, 2]) AS u
+FROM items
+WHERE kind @@@ pdb.term('manga')
+ORDER BY id, u
+LIMIT 6;
+
+-- Sanity: with `paradedb.enable_custom_scan = off` the query falls back to
+-- a plain PostgreSQL plan (no BaseScan involved) and should return 5 rows.
+-- This is the reference the fix restores parity with.
+SET paradedb.enable_custom_scan = off;
+SELECT id, unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
+FROM items
+WHERE kind = 'manga'
+ORDER BY id
+LIMIT 5;
+
+RESET paradedb.enable_custom_scan;
+DROP SCHEMA pdb_unnest_limit CASCADE;


### PR DESCRIPTION
# Ticket(s) Closed

- Closes #5573

## What

Narrows `classify_target_list_srf` so that only `unnest` calls whose sole argument is a ParadeDB snippet SRF placeholder — `pdb.snippets`, `pdb.snippet_positions`, and their legacy `paradedb.*` shims — are treated as row-preserving for LIMIT pushdown. `unnest` of any other expression (a Var, a `CASE`, a user function) is now treated the same as any other SRF: unsafe, so `is_limit_pushdown_safe` returns false and BaseScan does not absorb the LIMIT.

## Why

Base Scan classifies any `unnest` in the target list as row-preserving and lets its TopK cap the output at LIMIT rows. That assumption holds for `unnest(pdb.snippets(...))` — the paradedb snippet SRFs are placeholders that only fire for rows the CustomScan actually matched, and their output vectors are non-empty by construction on matching rows. But for `unnest` of a user expression the input can be empty (`ARRAY[]::T[]`) or NULL, and `unnest` of those emits zero rows. The ProjectSet above the scan then discards rows out of an already-capped input with nothing available to refill from.

The reproduction in #5573:

```sql
SELECT id,
       unnest(CASE WHEN id % 2 = 0 THEN ARRAY[1] ELSE '{}'::int[] END) AS u
FROM items
WHERE kind @@@ pdb.term('manga')
ORDER BY id
LIMIT 5;
```

returned 2 rows. Base Scan's TopK captured ids `1, 2, 4, 5, 7` (its five best matches), then ProjectSet dropped ids `1, 5, 7` — the odd ones — and nothing below could refill the LIMIT. Correct answer: 5 rows (ids `2, 4, 8, 10, 14`).

## How

Two coordinated changes in `pg_search/src/postgres/customscan/basescan/mod.rs`:

1. `classify_target_list_srf` no longer marks `is_unnest_func(...)` alone as `Safe`. It now additionally checks that the sole argument to the `unnest` is a `FuncExpr` whose funcid is one of `snippets_funcoids()` ∪ `snippet_positions_funcoids()`. Anything else falls through to `TargetListSrf::Unsafe`, and the outer target list loop returns `Unsafe` immediately.

2. `is_limit_pushdown_safe`'s existing `!classify_target_list_srf(root).is_unsafe()` gate and the LIMIT-pushdown filter's `unnest_override` sibling are unchanged, so the topology / predicate / SRF gating stays identical for every already-supported query shape.

Whether an array is empty or NULL is a data-dependent property unknowable at plan time, so we can only push LIMIT below `unnest` when the argument is a ParadeDB-controlled SRF with a non-empty-by-construction guarantee — which is exactly the `pdb.snippets` / `pdb.snippet_positions` case the pushdown was designed to preserve.

## Tests

New pg_regress test `basescan_limit_unnest.sql` with three assertions:

- Row-reducing `unnest` on a `CASE` producing empty arrays for odd ids returns exactly `LIMIT 5` rows.
- Same shape with `NULL::int[]` in place of `'{}'::int[]` also returns exactly `LIMIT 5` rows.
- Sanity: the non-reducing case `unnest(ARRAY[1, 2])` still returns `LIMIT 6` rows and still routes through the scan.
- Sanity: with `paradedb.enable_custom_scan = off` the plain-PG plan returns the same 5 rows (parity check).

Ran the FULL `cargo pgrx regress pg18` suite locally on the branch: **301 passed / 0 failed.** In particular `partitioned_snippets` — which exercises the `UNNEST(pdb.snippets(...))` path the narrowed `unnest`-is-safe override was designed to preserve — is green.

`cargo check --features=pg18 --no-default-features -p pg_search` is clean.