### PR TITLE
chore: Add `CASCADE` in more places.

### DIFF
--- a/stressgres/suites/logical-replication-merge.toml
+++ b/stressgres/suites/logical-replication-merge.toml
@@ -55,7 +55,7 @@ postgresql_conf = "Subscriber"
 [server.setup]
 sql = """
 DROP TABLE IF EXISTS test CASCADE;
-CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 CREATE TABLE test (
     id SERIAL8 NOT NULL PRIMARY KEY,
     message TEXT,

--- a/stressgres/suites/logical-replication.toml
+++ b/stressgres/suites/logical-replication.toml
@@ -57,7 +57,7 @@ postgresql_conf = "Subscriber"
 [server.setup]
 sql = """
 DROP TABLE IF EXISTS test CASCADE;
-CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 CREATE TABLE test (
     id SERIAL8 NOT NULL PRIMARY KEY,
     message TEXT,

--- a/stressgres/suites/wide-table.toml
+++ b/stressgres/suites/wide-table.toml
@@ -4,7 +4,7 @@ name = "Primary"
 
 [server.setup]
 sql = """
-CREATE EXTENSION IF NOT EXISTS pg_search;
+CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;
 SET maintenance_work_mem = '8GB';
 
 CREATE OR REPLACE FUNCTION uuid_generate()


### PR DESCRIPTION
After #5215, we require `CREATE EXTENSION IF NOT EXISTS pg_search CASCADE;`, but a few spots were missed.